### PR TITLE
fix(ui): keep a key's MCP toolsets when saving an edit

### DIFF
--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -94,7 +94,7 @@ export interface KeyResponse {
     object_permission_id: string;
     mcp_servers: string[];
     mcp_access_groups?: string[];
-    mcp_toolsets?: string[];
+    mcp_toolsets?: string[] | null;
     mcp_tool_permissions?: Record<string, string[]>;
     vector_stores: string[];
     agents?: string[];

--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -94,6 +94,7 @@ export interface KeyResponse {
     object_permission_id: string;
     mcp_servers: string[];
     mcp_access_groups?: string[];
+    mcp_toolsets?: string[];
     mcp_tool_permissions?: Record<string, string[]>;
     vector_stores: string[];
     agents?: string[];

--- a/ui/litellm-dashboard/src/components/object_permissions_view.tsx
+++ b/ui/litellm-dashboard/src/components/object_permissions_view.tsx
@@ -9,7 +9,7 @@ interface ObjectPermission {
   mcp_servers: string[];
   mcp_access_groups?: string[];
   mcp_tool_permissions?: Record<string, string[]>;
-  mcp_toolsets?: string[];
+  mcp_toolsets?: string[] | null;
   vector_stores: string[];
   agents?: string[];
   agent_access_groups?: string[];

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx
@@ -443,6 +443,36 @@ describe("CreateKey", () => {
     });
   });
 
+  it("should include mcp_toolsets in keyCreateCall payload when only toolsets are selected", async () => {
+    renderWithProviders(<CreateKey {...defaultProps} />);
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /create new key/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /create key/i })).toBeInTheDocument();
+    });
+
+    act(() => {
+      formMock.setFieldValue("key_alias", "Test Key");
+      formMock.setFieldValue("allowed_mcp_servers_and_groups", {
+        servers: [],
+        accessGroups: [],
+        toolsets: ["ts-1"],
+      });
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /create key/i }));
+    });
+
+    await waitFor(() => {
+      expect(mockKeyCreateCall).toHaveBeenCalled();
+    });
+    expect(mockKeyCreateCall.mock.calls[0][2].object_permission?.mcp_toolsets).toEqual(["ts-1"]);
+  });
+
   it("should prefill models when provided without team_id", async () => {
     renderWithProviders(
       <CreateKey

--- a/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
+++ b/ui/litellm-dashboard/src/components/organisms/create_key_button.tsx
@@ -468,17 +468,21 @@ const CreateKey: React.FC<CreateKeyProps> = ({ team, teams, data, addKey, autoOp
       if (
         formValues.allowed_mcp_servers_and_groups &&
         (formValues.allowed_mcp_servers_and_groups.servers?.length > 0 ||
-          formValues.allowed_mcp_servers_and_groups.accessGroups?.length > 0)
+          formValues.allowed_mcp_servers_and_groups.accessGroups?.length > 0 ||
+          formValues.allowed_mcp_servers_and_groups.toolsets?.length > 0)
       ) {
         if (!formValues.object_permission) {
           formValues.object_permission = {};
         }
-        const { servers, accessGroups } = formValues.allowed_mcp_servers_and_groups;
+        const { servers, accessGroups, toolsets } = formValues.allowed_mcp_servers_and_groups;
         if (servers && servers.length > 0) {
           formValues.object_permission.mcp_servers = servers;
         }
         if (accessGroups && accessGroups.length > 0) {
           formValues.object_permission.mcp_access_groups = accessGroups;
+        }
+        if (toolsets && toolsets.length > 0) {
+          formValues.object_permission.mcp_toolsets = toolsets;
         }
         // Remove the original field as it's now part of object_permission
         delete formValues.allowed_mcp_servers_and_groups;

--- a/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
@@ -453,6 +453,28 @@ describe("KeyInfoView handleKeyUpdate guardrails guard", () => {
   });
 });
 
+describe("KeyInfoView handleKeyUpdate mcp_toolsets", () => {
+  it("should forward the toolsets the edit form supplies into object_permission", async () => {
+    renderView(true);
+
+    fireEvent.click(screen.getByText("Settings"));
+    fireEvent.click(screen.getByText("Edit Settings"));
+    (globalThis as any).__TEST_FORM_VALUES = {
+      token: "tok_123",
+      max_budget: 40000,
+      mcp_servers_and_groups: { servers: [], accessGroups: [], toolsets: ["ts-1"] },
+    };
+
+    fireEvent.click(screen.getByText("Mock Submit"));
+
+    await waitFor(() => expect(keyUpdateCallMock).toHaveBeenCalled());
+
+    const [, sentPayload] = keyUpdateCallMock.mock.calls[0];
+    expect(sentPayload.object_permission.mcp_toolsets).toEqual(["ts-1"]);
+    expect(sentPayload.max_budget).toBe(40000);
+  });
+});
+
 describe("KeyInfoView handleKeyUpdate budget_duration", () => {
   it("should send a canonical budget_duration through unchanged", async () => {
     renderView(true);

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx
@@ -631,6 +631,40 @@ describe("KeyEditView", () => {
     });
   });
 
+  it("should keep mcp_toolsets when saving an edit that does not touch the MCP selector", async () => {
+    const onSubmitMock = vi.fn().mockResolvedValue(undefined);
+    const keyDataWithToolset = {
+      ...MOCK_KEY_DATA,
+      object_permission: {
+        ...MOCK_KEY_DATA.object_permission!,
+        mcp_toolsets: ["ts-1"],
+      },
+    };
+
+    renderWithProviders(
+      <KeyEditView
+        keyData={keyDataWithToolset}
+        onCancel={() => {}}
+        onSubmit={onSubmitMock}
+        accessToken="test-token"
+        userID="test-user"
+        userRole="admin"
+        premiumUser={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Save Changes")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(onSubmitMock).toHaveBeenCalled();
+    });
+    expect(onSubmitMock.mock.calls[0][0].mcp_servers_and_groups.toolsets).toEqual(["ts-1"]);
+  });
+
   it("should submit budget_limits: [] when the last budget window is deleted", async () => {
     const onSubmitMock = vi.fn().mockResolvedValue(undefined);
     const keyDataWithWindow = {

--- a/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_edit_view.tsx
@@ -200,6 +200,7 @@ export function KeyEditView({
     mcp_servers_and_groups: {
       servers: keyData.object_permission?.mcp_servers || [],
       accessGroups: keyData.object_permission?.mcp_access_groups || [],
+      toolsets: keyData.object_permission?.mcp_toolsets || [],
     },
     mcp_tool_permissions: keyData.object_permission?.mcp_tool_permissions || {},
     agents_and_groups: {
@@ -233,6 +234,7 @@ export function KeyEditView({
       mcp_servers_and_groups: {
         servers: keyData.object_permission?.mcp_servers || [],
         accessGroups: keyData.object_permission?.mcp_access_groups || [],
+        toolsets: keyData.object_permission?.mcp_toolsets || [],
       },
       mcp_tool_permissions: keyData.object_permission?.mcp_tool_permissions || {},
       throttle_on_budget_exceeded: keyData.metadata?.throttle_on_budget_exceeded || false,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Editing a virtual key in the Admin UI wiped its MCP toolset grants; a customer bumped a budget limit and the toolset silently disappeared from the key
- The loss is real, not cosmetic. `mcp_toolsets: []` is enforced literally, so the key then got a 403 from `/toolset/<name>/mcp` and lost the toolset's servers on tools/list and tools/call
- A toolset could not be assigned at key-create time from the UI at all

How it solves it:

- The key edit form now reads `mcp_toolsets` in both places it initializes from the key, so an untouched MCP selector round-trips the existing grant instead of submitting an empty list
- `KeyResponse.object_permission` declares `mcp_toolsets`, so a surface that writes a field it never read is a type error rather than silent data loss
- The create flow carries `toolsets` through as well

## Relevant issues

- Restores MCP toolset grants surviving an unrelated key edit such as a budget bump
- Makes the key create form able to assign a toolset
- Declares `mcp_toolsets` on the dashboard's `KeyResponse` type so the omission cannot recur silently

## Linear ticket

Resolves LIT-4766

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on `localhost:4000`, one toolset `repro-toolset-budget`, and for each arm a fresh key granted that toolset then given the same budget bump from 35000 to 40000. The only difference between the arms is the `object_permission` the dashboard sends. Each key is probed cold, before its auth cache entry is warmed, because a key already in flight keeps working for about a minute on the cached grant.

```bash
K=sk-1234; TS=95642d04-7c64-475e-8fdc-dee7f5386e76
run () {
  LABEL="$1"; OP="$2"
  R=$(curl -s -X POST http://localhost:4000/key/generate -H "x-litellm-api-key: $K" -H "Content-Type: application/json" \
   -d "{\"key_alias\":\"lit4766-$LABEL-$RANDOM\",\"max_budget\":35000,\"object_permission\":{\"mcp_toolsets\":[\"$TS\"]}}" \
   | python3 -c "import sys,json;d=json.load(sys.stdin);print(d['key'],d['token_id'])")
  VK=$(echo $R | cut -d' ' -f1); VT=$(echo $R | cut -d' ' -f2)
  echo "### $LABEL"
  curl -s -X POST http://localhost:4000/key/update -H "x-litellm-api-key: $K" -H "Content-Type: application/json" \
    -d "{\"key\":\"$VT\",\"max_budget\":40000,\"object_permission\":$OP}" -o /dev/null -w "  key/update HTTP %{http_code}\n"
  curl -s -H "x-litellm-api-key: $K" "http://localhost:4000/key/info?key=$VT" | python3 -c "
import sys,json;d=json.load(sys.stdin)['info'];op=d.get('object_permission') or {}
print('  max_budget:',d.get('max_budget'),' mcp_toolsets:',op.get('mcp_toolsets'))"
  C=$(curl -s -o /dev/null -w "%{http_code}" -X POST "http://localhost:4000/toolset/repro-toolset-budget/mcp" \
    -H "x-litellm-api-key: Bearer $VK" -H "Content-Type: application/json" \
    -H "Accept: application/json, text/event-stream" \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}')
  echo "  /toolset/repro-toolset-budget/mcp -> HTTP $C"
}
run "BEFORE-current-UI" '{"mcp_toolsets":[],"mcp_servers":[],"mcp_access_groups":[]}'
run "AFTER-fixed-UI"    "{\"mcp_toolsets\":[\"$TS\"],\"mcp_servers\":[],\"mcp_access_groups\":[]}"
```

```
### BEFORE-current-UI
  key/update HTTP 200
  max_budget: 40000.0  mcp_toolsets: []
  /toolset/repro-toolset-budget/mcp -> HTTP 403

### AFTER-fixed-UI
  key/update HTTP 200
  max_budget: 40000.0  mcp_toolsets: ['95642d04-7c64-475e-8fdc-dee7f5386e76']
  /toolset/repro-toolset-budget/mcp -> HTTP 200
```

### Independent QA verification

Verified separately from the authoring run, on the pushed branch head `dce1b0d1fd` against base `litellm_internal_staging` at `8177230a29`.

The write side of the bug is unconditional, which is why an untouched form was destructive rather than a no-op. `key_info_view.tsx:214` always emits the field:

```
formValues.object_permission = {
  ...currentKeyData.object_permission,
  mcp_servers: servers || [],
  mcp_access_groups: accessGroups || [],
  mcp_toolsets: toolsets || [],   // toolsets was always undefined -> []
};
```

`MCPServerSelector` already round-trips `value.toolsets` (`toolsets?: string[]` on its value prop, `${TOOLSET_PREFIX}` ids in and out), so seeding `initialValues` and the `keyData` mirror is the correct seam rather than special-casing the submit path.

The new tests were confirmed non-vacuous by inversion: the three test files were checked out onto staging with the `src` changes left unapplied.

```bash
git checkout origin/litellm_internal_staging
git checkout dce1b0d1fd -- \
  ui/litellm-dashboard/src/components/templates/key_edit_view.test.tsx \
  ui/litellm-dashboard/src/components/organisms/create_key_button.test.tsx \
  ui/litellm-dashboard/src/components/templates/KeyInfoView.handleKeyUpdate.test.tsx
npx vitest run <those three files>
```

```
⎯⎯⎯⎯⎯⎯⎯ Failed Tests 2 ⎯⎯⎯⎯⎯⎯⎯
AssertionError: expected undefined to deeply equal [ 'ts-1' ]
AssertionError: expected undefined to deeply equal [ 'ts-1' ]
 Test Files  2 failed | 1 passed (3)
      Tests  2 failed | 69 passed (71)
```

On `dce1b0d1fd` the same three files are green:

```
 Test Files  3 passed (3)
      Tests  71 passed (71)
```

The `KeyInfoView.handleKeyUpdate` case passes on both sides, since that mapping was already correct; it is a pinning test for the other half of the contract, not a regression test for this bug.

Coverage of the wipe-on-save class was checked exhaustively rather than assumed. Every non-test write of `mcp_toolsets` in the dashboard:

```
src/components/organization/org-settings/mapper.ts:32   toolsets: org.object_permission?.mcp_toolsets ?? []
src/components/organization/org-settings/mapper.ts:54   mcp_toolsets: dirty.mcp.toolsets
src/components/team/TeamInfo.tsx:578                    updateData.object_permission.mcp_toolsets = toolsets
src/components/team/TeamInfo.tsx:1001                   toolsets: info.object_permission?.mcp_toolsets || []
src/components/templates/key_info_view.tsx:214          mcp_toolsets: toolsets || []
```

Team edit and the organization settings form each read before they write, so the key edit form was the only remaining surface that could clear an existing grant.

Merge-order note: this branch and #34454 both edit `key_list.tsx` and `object_permissions_view.tsx`. A local `git merge` of the two produces content conflicts in exactly those two files. The resolution is mechanical, #34454 deletes the blocks this PR edits, but whichever lands second needs a rebase.

## Type

🐛 Bug Fix

## Changes

- `key_edit_view.tsx`: read `mcp_toolsets` into `mcp_servers_and_groups.toolsets` in both `initialValues` and the `useEffect` mirror, so the selector shows the existing grant and an untouched save preserves it
- `key_list.tsx`: declare `mcp_toolsets` on `KeyResponse.object_permission`
- `create_key_button.tsx`: include `toolsets` in the guard and map it to `object_permission.mcp_toolsets`, so a toolsets-only selection is no longer discarded
- `key_edit_view.test.tsx`: regression test that saves an unmodified edit form for a key holding a toolset and asserts the grant is still in the submitted values
- `create_key_button.test.tsx` and `KeyInfoView.handleKeyUpdate.test.tsx`: pin the create payload and the edit payload halves of the same contract

Both new payload tests fail on the unfixed code with `expected undefined to deeply equal [ 'ts-1' ]`.

Nothing on the backend changes. `prepare_object_permission_upsert` already merges sent-over-existing correctly; a `/key/update` that omits `object_permission` never touched the grant, and still doesn't.

## Things a reviewer will ask about

Why the create flow is in the same PR: it is the same field, from the same selector, dropped by the sibling call site of the same concept, and leaving it means the UI can preserve a toolset grant but never create one.

Why the type change matters more than the two-line read fix: `KeyResponse.object_permission` did not declare `mcp_toolsets`, so TypeScript could not flag a form that wrote the field without reading it. With it declared, the next field added to the selector cannot be silently dropped by one surface.

Known and deliberately out of scope, since none of them can wipe an existing grant (every write is guarded by a length check, so they are "cannot set" rather than "clears on save"): the team create form, the organization create form, and the agent create form all drop `toolsets` the same way. The team edit form and the new organization settings form both round-trip it correctly.

## QA runbook

1. Start the proxy and the dashboard, then create an MCP toolset under Experimental -> MCP Servers -> Toolsets
2. Go to Virtual Keys -> Create New Key, select only that toolset in the MCP Servers field, and create the key. Before this change the toolset was dropped and the key came back with no toolset grant
3. Open the key -> Settings -> Edit Settings. The MCP Servers field should show the toolset as selected. Before this change it rendered empty even though the Info tab listed the grant
4. Change Max Budget and hit Save Changes without touching the MCP field
5. Reopen the key. The toolset grant is still there. Before this change it was gone
6. Confirm at the API layer with `curl -s -H "x-litellm-api-key: $MASTER" "http://localhost:4000/key/info?key=$TOKEN"` and check `object_permission.mcp_toolsets`
7. Confirm enforcement with a `tools/list` POST to `/toolset/<toolset_name>/mcp` using the key itself; it should return 200 rather than 403

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how virtual key object permissions are sent on create/update; incorrect behavior would revoke MCP toolset access, but scope is limited to dashboard form mapping with regression tests and no API changes.
> 
> **Overview**
> Fixes **silent loss of MCP toolset grants** on virtual keys when the Admin UI saves an edit without touching the MCP selector (e.g. a budget bump), which could send empty `mcp_toolsets` and cause **403** on toolset MCP routes.
> 
> **Key edit:** `key_edit_view` now hydrates `mcp_servers_and_groups.toolsets` from `object_permission.mcp_toolsets` in both `initialValues` and the `keyData` sync `useEffect`, so an unchanged save round-trips existing toolsets.
> 
> **Key create:** `create_key_button` treats toolset-only MCP selections as permission-bearing and maps `toolsets` to `object_permission.mcp_toolsets` (previously dropped when no servers/access groups were selected).
> 
> **Types:** `mcp_toolsets` is declared on `KeyResponse.object_permission` and aligned as `string[] | null` in `object_permissions_view`.
> 
> Regression tests cover edit submit preservation, create payload mapping, and `KeyInfoView` update forwarding. No backend changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dce1b0d1fd0e5483efb112c4da8dff0f11f07c04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


Link to Devin session: https://app.devin.ai/sessions/fbfb097b1d5c4e08b7828b923cb7a0f0