### PR TITLE
refactor(ui): extract shared tab-routing helpers and adopt them in Models + Endpoints

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1161,6 +1161,11 @@
       "count": 1
     }
   },
+  "src/app/(dashboard)/models-and-endpoints/layout.tsx": {
+    "no-restricted-imports": {
+      "count": 1
+    }
+  },
   "src/app/(dashboard)/models-and-endpoints/utils/modelDataTransformer.ts": {
     "prefer-const": {
       "count": 6

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useTabRouting.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useTabRouting.test.tsx
@@ -1,0 +1,82 @@
+/* @vitest-environment jsdom */
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockPush, navState } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  navState: { pathname: "/logs" },
+}));
+vi.mock("next/navigation", () => ({
+  usePathname: () => navState.pathname,
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("@/components/networking", () => ({ serverRootPath: "" }));
+
+import { createTabRoutes } from "@/utils/tabRoutes";
+import { useTabRouting } from "./useTabRouting";
+
+const routes = createTabRoutes("logs", ["audit", "deleted-keys", "deleted-teams"] as const);
+
+const render = (ready = true) => {
+  const config = {
+    routes,
+    baseTabKey: "request-logs",
+    visibleKeys: ["audit", "deleted-keys", "deleted-teams"],
+    ready,
+  };
+  return renderHook(() => useTabRouting(config));
+};
+
+describe("useTabRouting", () => {
+  beforeEach(() => {
+    navState.pathname = "/logs";
+    mockPush.mockClear();
+  });
+
+  it("maps the base path to the base tab key", () => {
+    const { result } = render();
+    expect(result.current.activeSlug).toBe("");
+    expect(result.current.activeKey).toBe("request-logs");
+  });
+
+  it("uses the slug itself as the active key for a known nested tab", () => {
+    navState.pathname = "/ui/logs/audit";
+    const { result } = render();
+    expect(result.current.activeKey).toBe("audit");
+  });
+
+  it("falls back to the base tab key for an unknown slug", () => {
+    navState.pathname = "/ui/logs/bogus";
+    const { result } = render();
+    expect(result.current.activeKey).toBe("request-logs");
+  });
+
+  it("redirects an unknown slug to the base href once ready", () => {
+    const replaceMock = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", { configurable: true, value: { replace: replaceMock } });
+    navState.pathname = "/ui/logs/bogus";
+    render(true);
+    expect(replaceMock).toHaveBeenCalledWith("/ui/logs/");
+    Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
+  });
+
+  it("does not redirect while not ready (role/creds still loading)", () => {
+    const replaceMock = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", { configurable: true, value: { replace: replaceMock } });
+    navState.pathname = "/ui/logs/bogus";
+    render(false);
+    expect(replaceMock).not.toHaveBeenCalled();
+    Object.defineProperty(window, "location", { configurable: true, value: originalLocation });
+  });
+
+  it("pushes the tab href on change, mapping the base key back to the empty slug", () => {
+    const { result } = render();
+    result.current.onTabChange("audit");
+    expect(mockPush).toHaveBeenCalledWith("/ui/logs/audit/");
+    result.current.onTabChange("request-logs");
+    expect(mockPush).toHaveBeenCalledWith("/ui/logs/");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useTabRouting.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useTabRouting.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import type { TabRoutes } from "@/utils/tabRoutes";
+
+interface UseTabRoutingArgs {
+  routes: Pick<TabRoutes<string>, "tabHref" | "slugFromPathname">;
+  baseTabKey: string;
+  visibleKeys: readonly string[];
+  ready?: boolean;
+}
+
+interface TabRoutingState {
+  activeSlug: string;
+  activeKey: string;
+  onTabChange: (key: string) => void;
+}
+
+export function useTabRouting({ routes, baseTabKey, visibleKeys, ready = true }: UseTabRoutingArgs): TabRoutingState {
+  const { tabHref, slugFromPathname } = routes;
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const activeSlug = slugFromPathname(pathname);
+  const isKnownSlug = activeSlug === "" || visibleKeys.includes(activeSlug);
+  const activeKey = isKnownSlug ? activeSlug || baseTabKey : baseTabKey;
+
+  useEffect(() => {
+    if (ready && activeSlug !== "" && !isKnownSlug) {
+      window.location.replace(tabHref(""));
+    }
+  }, [ready, activeSlug, isKnownSlug, tabHref]);
+
+  const onTabChange = (key: string) => {
+    router.push(tabHref(key === baseTabKey ? "" : key));
+  };
+
+  return { activeSlug, activeKey, onTabChange };
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/layout.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/layout.tsx
@@ -1,19 +1,19 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { useEffect, useMemo, useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { useMemo, useState } from "react";
 import { Tabs } from "antd";
 import { RefreshIcon } from "@heroicons/react/outline";
 import { useQueryClient } from "@tanstack/react-query";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { useTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
 import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings";
+import { useTabRouting } from "@/app/(dashboard)/hooks/useTabRouting";
 import { all_admin_roles, internalUserRoles, isProxyAdminRole, isUserTeamAdminForAnyTeam } from "@/utils/roles";
 import CostOptimizationFeedbackBanner from "@/components/molecules/cost_optimization_feedback_banner";
 import ModelInfoView from "@/components/model_info_view";
 import TeamInfoView from "@/components/team/TeamInfo";
-import { modelTabHref, slugFromPathname, type ModelTabSlug } from "@/app/(dashboard)/models-and-endpoints/tabRoutes";
+import { modelsRoutes, type ModelTabSlug } from "@/app/(dashboard)/models-and-endpoints/tabRoutes";
 import { useModelDetailRouting } from "@/app/(dashboard)/models-and-endpoints/detailNavigation";
 import { useModelDashboardData } from "@/app/(dashboard)/models-and-endpoints/useModelDashboardData";
 
@@ -33,8 +33,6 @@ export default function ModelsAndEndpointsLayout({ children }: { children: React
   const { accessToken, userRole, userId: userID, premiumUser } = useAuthorized();
   const { data: teams, isLoading: teamsLoading } = useTeams();
   const { data: uiSettings, isLoading: uiSettingsLoading } = useUISettings();
-  const pathname = usePathname();
-  const router = useRouter();
   const queryClient = useQueryClient();
   const { modelId, teamId, close } = useModelDetailRouting();
   const { availableModelAccessGroups, allModelsOnProxy } = useModelDashboardData();
@@ -60,18 +58,13 @@ export default function ModelsAndEndpointsLayout({ children }: { children: React
     [shouldHideAddModelTab, isAdmin],
   );
 
-  const activeSlug = slugFromPathname(pathname);
-  const isKnownSlug = visibleSlugs.some((slug) => slug === activeSlug);
-  const activeKey = isKnownSlug ? activeSlug || BASE_TAB_KEY : BASE_TAB_KEY;
-
-  useEffect(() => {
-    if (teamsLoading || uiSettingsLoading) {
-      return;
-    }
-    if (activeSlug !== "" && !isKnownSlug) {
-      window.location.replace(modelTabHref(""));
-    }
-  }, [activeSlug, isKnownSlug, teamsLoading, uiSettingsLoading]);
+  const tabRoutingConfig = {
+    routes: modelsRoutes,
+    baseTabKey: BASE_TAB_KEY,
+    visibleKeys: visibleSlugs.filter(Boolean),
+    ready: !teamsLoading && !uiSettingsLoading,
+  };
+  const { activeKey, onTabChange } = useTabRouting(tabRoutingConfig);
 
   const allModelsLabel = isAdmin ? "All Models" : "Your Models";
   const tabItems = visibleSlugs.map((slug) => {
@@ -137,7 +130,7 @@ export default function ModelsAndEndpointsLayout({ children }: { children: React
         ) : (
           <Tabs
             activeKey={activeKey}
-            onChange={(key) => router.push(modelTabHref(key === BASE_TAB_KEY ? "" : key))}
+            onChange={onTabChange}
             items={tabItems}
             tabBarExtraContent={{
               right: (

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/tabRoutes.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/tabRoutes.ts
@@ -1,8 +1,6 @@
-import { migratedHref } from "@/utils/migratedPages";
+import { createTabRoutes } from "@/utils/tabRoutes";
 
-export const MODELS_BASE_SEGMENT = "models-and-endpoints";
-
-export const MODEL_TAB_SLUGS = [
+export const modelsRoutes = createTabRoutes("models-and-endpoints", [
   "add",
   "llm-credentials",
   "pass-through",
@@ -10,20 +8,11 @@ export const MODEL_TAB_SLUGS = [
   "retry-settings",
   "model-group-alias",
   "price-data",
-] as const;
+] as const);
 
-export type ModelTabSlug = (typeof MODEL_TAB_SLUGS)[number];
+export type ModelTabSlug = (typeof modelsRoutes.slugs)[number];
 
-export function modelTabHref(slug: string): string {
-  const base = migratedHref(MODELS_BASE_SEGMENT);
-  return slug ? `${base}/${slug}/` : `${base}/`;
-}
-
-export function slugFromPathname(pathname: string): string {
-  const parts = pathname.split("/").filter(Boolean);
-  const idx = parts.indexOf(MODELS_BASE_SEGMENT);
-  if (idx === -1) {
-    return "";
-  }
-  return parts[idx + 1] ?? "";
-}
+export const MODELS_BASE_SEGMENT = modelsRoutes.baseSegment;
+export const MODEL_TAB_SLUGS = modelsRoutes.slugs;
+export const modelTabHref = modelsRoutes.tabHref;
+export const slugFromPathname = modelsRoutes.slugFromPathname;

--- a/ui/litellm-dashboard/src/utils/tabRoutes.test.ts
+++ b/ui/litellm-dashboard/src/utils/tabRoutes.test.ts
@@ -1,0 +1,47 @@
+/* @vitest-environment jsdom */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/networking", () => ({ serverRootPath: "" }));
+
+import { createTabRoutes } from "./tabRoutes";
+
+const routes = createTabRoutes("logs", ["audit", "deleted-keys", "deleted-teams"] as const);
+
+describe("createTabRoutes.slugFromPathname", () => {
+  it("returns empty string for the base path with or without a trailing slash", () => {
+    expect(routes.slugFromPathname("/logs")).toBe("");
+    expect(routes.slugFromPathname("/logs/")).toBe("");
+  });
+
+  it("extracts the tab slug from dev and proxy-mounted (/ui) paths", () => {
+    expect(routes.slugFromPathname("/logs/audit")).toBe("audit");
+    expect(routes.slugFromPathname("/ui/logs/deleted-teams/")).toBe("deleted-teams");
+  });
+
+  it("returns the raw segment for an unknown tab so the caller can redirect to base", () => {
+    expect(routes.slugFromPathname("/ui/logs/bogus")).toBe("bogus");
+  });
+
+  it("returns empty string when the base segment is not in the path", () => {
+    expect(routes.slugFromPathname("/teams")).toBe("");
+  });
+});
+
+describe("createTabRoutes.tabHref", () => {
+  it("builds the trailing-slash base href for the empty slug", () => {
+    expect(routes.tabHref("")).toBe("/ui/logs/");
+  });
+
+  it("builds a trailing-slash href for every tab slug (required by static export)", () => {
+    for (const slug of routes.slugs) {
+      expect(routes.tabHref(slug)).toBe(`/ui/logs/${slug}/`);
+    }
+  });
+});
+
+describe("createTabRoutes metadata", () => {
+  it("preserves the base segment and slug tuple", () => {
+    expect(routes.baseSegment).toBe("logs");
+    expect(routes.slugs).toEqual(["audit", "deleted-keys", "deleted-teams"]);
+  });
+});

--- a/ui/litellm-dashboard/src/utils/tabRoutes.ts
+++ b/ui/litellm-dashboard/src/utils/tabRoutes.ts
@@ -1,0 +1,26 @@
+import { migratedHref } from "@/utils/migratedPages";
+
+export interface TabRoutes<Slug extends string> {
+  baseSegment: string;
+  slugs: readonly Slug[];
+  tabHref: (slug: string) => string;
+  slugFromPathname: (pathname: string) => string;
+}
+
+export function createTabRoutes<Slug extends string>(baseSegment: string, slugs: readonly Slug[]): TabRoutes<Slug> {
+  const tabHref = (slug: string): string => {
+    const base = migratedHref(baseSegment);
+    return slug ? `${base}/${slug}/` : `${base}/`;
+  };
+
+  const slugFromPathname = (pathname: string): string => {
+    const parts = pathname.split("/").filter(Boolean);
+    const idx = parts.indexOf(baseSegment);
+    if (idx === -1) {
+      return "";
+    }
+    return parts[idx + 1] ?? "";
+  };
+
+  return { baseSegment, slugs, tabHref, slugFromPathname };
+}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every per-tab-routed page copy-pastes the same URL<->slug logic and active-tab/redirect engine
- Starting from Models so the hardest consumer (role-gating + gated redirect) validates the shared code

How it solves it:

- Extract `createTabRoutes()` + `useTabRouting()` as reusable helpers
- Migrate Models + Endpoints onto them with behavior preserved
- Existing Models tests pass unchanged as the regression net

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Behavior-preserving refactor; the check is that Models + Endpoints still behaves exactly as before. Steps against a live proxy:

1. Build the dashboard and serve it through the proxy, then open http://localhost:4000/ui/?page=models
2. Click through the tabs (All Models, Add Model, LLM Credentials, Pass-Through, Health Status, Model Retry Settings, Model Group Alias, Price Data Reload); the address bar tracks each tab and a hard refresh on any of them reloads onto that tab
3. As a non-admin, hard-load a forbidden tab like /ui/models-and-endpoints/llm-credentials and confirm you land back on the base All Models tab only after auth resolves (not a flash-then-bounce)
4. Open a model row (the ?model= drill-in) and use Back to return to the tab; open a team the same way (?team=). Both still work
5. Confirm the export still prerenders every tab: `out/models-and-endpoints/index.html`, `.../add/index.html`, `.../health/index.html`, etc.

Screenshots to be attached.

## Type

🧹 Refactoring

## Changes

Per-tab routing (each tab of a page becomes its own prerendered route) is now on several pages, and each one copy-pastes the same two things: a `tabRoutes.ts` with an identical `slugFromPathname` plus a trailing-slash href builder, and a layout that derives the active tab from the pathname, redirects unknown slugs, and pushes on click. This PR extracts that into two reusable helpers and migrates the reference page, Models + Endpoints, onto them. It is a pure refactor; no user-visible behavior changes.

The first commit adds the helpers with unit tests and no consumers. `createTabRoutes(baseSegment, slugs)` (`src/utils/tabRoutes.ts`) returns `{ baseSegment, slugs, tabHref, slugFromPathname }`: `tabHref` builds the `/ui`-aware trailing-slash URL via the existing `migratedHref`, and `slugFromPathname` reads the active slug back off the path. `useTabRouting({ routes, baseTabKey, visibleKeys, ready })` (`src/app/(dashboard)/hooks/useTabRouting.ts`) derives `activeKey`, redirects an unknown or forbidden slug to base with `window.location.replace` once `ready`, and returns an `onTabChange` navigator. `visibleKeys` and `ready` are deliberate: a role-gated page passes its filtered tab set and defers the redirect until permissions resolve, so a user is never bounced off a still-loading valid tab.

The second commit migrates Models. Its `tabRoutes.ts` becomes a `createTabRoutes` call, with the existing named exports (`MODEL_TAB_SLUGS`, `modelTabHref`, `slugFromPathname`, `ModelTabSlug`) kept as thin re-exports so no call site or test changes. The layout drops its local active-tab derivation, its redirect `useEffect` and its `router.push` `onChange` for `useTabRouting`, wiring `visibleKeys: visibleSlugs.filter(Boolean)` and `ready: !teamsLoading && !uiSettingsLoading` so the role-gated redirect behaves identically. Everything page-specific stays inline: the antd tab bar (kept because it needs `tabBarExtraContent` for the refresh button and lazy `items`), the role-gated `visibleSlugs`, the refresh control, and the `?model=`/`?team=` drill-in overlay. Editing the file makes its pre-existing antd import a linted-as-changed violation, so that one import is now recorded in the suppressions baseline; no new antd was added, and converting Models to shadcn is intentionally out of scope.

This is deliberately the first page migrated because it is the only one that exercises role-gating and a data-gated redirect, so it proves the helper handles the hard cases before the simpler shadcn pages adopt it. Its existing `layout.test.tsx` and `tabRoutes.test.ts` pass unchanged, which is the regression guarantee.

Follow-ups (separate PRs, not in scope here): a shared `<TabRouteBar>` for the shadcn pages (with anchor-based triggers so middle-click / open-in-new-tab works), generalizing the drill-in into a small `useEntityDetailParams`, and re-aligning the four already-open per-tab PRs onto these helpers.

Tests: `src/utils/tabRoutes.test.ts` locks the href/slug mapping of the factory; `src/app/(dashboard)/hooks/useTabRouting.test.ts` covers active-key derivation, the ready-gated redirect (and the no-redirect-while-loading case), and the onTabChange href; the untouched Models `tabRoutes.test.ts` and `layout.test.tsx` continue to pass.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
