### PR TITLE
fix(proxy): restore atomic user upsert when adding team members

### DIFF
--- a/litellm/proxy/management_helpers/utils.py
+++ b/litellm/proxy/management_helpers/utils.py
@@ -295,10 +295,16 @@ async def add_new_member(
         # same new user is provisioned concurrently), seeding teams on create.
         # The teams append lives in the filtered update below rather than the
         # upsert's update branch so an already-existing user does not get a
-        # duplicate team id.
+        # duplicate team id. The update branch still has to write something:
+        # Prisma only compiles an upsert down to INSERT ... ON CONFLICT when it
+        # is non-empty, and falls back to a racy SELECT-then-INSERT when it is
+        # not, so this re-states user_id as a no-op rather than being empty.
         _returned_user = await UserRepository(prisma_client).table.upsert(
             where={"user_id": new_member.user_id},
-            data={"create": {"teams": [team_id], **new_user_defaults}, "update": {}},
+            data={
+                "create": {"teams": [team_id], **new_user_defaults},
+                "update": {"user_id": new_member.user_id},
+            },
         )
         await _append_team_id_if_absent(prisma_client, new_member.user_id, team_id)
         if _returned_user is not None:

--- a/tests/e2e/ui/tests/modelsPage/addModel.spec.ts
+++ b/tests/e2e/ui/tests/modelsPage/addModel.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { ADMIN_STORAGE_PATH, E2E_TEAM_CRUD_ALIAS, E2E_TEAM_CRUD_ID } from "../../constants";
+import { ADMIN_STORAGE_PATH, E2E_TEAM_CRUD_ID } from "../../constants";
 import { Role, users } from "../../fixtures/users";
 import { navigateToPage } from "../../helpers/navigation";
 import { Page } from "../../fixtures/pages";
@@ -56,17 +56,17 @@ test.describe("Add Model", () => {
       },
     });
     expect(createResponse.ok()).toBe(true);
+    const createdModelId = (await createResponse.json()).model_info?.id;
+    expect(createdModelId, "model id from /model/new").toBeTruthy();
 
     // Navigate to Models + Endpoints
     await page.goto("/ui");
     await page.getByText("Models + Endpoints").click();
 
-    // Click the new model row to open its detail view. The table renders
-    // a clickable outer row plus a nested detail row for the same model,
-    // so we target the first match (outer row) explicitly.
-    const modelRow = page.locator("tr", { hasText: modelName }).first();
-    await expect(modelRow).toBeVisible({ timeout: 10_000 });
-    await modelRow.click();
+    // The Model ID cell is the drill-in control; the row itself is not clickable.
+    const modelIdCell = page.getByTestId(`model-id-${createdModelId}`);
+    await expect(modelIdCell).toBeVisible({ timeout: 10_000 });
+    await modelIdCell.click();
 
     await expect(page.getByText("Back to Models").first()).toBeVisible({ timeout: 10_000 });
 
