### PR TITLE
fix: handle explicit outputInfo: null in Vertex AI batch response

### DIFF
--- a/litellm/llms/vertex_ai/batches/transformation.py
+++ b/litellm/llms/vertex_ai/batches/transformation.py
@@ -123,7 +123,8 @@ class VertexAIBatchTransformation:
         Gets the output file id from the Vertex AI Batch response
         """
 
-        output_file_id: str = response.get("outputInfo", OutputInfo()).get("gcsOutputDirectory", "")
+        output_info = response.get("outputInfo") or OutputInfo()
+        output_file_id: str = output_info.get("gcsOutputDirectory", "")
         if output_file_id:
             output_file_id = output_file_id.rstrip("/") + "/predictions.jsonl"
         if output_file_id and output_file_id != "/predictions.jsonl":

--- a/tests/test_litellm/llms/vertex_ai/batches/test_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/batches/test_transformation.py
@@ -226,6 +226,23 @@ def test_get_output_file_id_empty_output_info_falls_through_to_output_config():
     assert T._get_output_file_id_from_vertex_ai_batch_response(resp) == "gs://b/cfg/predictions.jsonl"
 
 
+def test_get_output_file_id_output_info_explicit_none_falls_through_to_output_config():
+    # Vertex AI can return "outputInfo": null in a 200 response (e.g. before it has
+    # asynchronously assigned the output directory). dict.get(key, default) does NOT
+    # substitute default when the key is present but explicitly None, so this must be
+    # handled explicitly instead of crashing with AttributeError: 'NoneType' object
+    # has no attribute 'get'.
+    resp = {
+        "outputInfo": None,
+        "outputConfig": {"gcsDestination": {"outputUriPrefix": "gs://b/cfg"}},
+    }
+    assert T._get_output_file_id_from_vertex_ai_batch_response(resp) == "gs://b/cfg/predictions.jsonl"
+
+
+def test_get_output_file_id_output_info_explicit_none_and_no_output_config():
+    assert T._get_output_file_id_from_vertex_ai_batch_response({"outputInfo": None}) == ""
+
+
 def test_get_output_file_id_no_output_info_and_no_output_config():
     assert T._get_output_file_id_from_vertex_ai_batch_response({}) == ""
 

--- a/tests/test_litellm/llms/vertex_ai/batches/test_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/batches/test_transformation.py
@@ -227,11 +227,6 @@ def test_get_output_file_id_empty_output_info_falls_through_to_output_config():
 
 
 def test_get_output_file_id_output_info_explicit_none_falls_through_to_output_config():
-    # Vertex AI can return "outputInfo": null in a 200 response (e.g. before it has
-    # asynchronously assigned the output directory). dict.get(key, default) does NOT
-    # substitute default when the key is present but explicitly None, so this must be
-    # handled explicitly instead of crashing with AttributeError: 'NoneType' object
-    # has no attribute 'get'.
     resp = {
         "outputInfo": None,
         "outputConfig": {"gcsDestination": {"outputUriPrefix": "gs://b/cfg"}},


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex AI batch responses with explicit `outputInfo: null` crash litellm
- Callers see an opaque `openai.InternalServerError` 500 from `create_batch()` / `retrieve_batch()`

How it solves it:

- Guard `outputInfo` with `or OutputInfo()` before calling `.get()` on it
- Matches the null-safe pattern already used for `inputConfig` in the sibling helper

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Vertex AI assigns the batch output directory asynchronously, so its API can return HTTP 200 with an explicit `"outputInfo": null` body. `dict.get(key, default)` only substitutes the default when the key is absent, not when it is present but explicitly `None`, so the old code crashed on exactly that response shape

Before, at the parent of the fix commit (`bd753aecf3`, pre-fix code):

```python
>>> raw_response = {"outputInfo": None, "outputConfig": {"gcsDestination": {"outputUriPrefix": "gs://bucket/output/"}}}
>>> raw_response.get("outputInfo", OutputInfo()).get("gcsOutputDirectory", "")
AttributeError: 'NoneType' object has no attribute 'get'
```

After, at the fix commit (`4cfb0f8d89`), same input:

```python
>>> VertexAIBatchTransformation._get_output_file_id_from_vertex_ai_batch_response(raw_response)
'gs://bucket/output/predictions.jsonl'
```

No crash; the response falls through cleanly to the existing `outputConfig`-derived path a few lines below, which already handles this case correctly once it is reachable

The original PR verified the unguarded call is present in litellm 1.83.10 through 1.93.0 by direct source inspection of each published version. There is no live production reproduction attached; the response shape used above is the one Vertex AI's own API is documented to allow. The 2 new regression tests in `tests/test_litellm/llms/vertex_ai/batches/test_transformation.py` cover `outputInfo: null` with and without an `outputConfig` fallback, and the full file (44 tests) passes locally at `4cfb0f8d89`

## Type

🐛 Bug Fix

## Changes

`litellm/llms/vertex_ai/batches/transformation.py` guards `outputInfo` being explicitly `None` before calling `.get()` on it, matching the null-safe pattern already used by the sibling `_get_input_file_id_from_vertex_ai_batch_response`. `tests/test_litellm/llms/vertex_ai/batches/test_transformation.py` adds 2 regression tests for `outputInfo: null`, with and without an `outputConfig` fallback available

## Behavior changes

`retrieve_batch()` / `create_batch()` against Vertex AI no longer raise a 500 when the response contains `outputInfo: null`; they now fall through to the `outputConfig` fallback (or return the batch without an output file id if that is also absent). No other behavior changes

## Credit

Adopted from #34097 by @htourinho-clgx, mirrored onto a `litellm_` branch so CircleCI and the internal lint workflow run. The original fix commit is cherry-picked as-is with the author's commit metadata preserved. The original PR's follow-up commit bumping `ui/litellm-dashboard` dependencies (brace-expansion, js-yaml) is intentionally excluded; this PR carries only `transformation.py` and its test file

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/34473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow null-guard in batch response parsing with regression tests; no auth, data, or API contract changes beyond avoiding the crash.
> 
> **Overview**
> Fixes a crash when Vertex AI batch APIs return **`"outputInfo": null`** (common while output paths are assigned asynchronously). **`dict.get("outputInfo", OutputInfo())`** does not replace an explicit `None`, so the old code called `.get()` on `None` and **`create_batch()` / `retrieve_batch()`** surfaced as 500s.
> 
> **`_get_output_file_id_from_vertex_ai_batch_response`** now uses **`response.get("outputInfo") or OutputInfo()`** before reading `gcsOutputDirectory`, so the handler can fall through to **`outputConfig`** like it already did for missing or empty `outputInfo`. Two regression tests cover `outputInfo: null` with and without that fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5d9dfdeae39aed87093664402678dee547a553c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
