### PR TITLE
fix(responses): preserve delete error status

### DIFF
--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -465,6 +465,8 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         """
         Transform the delete response API response into a DeleteResponseResult
         """
+        if not raw_response.is_success:
+            raise OpenAIError(message=raw_response.text, status_code=raw_response.status_code)
         try:
             raw_response_json = raw_response.json()
         except Exception:

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -13,6 +13,7 @@ sys.path.insert(
 import litellm
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
 from litellm.llms.azure.responses.transformation import AzureOpenAIResponsesAPIConfig
+from litellm.llms.openai.common_utils import OpenAIError
 from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
 from litellm.types.llms.openai import (
     ImageGenerationPartialImageEvent,
@@ -43,6 +44,30 @@ class TestOpenAIResponsesAPIConfig:
 
         # The function should return the params unchanged
         assert result == test_params
+
+    @pytest.mark.parametrize(
+        "config",
+        [OpenAIResponsesAPIConfig(), AzureOpenAIResponsesAPIConfig()],
+    )
+    def test_delete_response_preserves_not_found_status(self, config):
+        response = httpx.Response(
+            status_code=404,
+            json={
+                "error": {
+                    "message": "Response not found",
+                    "type": "invalid_request_error",
+                }
+            },
+            request=httpx.Request("DELETE", "https://example.com/v1/responses/resp_missing"),
+        )
+
+        with pytest.raises(OpenAIError) as exc_info:
+            config.transform_delete_response_api_response(
+                raw_response=response,
+                logging_obj=self.logging_obj,
+            )
+
+        assert exc_info.value.status_code == 404
 
     @pytest.mark.parametrize("max_output_tokens", [1, 15])
     def test_map_openai_params_clamps_max_output_tokens_below_minimum(self, max_output_tokens):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Missing responses return 500 through the proxy

How it solves it:

- Preserve upstream delete errors before response validation
- Cover both OpenAI and Azure response handlers

## Relevant issues

Fixes #34422

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Live Azure verification is pending because this environment has no Azure credentials

Local regression coverage at `f4b9357d53` confirms that Azure and OpenAI delete handlers preserve an upstream 404 instead of validating the error body as a successful delete result

## Type

🐛 Bug Fix

## Changes

The delete response transformer now rejects non-successful upstream responses before parsing them as `DeleteResponseResult`

The regression test sends a valid JSON error response with status 404 through both the OpenAI and Azure configurations and checks that the status remains 404

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR