### PR TITLE
refactor(ui): derive the dashboard object_permission type from the generated schema

### DIFF
--- a/ui/litellm-dashboard/src/components/agents/types.ts
+++ b/ui/litellm-dashboard/src/components/agents/types.ts
@@ -1,14 +1,12 @@
+import type { components } from "@/lib/http/schema";
+
 export interface AgentAttachedKey {
   token: string;
   key_alias?: string | null;
   key_name?: string | null;
 }
 
-export interface AgentObjectPermission {
-  mcp_servers?: string[];
-  mcp_access_groups?: string[];
-  mcp_tool_permissions?: Record<string, string[]>;
-}
+export type AgentObjectPermission = components["schemas"]["AgentObjectPermission"];
 
 export interface Agent {
   agent_id: string;

--- a/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/key_list.tsx
@@ -1,6 +1,7 @@
 import { Setter } from "@/types";
 import { useEffect, useState } from "react";
 import { keyListCall, Member, Organization } from "../networking";
+import type { ObjectPermission } from "../object_permission_types";
 
 export interface Team {
   team_id: string;
@@ -90,16 +91,7 @@ export interface KeyResponse {
   user_tpm_limit: number;
   user_rpm_limit: number;
   user_email: string;
-  object_permission?: {
-    object_permission_id: string;
-    mcp_servers: string[];
-    mcp_access_groups?: string[];
-    mcp_toolsets?: string[] | null;
-    mcp_tool_permissions?: Record<string, string[]>;
-    vector_stores: string[];
-    agents?: string[];
-    agent_access_groups?: string[];
-  };
+  object_permission?: ObjectPermission | null;
   access_group_ids?: string[];
   budget_fallbacks?: Record<string, string[]>;
   budget_limits?: Array<{ budget_duration: string; max_budget: number; reset_at?: string }>;

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -28,6 +28,7 @@ import { TagNewRequest, TagUpdateRequest, TagListResponse, TagInfoResponse } fro
 import { Team } from "./key_team_helpers/key_list";
 import { EmailEventSettingsResponse, EmailEventSettingsUpdateRequest } from "./email_events/types";
 import type { SkillRegisterRequest } from "./claude_code_plugins/types";
+import type { ObjectPermission } from "./object_permission_types";
 import { jsonFields } from "./common_components/check_openapi_schema";
 import NotificationsManager from "./molecules/notifications_manager";
 import type { MCPUserEnvVarsStatus } from "./mcp_tools/types";
@@ -208,13 +209,7 @@ export interface Organization {
   teams: any[] | null;
   users: any[] | null;
   members: any[] | null;
-  object_permission?: {
-    object_permission_id: string;
-    mcp_servers: string[];
-    mcp_access_groups?: string[];
-    mcp_toolsets?: string[];
-    vector_stores: string[];
-  };
+  object_permission?: ObjectPermission | null;
 }
 
 export interface CredentialItem {

--- a/ui/litellm-dashboard/src/components/object_permission_types.ts
+++ b/ui/litellm-dashboard/src/components/object_permission_types.ts
@@ -1,0 +1,3 @@
+import type { components } from "@/lib/http/schema";
+
+export type ObjectPermission = Partial<components["schemas"]["LiteLLM_ObjectPermissionTable"]>;

--- a/ui/litellm-dashboard/src/components/object_permissions_view.tsx
+++ b/ui/litellm-dashboard/src/components/object_permissions_view.tsx
@@ -3,21 +3,10 @@ import { Text } from "@tremor/react";
 import VectorStorePermissions from "./permissions/VectorStorePermissions";
 import MCPServerPermissions from "./permissions/MCPServerPermissions";
 import AgentPermissions from "./permissions/AgentPermissions";
-
-interface ObjectPermission {
-  object_permission_id: string;
-  mcp_servers: string[];
-  mcp_access_groups?: string[];
-  mcp_tool_permissions?: Record<string, string[]>;
-  mcp_toolsets?: string[] | null;
-  vector_stores: string[];
-  agents?: string[];
-  agent_access_groups?: string[];
-  search_tools?: string[];
-}
+import type { ObjectPermission } from "./object_permission_types";
 
 interface ObjectPermissionsViewProps {
-  objectPermission?: ObjectPermission;
+  objectPermission?: ObjectPermission | null;
   variant?: "card" | "inline";
   className?: string;
   accessToken?: string | null;

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -17,6 +17,7 @@ import {
 import { useGuardrails, GuardrailListItem } from "@/app/(dashboard)/hooks/guardrails/useGuardrails";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 import { mapEmptyStringToNull } from "@/utils/keyUpdateUtils";
+import type { ObjectPermission } from "@/components/object_permission_types";
 import { isProxyAdminRole } from "@/utils/roles";
 import {
   EditOutlined,
@@ -118,17 +119,7 @@ export interface TeamData {
     router_settings?: Record<string, any>;
     guardrails?: string[];
     policies?: string[];
-    object_permission?: {
-      object_permission_id: string;
-      mcp_servers: string[];
-      mcp_access_groups?: string[];
-      mcp_tool_permissions?: Record<string, string[]>;
-      mcp_toolsets?: string[];
-      vector_stores: string[];
-      agents?: string[];
-      agent_access_groups?: string[];
-      search_tools?: string[];
-    };
+    object_permission?: ObjectPermission | null;
     team_member_budget_table: {
       max_budget: number;
       budget_duration: string;


### PR DESCRIPTION
## TLDR

Problem this solves:

- The dashboard declared the server-owned `object_permission` shape by hand in five separate places, each with a different subset of fields and none of them matching the generated OpenAPI schema
- That is exactly what hid LIT-4766. `KeyResponse.object_permission` never declared `mcp_toolsets`, so a form that wrote the field without ever reading it compiled cleanly and silently wiped the grant on every save
- The same divergence produced the nullability finding on that fix: the schema says `string[] | null` for all of these fields while every hand-written copy said `string[]`, and two of them declared `mcp_servers` and `vector_stores` as non-optional

How it solves it:

- One exported alias over the generated `LiteLLM_ObjectPermissionTable`, imported by the four consumers that share that shape, with the hand-written duplicates deleted
- The agent shape stays separate, because the agent endpoint genuinely returns a narrower type; it now points at its own generated `AgentObjectPermission` instead of a hand-written copy

## Relevant issues

- Removes the type-level blind spot that let a UI form write an `object_permission` field it never read
- Collapses five hand-maintained copies of one server-owned shape down to one generated source
- Corrects nullability across the whole shape rather than the single field a review caught

## Linear ticket

Resolves LIT-4768

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

No new tests, deliberately. This is a type-only change with no runtime behavior to assert, so a new test here would assert nothing that could fail. The guarantee is enforced by the compiler and by the existing suite; see the proof section

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

No runtime behavior changes, so the meaningful proof is that the compiler agrees and nothing regressed. Both measured in the same worktree, stashing and unstashing the change so the numbers are comparable.

```bash
# baseline: staging, change stashed
npx tsc --noEmit 2>&1 | grep -c "error TS"
# 705

# with the change applied
npx tsc --noEmit 2>&1 | grep -c "error TS"
# 705

# and specifically, zero errors that did not already exist
diff <(sort tsc_base.txt) <(sort tsc_after.txt) | grep "^>"
# (no output)
```

```bash
npx vitest run --reporter=dot
#  Test Files  528 passed (528)
#       Tests  5293 passed (5293)
```

Worth noting what the first attempt caught, because it is the argument for doing this at all: aliasing to `LiteLLM_ObjectPermissionBase` produced eight new type errors, because `Base` has no `object_permission_id` and the shared view prop rejected `null`. The hand-written copies had been quietly papering over both. `Partial<LiteLLM_ObjectPermissionTable>` is the accurate read model: the dashboard receives this object from several endpoints and only ever reads it defensively with `?.` and `|| []`.

### Independent QA verification

Reproduced from a clean checkout rather than a stash, on the pushed branch head `0b420affbe` against base `litellm_internal_staging` at `8177230a29`, with `npm ci` in between so both runs used the same lockfile tree.

```bash
git checkout 8177230a29 && npx tsc --noEmit | grep "error TS" | sort > base.txt   # 705
git checkout 0b420affbe && npx tsc --noEmit | grep "error TS" | sort > after.txt  # 705
diff base.txt after.txt | grep "^>" | grep -v "public/assets/logos"
# (no output)
```

Same 705 on both sides, and no new error outside the pre-existing `Cannot find module '.../logos/*.svg'` noise that `tsc` already emits on staging.

Full suite on the branch:

```
 Test Files  1 failed | 527 passed (528)
      Tests  1 failed | 5293 passed (5294)
```

The one failure is `src/components/ui/ref-forwarding.test.tsx`, and it is an unrelated order-dependent flake, not a regression from this change. Run in isolation it is green on the branch and on staging alike:

```bash
npx vitest run src/components/ui/ref-forwarding.test.tsx
#  Test Files  1 passed (1)   <- on 0b420affbe
#  Test Files  1 passed (1)   <- on 8177230a29
```

`ui-unit-tests` is also green in CI on this branch.

On the field the refactor has to preserve, `mcp_toolsets` is present on the generated type the alias points at, so nothing is lost relative to the hand-written copies or to #34452:

```
LiteLLM_ObjectPermissionTable: {
    ...
    /** Mcp Toolsets */
    mcp_toolsets?: string[] | null;
    ...
}
```

Merge-order note: this branch and #34452 both edit `key_list.tsx` and `object_permissions_view.tsx`. A local `git merge` of the two produces content conflicts in exactly those two files. The resolution is mechanical, this PR deletes the blocks that one edits, but whichever lands second needs a rebase; after rebasing this one, keep the `ObjectPermission | null` prop on `object_permissions_view`.

## Type

🧹 Refactoring

## Changes

- `object_permission_types.ts`: new, three lines, exports `ObjectPermission` as `Partial<components["schemas"]["LiteLLM_ObjectPermissionTable"]>`
- `key_list.tsx`, `networking.tsx`, `team/TeamInfo.tsx`: hand-written inline shapes replaced with that alias
- `object_permissions_view.tsx`: local `interface ObjectPermission` deleted; its prop now accepts `null`, which the entity types actually produce
- `agents/types.ts`: `AgentObjectPermission` now aliases the generated `AgentObjectPermission` rather than restating three of its fields

Net effect is 14 insertions against 45 deletions. Nothing on the backend changes and no runtime code changes; this is types only.

## Things a reviewer will ask about

Why `Partial<...Table>` and not `...Base`: `Base` omits `object_permission_id`, which several call sites and fixtures carry, and `Table` makes every key required, which the same fixtures do not satisfy. Every consumer reads these fields defensively, so the honest read model is the table shape with optional keys. It still derives from the schema, so a field added upstream shows up automatically and a field removed upstream breaks the build.

Why the agent type stays separate: `components["schemas"]["AgentObjectPermission"]` is a real, narrower type in the schema, not an accident of hand-copying. Folding it into the shared alias would have widened the agent surface to fields its endpoint never returns.

Why no test: types are erased at runtime, so any test here would either be tautological or a no-op unless the suite ran under `vitest --typecheck`, which it does not. Asserting the alias has the fields the alias is defined to have is exactly the kind of coverage-padding the repo asks not to add.

## QA runbook

There is no user-visible change to exercise; this is a compile-time refactor. If you want to confirm nothing shifted, the surfaces that render `object_permission` are Virtual Keys key info, Teams team info, Organizations, and Agents. Each should show the same MCP servers, access groups, toolsets, vector stores, and agent grants it showed before.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Compile-time-only refactor with no runtime behavior changes; risk is limited to possible type mismatches surfacing at build time, which the PR author reports does not add new TS errors.
> 
> **Overview**
> Replaces **five divergent hand-written `object_permission` shapes** with a single shared type derived from the generated OpenAPI schema, so fields like `mcp_toolsets` and correct `string[] | null` nullability stay in sync with the API.
> 
> Adds `ObjectPermission` as `Partial<LiteLLM_ObjectPermissionTable>` and wires it through virtual keys (`KeyResponse`), org/team networking types, team info, and `ObjectPermissionsView` (prop now accepts `null`). **Agent** permissions stay on the narrower generated `AgentObjectPermission` alias instead of the shared table type.
> 
> No runtime or backend changes—types only (~45 lines of duplicate interfaces removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba9f6d75d8b57df480a32a9ba8209e32886aa9e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


Link to Devin session: https://app.devin.ai/sessions/fbfb097b1d5c4e08b7828b923cb7a0f0