### PR TITLE
fix(proxy): reject failed atomic budget reservations under fail_closed_budget_enforcement

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -2442,6 +2442,7 @@ async def _reserve_budget_after_common_checks(
         end_user_id=end_user_id,
         end_user_object=end_user_object,
         skip_user_budget_on_team_key=general_settings.get("skip_user_budget_on_team_key") is True,
+        fail_closed_budget_enforcement=general_settings.get("fail_closed_budget_enforcement") is True,
     )
 
 

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -68,14 +68,12 @@ def _raise_reservation_unavailable(counter_key: str) -> NoReturn:
     )
     raise HTTPException(
         status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-        detail={
-            "error": (
-                "Budget enforcement unavailable: the budget reservation could not "
-                "be written to the spend counter backend, and "
-                "fail_closed_budget_enforcement is enabled, so the request was "
-                "rejected to avoid exceeding the configured budget. Retry shortly."
-            )
-        },
+        detail=(
+            "Budget enforcement unavailable: the budget reservation could not "
+            "be written to the spend counter backend, and "
+            "fail_closed_budget_enforcement is enabled, so the request was "
+            "rejected to avoid exceeding the configured budget. Retry shortly."
+        ),
     )
 
 

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -4,7 +4,9 @@ import asyncio
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Mapping, Optional, Sequence, cast
+from typing import Any, Dict, List, Mapping, NoReturn, Optional, Sequence, cast
+
+from fastapi import HTTPException, status
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -57,6 +59,24 @@ class _CounterReservationUnavailable(Exception):
         self.touched_counter = touched_counter
         self.counter_invalidated = counter_invalidated
         super().__init__("Counter reservation unavailable")
+
+
+def _raise_reservation_unavailable(counter_key: str) -> NoReturn:
+    verbose_proxy_logger.warning(
+        "fail_closed_budget_enforcement: rejecting request — budget reservation for %s could not be written",
+        counter_key,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail={
+            "error": (
+                "Budget enforcement unavailable: the budget reservation could not "
+                "be written to the spend counter backend, and "
+                "fail_closed_budget_enforcement is enabled, so the request was "
+                "rejected to avoid exceeding the configured budget. Retry shortly."
+            )
+        },
+    )
 
 
 def get_reserved_counter_keys(budget_reservation: Optional[dict]) -> set:
@@ -138,6 +158,7 @@ async def reserve_budget_for_request(
     end_user_id: Optional[str] = None,
     end_user_object: Optional[Any] = None,
     skip_user_budget_on_team_key: bool = False,
+    fail_closed_budget_enforcement: bool = False,
 ) -> Optional[dict]:
     if valid_token is None or not RouteChecks.is_llm_api_route(route=route):
         return None
@@ -193,6 +214,8 @@ async def reserve_budget_for_request(
                         default_reserved_cost=reservation_cost,
                     )
                 applied_entries.remove(entry)
