### PR TITLE
feat: add budget_limits (multi-window budget) support for users

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260723000000_add_user_budget_limits/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260723000000_add_user_budget_limits/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "LiteLLM_UserTable" ADD COLUMN "budget_limits" JSONB;

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -249,8 +249,9 @@ model LiteLLM_UserTable {
     max_parallel_requests Int?
     tpm_limit     BigInt?
     rpm_limit     BigInt?
-    budget_duration String? 
+    budget_duration String?
     budget_reset_at DateTime?
+    budget_limits Json?
     allowed_cache_controls String[] @default([])
     policies         String[] @default([])
     model_spend      Json @default("{}")

--- a/litellm/models/user.py
+++ b/litellm/models/user.py
@@ -38,7 +38,7 @@ class LiteLLM_UserTable(LiteLLMPydanticObjectBase):
     rpm_limit: Optional[int] = None
     budget_duration: Optional[str] = None
     budget_reset_at: Optional[datetime] = None
-    budget_limits: Optional[List[BudgetLimitEntry]] = None
+    budget_limits: list[BudgetLimitEntry] | None = None
     allowed_cache_controls: List[str] = []
     policies: List[str] = []
     model_spend: Optional[Dict] = {}

--- a/litellm/models/user.py
+++ b/litellm/models/user.py
@@ -14,6 +14,7 @@ from litellm.models.object_permission import LiteLLM_ObjectPermissionTable
 from litellm.models.organization_membership import (
     LiteLLM_OrganizationMembershipTable,
 )
+from litellm.models.team import BudgetLimitEntry
 from litellm.types.llms.base import LiteLLMPydanticObjectBase
 
 
@@ -37,6 +38,7 @@ class LiteLLM_UserTable(LiteLLMPydanticObjectBase):
     rpm_limit: Optional[int] = None
     budget_duration: Optional[str] = None
     budget_reset_at: Optional[datetime] = None
+    budget_limits: Optional[List[BudgetLimitEntry]] = None
     allowed_cache_controls: List[str] = []
     policies: List[str] = []
     model_spend: Optional[Dict] = {}

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -693,6 +693,9 @@ async def common_checks(
                     valid_token=valid_token,
                 ),
                 _user_max_budget_check(),
+                _user_multi_budget_check(user_object=user_object)
+                if (team_object is None or team_object.team_id is None) and user_object is not None
+                else None,
                 _check_team_member_budget(
                     team_object=team_object,
                     user_object=user_object,
@@ -4001,6 +4004,41 @@ async def _team_multi_budget_check(
                 ),
                 entity_type=Litellm_EntityType.TEAM.value,
                 entity_id=team_object.team_id,
+            )
+
+
+async def _user_multi_budget_check(
+    user_object: Optional[LiteLLM_UserTable],
+):
+    """
+    Raises BudgetExceededError if any budget window in user_object.budget_limits is exceeded.
+
+    Each window has its own Redis counter keyed by spend:user:{user_id}:window:{budget_duration}.
+    """
+    if user_object is None or not user_object.budget_limits:
+        return
+
+    from litellm.proxy.proxy_server import get_current_spend
+
+    for window in user_object.budget_limits:
+        w: dict = window if isinstance(window, dict) else window.model_dump()
+        counter_key = f"spend:user:{user_object.user_id}:window:{w['budget_duration']}"
+        window_spend = await get_current_spend(
+            counter_key=counter_key,
+            fallback_spend=0.0,
+            max_budget=w["max_budget"],
+            window_entity_type="User",
+            window_entity_id=user_object.user_id,
+            window_start=get_budget_window_start(w),
+        )
+        if math.isfinite(w["max_budget"]) and window_spend >= w["max_budget"]:
+            raise litellm.BudgetExceededError(
+                current_cost=window_spend,
+                max_budget=w["max_budget"],
+                message=(
+                    f"ExceededBudget: User={user_object.user_id} over {w['budget_duration']} budget. "
+                    f"Spend=${window_spend:.4f}, Limit=${w['max_budget']:.2f}"
+                ),
             )
 
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -4008,7 +4008,7 @@ async def _team_multi_budget_check(
 
 
 async def _user_multi_budget_check(
-    user_object: Optional[LiteLLM_UserTable],
+    user_object: LiteLLM_UserTable | None,
 ):
     """
     Raises BudgetExceededError if any budget window in user_object.budget_limits is exceeded.

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import time
+from collections.abc import Coroutine
 from datetime import datetime, timezone
 from typing import Any, Callable, List, Literal, Optional, Union
 
@@ -701,8 +702,9 @@ class ResetBudgetJob:
 
     async def reset_budget_windows(self) -> None:
         """
-        For keys and teams with budget_limits, reset any individual windows where
-        reset_at <= now. Only the expired windows are reset; other windows are untouched.
+        For keys, teams, and users with budget_limits, reset any individual
+        windows where reset_at <= now.  Only the expired windows are reset;
+        other windows are untouched.
         """
 
         from litellm.proxy.proxy_server import spend_counter_cache
@@ -712,22 +714,69 @@ class ResetBudgetJob:
         # Note on raw SQL: prisma-client-python does not support null-filtering
         # on `Json?` columns (no DbNull/JsonNull sentinel — see
         # RobertCraigie/prisma-client-py#714). We use `query_raw` with
-        # `IS NOT NULL` so we don't materialize every key/team row on each
-        # tick of the reset job. Writes still go through the ORM.
+        # `IS NOT NULL` so we don't materialize every key/team/user row on
+        # each tick of the reset job. Writes still go through the ORM.
 
-        # --- Keys ---
+        await self._reset_entity_budget_windows(
+            query='SELECT token, budget_limits FROM "LiteLLM_VerificationToken" WHERE budget_limits IS NOT NULL',
+            id_column="token",
+            counter_prefix="spend:key",
+            update_fn=lambda row_id, windows_json: VerificationTokenRepository(self.prisma_client).table.update(
+                where={"token": row_id},
+                data={"budget_limits": windows_json},  # type: ignore[arg-type]
+            ),
+            entity_label="keys",
+            spend_counter_cache=spend_counter_cache,
+            now=now,
+        )
+
+        await self._reset_entity_budget_windows(
+            query='SELECT team_id, budget_limits FROM "LiteLLM_TeamTable" WHERE budget_limits IS NOT NULL',
+            id_column="team_id",
+            counter_prefix="spend:team",
+            update_fn=lambda row_id, windows_json: TeamRepository(self.prisma_client).table.update(
+                where={"team_id": row_id},
+                data={"budget_limits": windows_json},  # type: ignore[arg-type]
+            ),
+            entity_label="teams",
+            spend_counter_cache=spend_counter_cache,
+            now=now,
+        )
+
+        await self._reset_entity_budget_windows(
+            query='SELECT user_id, budget_limits FROM "LiteLLM_UserTable" WHERE budget_limits IS NOT NULL',
+            id_column="user_id",
+            counter_prefix="spend:user",
+            update_fn=lambda row_id, windows_json: UserRepository(self.prisma_client).table.update(
+                where={"user_id": row_id},
+                data={"budget_limits": windows_json},  # type: ignore[arg-type]
+            ),
+            entity_label="users",
+            spend_counter_cache=spend_counter_cache,
+            now=now,
+        )
+
+    async def _reset_entity_budget_windows(
+        self,
+        *,
+        query: str,
+        id_column: str,
+        counter_prefix: str,
+        update_fn: Callable[[str, str], Coroutine[Any, Any, Any]],
+        entity_label: str,
+        spend_counter_cache: Any,
+        now: datetime,
+    ) -> None:
         try:
-            key_rows = await self.prisma_client.db.query_raw(
-                'SELECT token, budget_limits FROM "LiteLLM_VerificationToken" WHERE budget_limits IS NOT NULL'
-            )
-            for row in key_rows:
+            rows = await self.prisma_client.db.query_raw(query)
+            for row in rows:
                 raw = row["budget_limits"]
                 if not raw:
                     continue
                 windows: list = raw if isinstance(raw, list) else json.loads(raw)
                 changed = False
                 for window in windows:
-                    counter_key = f"spend:key:{row['token']}:window:{window['budget_duration']}"
+                    counter_key = f"{counter_prefix}:{row[id_column]}:window:{window['budget_duration']}"
                     if await ResetBudgetJob._reset_expired_window(
                         window,
                         counter_key,
@@ -737,64 +786,9 @@ class ResetBudgetJob:
                     ):
                         changed = True
                 if changed:
-                    await VerificationTokenRepository(self.prisma_client).table.update(
-                        where={"token": row["token"]},
-                        data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
-                    )
+                    await update_fn(row[id_column], json.dumps(windows))
         except Exception as e:
-            verbose_proxy_logger.exception("Failed to reset budget windows for keys: %s", e)
-
-        # --- Teams ---
-        try:
-            team_rows = await self.prisma_client.db.query_raw(
-                'SELECT team_id, budget_limits FROM "LiteLLM_TeamTable" WHERE budget_limits IS NOT NULL'
-            )
-            for row in team_rows:
-                raw = row["budget_limits"]
-                if not raw:
-                    continue
-                windows = raw if isinstance(raw, list) else json.loads(raw)
-                changed = False
-                for window in windows:
-                    counter_key = f"spend:team:{row['team_id']}:window:{window['budget_duration']}"
-                    if await ResetBudgetJob._reset_expired_window(
-                        window,
-                        counter_key,
-                        spend_counter_cache,
-                        now,
-                        self.reset_settings,
-                    ):
-                        changed = True
-                if changed:
-                    await TeamRepository(self.prisma_client).table.update(
-                        where={"team_id": row["team_id"]},
-                        data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
-                    )
-        except Exception as e:
-            verbose_proxy_logger.exception("Failed to reset budget windows for teams: %s", e)
-
-        # --- Users ---
-        try:
-            user_rows = await self.prisma_client.db.query_raw(
-                'SELECT user_id, budget_limits FROM "LiteLLM_UserTable" WHERE budget_limits IS NOT NULL'
-            )
-            for row in user_rows:
-                raw = row["budget_limits"]
-                if not raw:
-                    continue
-                windows = raw if isinstance(raw, list) else json.loads(raw)
-                changed = False
-                for window in windows:
-                    counter_key = f"spend:user:{row['user_id']}:window:{window['budget_duration']}"
-                    if await ResetBudgetJob._reset_expired_window(window, counter_key, spend_counter_cache, now):
-                        changed = True
-                if changed:
-                    await UserRepository(self.prisma_client).table.update(
-                        where={"user_id": row["user_id"]},
-                        data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
-                    )
-        except Exception as e:
-            verbose_proxy_logger.exception("Failed to reset budget windows for users: %s", e)
+            verbose_proxy_logger.exception("Failed to reset budget windows for %s: %s", entity_label, e)
 
     @staticmethod
     async def _reset_budget_common(

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -749,7 +749,7 @@ class ResetBudgetJob:
             counter_prefix="spend:user",
             update_fn=lambda row_id, windows_json: UserRepository(self.prisma_client).table.update(
                 where={"user_id": row_id},
-                data={"budget_limits": windows_json},  # type: ignore[arg-type]
+                data={"budget_limits": windows_json},  # pyright: ignore[reportArgumentType]  # Prisma stubs type budget_limits as Json, but we pass a str
             ),
             entity_label="users",
             spend_counter_cache=spend_counter_cache,

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -26,6 +26,7 @@ from litellm.repositories.table_repositories import (
     TeamMembershipRepository,
 )
 from litellm.repositories.team_repository import TeamRepository
+from litellm.repositories.user_repository import UserRepository
 from litellm.repositories.verification_token_repository import (
     VerificationTokenRepository,
 )
@@ -771,6 +772,29 @@ class ResetBudgetJob:
                     )
         except Exception as e:
             verbose_proxy_logger.exception("Failed to reset budget windows for teams: %s", e)
+
+        # --- Users ---
+        try:
+            user_rows = await self.prisma_client.db.query_raw(
+                'SELECT user_id, budget_limits FROM "LiteLLM_UserTable" WHERE budget_limits IS NOT NULL'
+            )
+            for row in user_rows:
+                raw = row["budget_limits"]
+                if not raw:
+                    continue
+                windows = raw if isinstance(raw, list) else json.loads(raw)
+                changed = False
+                for window in windows:
+                    counter_key = f"spend:user:{row['user_id']}:window:{window['budget_duration']}"
+                    if await ResetBudgetJob._reset_expired_window(window, counter_key, spend_counter_cache, now):
+                        changed = True
+                if changed:
+                    await UserRepository(self.prisma_client).table.update(
+                        where={"user_id": row["user_id"]},
+                        data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
+                    )
+        except Exception as e:
+            verbose_proxy_logger.exception("Failed to reset budget windows for users: %s", e)
 
     @staticmethod
     async def _reset_budget_common(

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -1117,6 +1117,20 @@ def _update_internal_user_params(
                 budget_duration=non_default_values["budget_duration"]
             )
 
+    if "budget_limits" in non_default_values:
+        raw_windows = non_default_values["budget_limits"]
+        if raw_windows:
+            from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+
+            initialized_windows = []
+            for window in raw_windows:
+                w = window if isinstance(window, dict) else window.model_dump()
+                w["reset_at"] = get_budget_reset_time(budget_duration=w["budget_duration"]).isoformat()
+                initialized_windows.append(w)
+            non_default_values["budget_limits"] = json.dumps(initialized_windows)
+        else:
+            non_default_values["budget_limits"] = json.dumps(None)
+
     return non_default_values
 
 
@@ -1247,7 +1261,7 @@ async def _update_single_user_helper(
     )
     _is_self_update = _target_user_id is not None and user_api_key_dict.user_id == _target_user_id
     if _is_self_update and user_api_key_dict.user_role != LitellmUserRoles.PROXY_ADMIN.value:
-        _protected_fields = ("max_budget", "soft_budget", "spend")
+        _protected_fields = ("max_budget", "soft_budget", "spend", "budget_limits")
         for _field in _protected_fields:
             if _field in non_default_values:
                 raise HTTPException(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -3689,6 +3689,7 @@ async def generate_key_helper_fn(
             "allowed_cache_controls": allowed_cache_controls,
             "sso_user_id": sso_user_id,
             "object_permission_id": object_permission_id,
+            "budget_limits": budget_limits_json,
         }
         if teams is not None:
             user_data["teams"] = teams

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -2450,13 +2450,32 @@ async def increment_spend_counters(
 
     async def _user_scope(scope_user_id: str) -> None:
         user_counter_key = f"spend:user:{scope_user_id}"
-        if user_counter_key in reserved_counter_keys:
-            return
-        await _init_and_increment_spend_counter(
-            counter_key=user_counter_key,
-            source_cache_key=scope_user_id,
-            increment=cost,
-        )
+        if user_counter_key not in reserved_counter_keys:
+            await _init_and_increment_spend_counter(
+                counter_key=user_counter_key,
+                source_cache_key=scope_user_id,
+                increment=cost,
+            )
+
+        user_obj = await user_api_key_cache.async_get_cache(key=scope_user_id)
+        if user_obj is not None:
+            user_budget_limits = getattr(user_obj, "budget_limits", None) or (
+                user_obj.get("budget_limits") if isinstance(user_obj, dict) else None
+            )
+            if isinstance(user_budget_limits, str):
+                user_budget_limits = json.loads(user_budget_limits)
+            if isinstance(user_budget_limits, list):
+                for window in user_budget_limits:
+                    duration = window["budget_duration"] if isinstance(window, dict) else window.budget_duration
+                    user_window_counter = f"spend:user:{scope_user_id}:window:{duration}"
+                    if user_window_counter not in reserved_counter_keys:
+                        await _init_and_increment_window_spend_counter(
+                            counter_key=user_window_counter,
+                            entity_type="User",
+                            entity_id=scope_user_id,
+                            window_start=get_budget_window_start(window),
+                            increment=cost,
+                        )
 
     scope_coros = tuple(
         coro

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -249,8 +249,9 @@ model LiteLLM_UserTable {
     max_parallel_requests Int?
     tpm_limit     BigInt?
     rpm_limit     BigInt?
-    budget_duration String? 
+    budget_duration String?
     budget_reset_at DateTime?
+    budget_limits Json?
     allowed_cache_controls String[] @default([])
     policies         String[] @default([])
     model_spend      Json @default("{}")

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -379,6 +379,20 @@ async def _get_budget_counters(
                 entity_id=user_object.user_id,
             )
         )
+    if (
+        (team_object is None or team_object.team_id is None)
+        and user_object is not None
+        and user_object.user_id is not None
+    ):
+        counters.extend(
+            _get_budget_limit_counters(
+                entity_prefix=f"spend:user:{user_object.user_id}",
+                entity_type="User",
+                entity_id=user_object.user_id,
+                budget_limits=user_object.budget_limits,
+                fallback_spend=float(user_object.spend or 0.0),
+            )
+        )
 
     end_user_counter = await _get_end_user_budget_counter(
         valid_token=valid_token,

--- a/tests/e2e/quota_management/budgets/budget_client.py
+++ b/tests/e2e/quota_management/budgets/budget_client.py
@@ -294,7 +294,6 @@ class BudgetClient:
 
     # ---- internal user --------------------------------------------------
 
-<<<<<<< HEAD:tests/e2e/quota_management/budgets/budget_client.py
     def create_user(
         self,
         *,

--- a/tests/e2e/quota_management/budgets/budget_client.py
+++ b/tests/e2e/quota_management/budgets/budget_client.py
@@ -34,8 +34,9 @@ _TEAM_READY_SLEEP_SECONDS = 0.4
 
 
 class UserNewBody(BaseModel):
-    max_budget: float
+    max_budget: float | None = None
     budget_duration: str | None = None
+    budget_limits: list[BudgetWindow] | None = None
 
 
 class UserNewResponse(BaseModel):
@@ -293,12 +294,19 @@ class BudgetClient:
 
     # ---- internal user --------------------------------------------------
 
-    def create_user(self, *, max_budget: float, budget_duration: str | None = None) -> str:
+<<<<<<< HEAD:tests/e2e/quota_management/budgets/budget_client.py
+    def create_user(
+        self,
+        *,
+        max_budget: float | None = None,
+        budget_duration: str | None = None,
+        budget_limits: list[BudgetWindow] | None = None,
+    ) -> str:
         return unwrap(
             self.proxy.transport.post(
                 "/user/new",
                 headers=self.proxy.transport.master,
-                json=UserNewBody(max_budget=max_budget, budget_duration=budget_duration),
+                json=UserNewBody(max_budget=max_budget, budget_duration=budget_duration, budget_limits=budget_limits),
                 response_type=UserNewResponse,
             )
         ).user_id

--- a/tests/e2e/quota_management/budgets/test_user_multi_window_budget_e2e.py
+++ b/tests/e2e/quota_management/budgets/test_user_multi_window_budget_e2e.py
@@ -1,0 +1,62 @@
+"""Live e2e: a user's multi-window budgets (budget_limits) enforce AND reset per window.
+
+The user analog of test_team_multi_window_budget_e2e.py. A user is created with a
+tight 30s window and a roomy 1m window; a personal key (no team) blocks once the tight
+window's cap is exceeded. After the 30s elapses and the reset job runs, the window
+resets and calls flow again.
+
+User budget_limits enforcement only fires for personal keys (team_id is None), matching
+the single-budget user check.
+"""
+
+import time
+
+import pytest
+
+from budget_client import BudgetClient, is_budget_block
+from e2e_config import unique_marker
+from e2e_http import require_successful_call
+from lifecycle import ResourceManager
+from models import BudgetWindow
+
+pytestmark = pytest.mark.e2e
+
+WINDOW_SECONDS = 30
+
+
+def _call(client: BudgetClient, key: str):
+    return client.chat(key, "claude-haiku-4-5", f"user-window {unique_marker()}", max_tokens=16)
+
+
+def test_user_short_window_blocks_then_resets(client: BudgetClient, resources: ResourceManager) -> None:
+    user_id = client.create_user(
+        budget_limits=[
+            BudgetWindow(budget_duration=f"{WINDOW_SECONDS}s", max_budget=3e-6),
+            BudgetWindow(budget_duration="1m", max_budget=1.0),
+        ],
+    )
+    resources.defer(lambda: client.delete_user(user_id))
+    key = client.generate_key(user_id=user_id)
+    resources.defer(lambda: client.delete_key(key))
+
+    start = time.monotonic()
+    blocked = False
+    for _ in range(20):
+        result = _call(client, key)
+        if is_budget_block(result):
+            blocked = True
+            break
+        require_successful_call(result)
+        time.sleep(2)
+    assert blocked, f"user {WINDOW_SECONDS}s window never enforced"
+
+    deadline = time.monotonic() + 150
+    while time.monotonic() < deadline:
+        time.sleep(5)
+        result = _call(client, key)
+        if result.ok:
+            elapsed = time.monotonic() - start
+            assert elapsed < WINDOW_SECONDS + 90, f"reset took {elapsed:.0f}s - too long for a {WINDOW_SECONDS}s window"
+            return
+        assert is_budget_block(result), f"non-budget error during reset wait: {result.body[:200]}"
+    pytest.fail(f"user {WINDOW_SECONDS}s window never reset within 150s")

--- a/tests/test_litellm/proxy/auth/test_user_multi_budget_windows.py
+++ b/tests/test_litellm/proxy/auth/test_user_multi_budget_windows.py
@@ -9,6 +9,7 @@ import pytest
 import litellm
 from litellm.models.team import BudgetLimitEntry
 from litellm.models.user import LiteLLM_UserTable
+from litellm.proxy.auth.auth_checks import _user_multi_budget_check
 
 
 def _make_user(**kwargs) -> LiteLLM_UserTable:
@@ -23,7 +24,6 @@ def _make_user(**kwargs) -> LiteLLM_UserTable:
 
 
 def test_user_model_accepts_budget_limits():
-    """LiteLLM_UserTable must accept a budget_limits field."""
     user = _make_user(
         budget_limits=[
             {"budget_duration": "1hr", "max_budget": 5.0, "reset_at": None},
@@ -32,3 +32,108 @@ def test_user_model_accepts_budget_limits():
     )
     assert user.budget_limits is not None
     assert len(user.budget_limits) == 2
+
+
+@pytest.mark.asyncio
+async def test_user_no_budget_limits_passes():
+    user = _make_user(budget_limits=[])
+    await _user_multi_budget_check(user_object=user)
+
+
+@pytest.mark.asyncio
+async def test_user_none_budget_limits_passes():
+    user = _make_user(budget_limits=None)
+    await _user_multi_budget_check(user_object=user)
+
+
+@pytest.mark.asyncio
+async def test_user_none_object_passes():
+    await _user_multi_budget_check(user_object=None)
+
+
+@pytest.mark.asyncio
+async def test_user_under_budget_passes():
+    user = _make_user(
+        budget_limits=[
+            {"budget_duration": "1hr", "max_budget": 10.0, "reset_at": None},
+            {"budget_duration": "1d", "max_budget": 100.0, "reset_at": None},
+        ]
+    )
+    with patch(
+        "litellm.proxy.proxy_server.get_current_spend",
+        new_callable=AsyncMock,
+        return_value=1.0,
+    ):
+        await _user_multi_budget_check(user_object=user)
+
+
+@pytest.mark.asyncio
+async def test_user_over_hourly_window_raises():
+    user = _make_user(
+        budget_limits=[
+            {"budget_duration": "1hr", "max_budget": 5.0, "reset_at": None},
+            {"budget_duration": "1d", "max_budget": 100.0, "reset_at": None},
+        ]
+    )
+    spend_by_window = [6.0, 6.0]
+    call_count = 0
+
+    async def fake_get_spend(counter_key, fallback_spend, max_budget=None, **kwargs):
+        nonlocal call_count
+        val = spend_by_window[call_count]
+        call_count += 1
+        return val
+
+    with patch(
+        "litellm.proxy.proxy_server.get_current_spend", side_effect=fake_get_spend
+    ):
+        with pytest.raises(litellm.BudgetExceededError) as exc_info:
+            await _user_multi_budget_check(user_object=user)
+
+    err = exc_info.value
+    assert err.status_code == 429
+    assert "1hr" in str(err)
+    assert "User=" in str(err)
+
+
+@pytest.mark.asyncio
+async def test_user_over_daily_window_raises():
+    user = _make_user(
+        budget_limits=[
+            {"budget_duration": "1hr", "max_budget": 50.0, "reset_at": None},
+            {"budget_duration": "1d", "max_budget": 5.0, "reset_at": None},
+        ]
+    )
+    spend_by_window = [1.0, 10.0]
+    call_count = 0
+
+    async def fake_get_spend(counter_key, fallback_spend, max_budget=None, **kwargs):
+        nonlocal call_count
+        val = spend_by_window[call_count]
+        call_count += 1
+        return val
+
+    with patch(
+        "litellm.proxy.proxy_server.get_current_spend", side_effect=fake_get_spend
+    ):
+        with pytest.raises(litellm.BudgetExceededError) as exc_info:
+            await _user_multi_budget_check(user_object=user)
+
+    err = exc_info.value
+    assert err.status_code == 429
+    assert "1d" in str(err)
+
+
+@pytest.mark.asyncio
+async def test_user_budget_limit_entry_objects_coerced():
+    user = _make_user(
+        budget_limits=[
+            BudgetLimitEntry(budget_duration="1hr", max_budget=10.0),
+        ]
+    )
+    with patch(
+        "litellm.proxy.proxy_server.get_current_spend",
+        new_callable=AsyncMock,
+        return_value=1.0,
+    ):
+        await _user_multi_budget_check(user_object=user)

--- a/tests/test_litellm/proxy/auth/test_user_multi_budget_windows.py
+++ b/tests/test_litellm/proxy/auth/test_user_multi_budget_windows.py
@@ -1,0 +1,34 @@
+"""
+Unit tests for multi-budget-window enforcement on users.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import litellm
+from litellm.models.team import BudgetLimitEntry
+from litellm.models.user import LiteLLM_UserTable
+
+
+def _make_user(**kwargs) -> LiteLLM_UserTable:
+    defaults = dict(
+        user_id="test-user-123",
+        spend=0.0,
+        max_budget=None,
+        budget_limits=[],
+    )
+    defaults.update(kwargs)
+    return LiteLLM_UserTable(**defaults)
+
+
+def test_user_model_accepts_budget_limits():
+    """LiteLLM_UserTable must accept a budget_limits field."""
+    user = _make_user(
+        budget_limits=[
+            {"budget_duration": "1hr", "max_budget": 5.0, "reset_at": None},
+            {"budget_duration": "1d", "max_budget": 50.0, "reset_at": None},
+        ]
+    )
+    assert user.budget_limits is not None
+    assert len(user.budget_limits) == 2

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -6,7 +6,7 @@ import time
 import types
 from datetime import datetime, timedelta, timezone
 from datetime import time as dt_time
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -1065,25 +1065,30 @@ def _make_reset_budget_windows_job(
     monkeypatch,
     key_rows: List[Dict[str, Any]],
     team_rows: List[Dict[str, Any]],
+    user_rows: Optional[List[Dict[str, Any]]] = None,
 ):
     """Build a ResetBudgetJob with a fully-mocked prisma client and a fake
     `litellm.proxy.proxy_server` module exposing a stub `spend_counter_cache`.
 
     Returns (job, prisma_client_mock, spend_counter_cache_mock).
     """
+    if user_rows is None:
+        user_rows = []
     prisma_client = MagicMock()
 
     async def fake_query_raw(query: str, *args, **kwargs):
-        # Dispatch by table name in the SQL so a single stub covers both calls.
         if '"LiteLLM_VerificationToken"' in query:
             return key_rows
         if '"LiteLLM_TeamTable"' in query:
             return team_rows
+        if '"LiteLLM_UserTable"' in query:
+            return user_rows
         raise AssertionError(f"Unexpected query_raw call: {query}")
 
     prisma_client.db.query_raw = AsyncMock(side_effect=fake_query_raw)
     prisma_client.db.litellm_verificationtoken.update = AsyncMock(return_value=None)
     prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=None)
+    prisma_client.db.litellm_usertable.update = AsyncMock(return_value=None)
 
     # Stub out litellm.proxy.proxy_server so the in-function
     # `from litellm.proxy.proxy_server import spend_counter_cache` resolves
@@ -1111,13 +1116,15 @@ def test_reset_budget_windows_uses_is_not_null_filter(monkeypatch):
     asyncio.run(job.reset_budget_windows())
 
     queries = [call.args[0] for call in prisma_client.db.query_raw.await_args_list]
-    assert len(queries) == 2, queries
-    key_query, team_query = queries
+    assert len(queries) == 3, queries
+    key_query, team_query, user_query = queries
 
     assert '"LiteLLM_VerificationToken"' in key_query
     assert "budget_limits IS NOT NULL" in key_query
     assert '"LiteLLM_TeamTable"' in team_query
     assert "budget_limits IS NOT NULL" in team_query
+    assert '"LiteLLM_UserTable"' in user_query
+    assert "budget_limits IS NOT NULL" in user_query
 
 
 def test_reset_budget_windows_resets_expired_key_window(monkeypatch):
@@ -1757,3 +1764,29 @@ def test_get_data_reset_query_selects_null_budget_reset_at(table_name):
     )
 
     _asserts_null_reset_is_due(_extract_reset_where(find_many))
