### PR TITLE
feat(proxy): add per-deployment keepalive_seconds SSE heartbeat to prevent load-balancer timeout on long streams

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -3996,6 +3996,7 @@ class LitellmDataForBackendLLMCall(TypedDict, total=False):
     stream_timeout: float | None
     user: str | None
     num_retries: int | None
+    keepalive_seconds: float | None
 
 
 class LitellmMetadataFromRequestHeaders(TypedDict, total=False):

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -4031,6 +4031,7 @@ class LitellmDataForBackendLLMCall(TypedDict, total=False):
     # deliberately tiny value isn't treated as a deployment health signal (see
     # cooldown_handlers._trigger_cooldown_for_failed_deployment).
     client_side_timeout: bool
+    keepalive_seconds: float | None
 
 
 class LitellmMetadataFromRequestHeaders(TypedDict, total=False):

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -883,7 +883,7 @@ class LiteLLMProxyRequestSetup:
         return None
 
     @staticmethod
-    def _get_keepalive_seconds_from_request(headers: dict) -> float | None:
+    def _get_keepalive_seconds_from_request(headers: Mapping[str, str]) -> float | None:
         """
         Get `keepalive_seconds` from the request headers, for clients (e.g. the
         Vercel AI SDK) that can set custom headers more easily than extra body

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -815,7 +815,7 @@ class LiteLLMProxyRequestSetup:
         return None
 
     @staticmethod
-    def _get_keepalive_seconds_from_request(headers: dict) -> float | None:
+    def _get_keepalive_seconds_from_request(headers: Mapping[str, str]) -> float | None:
         """
         Get `keepalive_seconds` from the request headers, for clients (e.g. the
         Vercel AI SDK) that can set custom headers more easily than extra body

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -815,6 +815,19 @@ class LiteLLMProxyRequestSetup:
         return None
 
     @staticmethod
+    def _get_keepalive_seconds_from_request(headers: dict) -> float | None:
+        """
+        Get `keepalive_seconds` from the request headers, for clients (e.g. the
+        Vercel AI SDK) that can set custom headers more easily than extra body
+        fields. Subject to the same deployment-level allow_client_keepalive_override
+        gate as the request body field: see _resolve_keepalive_seconds.
+        """
+        keepalive_seconds_header = headers.get("x-litellm-keepalive-seconds", None)
+        if keepalive_seconds_header is not None:
+            return float(keepalive_seconds_header)
+        return None
+
+    @staticmethod
     def _get_num_retries_from_request(headers: dict) -> int | None:
         """
         Workaround for client request from Vercel's AI SDK.
@@ -1028,6 +1041,10 @@ class LiteLLMProxyRequestSetup:
         num_retries: Final = LiteLLMProxyRequestSetup._get_num_retries_from_request(headers)
         if num_retries is not None:
             data["num_retries"] = num_retries
+
+        keepalive_seconds = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(headers)
+        if keepalive_seconds is not None:
+            data["keepalive_seconds"] = keepalive_seconds
 
         return data
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -883,6 +883,19 @@ class LiteLLMProxyRequestSetup:
         return None
 
     @staticmethod
+    def _get_keepalive_seconds_from_request(headers: dict) -> float | None:
+        """
+        Get `keepalive_seconds` from the request headers, for clients (e.g. the
+        Vercel AI SDK) that can set custom headers more easily than extra body
+        fields. Subject to the same deployment-level allow_client_keepalive_override
+        gate as the request body field: see _resolve_keepalive_seconds.
+        """
+        keepalive_seconds_header = headers.get("x-litellm-keepalive-seconds", None)
+        if keepalive_seconds_header is not None:
+            return float(keepalive_seconds_header)
+        return None
+
+    @staticmethod
     def _get_num_retries_from_request(headers: dict) -> int | None:
         """
         Workaround for client request from Vercel's AI SDK.
@@ -1113,6 +1126,10 @@ class LiteLLMProxyRequestSetup:
         num_retries: Final = LiteLLMProxyRequestSetup._get_num_retries_from_request(headers)
         if num_retries is not None:
             data["num_retries"] = num_retries
+
+        keepalive_seconds = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(headers)
+        if keepalive_seconds is not None:
+            data["keepalive_seconds"] = keepalive_seconds
 
         return data
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -890,7 +890,7 @@ class LiteLLMProxyRequestSetup:
         fields. Subject to the same deployment-level allow_client_keepalive_override
         gate as the request body field: see _resolve_keepalive_seconds.
         """
-        keepalive_seconds_header = headers.get("x-litellm-keepalive-seconds", None)
+        keepalive_seconds_header: Final = headers.get("x-litellm-keepalive-seconds", None)
         if keepalive_seconds_header is not None:
             return float(keepalive_seconds_header)
         return None
@@ -1127,7 +1127,7 @@ class LiteLLMProxyRequestSetup:
         if num_retries is not None:
             data["num_retries"] = num_retries
 
-        keepalive_seconds = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(headers)
+        keepalive_seconds: Final = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(headers)
         if keepalive_seconds is not None:
             data["keepalive_seconds"] = keepalive_seconds
 

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -822,7 +822,7 @@ class LiteLLMProxyRequestSetup:
         fields. Subject to the same deployment-level allow_client_keepalive_override
         gate as the request body field: see _resolve_keepalive_seconds.
         """
-        keepalive_seconds_header = headers.get("x-litellm-keepalive-seconds", None)
+        keepalive_seconds_header: Final = headers.get("x-litellm-keepalive-seconds", None)
         if keepalive_seconds_header is not None:
             return float(keepalive_seconds_header)
         return None
@@ -1042,7 +1042,7 @@ class LiteLLMProxyRequestSetup:
         if num_retries is not None:
             data["num_retries"] = num_retries
 
-        keepalive_seconds = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(headers)
+        keepalive_seconds: Final = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(headers)
         if keepalive_seconds is not None:
             data["keepalive_seconds"] = keepalive_seconds
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15,7 +15,7 @@ import threading
 import time
 import traceback
 import warnings
-from collections.abc import AsyncGenerator, Callable, Mapping
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
 from datetime import datetime, timedelta, timezone
 from types import MappingProxyType, UnionType
 from typing import (
@@ -7650,7 +7650,7 @@ _KEEPALIVE_MIN_SECONDS = 1.0
 _KEEPALIVE_MAX_SECONDS = 300.0
 
 
-async def _iter_with_keepalive(aiter: Any, keepalive_seconds: float) -> AsyncGenerator[Any, None]:
+async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: float) -> AsyncGenerator[Any, None]:
     if keepalive_seconds <= 0:
         async for item in aiter:
             yield item
@@ -7686,7 +7686,7 @@ class _DeploymentKeepaliveConfig(NamedTuple):
     allow_client_override: bool
 
 
-def _keepalive_from_deployment_config(request_data: dict[str, Any], response: Any) -> _DeploymentKeepaliveConfig | None:
+def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response) -> _DeploymentKeepaliveConfig | None:
     if llm_router is None:
         return None
 
@@ -7727,7 +7727,7 @@ def _keepalive_from_deployment_config(request_data: dict[str, Any], response: An
     return None
 
 
-def _is_explicit_keepalive_disable(raw: Any) -> bool:
+def _is_explicit_keepalive_disable(raw) -> bool:
     if raw is None:
         return False
     try:
@@ -7736,7 +7736,7 @@ def _is_explicit_keepalive_disable(raw: Any) -> bool:
         return False
 
 
-def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = None) -> float:
+def _resolve_keepalive_seconds(request_data: Mapping[str, Any], response=None) -> float:
     deployment_config = _keepalive_from_deployment_config(request_data, response)
     deployment_raw = deployment_config.keepalive_seconds if deployment_config is not None else None
     allow_client_override = deployment_config.allow_client_override if deployment_config is not None else False

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7676,7 +7676,7 @@ async def _iter_with_keepalive(aiter: Any, keepalive_seconds: float) -> AsyncGen
             pending.cancel()
             try:
                 await pending
-            except BaseException:
+            except asyncio.CancelledError:
                 pass
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7541,18 +7541,30 @@ _KEEPALIVE_MAX_SECONDS: Final = 300.0
 _EMPTY_MAPPING: Final[Mapping[str, Any]] = MappingProxyType({})
 
 
-async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: float) -> AsyncGenerator[Any, None]:
+async def _iter_with_keepalive(
+    aiter: AsyncIterator[Any],
+    resolve_keepalive_seconds: Callable[[object], float],
+    keepalive_seconds: float,
+) -> AsyncGenerator[Any, None]:
+    """Wrap `aiter` with idle-gap heartbeats, re-resolving the interval after each
+    real chunk via `resolve_keepalive_seconds`. A mid-stream router fallback can
+    swap in a deployment with a different (or disabled) keepalive policy partway
+    through the same stream; re-resolving against each chunk's own identity
+    (rather than trusting the interval picked before iteration started) keeps the
+    heartbeat behavior in sync with whichever deployment actually produced it."""
     if keepalive_seconds <= 0:
         async for item in aiter:
             yield item
         return
 
     pending: asyncio.Task[Any] | None = None  # rebind-ok: rebound each loop iteration
+    current_keepalive_seconds = keepalive_seconds  # rebind-ok: re-resolved after each chunk
     try:
         while True:
             if pending is None:
                 pending = asyncio.create_task(aiter.__anext__())
-            done, _ = await asyncio.wait((pending,), timeout=keepalive_seconds)
+            timeout = current_keepalive_seconds if current_keepalive_seconds > 0 else None
+            done, _ = await asyncio.wait((pending,), timeout=timeout)
             if not done:
                 yield _STREAM_KEEPALIVE
                 continue
@@ -7563,6 +7575,7 @@ async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: flo
             finally:
                 pending = None
             yield item
+            current_keepalive_seconds = resolve_keepalive_seconds(item)
     finally:
         if pending is not None and not pending.done():
             pending.cancel()
@@ -7716,7 +7729,13 @@ async def async_data_generator(
 
         _ka_secs: Final = _resolve_keepalive_seconds(request_data, response)
         stream_source: Final = (
-            _iter_with_keepalive(stream_iterator.__aiter__(), _ka_secs) if _ka_secs > 0 else stream_iterator
+            _iter_with_keepalive(
+                stream_iterator.__aiter__(),
+                lambda item: _resolve_keepalive_seconds(request_data, item),
+                _ka_secs,
+            )
+            if _ka_secs > 0
+            else stream_iterator
         )
 
         async for item in stream_source:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7548,23 +7548,30 @@ async def _iter_with_keepalive(
 ) -> AsyncGenerator[Any, None]:
     """Wrap `aiter` with idle-gap heartbeats, re-resolving the interval after each
     real chunk via `resolve_keepalive_seconds`. A mid-stream router fallback can
-    swap in a deployment with a different (or disabled) keepalive policy partway
-    through the same stream; re-resolving against each chunk's own identity
-    (rather than trusting the interval picked before iteration started) keeps the
-    heartbeat behavior in sync with whichever deployment actually produced it."""
-    if keepalive_seconds <= 0:
-        async for item in aiter:
-            yield item
-        return
-
+    swap in a deployment with a different keepalive policy, including one that
+    newly enables or newly disables heartbeats, partway through the same stream;
+    re-resolving against each chunk's own identity (rather than trusting the
+    interval picked before iteration started, or picked the last time it went
+    inactive) keeps the heartbeat behavior in sync with whichever deployment
+    actually produced it, in both directions. While the interval is <= 0, no
+    task is created and no timeout is awaited: a chunk is forwarded the moment
+    it arrives, at the same cost as a bare `async for`."""
     pending: asyncio.Task[Any] | None = None  # rebind-ok: rebound each loop iteration
     current_keepalive_seconds = keepalive_seconds  # rebind-ok: re-resolved after each chunk
     try:
         while True:
+            if current_keepalive_seconds <= 0:
+                try:
+                    item = await aiter.__anext__()
+                except StopAsyncIteration:
+                    break
+                yield item
+                current_keepalive_seconds = resolve_keepalive_seconds(item)
+                continue
+
             if pending is None:
                 pending = asyncio.create_task(aiter.__anext__())
-            timeout = current_keepalive_seconds if current_keepalive_seconds > 0 else None
-            done, _ = await asyncio.wait((pending,), timeout=timeout)
+            done, _ = await asyncio.wait((pending,), timeout=current_keepalive_seconds)
             if not done:
                 yield _STREAM_KEEPALIVE
                 continue
@@ -7727,14 +7734,19 @@ async def async_data_generator(
         else:
             stream_iterator = response
 
-        _ka_secs: Final = _resolve_keepalive_seconds(request_data, response)
+        # A stream can start on a deployment with keepalive off and fall back
+        # mid-stream to one that enables it: only skip wrapping altogether when
+        # there's no router to ever fall back through in the first place (in
+        # which case _resolve_keepalive_seconds can never return non-zero for
+        # any chunk of this stream), not merely because the first chunk's
+        # deployment happens to start with it off.
         stream_source: Final = (
             _iter_with_keepalive(
                 stream_iterator.__aiter__(),
                 lambda item: _resolve_keepalive_seconds(request_data, item),
-                _ka_secs,
+                _resolve_keepalive_seconds(request_data, response),
             )
-            if _ka_secs > 0
+            if llm_router is not None
             else stream_iterator
         )
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7644,11 +7644,11 @@ def _pop_complete_sse_frame(buffer: str) -> tuple[str | None, str]:
     return buffer[:frame_end], buffer[frame_end:]
 
 
-_STREAM_KEEPALIVE = object()
+_STREAM_KEEPALIVE: Final = object()
 
-_KEEPALIVE_MIN_SECONDS = 1.0
-_KEEPALIVE_MAX_SECONDS = 300.0
-_EMPTY_MAPPING: Mapping[str, Any] = MappingProxyType({})
+_KEEPALIVE_MIN_SECONDS: Final = 1.0
+_KEEPALIVE_MAX_SECONDS: Final = 300.0
+_EMPTY_MAPPING: Final[Mapping[str, Any]] = MappingProxyType({})
 
 
 async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: float) -> AsyncGenerator[Any, None]:
@@ -7657,7 +7657,7 @@ async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: flo
             yield item
         return
 
-    pending: asyncio.Task[Any] | None = None
+    pending: asyncio.Task[Any] | None = None  # rebind-ok: rebound each loop iteration
     try:
         while True:
             if pending is None:
@@ -7687,14 +7687,16 @@ class _DeploymentKeepaliveConfig(NamedTuple):
     allow_client_override: bool
 
 
-def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response) -> _DeploymentKeepaliveConfig | None:
+def _keepalive_from_deployment_config(
+    request_data: Mapping[str, Any], response: object
+) -> _DeploymentKeepaliveConfig | None:
     if llm_router is None:
         return None
 
-    hidden = getattr(response, "_hidden_params", None)
-    model_id = hidden.get("model_id") if isinstance(hidden, dict) else None
-    if model_id:
-        deployment = llm_router.get_deployment(model_id=model_id)
+    hidden: Final = get_hidden_params_dict(response)
+    model_id: Final = hidden.get("model_id")
+    if isinstance(model_id, str) and model_id:
+        deployment: Final = llm_router.get_deployment(model_id=model_id)
         # A populated model_id names the specific deployment that served this
         # stream. If it no longer resolves (e.g. removed by a config reload
         # mid-stream), that's a stale identity, not an absent one: don't fall
@@ -7713,7 +7715,7 @@ def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response)
     # model_name agrees on both keepalive_seconds and
     # allow_client_keepalive_override (including deployments that leave either
     # field unset), so a stream never inherits a sibling deployment's policy.
-    configs = frozenset(
+    configs: Final = frozenset(
         (
             (deployment_dict.get("litellm_params") or _EMPTY_MAPPING).get("keepalive_seconds"),
             bool(
@@ -7730,19 +7732,19 @@ def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response)
     return None
 
 
-def _is_explicit_keepalive_disable(raw) -> bool:
-    if raw is None:
+def _is_explicit_keepalive_disable(raw: object) -> bool:
+    if not isinstance(raw, (int, float, str)):
         return False
     try:
         return float(raw) <= 0
-    except (TypeError, ValueError):
+    except ValueError:
         return False
 
 
-def _resolve_keepalive_seconds(request_data: Mapping[str, Any], response=None) -> float:
-    deployment_config = _keepalive_from_deployment_config(request_data, response)
-    deployment_raw = deployment_config.keepalive_seconds if deployment_config is not None else None
-    allow_client_override = deployment_config.allow_client_override if deployment_config is not None else False
+def _resolve_keepalive_seconds(request_data: Mapping[str, Any], response: object = None) -> float:
+    deployment_config: Final = _keepalive_from_deployment_config(request_data, response)
+    deployment_raw: Final = deployment_config.keepalive_seconds if deployment_config is not None else None
+    allow_client_override: Final = deployment_config.allow_client_override if deployment_config is not None else False
 
     # An operator setting keepalive_seconds: 0 on a deployment is an explicit hard
     # disable: an authenticated client must not be able to re-enable heartbeats
@@ -7754,16 +7756,15 @@ def _resolve_keepalive_seconds(request_data: Mapping[str, Any], response=None) -
     # keepalive_seconds is operator-only unless the deployment explicitly opts in:
     # a client can't unilaterally enable heartbeats (and the LB-idle-timeout
     # evasion that comes with them) for a deployment that never configured this.
-    raw = request_data.get("keepalive_seconds") if allow_client_override else None
-    if raw is None:
-        raw = deployment_raw
+    client_supplied: Final = request_data.get("keepalive_seconds") if allow_client_override else None
+    raw: Final = client_supplied if client_supplied is not None else deployment_raw
     try:
-        value = float(raw) if raw is not None else 0.0
-    except (TypeError, ValueError):
+        value: Final = float(raw) if isinstance(raw, (int, float, str)) else 0.0
+    except ValueError:
         return 0.0
     if value <= 0:
         return 0.0
-    clamped = max(_KEEPALIVE_MIN_SECONDS, min(value, _KEEPALIVE_MAX_SECONDS))
+    clamped: Final = max(_KEEPALIVE_MIN_SECONDS, min(value, _KEEPALIVE_MAX_SECONDS))
     if clamped != value:
         verbose_proxy_logger.info(
             "keepalive_seconds=%s clamped to %s [min=%s, max=%s]",
@@ -7823,8 +7824,10 @@ async def async_data_generator(
         else:
             stream_iterator = response
 
-        _ka_secs = _resolve_keepalive_seconds(request_data, response)
-        stream_source = _iter_with_keepalive(stream_iterator.__aiter__(), _ka_secs) if _ka_secs > 0 else stream_iterator
+        _ka_secs: Final = _resolve_keepalive_seconds(request_data, response)
+        stream_source: Final = (
+            _iter_with_keepalive(stream_iterator.__aiter__(), _ka_secs) if _ka_secs > 0 else stream_iterator
+        )
 
         async for item in stream_source:
             if item is _STREAM_KEEPALIVE:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7594,10 +7594,27 @@ def _keepalive_from_deployment_config(request_data: dict[str, Any], response: An
     return None
 
 
+def _is_explicit_keepalive_disable(raw: Any) -> bool:
+    if raw is None:
+        return False
+    try:
+        return float(raw) <= 0
+    except (TypeError, ValueError):
+        return False
+
+
 def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = None) -> float:
+    deployment_raw = _keepalive_from_deployment_config(request_data, response)
+    # An operator setting keepalive_seconds: 0 on a deployment is an explicit hard
+    # disable: an authenticated client must not be able to re-enable heartbeats
+    # (and the idle-timeout evasion that comes with them) for a deployment the
+    # operator opted out of, regardless of what the request body asks for.
+    if _is_explicit_keepalive_disable(deployment_raw):
+        return 0.0
+
     raw = request_data.get("keepalive_seconds")
     if raw is None:
-        raw = _keepalive_from_deployment_config(request_data, response)
+        raw = deployment_raw
     try:
         value = float(raw) if raw is not None else 0.0
     except (TypeError, ValueError):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -23,6 +23,7 @@ from typing import (
     Any,
     Final,
     Literal,
+    NamedTuple,
     Optional,
     TypedDict,
     Union,
@@ -7570,7 +7571,12 @@ async def _iter_with_keepalive(aiter: Any, keepalive_seconds: float) -> AsyncGen
                 pass
 
 
-def _keepalive_from_deployment_config(request_data: dict[str, Any], response: Any) -> Any:
+class _DeploymentKeepaliveConfig(NamedTuple):
+    keepalive_seconds: Any
+    allow_client_override: bool
+
+
+def _keepalive_from_deployment_config(request_data: dict[str, Any], response: Any) -> _DeploymentKeepaliveConfig | None:
     if llm_router is None:
         return None
 
@@ -7584,21 +7590,30 @@ def _keepalive_from_deployment_config(request_data: dict[str, Any], response: An
         # through to guessing via model_name below, since a currently-live
         # sibling deployment's config was never what actually served this
         # stream.
-        if deployment is not None:
-            return getattr(deployment.litellm_params, "keepalive_seconds", None)
-        return None
+        if deployment is None:
+            return None
+        return _DeploymentKeepaliveConfig(
+            keepalive_seconds=getattr(deployment.litellm_params, "keepalive_seconds", None),
+            allow_client_override=bool(getattr(deployment.litellm_params, "allow_client_keepalive_override", False)),
+        )
 
     # No model_id at all to pin down which deployment actually served this
     # stream: only trust the fallback when every deployment under this
-    # model_name agrees, including deployments that leave keepalive_seconds
-    # unset (None), so an unconfigured deployment never inherits a sibling's
-    # configured interval.
-    values = {
-        (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")
+    # model_name agrees on both keepalive_seconds and
+    # allow_client_keepalive_override (including deployments that leave either
+    # field unset), so a stream never inherits a sibling deployment's policy.
+    configs = {
+        (
+            (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds"),
+            bool((deployment_dict.get("litellm_params") or {}).get("allow_client_keepalive_override", False)),
+        )
         for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []
     }
-    if len(values) == 1:
-        return values.pop()
+    if len(configs) == 1:
+        keepalive_seconds, allow_client_override = configs.pop()
+        return _DeploymentKeepaliveConfig(
+            keepalive_seconds=keepalive_seconds, allow_client_override=allow_client_override
+        )
     return None
 
 
@@ -7612,7 +7627,10 @@ def _is_explicit_keepalive_disable(raw: Any) -> bool:
 
 
 def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = None) -> float:
-    deployment_raw = _keepalive_from_deployment_config(request_data, response)
+    deployment_config = _keepalive_from_deployment_config(request_data, response)
+    deployment_raw = deployment_config.keepalive_seconds if deployment_config is not None else None
+    allow_client_override = deployment_config.allow_client_override if deployment_config is not None else False
+
     # An operator setting keepalive_seconds: 0 on a deployment is an explicit hard
     # disable: an authenticated client must not be able to re-enable heartbeats
     # (and the idle-timeout evasion that comes with them) for a deployment the
@@ -7620,7 +7638,10 @@ def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = Non
     if _is_explicit_keepalive_disable(deployment_raw):
         return 0.0
 
-    raw = request_data.get("keepalive_seconds")
+    # keepalive_seconds is operator-only unless the deployment explicitly opts in:
+    # a client can't unilaterally enable heartbeats (and the LB-idle-timeout
+    # evasion that comes with them) for a deployment that never configured this.
+    raw = request_data.get("keepalive_seconds") if allow_client_override else None
     if raw is None:
         raw = deployment_raw
     try:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7703,7 +7703,7 @@ def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = Non
     if raw is None:
         raw = _keepalive_from_deployment_config(request_data, response)
     try:
-        value = float(raw or 0)
+        value = float(raw) if raw is not None else 0.0
     except (TypeError, ValueError):
         return 0.0
     if value <= 0:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7583,6 +7583,20 @@ def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response)
 
     hidden = getattr(response, "_hidden_params", None)
     model_id = hidden.get("model_id") if isinstance(hidden, dict) else None
+    if not model_id:
+        # A router-level fallback rewrites kwargs["model"] on the fallback
+        # handler's own local **kwargs copy, not on this request_data dict, so
+        # request_data.get("model") still names the pre-fallback model group.
+        # metadata/litellm_metadata.model_info.id, by contrast, is mutated on
+        # this same dict by Router._update_kwargs_with_deployment on every
+        # attempt (including fallbacks) and reliably names the deployment that
+        # actually served the call; same source ProxyLogging._build_litellm_call_info
+        # uses for logging.
+        for meta_key in ("metadata", "litellm_metadata"):
+            model_info = (request_data.get(meta_key) or _EMPTY_MAPPING).get("model_info") or _EMPTY_MAPPING
+            model_id = model_info.get("id")
+            if model_id:
+                break
     if model_id:
         deployment = llm_router.get_deployment(model_id=model_id)
         # A populated model_id names the specific deployment that served this

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17,7 +17,7 @@ import traceback
 import warnings
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
 from datetime import datetime, timedelta, timezone
-from types import UnionType
+from types import MappingProxyType, UnionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -7538,6 +7538,7 @@ _STREAM_KEEPALIVE = object()
 
 _KEEPALIVE_MIN_SECONDS = 1.0
 _KEEPALIVE_MAX_SECONDS = 300.0
+_EMPTY_MAPPING: Mapping[str, Any] = MappingProxyType({})
 
 
 async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: float) -> AsyncGenerator[Any, None]:
@@ -7551,7 +7552,7 @@ async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: flo
         while True:
             if pending is None:
                 pending = asyncio.create_task(aiter.__anext__())
-            done, _ = await asyncio.wait({pending}, timeout=keepalive_seconds)
+            done, _ = await asyncio.wait((pending,), timeout=keepalive_seconds)
             if not done:
                 yield _STREAM_KEEPALIVE
                 continue
@@ -7602,15 +7603,17 @@ def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response)
     # model_name agrees on both keepalive_seconds and
     # allow_client_keepalive_override (including deployments that leave either
     # field unset), so a stream never inherits a sibling deployment's policy.
-    configs = {
+    configs = frozenset(
         (
-            (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds"),
-            bool((deployment_dict.get("litellm_params") or {}).get("allow_client_keepalive_override", False)),
+            (deployment_dict.get("litellm_params") or _EMPTY_MAPPING).get("keepalive_seconds"),
+            bool(
+                (deployment_dict.get("litellm_params") or _EMPTY_MAPPING).get("allow_client_keepalive_override", False)
+            ),
         )
-        for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []
-    }
+        for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or ()
+    )
     if len(configs) == 1:
-        keepalive_seconds, allow_client_override = configs.pop()
+        keepalive_seconds, allow_client_override = next(iter(configs))
         return _DeploymentKeepaliveConfig(
             keepalive_seconds=keepalive_seconds, allow_client_override=allow_client_override
         )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7692,15 +7692,15 @@ def _keepalive_from_deployment_config(request_data: dict[str, Any], response: An
             return getattr(deployment.litellm_params, "keepalive_seconds", None)
 
     # No model_id to pin down which deployment actually served this stream: only
-    # trust the fallback when every deployment under this model_name agrees, so we
-    # never apply one deployment's interval (or disable) to another's stream.
-    configured_values = {
-        raw
+    # trust the fallback when every deployment under this model_name agrees,
+    # including deployments that leave keepalive_seconds unset (None), so an
+    # unconfigured deployment never inherits a sibling's configured interval.
+    values = {
+        (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")
         for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []
-        if (raw := (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")) is not None
     }
-    if len(configured_values) == 1:
-        return configured_values.pop()
+    if len(values) == 1:
+        return values.pop()
     return None
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7688,13 +7688,21 @@ def _keepalive_from_deployment_config(request_data: dict[str, Any], response: An
     model_id = hidden.get("model_id") if isinstance(hidden, dict) else None
     if model_id:
         deployment = llm_router.get_deployment(model_id=model_id)
+        # A populated model_id names the specific deployment that served this
+        # stream. If it no longer resolves (e.g. removed by a config reload
+        # mid-stream), that's a stale identity, not an absent one: don't fall
+        # through to guessing via model_name below, since a currently-live
+        # sibling deployment's config was never what actually served this
+        # stream.
         if deployment is not None:
             return getattr(deployment.litellm_params, "keepalive_seconds", None)
+        return None
 
-    # No model_id to pin down which deployment actually served this stream: only
-    # trust the fallback when every deployment under this model_name agrees,
-    # including deployments that leave keepalive_seconds unset (None), so an
-    # unconfigured deployment never inherits a sibling's configured interval.
+    # No model_id at all to pin down which deployment actually served this
+    # stream: only trust the fallback when every deployment under this
+    # model_name agrees, including deployments that leave keepalive_seconds
+    # unset (None), so an unconfigured deployment never inherits a sibling's
+    # configured interval.
     values = {
         (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")
         for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15,7 +15,7 @@ import threading
 import time
 import traceback
 import warnings
-from collections.abc import AsyncGenerator, Callable, Mapping
+from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping
 from datetime import datetime, timedelta, timezone
 from types import UnionType
 from typing import (
@@ -7540,7 +7540,7 @@ _KEEPALIVE_MIN_SECONDS = 1.0
 _KEEPALIVE_MAX_SECONDS = 300.0
 
 
-async def _iter_with_keepalive(aiter: Any, keepalive_seconds: float) -> AsyncGenerator[Any, None]:
+async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: float) -> AsyncGenerator[Any, None]:
     if keepalive_seconds <= 0:
         async for item in aiter:
             yield item
@@ -7576,7 +7576,7 @@ class _DeploymentKeepaliveConfig(NamedTuple):
     allow_client_override: bool
 
 
-def _keepalive_from_deployment_config(request_data: dict[str, Any], response: Any) -> _DeploymentKeepaliveConfig | None:
+def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response) -> _DeploymentKeepaliveConfig | None:
     if llm_router is None:
         return None
 
@@ -7617,7 +7617,7 @@ def _keepalive_from_deployment_config(request_data: dict[str, Any], response: An
     return None
 
 
-def _is_explicit_keepalive_disable(raw: Any) -> bool:
+def _is_explicit_keepalive_disable(raw) -> bool:
     if raw is None:
         return False
     try:
@@ -7626,7 +7626,7 @@ def _is_explicit_keepalive_disable(raw: Any) -> bool:
         return False
 
 
-def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = None) -> float:
+def _resolve_keepalive_seconds(request_data: Mapping[str, Any], response=None) -> float:
     deployment_config = _keepalive_from_deployment_config(request_data, response)
     deployment_raw = deployment_config.keepalive_seconds if deployment_config is not None else None
     allow_client_override = deployment_config.allow_client_override if deployment_config is not None else False

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7796,6 +7796,34 @@ def _resolve_keepalive_seconds(request_data: Mapping[str, Any], response: object
     return clamped
 
 
+def _make_keepalive_resolver(request_data: Mapping[str, Any]) -> Callable[[object], float]:
+    """Wrap `_resolve_keepalive_seconds` with a memo keyed on the serving
+    deployment's model_id. The steady-state case (no mid-stream fallback, the
+    overwhelming majority of streams) sees the same model_id on every chunk, so
+    this turns the per-chunk cost from a full `llm_router.get_deployment()`
+    Pydantic rebuild into a cheap hidden-params read once the first chunk for
+    that model_id has been resolved. A missing/empty model_id can't be trusted
+    as a cache key (see `_keepalive_from_deployment_config`'s model_name
+    fallback, which reflects current router state rather than one deployment's
+    fixed identity), so those chunks always resolve fresh, matching prior
+    behavior exactly.
+    """
+    last_model_id: str | None = None  # rebind-ok: memoized identity of the last-resolved chunk
+    last_value: float = 0.0  # rebind-ok: cached resolution for last_model_id
+
+    def _resolve(item: object) -> float:
+        nonlocal last_model_id, last_value
+        model_id = get_hidden_params_dict(item).get("model_id")
+        if isinstance(model_id, str) and model_id and model_id == last_model_id:
+            return last_value
+        value: Final = _resolve_keepalive_seconds(request_data, item)
+        if isinstance(model_id, str) and model_id:
+            last_model_id, last_value = model_id, value
+        return value
+
+    return _resolve
+
+
 async def async_data_generator(
     response,
     user_api_key_dict: UserAPIKeyAuth,
@@ -7850,11 +7878,12 @@ async def async_data_generator(
         # which case _resolve_keepalive_seconds can never return non-zero for
         # any chunk of this stream), not merely because the first chunk's
         # deployment happens to start with it off.
+        resolve_keepalive_seconds: Final = _make_keepalive_resolver(request_data)
         stream_source: Final = (
             _iter_with_keepalive(
                 stream_iterator.__aiter__(),
-                lambda item: _resolve_keepalive_seconds(request_data, item),
-                _resolve_keepalive_seconds(request_data, response),
+                resolve_keepalive_seconds,
+                resolve_keepalive_seconds(response),
             )
             if llm_router is not None
             else stream_iterator

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7534,11 +7534,11 @@ def _pop_complete_sse_frame(buffer: str) -> tuple[str | None, str]:
     return buffer[:frame_end], buffer[frame_end:]
 
 
-_STREAM_KEEPALIVE = object()
+_STREAM_KEEPALIVE: Final = object()
 
-_KEEPALIVE_MIN_SECONDS = 1.0
-_KEEPALIVE_MAX_SECONDS = 300.0
-_EMPTY_MAPPING: Mapping[str, Any] = MappingProxyType({})
+_KEEPALIVE_MIN_SECONDS: Final = 1.0
+_KEEPALIVE_MAX_SECONDS: Final = 300.0
+_EMPTY_MAPPING: Final[Mapping[str, Any]] = MappingProxyType({})
 
 
 async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: float) -> AsyncGenerator[Any, None]:
@@ -7547,7 +7547,7 @@ async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: flo
             yield item
         return
 
-    pending: asyncio.Task[Any] | None = None
+    pending: asyncio.Task[Any] | None = None  # rebind-ok: rebound each loop iteration
     try:
         while True:
             if pending is None:
@@ -7577,14 +7577,16 @@ class _DeploymentKeepaliveConfig(NamedTuple):
     allow_client_override: bool
 
 
-def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response) -> _DeploymentKeepaliveConfig | None:
+def _keepalive_from_deployment_config(
+    request_data: Mapping[str, Any], response: object
+) -> _DeploymentKeepaliveConfig | None:
     if llm_router is None:
         return None
 
-    hidden = getattr(response, "_hidden_params", None)
-    model_id = hidden.get("model_id") if isinstance(hidden, dict) else None
-    if model_id:
-        deployment = llm_router.get_deployment(model_id=model_id)
+    hidden: Final = get_hidden_params_dict(response)
+    model_id: Final = hidden.get("model_id")
+    if isinstance(model_id, str) and model_id:
+        deployment: Final = llm_router.get_deployment(model_id=model_id)
         # A populated model_id names the specific deployment that served this
         # stream. If it no longer resolves (e.g. removed by a config reload
         # mid-stream), that's a stale identity, not an absent one: don't fall
@@ -7603,7 +7605,7 @@ def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response)
     # model_name agrees on both keepalive_seconds and
     # allow_client_keepalive_override (including deployments that leave either
     # field unset), so a stream never inherits a sibling deployment's policy.
-    configs = frozenset(
+    configs: Final = frozenset(
         (
             (deployment_dict.get("litellm_params") or _EMPTY_MAPPING).get("keepalive_seconds"),
             bool(
@@ -7620,19 +7622,19 @@ def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response)
     return None
 
 
-def _is_explicit_keepalive_disable(raw) -> bool:
-    if raw is None:
+def _is_explicit_keepalive_disable(raw: object) -> bool:
+    if not isinstance(raw, (int, float, str)):
         return False
     try:
         return float(raw) <= 0
-    except (TypeError, ValueError):
+    except ValueError:
         return False
 
 
-def _resolve_keepalive_seconds(request_data: Mapping[str, Any], response=None) -> float:
-    deployment_config = _keepalive_from_deployment_config(request_data, response)
-    deployment_raw = deployment_config.keepalive_seconds if deployment_config is not None else None
-    allow_client_override = deployment_config.allow_client_override if deployment_config is not None else False
+def _resolve_keepalive_seconds(request_data: Mapping[str, Any], response: object = None) -> float:
+    deployment_config: Final = _keepalive_from_deployment_config(request_data, response)
+    deployment_raw: Final = deployment_config.keepalive_seconds if deployment_config is not None else None
+    allow_client_override: Final = deployment_config.allow_client_override if deployment_config is not None else False
 
     # An operator setting keepalive_seconds: 0 on a deployment is an explicit hard
     # disable: an authenticated client must not be able to re-enable heartbeats
@@ -7644,16 +7646,15 @@ def _resolve_keepalive_seconds(request_data: Mapping[str, Any], response=None) -
     # keepalive_seconds is operator-only unless the deployment explicitly opts in:
     # a client can't unilaterally enable heartbeats (and the LB-idle-timeout
     # evasion that comes with them) for a deployment that never configured this.
-    raw = request_data.get("keepalive_seconds") if allow_client_override else None
-    if raw is None:
-        raw = deployment_raw
+    client_supplied: Final = request_data.get("keepalive_seconds") if allow_client_override else None
+    raw: Final = client_supplied if client_supplied is not None else deployment_raw
     try:
-        value = float(raw) if raw is not None else 0.0
-    except (TypeError, ValueError):
+        value: Final = float(raw) if isinstance(raw, (int, float, str)) else 0.0
+    except ValueError:
         return 0.0
     if value <= 0:
         return 0.0
-    clamped = max(_KEEPALIVE_MIN_SECONDS, min(value, _KEEPALIVE_MAX_SECONDS))
+    clamped: Final = max(_KEEPALIVE_MIN_SECONDS, min(value, _KEEPALIVE_MAX_SECONDS))
     if clamped != value:
         verbose_proxy_logger.info(
             "keepalive_seconds=%s clamped to %s [min=%s, max=%s]",
@@ -7713,8 +7714,10 @@ async def async_data_generator(
         else:
             stream_iterator = response
 
-        _ka_secs = _resolve_keepalive_seconds(request_data, response)
-        stream_source = _iter_with_keepalive(stream_iterator.__aiter__(), _ka_secs) if _ka_secs > 0 else stream_iterator
+        _ka_secs: Final = _resolve_keepalive_seconds(request_data, response)
+        stream_source: Final = (
+            _iter_with_keepalive(stream_iterator.__aiter__(), _ka_secs) if _ka_secs > 0 else stream_iterator
+        )
 
         async for item in stream_source:
             if item is _STREAM_KEEPALIVE:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7693,20 +7693,6 @@ def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response)
 
     hidden = getattr(response, "_hidden_params", None)
     model_id = hidden.get("model_id") if isinstance(hidden, dict) else None
-    if not model_id:
-        # A router-level fallback rewrites kwargs["model"] on the fallback
-        # handler's own local **kwargs copy, not on this request_data dict, so
-        # request_data.get("model") still names the pre-fallback model group.
-        # metadata/litellm_metadata.model_info.id, by contrast, is mutated on
-        # this same dict by Router._update_kwargs_with_deployment on every
-        # attempt (including fallbacks) and reliably names the deployment that
-        # actually served the call; same source ProxyLogging._build_litellm_call_info
-        # uses for logging.
-        for meta_key in ("metadata", "litellm_metadata"):
-            model_info = (request_data.get(meta_key) or _EMPTY_MAPPING).get("model_info") or _EMPTY_MAPPING
-            model_id = model_info.get("id")
-            if model_id:
-                break
     if model_id:
         deployment = llm_router.get_deployment(model_id=model_id)
         # A populated model_id names the specific deployment that served this

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7658,23 +7658,30 @@ async def _iter_with_keepalive(
 ) -> AsyncGenerator[Any, None]:
     """Wrap `aiter` with idle-gap heartbeats, re-resolving the interval after each
     real chunk via `resolve_keepalive_seconds`. A mid-stream router fallback can