+                if fail_closed_budget_enforcement:
+                    _raise_reservation_unavailable(counter_key=counter.counter_key)
                 continue
 
             if reserved_value is not None:

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -180,6 +180,45 @@ async def test_budget_reservation_runs_when_not_disabled():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "general_settings,expected_flag",
+    [
+        ({"fail_closed_budget_enforcement": True}, True),
+        ({}, False),
+    ],
+)
+async def test_fail_closed_budget_enforcement_reaches_reservation(
+    general_settings, expected_flag
+):
+    """#33923: the strict flag must be threaded into reserve_budget_for_request so a
+    failed reservation write can reject instead of failing open."""
+    user_api_key_auth_obj = UserAPIKeyAuth(token="test_token")
+
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation.reserve_budget_for_request",
+        new=AsyncMock(return_value=None),
+    ) as mock_reserve:
+        await _reserve_budget_after_common_checks(
+            user_api_key_auth_obj=user_api_key_auth_obj,
+            request_data={"model": "gpt-4o"},
+            route="/v1/chat/completions",
+            llm_router=None,
+            team_object=None,
+            user_object=None,
+            prisma_client=None,
+            user_api_key_cache=MagicMock(),
+            proxy_logging_obj=MagicMock(),
+            skip_budget_checks=False,
+            general_settings=general_settings,
+        )
+
+    assert (
+        mock_reserve.await_args.kwargs["fail_closed_budget_enforcement"]
+        is expected_flag
+    )
+
+
+@pytest.mark.asyncio
 async def test_should_not_reuse_cached_key_object_for_request_state():
     key_cache = DualCache()
     cached_key = UserAPIKeyAuth(

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
 import litellm
 from litellm.caching.dual_cache import DualCache
@@ -1559,6 +1560,100 @@ async def test_should_skip_reservation_when_counter_increment_fails(
             key="spend:key:key-budget-reserve-unavailable"
         )
         is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_should_raise_503_when_counter_increment_fails_and_fail_closed(
+    spend_counter_state,
+    monkeypatch,
+):
+    """#33923: with fail_closed_budget_enforcement on, a failed reservation write
+    must reject instead of silently degrading to read-time-only enforcement."""
+    counter_cache, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    valid_token = UserAPIKeyAuth(
+        token="key-budget-reserve-fail-closed",
+        spend=0.0,
+        max_budget=1.0,
+    )
+
+    async def fail_increment_cache(*args, **kwargs):
+        raise RuntimeError("counter unavailable")
+
+    monkeypatch.setattr(counter_cache, "async_increment_cache", fail_increment_cache)
+
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
+        return_value=0.5,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await reserve_budget_for_request(
+                request_body=_request_body(),
+                route="/chat/completions",
+                llm_router=None,
+                valid_token=valid_token,
+                team_object=None,
+                user_object=None,
+                prisma_client=None,
+                user_api_key_cache=key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+                fail_closed_budget_enforcement=True,
+            )
+
+    assert exc_info.value.status_code == 503
+    assert (
+        counter_cache.in_memory_cache.get_cache(
+            key="spend:key:key-budget-reserve-fail-closed"
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_fail_closed_releases_earlier_counters_before_503(
+    spend_counter_state,
+):
+    """#33923: when a later counter's reservation write fails in strict mode, the
+    counters that already reserved must be released before the 503 propagates."""
+    counter_cache, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    valid_token = UserAPIKeyAuth(
+        token="key-budget-fail-closed-release",
+        spend=0.0,
+        max_budget=1.0,
+        budget_limits=[
+            {
+                "budget_duration": "1h",
+                "max_budget": 1.0,
+            }
+        ],
+    )
+
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
+        return_value=0.5,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await reserve_budget_for_request(
+                request_body=_request_body(),
+                route="/chat/completions",
+                llm_router=None,
+                valid_token=valid_token,
+                team_object=None,
+                user_object=None,
+                prisma_client=None,
+                user_api_key_cache=key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+                fail_closed_budget_enforcement=True,
+            )
+
+    assert exc_info.value.status_code == 503
+    assert (
+        counter_cache.in_memory_cache.get_cache(
+            key="spend:key:key-budget-fail-closed-release"
+        )
+        == 0.0
     )
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- fail_closed_budget_enforcement did not cover the atomic reservation write
- a Redis outage let concurrent requests overspend past a configured budget

How it solves it:

- thread the strict flag into reserve_budget_for_request
- a failed reservation write now returns 503 instead of failing open

## Relevant issues

Fixes #33923

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Before/after QA on a live proxy on :4000 against real `anthropic/claude-haiku-4-5`, a virtual key with `max_budget: 5.0`, and a throwaway Redis wired via `general_settings.coordination_redis` with `fail_closed_budget_enforcement: true`. Redis (the spend counter backend) is stopped mid-test so the reservation write fails, then the same `/v1/chat/completions` is sent again. On base `df3050f538` the request fails open (HTTP 200); on this PR (`2046bd83e5`) it is rejected (HTTP 503)

![before-after QA for PR 34429](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvM2ZjNmUzYTItZDNjMC00MjBlLTg4NDAtZWM0MDI4ZmM5Y2ExIiwiaWF0IjoxNzg0ODQzNTY0LCJleHAiOjE3ODU0NDgzNjQsImZpbGVuYW1lIjoiYmVmb3JlLWFmdGVyLTM0NDI5LndlYnAifQ.MJFiaD3-1dL0dhFAsArRaynVwi883FjKA6L2zurKs_U)

Live proxy on :4123 against real Groq (`groq/openai/gpt-oss-20b`), a virtual key with `max_budget: 1.0`, and a throwaway Redis on :6391 wired via `general_settings.coordination_redis`. Redis is stopped mid-test to simulate the reservation-write failure

Before the fix (source restored to `df3050f538`, `fail_closed_budget_enforcement: true`): with Redis down the request fails open

```
=== warmup: Redis UP, flag ON, PRE-FIX ===
HTTP 200
redis stopped
=== BEFORE FIX: Redis DOWN, flag ON (bug = fails open 200) ===
{"id":"chatcmpl-323af3b9-...","model":"gpt-oss-20b","object":"chat.completion", ...}
HTTP 200
```

After the fix (commit `2046bd83e5`), three legs:

Leg 1, Redis up, `fail_closed_budget_enforcement: true` -> normal 200

```
=== Request 1: Redis UP, flag ON ===
{"id":"chatcmpl-18eca7a0-...","model":"gpt-oss-20b","object":"chat.completion", ...}
HTTP 200
```

Leg 2, Redis stopped, `fail_closed_budget_enforcement: true` -> 503, request rejected

```
=== Request 2: Redis DOWN, flag ON ===
{"error":{"message":"{'error': 'Budget enforcement unavailable: the budget reservation could not be written to the spend counter backend, and fail_closed_budget_enforcement is enabled, so the request was rejected to avoid exceeding the configured budget. Retry shortly.'}","type":"auth_error","param":"None","code":"503"}}
HTTP 503
```

Leg 3, control with the flag absent, Redis stopped -> unchanged fail-open 200

```
=== warmup request: Redis UP, flag OFF ===
HTTP 200
redis stopped
=== Request 3: Redis DOWN, flag OFF ===
{"id":"chatcmpl-e4043915-...","model":"gpt-oss-20b","object":"chat.completion", ...}
HTTP 200
```

## Type

🐛 Bug Fix

## Changes

The strict setting was only consulted by the read-time spend check (`get_current_spend`), which returns 503 when current spend cannot be verified. The atomic pre-call reservation ran later and failed open independently: `reserve_budget_for_request` caught `_CounterReservationUnavailable` per counter, dropped that counter, and continued, so a Redis timeout or failover degraded the request to read-time-only enforcement. Concurrent requests could then all pass the same under-budget read and all reach the provider before any completed cost was recorded

`reserve_budget_for_request` now takes a `fail_closed_budget_enforcement` argument, threaded from `general_settings` at the call site in `_reserve_budget_after_common_checks`. When it is true and a counter's reservation write is unavailable, the request is rejected with 503 rather than continuing without an admission hold. The outer cleanup already releases any counters that reserved before the failing one, so a multi-counter request (key plus team plus user) does not leave a partial hold behind. Default behavior with the flag absent or false is unchanged, and the unknown-model-cost early return still degrades to read-time enforcement since that is a pricing gap rather than an infrastructure failure

## QA runbook

- tests/test_litellm/proxy/test_budget_reservation.py::test_should_raise_503_when_counter_increment_fails_and_fail_closed - with the strict flag on, a failed reservation write rejects the request instead of degrading to read-time-only
  - [ ] Generate a key with max_budget: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"max_budget": 1.0}'
  - [ ] With coordination_redis pointed at a throwaway Redis and fail_closed_budget_enforcement true, send one /v1/chat/completions, then stop Redis and send another
  - [ ] Expect the second request to return 503 naming budget enforcement unavailable, and no spend counter left behind for that key
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/test_litellm/proxy/test_budget_reservation.py::test_fail_closed_releases_earlier_counters_before_503 - when a later counter's write fails in strict mode, counters that already reserved are released before the 503 propagates
  - [ ] Generate a key with both max_budget and a windowed budget_limits entry so the request holds more than one counter
  - [ ] With the strict flag on and the window counter's initialization forced to fail, send one /v1/chat/completions
  - [ ] Expect a 503 and the key's own spend counter back at its starting value (the earlier reservation was released, not left dangling)
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/test_litellm/proxy/auth/test_user_api_key_auth.py::test_fail_closed_budget_enforcement_reaches_reservation - the general_settings flag is actually threaded into reserve_budget_for_request rather than dropped at the call site
  - [ ] Call _reserve_budget_after_common_checks with general_settings {"fail_closed_budget_enforcement": true} and again with {}
  - [ ] Expect reserve_budget_for_request to receive fail_closed_budget_enforcement true in the first case and false in the second
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/1cf22593ac2c4933841c4d03bcfeaab1