### PR TITLE
fix(anthropic-adapter): open the first content block with the real upstream type so reasoning-first streams start with thinking

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -393,24 +393,23 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                 if compaction_event is not None:
                     return compaction_event
 
-            if self.sent_content_block_start is False:
-                self.sent_content_block_start = True
-                self.sent_content_block_finish = False
-                self.chunk_queue.append(
-                    {
-                        "type": "content_block_start",
-                        "index": self.current_content_block_index,
-                        "content_block": {"type": "text", "text": ""},
-                    }
-                )
-                return self.chunk_queue.popleft()
-
             for chunk in self.completion_stream:
                 if chunk == "None" or chunk is None:
                     raise Exception
 
                 should_start_new_block = self._should_start_new_content_block(chunk)
-                if should_start_new_block:
+                is_opening_first_block = self.sent_content_block_start is False
+                if is_opening_first_block:
+                    self.sent_content_block_start = True
+                    self.sent_content_block_finish = False
+                    self.chunk_queue.append(
+                        {
+                            "type": "content_block_start",
+                            "index": self.current_content_block_index,
+                            "content_block": self.current_content_block_start,
+                        }
+                    )
+                elif should_start_new_block:
                     self._increment_content_block_index()
 
                 # applied_edits only needs to flow to the final message_delta
@@ -447,7 +446,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                     # ``not self.queued_usage_chunk``.
                     continue
 
-                if should_start_new_block and not self.sent_content_block_finish:
+                if should_start_new_block and not is_opening_first_block and not self.sent_content_block_finish:
                     # Queue the sequence: content_block_stop -> content_block_start
                     # -> (optionally) the trigger chunk's delta.
                     #
@@ -615,25 +614,23 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                 if compaction_event is not None:
                     return compaction_event
 
-            if self.sent_content_block_start is False:
-                self.sent_content_block_start = True
-                self.sent_content_block_finish = False
-                self.chunk_queue.append(
-                    {
-                        "type": "content_block_start",
-                        "index": self.current_content_block_index,
-                        "content_block": {"type": "text", "text": ""},
-                    }
-                )
-                return self.chunk_queue.popleft()
-
             async for chunk in self.completion_stream:
                 if chunk == "None" or chunk is None:
                     raise Exception
 
-                # Check if we need to start a new content block
                 should_start_new_block = self._should_start_new_content_block(chunk)
-                if should_start_new_block:
+                is_opening_first_block = self.sent_content_block_start is False
+                if is_opening_first_block:
+                    self.sent_content_block_start = True
+                    self.sent_content_block_finish = False
+                    self.chunk_queue.append(
+                        {
+                            "type": "content_block_start",
+                            "index": self.current_content_block_index,
+                            "content_block": self.current_content_block_start,
+                        }
+                    )
+                elif should_start_new_block:
                     self._increment_content_block_index()
 
                 # applied_edits only needs to flow to the final message_delta
@@ -664,7 +661,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                 # Check if this processed chunk has a stop_reason - hold it for next chunk
 
                 if not self.queued_usage_chunk:
-                    if should_start_new_block and not self.sent_content_block_finish:
+                    if should_start_new_block and not is_opening_first_block and not self.sent_content_block_finish:
                         # Queue the sequence: content_block_stop -> content_block_start
                         # -> (optionally) the trigger chunk's delta.
                         #

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -399,6 +399,8 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
 
                 should_start_new_block = self._should_start_new_content_block(chunk)
                 is_opening_first_block = self.sent_content_block_start is False
+                if is_opening_first_block and self._is_blank_delta(chunk):
+                    continue
                 if is_opening_first_block:
                     self.sent_content_block_start = True
                     self.sent_content_block_finish = False
@@ -620,6 +622,8 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
 
                 should_start_new_block = self._should_start_new_content_block(chunk)
                 is_opening_first_block = self.sent_content_block_start is False
+                if is_opening_first_block and self._is_blank_delta(chunk):
+                    continue
                 if is_opening_first_block:
                     self.sent_content_block_start = True
                     self.sent_content_block_finish = False
@@ -871,6 +875,22 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
         if delta_type not in _STREAMING_DELTA_TYPES:
             return False
         return bool(delta.get(_delta_payload_field(delta_type)))
+
+    @staticmethod
+    def _is_blank_delta(chunk: "ModelResponseStream") -> bool:
+        choice = chunk.choices[0]
+        if choice.finish_reason is not None:
+            return False
+        delta = choice.delta
+        if getattr(delta, "tool_calls", None):
+            return False
+        if getattr(delta, "content", None):
+            return False
+        if getattr(delta, "reasoning_content", None):
+            return False
+        if getattr(delta, "thinking_blocks", None):
+            return False
+        return True
 
     def _should_start_new_content_block(self, chunk: "ModelResponseStream") -> bool:
         """

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
@@ -506,3 +506,79 @@ def test_empty_content_chunk_mid_text_block_is_suppressed_sync():
 
     assert _text_deltas(events) == ["Hi", " there"]
     _assert_deltas_match_their_block_type(events)
+
+
+def _thinking_first_chunks() -> List[MagicMock]:
+    return [
+        _thinking_chunk("Let me think"),
+        _thinking_chunk("about it."),
+        _make_chunk(Delta(content="42")),
+        _make_chunk(Delta(content=None), finish_reason="stop"),
+    ]
+
+
+def _assert_thinking_first_block_opens_at_index_zero(events: List[dict]) -> None:
+    starts = [
+        (e["index"], e["content_block"]["type"])
+        for e in events
+        if e.get("type") == "content_block_start"
+    ]
+    assert starts == [(0, "thinking"), (1, "text")], starts
+    assert "" not in _text_deltas(events)
+    assert _thinking_deltas(events) == ["Let me think", "about it."]
+    assert _text_deltas(events) == ["42"]
+    _assert_deltas_match_their_block_type(events)
+
+
+def test_thinking_first_stream_opens_thinking_block_at_index_zero_sync():
+    """Bug A regression: when the model's first output is reasoning the adapter
+    must open the first content block as ``thinking`` at index 0. The previous
+    code pre-emitted a hardcoded empty ``text`` block at index 0 before
+    inspecting any upstream chunk, then opened ``thinking`` at index 1; strict
+    Anthropic SDK clients with thinking enabled reject that stream with
+    "Content block is not a thinking block".
+    """
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=iter(_thinking_first_chunks()),
+        model="claude-x",
+    )
+    _assert_thinking_first_block_opens_at_index_zero(_drain_sync(wrapper))
+
+
+@pytest.mark.asyncio
+async def test_thinking_first_stream_opens_thinking_block_at_index_zero_async():
+    """Async twin of the Bug A regression; the proxy serves the async iterator,
+    so the first block must be ``thinking`` at index 0 on this path too.
+    """
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=_AsyncStream(_thinking_first_chunks()),
+        model="claude-x",
+    )
+    _assert_thinking_first_block_opens_at_index_zero(await _drain_async(wrapper))
+
+
+def _reasoning_content_chunk(reasoning: str) -> MagicMock:
+    return _make_chunk(Delta(content=None, reasoning_content=reasoning))
+
+
+def _reasoning_first_chunks() -> List[MagicMock]:
+    return [
+        _reasoning_content_chunk("Let me think"),
+        _reasoning_content_chunk("about it."),
+        _make_chunk(Delta(content="42")),
+        _make_chunk(Delta(content=None), finish_reason="stop"),
+    ]
+
+
+def test_reasoning_content_first_stream_opens_thinking_block_at_index_zero_sync():
+    """The reported backend (hosted_vllm; vLLM and SGLang reasoning parsers)
+    surfaces reasoning as OpenAI ``reasoning_content`` with no
+    ``thinking_blocks``. Such a stream must also open the first content block as
+    ``thinking`` at index 0, exercising the reasoning_content branch of the
+    chunk translator rather than the thinking_blocks branch the other twins use.
+    """
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=iter(_reasoning_first_chunks()),
+        model="claude-x",
+    )
+    _assert_thinking_first_block_opens_at_index_zero(_drain_sync(wrapper))

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
@@ -582,3 +582,86 @@ def test_reasoning_content_first_stream_opens_thinking_block_at_index_zero_sync(
         model="claude-x",
     )
     _assert_thinking_first_block_opens_at_index_zero(_drain_sync(wrapper))
+
+
+def _blank_lead_chunks() -> List[MagicMock]:
+    return [
+        _make_chunk(Delta(content=None)),
+        _thinking_chunk("Let me think"),
+        _thinking_chunk("about it."),
+        _make_chunk(Delta(content="42")),
+        _make_chunk(Delta(content=None), finish_reason="stop"),
+    ]
+
+
+def _role_only_reasoning_content_lead_chunks() -> List[MagicMock]:
+    return [
+        _make_chunk(Delta(role="assistant", content=None, tool_calls=[])),
+        _reasoning_content_chunk("Let me think"),
+        _reasoning_content_chunk("about it."),
+        _make_chunk(Delta(content="42")),
+        _make_chunk(Delta(content=None), finish_reason="stop"),
+    ]
+
+
+def test_contentless_lead_chunk_does_not_open_text_block_before_thinking_sync():
+    """OpenAI-compatible streaming backends open the response with a contentless
+    priming chunk (an empty delta, e.g. the {role: assistant} lead-in) before the
+    first real token. Such a lead chunk must NOT commit index 0 to an empty text
+    block; the following thinking chunk must still open thinking at index 0, or
+    strict Anthropic SDK clients reject the stream.
+    """
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=iter(_blank_lead_chunks()),
+        model="claude-x",
+    )
+    _assert_thinking_first_block_opens_at_index_zero(_drain_sync(wrapper))
+
+
+def test_role_only_lead_chunk_does_not_open_text_block_before_reasoning_content_sync():
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=iter(_role_only_reasoning_content_lead_chunks()),
+        model="claude-x",
+    )
+    _assert_thinking_first_block_opens_at_index_zero(_drain_sync(wrapper))
+
+
+@pytest.mark.asyncio
+async def test_contentless_lead_chunk_does_not_open_text_block_before_thinking_async():
+    """Async twin; the proxy serves the async iterator, so the contentless lead
+    chunk must be skipped on this path too.
+    """
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=_AsyncStream(_blank_lead_chunks()),
+        model="claude-x",
+    )
+    _assert_thinking_first_block_opens_at_index_zero(await _drain_async(wrapper))
+
+
+@pytest.mark.asyncio
+async def test_role_only_lead_chunk_does_not_open_text_block_before_reasoning_content_async():
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=_AsyncStream(_role_only_reasoning_content_lead_chunks()),
+        model="claude-x",
+    )
+    _assert_thinking_first_block_opens_at_index_zero(await _drain_async(wrapper))
+
+
+def test_finish_first_chunk_is_not_deferred_sync():
+    """A stream whose first upstream chunk is already the finish event must not
+    be skipped by the blank-delta deferral. ``_is_blank_delta`` returns False
+    for a finish chunk so the message_delta still flows (with an empty text
+    block opened and closed first); without that guard the deferral would drop
+    the terminal event entirely.
+    """
+    chunks = [_make_chunk(Delta(content=None), finish_reason="stop")]
+    wrapper = AnthropicStreamWrapper(completion_stream=iter(chunks), model="claude-x")
+    events = _drain_sync(wrapper)
+
+    assert [e["type"] for e in events] == [
+        "message_start",
+        "content_block_start",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_parallel_tool_calls.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_parallel_tool_calls.py
@@ -134,13 +134,6 @@ def test_anthropic_stream_wrapper_single_tool_call():
     # Verify the expected sequence of chunk types
     expected_types = [
         "message_start",  # Initial message start
-        # TODO: for future contributors: if the initial content_block_start
-        # respects the upstream's starting chunk, the initial empty text block
-        # should be removed (and this test should be updated accordingly)
-        # ---------------------------------------------------------------------
-        "content_block_start",  # Initial empty text block start
-        "content_block_stop",  # End of empty text block
-        # ---------------------------------------------------------------------
         "content_block_start",  # Start of first tool_use content block
         "content_block_delta",  # {"city":
         "content_block_delta",  # "NY"}
@@ -196,13 +189,6 @@ def test_anthropic_stream_wrapper_back_to_back_tool_calls():
     # Verify the expected sequence of chunk types
     expected_types = [
         "message_start",  # Initial message start
-        # TODO: for future contributors: if the initial content_block_start
-        # respects the upstream's starting chunk, the initial empty text block
-        # should be removed (and this test should be updated accordingly)
-        # ---------------------------------------------------------------------
-        "content_block_start",  # Initial empty text block start
-        "content_block_stop",  # End of empty text block
-        # ---------------------------------------------------------------------
         "content_block_start",  # Start of first tool_use content block
         "content_block_delta",  # {"city":
         "content_block_delta",  # "NY"}
@@ -267,13 +253,6 @@ def test_anthropic_stream_wrapper_interleaved_tool_calls_and_text():
     # Verify the expected sequence of chunk types
     expected_types = [
         "message_start",  # Initial message start
-        # TODO: for future contributors: if the initial content_block_start
-        # respects the upstream's starting chunk, the initial empty text block
-        # should be removed (and this test should be updated accordingly)
-        # ---------------------------------------------------------------------
-        "content_block_start",  # Initial empty text block start
-        "content_block_stop",  # End of empty text block
-        # ---------------------------------------------------------------------
         "content_block_start",  # Start of first tool_use content block
         "content_block_delta",  # {"city":
         "content_block_delta",  # "NY"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- The Anthropic `/v1/messages` pass-through adapter emitted a hardcoded empty `text` block at index 0 before reading any upstream chunk
- When a reasoning model led with thinking, thinking then opened at index 1, leaving a spurious empty text block at index 0 that strict Anthropic SDK clients with extended thinking reject with "Content block is not a thinking block"

How it solves it:

- Defer the first `content_block_start` until the first upstream chunk arrives, and open index 0 with that chunk's real type (text, thinking, or tool_use)
- Mirror the change across the sync `__next__` and async `__anext__` paths

## Relevant issues

Fixes #29518. Relates to #30043, the umbrella report for Claude Code to vLLM streaming through this adapter.

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review 

## Proof of Fix

Reproduce against a live proxy fronting a reasoning backend. Launch the proxy, then stream a thinking-enabled request:

```
curl -sS -N http://localhost:4000/v1/messages \
-H "x-api-key: <key>" \
-H "anthropic-version: 2023-06-01" \
-H "content-type:application/json" \
-d '{"model":"<reasoning-model>","max_tokens":2048,"stream":true,"thinking":{"type":"enabled","budget_tokens":1024},"messages":[{"role":"user","content":"Write a python function that adds two numbers."}]}'
```

Before the fix the `content_block_start` order is text at index 0 (empty, followed by an empty `text_delta` and a `content_block_stop`), then thinking at index 1, then the answer text at index 2. After the fix the first `content_block_start` is thinking at index 0 with no leading text block, and the answer text follows at index 1.

## Type

🐛 Bug Fix

## Changes

In `litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py`, `AnthropicStreamWrapper` previously unconditionally queued a `content_block_start` with a hardcoded `{"type": "text", "text": ""}` body before the main loop consumed any upstream chunk. That committed the first block to `text` regardless of what the model actually emitted first.

The fix removes that pre-emit gate. The main loop now opens the first content block lazily on the first real upstream chunk, using that chunk's translated type at index 0, with no preceding `content_block_stop` and no index increment. The existing block-transition branch is additionally guarded with `not is_opening_first_block` so the first block is never emitted a second time as a transition. The same change is applied to both the sync `__next__` and async `__anext__` paths.

This preserves every adjacent behaviour. The `_delta_has_content` re-emit still returns the first token of each block (#30014), empty deltas are still suppressed (#33315), the compaction block still owns its own index lifecycle ahead of the main loop, and text-first, tool_use-first, and thinking-first responses each still open the correct block type at index 0.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

## Maintainer live verification

A/B against a live proxy at the merge base (712136d10d) and at this head (4279e1459d), each side launched from its own worktree with the loaded litellm module path asserted, fronting real gemini/gemini-2.5-flash with no mocks. Observed /v1/messages streaming block orderings:

```
thinking enabled   base: text@0 (empty) -> thinking@1 -> text@2    head: thinking@0 -> text@1
forced tool call   base: text@0 (empty) -> tool_use@1              head: tool_use@0
plain text         base: text@0                                    head: text@0 (unchanged)
```

The head ordering matches the real Anthropic API captured the same day: claude-sonnet-4-6 with thinking enabled streams thinking@0 -> text@1 and a forced tool call streams tool_use@0, and Claude on Bedrock produces the same shapes. The anthropic Python SDK (0.120.2) pointed at the head proxy accepts the stream and assembles the thinking and text blocks with stop_reason and usage intact

A second pass with a dedicated Postgres per side shows spend rows written identically for every leg (streaming and non-streaming, plus chat completions), and key create -> use -> info -> delete -> 401 behaves the same on both sides. Merging current litellm_internal_staging into this head is conflict free and the same scenarios behave identically on the merged tree. The changed lines in streaming_iterator.py all sit inside the mapped unit suite's coverage (542 tests passing at head)

One adjacent observation, present on the merge base as well as on this head and therefore unrelated to this PR: a Bedrock guardrail in post_call mode applied to a streaming /v1/messages request on this adapter path returns 500 because the guardrail streaming hook passes SSE bytes into stream_chunk_builder; tracked separately

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core streaming SSE ordering for the Anthropic pass-through adapter, but scope is limited to first-block handling with broad regression tests; wrong edge-case handling could still break Claude Code or tool-call streams.
> 
> **Overview**
> Fixes reasoning-first and tool-first `/v1/messages` streams where the adapter used to **always** emit an empty `text` `content_block_start` at index 0 before reading upstream chunks, pushing real `thinking` or `tool_use` blocks to index 1 and breaking strict Anthropic SDK clients.
> 
> **`AnthropicStreamWrapper`** (sync `__next__` and async `__anext__`) now opens the first block **lazily** on the first meaningful upstream chunk, using `current_content_block_start` from translation instead of a hardcoded empty text block. **Blank priming deltas** (empty content, role-only lead-ins) are skipped via new **`_is_blank_delta`** so they do not lock index 0 to text. The block-transition path is gated with **`not is_opening_first_block`** so the first block is not closed/re-opened as a spurious transition.
> 
> Tests cover thinking-first (`thinking_blocks` and `reasoning_content`), contentless leads, finish-only first chunks, and updated parallel tool-call expectations (no leading empty text block).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4279e1459d015692bc94c6f11c5d74dc18971506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->