-    swap in a deployment with a different (or disabled) keepalive policy partway
-    through the same stream; re-resolving against each chunk's own identity
-    (rather than trusting the interval picked before iteration started) keeps the
-    heartbeat behavior in sync with whichever deployment actually produced it."""
-    if keepalive_seconds <= 0:
-        async for item in aiter:
-            yield item
-        return
-
+    swap in a deployment with a different keepalive policy, including one that
+    newly enables or newly disables heartbeats, partway through the same stream;
+    re-resolving against each chunk's own identity (rather than trusting the
+    interval picked before iteration started, or picked the last time it went
+    inactive) keeps the heartbeat behavior in sync with whichever deployment
+    actually produced it, in both directions. While the interval is <= 0, no
+    task is created and no timeout is awaited: a chunk is forwarded the moment
+    it arrives, at the same cost as a bare `async for`."""
     pending: asyncio.Task[Any] | None = None  # rebind-ok: rebound each loop iteration
     current_keepalive_seconds = keepalive_seconds  # rebind-ok: re-resolved after each chunk
     try:
         while True:
+            if current_keepalive_seconds <= 0:
+                try:
+                    item = await aiter.__anext__()
+                except StopAsyncIteration:
+                    break
+                yield item
+                current_keepalive_seconds = resolve_keepalive_seconds(item)
+                continue
+
             if pending is None:
                 pending = asyncio.create_task(aiter.__anext__())
-            timeout = current_keepalive_seconds if current_keepalive_seconds > 0 else None
-            done, _ = await asyncio.wait((pending,), timeout=timeout)
+            done, _ = await asyncio.wait((pending,), timeout=current_keepalive_seconds)
             if not done:
                 yield _STREAM_KEEPALIVE
                 continue
