### PR TITLE
fix(cost_calculator): itemize cache costs for OpenAI Responses API

### DIFF
--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -24,6 +24,7 @@ from litellm.litellm_core_utils.llm_cost_calc.usage_object_transformation import
 from litellm.litellm_core_utils.llm_cost_calc.utils import (
     CostCalculatorUtils,
     _generic_cost_per_character,
+    _get_cost_per_unit,
     _get_service_tier_cost_key,
     _parse_prompt_tokens_details,
     calculate_cost_component,
@@ -952,6 +953,58 @@ def _apply_cost_margin(
     return base_cost, margin_percent, margin_fixed_amount, margin_total_amount
 
 
+def _compute_cache_cost_itemization(
+    model: Optional[str],
+    custom_llm_provider: Optional[str],
+    cache_read_input_tokens: Optional[int],
+    cache_creation_input_tokens: Optional[int],
+    service_tier: Optional[str] = None,
+) -> Tuple[Optional[float], Optional[float]]:
+    """
+    Compute itemized cache-read and cache-creation costs from token counts and model pricing.
+
+    These are additive annotations that overlap ``input_cost`` (same convention as the
+    Anthropic path): the grand total is unaffected.
+
+    Returns:
+        Tuple[Optional[float], Optional[float]] - (cache_read_cost, cache_creation_cost)
+        Either value is None when the corresponding token count is absent/zero or when
+        no pricing entry exists for the model.
+    """
+    if not model:
+        return None, None
+    if not (cache_read_input_tokens or cache_creation_input_tokens):
+        return None, None
+
+    try:
+        model_info = _cached_get_model_info_helper(
+            model=model, custom_llm_provider=custom_llm_provider
+        )
+    except Exception:
+        return None, None
+
+    cache_read_cost: Optional[float] = None
+    cache_creation_cost: Optional[float] = None
+
+    if cache_read_input_tokens:
+        _cr_key = _get_service_tier_cost_key(
+            "cache_read_input_token_cost", service_tier
+        )
+        _cr_rate = _get_cost_per_unit(model_info, _cr_key, None)
+        if _cr_rate is not None:
+            cache_read_cost = float(cache_read_input_tokens) * float(_cr_rate)
+
+    if cache_creation_input_tokens:
+        _cc_key = _get_service_tier_cost_key(
+            "cache_creation_input_token_cost", service_tier
+        )
+        _cc_rate = _get_cost_per_unit(model_info, _cc_key, None)
+        if _cc_rate is not None:
+            cache_creation_cost = float(cache_creation_input_tokens) * float(_cc_rate)
+
+    return cache_read_cost, cache_creation_cost
+
+
 def _store_cost_breakdown_in_logging_obj(
     litellm_logging_obj: Optional[LitellmLoggingObject],
     prompt_tokens_cost_usd_dollar: float,
@@ -965,6 +1018,8 @@ def _store_cost_breakdown_in_logging_obj(
     margin_percent: Optional[float] = None,
     margin_fixed_amount: Optional[float] = None,
     margin_total_amount: Optional[float] = None,
+    cache_read_cost: Optional[float] = None,
+    cache_creation_cost: Optional[float] = None,
 ) -> None:
     """
     Helper function to store cost breakdown in the logging object.
@@ -982,6 +1037,8 @@ def _store_cost_breakdown_in_logging_obj(
         margin_percent: Margin percentage applied (0.10 = 10%)
         margin_fixed_amount: Fixed margin amount in USD
         margin_total_amount: Total margin added in USD
+        cache_read_cost: Cost attributable to cache-read tokens (additive annotation, overlaps input_cost)
+        cache_creation_cost: Cost attributable to cache-write/creation tokens (additive annotation, overlaps input_cost)
     """
     if litellm_logging_obj is None:
         return
@@ -1000,6 +1057,8 @@ def _store_cost_breakdown_in_logging_obj(
             margin_percent=margin_percent,
             margin_fixed_amount=margin_fixed_amount,
             margin_total_amount=margin_total_amount,
+            cache_read_cost=cache_read_cost,
+            cache_creation_cost=cache_creation_cost,
         )
 
     except Exception as breakdown_error:
@@ -1195,6 +1254,13 @@ def completion_cost(  # noqa: PLR0915
                         cache_read_input_tokens = prompt_tokens_details.get(
                             "cached_tokens", 0
                         )
+                        # Fall back to prompt_tokens_details for cache creation tokens
+                        # (used by OpenAI Responses API which reports via cache_write_tokens
+                        # or cache_creation_tokens under prompt_tokens_details)
+                        if not cache_creation_input_tokens:
+                            cache_creation_input_tokens = prompt_tokens_details.get(
+                                "cache_creation_tokens", 0
+                            ) or prompt_tokens_details.get("cache_write_tokens", 0)
 
                     total_time = getattr(completion_response, "_response_ms", 0)
 
@@ -1589,6 +1655,16 @@ def completion_cost(  # noqa: PLR0915
 
                 # Store cost breakdown in logging object if available
                 if litellm_logging_obj is not None:
+                    (
+                        _cache_read_cost,
+                        _cache_creation_cost,
+                    ) = _compute_cache_cost_itemization(
+                        model=model,
+                        custom_llm_provider=custom_llm_provider,
+                        cache_read_input_tokens=cache_read_input_tokens,
+                        cache_creation_input_tokens=cache_creation_input_tokens,
+                        service_tier=service_tier,
+                    )
                     _store_cost_breakdown_in_logging_obj(
                         litellm_logging_obj=litellm_logging_obj,
                         prompt_tokens_cost_usd_dollar=prompt_tokens_cost_usd_dollar,
@@ -1602,6 +1678,8 @@ def completion_cost(  # noqa: PLR0915
                         margin_percent=margin_percent,
                         margin_fixed_amount=margin_fixed_amount,
                         margin_total_amount=margin_total_amount,
+                        cache_read_cost=_cache_read_cost,
+                        cache_creation_cost=_cache_creation_cost,
                     )
 
                 return _final_cost

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -1377,6 +1377,8 @@ class Logging(LiteLLMLoggingBaseClass):
         margin_percent: Optional[float] = None,
         margin_fixed_amount: Optional[float] = None,
         margin_total_amount: Optional[float] = None,
+        cache_read_cost: Optional[float] = None,
+        cache_creation_cost: Optional[float] = None,
     ) -> None:
         """
         Helper method to store cost breakdown in the logging object.
@@ -1393,6 +1395,8 @@ class Logging(LiteLLMLoggingBaseClass):
             margin_percent: Margin percentage applied (0.10 = 10%)
             margin_fixed_amount: Fixed margin amount in USD
             margin_total_amount: Total margin added in USD
+            cache_read_cost: Cost attributable to cache-read tokens (additive annotation, overlaps input_cost)
+            cache_creation_cost: Cost attributable to cache-write/creation tokens (additive annotation, overlaps input_cost)
         """
 
         self.cost_breakdown = CostBreakdown(
@@ -1425,6 +1429,12 @@ class Logging(LiteLLMLoggingBaseClass):
             self.cost_breakdown["margin_fixed_amount"] = margin_fixed_amount
         if margin_total_amount is not None:
             self.cost_breakdown["margin_total_amount"] = margin_total_amount
+
+        # Store cache cost itemization if provided
+        if cache_read_cost is not None:
+            self.cost_breakdown["cache_read_cost"] = cache_read_cost
+        if cache_creation_cost is not None:
+            self.cost_breakdown["cache_creation_cost"] = cache_creation_cost
 
     def _response_cost_calculator(
         self,

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2810,6 +2810,10 @@ class CostBreakdown(TypedDict, total=False):
     margin_percent: float  # Margin percentage applied (e.g., 0.10 = 10%) (optional)
     margin_fixed_amount: float  # Fixed margin amount in USD (optional)
     margin_total_amount: float  # Total margin added in USD (optional)
+    cache_read_cost: float  # Cost attributable to cache-read tokens (optional)
+    cache_creation_cost: (
+        float  # Cost attributable to cache-write/creation tokens (optional)
+    )
 
 
 class StandardLoggingPayloadStatusFields(TypedDict, total=False):

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_cache_cost_itemization.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_cache_cost_itemization.py
@@ -1,0 +1,264 @@
+"""
+Tests for issue #34309:
+cache_read_cost / cache_creation_cost in cost_breakdown are null for providers
+that report cache tokens via prompt_tokens_details (e.g. OpenAI Responses API)
+instead of Anthropic-style top-level usage keys.
+"""
+
+import time
+
+import pytest
+
+import litellm
+from litellm.cost_calculator import completion_cost
+from litellm.litellm_core_utils.litellm_logging import Logging
+from litellm.types.utils import (
+    ModelResponse,
+    PromptTokensDetailsWrapper,
+    Usage,
+)
+
+MODEL = "openai/gpt-5-cacheitemize-test-34309"
+
+# Standard rates used throughout these tests.
+INPUT_RATE = 5e-6
+OUTPUT_RATE = 30e-6
+CACHE_READ_RATE = 5e-7
+CACHE_WRITE_RATE = 6.25e-6
+
+
+@pytest.fixture(autouse=True)
+def _register_model():
+    litellm.register_model(
+        {
+            MODEL: {
+                "litellm_provider": "openai",
+                "mode": "chat",
+                "input_cost_per_token": INPUT_RATE,
+                "output_cost_per_token": OUTPUT_RATE,
+                "cache_read_input_token_cost": CACHE_READ_RATE,
+                "cache_creation_input_token_cost": CACHE_WRITE_RATE,
+            },
+        },
+    )
+    yield
+
+
+def _new_logging_obj() -> Logging:
+    return Logging(
+        model=MODEL,
+        messages=[{"role": "user", "content": "hi"}],
+        stream=False,
+        call_type="completion",
+        start_time=time.time(),
+        litellm_call_id="test-34309",
+        function_id="test-34309",
+    )
+
+
+def _openai_style_usage(cached: int, cache_write: int, fresh: int, out: int) -> Usage:
+    """Build a Usage object that mimics the OpenAI Responses API:
+    cache-read  -> prompt_tokens_details.cached_tokens
+    cache-write -> prompt_tokens_details.cache_creation_tokens
+    No top-level cache_read_input_tokens / cache_creation_input_tokens.
+    """
+    ptd = PromptTokensDetailsWrapper(cached_tokens=cached)
+    # cache_creation_tokens is the standard field used by _parse_prompt_tokens_details
+    setattr(ptd, "cache_creation_tokens", cache_write)
+    return Usage(
+        prompt_tokens=cached + cache_write + fresh,
+        completion_tokens=out,
+        total_tokens=cached + cache_write + fresh + out,
+        prompt_tokens_details=ptd,
+    )
+
+
+def _response_with_usage(usage: Usage) -> ModelResponse:
+    resp = ModelResponse()
+    resp.model = MODEL
+    resp.usage = usage  # type: ignore[attr-defined]
+    return resp
+
+
+def test_openai_style_cache_read_cost_itemized():
+    """cache_read_cost is populated from prompt_tokens_details.cached_tokens."""
+    cached = 16000
+    fresh = 100
+    out = 50
+    usage = _openai_style_usage(cached=cached, cache_write=0, fresh=fresh, out=out)
+    logging_obj = _new_logging_obj()
+
+    completion_cost(
+        completion_response=_response_with_usage(usage),
+        model=MODEL,
+        custom_llm_provider="openai",
+        litellm_logging_obj=logging_obj,
+    )
+
+    breakdown = logging_obj.cost_breakdown
+    assert breakdown is not None, "cost_breakdown was not populated"
+    assert breakdown.get("cache_read_cost") == pytest.approx(
+        cached * CACHE_READ_RATE, rel=1e-6
+    ), (
+        f"cache_read_cost not itemized: got {breakdown.get('cache_read_cost')!r}, "
+        f"expected {cached * CACHE_READ_RATE}"
+    )
+    assert breakdown.get("cache_creation_cost") is None or breakdown.get(
+        "cache_creation_cost"
+    ) == pytest.approx(0.0, abs=1e-12)
+
+
+def test_openai_style_cache_creation_cost_itemized():
+    """cache_creation_cost is populated from prompt_tokens_details.cache_creation_tokens."""
+    cache_write = 26022
+    fresh = 100
+    out = 50
+    usage = _openai_style_usage(cached=0, cache_write=cache_write, fresh=fresh, out=out)
+    logging_obj = _new_logging_obj()
+
+    completion_cost(
+        completion_response=_response_with_usage(usage),
+        model=MODEL,
+        custom_llm_provider="openai",
+        litellm_logging_obj=logging_obj,
+    )
+
+    breakdown = logging_obj.cost_breakdown
+    assert breakdown is not None
+    assert breakdown.get("cache_creation_cost") == pytest.approx(
+        cache_write * CACHE_WRITE_RATE, rel=1e-6
+    ), (
+        f"cache_creation_cost not itemized: got {breakdown.get('cache_creation_cost')!r}, "
+        f"expected {cache_write * CACHE_WRITE_RATE}"
+    )
+
+
+def test_openai_style_both_cache_costs_itemized():
+    """Both cache_read_cost and cache_creation_cost are populated when both counts present."""
+    cached = 16000
+    cache_write = 26022
+    fresh = 100
+    out = 50
+    usage = _openai_style_usage(
+        cached=cached, cache_write=cache_write, fresh=fresh, out=out
+    )
+    logging_obj = _new_logging_obj()
+
+    total = completion_cost(
+        completion_response=_response_with_usage(usage),
+        model=MODEL,
+        custom_llm_provider="openai",
+        litellm_logging_obj=logging_obj,
+    )
+
+    breakdown = logging_obj.cost_breakdown
+    assert breakdown is not None
+    assert breakdown.get("cache_read_cost") == pytest.approx(
+        cached * CACHE_READ_RATE, rel=1e-6
+    )
+    assert breakdown.get("cache_creation_cost") == pytest.approx(
+        cache_write * CACHE_WRITE_RATE, rel=1e-6
+    )
+    # Grand total is unaffected by itemization.
+    assert total == pytest.approx(breakdown["total_cost"], rel=1e-6)
+
+
+def test_cache_cost_itemization_semantics_match_anthropic_convention():
+    """input_cost stays the full folded prompt-side spend; cache fields are additive annotations.
+
+    This matches the Anthropic-path convention so downstream consumers see consistent
+    semantics regardless of provider.
+    """
+    cached = 16000
+    cache_write = 26022
+    fresh = 100
+    out = 50
+    usage = _openai_style_usage(
+        cached=cached, cache_write=cache_write, fresh=fresh, out=out
+    )
+    logging_obj = _new_logging_obj()
+
+    completion_cost(
+        completion_response=_response_with_usage(usage),
+        model=MODEL,
+        custom_llm_provider="openai",
+        litellm_logging_obj=logging_obj,
+    )
+
+    b = logging_obj.cost_breakdown
+    assert b is not None
+
+    # input_cost must be the full prompt-side cost (cache dollars folded in).
+    expected_input = (
+        fresh * INPUT_RATE + cached * CACHE_READ_RATE + cache_write * CACHE_WRITE_RATE
+    )
+    assert b.get("input_cost") == pytest.approx(expected_input, rel=1e-6)
+
+    # Cache annotations overlap input_cost (they are NOT disjoint from it).
+    assert b.get("cache_read_cost") == pytest.approx(cached * CACHE_READ_RATE, rel=1e-6)
+    assert b.get("cache_creation_cost") == pytest.approx(
+        cache_write * CACHE_WRITE_RATE, rel=1e-6
+    )
+
+    # total_cost == input_cost + output_cost (cache fields are annotations only).
+    assert (b["input_cost"] + b.get("output_cost", 0.0)) == pytest.approx(
+        b["total_cost"], rel=1e-6
+    )
+
+
+def test_anthropic_style_cache_itemization_still_works():
+    """Regression: Anthropic-style top-level cache keys continue to populate the breakdown."""
+    cache_read_tokens = 2000
+    cache_creation_tokens = 3000
+    fresh = 100
+    out = 50
+    usage = Usage(
+        prompt_tokens=cache_read_tokens + cache_creation_tokens + fresh,
+        completion_tokens=out,
+        total_tokens=cache_read_tokens + cache_creation_tokens + fresh + out,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=cache_read_tokens,
+        ),
+    )
+    # Anthropic reports these as top-level usage attributes.
+    setattr(usage, "cache_read_input_tokens", cache_read_tokens)
+    setattr(usage, "cache_creation_input_tokens", cache_creation_tokens)
+    logging_obj = _new_logging_obj()
+
+    completion_cost(
+        completion_response=_response_with_usage(usage),
+        model=MODEL,
+        custom_llm_provider="openai",
+        litellm_logging_obj=logging_obj,
+    )
+
+    b = logging_obj.cost_breakdown
+    assert b is not None
+    assert b.get("cache_read_cost") == pytest.approx(
+        cache_read_tokens * CACHE_READ_RATE, rel=1e-6
+    )
+    assert b.get("cache_creation_cost") == pytest.approx(
+        cache_creation_tokens * CACHE_WRITE_RATE, rel=1e-6
+    )
+
+
+def test_no_cache_tokens_leaves_cache_fields_absent():
+    """When there are no cache tokens, cache_read_cost and cache_creation_cost are not set."""
+    usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=50,
+        total_tokens=150,
+    )
+    logging_obj = _new_logging_obj()
+
+    completion_cost(
+        completion_response=_response_with_usage(usage),
+        model=MODEL,
+        custom_llm_provider="openai",
+        litellm_logging_obj=logging_obj,
+    )
+
+    b = logging_obj.cost_breakdown
+    assert b is not None
+    assert "cache_read_cost" not in b
+    assert "cache_creation_cost" not in b


### PR DESCRIPTION
## Summary

- `CostBreakdown` TypedDict gains two new optional fields: `cache_read_cost` and `cache_creation_cost`
- `_store_cost_breakdown_in_logging_obj` and `set_cost_breakdown` now accept and propagate these fields
- New `_compute_cache_cost_itemization` helper computes itemized cache costs from token counts and model pricing
- `completion_cost` now falls back to `prompt_tokens_details.cache_creation_tokens` (and `cache_write_tokens`) when the Anthropic-style top-level `cache_creation_input_tokens` is absent -- matching the existing fallback for `cache_read_input_tokens`
- At the main completion call site the computed cache costs are passed to the breakdown function

The convention matches the existing Anthropic path: `input_cost` remains the full folded prompt-side cost and `cache_read_cost` / `cache_creation_cost` are additive annotations (they overlap `input_cost`, they do not partition it). The grand total is unaffected.

## Test plan

- [x] `test_openai_style_cache_read_cost_itemized` -- cache_read_cost populated from prompt_tokens_details.cached_tokens
- [x] `test_openai_style_cache_creation_cost_itemized` -- cache_creation_cost populated from prompt_tokens_details.cache_creation_tokens
- [x] `test_openai_style_both_cache_costs_itemized` -- both fields populated; total_cost unchanged
- [x] `test_cache_cost_itemization_semantics_match_anthropic_convention` -- input_cost remains full folded prompt-side cost
- [x] `test_anthropic_style_cache_itemization_still_works` -- regression: Anthropic top-level keys still work
- [x] `test_no_cache_tokens_leaves_cache_fields_absent` -- fields absent when no cache tokens present
- [x] All 63 existing tests in `tests/test_litellm/litellm_core_utils/llm_cost_calc/` pass

Fixes #34309