@@ -137,11 +137,11 @@ test.describe("Add Model", () => {
     await page.waitForTimeout(2000);
 
     // Search for the model we just added
-    await page.locator('input[placeholder="Search model names..."]').fill("claude-haiku-4-5");
+    await page.getByPlaceholder("Search model names").fill("claude-haiku-4-5");
     await page.waitForTimeout(1000);
 
     // Verify the model appears in the results count (not "Showing 0 results")
-    await expect(page.getByTestId("models-results-count")).toHaveText(/Showing \d+ - \d+ of \d+ results/, {
+    await expect(page.getByTestId("pagination-range")).toHaveText(/Showing \d+-\d+ of \d+/, {
       timeout: 15_000,
     });
 
@@ -228,24 +228,24 @@ test.describe("Add Model", () => {
       // searching.
       await page.waitForTimeout(2000);
 
-      await page.locator('input[placeholder="Search model names..."]').fill("cohere");
+      await page.getByPlaceholder("Search model names").fill("cohere");
       await page.waitForTimeout(1000);
 
       // Confirm the search returned at least one result — gives a clear
       // failure message when the table is empty instead of timing out on a
       // row assertion.
-      await expect(page.getByTestId("models-results-count")).toHaveText(/Showing \d+ - \d+ of \d+ results/, {
+      await expect(page.getByTestId("pagination-range")).toHaveText(/Showing \d+-\d+ of \d+/, {
         timeout: 15_000,
       });
 
-      // Stronger than "alias appears somewhere in tbody" — pin the assertion
+      // Stronger than "the team appears somewhere in tbody" — pin the assertion
       // to a single row that has BOTH the cohere model_name AND the seeded
-      // team alias, so a stale cohere row from "Add wildcard route" (no team)
-      // can't satisfy the check.
+      // team, so a stale cohere row from "Add wildcard route" (no team) can't
+      // satisfy the check. The Team ID column renders the id, not the alias.
       const teamCohereRow = page
         .locator("table tbody tr")
         .filter({ hasText: "cohere/" })
-        .filter({ hasText: E2E_TEAM_CRUD_ALIAS });
+        .filter({ hasText: E2E_TEAM_CRUD_ID });
       await expect(teamCohereRow).toHaveCount(1, { timeout: 15_000 });
     } finally {
       await deleteTeamScopedCohereModels();
@@ -281,11 +281,11 @@ test.describe("Add Model", () => {
     await page.waitForTimeout(2000);
 
     // Search for the wildcard model
-    await page.locator('input[placeholder="Search model names..."]').fill("cohere");
+    await page.getByPlaceholder("Search model names").fill("cohere");
     await page.waitForTimeout(1000);
 
     // Verify the model appears in the results count (not "Showing 0 results")
-    await expect(page.getByTestId("models-results-count")).toHaveText(/Showing \d+ - \d+ of \d+ results/, {
+    await expect(page.getByTestId("pagination-range")).toHaveText(/Showing \d+-\d+ of \d+/, {
       timeout: 15_000,
     });
 

--- a/tests/e2e/ui/tests/modelsPage/clearCustomPricing.spec.ts
+++ b/tests/e2e/ui/tests/modelsPage/clearCustomPricing.spec.ts
@@ -67,9 +67,10 @@ test.describe("Clear custom pricing on a deployment", () => {
     await page.goto("/ui");
     await page.getByText("Models + Endpoints").click();
 
-    const modelRow = page.locator("tr", { hasText: modelName }).first();
-    await expect(modelRow).toBeVisible({ timeout: 15_000 });
-    await modelRow.click();
+    // The Model ID cell is the drill-in control; the row itself is not clickable.
+    const modelIdCell = page.getByTestId(`model-id-${createdModelId}`);
+    await expect(modelIdCell).toBeVisible({ timeout: 15_000 });
+    await modelIdCell.click();
     await expect(page.getByText("Back to Models").first()).toBeVisible({
       timeout: 10_000,
     });

--- a/tests/llm_translation/test_openai.py
+++ b/tests/llm_translation/test_openai.py
@@ -518,7 +518,7 @@ async def test_openai_codex_stream(sync_mode):
     from litellm.main import stream_chunk_builder
 
     kwargs = {
-        "model": "openai/gpt-5.2-codex",
+        "model": "openai/gpt-5.3-codex",
         "messages": [{"role": "user", "content": "Hey!"}],
         "stream": True,
     }
@@ -550,7 +550,7 @@ async def test_openai_codex(sync_mode):
             {
                 "model_name": "openai-codex-mini-latest",
                 "litellm_params": {
-                    "model": "openai/gpt-5.2-codex",
+                    "model": "openai/gpt-5.3-codex",
                 },
             }
         ]

--- a/tests/test_litellm/proxy/management_helpers/test_management_helpers_utils.py
+++ b/tests/test_litellm/proxy/management_helpers/test_management_helpers_utils.py
@@ -1076,6 +1076,13 @@ async def test_add_new_member_creates_missing_user_atomically_via_upsert():
     would race a check-then-create into a duplicate-key failure. The upsert seeds
     teams on create, and the filtered append is a no-op because the team is
     already present on the freshly created row.
+
+    Calling upsert is not on its own enough to be atomic: Prisma only compiles it
+    down to a single INSERT ... ON CONFLICT when the update branch is non-empty,
+    and otherwise emits SELECT-then-INSERT, which loses the race. That is how
+    parallel /team/new calls naming the same new member started returning 500
+    "Unique constraint failed on the fields: (user_id)", so the shape of both
+    branches is pinned here.
     """
     from litellm.proxy._types import LitellmUserRoles
 
@@ -1114,5 +1121,7 @@ async def test_add_new_member_creates_missing_user_atomically_via_upsert():
     # non-atomic standalone create that could race under concurrent provisioning
     mock_prisma_client.db.litellm_usertable.upsert.assert_called_once()
     mock_prisma_client.db.litellm_usertable.create.assert_not_called()
-    create_data = mock_prisma_client.db.litellm_usertable.upsert.call_args.kwargs["data"]["create"]
-    assert create_data["teams"] == ["team-1"]
+    upsert_data = mock_prisma_client.db.litellm_usertable.upsert.call_args.kwargs["data"]
+    assert upsert_data["create"]["teams"] == ["team-1"]
+    assert upsert_data["update"], "empty update branch degrades the upsert to a racy SELECT-then-INSERT"
+    assert "teams" not in upsert_data["update"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Parallel `/team/new` naming one new member returns 500
- Live codex tests pin `gpt-5.2-codex`, deprecated by OpenAI
- Five models page e2e specs pinned to pre-DataTable selectors

How it solves it:

- Keep the user upsert on Prisma's native `ON CONFLICT` path
- Move the codex tests to `gpt-5.3-codex`
- Retarget the specs at the shared DataTable's controls

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Note on scope: this is three separate red checks from one CI run rather than one problem. They are independent commits and can be split if you would rather review them apart

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### 1. Parallel `/team/new` no longer 500s

Ten concurrent `/team/new`, each naming the same member that does not exist yet, against a local proxy on a throwaway postgres

Before, at `c255f53bfb`:

```
$ ./proof_run.sh
member user_id=qa-C48375D8-0E3D-4C57-A3FD-5E6B268D8B5F  (no such user exists yet)
team/new #8 -> HTTP 500
team/new #5 -> HTTP 500
team/new #1 -> HTTP 200
team/new #3 -> HTTP 200
team/new #4 -> HTTP 200
team/new #6 -> HTTP 200
team/new #7 -> HTTP 200
team/new #9 -> HTTP 200
team/new #10 -> HTTP 200
team/new #2 -> HTTP 200

first non-200 body (if any):
{"error":{"message":"{'error': \"Unable to add user - user_id='qa-C48375D8-0E3D-4C57-A3FD-5E6B268D8B5F' user_email=None role='user', to team - 19820dc2-aadf-4583-bf88-4749bf5d380e, for reason - Unique constraint failed on the fields: (`user_id`)\"}","type":"internal_server_error","param":"None","code":"500"}}
```

After, at `b71c93ec14`:

```
$ ./proof_run.sh
member user_id=qa-00F490F5-5633-499F-BFFF-2CFBC7E185DC  (no such user exists yet)
team/new #6 -> HTTP 200
team/new #1 -> HTTP 200
team/new #7 -> HTTP 200
team/new #2 -> HTTP 200
team/new #5 -> HTTP 200
team/new #4 -> HTTP 200
team/new #10 -> HTTP 200
team/new #8 -> HTTP 200
team/new #3 -> HTTP 200
team/new #9 -> HTTP 200

first non-200 body (if any):
```

The membership is genuinely reconciled rather than the error being swallowed, so the member lands in all ten teams and picks up no duplicate team id

```
$ curl -sS "http://localhost:4000/user/info?user_id=qa-00F490F5-5633-499F-BFFF-2CFBC7E185DC" \
    -H "Authorization: Bearer sk-1234" | jq -r '.user_info.teams | "teams joined: \(length) | distinct: \(unique | length)"'
teams joined: 10 | distinct: 10
```

`proof_run.sh` is ten backgrounded curls against one uuid:

```bash
USER_ID="qa-$(uuidgen)"
for i in $(seq 1 10); do
  curl -sS -o /tmp/team_$i.json -w "team/new #$i -> HTTP %{http_code}\n" -X POST http://localhost:4000/team/new \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d "{\"team_alias\":\"qa-team-$i\",\"members_with_roles\":[{\"role\":\"user\",\"user_id\":\"$USER_ID\"}]}" &
done
wait
```

### 2. Codex model deprecation

Both model strings configured on the same live proxy at `b71c93ec14`, hitting the real OpenAI API

```
$ curl -sS -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" -d '{"model":"codex-old","messages":[{"role":"user","content":"Hey!"}]}'
{"error":{"message":"litellm.NotFoundError: OpenAIException - {\n  \"error\": {\n    \"message\": \"The model `gpt-5.2-codex` has been deprecated, learn more here: https://platform.openai.com/docs/deprecations\",\n    \"type\": \"invalid_request_error\",\n    \"param\": null,\n    \"code\": \"model_not_found\"\n  }\n}. ...

$ curl -sS -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" -d '{"model":"codex-new","messages":[{"role":"user","content":"Hey!"}]}'
content: Hey! How can I help?
usage: 21 tokens
```

`gpt-5.1-codex` and `gpt-5.1-codex-max` are deprecated too; `gpt-5.3-codex` is the current one

### 3. Models page e2e

Full Admin UI Playwright suite against a local proxy serving a fresh dashboard build, seeded postgres and the mock upstream, run at CI parity (`CI=true`, so `workers: 1`)

Before, at `c255f53bfb`:

```
  5 failed
    [chromium] › tests/modelsPage/addModel.spec.ts:35:7 › Add Model › Edit team model TPM and RPM limits
    [chromium] › tests/modelsPage/addModel.spec.ts:112:7 › Add Model › Add specific model and verify it appears in All Models
    [chromium] › tests/modelsPage/addModel.spec.ts:153:7 › Add Model › Add team-only model via Team-BYOK toggle and verify it appears with the team
    [chromium] › tests/modelsPage/addModel.spec.ts:255:7 › Add Model › Add wildcard route and verify it appears in All Models
    [chromium] › tests/modelsPage/clearCustomPricing.spec.ts:65:7 › Clear custom pricing on a deployment › UI sends null for cleared pricing and backend removes the override
```

After, at `b71c93ec14`:

```
$ CI=true npx playwright test --config playwright.config.ts --reporter=line
  4 skipped
  82 passed (2.3m)
```

## Type

🐛 Bug Fix

✅ Test

## Changes

`add_new_member` builds the member's user row with a Prisma upsert. That upsert passed an empty update branch, and Prisma only compiles an upsert down to a single `INSERT ... ON CONFLICT` when the update branch writes something; with an empty one it emits `SELECT` then `INSERT` instead. Concurrent requests naming the same new member therefore all read "no such user" and all insert, and every loser of the race turns into a 500. Postgres statement logs show the two shapes plainly: the empty form logs `BEGIN / SELECT / INSERT / COMMIT`, the non-empty form logs `INSERT ... ON CONFLICT ("user_id") DO UPDATE SET`. The update branch now re-states `user_id` as a no-op so the native path comes back. The teams append stays in the filtered `update_many` below it, so an already-existing member still cannot pick up a duplicate team id, which is what that shape was protecting

The unit test named `test_add_new_member_creates_missing_user_atomically_via_upsert` asserted only that `upsert` had been called on a mock, so it stayed green straight through the regression. It now pins the shape of both branches and goes red when the update branch returns to empty

Separately, OpenAI deprecated `gpt-5.2-codex`, so the two live codex tests move to `gpt-5.3-codex`. The remaining `gpt-5.2-codex` references in the suite are mocked transformation tests and keep working

The models page e2e specs were pinned to three things the shared DataTable migration changed. Row click no longer opens the detail view because the Model ID cell owns that now, so both specs click its `model-id-<id>` test id. The search placeholder switched from an ASCII `...` to a real ellipsis, so the specs match a substring rather than an exact attribute that punctuation can break again. The results count moved from `models-results-count` to the shared pagination's `pagination-range`, with a different format. The Team-BYOK test also filtered rows on the team alias, which the Team ID column renders in neither the old nor the new table, so it filters on the team id now

## QA runbook

Prerequisites: a proxy on `localhost:4000` serving a fresh dashboard build against the seeded e2e postgres and the mock upstream on `127.0.0.1:8090`, exactly as `tests/e2e/ui/run_e2e.sh` sets up. `LITELLM_LICENSE` must be set for the Team-BYOK test; without it that test skips itself

- `tests/e2e/ui/tests/modelsPage/addModel.spec.ts` "Edit team model TPM and RPM limits" - a team-scoped deployment opens from the table and its TPM/RPM survive a save
  - [ ] `POST /model/new` with the master key, a team-scoped `openai/fake-gpt-4` pointed at the mock, `tpm: 100` and `rpm: 200`, and keep the returned `model_info.id`
  - [ ] Open http://localhost:4000/ui, click Models + Endpoints, and click that model id in the Model ID column; expect the detail view with "Back to Models"
  - [ ] Click Edit Settings, set TPM to 999 and RPM to 888, click Save Changes, and expect both values rendered back in view mode
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky
- `tests/e2e/ui/tests/modelsPage/addModel.spec.ts` "Add specific model and verify it appears in All Models" - a model added through the form is findable by search
  - [ ] On the Add Model tab pick Anthropic, select claude-haiku-4-5, enter any api key, and click Add Model
  - [ ] Switch to All Models, type `claude-haiku-4-5` into the search box, and expect the pagination line to read "Showing 1-N of N" rather than "No results"
  - [ ] Expect a row in the table body naming claude-haiku-4-5
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky
- `tests/e2e/ui/tests/modelsPage/addModel.spec.ts` "Add team-only model via Team-BYOK toggle and verify it appears with the team" - a Team-BYOK model lands attached to the chosen team
  - [ ] On the Add Model tab pick Cohere and the wildcard option, enter any api key, turn the Team-BYOK Model switch on, and pick `e2e-team-crud` in the Team dropdown
  - [ ] Click Add Model and expect the "created successfully" notification
  - [ ] Switch to All Models, search `cohere`, and expect exactly one row carrying both `cohere/` and `e2e-team-crud` in its Team ID column
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky
- `tests/e2e/ui/tests/modelsPage/addModel.spec.ts` "Add wildcard route and verify it appears in All Models" - a wildcard route shows up as a real row
  - [ ] On the Add Model tab pick Cohere and the wildcard option, enter any api key, and click Add Model
  - [ ] Switch to All Models, search `cohere`, and expect the pagination line to read "Showing 1-N of N" and a `cohere/` row in the body
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky
- `tests/e2e/ui/tests/modelsPage/clearCustomPricing.spec.ts` "UI sends null for cleared pricing and backend removes the override" - clearing the pricing fields removes the override from the DB
  - [ ] `POST /model/new` with `input_cost_per_token`, `output_cost_per_token`, `cache_read_input_token_cost` and `cache_creation_input_token_cost` set, and keep the returned `model_info.id`
  - [ ] Open Models + Endpoints, click that model id, and expect the seeded rates rendered as 77.7000 and 99.9000 per 1M tokens
  - [ ] Click Edit Settings, clear all four cost fields, click Save Changes, and expect the outgoing `PATCH /model/<id>/update` to carry explicit nulls for all four
  - [ ] Re-read the deployment through the management API and expect the seeded rates gone from both `litellm_params` and `model_info`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