@@ -7837,14 +7844,19 @@ async def async_data_generator(
         else:
             stream_iterator = response
 
-        _ka_secs: Final = _resolve_keepalive_seconds(request_data, response)
+        # A stream can start on a deployment with keepalive off and fall back
+        # mid-stream to one that enables it: only skip wrapping altogether when
+        # there's no router to ever fall back through in the first place (in
+        # which case _resolve_keepalive_seconds can never return non-zero for
+        # any chunk of this stream), not merely because the first chunk's
+        # deployment happens to start with it off.
         stream_source: Final = (
             _iter_with_keepalive(
                 stream_iterator.__aiter__(),
                 lambda item: _resolve_keepalive_seconds(request_data, item),
-                _ka_secs,
+                _resolve_keepalive_seconds(request_data, response),
             )
-            if _ka_secs > 0
+            if llm_router is not None
             else stream_iterator
         )
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7578,13 +7578,21 @@ def _keepalive_from_deployment_config(request_data: dict[str, Any], response: An
     model_id = hidden.get("model_id") if isinstance(hidden, dict) else None
     if model_id:
         deployment = llm_router.get_deployment(model_id=model_id)
+        # A populated model_id names the specific deployment that served this
+        # stream. If it no longer resolves (e.g. removed by a config reload
+        # mid-stream), that's a stale identity, not an absent one: don't fall
+        # through to guessing via model_name below, since a currently-live
+        # sibling deployment's config was never what actually served this
+        # stream.
         if deployment is not None:
             return getattr(deployment.litellm_params, "keepalive_seconds", None)
+        return None
 
-    # No model_id to pin down which deployment actually served this stream: only
-    # trust the fallback when every deployment under this model_name agrees,
-    # including deployments that leave keepalive_seconds unset (None), so an
-    # unconfigured deployment never inherits a sibling's configured interval.
+    # No model_id at all to pin down which deployment actually served this
+    # stream: only trust the fallback when every deployment under this
+    # model_name agrees, including deployments that leave keepalive_seconds
+    # unset (None), so an unconfigured deployment never inherits a sibling's
+    # configured interval.
     values = {
         (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")
         for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7648,6 +7648,7 @@ _STREAM_KEEPALIVE = object()
 
 _KEEPALIVE_MIN_SECONDS = 1.0
 _KEEPALIVE_MAX_SECONDS = 300.0
+_EMPTY_MAPPING: Mapping[str, Any] = MappingProxyType({})
 
 
 async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: float) -> AsyncGenerator[Any, None]:
@@ -7661,7 +7662,7 @@ async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: flo
         while True:
             if pending is None:
                 pending = asyncio.create_task(aiter.__anext__())
-            done, _ = await asyncio.wait({pending}, timeout=keepalive_seconds)
+            done, _ = await asyncio.wait((pending,), timeout=keepalive_seconds)
             if not done:
                 yield _STREAM_KEEPALIVE
                 continue
@@ -7712,15 +7713,17 @@ def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response)
     # model_name agrees on both keepalive_seconds and
     # allow_client_keepalive_override (including deployments that leave either
     # field unset), so a stream never inherits a sibling deployment's policy.
-    configs = {
+    configs = frozenset(
         (
-            (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds"),
-            bool((deployment_dict.get("litellm_params") or {}).get("allow_client_keepalive_override", False)),
+            (deployment_dict.get("litellm_params") or _EMPTY_MAPPING).get("keepalive_seconds"),
+            bool(
+                (deployment_dict.get("litellm_params") or _EMPTY_MAPPING).get("allow_client_keepalive_override", False)
+            ),
         )
-        for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []
-    }
+        for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or ()
+    )
     if len(configs) == 1:
-        keepalive_seconds, allow_client_override = configs.pop()
+        keepalive_seconds, allow_client_override = next(iter(configs))
         return _DeploymentKeepaliveConfig(
             keepalive_seconds=keepalive_seconds, allow_client_override=allow_client_override
         )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7643,6 +7643,83 @@ def _pop_complete_sse_frame(buffer: str) -> tuple[str | None, str]:
     return buffer[:frame_end], buffer[frame_end:]
 
 
+_STREAM_KEEPALIVE = object()
+
+_KEEPALIVE_MIN_SECONDS = 1.0
+_KEEPALIVE_MAX_SECONDS = 300.0
+
+
+async def _iter_with_keepalive(aiter: Any, keepalive_seconds: float) -> AsyncGenerator[Any, None]:
+    if keepalive_seconds <= 0:
+        async for item in aiter:
+            yield item
+        return
+
+    pending: asyncio.Task[Any] | None = None
+    try:
+        while True:
+            if pending is None:
+                pending = asyncio.create_task(aiter.__anext__())
+            done, _ = await asyncio.wait({pending}, timeout=keepalive_seconds)
+            if not done:
+                yield _STREAM_KEEPALIVE
+                continue
+            try:
+                item = pending.result()
+            except StopAsyncIteration:
+                break
+            finally:
+                pending = None
+            yield item
+    finally:
+        if pending is not None and not pending.done():
+            pending.cancel()
+            try:
+                await pending
+            except BaseException:
+                pass
+
+
+def _keepalive_from_deployment_config(request_data: dict[str, Any], response: Any) -> Any:
+    if llm_router is None:
+        return None
+
+    hidden = getattr(response, "_hidden_params", None)
+    model_id = hidden.get("model_id") if isinstance(hidden, dict) else None
+    if model_id:
+        deployment = llm_router.get_deployment(model_id=model_id)
+        if deployment is not None:
+            return getattr(deployment.litellm_params, "keepalive_seconds", None)
+
+    for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []:
+        raw = (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")
+        if raw is not None:
+            return raw
+    return None
+
+
+def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = None) -> float:
+    raw = request_data.get("keepalive_seconds")
+    if raw is None:
+        raw = _keepalive_from_deployment_config(request_data, response)
+    try:
+        value = float(raw or 0)
+    except (TypeError, ValueError):
+        return 0.0
+    if value <= 0:
+        return 0.0
+    clamped = max(_KEEPALIVE_MIN_SECONDS, min(value, _KEEPALIVE_MAX_SECONDS))
+    if clamped != value:
+        verbose_proxy_logger.info(
+            "keepalive_seconds=%s clamped to %s [min=%s, max=%s]",
+            value,
+            clamped,
+            _KEEPALIVE_MIN_SECONDS,
+            _KEEPALIVE_MAX_SECONDS,
+        )
+    return clamped
+
+
 async def async_data_generator(
     response,
     user_api_key_dict: UserAPIKeyAuth,
@@ -7691,7 +7768,14 @@ async def async_data_generator(
         else:
             stream_iterator = response
 
-        async for chunk in stream_iterator:
+        _ka_secs = _resolve_keepalive_seconds(request_data, response)
+        stream_source = _iter_with_keepalive(stream_iterator.__aiter__(), _ka_secs) if _ka_secs > 0 else stream_iterator
+
+        async for item in stream_source:
+            if item is _STREAM_KEEPALIVE:
+                yield ": ping\n\n"
+                continue
+            chunk = cast(Any, item)
             if needs_per_chunk_hook:
                 ### CALL HOOKS ### - modify outgoing data
                 chunk, _str_so_far = await _apply_streaming_chunk_hooks(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7691,10 +7691,16 @@ def _keepalive_from_deployment_config(request_data: dict[str, Any], response: An
         if deployment is not None:
             return getattr(deployment.litellm_params, "keepalive_seconds", None)
 
-    for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []:
-        raw = (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")
-        if raw is not None:
-            return raw
+    # No model_id to pin down which deployment actually served this stream: only
+    # trust the fallback when every deployment under this model_name agrees, so we
+    # never apply one deployment's interval (or disable) to another's stream.
+    configured_values = {
+        raw
+        for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []
+        if (raw := (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")) is not None
+    }
+    if len(configured_values) == 1:
+        return configured_values.pop()
     return None
 
 
@@ -7775,7 +7781,7 @@ async def async_data_generator(
             if item is _STREAM_KEEPALIVE:
                 yield ": ping\n\n"
                 continue
-            chunk = cast(Any, item)
+            chunk = cast(Any, item)  # cast-ok: sentinel already handled above, item is a real chunk here
             if needs_per_chunk_hook:
                 ### CALL HOOKS ### - modify outgoing data
                 chunk, _str_so_far = await _apply_streaming_chunk_hooks(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7704,10 +7704,27 @@ def _keepalive_from_deployment_config(request_data: dict[str, Any], response: An
     return None
 
 
+def _is_explicit_keepalive_disable(raw: Any) -> bool:
+    if raw is None:
+        return False
+    try:
+        return float(raw) <= 0
+    except (TypeError, ValueError):
+        return False
+
+
 def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = None) -> float:
+    deployment_raw = _keepalive_from_deployment_config(request_data, response)
+    # An operator setting keepalive_seconds: 0 on a deployment is an explicit hard
+    # disable: an authenticated client must not be able to re-enable heartbeats
+    # (and the idle-timeout evasion that comes with them) for a deployment the
+    # operator opted out of, regardless of what the request body asks for.
+    if _is_explicit_keepalive_disable(deployment_raw):
+        return 0.0
+
     raw = request_data.get("keepalive_seconds")
     if raw is None:
-        raw = _keepalive_from_deployment_config(request_data, response)
+        raw = deployment_raw
     try:
         value = float(raw) if raw is not None else 0.0
     except (TypeError, ValueError):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7651,18 +7651,30 @@ _KEEPALIVE_MAX_SECONDS: Final = 300.0
 _EMPTY_MAPPING: Final[Mapping[str, Any]] = MappingProxyType({})
 
 
-async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: float) -> AsyncGenerator[Any, None]:
+async def _iter_with_keepalive(
+    aiter: AsyncIterator[Any],
+    resolve_keepalive_seconds: Callable[[object], float],
+    keepalive_seconds: float,
+) -> AsyncGenerator[Any, None]:
+    """Wrap `aiter` with idle-gap heartbeats, re-resolving the interval after each
+    real chunk via `resolve_keepalive_seconds`. A mid-stream router fallback can
+    swap in a deployment with a different (or disabled) keepalive policy partway
+    through the same stream; re-resolving against each chunk's own identity
+    (rather than trusting the interval picked before iteration started) keeps the
+    heartbeat behavior in sync with whichever deployment actually produced it."""
     if keepalive_seconds <= 0:
         async for item in aiter:
             yield item
         return
 
     pending: asyncio.Task[Any] | None = None  # rebind-ok: rebound each loop iteration
+    current_keepalive_seconds = keepalive_seconds  # rebind-ok: re-resolved after each chunk
     try:
         while True:
             if pending is None:
                 pending = asyncio.create_task(aiter.__anext__())
-            done, _ = await asyncio.wait((pending,), timeout=keepalive_seconds)
+            timeout = current_keepalive_seconds if current_keepalive_seconds > 0 else None
+            done, _ = await asyncio.wait((pending,), timeout=timeout)
             if not done:
                 yield _STREAM_KEEPALIVE
                 continue
@@ -7673,6 +7685,7 @@ async def _iter_with_keepalive(aiter: AsyncIterator[Any], keepalive_seconds: flo
             finally:
                 pending = None
             yield item
+            current_keepalive_seconds = resolve_keepalive_seconds(item)
     finally:
         if pending is not None and not pending.done():
             pending.cancel()
@@ -7826,7 +7839,13 @@ async def async_data_generator(
 
         _ka_secs: Final = _resolve_keepalive_seconds(request_data, response)
         stream_source: Final = (
-            _iter_with_keepalive(stream_iterator.__aiter__(), _ka_secs) if _ka_secs > 0 else stream_iterator
+            _iter_with_keepalive(
+                stream_iterator.__aiter__(),
+                lambda item: _resolve_keepalive_seconds(request_data, item),
+                _ka_secs,
+            )
+            if _ka_secs > 0
+            else stream_iterator
         )
 
         async for item in stream_source:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -23,6 +23,7 @@ from typing import (
     Any,
     Final,
     Literal,
+    NamedTuple,
     Optional,
     TypedDict,
     Union,
@@ -7680,7 +7681,12 @@ async def _iter_with_keepalive(aiter: Any, keepalive_seconds: float) -> AsyncGen
                 pass
 
 
-def _keepalive_from_deployment_config(request_data: dict[str, Any], response: Any) -> Any:
+class _DeploymentKeepaliveConfig(NamedTuple):
+    keepalive_seconds: Any
+    allow_client_override: bool
+
+
+def _keepalive_from_deployment_config(request_data: dict[str, Any], response: Any) -> _DeploymentKeepaliveConfig | None:
     if llm_router is None:
         return None
 
@@ -7694,21 +7700,30 @@ def _keepalive_from_deployment_config(request_data: dict[str, Any], response: An
         # through to guessing via model_name below, since a currently-live
         # sibling deployment's config was never what actually served this
         # stream.
-        if deployment is not None:
-            return getattr(deployment.litellm_params, "keepalive_seconds", None)
-        return None
+        if deployment is None:
+            return None
+        return _DeploymentKeepaliveConfig(
+            keepalive_seconds=getattr(deployment.litellm_params, "keepalive_seconds", None),
+            allow_client_override=bool(getattr(deployment.litellm_params, "allow_client_keepalive_override", False)),
+        )
 
     # No model_id at all to pin down which deployment actually served this
     # stream: only trust the fallback when every deployment under this
-    # model_name agrees, including deployments that leave keepalive_seconds
-    # unset (None), so an unconfigured deployment never inherits a sibling's
-    # configured interval.
-    values = {
-        (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")
+    # model_name agrees on both keepalive_seconds and
+    # allow_client_keepalive_override (including deployments that leave either
+    # field unset), so a stream never inherits a sibling deployment's policy.
+    configs = {
+        (
+            (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds"),
+            bool((deployment_dict.get("litellm_params") or {}).get("allow_client_keepalive_override", False)),
+        )
         for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []
     }
-    if len(values) == 1:
-        return values.pop()
+    if len(configs) == 1:
+        keepalive_seconds, allow_client_override = configs.pop()
+        return _DeploymentKeepaliveConfig(
+            keepalive_seconds=keepalive_seconds, allow_client_override=allow_client_override
+        )
     return None
 
 
@@ -7722,7 +7737,10 @@ def _is_explicit_keepalive_disable(raw: Any) -> bool:
 
 
 def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = None) -> float:
-    deployment_raw = _keepalive_from_deployment_config(request_data, response)
+    deployment_config = _keepalive_from_deployment_config(request_data, response)
+    deployment_raw = deployment_config.keepalive_seconds if deployment_config is not None else None
+    allow_client_override = deployment_config.allow_client_override if deployment_config is not None else False
+
     # An operator setting keepalive_seconds: 0 on a deployment is an explicit hard
     # disable: an authenticated client must not be able to re-enable heartbeats
     # (and the idle-timeout evasion that comes with them) for a deployment the
@@ -7730,7 +7748,10 @@ def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = Non
     if _is_explicit_keepalive_disable(deployment_raw):
         return 0.0
 
-    raw = request_data.get("keepalive_seconds")
+    # keepalive_seconds is operator-only unless the deployment explicitly opts in:
+    # a client can't unilaterally enable heartbeats (and the LB-idle-timeout
+    # evasion that comes with them) for a deployment that never configured this.
+    raw = request_data.get("keepalive_seconds") if allow_client_override else None
     if raw is None:
         raw = deployment_raw
     try:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7796,29 +7796,43 @@ def _resolve_keepalive_seconds(request_data: Mapping[str, Any], response: object
     return clamped
 
 
+_KEEPALIVE_CACHE_TTL_SECONDS: Final = 5.0
+
+
 def _make_keepalive_resolver(request_data: Mapping[str, Any]) -> Callable[[object], float]:
     """Wrap `_resolve_keepalive_seconds` with a memo keyed on the serving
     deployment's model_id. The steady-state case (no mid-stream fallback, the
     overwhelming majority of streams) sees the same model_id on every chunk, so
     this turns the per-chunk cost from a full `llm_router.get_deployment()`
-    Pydantic rebuild into a cheap hidden-params read once the first chunk for
-    that model_id has been resolved. A missing/empty model_id can't be trusted
-    as a cache key (see `_keepalive_from_deployment_config`'s model_name
-    fallback, which reflects current router state rather than one deployment's
-    fixed identity), so those chunks always resolve fresh, matching prior
-    behavior exactly.
+    Pydantic rebuild into a cheap hidden-params read once per
+    `_KEEPALIVE_CACHE_TTL_SECONDS` for that model_id. The cache expires on its
+    own rather than living for the life of the stream, so an operator's live
+    config change (disabling keepalive, revoking client override, or removing
+    the deployment) is observed within a bounded window instead of being able
+    to be evaded by an already-in-flight stream indefinitely. A missing/empty
+    model_id can't be trusted as a cache key (see
+    `_keepalive_from_deployment_config`'s model_name fallback, which reflects
+    current router state rather than one deployment's fixed identity), so
+    those chunks always resolve fresh, matching prior behavior exactly.
     """
     last_model_id: str | None = None  # rebind-ok: memoized identity of the last-resolved chunk
     last_value: float = 0.0  # rebind-ok: cached resolution for last_model_id
+    last_resolved_at: float = float("-inf")  # rebind-ok: monotonic timestamp of the last real resolution
 
     def _resolve(item: object) -> float:
-        nonlocal last_model_id, last_value
+        nonlocal last_model_id, last_value, last_resolved_at
         model_id = get_hidden_params_dict(item).get("model_id")
-        if isinstance(model_id, str) and model_id and model_id == last_model_id:
+        now: Final = time.monotonic()
+        if (
+            isinstance(model_id, str)
+            and model_id
+            and model_id == last_model_id
+            and now - last_resolved_at < _KEEPALIVE_CACHE_TTL_SECONDS
+        ):
             return last_value
         value: Final = _resolve_keepalive_seconds(request_data, item)
         if isinstance(model_id, str) and model_id:
-            last_model_id, last_value = model_id, value
+            last_model_id, last_value, last_resolved_at = model_id, value, now
         return value
 
     return _resolve

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7582,15 +7582,15 @@ def _keepalive_from_deployment_config(request_data: dict[str, Any], response: An
             return getattr(deployment.litellm_params, "keepalive_seconds", None)
 
     # No model_id to pin down which deployment actually served this stream: only
-    # trust the fallback when every deployment under this model_name agrees, so we
-    # never apply one deployment's interval (or disable) to another's stream.
-    configured_values = {
-        raw
+    # trust the fallback when every deployment under this model_name agrees,
+    # including deployments that leave keepalive_seconds unset (None), so an
+    # unconfigured deployment never inherits a sibling's configured interval.
+    values = {
+        (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")
         for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []
-        if (raw := (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")) is not None
     }
-    if len(configured_values) == 1:
-        return configured_values.pop()
+    if len(values) == 1:
+        return values.pop()
     return None
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7593,7 +7593,7 @@ def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = Non
     if raw is None:
         raw = _keepalive_from_deployment_config(request_data, response)
     try:
-        value = float(raw or 0)
+        value = float(raw) if raw is not None else 0.0
     except (TypeError, ValueError):
         return 0.0
     if value <= 0:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7533,6 +7533,83 @@ def _pop_complete_sse_frame(buffer: str) -> tuple[str | None, str]:
     return buffer[:frame_end], buffer[frame_end:]
 
 
+_STREAM_KEEPALIVE = object()
+
+_KEEPALIVE_MIN_SECONDS = 1.0
+_KEEPALIVE_MAX_SECONDS = 300.0
+
+
+async def _iter_with_keepalive(aiter: Any, keepalive_seconds: float) -> AsyncGenerator[Any, None]:
+    if keepalive_seconds <= 0:
+        async for item in aiter:
+            yield item
+        return
+
+    pending: asyncio.Task[Any] | None = None
+    try:
+        while True:
+            if pending is None:
+                pending = asyncio.create_task(aiter.__anext__())
+            done, _ = await asyncio.wait({pending}, timeout=keepalive_seconds)
+            if not done:
+                yield _STREAM_KEEPALIVE
+                continue
+            try:
+                item = pending.result()
+            except StopAsyncIteration:
+                break
+            finally:
+                pending = None
+            yield item
+    finally:
+        if pending is not None and not pending.done():
+            pending.cancel()
+            try:
+                await pending
+            except BaseException:
+                pass
+
+
+def _keepalive_from_deployment_config(request_data: dict[str, Any], response: Any) -> Any:
+    if llm_router is None:
+        return None
+
+    hidden = getattr(response, "_hidden_params", None)
+    model_id = hidden.get("model_id") if isinstance(hidden, dict) else None
+    if model_id:
+        deployment = llm_router.get_deployment(model_id=model_id)
+        if deployment is not None:
+            return getattr(deployment.litellm_params, "keepalive_seconds", None)
+
+    for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []:
+        raw = (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")
+        if raw is not None:
+            return raw
+    return None
+
+
+def _resolve_keepalive_seconds(request_data: dict[str, Any], response: Any = None) -> float:
+    raw = request_data.get("keepalive_seconds")
+    if raw is None:
+        raw = _keepalive_from_deployment_config(request_data, response)
+    try:
+        value = float(raw or 0)
+    except (TypeError, ValueError):
+        return 0.0
+    if value <= 0:
+        return 0.0
+    clamped = max(_KEEPALIVE_MIN_SECONDS, min(value, _KEEPALIVE_MAX_SECONDS))
+    if clamped != value:
+        verbose_proxy_logger.info(
+            "keepalive_seconds=%s clamped to %s [min=%s, max=%s]",
+            value,
+            clamped,
+            _KEEPALIVE_MIN_SECONDS,
+            _KEEPALIVE_MAX_SECONDS,
+        )
+    return clamped
+
+
 async def async_data_generator(
     response,
     user_api_key_dict: UserAPIKeyAuth,
@@ -7581,7 +7658,14 @@ async def async_data_generator(
         else:
             stream_iterator = response
 
-        async for chunk in stream_iterator:
+        _ka_secs = _resolve_keepalive_seconds(request_data, response)
+        stream_source = _iter_with_keepalive(stream_iterator.__aiter__(), _ka_secs) if _ka_secs > 0 else stream_iterator
+
+        async for item in stream_source:
+            if item is _STREAM_KEEPALIVE:
+                yield ": ping\n\n"
+                continue
+            chunk = cast(Any, item)
             if needs_per_chunk_hook:
                 ### CALL HOOKS ### - modify outgoing data
                 chunk, _str_so_far = await _apply_streaming_chunk_hooks(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7566,7 +7566,7 @@ async def _iter_with_keepalive(aiter: Any, keepalive_seconds: float) -> AsyncGen
             pending.cancel()
             try:
                 await pending
-            except BaseException:
+            except asyncio.CancelledError:
                 pass
 
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7693,6 +7693,20 @@ def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response)
 
     hidden = getattr(response, "_hidden_params", None)
     model_id = hidden.get("model_id") if isinstance(hidden, dict) else None
+    if not model_id:
+        # A router-level fallback rewrites kwargs["model"] on the fallback
+        # handler's own local **kwargs copy, not on this request_data dict, so
+        # request_data.get("model") still names the pre-fallback model group.
+        # metadata/litellm_metadata.model_info.id, by contrast, is mutated on
+        # this same dict by Router._update_kwargs_with_deployment on every
+        # attempt (including fallbacks) and reliably names the deployment that
+        # actually served the call; same source ProxyLogging._build_litellm_call_info
+        # uses for logging.
+        for meta_key in ("metadata", "litellm_metadata"):
+            model_info = (request_data.get(meta_key) or _EMPTY_MAPPING).get("model_info") or _EMPTY_MAPPING
+            model_id = model_info.get("id")
+            if model_id:
+                break
     if model_id:
         deployment = llm_router.get_deployment(model_id=model_id)
         # A populated model_id names the specific deployment that served this

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7581,10 +7581,16 @@ def _keepalive_from_deployment_config(request_data: dict[str, Any], response: An
         if deployment is not None:
             return getattr(deployment.litellm_params, "keepalive_seconds", None)
 
-    for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []:
-        raw = (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")
-        if raw is not None:
-            return raw
+    # No model_id to pin down which deployment actually served this stream: only
+    # trust the fallback when every deployment under this model_name agrees, so we
+    # never apply one deployment's interval (or disable) to another's stream.
+    configured_values = {
+        raw
+        for deployment_dict in llm_router.get_model_list(model_name=request_data.get("model")) or []
+        if (raw := (deployment_dict.get("litellm_params") or {}).get("keepalive_seconds")) is not None
+    }
+    if len(configured_values) == 1:
+        return configured_values.pop()
     return None
 
 
@@ -7665,7 +7671,7 @@ async def async_data_generator(
             if item is _STREAM_KEEPALIVE:
                 yield ": ping\n\n"
                 continue
-            chunk = cast(Any, item)
+            chunk = cast(Any, item)  # cast-ok: sentinel already handled above, item is a real chunk here
             if needs_per_chunk_hook:
                 ### CALL HOOKS ### - modify outgoing data
                 chunk, _str_so_far = await _apply_streaming_chunk_hooks(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -7583,20 +7583,6 @@ def _keepalive_from_deployment_config(request_data: Mapping[str, Any], response)
 
     hidden = getattr(response, "_hidden_params", None)
     model_id = hidden.get("model_id") if isinstance(hidden, dict) else None
-    if not model_id:
-        # A router-level fallback rewrites kwargs["model"] on the fallback
-        # handler's own local **kwargs copy, not on this request_data dict, so
-        # request_data.get("model") still names the pre-fallback model group.
-        # metadata/litellm_metadata.model_info.id, by contrast, is mutated on
-        # this same dict by Router._update_kwargs_with_deployment on every
-        # attempt (including fallbacks) and reliably names the deployment that
-        # actually served the call; same source ProxyLogging._build_litellm_call_info
-        # uses for logging.
-        for meta_key in ("metadata", "litellm_metadata"):
-            model_info = (request_data.get(meta_key) or _EMPTY_MAPPING).get("model_info") or _EMPTY_MAPPING
-            model_id = model_info.get("id")
-            if model_id:
-                break
     if model_id:
         deployment = llm_router.get_deployment(model_id=model_id)
         # A populated model_id names the specific deployment that served this

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -282,6 +282,11 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     max_budget: float | None = None
     budget_duration: str | None = None
     keepalive_seconds: float | None = None
+    # keepalive_seconds is operator-only by default: a client's request-level
+    # value is ignored unless the deployment opts in here. Prevents a client
+    # from unilaterally enabling heartbeats (and the LB-idle-timeout evasion
+    # that comes with them) for a deployment that never configured them.
+    allow_client_keepalive_override: bool | None = False
     use_in_pass_through: bool | None = False
     use_litellm_proxy: bool | None = False
     use_chat_completions_api: bool | None = None
@@ -459,6 +464,7 @@ class LiteLLMParamsTypedDict(TypedDict, total=False):
     max_budget: float | None
     budget_duration: str | None
     keepalive_seconds: float | None
+    allow_client_keepalive_override: bool | None
 
     # per-deployment cooldown override
     cooldown_time: float | None

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -281,6 +281,7 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     # Deployment budgets
     max_budget: float | None = None
     budget_duration: str | None = None
+    keepalive_seconds: float | None = None
     use_in_pass_through: bool | None = False
     use_litellm_proxy: bool | None = False
     use_chat_completions_api: bool | None = None
@@ -457,6 +458,7 @@ class LiteLLMParamsTypedDict(TypedDict, total=False):
     # deployment budgets
     max_budget: float | None
     budget_duration: str | None
+    keepalive_seconds: float | None
 
     # per-deployment cooldown override
     cooldown_time: float | None

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -237,6 +237,7 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     # Deployment budgets
     max_budget: float | None = None
     budget_duration: str | None = None
+    keepalive_seconds: float | None = None
     use_in_pass_through: bool | None = False
     use_litellm_proxy: bool | None = False
     use_chat_completions_api: bool | None = None
@@ -417,6 +418,7 @@ class LiteLLMParamsTypedDict(TypedDict, total=False):
     # deployment budgets
     max_budget: float | None
     budget_duration: str | None
+    keepalive_seconds: float | None
 
 
 class DeploymentTypedDict(TypedDict, total=False):

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -238,6 +238,11 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     max_budget: float | None = None
     budget_duration: str | None = None
     keepalive_seconds: float | None = None
+    # keepalive_seconds is operator-only by default: a client's request-level
+    # value is ignored unless the deployment opts in here. Prevents a client
+    # from unilaterally enabling heartbeats (and the LB-idle-timeout evasion
+    # that comes with them) for a deployment that never configured them.
+    allow_client_keepalive_override: bool | None = False
     use_in_pass_through: bool | None = False
     use_litellm_proxy: bool | None = False
     use_chat_completions_api: bool | None = None
@@ -419,6 +424,7 @@ class LiteLLMParamsTypedDict(TypedDict, total=False):
     max_budget: float | None
     budget_duration: str | None
     keepalive_seconds: float | None
+    allow_client_keepalive_override: bool | None
 
 
 class DeploymentTypedDict(TypedDict, total=False):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3399,6 +3399,7 @@ all_litellm_params = (
     + [
         "metadata",
         "litellm_metadata",
+        "keepalive_seconds",
         "litellm_trace_id",
         "litellm_request_debug",
         "guardrails",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3383,6 +3383,7 @@ all_litellm_params = (
     + [
         "metadata",
         "litellm_metadata",
+        "keepalive_seconds",
         "litellm_trace_id",
         "litellm_request_debug",
         "guardrails",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3400,6 +3400,7 @@ all_litellm_params = (
         "metadata",
         "litellm_metadata",
         "keepalive_seconds",
+        "allow_client_keepalive_override",
         "litellm_trace_id",
         "litellm_request_debug",
         "guardrails",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3384,6 +3384,7 @@ all_litellm_params = (
         "metadata",
         "litellm_metadata",
         "keepalive_seconds",
+        "allow_client_keepalive_override",
         "litellm_trace_id",
         "litellm_request_debug",
         "guardrails",

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -914,3 +914,199 @@ def test_select_data_generator_missing_required_kwarg_raises_type_error():
     streaming starts."""
     with pytest.raises(TypeError):
         select_data_generator(response=_async_iter([]), user_api_key_dict=_user_auth())  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# SSE keepalive helpers
+# ---------------------------------------------------------------------------
+
+
+from litellm.proxy.proxy_server import (  # noqa: E402
+    _iter_with_keepalive,
+    _keepalive_from_deployment_config,
+    _resolve_keepalive_seconds,
+)
+from litellm.proxy.proxy_server import _KEEPALIVE_MAX_SECONDS, _KEEPALIVE_MIN_SECONDS  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_iter_with_keepalive_hot_path_no_task_wrapping():
+    """When keepalive_seconds <= 0, the generator is a transparent pass-through."""
+    chunks = [_simple_chunk(content="a"), _simple_chunk(content="b")]
+    out = []
+    async for item in _iter_with_keepalive(_async_iter(chunks), keepalive_seconds=0):
+        out.append(item)
+
+    assert out == chunks
+    assert ps._STREAM_KEEPALIVE not in out
+
+
+@pytest.mark.asyncio
+async def test_iter_with_keepalive_emits_sentinel_when_stream_stalls():
+    """With a short keepalive interval and a stalled upstream, _STREAM_KEEPALIVE
+    sentinels appear before the delayed chunk arrives."""
+    import asyncio
+
+    async def _slow_stream():
+        yield _simple_chunk(content="first")
+        await asyncio.sleep(0.3)
+        yield _simple_chunk(content="second")
+
+    items = []
+    async for item in _iter_with_keepalive(_slow_stream(), keepalive_seconds=0.05):
+        items.append(item)
+
+    sentinels = [i for i in items if i is ps._STREAM_KEEPALIVE]
+    real_chunks = [i for i in items if i is not ps._STREAM_KEEPALIVE]
+
+    assert len(sentinels) >= 2, f"expected >= 2 sentinels during 0.3s stall; got {len(sentinels)}"
+    assert len(real_chunks) == 2
+    assert real_chunks[0].choices[0].delta.content == "first"
+    assert real_chunks[1].choices[0].delta.content == "second"
+
+
+@pytest.mark.asyncio
+async def test_iter_with_keepalive_cancel_on_early_close():
+    """Closing the generator early cancels the in-flight task without raising."""
+    import asyncio
+
+    async def _infinite_stream():
+        while True:
+            await asyncio.sleep(10)
+            yield _simple_chunk()
+
+    gen = _iter_with_keepalive(_infinite_stream(), keepalive_seconds=0.05)
+    # Advance once to get the sentinel; then close before the real chunk.
+    first = await gen.__anext__()
+    assert first is ps._STREAM_KEEPALIVE
+    # aclose must not raise, and must drain the cancelled task cleanly.
+    await gen.aclose()
+
+
+def test_resolve_keepalive_seconds_request_value_wins(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _resolve_keepalive_seconds({"keepalive_seconds": 30}, response=None)
+    assert result == 30.0
+
+
+def test_resolve_keepalive_seconds_explicit_zero_disables(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _resolve_keepalive_seconds({"keepalive_seconds": 0}, response=None)
+    assert result == 0.0
+
+
+def test_resolve_keepalive_seconds_clamps_below_minimum(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _resolve_keepalive_seconds({"keepalive_seconds": 0.001}, response=None)
+    assert result == _KEEPALIVE_MIN_SECONDS
+
+
+def test_resolve_keepalive_seconds_clamps_above_maximum(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _resolve_keepalive_seconds({"keepalive_seconds": 9999}, response=None)
+    assert result == _KEEPALIVE_MAX_SECONDS
+
+
+def test_resolve_keepalive_seconds_non_numeric_returns_zero(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _resolve_keepalive_seconds({"keepalive_seconds": "not-a-number"}, response=None)
+    assert result == 0.0
+
+
+def test_resolve_keepalive_seconds_absent_returns_zero(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _resolve_keepalive_seconds({}, response=None)
+    assert result == 0.0
+
+
+def test_keepalive_from_deployment_config_reads_by_model_id(monkeypatch):
+    from unittest.mock import MagicMock
+
+    deployment = MagicMock()
+    deployment.litellm_params.keepalive_seconds = 45.0
+
+    router = MagicMock()
+    router.get_deployment.return_value = deployment
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {"model_id": "deploy-abc"}
+
+    result = _keepalive_from_deployment_config({"model": "my-model"}, response)
+    assert result == 45.0
+    router.get_deployment.assert_called_once_with(model_id="deploy-abc")
+
+
+def test_keepalive_from_deployment_config_fallback_by_name(monkeypatch):
+    from unittest.mock import MagicMock
+
+    router = MagicMock()
+    router.get_deployment.return_value = None
+    router.get_model_list.return_value = [
+        {"litellm_params": {"keepalive_seconds": 20.0}},
+    ]
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {}
+
+    result = _keepalive_from_deployment_config({"model": "slow-model"}, response)
+    assert result == 20.0
+    router.get_model_list.assert_called_once_with(model_name="slow-model")
+
+
+def test_keepalive_from_deployment_config_no_router_returns_none(monkeypatch):
+    monkeypatch.setattr(ps, "llm_router", None)
+    result = _keepalive_from_deployment_config({"model": "gpt-4"}, None)
+    assert result is None
+
+
+def test_keepalive_seconds_in_all_litellm_params():
+    from litellm.types.utils import all_litellm_params
+
+    assert "keepalive_seconds" in all_litellm_params
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_emits_ping_heartbeat(monkeypatch):
+    """When keepalive_seconds is set, ': ping' frames appear during upstream stalls."""
+    import asyncio
+
+    _patch_logging_flags(monkeypatch)
+    monkeypatch.setattr(ps, "_KEEPALIVE_MIN_SECONDS", 0.05)
+
+    async def _slow_response():
+        yield _simple_chunk(content="hello")
+        await asyncio.sleep(0.4)
+        yield _simple_chunk(content="world")
+
+    out = []
+    async for line in async_data_generator(
+        response=_slow_response(),
+        user_api_key_dict=_user_auth(),
+        request_data={"model": "gpt-4", "keepalive_seconds": 0.05},
+    ):
+        out.append(line)
+
+    pings = [item for item in out if item == ": ping\n\n"]
+    assert len(pings) >= 2, f"expected >= 2 ping frames; got {len(pings)}"
+    assert out[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_no_keepalive_no_pings(monkeypatch):
+    """Without keepalive_seconds, no ': ping' frames are emitted."""
+    _patch_logging_flags(monkeypatch)
+
+    out = []
+    async for line in async_data_generator(
+        response=_async_iter([_simple_chunk(content="hello")]),
+        user_api_key_dict=_user_auth(),
+        request_data={"model": "gpt-4"},
+    ):
+        out.append(line)
+
+    assert ": ping\n\n" not in out
+    assert out[-1] == "data: [DONE]\n\n"

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -1057,6 +1057,49 @@ def test_keepalive_from_deployment_config_fallback_by_name(monkeypatch):
     router.get_model_list.assert_called_once_with(model_name="slow-model")
 
 
+def test_keepalive_from_deployment_config_fallback_by_name_agreeing_deployments(monkeypatch):
+    """Multiple deployments under the same model_name with the same keepalive_seconds
+    is unambiguous, so the shared value is used even without a model_id."""
+    from unittest.mock import MagicMock
+
+    router = MagicMock()
+    router.get_deployment.return_value = None
+    router.get_model_list.return_value = [
+        {"litellm_params": {"keepalive_seconds": 20.0}},
+        {"litellm_params": {"keepalive_seconds": 20.0}},
+    ]
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {}
+
+    result = _keepalive_from_deployment_config({"model": "slow-model"}, response)
+    assert result == 20.0
+
+
+def test_keepalive_from_deployment_config_fallback_by_name_conflicting_deployments(monkeypatch):
+    """Without a model_id, if deployments under the same model_name disagree on
+    keepalive_seconds, we can't tell which one served the stream: don't guess and
+    apply the wrong deployment's interval (or override an explicit disable)."""
+    from unittest.mock import MagicMock
+
+    router = MagicMock()
+    router.get_deployment.return_value = None
+    router.get_model_list.return_value = [
+        {"litellm_params": {"keepalive_seconds": 20.0}},
+        {"litellm_params": {"keepalive_seconds": 0}},
+    ]
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {}
+
+    result = _keepalive_from_deployment_config({"model": "slow-model"}, response)
+    assert result is None
+
+
 def test_keepalive_from_deployment_config_no_router_returns_none(monkeypatch):
     monkeypatch.setattr(ps, "llm_router", None)
     result = _keepalive_from_deployment_config({"model": "gpt-4"}, None)

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -916,6 +916,7 @@ def test_select_data_generator_missing_required_kwarg_raises_type_error():
 from litellm.proxy.proxy_server import (  # noqa: E402
     _iter_with_keepalive,
     _keepalive_from_deployment_config,
+    _make_keepalive_resolver,
     _resolve_keepalive_seconds,
 )
 from litellm.proxy.proxy_server import _KEEPALIVE_MAX_SECONDS, _KEEPALIVE_MIN_SECONDS  # noqa: E402
@@ -1365,6 +1366,83 @@ def test_keepalive_from_deployment_config_no_router_returns_none(monkeypatch):
     assert result is None
 
 
+def test_make_keepalive_resolver_caches_by_model_id(monkeypatch):
+    """The steady-state case (no fallback): every chunk shares the same
+    model_id, so the deployment lookup must happen once, not once per chunk."""
+    from unittest.mock import MagicMock
+
+    deployment = MagicMock()
+    deployment.litellm_params.keepalive_seconds = 5.0
+    deployment.litellm_params.allow_client_keepalive_override = False
+
+    router = MagicMock()
+    router.get_deployment.return_value = deployment
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    resolve = _make_keepalive_resolver({"model": "my-model"})
+
+    first = _simple_chunk(content="a")
+    first._hidden_params = {"model_id": "deploy-steady"}
+    second = _simple_chunk(content="b")
+    second._hidden_params = {"model_id": "deploy-steady"}
+
+    assert resolve(first) == 5.0
+    assert resolve(second) == 5.0
+    router.get_deployment.assert_called_once_with(model_id="deploy-steady")
+
+
+def test_make_keepalive_resolver_reresolves_on_model_id_change(monkeypatch):
+    """A mid-stream fallback changes model_id: the cache must miss and
+    re-resolve against the new deployment, not keep serving the stale value."""
+    from unittest.mock import MagicMock
+
+    before = MagicMock()
+    before.litellm_params.keepalive_seconds = 5.0
+    before.litellm_params.allow_client_keepalive_override = False
+
+    after = MagicMock()
+    after.litellm_params.keepalive_seconds = 30.0
+    after.litellm_params.allow_client_keepalive_override = False
+
+    router = MagicMock()
+    router.get_deployment.side_effect = lambda model_id: {"deploy-a": before, "deploy-b": after}[model_id]
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    resolve = _make_keepalive_resolver({"model": "my-model"})
+
+    chunk_a = _simple_chunk(content="a")
+    chunk_a._hidden_params = {"model_id": "deploy-a"}
+    chunk_b = _simple_chunk(content="b")
+    chunk_b._hidden_params = {"model_id": "deploy-b"}
+
+    assert resolve(chunk_a) == 5.0
+    assert resolve(chunk_b) == 30.0
+    assert router.get_deployment.call_count == 2
+
+
+def test_make_keepalive_resolver_missing_model_id_never_cached(monkeypatch):
+    """Without a model_id there's no reliable cache key (see the model_name
+    fallback in _keepalive_from_deployment_config), so every chunk must
+    re-resolve fresh rather than reuse a stale guess."""
+    from unittest.mock import MagicMock
+
+    router = MagicMock()
+    router.get_deployment.return_value = None
+    router.get_model_list.return_value = [{"litellm_params": {"keepalive_seconds": 12.0}}]
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    resolve = _make_keepalive_resolver({"model": "slow-model"})
+
+    chunk_a = _simple_chunk(content="a")
+    chunk_a._hidden_params = {}
+    chunk_b = _simple_chunk(content="b")
+    chunk_b._hidden_params = {}
+
+    assert resolve(chunk_a) == 12.0
+    assert resolve(chunk_b) == 12.0
+    assert router.get_model_list.call_count == 2
+
+
 def test_keepalive_seconds_in_all_litellm_params():
     from litellm.types.utils import all_litellm_params
 
@@ -1429,4 +1507,50 @@ async def test_async_data_generator_no_keepalive_no_pings(monkeypatch):
         out.append(line)
 
     assert ": ping\n\n" not in out
+    assert out[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_resolves_deployment_once_per_steady_stream(monkeypatch):
+    """Regression test for the per-chunk resolver cost: a stream where every
+    real chunk comes from the same deployment (the common, no-fallback case)
+    must only pay for one `llm_router.get_deployment()` call, not one per
+    chunk. Before caching, this asserted 1 but got len(chunks) since the
+    resolver re-ran the full deployment lookup after every single chunk.
+
+    The very first resolve happens on the raw `response` object before any
+    chunk is yielded; a bare async generator (unlike the real
+    CustomStreamWrapper this stands in for) can't carry `_hidden_params`, so
+    that one call goes through the model_name fallback instead of
+    `get_deployment` — hence it's asserted separately.
+    """
+    from unittest.mock import MagicMock
+
+    _patch_logging_flags(monkeypatch)
+
+    deployment = MagicMock()
+    deployment.litellm_params.keepalive_seconds = None
+    deployment.litellm_params.allow_client_keepalive_override = False
+
+    router = MagicMock()
+    router.get_deployment.return_value = deployment
+    router.get_model_list.return_value = [{"litellm_params": {}}]
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    async def _steady_response():
+        for content in ("a", "b", "c", "d", "e"):
+            chunk = _simple_chunk(content=content)
+            chunk._hidden_params = {"model_id": "deploy-steady"}
+            yield chunk
+
+    out = []
+    async for line in async_data_generator(
+        response=_steady_response(),
+        user_api_key_dict=_user_auth(),
+        request_data={"model": "gpt-4"},
+    ):
+        out.append(line)
+
+    assert router.get_deployment.call_count == 1
+    assert router.get_model_list.call_count == 1
     assert out[-1] == "data: [DONE]\n\n"

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -196,9 +196,7 @@ async def test_async_assistants_data_generator_hook_failure_yields_error_chunk(
     async def _noop_failure(*args, **kwargs):
         return None
 
-    monkeypatch.setattr(
-        ps.proxy_logging_obj, "async_post_call_streaming_hook", _boom_hook
-    )
+    monkeypatch.setattr(ps.proxy_logging_obj, "async_post_call_streaming_hook", _boom_hook)
     monkeypatch.setattr(ps.proxy_logging_obj, "post_call_failure_hook", _noop_failure)
 
     stream = _FakeAssistantsStream([_simple_chunk()])
@@ -385,9 +383,7 @@ def test_get_streaming_fallback_metadata_no_additional_headers():
 def test_get_streaming_fallback_metadata_zero_fallback_count():
     stream = _FakeStream(
         [],
-        hidden_params={
-            "additional_headers": {"x-litellm-attempted-fallbacks": 0}
-        },
+        hidden_params={"additional_headers": {"x-litellm-attempted-fallbacks": 0}},
     )
     assert _get_streaming_fallback_metadata(stream) == (False, None, [])
 
@@ -558,9 +554,7 @@ async def test_apply_streaming_chunk_hooks_appends_to_str_so_far(monkeypatch):
     async def _passthrough(*, user_api_key_dict, response, data, str_so_far=None):
         return response
 
-    monkeypatch.setattr(
-        ps.proxy_logging_obj, "async_post_call_streaming_hook", _passthrough
-    )
+    monkeypatch.setattr(ps.proxy_logging_obj, "async_post_call_streaming_hook", _passthrough)
 
     new_chunk, new_str = await _apply_streaming_chunk_hooks(
         chunk=chunk,
@@ -870,9 +864,7 @@ async def test_async_data_generator_mid_stream_exception_yields_error_payload(
         out.append(line)
 
     # First entry is the successful "partial" chunk (bytes), last is the error.
-    assert any(
-        isinstance(item, str) and item.startswith('data: {"error":') for item in out
-    )
+    assert any(isinstance(item, str) and item.startswith('data: {"error":') for item in out)
 
 
 # ---------------------------------------------------------------------------
@@ -1268,6 +1260,68 @@ def test_keepalive_from_deployment_config_no_router_returns_none(monkeypatch):
     monkeypatch.setattr(ps, "llm_router", None)
     result = _keepalive_from_deployment_config({"model": "gpt-4"}, None)
     assert result is None
+
+
+def test_keepalive_from_deployment_config_uses_metadata_model_info_after_fallback(monkeypatch):
+    """A router-level fallback rewrites kwargs["model"] on the fallback handler's
+    own local **kwargs copy, not on this request_data dict, so request_data["model"]
+    still names the pre-fallback model group even after a successful fallback.
+    metadata.model_info.id is mutated on this same dict by every deployment attempt
+    (including fallbacks), so it must be preferred over guessing from the stale
+    model group name."""
+    from unittest.mock import MagicMock
+
+    fallback_deployment = MagicMock()
+    fallback_deployment.litellm_params.keepalive_seconds = 30.0
+    fallback_deployment.litellm_params.allow_client_keepalive_override = False
+
+    router = MagicMock()
+    router.get_deployment.return_value = fallback_deployment
+    router.get_model_list.side_effect = AssertionError(
+        "must not guess by the stale model group name when metadata.model_info.id is available"
+    )
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {}
+
+    request_data = {
+        "model": "model-group-a",
+        "metadata": {"model_info": {"id": "deploy-in-group-b"}},
+    }
+    result = _keepalive_from_deployment_config(request_data, response)
+    assert result == ps._DeploymentKeepaliveConfig(keepalive_seconds=30.0, allow_client_override=False)
+    router.get_deployment.assert_called_once_with(model_id="deploy-in-group-b")
+
+
+def test_keepalive_from_deployment_config_uses_litellm_metadata_model_info_after_fallback(monkeypatch):
+    """Same as the metadata case, but for the litellm_metadata variable name used
+    by the Responses API call path."""
+    from unittest.mock import MagicMock
+
+    fallback_deployment = MagicMock()
+    fallback_deployment.litellm_params.keepalive_seconds = 15.0
+    fallback_deployment.litellm_params.allow_client_keepalive_override = True
+
+    router = MagicMock()
+    router.get_deployment.return_value = fallback_deployment
+    router.get_model_list.side_effect = AssertionError(
+        "must not guess by the stale model group name when litellm_metadata.model_info.id is available"
+    )
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {}
+
+    request_data = {
+        "model": "model-group-a",
+        "litellm_metadata": {"model_info": {"id": "deploy-in-group-b"}},
+    }
+    result = _keepalive_from_deployment_config(request_data, response)
+    assert result == ps._DeploymentKeepaliveConfig(keepalive_seconds=15.0, allow_client_override=True)
+    router.get_deployment.assert_called_once_with(model_id="deploy-in-group-b")
 
 
 def test_keepalive_seconds_in_all_litellm_params():

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -1443,6 +1443,49 @@ def test_make_keepalive_resolver_missing_model_id_never_cached(monkeypatch):
     assert router.get_model_list.call_count == 2
 
 
+def test_make_keepalive_resolver_expires_cache_after_ttl(monkeypatch):
+    """An operator's live config change (revoking override, disabling
+    keepalive, removing the deployment) must be observed within
+    _KEEPALIVE_CACHE_TTL_SECONDS, not frozen for the rest of an
+    already-in-flight stream just because the model_id hasn't changed."""
+    from unittest.mock import MagicMock
+
+    before = MagicMock()
+    before.litellm_params.keepalive_seconds = 20.0
+    before.litellm_params.allow_client_keepalive_override = False
+
+    after = MagicMock()
+    after.litellm_params.keepalive_seconds = 0
+    after.litellm_params.allow_client_keepalive_override = False
+
+    router = MagicMock()
+    router.get_deployment.return_value = before
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    clock = {"t": 0.0}
+    monkeypatch.setattr(ps.time, "monotonic", lambda: clock["t"])
+
+    resolve = _make_keepalive_resolver({"model": "my-model"})
+
+    chunk = _simple_chunk(content="a")
+    chunk._hidden_params = {"model_id": "deploy-live"}
+
+    assert resolve(chunk) == 20.0
+    assert router.get_deployment.call_count == 1
+
+    # Still within the TTL: same model_id, cached value reused even though
+    # the router's live config has since changed underneath it.
+    router.get_deployment.return_value = after
+    clock["t"] = ps._KEEPALIVE_CACHE_TTL_SECONDS - 0.01
+    assert resolve(chunk) == 20.0
+    assert router.get_deployment.call_count == 1
+
+    # Past the TTL: the config-reload disable is now observed.
+    clock["t"] = ps._KEEPALIVE_CACHE_TTL_SECONDS + 0.01
+    assert resolve(chunk) == 0.0
+    assert router.get_deployment.call_count == 2
+
+
 def test_keepalive_seconds_in_all_litellm_params():
     from litellm.types.utils import all_litellm_params
 

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -1019,6 +1019,28 @@ def test_resolve_keepalive_seconds_absent_returns_zero(monkeypatch):
     assert result == 0.0
 
 
+def test_resolve_keepalive_seconds_deployment_disable_cannot_be_overridden_by_request(monkeypatch):
+    """A deployment that explicitly sets keepalive_seconds: 0 is a hard operator
+    disable: an authenticated client must not be able to re-enable heartbeats for
+    that deployment by passing a positive value in the request body, since that
+    would let a client evade the deployment's idle-timeout behavior at will."""
+    from unittest.mock import MagicMock
+
+    deployment = MagicMock()
+    deployment.litellm_params.keepalive_seconds = 0
+
+    router = MagicMock()
+    router.get_deployment.return_value = deployment
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {"model_id": "deploy-disabled"}
+
+    result = _resolve_keepalive_seconds({"model": "my-model", "keepalive_seconds": 250}, response=response)
+    assert result == 0.0
+
+
 def test_keepalive_from_deployment_config_reads_by_model_id(monkeypatch):
     from unittest.mock import MagicMock
 

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -1060,6 +1060,31 @@ def test_keepalive_from_deployment_config_reads_by_model_id(monkeypatch):
     router.get_deployment.assert_called_once_with(model_id="deploy-abc")
 
 
+def test_keepalive_from_deployment_config_stale_model_id_does_not_fall_through(monkeypatch):
+    """A populated model_id names the specific deployment that served the stream.
+    If that ID no longer resolves (e.g. removed by a config reload mid-stream),
+    that's a stale identity, not an absent one: it must not fall through to the
+    model_name fallback, since a currently-live sibling deployment's config was
+    never what actually served this stream, even if that sibling's config is
+    unambiguous on its own."""
+    from unittest.mock import MagicMock
+
+    router = MagicMock()
+    router.get_deployment.return_value = None
+    router.get_model_list.return_value = [
+        {"litellm_params": {"keepalive_seconds": 20.0}},
+    ]
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {"model_id": "stale-deploy-id"}
+
+    result = _keepalive_from_deployment_config({"model": "slow-model"}, response)
+    assert result is None
+    router.get_model_list.assert_not_called()
+
+
 def test_keepalive_from_deployment_config_fallback_by_name(monkeypatch):
     from unittest.mock import MagicMock
 

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -1276,6 +1276,17 @@ def test_keepalive_seconds_in_all_litellm_params():
     assert "keepalive_seconds" in all_litellm_params
 
 
+def test_allow_client_keepalive_override_in_all_litellm_params():
+    """allow_client_keepalive_override is a deployment-only control flag: if it's
+    missing from all_litellm_params, it leaks straight through into the actual
+    provider API call as an unrecognized field and gets rejected (confirmed live
+    against the real Anthropic API, which returns 'Extra inputs are not
+    permitted')."""
+    from litellm.types.utils import all_litellm_params
+
+    assert "allow_client_keepalive_override" in all_litellm_params
+
+
 @pytest.mark.asyncio
 async def test_async_data_generator_emits_ping_heartbeat(monkeypatch):
     """When keepalive_seconds is set on a deployment that allows client override,

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -196,7 +196,9 @@ async def test_async_assistants_data_generator_hook_failure_yields_error_chunk(
     async def _noop_failure(*args, **kwargs):
         return None
 
-    monkeypatch.setattr(ps.proxy_logging_obj, "async_post_call_streaming_hook", _boom_hook)
+    monkeypatch.setattr(
+        ps.proxy_logging_obj, "async_post_call_streaming_hook", _boom_hook
+    )
     monkeypatch.setattr(ps.proxy_logging_obj, "post_call_failure_hook", _noop_failure)
 
     stream = _FakeAssistantsStream([_simple_chunk()])
@@ -383,7 +385,9 @@ def test_get_streaming_fallback_metadata_no_additional_headers():
 def test_get_streaming_fallback_metadata_zero_fallback_count():
     stream = _FakeStream(
         [],
-        hidden_params={"additional_headers": {"x-litellm-attempted-fallbacks": 0}},
+        hidden_params={
+            "additional_headers": {"x-litellm-attempted-fallbacks": 0}
+        },
     )
     assert _get_streaming_fallback_metadata(stream) == (False, None, [])
 
@@ -554,7 +558,9 @@ async def test_apply_streaming_chunk_hooks_appends_to_str_so_far(monkeypatch):
     async def _passthrough(*, user_api_key_dict, response, data, str_so_far=None):
         return response
 
-    monkeypatch.setattr(ps.proxy_logging_obj, "async_post_call_streaming_hook", _passthrough)
+    monkeypatch.setattr(
+        ps.proxy_logging_obj, "async_post_call_streaming_hook", _passthrough
+    )
 
     new_chunk, new_str = await _apply_streaming_chunk_hooks(
         chunk=chunk,
@@ -864,7 +870,9 @@ async def test_async_data_generator_mid_stream_exception_yields_error_payload(
         out.append(line)
 
     # First entry is the successful "partial" chunk (bytes), last is the error.
-    assert any(isinstance(item, str) and item.startswith('data: {"error":') for item in out)
+    assert any(
+        isinstance(item, str) and item.startswith('data: {"error":') for item in out
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1260,68 +1268,6 @@ def test_keepalive_from_deployment_config_no_router_returns_none(monkeypatch):
     monkeypatch.setattr(ps, "llm_router", None)
     result = _keepalive_from_deployment_config({"model": "gpt-4"}, None)
     assert result is None
-
-
-def test_keepalive_from_deployment_config_uses_metadata_model_info_after_fallback(monkeypatch):
-    """A router-level fallback rewrites kwargs["model"] on the fallback handler's
-    own local **kwargs copy, not on this request_data dict, so request_data["model"]
-    still names the pre-fallback model group even after a successful fallback.
-    metadata.model_info.id is mutated on this same dict by every deployment attempt
-    (including fallbacks), so it must be preferred over guessing from the stale
-    model group name."""
-    from unittest.mock import MagicMock
-
-    fallback_deployment = MagicMock()
-    fallback_deployment.litellm_params.keepalive_seconds = 30.0
-    fallback_deployment.litellm_params.allow_client_keepalive_override = False
-
-    router = MagicMock()
-    router.get_deployment.return_value = fallback_deployment
-    router.get_model_list.side_effect = AssertionError(
-        "must not guess by the stale model group name when metadata.model_info.id is available"
-    )
-
-    monkeypatch.setattr(ps, "llm_router", router)
-
-    response = MagicMock()
-    response._hidden_params = {}
-
-    request_data = {
-        "model": "model-group-a",
-        "metadata": {"model_info": {"id": "deploy-in-group-b"}},
-    }
-    result = _keepalive_from_deployment_config(request_data, response)
-    assert result == ps._DeploymentKeepaliveConfig(keepalive_seconds=30.0, allow_client_override=False)
-    router.get_deployment.assert_called_once_with(model_id="deploy-in-group-b")
-
-
-def test_keepalive_from_deployment_config_uses_litellm_metadata_model_info_after_fallback(monkeypatch):
-    """Same as the metadata case, but for the litellm_metadata variable name used
-    by the Responses API call path."""
-    from unittest.mock import MagicMock
-
-    fallback_deployment = MagicMock()
-    fallback_deployment.litellm_params.keepalive_seconds = 15.0
-    fallback_deployment.litellm_params.allow_client_keepalive_override = True
-
-    router = MagicMock()
-    router.get_deployment.return_value = fallback_deployment
-    router.get_model_list.side_effect = AssertionError(
-        "must not guess by the stale model group name when litellm_metadata.model_info.id is available"
-    )
-
-    monkeypatch.setattr(ps, "llm_router", router)
-
-    response = MagicMock()
-    response._hidden_params = {}
-
-    request_data = {
-        "model": "model-group-a",
-        "litellm_metadata": {"model_info": {"id": "deploy-in-group-b"}},
-    }
-    result = _keepalive_from_deployment_config(request_data, response)
-    assert result == ps._DeploymentKeepaliveConfig(keepalive_seconds=15.0, allow_client_override=True)
-    router.get_deployment.assert_called_once_with(model_id="deploy-in-group-b")
 
 
 def test_keepalive_seconds_in_all_litellm_params():

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -1100,6 +1100,30 @@ def test_keepalive_from_deployment_config_fallback_by_name_conflicting_deploymen
     assert result is None
 
 
+def test_keepalive_from_deployment_config_fallback_by_name_configured_plus_unset(monkeypatch):
+    """A deployment that leaves keepalive_seconds unset entirely (not explicitly 0)
+    must not inherit a sibling deployment's configured interval: without a model_id
+    we can't tell which deployment served the stream, so mixing a configured
+    deployment with an unconfigured one is just as ambiguous as two conflicting
+    configured values."""
+    from unittest.mock import MagicMock
+
+    router = MagicMock()
+    router.get_deployment.return_value = None
+    router.get_model_list.return_value = [
+        {"litellm_params": {"keepalive_seconds": 20.0}},
+        {"litellm_params": {}},
+    ]
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {}
+
+    result = _keepalive_from_deployment_config({"model": "slow-model"}, response)
+    assert result is None
+
+
 def test_keepalive_from_deployment_config_no_router_returns_none(monkeypatch):
     monkeypatch.setattr(ps, "llm_router", None)
     result = _keepalive_from_deployment_config({"model": "gpt-4"}, None)

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -196,9 +196,7 @@ async def test_async_assistants_data_generator_hook_failure_yields_error_chunk(
     async def _noop_failure(*args, **kwargs):
         return None
 
-    monkeypatch.setattr(
-        ps.proxy_logging_obj, "async_post_call_streaming_hook", _boom_hook
-    )
+    monkeypatch.setattr(ps.proxy_logging_obj, "async_post_call_streaming_hook", _boom_hook)
     monkeypatch.setattr(ps.proxy_logging_obj, "post_call_failure_hook", _noop_failure)
 
     stream = _FakeAssistantsStream([_simple_chunk()])
@@ -385,9 +383,7 @@ def test_get_streaming_fallback_metadata_no_additional_headers():
 def test_get_streaming_fallback_metadata_zero_fallback_count():
     stream = _FakeStream(
         [],
-        hidden_params={
-            "additional_headers": {"x-litellm-attempted-fallbacks": 0}
-        },
+        hidden_params={"additional_headers": {"x-litellm-attempted-fallbacks": 0}},
     )
     assert _get_streaming_fallback_metadata(stream) == (False, None, [])
 
@@ -558,9 +554,7 @@ async def test_apply_streaming_chunk_hooks_appends_to_str_so_far(monkeypatch):
     async def _passthrough(*, user_api_key_dict, response, data, str_so_far=None):
         return response
 
-    monkeypatch.setattr(
-        ps.proxy_logging_obj, "async_post_call_streaming_hook", _passthrough
-    )
+    monkeypatch.setattr(ps.proxy_logging_obj, "async_post_call_streaming_hook", _passthrough)
 
     new_chunk, new_str = await _apply_streaming_chunk_hooks(
         chunk=chunk,
@@ -870,9 +864,7 @@ async def test_async_data_generator_mid_stream_exception_yields_error_payload(
         out.append(line)
 
     # First entry is the successful "partial" chunk (bytes), last is the error.
-    assert any(
-        isinstance(item, str) and item.startswith('data: {"error":') for item in out
-    )
+    assert any(isinstance(item, str) and item.startswith('data: {"error":') for item in out)
 
 
 # ---------------------------------------------------------------------------
@@ -934,7 +926,7 @@ async def test_iter_with_keepalive_hot_path_no_task_wrapping():
     """When keepalive_seconds <= 0, the generator is a transparent pass-through."""
     chunks = [_simple_chunk(content="a"), _simple_chunk(content="b")]
     out = []
-    async for item in _iter_with_keepalive(_async_iter(chunks), keepalive_seconds=0):
+    async for item in _iter_with_keepalive(_async_iter(chunks), lambda _: 0, keepalive_seconds=0):
         out.append(item)
 
     assert out == chunks
@@ -944,7 +936,9 @@ async def test_iter_with_keepalive_hot_path_no_task_wrapping():
 @pytest.mark.asyncio
 async def test_iter_with_keepalive_emits_sentinel_when_stream_stalls():
     """With a short keepalive interval and a stalled upstream, _STREAM_KEEPALIVE
-    sentinels appear before the delayed chunk arrives."""
+    sentinels appear before the delayed chunk arrives. The resolver returns a
+    constant interval, since this test pins the timing mechanics, not
+    re-resolution."""
     import asyncio
 
     async def _slow_stream():
@@ -953,7 +947,7 @@ async def test_iter_with_keepalive_emits_sentinel_when_stream_stalls():
         yield _simple_chunk(content="second")
 
     items = []
-    async for item in _iter_with_keepalive(_slow_stream(), keepalive_seconds=0.05):
+    async for item in _iter_with_keepalive(_slow_stream(), lambda _: 0.05, keepalive_seconds=0.05):
         items.append(item)
 
     sentinels = [i for i in items if i is ps._STREAM_KEEPALIVE]
@@ -975,12 +969,79 @@ async def test_iter_with_keepalive_cancel_on_early_close():
             await asyncio.sleep(10)
             yield _simple_chunk()
 
-    gen = _iter_with_keepalive(_infinite_stream(), keepalive_seconds=0.05)
+    gen = _iter_with_keepalive(_infinite_stream(), lambda _: 0.05, keepalive_seconds=0.05)
     # Advance once to get the sentinel; then close before the real chunk.
     first = await gen.__anext__()
     assert first is ps._STREAM_KEEPALIVE
     # aclose must not raise, and must drain the cancelled task cleanly.
     await gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_iter_with_keepalive_disables_after_fallback_lowers_interval():
+    """Greptile P1: a mid-stream router fallback can hand off to a deployment
+    with a different (or disabled) keepalive policy partway through the same
+    stream. The interval must be re-resolved against each chunk's own identity,
+    not the one picked before iteration started, or heartbeats keep using the
+    pre-fallback deployment's policy for the rest of the stream."""
+    import asyncio
+
+    async def _slow_stream():
+        yield _simple_chunk(content="first")
+        await asyncio.sleep(0.3)
+        yield _simple_chunk(content="second")
+
+    def _resolver(item):
+        # First chunk resolves under the enabled interval used to start the
+        # wrapper; every chunk after that resolves as if a fallback disabled it.
+        return 0.0 if item.choices[0].delta.content == "first" else 999.0
+
+    items = []
+    async for item in _iter_with_keepalive(_slow_stream(), _resolver, keepalive_seconds=0.05):
+        items.append(item)
+
+    sentinels = [i for i in items if i is ps._STREAM_KEEPALIVE]
+    real_chunks = [i for i in items if i is not ps._STREAM_KEEPALIVE]
+
+    assert sentinels == [], f"expected no sentinels once the resolver disables keepalive; got {len(sentinels)}"
+    assert len(real_chunks) == 2
+    assert real_chunks[0].choices[0].delta.content == "first"
+    assert real_chunks[1].choices[0].delta.content == "second"
+
+
+@pytest.mark.asyncio
+async def test_iter_with_keepalive_enables_after_fallback_raises_interval():
+    """Symmetric case: a mid-stream fallback to a deployment with a *shorter*
+    keepalive interval must take effect immediately, not stay pinned to the
+    longer interval the stream started with. The interval used to wait for a
+    chunk is resolved from the *previous* chunk (the only one seen so far when
+    that wait begins), so the stall has to follow the fallback chunk rather
+    than precede it: waiting for "third" is where the shorter interval bites."""
+    import asyncio
+
+    async def _slow_stream():
+        yield _simple_chunk(content="first")
+        yield _simple_chunk(content="second")
+        await asyncio.sleep(0.3)
+        yield _simple_chunk(content="third")
+
+    def _resolver(item):
+        # "first" resolves under an interval too long to fire before "second"
+        # arrives; "second" (the fallback chunk) resolves as if the fallback
+        # deployment enabled a much shorter interval for everything after it.
+        return 999.0 if item.choices[0].delta.content == "first" else 0.05
+
+    items = []
+    async for item in _iter_with_keepalive(_slow_stream(), _resolver, keepalive_seconds=999.0):
+        items.append(item)
+
+    sentinels = [i for i in items if i is ps._STREAM_KEEPALIVE]
+    real_chunks = [i for i in items if i is not ps._STREAM_KEEPALIVE]
+
+    assert len(sentinels) >= 2, (
+        f"expected >= 2 sentinels once the resolver enables a short interval; got {len(sentinels)}"
+    )
+    assert len(real_chunks) == 3
 
 
 def test_resolve_keepalive_seconds_client_value_ignored_without_override_permission(monkeypatch):

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -983,33 +983,122 @@ async def test_iter_with_keepalive_cancel_on_early_close():
     await gen.aclose()
 
 
-def test_resolve_keepalive_seconds_request_value_wins(monkeypatch):
-    monkeypatch.setattr(ps, "llm_router", None)
-    result = _resolve_keepalive_seconds({"keepalive_seconds": 30}, response=None)
+def test_resolve_keepalive_seconds_client_value_ignored_without_override_permission(monkeypatch):
+    """keepalive_seconds is operator-only by default: a deployment that hasn't set
+    allow_client_keepalive_override must not let a client's request-level value
+    change its behavior at all, since that would let any authenticated client
+    unilaterally enable heartbeats (and the LB-idle-timeout evasion that comes
+    with them) for a deployment that never opted in."""
+    from unittest.mock import MagicMock
+
+    deployment = MagicMock()
+    deployment.litellm_params.keepalive_seconds = 15.0
+    deployment.litellm_params.allow_client_keepalive_override = False
+
+    router = MagicMock()
+    router.get_deployment.return_value = deployment
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {"model_id": "deploy-locked"}
+
+    result = _resolve_keepalive_seconds({"model": "my-model", "keepalive_seconds": 1}, response=response)
+    assert result == 15.0
+
+
+def test_resolve_keepalive_seconds_request_value_wins_when_override_allowed(monkeypatch):
+    from unittest.mock import MagicMock
+
+    deployment = MagicMock()
+    deployment.litellm_params.keepalive_seconds = None
+    deployment.litellm_params.allow_client_keepalive_override = True
+
+    router = MagicMock()
+    router.get_deployment.return_value = deployment
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {"model_id": "deploy-opt-in"}
+
+    result = _resolve_keepalive_seconds({"model": "my-model", "keepalive_seconds": 30}, response=response)
     assert result == 30.0
 
 
-def test_resolve_keepalive_seconds_explicit_zero_disables(monkeypatch):
-    monkeypatch.setattr(ps, "llm_router", None)
-    result = _resolve_keepalive_seconds({"keepalive_seconds": 0}, response=None)
+def test_resolve_keepalive_seconds_explicit_zero_disables_when_override_allowed(monkeypatch):
+    from unittest.mock import MagicMock
+
+    deployment = MagicMock()
+    deployment.litellm_params.keepalive_seconds = 20.0
+    deployment.litellm_params.allow_client_keepalive_override = True
+
+    router = MagicMock()
+    router.get_deployment.return_value = deployment
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {"model_id": "deploy-opt-in"}
+
+    result = _resolve_keepalive_seconds({"model": "my-model", "keepalive_seconds": 0}, response=response)
     assert result == 0.0
 
 
 def test_resolve_keepalive_seconds_clamps_below_minimum(monkeypatch):
-    monkeypatch.setattr(ps, "llm_router", None)
-    result = _resolve_keepalive_seconds({"keepalive_seconds": 0.001}, response=None)
+    from unittest.mock import MagicMock
+
+    deployment = MagicMock()
+    deployment.litellm_params.keepalive_seconds = None
+    deployment.litellm_params.allow_client_keepalive_override = True
+
+    router = MagicMock()
+    router.get_deployment.return_value = deployment
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {"model_id": "deploy-opt-in"}
+
+    result = _resolve_keepalive_seconds({"model": "my-model", "keepalive_seconds": 0.001}, response=response)
     assert result == _KEEPALIVE_MIN_SECONDS
 
 
 def test_resolve_keepalive_seconds_clamps_above_maximum(monkeypatch):
-    monkeypatch.setattr(ps, "llm_router", None)
-    result = _resolve_keepalive_seconds({"keepalive_seconds": 9999}, response=None)
+    from unittest.mock import MagicMock
+
+    deployment = MagicMock()
+    deployment.litellm_params.keepalive_seconds = None
+    deployment.litellm_params.allow_client_keepalive_override = True
+
+    router = MagicMock()
+    router.get_deployment.return_value = deployment
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {"model_id": "deploy-opt-in"}
+
+    result = _resolve_keepalive_seconds({"model": "my-model", "keepalive_seconds": 9999}, response=response)
     assert result == _KEEPALIVE_MAX_SECONDS
 
 
 def test_resolve_keepalive_seconds_non_numeric_returns_zero(monkeypatch):
-    monkeypatch.setattr(ps, "llm_router", None)
-    result = _resolve_keepalive_seconds({"keepalive_seconds": "not-a-number"}, response=None)
+    from unittest.mock import MagicMock
+
+    deployment = MagicMock()
+    deployment.litellm_params.keepalive_seconds = None
+    deployment.litellm_params.allow_client_keepalive_override = True
+
+    router = MagicMock()
+    router.get_deployment.return_value = deployment
+
+    monkeypatch.setattr(ps, "llm_router", router)
+
+    response = MagicMock()
+    response._hidden_params = {"model_id": "deploy-opt-in"}
+
+    result = _resolve_keepalive_seconds({"model": "my-model", "keepalive_seconds": "not-a-number"}, response=response)
     assert result == 0.0
 
 
@@ -1023,11 +1112,14 @@ def test_resolve_keepalive_seconds_deployment_disable_cannot_be_overridden_by_re
     """A deployment that explicitly sets keepalive_seconds: 0 is a hard operator
     disable: an authenticated client must not be able to re-enable heartbeats for
     that deployment by passing a positive value in the request body, since that
-    would let a client evade the deployment's idle-timeout behavior at will."""
+    would let a client evade the deployment's idle-timeout behavior at will. This
+    holds even if the deployment also grants override permission, since an
+    explicit disable is a stronger, unconditional signal than an override grant."""
     from unittest.mock import MagicMock
 
     deployment = MagicMock()
     deployment.litellm_params.keepalive_seconds = 0
+    deployment.litellm_params.allow_client_keepalive_override = True
 
     router = MagicMock()
     router.get_deployment.return_value = deployment
@@ -1046,6 +1138,7 @@ def test_keepalive_from_deployment_config_reads_by_model_id(monkeypatch):
 
     deployment = MagicMock()
     deployment.litellm_params.keepalive_seconds = 45.0
+    deployment.litellm_params.allow_client_keepalive_override = True
 
     router = MagicMock()
     router.get_deployment.return_value = deployment
@@ -1056,7 +1149,7 @@ def test_keepalive_from_deployment_config_reads_by_model_id(monkeypatch):
     response._hidden_params = {"model_id": "deploy-abc"}
 
     result = _keepalive_from_deployment_config({"model": "my-model"}, response)
-    assert result == 45.0
+    assert result == ps._DeploymentKeepaliveConfig(keepalive_seconds=45.0, allow_client_override=True)
     router.get_deployment.assert_called_once_with(model_id="deploy-abc")
 
 
@@ -1100,7 +1193,7 @@ def test_keepalive_from_deployment_config_fallback_by_name(monkeypatch):
     response._hidden_params = {}
 
     result = _keepalive_from_deployment_config({"model": "slow-model"}, response)
-    assert result == 20.0
+    assert result == ps._DeploymentKeepaliveConfig(keepalive_seconds=20.0, allow_client_override=False)
     router.get_model_list.assert_called_once_with(model_name="slow-model")
 
 
@@ -1112,8 +1205,8 @@ def test_keepalive_from_deployment_config_fallback_by_name_agreeing_deployments(
     router = MagicMock()
     router.get_deployment.return_value = None
     router.get_model_list.return_value = [
-        {"litellm_params": {"keepalive_seconds": 20.0}},
-        {"litellm_params": {"keepalive_seconds": 20.0}},
+        {"litellm_params": {"keepalive_seconds": 20.0, "allow_client_keepalive_override": True}},
+        {"litellm_params": {"keepalive_seconds": 20.0, "allow_client_keepalive_override": True}},
     ]
 
     monkeypatch.setattr(ps, "llm_router", router)
@@ -1122,7 +1215,7 @@ def test_keepalive_from_deployment_config_fallback_by_name_agreeing_deployments(
     response._hidden_params = {}
 
     result = _keepalive_from_deployment_config({"model": "slow-model"}, response)
-    assert result == 20.0
+    assert result == ps._DeploymentKeepaliveConfig(keepalive_seconds=20.0, allow_client_override=True)
 
 
 def test_keepalive_from_deployment_config_fallback_by_name_conflicting_deployments(monkeypatch):
@@ -1185,11 +1278,18 @@ def test_keepalive_seconds_in_all_litellm_params():
 
 @pytest.mark.asyncio
 async def test_async_data_generator_emits_ping_heartbeat(monkeypatch):
-    """When keepalive_seconds is set, ': ping' frames appear during upstream stalls."""
+    """When keepalive_seconds is set on a deployment that allows client override,
+    ': ping' frames appear during upstream stalls."""
     import asyncio
+    from unittest.mock import MagicMock
 
     _patch_logging_flags(monkeypatch)
     monkeypatch.setattr(ps, "_KEEPALIVE_MIN_SECONDS", 0.05)
+
+    router = MagicMock()
+    router.get_deployment.return_value = None
+    router.get_model_list.return_value = [{"litellm_params": {"allow_client_keepalive_override": True}}]
+    monkeypatch.setattr(ps, "llm_router", router)
 
     async def _slow_response():
         yield _simple_chunk(content="hello")

--- a/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
+++ b/tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py
@@ -1044,6 +1044,40 @@ async def test_iter_with_keepalive_enables_after_fallback_raises_interval():
     assert len(real_chunks) == 3
 
 
+@pytest.mark.asyncio
+async def test_iter_with_keepalive_activates_from_a_fully_disabled_start():
+    """Greptile P1: a stream can start on a deployment with keepalive off
+    (keepalive_seconds passed in as 0, not merely a long interval) and fall back
+    mid-stream to one that enables it. The 0-second start must not be treated as
+    a one-time decision to skip heartbeats for the rest of the stream: no task
+    is created while inactive, but every chunk still re-resolves so the fallback
+    chunk can switch the stream into task-wrapped mode."""
+    import asyncio
+
+    async def _slow_stream():
+        yield _simple_chunk(content="first")
+        yield _simple_chunk(content="second")
+        await asyncio.sleep(0.3)
+        yield _simple_chunk(content="third")
+
+    def _resolver(item):
+        # "first" resolves to stay off; "second" (the fallback chunk) resolves
+        # as if the fallback deployment newly enabled a short interval.
+        return 0.0 if item.choices[0].delta.content == "first" else 0.05
+
+    items = []
+    async for item in _iter_with_keepalive(_slow_stream(), _resolver, keepalive_seconds=0):
+        items.append(item)
+
+    sentinels = [i for i in items if i is ps._STREAM_KEEPALIVE]
+    real_chunks = [i for i in items if i is not ps._STREAM_KEEPALIVE]
+
+    assert len(sentinels) >= 2, (
+        f"expected >= 2 sentinels once the resolver activates from a disabled start; got {len(sentinels)}"
+    )
+    assert len(real_chunks) == 3
+
+
 def test_resolve_keepalive_seconds_client_value_ignored_without_override_permission(monkeypatch):
     """keepalive_seconds is operator-only by default: a deployment that hasn't set
     allow_client_keepalive_override must not let a client's request-level value

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -2008,6 +2008,54 @@ def test_get_num_retries_from_request():
     assert result == -1
 
 
+def test_get_keepalive_seconds_from_request():
+    """
+    Test LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request method
+    """
+    # Header present with valid float string
+    headers_with_keepalive = {"x-litellm-keepalive-seconds": "15"}
+    result = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(
+        headers_with_keepalive
+    )
+    assert result == 15.0
+
+    # Header not present
+    result = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(
+        {"Content-Type": "application/json"}
+    )
+    assert result is None
+
+    # Empty headers dictionary
+    result = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request({})
+    assert result is None
+
+    # Header present with a fractional value
+    result = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(
+        {"x-litellm-keepalive-seconds": "1.5"}
+    )
+    assert result == 1.5
+
+    # Header present with invalid value raises ValueError, matching the other
+    # x-litellm-* numeric header helpers (_get_timeout_from_request, etc.)
+    with pytest.raises(ValueError):
+        LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(
+            {"x-litellm-keepalive-seconds": "not-a-number"}
+        )
+
+
+def test_add_litellm_data_for_backend_llm_call_merges_keepalive_seconds_header():
+    """
+    The x-litellm-keepalive-seconds header must be merged into the data dict
+    that add_litellm_data_to_request later data.update()s onto the request body,
+    the same way x-litellm-timeout/x-litellm-num-retries already are.
+    """
+    result = LiteLLMProxyRequestSetup.add_litellm_data_for_backend_llm_call(
+        headers={"x-litellm-keepalive-seconds": "20"},
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+    )
+    assert result.get("keepalive_seconds") == 20.0
+
+
 def test_add_user_api_key_auth_to_request_metadata():
     """
     Test that add_user_api_key_auth_to_request_metadata properly adds user API key authentication data to request metadata

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -2119,6 +2119,7 @@ def test_add_litellm_data_for_backend_llm_call_merges_keepalive_seconds_header()
     """
     result = LiteLLMProxyRequestSetup.add_litellm_data_for_backend_llm_call(
         headers={"x-litellm-keepalive-seconds": "20"},
+        request_data={},
         user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
     )
     assert result.get("keepalive_seconds") == 20.0

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -2076,6 +2076,54 @@ def test_get_num_retries_from_request():
     assert result == -1
 
 
+def test_get_keepalive_seconds_from_request():
+    """
+    Test LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request method
+    """
+    # Header present with valid float string
+    headers_with_keepalive = {"x-litellm-keepalive-seconds": "15"}
+    result = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(
+        headers_with_keepalive
+    )
+    assert result == 15.0
+
+    # Header not present
+    result = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(
+        {"Content-Type": "application/json"}
+    )
+    assert result is None
+
+    # Empty headers dictionary
+    result = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request({})
+    assert result is None
+
+    # Header present with a fractional value
+    result = LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(
+        {"x-litellm-keepalive-seconds": "1.5"}
+    )
+    assert result == 1.5
+
+    # Header present with invalid value raises ValueError, matching the other
+    # x-litellm-* numeric header helpers (_get_timeout_from_request, etc.)
+    with pytest.raises(ValueError):
+        LiteLLMProxyRequestSetup._get_keepalive_seconds_from_request(
+            {"x-litellm-keepalive-seconds": "not-a-number"}
+        )
+
+
+def test_add_litellm_data_for_backend_llm_call_merges_keepalive_seconds_header():
+    """
+    The x-litellm-keepalive-seconds header must be merged into the data dict
+    that add_litellm_data_to_request later data.update()s onto the request body,
+    the same way x-litellm-timeout/x-litellm-num-retries already are.
+    """
+    result = LiteLLMProxyRequestSetup.add_litellm_data_for_backend_llm_call(
+        headers={"x-litellm-keepalive-seconds": "20"},
+        user_api_key_dict=UserAPIKeyAuth(api_key="sk-test"),
+    )
+    assert result.get("keepalive_seconds") == 20.0
+
+
 def test_add_user_api_key_auth_to_request_metadata():
     """
     Test that add_user_api_key_auth_to_request_metadata properly adds user API key authentication data to request metadata

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -26911,6 +26911,8 @@ export interface components {
             input_cost_per_video_token?: number | null;
             /** Itpm */
             itpm?: number | null;
+            /** Keepalive Seconds */
+            keepalive_seconds?: number | null;
             /** Litellm Credential Name */
             litellm_credential_name?: string | null;
             /** Litellm Trace Id */
@@ -35587,6 +35589,8 @@ export interface components {
             input_cost_per_video_token?: number | null;
             /** Itpm */
             itpm?: number | null;
+            /** Keepalive Seconds */
+            keepalive_seconds?: number | null;
             /** Litellm Credential Name */
             litellm_credential_name?: string | null;
             /** Litellm Trace Id */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -26758,6 +26758,11 @@ export interface components {
             } | null;
             /** Adaptive Router Default Model */
             adaptive_router_default_model?: string | null;
+            /**
+             * Allow Client Keepalive Override
+             * @default false
+             */
+            allow_client_keepalive_override: boolean | null;
             /** Annotation Cost Per Page */
             annotation_cost_per_page?: number | null;
             /** Api Base */
@@ -35429,6 +35434,11 @@ export interface components {
             } | null;
             /** Adaptive Router Default Model */
             adaptive_router_default_model?: string | null;
+            /**
+             * Allow Client Keepalive Override
+             * @default false
+             */
+            allow_client_keepalive_override: boolean | null;
             /** Annotation Cost Per Page */
             annotation_cost_per_page?: number | null;
             /** Api Base */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -26630,6 +26630,8 @@ export interface components {
             input_cost_per_video_token?: number | null;
             /** Itpm */
             itpm?: number | null;
+            /** Keepalive Seconds */
+            keepalive_seconds?: number | null;
             /** Litellm Credential Name */
             litellm_credential_name?: string | null;
             /** Litellm Trace Id */
@@ -35210,6 +35212,8 @@ export interface components {
             input_cost_per_video_token?: number | null;
             /** Itpm */
             itpm?: number | null;
+            /** Keepalive Seconds */
+            keepalive_seconds?: number | null;
             /** Litellm Credential Name */
             litellm_credential_name?: string | null;
             /** Litellm Trace Id */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -26481,6 +26481,11 @@ export interface components {
             } | null;
             /** Adaptive Router Default Model */
             adaptive_router_default_model?: string | null;
+            /**
+             * Allow Client Keepalive Override
+             * @default false
+             */
+            allow_client_keepalive_override: boolean | null;
             /** Annotation Cost Per Page */
             annotation_cost_per_page?: number | null;
             /** Api Base */
@@ -35056,6 +35061,11 @@ export interface components {
             } | null;
             /** Adaptive Router Default Model */
             adaptive_router_default_model?: string | null;
+            /**
+             * Allow Client Keepalive Override
+             * @default false
+             */
+            allow_client_keepalive_override: boolean | null;
             /** Annotation Cost Per Page */
             annotation_cost_per_page?: number | null;
             /** Api Base */


### PR DESCRIPTION
## Relevant issues

Closes #31877

Supersedes #33259 (closed — superseded due to worktree/branch cleanup; same feature, carried forward with an additional fix for explicit `None` handling in `keepalive_seconds` extraction).

## Linear ticket

N/A

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Example config

`keepalive_seconds` is set as a deployment-level default under `litellm_params`. It is operator-only by default: a client's request-level `keepalive_seconds` is ignored unless the deployment also sets `allow_client_keepalive_override: true`. An explicit deployment-level `keepalive_seconds: 0` is a hard disable that takes priority over everything, including a grant of override permission.

```yaml
model_list:
  - model_name: anthropic-haiku-4-5
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_key: os.environ/ANTHROPIC_API_KEY
      keepalive_seconds: 15   # emit an SSE ": ping" comment frame after 15s of stream silence
      allow_client_keepalive_override: true   # let a request override the 15s default

general_settings:
  master_key: sk-1234
```

```bash
curl -N -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"say hi"}],"stream":true}'
```

with `allow_client_keepalive_override: true` set, a request can override the deployment's default (including disabling it with an explicit `0`) via the request body:

```bash
curl -N -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"say hi"}],"stream":true,"keepalive_seconds":1}'
```

or via a request header, for clients (e.g. the Vercel AI SDK) that can set custom headers more easily than extra body fields — the header goes through the exact same `allow_client_keepalive_override` gate as the body field, so it can't enable heartbeats for a deployment that hasn't opted in either:

```bash
curl -N -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "x-litellm-keepalive-seconds: 1" \
  -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"say hi"}],"stream":true}'
```

Without `allow_client_keepalive_override`, both the request body field and the header are silently ignored and the deployment's own configured value (or no heartbeats, if unset) applies instead.

## Screenshots / Proof of Fix

Ran the proxy locally against real Anthropic API calls (`dev_config.yaml`, master key `sk-1234`):

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --port 4000 2>&1 | tee litellm.log
```

Baseline, keepalive off, no `: ping` noise:

```bash
curl -s -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"say hi"}],"stream":true}'
```
Got a normal SSE response, no ping frames, since there was no idle gap.

Then, to force a genuine multi-second silence window against a real provider (no mocking), a request with `reasoning_effort: "xhigh"` against `anthropic-opus-4-8` on a hard reasoning prompt, `keepalive_seconds: 1` (deployment configured with `allow_client_keepalive_override: true`):

```bash
curl -N -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -d '{"model":"anthropic-opus-4-8","messages":[{"role":"user","content":"<hard multi-step reasoning prompt>"}],"stream":true,"keepalive_seconds":1,"reasoning_effort":"xhigh","max_tokens":12000}'
```

Over a ~90 second real Anthropic call, the proxy emitted 89 `: ping\n\n` SSE comment frames at roughly 1-second intervals while the model was silently reasoning, then the real completion event followed. This confirms `_iter_with_keepalive` correctly detects per-chunk idle gaps and emits heartbeats against a live, unmocked provider stream, not just in the unit tests.

Re-ran the same hard-reasoning prompt against the same opt-in deployment, this time supplying `keepalive_seconds` via the `x-litellm-keepalive-seconds: 1` header instead of the request body: 88 real `: ping` frames, clean completion, no errors. Then ran it again against a deployment without `allow_client_keepalive_override`, header still set to `1`: 0 pings, confirming the header is subject to the exact same operator-opt-in gate as the body field.

## Type

New Feature

## Changes

`litellm/types/utils.py`: adds `"keepalive_seconds"` and `"allow_client_keepalive_override"` to `all_litellm_params` so neither parameter is stripped from request bodies before reaching the streaming generator, nor leaks through to the provider API.

`litellm/types/router.py`: adds `keepalive_seconds: Optional[float]` and `allow_client_keepalive_override: Optional[bool]` (default `False`) to both `LiteLLMParamsTypedDict` and `GenericLiteLLMParams`, so both fields are accepted in deployment YAML config and pass Pydantic validation.

`litellm/proxy/proxy_server.py`: adds a `_STREAM_KEEPALIVE` sentinel object, `_KEEPALIVE_MIN_SECONDS` and `_KEEPALIVE_MAX_SECONDS` constants, and helper functions `_iter_with_keepalive`, `_keepalive_from_deployment_config`, `_resolve_keepalive_seconds`. `async_data_generator` wraps the stream with `_iter_with_keepalive` when keepalive is enabled and emits `": ping\n\n"` SSE comment frames on each idle interval.

`litellm/proxy/litellm_pre_call_utils.py` and `litellm/proxy/_types.py`: adds `_get_keepalive_seconds_from_request` (an `x-litellm-keepalive-seconds` header reader, following the existing `x-litellm-timeout`/`x-litellm-num-retries` convention) and merges it into the same `data["keepalive_seconds"]` field the request body already populates, so it flows through the identical `_resolve_keepalive_seconds` precedence and `allow_client_keepalive_override` gate.

Also includes several correctness and security fixes made during review:
- Use explicit `None` check instead of truthiness when extracting `keepalive_seconds`, so a value of `0` (explicit disable) is respected instead of being treated as falsy/unset.
- The deployment-resolution fallback used when a stream lacks `_hidden_params.model_id` now only trusts a guess when every deployment under that `model_name` agrees (including deployments that leave the field unset), so a stream never inherits a sibling deployment's interval.
- A populated but unresolvable `model_id` (e.g. a deployment removed by a config reload mid-stream) no longer falls through to the `model_name`-based guess; a stale identity is treated as unknown, not absent.
- **Security:** deployment-level `keepalive_seconds: 0` is a hard operator disable that a request can never re-enable, regardless of what the request body asks for.
- **Security:** `keepalive_seconds` is operator-only by default. A client's request-level value (body or header) has no effect at all unless the resolved deployment explicitly sets `allow_client_keepalive_override: true`; otherwise it is silently ignored and the deployment's own configured value (or disabled, if unset) applies. This closes a resource-exhaustion vector where any authenticated client could unilaterally enable heartbeats for a deployment that never configured this, using them to keep an idle-looking stream alive past a load balancer's idle timeout and hold a `max_parallel_requests` slot open longer than the operator intended.
- Registered `allow_client_keepalive_override` in `all_litellm_params` alongside `keepalive_seconds`, so it is stripped before the request reaches the provider instead of being sent through as an unrecognized field (caught live against the real Anthropic API, which rejected it with a 400).

`tests/test_litellm/proxy/proxy_server/test_streaming_helpers.py`: unit tests covering sentinel emission, hot-path transparency, cancel-on-close cleanup, priority resolution (including the deployment hard-disable and no-override-permission cases), deployment config lookup by model ID and by name (including agreeing/conflicting/unset-mixed deployments and a stale model ID), params registration, and integration through `async_data_generator`.

`tests/test_litellm/proxy/test_litellm_pre_call_utils.py`: unit tests for `_get_keepalive_seconds_from_request` (valid/missing/empty/fractional/invalid header values) and for the header merging into `add_litellm_data_for_backend_llm_call`'s output.
