### PR TITLE
fix(ui): keep cache leakage time range picker inline at narrow widths

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.tsx
@@ -102,8 +102,8 @@ const CacheLeakageCard: React.FC<CacheLeakageCardProps> = ({ activity }) => {
     <TooltipProvider delay={300}>
       <Card>
         <CardHeader>
-          <div className="flex flex-wrap items-start justify-between gap-4">
-            <div>
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0">
               <CardTitle>Cache leakage by {dimension === "model" ? "model" : "virtual key"}</CardTitle>
               <p className="mt-1 text-sm text-muted-foreground">
                 {subject} sending large volumes of uncached input with a low cache hit rate are likely missing prompt
@@ -111,7 +111,9 @@ const CacheLeakageCard: React.FC<CacheLeakageCardProps> = ({ activity }) => {
                 {dimension === "model" ? " Limited to Anthropic (Claude) models, which support prompt caching." : ""}
               </p>
             </div>
-            <AdvancedDatePicker value={dateValue} onValueChange={onDateChange} />
+            <div className="shrink-0">
+              <AdvancedDatePicker value={dateValue} onValueChange={onDateChange} />
+            </div>
           </div>
           <Tabs
             value={dimension}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Time range picker drops below the description at higher zoom
- Cache leakage header wastes a full row on the picker

How it solves it:

- Pin the picker right; let the description wrap instead
- Stack the header only below the md breakpoint

## Relevant issues

- Keeps the cache leakage card's "Select Time Range" picker on the right edge of the header instead of letting it wrap onto its own line
- Lets the title and description column shrink and wrap to two lines, which is the behavior the header should have had
- Falls back to a stacked header below md, where the picker is too wide to sit beside anything

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

On the tests box: this is a CSS-class-only change and jsdom does not compute layout, so any test here would assert className strings and pass whether or not the header actually renders correctly; that is a change detector, not a regression test. The existing `CacheLeakageCard.test.tsx` suite still passes (4/4), and the real verification is the before/after screenshots below

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Screenshots to be attached: the Prompt Caching tab of the Cost Optimization page at a zoom level where the header no longer has room for both columns side by side

Before (at 43e7b96b83): the picker wraps under the description and sits on its own line above the tabs

After (at 2b77e8c4db): the description wraps to two lines and the picker stays flush right, in line with the title

Repro steps for both:

1. `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver`
2. `npm run dev` in `ui/litellm-dashboard`
3. Open http://localhost:3000/ui/?page=cost-optimization and select the Prompt Caching tab
4. At 100% zoom, confirm the picker is on the right of the header
5. Zoom to 150% and 175% and confirm the picker stays on the right while the description grows to two or three lines
6. Narrow the window below the md breakpoint and confirm the header stacks, with the picker under the description

## Type

🐛 Bug Fix

## Changes

`CacheLeakageCard`'s header row was `flex flex-wrap items-start justify-between gap-4` with the picker as a bare flex item. Under `flex-wrap` the picker is the element that gives way when the row runs short, so at higher zoom it wrapped onto its own line and pushed the tabs down

The header is now `flex flex-col gap-4 md:flex-row md:items-start md:justify-between`; the picker is wrapped in a `shrink-0` div and the title/description column carries `min-w-0`, so the description is what gives way and wraps. `AdvancedDatePicker` needs roughly 440px (a `w-[300px]` trigger plus a `whitespace-nowrap` label), which is why the stacked layout is kept below md rather than squeezing it further

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR (no new tests; see the note under the pre-submission checklist)
