### PR TITLE
feat(ui): show in the log drawer and session sidebar when an auto-router served a request

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -4318,7 +4318,7 @@
   },
   "src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx": {
     "no-nested-ternary": {
-      "count": 3
+      "count": 2
     },
     "no-restricted-imports": {
       "count": 1

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.test.ts
@@ -3,13 +3,17 @@ import { renderHook, waitFor } from "@testing-library/react";
 import React, { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  isAutoRouterDeployment,
+  selectAutoRouterModelGroups,
   useAllProxyModels,
+  useAutoRouterModelGroups,
   useInfiniteModelInfo,
   useModelHub,
   useModelsInfo,
   useSelectedTeamModels,
   useUserModels,
   type AllProxyModelsResponse,
+  type AutoRouterCandidateDeployment,
   type PaginatedModelInfoResponse,
   type ProxyModel,
 } from "./useModels";
@@ -916,5 +920,163 @@ describe("useInfiniteModelInfo", () => {
     expect(result.current.data).toBeUndefined();
     expect(result.current.isFetched).toBe(false);
     expect(modelInfoCall).not.toHaveBeenCalled();
+  });
+});
+
+describe("isAutoRouterDeployment", () => {
+  const cases: [string, string | null | undefined, boolean][] = [
+    ["base semantic auto-router", "auto_router/my_router", true],
+    ["complexity router", "auto_router/complexity_router", true],
+    ["adaptive router", "auto_router/adaptive_router", true],
+    ["quality router", "auto_router/quality_router", true],
+    ["plain provider alias", "anthropic/claude-haiku-4-5", false],
+    ["wildcard deployment", "openai/*", false],
+    ["name merely containing the prefix", "openai/auto_router/nope", false],
+    ["missing model", undefined, false],
+    ["null model", null, false],
+  ];
+
+  it.each(cases)("returns %s -> %s", (_label, litellmParamsModel, expected) => {
+    expect(isAutoRouterDeployment({ model_name: "some-group", litellm_params: { model: litellmParamsModel } })).toBe(
+      expected,
+    );
+  });
+
+  it("returns false when litellm_params is absent", () => {
+    expect(isAutoRouterDeployment({ model_name: "some-group" })).toBe(false);
+  });
+});
+
+describe("selectAutoRouterModelGroups", () => {
+  it("keeps only the public model_name of auto-router deployments", () => {
+    const deployments: AutoRouterCandidateDeployment[] = [
+      { model_name: "smart-router", litellm_params: { model: "auto_router/complexity_router" } },
+      { model_name: "claude-haiku", litellm_params: { model: "anthropic/claude-haiku-4-5" } },
+      { model_name: "claude-sonnet", litellm_params: { model: "anthropic/claude-sonnet-4-5" } },
+      { model_name: "cheap-router", litellm_params: { model: "auto_router/adaptive_router" } },
+    ];
+
+    expect(selectAutoRouterModelGroups(deployments)).toEqual(new Set(["smart-router", "cheap-router"]));
+  });
+
+  it("drops auto-router deployments that have no public model_name", () => {
+    expect(
+      selectAutoRouterModelGroups([{ model_name: "", litellm_params: { model: "auto_router/complexity_router" } }]),
+    ).toEqual(new Set());
+  });
+
+  it("returns an empty set for an empty model list", () => {
+    expect(selectAutoRouterModelGroups([])).toEqual(new Set());
+  });
+});
+
+describe("useAutoRouterModelGroups", () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.clearAllMocks();
+    mockUseAuthorized.mockReturnValue({
+      accessToken: "test-access-token",
+      userId: "test-user-id",
+      userRole: "Admin",
+      token: "test-token",
+      userEmail: "test@example.com",
+      premiumUser: false,
+      disabledPersonalKeyCreation: null,
+      showSSOBanner: false,
+    });
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  it("resolves the set of auto-router model groups from the deployment list", async () => {
+    (modelInfoCall as any).mockResolvedValue({
+      data: [
+        { model_name: "smart-router", litellm_params: { model: "auto_router/complexity_router" } },
+        { model_name: "claude-haiku", litellm_params: { model: "anthropic/claude-haiku-4-5" } },
+      ],
+      total_count: 2,
+      current_page: 1,
+      total_pages: 1,
+      size: 1000,
+    });
+
+    const { result } = renderHook(() => useAutoRouterModelGroups(), { wrapper });
+
+    await waitFor(() => expect(result.current.size).toBe(1));
+    expect(result.current.has("smart-router")).toBe(true);
+    expect(result.current.has("claude-haiku")).toBe(false);
+  });
+
+  it("requests a single large page when the proxy reports only one page of deployments", async () => {
+    (modelInfoCall as any).mockResolvedValue({
+      data: [],
+      total_count: 0,
+      current_page: 1,
+      total_pages: 1,
+      size: 1000,
+    });
+
+    renderHook(() => useAutoRouterModelGroups(), { wrapper });
+
+    await waitFor(() => expect(modelInfoCall).toHaveBeenCalled());
+    expect(modelInfoCall).toHaveBeenCalledWith("test-access-token", "test-user-id", "Admin", 1, 1000);
+    expect(modelInfoCall).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows total_pages so an auto-router past the first page is still found", async () => {
+    (modelInfoCall as any).mockImplementation((_t: string, _u: string, _r: string, page: number) => {
+      if (page === 1) {
+        return Promise.resolve({
+          data: [{ model_name: "claude-haiku", litellm_params: { model: "anthropic/claude-haiku-4-5" } }],
+          total_count: 3,
+          current_page: 1,
+          total_pages: 3,
+          size: 1000,
+        });
+      }
+      if (page === 2) {
+        return Promise.resolve({
+          data: [{ model_name: "claude-sonnet", litellm_params: { model: "anthropic/claude-sonnet-4-5" } }],
+          total_count: 3,
+          current_page: 2,
+          total_pages: 3,
+          size: 1000,
+        });
+      }
+      return Promise.resolve({
+        data: [{ model_name: "late-router", litellm_params: { model: "auto_router/complexity_router" } }],
+        total_count: 3,
+        current_page: 3,
+        total_pages: 3,
+        size: 1000,
+      });
+    });
+
+    const { result } = renderHook(() => useAutoRouterModelGroups(), { wrapper });
+
+    await waitFor(() => expect(result.current.size).toBe(1));
+    expect(result.current.has("late-router")).toBe(true);
+    expect(modelInfoCall).toHaveBeenCalledTimes(3);
+    expect(modelInfoCall).toHaveBeenCalledWith("test-access-token", "test-user-id", "Admin", 3, 1000);
+  });
+
+  it("returns an empty set before the model list resolves", () => {
+    (modelInfoCall as any).mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useAutoRouterModelGroups(), { wrapper });
+
+    expect(result.current.size).toBe(0);
+  });
+
+  it("returns an empty set when the model list request fails", async () => {
+    (modelInfoCall as any).mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useAutoRouterModelGroups(), { wrapper });
+
+    await waitFor(() => expect(modelInfoCall).toHaveBeenCalled());
+    expect(result.current.size).toBe(0);
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/models/useModels.ts
@@ -24,6 +24,7 @@ export interface PaginatedModelInfoResponse {
 
 const modelKeys = createQueryKeys("models");
 const modelHubKeys = createQueryKeys("modelHub");
+const autoRouterKeys = createQueryKeys("autoRouterModelGroups");
 const allProxyModelsKeys = createQueryKeys("allProxyModels");
 const selectedTeamModelsKeys = createQueryKeys("selectedTeamModels");
 const infiniteModelKeys = createQueryKeys("infiniteModels");
@@ -57,6 +58,65 @@ export const useModelsInfo = (
       await modelInfoCall(accessToken!, userId!, userRole!, page, size, search, modelId, teamId, sortBy, sortOrder),
     enabled: Boolean(accessToken && userId && userRole),
   });
+};
+
+const AUTO_ROUTER_MODEL_PREFIX = "auto_router/";
+const AUTO_ROUTER_LOOKUP_PAGE_SIZE = 1000;
+const NO_AUTO_ROUTERS: ReadonlySet<string> = new Set<string>();
+
+export interface AutoRouterCandidateDeployment {
+  model_name?: string | null;
+  litellm_params?: { model?: string | null } | null;
+}
+
+export const isAutoRouterDeployment = (deployment: AutoRouterCandidateDeployment): boolean =>
+  Boolean(deployment?.litellm_params?.model?.startsWith(AUTO_ROUTER_MODEL_PREFIX));
+
+export const selectAutoRouterModelGroups = (deployments: AutoRouterCandidateDeployment[]): ReadonlySet<string> =>
+  new Set(
+    deployments
+      .filter(isAutoRouterDeployment)
+      .map((deployment) => deployment.model_name)
+      .filter((modelName): modelName is string => Boolean(modelName)),
+  );
+
+const fetchAllModelDeployments = async (
+  accessToken: string,
+  userId: string,
+  userRole: string,
+): Promise<AutoRouterCandidateDeployment[]> => {
+  const firstPage: PaginatedModelInfoResponse = await modelInfoCall(
+    accessToken,
+    userId,
+    userRole,
+    1,
+    AUTO_ROUTER_LOOKUP_PAGE_SIZE,
+  );
+  const totalPages = firstPage?.total_pages ?? 1;
+  const remainingPages = await Promise.all(
+    Array.from({ length: Math.max(0, totalPages - 1) }, (_unused, index) =>
+      modelInfoCall(accessToken, userId, userRole, index + 2, AUTO_ROUTER_LOOKUP_PAGE_SIZE),
+    ),
+  );
+  return [firstPage, ...remainingPages].flatMap(
+    (page: PaginatedModelInfoResponse) => page?.data ?? [],
+  ) as AutoRouterCandidateDeployment[];
+};
+
+export const useAutoRouterModelGroups = (): ReadonlySet<string> => {
+  const { accessToken, userId, userRole } = useAuthorized();
+  const { data } = useQuery<AutoRouterCandidateDeployment[], Error, ReadonlySet<string>>({
+    queryKey: autoRouterKeys.list({
+      filters: {
+        ...(userId && { userId }),
+        ...(userRole && { userRole }),
+      },
+    }),
+    queryFn: async () => await fetchAllModelDeployments(accessToken!, userId!, userRole!),
+    enabled: Boolean(accessToken && userId && userRole),
+    select: selectAutoRouterModelGroups,
+  });
+  return data ?? NO_AUTO_ROUTERS;
 };
 
 export const useModelHub = () => {

--- a/ui/litellm-dashboard/src/components/shared/table_cells/AutoRouterTag.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/AutoRouterTag.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { AutoRouterModelGroupsProvider, AutoRouterTag } from "./AutoRouterTag";
+
+vi.mock("@/app/(dashboard)/hooks/models/useModels", () => ({
+  useAutoRouterModelGroups: vi.fn(),
+}));
+
+import { useAutoRouterModelGroups } from "@/app/(dashboard)/hooks/models/useModels";
+
+const mockUseAutoRouterModelGroups = vi.mocked(useAutoRouterModelGroups);
+
+const renderInProvider = (ui: React.ReactNode) =>
+  render(<AutoRouterModelGroupsProvider>{ui}</AutoRouterModelGroupsProvider>);
+
+describe("AutoRouterTag", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("names the router that served the request", () => {
+    mockUseAutoRouterModelGroups.mockReturnValue(new Set(["smart-router"]));
+
+    renderInProvider(<AutoRouterTag modelGroup="smart-router" />);
+
+    const tag = screen.getByTitle('Routed by auto-router "smart-router"');
+    expect(tag).toHaveTextContent("smart-router");
+    expect(tag.querySelector("svg")).not.toBeNull();
+  });
+
+  it("does not tag a plain alias whose model group differs from the resolved model", () => {
+    mockUseAutoRouterModelGroups.mockReturnValue(new Set(["smart-router"]));
+
+    renderInProvider(<AutoRouterTag modelGroup="claude-haiku" />);
+
+    expect(screen.queryByText("claude-haiku")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing while the model list is unavailable, so a routed row is never mislabelled", () => {
+    mockUseAutoRouterModelGroups.mockReturnValue(new Set<string>());
+
+    const { container } = renderInProvider(<AutoRouterTag modelGroup="smart-router" />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it.each([[undefined], [null], [""]])("renders nothing when the row carries no model group (%s)", (modelGroup) => {
+    mockUseAutoRouterModelGroups.mockReturnValue(new Set(["smart-router"]));
+
+    const { container } = renderInProvider(<AutoRouterTag modelGroup={modelGroup} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing outside a provider instead of requiring a QueryClient", () => {
+    const { container } = render(<AutoRouterTag modelGroup="smart-router" />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockUseAutoRouterModelGroups).not.toHaveBeenCalled();
+  });
+});

--- a/ui/litellm-dashboard/src/components/shared/table_cells/AutoRouterTag.tsx
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/AutoRouterTag.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+import { Waypoints } from "lucide-react";
+
+import { useAutoRouterModelGroups } from "@/app/(dashboard)/hooks/models/useModels";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/cva.config";
+
+const NO_AUTO_ROUTERS: ReadonlySet<string> = new Set<string>();
+
+const AutoRouterModelGroupsContext = createContext<ReadonlySet<string>>(NO_AUTO_ROUTERS);
+
+export function AutoRouterModelGroupsProvider({ children }: { children: ReactNode }) {
+  const autoRouterModelGroups = useAutoRouterModelGroups();
+
+  return (
+    <AutoRouterModelGroupsContext.Provider value={autoRouterModelGroups}>
+      {children}
+    </AutoRouterModelGroupsContext.Provider>
+  );
+}
+
+export function useIsAutoRoutedModelGroup(modelGroup?: string | null): boolean {
+  const autoRouterModelGroups = useContext(AutoRouterModelGroupsContext);
+
+  return Boolean(modelGroup) && autoRouterModelGroups.has(modelGroup as string);
+}
+
+export function AutoRouterIcon({ size = 12, className }: { size?: number; className?: string }) {
+  return <Waypoints size={size} className={className} aria-hidden />;
+}
+
+export interface AutoRouterTagProps {
+  modelGroup?: string | null;
+  className?: string;
+}
+
+export function AutoRouterTag({ modelGroup, className }: AutoRouterTagProps) {
+  const isAutoRouted = useIsAutoRoutedModelGroup(modelGroup);
+
+  if (!isAutoRouted) return null;
+
+  return (
+    <Badge
+      variant="secondary"
+      title={`Routed by auto-router "${modelGroup}"`}
+      className={cn("gap-1.5 px-2.5 py-1 text-sm font-normal text-foreground", className)}
+    >
+      <Waypoints aria-hidden />
+      {modelGroup}
+    </Badge>
+  );
+}

--- a/ui/litellm-dashboard/src/components/shared/table_cells/index.ts
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/index.ts
@@ -1,3 +1,10 @@
+export {
+  AutoRouterTag,
+  AutoRouterIcon,
+  AutoRouterModelGroupsProvider,
+  useIsAutoRoutedModelGroup,
+  type AutoRouterTagProps,
+} from "./AutoRouterTag";
 export { CellTooltip } from "./cell_tooltip";
 export { DateCell, formatCellDate, formatFullTimestamp, type DatePrecision } from "./date_cell";
 export { IdCell, type IdCellVariant } from "./id_cell";

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/DrawerHeader.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/DrawerHeader.tsx
@@ -2,6 +2,7 @@ import { Button, Space, Tag, Tooltip, Typography } from "antd";
 import { CloseOutlined, UpOutlined, DownOutlined } from "@ant-design/icons";
 import moment from "moment";
 import { LogEntry } from "../columns";
+import { AutoRouterTag } from "@/components/shared/table_cells";
 import { getProviderLogoAndName } from "../../provider_info_helpers";
 import {
   DRAWER_HEADER_PADDING,
@@ -57,6 +58,7 @@ export function DrawerHeader({
       {/* Row 0: Model + Provider with Logo */}
       <ModelProviderSection
         model={log.model}
+        modelGroup={log.model_group}
         providerLogo={providerInfo?.logo}
         providerName={providerInfo?.displayName}
       />
@@ -80,10 +82,12 @@ export function DrawerHeader({
  */
 function ModelProviderSection({
   model,
+  modelGroup,
   providerLogo,
   providerName,
 }: {
   model: string;
+  modelGroup?: string;
   providerLogo?: string;
   providerName?: string;
 }) {
@@ -109,6 +113,7 @@ function ModelProviderSection({
             {providerName}
           </Text>
         )}
+        <AutoRouterTag modelGroup={modelGroup} />
       </Space>
     </Space>
   );

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { LogDetailsDrawer } from "./LogDetailsDrawer";
 import { sessionSpendLogsCall } from "../../networking";
 import { LogEntry } from "../columns";
+import { AutoRouterModelGroupsProvider } from "@/components/shared/table_cells";
 
 vi.mock("../../networking", () => ({
   sessionSpendLogsCall: vi.fn(),
@@ -20,6 +21,10 @@ vi.mock("./LogDetailContent", () => ({
 
 vi.mock("./DrawerHeader", () => ({
   DrawerHeader: () => null,
+}));
+
+vi.mock("@/app/(dashboard)/hooks/models/useModels", () => ({
+  useAutoRouterModelGroups: vi.fn(() => new Set(["smart-router"])),
 }));
 
 const makeLog = (overrides: Partial<LogEntry>): LogEntry => ({
@@ -116,5 +121,46 @@ describe("LogDetailsDrawer session sidebar sorting", () => {
     rerender(drawer(true));
 
     await waitFor(() => expect(sidebarEventNames()).toEqual(["tool-early", "llm-late", "llm-early", "tool-late"]));
+  });
+});
+
+describe("LogDetailsDrawer session sidebar auto-router icon", () => {
+  const routedSessionLogs = [
+    makeLog({ request_id: "routed", model: "claude-opus-4-8", model_group: "smart-router" }),
+    makeLog({ request_id: "direct", model: "claude-haiku-4-5", model_group: "claude-haiku" }),
+  ];
+
+  const renderRoutedSession = () => {
+    vi.mocked(sessionSpendLogsCall).mockResolvedValue({ data: routedSessionLogs, total: 2, total_pages: 1 });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <AutoRouterModelGroupsProvider>
+          <LogDetailsDrawer open onClose={() => {}} logEntry={null} sessionId="session-1" accessToken="token" />
+        </AutoRouterModelGroupsProvider>
+      </QueryClientProvider>,
+    );
+  };
+
+  const rowFor = (label: string): HTMLElement => {
+    const row = Array.from(document.body.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes(label),
+    );
+    if (!row) throw new Error(`no sidebar row for ${label}`);
+    return row;
+  };
+
+  it("marks the auto-routed entry with the router icon and leaves a direct call on the default icon", async () => {
+    renderRoutedSession();
+
+    await waitFor(() => expect(screen.queryByText("claude-opus-4-8")).not.toBeNull());
+
+    const routedRow = rowFor("claude-opus-4-8");
+    const directRow = rowFor("claude-haiku-4-5");
+
+    expect(routedRow.querySelector(".lucide-waypoints")).not.toBeNull();
+    expect(routedRow.querySelector(".lucide-sparkles")).toBeNull();
+    expect(directRow.querySelector(".lucide-sparkles")).not.toBeNull();
+    expect(directRow.querySelector(".lucide-waypoints")).toBeNull();
   });
 });

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -3,6 +3,7 @@ import { Button, Drawer, Segmented } from "antd";
 import { CheckOutlined, CopyOutlined, LeftOutlined, RightOutlined } from "@ant-design/icons";
 import { Bot, Sparkles, Wrench } from "lucide-react";
 import { LogEntry } from "../columns";
+import { AutoRouterIcon, useIsAutoRoutedModelGroup } from "@/components/shared/table_cells";
 import { AGENT_CALL_TYPES, MCP_CALL_TYPES } from "../constants";
 import { getEventDisplayName } from "../utils";
 import { DrawerHeader } from "./DrawerHeader";
@@ -46,9 +47,17 @@ interface TraceEventRowProps {
   onClick: () => void;
 }
 
+const TRACE_EVENT_ICON_CLASS = "text-slate-500 shrink-0";
+
+function TraceEventIcon({ callType, isAutoRouted }: { callType: string; isAutoRouted: boolean }) {
+  if (MCP_CALL_TYPES.includes(callType)) return <Wrench size={12} className={TRACE_EVENT_ICON_CLASS} />;
+  if (AGENT_CALL_TYPES.includes(callType)) return <Bot size={12} className={TRACE_EVENT_ICON_CLASS} />;
+  if (isAutoRouted) return <AutoRouterIcon size={12} className={TRACE_EVENT_ICON_CLASS} />;
+  return <Sparkles size={12} className={TRACE_EVENT_ICON_CLASS} />;
+}
+
 function TraceEventRow({ row, isSelected, onClick }: TraceEventRowProps) {
-  const isMcp = MCP_CALL_TYPES.includes(row.call_type);
-  const isAgent = AGENT_CALL_TYPES.includes(row.call_type);
+  const isAutoRouted = useIsAutoRoutedModelGroup(row.model_group);
   const durationValue =
     row.request_duration_ms != null
       ? (row.request_duration_ms / 1000).toFixed(3)
@@ -65,13 +74,7 @@ function TraceEventRow({ row, isSelected, onClick }: TraceEventRowProps) {
       onClick={onClick}
     >
       <div className="flex items-center gap-1">
-        {isMcp ? (
-          <Wrench size={12} className="text-slate-500 shrink-0" />
-        ) : isAgent ? (
-          <Bot size={12} className="text-slate-500 shrink-0" />
-        ) : (
-          <Sparkles size={12} className="text-slate-500 shrink-0" />
-        )}
+        <TraceEventIcon callType={row.call_type} isAutoRouted={isAutoRouted} />
         <span className="text-xs font-medium text-slate-900 truncate">
           {getEventDisplayName(row.call_type, row.model)}
         </span>

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
@@ -5,6 +5,7 @@ import type { ColumnFiltersState, OnChangeFn, PaginationState, SortingState } fr
 import moment from "moment";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { AutoRouterModelGroupsProvider } from "@/components/shared/table_cells";
 import { internalUserRoles } from "../../utils/roles";
 import type { KeyResponse } from "../key_team_helpers/key_list";
 import { keyInfoV1Call } from "../networking";
@@ -202,7 +203,7 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
   }
 
   return (
-    <>
+    <AutoRouterModelGroupsProvider>
       <div className="flex items-center justify-between mb-4">
         <h1 className="text-xl font-semibold">Request Logs</h1>
       </div>
@@ -259,6 +260,6 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
         onSelectLog={setSelectedLog}
         startTime={moment(startTime).utc().format("YYYY-MM-DD HH:mm:ss")}
       />
-    </>
+    </AutoRouterModelGroupsProvider>
   );
 }

--- a/ui/litellm-dashboard/src/components/view_logs/columns.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/columns.tsx
@@ -16,6 +16,7 @@ export type LogEntry = {
   team_id: string;
   model: string;
   model_id: string;
+  model_group?: string;
   api_base?: string;
   call_type: string;
   spend: number;


### PR DESCRIPTION
## TLDR

Problem this solves:

- The logs already show which model served a request, but nothing shows that an auto-router picked it
- The requested name is already on every spend-log row as `model_group`, and both UI endpoints already return it; the dashboard type dropped the field

How it solves it:

- The request drawer header names the router in a badge, and the session sidebar swaps that entry's leading icon
- Decides "is this an auto-router" from the deployment list rather than from `model_group != model`, which is true for ordinary aliases too

## Relevant issues

- Makes it visible in the request drawer and the session view that an auto-router chose the model
- Reads the auto-router set once per logs tree and shares it through context, so the two surfaces cannot disagree
- No backend, schema or migration change; the data was already on the wire

## Linear ticket

Resolves LIT-4748

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran a local proxy against real Anthropic with one auto-router (`smart-router`, a complexity router over `claude-haiku` / `claude-sonnet` / `claude-opus`) plus two plain aliases, then read back what the UI endpoints serve

```bash
for M in smart-router claude-haiku claude-sonnet; do
  curl -s http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-lit4748" -H "Content-Type: application/json" \
    -d "{\"model\":\"$M\",\"messages\":[{\"role\":\"user\",\"content\":\"say hi in 3 words\"}],\"max_tokens\":20,\"litellm_session_id\":\"lit4748-demo\"}"
done

curl -s "http://localhost:4000/spend/logs/ui?page=1&page_size=5&start_date=2020-01-01%2000:00:00&end_date=2030-01-01%2000:00:00" \
  -H "Authorization: Bearer sk-lit4748"
```

Both `/spend/logs/ui` and `/spend/logs/session/ui` return `model_group` on every row

```
model_group='claude-sonnet' model='anthropic/claude-sonnet-4-5'
model_group='claude-haiku'  model='anthropic/claude-haiku-4-5'
model_group='smart-router'  model='anthropic/claude-haiku-4-5'
```

This is also why the indication is not driven by comparing the two columns. All three rows have `model_group != model`, because that is what a `model_name` alias is; only the third row went through an auto-router. The auto-routed row is otherwise indistinguishable server side, with the same `model_id` as the direct `claude-haiku` row and an identical `metadata` key set, so the requested name is matched against the deployments whose `litellm_params.model` starts with `auto_router/`

```
$ curl -s http://localhost:4000/v2/model/info -H "Authorization: Bearer <key>"
model_name='claude-haiku'  litellm_params.model='anthropic/claude-haiku-4-5'
model_name='claude-sonnet' litellm_params.model='anthropic/claude-sonnet-4-5'
model_name='claude-opus'   litellm_params.model='anthropic/claude-opus-4-8'
model_name='smart-router'  litellm_params.model='auto_router/complexity_router'
```

Verified that a non-admin virtual key gets the same `litellm_params.model` values from that endpoint, so the indication renders for non-admins too

## Type

🆕 New Feature

## Changes

- `LogEntry` carries `model_group`, and `useAutoRouterModelGroups` resolves the set of auto-router model groups from every page of `/v2/model/info`, keyed on the `auto_router/` prefix so complexity, adaptive and quality routers are all covered
- New `AutoRouterTag` and `AutoRouterModelGroupsProvider` in `shared/table_cells`, mounted once in the logs panel so both surfaces share one lookup
- Drawer header shows a badge naming the router next to the provider; the session sidebar entry swaps its leading icon
- `TraceEventRow`'s icon choice moves into a small `TraceEventIcon` with early returns, which drops two grandfathered `no-nested-ternary` suppressions
- Nothing renders when the model list has not loaded, when the request failed, or outside the provider, so a row is never mislabelled

Things a reviewer will ask about

The indication is a lookup rather than a string comparison because `model_group != model` holds for every plain alias and every wildcard deployment, so a mismatch-based badge would fire on nearly every row and single out nothing. `AutoRouterTag` reads its set from context with an empty-set default instead of calling the query hook itself, so any consumer outside a provider keeps rendering without a `QueryClient`

Left alone deliberately: `model_info_view.tsx` and `edit_auto_router_modal.tsx` hand-roll a narrower `auto_router/complexity_router` check. That asks a different question, namely whether the complexity-router edit UI applies, and widening it to the general prefix would wrongly show that UI for adaptive and quality routers

## QA runbook

1. Start a proxy with an auto-router and at least one plain alias, for example a `smart-router` model whose `litellm_params.model` is `auto_router/complexity_router` alongside a `claude-haiku` model whose `litellm_params.model` is `anthropic/claude-haiku-4-5`
2. Send three requests so there is one routed row and two direct rows, passing the same `litellm_session_id` on all three so they group into one session

```bash
for M in smart-router claude-haiku claude-sonnet; do
  curl -s http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d "{\"model\":\"$M\",\"messages\":[{\"role\":\"user\",\"content\":\"say hi in 3 words\"}],\"max_tokens\":20,\"litellm_session_id\":\"lit4748-demo\"}"
done
```

3. Go to http://localhost:4000/ui/?page=logs and click the `smart-router` row. The drawer header shows the resolved model, the provider, then a badge naming `smart-router`
4. Click a `claude-haiku` or `claude-sonnet` row. The header shows no badge, exactly as before this PR
5. Click the session id to open the session view. In the left trace list the auto-routed entry carries the router icon while the two direct entries keep the default icon
6. Remove the auto-router from the config and reload. Every row and every session entry renders exactly as before this PR

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only, read-only UI over existing log and model-info APIs; mislabeling is avoided by not rendering until the router set is known.
> 
> **Overview**
> Request logs now surface **auto-router** routing in the drawer header and session trace sidebar, using `model_group` from spend-log rows and a shared deployment lookup instead of comparing requested vs resolved model names.
> 
> **`LogEntry`** gains optional **`model_group`**. **`useAutoRouterModelGroups`** loads all pages of `/v2/model/info`, treats deployments whose `litellm_params.model` starts with `auto_router/` as routers, and exposes their public `model_name` set. **`AutoRouterModelGroupsProvider`** mounts once on the request logs panel so drawer header and sidebar share one cached lookup.
> 
> The drawer header shows an **`AutoRouterTag`** badge naming the router when `model_group` matches that set. Session sidebar rows use the waypoints icon for auto-routed entries (via **`TraceEventIcon`**). Tags and icons stay hidden while the lookup is loading, on failure, or outside the provider so rows are not mislabeled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42aba4f32a4238de6686d2a62c410d4eb6e5cdb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->