+
+
+def test_reset_budget_windows_resets_expired_user_window(monkeypatch):
+    now = datetime.utcnow()
+    expired = (now - timedelta(minutes=1)).isoformat() + "Z"
+
+    user_rows = [
+        {
+            "user_id": "user-expired",
+            "budget_limits": [{"budget_duration": "1hr", "reset_at": expired}],
+        }
+    ]
+    job, prisma_client, spend_counter_cache = _make_reset_budget_windows_job(
+        monkeypatch, key_rows=[], team_rows=[], user_rows=user_rows
+    )
+
+    asyncio.run(job.reset_budget_windows())
+
+    prisma_client.db.litellm_usertable.update.assert_awaited_once()
+    call_kwargs = prisma_client.db.litellm_usertable.update.await_args.kwargs
+    assert call_kwargs["where"] == {"user_id": "user-expired"}
+    assert "budget_limits" in call_kwargs["data"]
+
+    spend_counter_cache.in_memory_cache.set_cache.assert_any_call(
+        key="spend:user:user-expired:window:1hr", value=0.0
+    )

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -3550,3 +3550,42 @@ async def test_resolve_user_email_metadata_skips_db_when_no_user_ids(mocker):
 
     assert result == {}
     find_many.assert_not_called()
+
+
+def test_update_internal_user_params_initializes_budget_limits():
+    from litellm.proxy._types import UpdateUserRequest
+    from litellm.proxy.management_endpoints.internal_user_endpoints import (
+        _update_internal_user_params,
+    )
+
+    data = UpdateUserRequest(
+        user_id="test-user",
+        budget_limits=[
+            {"budget_duration": "1hr", "max_budget": 5.0},
+            {"budget_duration": "1d", "max_budget": 50.0},
+        ],
+    )
+    data_json = data.model_dump(exclude_unset=True)
+    non_default_values = _update_internal_user_params(data_json=data_json, data=data)
+
+    import json
+
+    parsed = json.loads(non_default_values["budget_limits"])
+    assert len(parsed) == 2
+    assert parsed[0]["budget_duration"] == "1hr"
+    assert parsed[0]["reset_at"] is not None
+    assert parsed[1]["budget_duration"] == "1d"
+    assert parsed[1]["reset_at"] is not None
+
+
+def test_update_internal_user_params_empty_budget_limits_not_included():
+    from litellm.proxy._types import UpdateUserRequest
+    from litellm.proxy.management_endpoints.internal_user_endpoints import (
+        _update_internal_user_params,
+    )
+
+    data = UpdateUserRequest(user_id="test-user", budget_limits=[])
+    data_json = data.model_dump(exclude_unset=True)
+    non_default_values = _update_internal_user_params(data_json=data_json, data=data)
+
+    assert "budget_limits" not in non_default_values


### PR DESCRIPTION
## TLDR

Problem this solves:

- Users lack multi-window budget support (budget_limits), unlike API keys and teams
- A user can only have a single budget window (max_budget + budget_duration)

How it solves it:

- Adds budget_limits column to LiteLLM_UserTable and wires enforcement, spend tracking, and reset

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Proof of fix will be provided after running a live proxy instance. Manual QA steps:

1. Start proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`

2. Create a user with budget_limits:
```bash
curl -s -X POST http://localhost:4000/user/new \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"budget_limits": [{"budget_duration": "30s", "max_budget": 0.0001}, {"budget_duration": "1h", "max_budget": 1.0}]}'
```

3. Generate a key for that user (no team):
```bash
curl -s -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"user_id": "<user_id_from_step_2>"}'
```

4. Send chat completions with the key until the 30s window budget is exceeded:
```bash
for i in $(seq 1 20); do
  curl -s -X POST http://localhost:4000/chat/completions \
    -H "Authorization: Bearer <key_from_step_3>" \
    -H "Content-Type: application/json" \
    -d '{"model": "claude-haiku-4-5", "messages": [{"role": "user", "content": "say hi"}], "max_tokens": 16}'
  echo
  sleep 2
done
```

5. Expect a `budget_exceeded` error once spend exceeds the 30s window's max_budget of $0.0001

6. Wait ~30s for the reset job to run, then verify calls succeed again

## Type

🆕 New Feature

## Changes

Schema: adds a `budget_limits` column (Json, nullable) to `LiteLLM_UserTable` in both Prisma schemas plus a SQL migration

Model: adds `budget_limits: list[BudgetLimitEntry] | None` to `LiteLLM_UserTable` pydantic model

Auth enforcement (`auth_checks.py`): adds `_user_multi_budget_check` which reads the user's budget_limits windows and checks each window's Redis spend counter against its max_budget. Raises `BudgetExceededError` if any window is exceeded. Only fires for personal keys (no team_id), matching the single-budget user check

Spend tracking (`proxy_server.py`): inside the existing `_user_scope` function in `increment_spend_counters`, reads the user object from cache and increments per-window Redis counters (`spend:user:{id}:window:{duration}`) for each budget_limits window

Budget reservation (`budget_reservation.py`): extends `_get_budget_limits_counters` to include user budget_limits window counters in the reservation set

Reset job (`reset_budget_job.py`): extracts a shared `_reset_entity_budget_windows` helper to deduplicate the key/team/user window reset logic. The user section queries `LiteLLM_UserTable` for rows with non-null budget_limits and resets expired windows (zeroing the Redis counter, advancing reset_at, persisting to DB)

User management (`internal_user_endpoints.py`): initializes budget_limits windows with `reset_at` timestamps on `/user/new` and `/user/update`. Adds `budget_limits` to `_protected_fields` so non-admin updates cannot set it

Key management (`key_management_endpoints.py`): passes the user's budget_limits into the user data when creating a key, so the user object in cache has the windows available for enforcement

## QA runbook

- tests/e2e/quota_management/budgets/test_user_multi_window_budget_e2e.py::test_user_short_window_blocks_then_resets - a user with a tight 30s window and a roomy 1m window gets blocked once the tight window's cap is exceeded, and calls resume after the window resets
  - [ ] Create a user with budget_limits: `[{"budget_duration": "30s", "max_budget": 3e-6}, {"budget_duration": "1m", "max_budget": 1.0}]`
  - [ ] Generate a personal key (no team) for the user
  - [ ] Send up to 20 chat completions (claude-haiku-4-5, max_tokens=16) with 2s sleep between
  - [ ] Expect a budget_exceeded error before all 20 calls complete (the 30s/$3e-6 window is tiny)
  - [ ] After the block, poll every 5s for up to 150s; expect the reset job to run and calls to succeed again
  - [ ] Verify the reset happened within 90s of the window's 30s duration (not stuck forever)
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR