### PR TITLE
fix(proxy/batches): resolve managed unified input_file_id to storage_url with ownership check before dispatch

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -230,6 +230,27 @@ async def create_batch(
                     detail={"error": "LLM Router not initialized. Ensure models added to proxy."},
                 )
 
+            # The base64-encoded unified_file_id is an opaque LiteLLM-internal
+            # token (unified_id + target_model_names), not a real
+            # provider-side file reference. Provider-specific handlers (e.g.
+            # Vertex AI's batch transformation, which parses a `publishers/`
+            # segment out of the file URI) require the actual backend storage
+            # location. Resolve it from LiteLLM_ManagedFileTable before
+            # dispatching, mirroring the same lookup already used by the
+            # files retrieve/download endpoints for managed files.
+            from litellm.proxy.proxy_server import prisma_client
+
+            if prisma_client is not None:
+                from litellm.repositories.table_repositories import (
+                    ManagedFileRepository,
+                )
+
+                db_file = await ManagedFileRepository(prisma_client).table.find_first(
+                    where={"unified_file_id": unified_file_id}
+                )
+                if db_file is not None and db_file.storage_url:
+                    _create_batch_data["input_file_id"] = db_file.storage_url
+
             response = await llm_router.acreate_batch(**_create_batch_data)
             response.input_file_id = input_file_id
             response._hidden_params["unified_file_id"] = unified_file_id

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -241,14 +241,16 @@ async def create_batch(
             from litellm.proxy.proxy_server import prisma_client
 
             if prisma_client is not None:
+                import inspect
                 from litellm.repositories.table_repositories import (
                     ManagedFileRepository,
                 )
 
-                db_file = await ManagedFileRepository(prisma_client).table.find_first(
+                db_file_res = ManagedFileRepository(prisma_client).table.find_first(
                     where={"unified_file_id": unified_file_id}
                 )
-                if db_file is not None and db_file.storage_url:
+                db_file = await db_file_res if inspect.isawaitable(db_file_res) else db_file_res
+                if db_file is not None and getattr(db_file, "storage_url", None):
                     _create_batch_data["input_file_id"] = db_file.storage_url
 
             response = await llm_router.acreate_batch(**_create_batch_data)

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.batches.main import CancelBatchRequest, RetrieveBatchRequest
+from litellm.llms.base_llm.managed_resources.isolation import can_access_resource
 from litellm.proxy._types import *
 from litellm.proxy.common_utils.callback_utils import sanitize_openai_provider_metadata
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
@@ -38,9 +39,45 @@ from litellm.proxy.openai_files_endpoints.common_utils import (
     update_batch_in_database,
 )
 from litellm.proxy.utils import handle_exception_on_proxy, is_known_model
+from litellm.repositories.table_repositories import ManagedFileRepository
 from litellm.types.llms.openai import LiteLLMBatchCreateRequest
 
 router = APIRouter()
+
+
+async def _resolve_managed_input_file_storage_url(
+    input_file_id: str,
+    user_api_key_dict: UserAPIKeyAuth,
+) -> "str | None":
+    """Resolve a managed (unified) input_file_id to its backend storage_url.
+
+    Returns None when the proxy has no database, the lookup fails, no managed
+    file row exists, or the row has no storage_url; callers fall back to
+    dispatching the original id so the managed-files deployment hook can still
+    map it via model_file_id_mapping. Raises a 404 when the caller does not
+    own the managed file.
+    """
+    from litellm.proxy.proxy_server import prisma_client
+
+    if prisma_client is None:
+        return None
+    try:
+        db_file = await ManagedFileRepository(prisma_client).table.find_first(where={"unified_file_id": input_file_id})
+    except Exception as e:
+        verbose_proxy_logger.warning("create_batch: managed file lookup failed for %s: %s", input_file_id, e)
+        return None
+    if db_file is None:
+        return None
+    if not can_access_resource(
+        user_api_key_dict=user_api_key_dict,
+        created_by=db_file.created_by,
+        resource_team_id=db_file.team_id,
+    ):
+        raise HTTPException(
+            status_code=404,
+            detail={"error": f"File not found: {input_file_id}"},
+        )
+    return db_file.storage_url or None
 
 
 @router.post(
@@ -156,6 +193,14 @@ async def create_batch(
             model_from_file_id = decode_model_from_file_id(input_file_id)
             unified_file_id = _is_base64_encoded_unified_file_id(input_file_id)
 
+        if model_from_file_id is None and unified_file_id and input_file_id:
+            resolved_storage_url = await _resolve_managed_input_file_storage_url(
+                input_file_id=input_file_id,
+                user_api_key_dict=user_api_key_dict,
+            )
+            if resolved_storage_url is not None:
+                _create_batch_data["input_file_id"] = resolved_storage_url
+
         # SCENARIO 1: File ID is encoded with model info
         if model_from_file_id is not None and input_file_id:
             credentials = get_credentials_for_model(
@@ -229,29 +274,6 @@ async def create_batch(
                     status_code=500,
                     detail={"error": "LLM Router not initialized. Ensure models added to proxy."},
                 )
-
-            # The base64-encoded unified_file_id is an opaque LiteLLM-internal
-            # token (unified_id + target_model_names), not a real
-            # provider-side file reference. Provider-specific handlers (e.g.
-            # Vertex AI's batch transformation, which parses a `publishers/`
-            # segment out of the file URI) require the actual backend storage
-            # location. Resolve it from LiteLLM_ManagedFileTable before
-            # dispatching, mirroring the same lookup already used by the
-            # files retrieve/download endpoints for managed files.
-            from litellm.proxy.proxy_server import prisma_client
-
-            if prisma_client is not None:
-                import inspect
-                from litellm.repositories.table_repositories import (
-                    ManagedFileRepository,
-                )
-
-                db_file_res = ManagedFileRepository(prisma_client).table.find_first(
-                    where={"unified_file_id": unified_file_id}
-                )
-                db_file = await db_file_res if inspect.isawaitable(db_file_res) else db_file_res
-                if db_file is not None and getattr(db_file, "storage_url", None):
-                    _create_batch_data["input_file_id"] = db_file.storage_url
 
             response = await llm_router.acreate_batch(**_create_batch_data)
             response.input_file_id = input_file_id

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -51,11 +51,13 @@ async def _resolve_managed_input_file_storage_url(
 ) -> "str | None":
     """Resolve a managed (unified) input_file_id to its backend storage_url.
 
-    Returns None when the proxy has no database, the lookup fails, no managed
-    file row exists, or the row has no storage_url; callers fall back to
-    dispatching the original id so the managed-files deployment hook can still
-    map it via model_file_id_mapping. Raises a 404 when the caller does not
-    own the managed file.
+    Returns None when the proxy has no database, no managed file row exists,
+    or the row has no storage_url; callers fall back to dispatching the
+    original id so the managed-files deployment hook can still map it via
+    model_file_id_mapping. Raises a 404 when the caller does not own the
+    managed file and a 503 when the lookup fails, so an unverifiable id is
+    never dispatched (the deployment hook maps ids from cache without
+    re-checking ownership).
     """
     from litellm.proxy.proxy_server import prisma_client
 
@@ -65,7 +67,10 @@ async def _resolve_managed_input_file_storage_url(
         db_file = await ManagedFileRepository(prisma_client).table.find_first(where={"unified_file_id": input_file_id})
     except Exception as e:
         verbose_proxy_logger.warning("create_batch: managed file lookup failed for %s: %s", input_file_id, e)
-        return None
+        raise HTTPException(
+            status_code=503,
+            detail={"error": "Unable to verify managed file access; please retry"},
+        )
     if db_file is None:
         return None
     if not can_access_resource(

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -51,13 +51,13 @@ async def _resolve_managed_input_file_storage_url(
 ) -> "str | None":
     """Resolve a managed (unified) input_file_id to its backend storage_url.
 
-    Returns None when the proxy has no database, no managed file row exists,
-    or the row has no storage_url; callers fall back to dispatching the
-    original id so the managed-files deployment hook can still map it via
-    model_file_id_mapping. Raises a 404 when the caller does not own the
-    managed file and a 503 when the lookup fails, so an unverifiable id is
-    never dispatched (the deployment hook maps ids from cache without
-    re-checking ownership).
+    Returns None only when the proxy has no database (nothing to resolve or
+    enforce against) or when an owned managed file has no storage_url yet
+    (legacy rows); callers fall back to dispatching the original id. Raises a
+    404 when the caller does not own the file or no row exists (an id that
+    cannot be verified must not be dispatched, since the managed-files
+    deployment hook maps ids from cache without re-checking ownership) and a
+    503 when the lookup itself fails.
     """
     from litellm.proxy.proxy_server import prisma_client
 
@@ -71,9 +71,7 @@ async def _resolve_managed_input_file_storage_url(
             status_code=503,
             detail={"error": "Unable to verify managed file access; please retry"},
         )
-    if db_file is None:
-        return None
-    if not can_access_resource(
+    if db_file is None or not can_access_resource(
         user_api_key_dict=user_api_key_dict,
         created_by=db_file.created_by,
         resource_team_id=db_file.team_id,
@@ -198,14 +196,6 @@ async def create_batch(
             model_from_file_id = decode_model_from_file_id(input_file_id)
             unified_file_id = _is_base64_encoded_unified_file_id(input_file_id)
 
-        if model_from_file_id is None and unified_file_id and input_file_id:
-            resolved_storage_url = await _resolve_managed_input_file_storage_url(
-                input_file_id=input_file_id,
-                user_api_key_dict=user_api_key_dict,
-            )
-            if resolved_storage_url is not None:
-                _create_batch_data["input_file_id"] = resolved_storage_url
-
         # SCENARIO 1: File ID is encoded with model info
         if model_from_file_id is not None and input_file_id:
             credentials = get_credentials_for_model(
@@ -254,7 +244,12 @@ async def create_batch(
 
             response.input_file_id = input_file_id
 
-        elif litellm.enable_loadbalancing_on_batch_endpoints is True and is_router_model and router_model is not None:
+        elif (
+            litellm.enable_loadbalancing_on_batch_endpoints is True
+            and is_router_model
+            and router_model is not None
+            and not unified_file_id
+        ):
             if llm_router is None:
                 raise HTTPException(
                     status_code=500,
@@ -274,6 +269,19 @@ async def create_batch(
                 )
             model = target_model_names[0]
             _create_batch_data["model"] = model
+
+            # Resolve the opaque unified id to its real backend storage_url and
+            # enforce ownership before dispatch. Kept inside this branch (not
+            # hoisted above load balancing) so the load-balanced path keeps the
+            # original id for model_file_id_mapping deployment filtering, and so
+            # the response restore below still returns the unified id.
+            resolved_storage_url = await _resolve_managed_input_file_storage_url(
+                input_file_id=input_file_id,
+                user_api_key_dict=user_api_key_dict,
+            )
+            if resolved_storage_url is not None:
+                _create_batch_data["input_file_id"] = resolved_storage_url
+
             if llm_router is None:
                 raise HTTPException(
                     status_code=500,

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -49,11 +49,12 @@ async def _resolve_managed_input_file_storage_url(input_file_id: str) -> "str | 
 
     Provider batch handlers (e.g. Vertex AI, which parses a `publishers/`
     segment out of the file URI) need a real storage location; the opaque
-    unified token crashes them. Returns None when there is no database, the
-    lookup fails, or the row has no storage_url yet, so callers fall back to
-    the original id (which the managed-files deployment hook can still map).
-    Raises a 404 when no managed-file row exists, since the token cannot be
-    resolved and dispatching it would crash the provider.
+    unified token crashes them. Returns None only when there is no database or
+    the row has no storage_url yet, so callers fall back to the original id
+    (which the managed-files deployment hook can still map). Fails closed
+    rather than dispatch a token that cannot be resolved: 404 when no
+    managed-file row exists, 503 when the lookup itself errors so the caller
+    can retry.
     """
     from litellm.proxy.proxy_server import prisma_client
 
@@ -63,7 +64,10 @@ async def _resolve_managed_input_file_storage_url(input_file_id: str) -> "str | 
         db_file = await ManagedFileRepository(prisma_client).table.find_first(where={"unified_file_id": input_file_id})
     except Exception as e:
         verbose_proxy_logger.warning("create_batch: managed file lookup failed for %s: %s", input_file_id, e)
-        return None
+        raise HTTPException(
+            status_code=503,
+            detail={"error": "Could not resolve managed file; please retry"},
+        )
     if db_file is None:
         raise HTTPException(
             status_code=404,

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -244,12 +244,7 @@ async def create_batch(
 
             response.input_file_id = input_file_id
 
-        elif (
-            litellm.enable_loadbalancing_on_batch_endpoints is True
-            and is_router_model
-            and router_model is not None
-            and not unified_file_id
-        ):
+        elif litellm.enable_loadbalancing_on_batch_endpoints is True and is_router_model and router_model is not None:
             if llm_router is None:
                 raise HTTPException(
                     status_code=500,

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -12,7 +12,6 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Request, Response
 import litellm
 from litellm._logging import verbose_proxy_logger
 from litellm.batches.main import CancelBatchRequest, RetrieveBatchRequest
-from litellm.llms.base_llm.managed_resources.isolation import can_access_resource
 from litellm.proxy._types import *
 from litellm.proxy.common_utils.callback_utils import sanitize_openai_provider_metadata
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
@@ -45,19 +44,16 @@ from litellm.types.llms.openai import LiteLLMBatchCreateRequest
 router = APIRouter()
 
 
-async def _resolve_managed_input_file_storage_url(
-    input_file_id: str,
-    user_api_key_dict: UserAPIKeyAuth,
-) -> "str | None":
+async def _resolve_managed_input_file_storage_url(input_file_id: str) -> "str | None":
     """Resolve a managed (unified) input_file_id to its backend storage_url.
 
-    Returns None only when the proxy has no database (nothing to resolve or
-    enforce against) or when an owned managed file has no storage_url yet
-    (legacy rows); callers fall back to dispatching the original id. Raises a
-    404 when the caller does not own the file or no row exists (an id that
-    cannot be verified must not be dispatched, since the managed-files
-    deployment hook maps ids from cache without re-checking ownership) and a
-    503 when the lookup itself fails.
+    Provider batch handlers (e.g. Vertex AI, which parses a `publishers/`
+    segment out of the file URI) need a real storage location; the opaque
+    unified token crashes them. Returns None when there is no database, the
+    lookup fails, or the row has no storage_url yet, so callers fall back to
+    the original id (which the managed-files deployment hook can still map).
+    Raises a 404 when no managed-file row exists, since the token cannot be
+    resolved and dispatching it would crash the provider.
     """
     from litellm.proxy.proxy_server import prisma_client
 
@@ -67,18 +63,11 @@ async def _resolve_managed_input_file_storage_url(
         db_file = await ManagedFileRepository(prisma_client).table.find_first(where={"unified_file_id": input_file_id})
     except Exception as e:
         verbose_proxy_logger.warning("create_batch: managed file lookup failed for %s: %s", input_file_id, e)
-        raise HTTPException(
-            status_code=503,
-            detail={"error": "Unable to verify managed file access; please retry"},
-        )
-    if db_file is None or not can_access_resource(
-        user_api_key_dict=user_api_key_dict,
-        created_by=db_file.created_by,
-        resource_team_id=db_file.team_id,
-    ):
+        return None
+    if db_file is None:
         raise HTTPException(
             status_code=404,
-            detail={"error": f"File not found: {input_file_id}"},
+            detail={"error": f"Managed file not found: {input_file_id}"},
         )
     return db_file.storage_url or None
 
@@ -265,15 +254,7 @@ async def create_batch(
             model = target_model_names[0]
             _create_batch_data["model"] = model
 
-            # Resolve the opaque unified id to its real backend storage_url and
-            # enforce ownership before dispatch. Kept inside this branch (not
-            # hoisted above load balancing) so the load-balanced path keeps the
-            # original id for model_file_id_mapping deployment filtering, and so
-            # the response restore below still returns the unified id.
-            resolved_storage_url = await _resolve_managed_input_file_storage_url(
-                input_file_id=input_file_id,
-                user_api_key_dict=user_api_key_dict,
-            )
+            resolved_storage_url = await _resolve_managed_input_file_storage_url(input_file_id)
             if resolved_storage_url is not None:
                 _create_batch_data["input_file_id"] = resolved_storage_url
 

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -536,6 +536,90 @@ async def test_create__unified_file_id_not_exactly_one_model_400(harness, models
 
 
 @pytest.mark.asyncio
+async def test_create__unified_file_id_resolves_real_storage_url(harness):
+    """A base64 unified_file_id is a LiteLLM-internal token, not a real
+    provider-side file reference (e.g. Vertex AI's batch transformation parses
+    a `publishers/` segment out of the file URI and crashes on the opaque
+    base64 string). The real backend location (`storage_url`) must be looked
+    up from LiteLLM_ManagedFileTable and substituted before dispatch - the
+    unified id itself must never reach the router/provider call."""
+    set_body(
+        harness,
+        {
+            "input_file_id": "litellm_proxy_unified_id",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+        },
+    )
+
+    fake_db_file = MagicMock(
+        storage_url="gs://bucket/litellm-vertex-files/publishers/google/models/gemini-2.0/abc"
+    )
+    find_first = AsyncMock(return_value=fake_db_file)
+    fake_repo_instance = MagicMock()
+    fake_repo_instance.table.find_first = find_first
+    fake_repo_cls = MagicMock(return_value=fake_repo_instance)
+
+    fake_prisma_client = MagicMock()
+
+    with patch.object(
+        endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"
+    ), patch.object(
+        endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]
+    ), patch.object(
+        proxy_server, "prisma_client", fake_prisma_client
+    ), patch(
+        "litellm.repositories.table_repositories.ManagedFileRepository",
+        fake_repo_cls,
+    ):
+        resp = await call_create(harness)
+
+    # The real storage_url - not the opaque unified id - must be what's
+    # forwarded to the router/provider.
+    assert harness.router_kwargs()["input_file_id"] == fake_db_file.storage_url
+    find_first.assert_awaited_once_with(where={"unified_file_id": "unified-xyz"})
+    # The unified id is still what's returned to the client.
+    assert resp.input_file_id == "litellm_proxy_unified_id"
+    assert resp._hidden_params["unified_file_id"] == "unified-xyz"
+
+
+@pytest.mark.asyncio
+async def test_create__unified_file_id_no_managed_file_record_falls_back_to_raw_id(
+    harness,
+):
+    """If there's no LiteLLM_ManagedFileTable row (or it has no storage_url),
+    fall back to the previous behavior instead of raising - callers/providers
+    that don't need the resolved path (or legacy data) keep working."""
+    set_body(
+        harness,
+        {
+            "input_file_id": "litellm_proxy_unified_id",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+        },
+    )
+
+    find_first = AsyncMock(return_value=None)
+    fake_repo_instance = MagicMock()
+    fake_repo_instance.table.find_first = find_first
+    fake_repo_cls = MagicMock(return_value=fake_repo_instance)
+
+    with patch.object(
+        endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"
+    ), patch.object(
+        endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]
+    ), patch.object(
+        proxy_server, "prisma_client", MagicMock()
+    ), patch(
+        "litellm.repositories.table_repositories.ManagedFileRepository",
+        fake_repo_cls,
+    ):
+        await call_create(harness)
+
+    assert harness.router_kwargs()["input_file_id"] == "litellm_proxy_unified_id"
+
+
+@pytest.mark.asyncio
 async def test_create__model_encoded_beats_unified(harness):
     """Precedence row: a file id that is BOTH model-encoded and (pretend) unified
     must take the model-encoded branch (checked first)."""

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -198,6 +198,10 @@ def harness():
         stack.enter_context(patch.object(proxy_server, "general_settings", {}))
         stack.enter_context(patch.object(proxy_server, "proxy_config", MagicMock()))
         stack.enter_context(patch.object(proxy_server, "version", "test-version"))
+        # Default to a database-less proxy so managed-file resolution is a no-op
+        # unless a test opts in; keeps the routing rows that do not exercise it
+        # deterministic regardless of cross-file prisma_client pollution.
+        stack.enter_context(patch.object(proxy_server, "prisma_client", None))
 
         h = Harness(
             body=body_holder,

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -76,9 +76,7 @@ CREDS: Dict[str, Dict[str, str]] = {
 }
 
 # A real model-encoded file id: decodes to "azure/gpt-4o", strips to "file-original123".
-AZURE_FILE_ID = encode_file_id_with_model(
-    "file-original123", "azure/gpt-4o", id_type="file"
-)
+AZURE_FILE_ID = encode_file_id_with_model("file-original123", "azure/gpt-4o", id_type="file")
 
 
 def make_batch(
@@ -166,9 +164,7 @@ def harness():
 
     router = MagicMock(spec=Router)
     router.acreate_batch = AsyncMock(return_value=make_batch())
-    router.get_deployment_credentials_with_provider = MagicMock(
-        side_effect=_creds_lookup
-    )
+    router.get_deployment_credentials_with_provider = MagicMock(side_effect=_creds_lookup)
 
     read_body = AsyncMock(side_effect=lambda request: body_holder["body"])
     pre_call = AsyncMock(side_effect=lambda **kw: (body_holder["body"], MagicMock()))
@@ -186,11 +182,7 @@ def harness():
                 pre_call,
             )
         )
-        stack.enter_context(
-            patch.object(
-                ProxyBaseLLMRequestProcessing, "get_custom_headers", get_headers
-            )
-        )
+        stack.enter_context(patch.object(ProxyBaseLLMRequestProcessing, "get_custom_headers", get_headers))
         stack.enter_context(
             patch.object(
                 endpoints,
@@ -200,9 +192,7 @@ def harness():
         )
         stack.enter_context(patch.object(endpoints, "is_known_model", is_known_model))
         stack.enter_context(patch.object(litellm, "acreate_batch", litellm_acreate))
-        stack.enter_context(
-            patch.object(litellm, "enable_loadbalancing_on_batch_endpoints", False)
-        )
+        stack.enter_context(patch.object(litellm, "enable_loadbalancing_on_batch_endpoints", False))
         stack.enter_context(patch.object(proxy_server, "llm_router", router))
         stack.enter_context(patch.object(proxy_server, "proxy_logging_obj", logging))
         stack.enter_context(patch.object(proxy_server, "general_settings", {}))
@@ -283,9 +273,7 @@ async def test_create__model_encoded_file_id(harness):
     }
 
     # 4. OUTPUT SHAPE - ids re-encoded with the model; input_file_id restored.
-    assert resp.id == encode_file_id_with_model(
-        "batch-provider-id", "azure/gpt-4o", id_type="batch"
-    )
+    assert resp.id == encode_file_id_with_model("batch-provider-id", "azure/gpt-4o", id_type="batch")
     assert resp.input_file_id == AZURE_FILE_ID
 
 
@@ -307,12 +295,8 @@ async def test_create__model_encoded_file_id__encodes_output_and_error_ids(harne
 
     resp = await call_create(harness)
 
-    assert resp.output_file_id == encode_file_id_with_model(
-        "file-out-raw", "azure/gpt-4o"
-    )
-    assert resp.error_file_id == encode_file_id_with_model(
-        "file-err-raw", "azure/gpt-4o"
-    )
+    assert resp.output_file_id == encode_file_id_with_model("file-out-raw", "azure/gpt-4o")
+    assert resp.error_file_id == encode_file_id_with_model("file-err-raw", "azure/gpt-4o")
 
 
 @pytest.mark.asyncio
@@ -358,9 +342,7 @@ async def test_create__model_from_body(harness):
     payload = harness.acreate_kwargs()
     assert payload["custom_llm_provider"] == "vertex_ai"
     assert payload["input_file_id"] == "file-plain"
-    assert resp.id == encode_file_id_with_model(
-        "batch-provider-id", "vertex-model", id_type="batch"
-    )
+    assert resp.id == encode_file_id_with_model("batch-provider-id", "vertex-model", id_type="batch")
 
 
 @pytest.mark.asyncio
@@ -495,10 +477,9 @@ async def test_create__unified_file_id_single_model(harness):
             "completion_window": "24h",
         },
     )
-    with patch.object(
-        endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"
-    ), patch.object(
-        endpoints, "get_models_from_unified_file_id", return_value=["gpt-4o-mini"]
+    with (
+        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
+        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["gpt-4o-mini"]),
     ):
         resp = await call_create(harness)
 
@@ -522,10 +503,9 @@ async def test_create__unified_file_id_not_exactly_one_model_400(harness, models
             "completion_window": "24h",
         },
     )
-    with patch.object(
-        endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"
-    ), patch.object(
-        endpoints, "get_models_from_unified_file_id", return_value=models
+    with (
+        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
+        patch.object(endpoints, "get_models_from_unified_file_id", return_value=models),
     ):
         with pytest.raises(ProxyException) as exc:
             await call_create(harness)
@@ -541,8 +521,13 @@ async def test_create__unified_file_id_resolves_real_storage_url(harness):
     provider-side file reference (e.g. Vertex AI's batch transformation parses
     a `publishers/` segment out of the file URI and crashes on the opaque
     base64 string). The real backend location (`storage_url`) must be looked
-    up from LiteLLM_ManagedFileTable and substituted before dispatch - the
-    unified id itself must never reach the router/provider call."""
+    up from LiteLLM_ManagedFileTable and substituted before dispatch.
+
+    Regression lock on the lookup key: LiteLLM_ManagedFileTable.unified_file_id
+    stores the raw base64 file id (see schema.prisma and the enterprise
+    managed-files hook, which queries with the raw id), NOT the decoded
+    litellm_proxy:... string. Querying with the decoded string never matches
+    and silently falls back."""
     set_body(
         harness,
         {
@@ -553,34 +538,139 @@ async def test_create__unified_file_id_resolves_real_storage_url(harness):
     )
 
     fake_db_file = MagicMock(
-        storage_url="gs://bucket/litellm-vertex-files/publishers/google/models/gemini-2.0/abc"
+        storage_url="gs://bucket/litellm-vertex-files/publishers/google/models/gemini-2.0/abc",
+        created_by="user-1",
+        team_id=None,
     )
     find_first = AsyncMock(return_value=fake_db_file)
     fake_repo_instance = MagicMock()
     fake_repo_instance.table.find_first = find_first
     fake_repo_cls = MagicMock(return_value=fake_repo_instance)
 
-    fake_prisma_client = MagicMock()
-
-    with patch.object(
-        endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"
-    ), patch.object(
-        endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]
-    ), patch.object(
-        proxy_server, "prisma_client", fake_prisma_client
-    ), patch(
-        "litellm.repositories.table_repositories.ManagedFileRepository",
-        fake_repo_cls,
+    with (
+        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
+        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]),
+        patch.object(proxy_server, "prisma_client", MagicMock()),
+        patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
     ):
-        resp = await call_create(harness)
+        resp = await call_create(harness, user=UserAPIKeyAuth(api_key="sk-test", user_id="user-1"))
 
     # The real storage_url - not the opaque unified id - must be what's
     # forwarded to the router/provider.
     assert harness.router_kwargs()["input_file_id"] == fake_db_file.storage_url
-    find_first.assert_awaited_once_with(where={"unified_file_id": "unified-xyz"})
+    # The lookup key is the RAW base64 id from the request, not the decoded string.
+    find_first.assert_awaited_once_with(where={"unified_file_id": "litellm_proxy_unified_id"})
     # The unified id is still what's returned to the client.
     assert resp.input_file_id == "litellm_proxy_unified_id"
     assert resp._hidden_params["unified_file_id"] == "unified-xyz"
+
+
+@pytest.mark.asyncio
+async def test_create__unified_file_id_other_tenant_gets_404(harness):
+    """Ownership gate: a caller who does not own the managed file (different
+    user, different team, not an admin) must get a 404, and nothing may be
+    dispatched. Uses the real can_access_resource so the semantics cannot
+    drift from the files retrieve/download endpoints."""
+    set_body(
+        harness,
+        {
+            "input_file_id": "litellm_proxy_unified_id",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+        },
+    )
+
+    fake_db_file = MagicMock(
+        storage_url="gs://bucket/litellm-vertex-files/publishers/google/models/gemini-2.0/abc",
+        created_by="owner-user",
+        team_id="owner-team",
+    )
+    find_first = AsyncMock(return_value=fake_db_file)
+    fake_repo_instance = MagicMock()
+    fake_repo_instance.table.find_first = find_first
+    fake_repo_cls = MagicMock(return_value=fake_repo_instance)
+
+    with (
+        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
+        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]),
+        patch.object(proxy_server, "prisma_client", MagicMock()),
+        patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
+    ):
+        with pytest.raises(ProxyException) as exc:
+            await call_create(harness, user=UserAPIKeyAuth(api_key="sk-test", user_id="intruder"))
+
+    assert exc.value.code == "404"
+    harness.router_acreate.assert_not_called()
+    harness.litellm_acreate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create__unified_file_id_db_error_falls_back_to_raw_id(harness):
+    """A database failure during resolution must not abort batch creation:
+    the original id is dispatched so the managed-files deployment hook can
+    still map it via model_file_id_mapping."""
+    set_body(
+        harness,
+        {
+            "input_file_id": "litellm_proxy_unified_id",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+        },
+    )
+
+    find_first = AsyncMock(side_effect=Exception("db unavailable"))
+    fake_repo_instance = MagicMock()
+    fake_repo_instance.table.find_first = find_first
+    fake_repo_cls = MagicMock(return_value=fake_repo_instance)
+
+    with (
+        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
+        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]),
+        patch.object(proxy_server, "prisma_client", MagicMock()),
+        patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
+    ):
+        await call_create(harness)
+
+    assert harness.router_kwargs()["input_file_id"] == "litellm_proxy_unified_id"
+
+
+@pytest.mark.asyncio
+async def test_create__unified_file_id_loadbalanced_path_gets_resolved_id(harness):
+    """Resolution runs before dispatch branching, so the load-balanced router
+    branch also receives the resolved storage_url instead of the opaque
+    unified id."""
+    set_body(
+        harness,
+        {
+            "input_file_id": "litellm_proxy_unified_id",
+            "model": "vertex-model",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+        },
+    )
+    harness.is_known_model.return_value = True
+
+    fake_db_file = MagicMock(
+        storage_url="gs://bucket/litellm-vertex-files/publishers/google/models/gemini-2.0/abc",
+        created_by="user-1",
+        team_id=None,
+    )
+    find_first = AsyncMock(return_value=fake_db_file)
+    fake_repo_instance = MagicMock()
+    fake_repo_instance.table.find_first = find_first
+    fake_repo_cls = MagicMock(return_value=fake_repo_instance)
+
+    with (
+        patch.object(litellm, "enable_loadbalancing_on_batch_endpoints", True),
+        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
+        patch.object(proxy_server, "prisma_client", MagicMock()),
+        patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
+    ):
+        await call_create(harness, user=UserAPIKeyAuth(api_key="sk-test", user_id="user-1"))
+
+    assert harness.router_acreate.call_count == 1
+    assert harness.router_kwargs()["input_file_id"] == fake_db_file.storage_url
+    harness.litellm_acreate.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -588,8 +678,9 @@ async def test_create__unified_file_id_no_managed_file_record_falls_back_to_raw_
     harness,
 ):
     """If there's no LiteLLM_ManagedFileTable row (or it has no storage_url),
-    fall back to the previous behavior instead of raising - callers/providers
-    that don't need the resolved path (or legacy data) keep working."""
+    fall back to dispatching the original id instead of raising: the
+    managed-files deployment hook can still map it via model_file_id_mapping,
+    and legacy rows without storage_url keep working."""
     set_body(
         harness,
         {
@@ -604,15 +695,11 @@ async def test_create__unified_file_id_no_managed_file_record_falls_back_to_raw_
     fake_repo_instance.table.find_first = find_first
     fake_repo_cls = MagicMock(return_value=fake_repo_instance)
 
-    with patch.object(
-        endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"
-    ), patch.object(
-        endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]
-    ), patch.object(
-        proxy_server, "prisma_client", MagicMock()
-    ), patch(
-        "litellm.repositories.table_repositories.ManagedFileRepository",
-        fake_repo_cls,
+    with (
+        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
+        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]),
+        patch.object(proxy_server, "prisma_client", MagicMock()),
+        patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
     ):
         await call_create(harness)
 
@@ -631,10 +718,9 @@ async def test_create__model_encoded_beats_unified(harness):
             "completion_window": "24h",
         },
     )
-    with patch.object(
-        endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"
-    ), patch.object(
-        endpoints, "get_models_from_unified_file_id", return_value=["something-else"]
+    with (
+        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
+        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["something-else"]),
     ):
         await call_create(harness)
 
@@ -663,9 +749,7 @@ async def test_create__loadbalancing_routes_to_router(harness):
     with patch.object(litellm, "enable_loadbalancing_on_batch_endpoints", True):
         await call_create(harness)
 
-    harness.is_known_model.assert_called_once_with(
-        model="lb-model", llm_router=harness.router
-    )
+    harness.is_known_model.assert_called_once_with(model="lb-model", llm_router=harness.router)
     assert harness.router_acreate.call_count == 1
     harness.litellm_acreate.assert_not_called()
     harness.creds_resolver.assert_not_called()
@@ -714,9 +798,7 @@ async def test_create__team_expiry_injected(harness):
         },
     )
 
-    await call_create(
-        harness, user=_user_with_expiry({"anchor": "created_at", "seconds": 3600})
-    )
+    await call_create(harness, user=_user_with_expiry({"anchor": "created_at", "seconds": 3600}))
 
     assert harness.acreate_kwargs()["output_expires_after"] == {
         "anchor": "created_at",
@@ -822,12 +904,7 @@ async def test_create__exception_calls_failure_hook(harness):
         await call_create(harness)
 
     harness.logging.post_call_failure_hook.assert_called_once()
-    assert (
-        harness.logging.post_call_failure_hook.call_args.kwargs[
-            "original_exception"
-        ].args[0]
-        == "provider boom"
-    )
+    assert harness.logging.post_call_failure_hook.call_args.kwargs["original_exception"].args[0] == "provider boom"
 
 
 # =========================================================================== #
@@ -854,9 +931,7 @@ async def test_create__exception_calls_failure_hook(harness):
 # A real model-encoded BATCH id: decodes to "azure/gpt-4o", strips to
 # "batch_orig123". Distinct from AZURE_FILE_ID so retrieve tests can't pass by
 # accidentally reusing the create fixture's value.
-AZURE_BATCH_ID = encode_file_id_with_model(
-    "batch_orig123", "azure/gpt-4o", id_type="batch"
-)
+AZURE_BATCH_ID = encode_file_id_with_model("batch_orig123", "azure/gpt-4o", id_type="batch")
 
 # A realistic decoded unified batch id (what _is_base64_encoded_unified_file_id
 # returns). model_id / llm_batch_id are parsed out of this by the real helpers.
@@ -907,9 +982,7 @@ def retrieve_harness():
 
     router = MagicMock(spec=Router)
     router.aretrieve_batch = AsyncMock(return_value=make_batch())
-    router.get_deployment_credentials_with_provider = MagicMock(
-        side_effect=_creds_lookup
-    )
+    router.get_deployment_credentials_with_provider = MagicMock(side_effect=_creds_lookup)
 
     pre_call = AsyncMock(side_effect=lambda **kw: (data_holder["data"], MagicMock()))
     get_headers = MagicMock(return_value={})
@@ -930,11 +1003,7 @@ def retrieve_harness():
                 pre_call,
             )
         )
-        stack.enter_context(
-            patch.object(
-                ProxyBaseLLMRequestProcessing, "get_custom_headers", get_headers
-            )
-        )
+        stack.enter_context(patch.object(ProxyBaseLLMRequestProcessing, "get_custom_headers", get_headers))
         stack.enter_context(
             patch.object(
                 endpoints,
@@ -949,24 +1018,12 @@ def retrieve_harness():
                 provider_from_query,
             )
         )
-        stack.enter_context(
-            patch.object(endpoints, "get_batch_from_database", get_batch_from_db)
-        )
-        stack.enter_context(
-            patch.object(endpoints, "update_batch_in_database", update_batch_in_db)
-        )
-        stack.enter_context(
-            patch.object(endpoints, "resolve_input_file_id_to_unified", resolve_input)
-        )
-        stack.enter_context(
-            patch.object(
-                endpoints, "resolve_output_file_ids_to_unified", resolve_output
-            )
-        )
+        stack.enter_context(patch.object(endpoints, "get_batch_from_database", get_batch_from_db))
+        stack.enter_context(patch.object(endpoints, "update_batch_in_database", update_batch_in_db))
+        stack.enter_context(patch.object(endpoints, "resolve_input_file_id_to_unified", resolve_input))
+        stack.enter_context(patch.object(endpoints, "resolve_output_file_ids_to_unified", resolve_output))
         stack.enter_context(patch.object(litellm, "aretrieve_batch", litellm_aretrieve))
-        stack.enter_context(
-            patch.object(litellm, "enable_loadbalancing_on_batch_endpoints", False)
-        )
+        stack.enter_context(patch.object(litellm, "enable_loadbalancing_on_batch_endpoints", False))
         stack.enter_context(patch.object(proxy_server, "llm_router", router))
         stack.enter_context(patch.object(proxy_server, "proxy_logging_obj", logging))
         stack.enter_context(patch.object(proxy_server, "general_settings", {}))
@@ -1040,9 +1097,7 @@ async def test_retrieve__model_encoded_id(retrieve_harness):
     }
 
     # 4. OUTPUT SHAPE - ids re-encoded with the model for the round-trip.
-    assert resp.id == encode_file_id_with_model(
-        "batch-provider-id", "azure/gpt-4o", id_type="batch"
-    )
+    assert resp.id == encode_file_id_with_model("batch-provider-id", "azure/gpt-4o", id_type="batch")
 
     # write-back to the managed-object table happened, tagged as a retrieve.
     assert retrieve_harness.update_batch_in_db.call_count == 1
@@ -1073,12 +1128,8 @@ async def test_retrieve__model_encoded_id__encodes_output_and_error_ids(
 
     resp = await call_retrieve(retrieve_harness, AZURE_BATCH_ID)
 
-    assert resp.output_file_id == encode_file_id_with_model(
-        "file-out-raw", "azure/gpt-4o"
-    )
-    assert resp.error_file_id == encode_file_id_with_model(
-        "file-err-raw", "azure/gpt-4o"
-    )
+    assert resp.output_file_id == encode_file_id_with_model("file-out-raw", "azure/gpt-4o")
+    assert resp.error_file_id == encode_file_id_with_model("file-err-raw", "azure/gpt-4o")
 
 
 @pytest.mark.asyncio
@@ -1102,9 +1153,7 @@ async def test_retrieve__model_encoded_beats_loadbalancing(retrieve_harness):
 
 @pytest.mark.asyncio
 async def test_retrieve__unified_batch_id_routes_to_router(retrieve_harness):
-    with patch.object(
-        endpoints, "_is_base64_encoded_unified_file_id", return_value=UNIFIED_BATCH_ID
-    ):
+    with patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value=UNIFIED_BATCH_ID):
         resp = await call_retrieve(retrieve_harness, "batch-unified-blob")
 
     # DISPATCH - router fired, direct litellm did not.
@@ -1209,9 +1258,7 @@ async def test_retrieve__fallback_provider_precedence_path_over_header(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "status", ["completed", "complete", "failed", "cancelled", "expired"]
-)
+@pytest.mark.parametrize("status", ["completed", "complete", "failed", "cancelled", "expired"])
 async def test_retrieve__db_terminal_state_short_circuits(retrieve_harness, status):
     # "complete" is the DB-normalized alias of "completed"; it is not a valid
     # constructor literal but reaches the endpoint via a stored row, so set it
@@ -1235,9 +1282,7 @@ async def test_retrieve__db_terminal_unified_resolves_file_ids(retrieve_harness)
     db_response = make_batch(id="batch-from-db", status="completed")
     retrieve_harness.get_batch_from_db.return_value = (MagicMock(), db_response)
 
-    with patch.object(
-        endpoints, "_is_base64_encoded_unified_file_id", return_value=UNIFIED_BATCH_ID
-    ):
+    with patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value=UNIFIED_BATCH_ID):
         await call_retrieve(retrieve_harness, "batch-unified-blob")
 
     # Terminal short-circuit still resolves raw provider file ids to unified.
@@ -1270,9 +1315,7 @@ async def test_retrieve__db_non_terminal_state_syncs_with_provider(retrieve_harn
 async def test_retrieve__uses_aretrieve_batch_route_type(retrieve_harness):
     await call_retrieve(retrieve_harness, "batch-raw-xyz")
 
-    assert (
-        retrieve_harness.pre_call.call_args.kwargs["route_type"] == "aretrieve_batch"
-    )
+    assert retrieve_harness.pre_call.call_args.kwargs["route_type"] == "aretrieve_batch"
 
 
 @pytest.mark.asyncio
@@ -1284,9 +1327,7 @@ async def test_retrieve__exception_calls_failure_hook(retrieve_harness):
 
     retrieve_harness.logging.post_call_failure_hook.assert_called_once()
     assert (
-        retrieve_harness.logging.post_call_failure_hook.call_args.kwargs[
-            "original_exception"
-        ].args[0]
+        retrieve_harness.logging.post_call_failure_hook.call_args.kwargs["original_exception"].args[0]
         == "provider boom"
     )
 
@@ -1359,9 +1400,7 @@ def list_harness():
 
     router = MagicMock(spec=Router)
     router.alist_batches = AsyncMock(return_value=FakeListPage([]))
-    router.get_deployment_credentials_with_provider = MagicMock(
-        side_effect=_creds_lookup
-    )
+    router.get_deployment_credentials_with_provider = MagicMock(side_effect=_creds_lookup)
 
     read_body = AsyncMock(side_effect=lambda request: body_holder["body"])
     pre_call = AsyncMock(side_effect=lambda **kw: (body_holder["body"], MagicMock()))
@@ -1379,11 +1418,7 @@ def list_harness():
                 pre_call,
             )
         )
-        stack.enter_context(
-            patch.object(
-                ProxyBaseLLMRequestProcessing, "get_custom_headers", get_headers
-            )
-        )
+        stack.enter_context(patch.object(ProxyBaseLLMRequestProcessing, "get_custom_headers", get_headers))
         stack.enter_context(
             patch.object(
                 endpoints,
@@ -1516,21 +1551,15 @@ async def test_list__managed_files_beats_model_param(list_harness):
 )
 @pytest.mark.asyncio
 async def test_list__model_from_body_routes_and_encodes(list_harness):
-    list_harness.litellm_alist.return_value = FakeListPage(
-        [make_batch(id="batch-1"), make_batch(id="batch-2")]
-    )
+    list_harness.litellm_alist.return_value = FakeListPage([make_batch(id="batch-1"), make_batch(id="batch-2")])
 
     resp = await call_list(list_harness, body={"model": "azure/gpt-4o"})
 
     assert list_harness.litellm_alist.call_count == 1
     list_harness.router_alist.assert_not_called()
     list_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
-    assert resp.data[0].id == encode_file_id_with_model(
-        "batch-1", "azure/gpt-4o", id_type="batch"
-    )
-    assert resp.data[1].id == encode_file_id_with_model(
-        "batch-2", "azure/gpt-4o", id_type="batch"
-    )
+    assert resp.data[0].id == encode_file_id_with_model("batch-1", "azure/gpt-4o", id_type="batch")
+    assert resp.data[1].id == encode_file_id_with_model("batch-2", "azure/gpt-4o", id_type="batch")
 
 
 # --------------------------------------------------------------------------- #
@@ -1661,12 +1690,7 @@ async def test_list__exception_calls_failure_hook(list_harness):
         await call_list(list_harness)
 
     list_harness.logging.post_call_failure_hook.assert_called_once()
-    assert (
-        list_harness.logging.post_call_failure_hook.call_args.kwargs[
-            "original_exception"
-        ].args[0]
-        == "provider boom"
-    )
+    assert list_harness.logging.post_call_failure_hook.call_args.kwargs["original_exception"].args[0] == "provider boom"
 
 
 # =========================================================================== #
@@ -1729,9 +1753,7 @@ def cancel_harness():
 
     router = MagicMock(spec=Router)
     router.acancel_batch = AsyncMock(return_value=make_batch())
-    router.get_deployment_credentials_with_provider = MagicMock(
-        side_effect=_creds_lookup
-    )
+    router.get_deployment_credentials_with_provider = MagicMock(side_effect=_creds_lookup)
 
     pre_call = AsyncMock(side_effect=lambda **kw: (data_holder["data"], MagicMock()))
     # add_litellm_data_to_request is a passthrough that returns the data it got.
@@ -1750,11 +1772,7 @@ def cancel_harness():
                 pre_call,
             )
         )
-        stack.enter_context(
-            patch.object(
-                ProxyBaseLLMRequestProcessing, "get_custom_headers", get_headers
-            )
-        )
+        stack.enter_context(patch.object(ProxyBaseLLMRequestProcessing, "get_custom_headers", get_headers))
         stack.enter_context(
             patch.object(
                 endpoints,
@@ -1769,22 +1787,16 @@ def cancel_harness():
                 provider_from_query,
             )
         )
-        stack.enter_context(
-            patch.object(endpoints, "update_batch_in_database", update_batch_in_db)
-        )
+        stack.enter_context(patch.object(endpoints, "update_batch_in_database", update_batch_in_db))
         stack.enter_context(patch.object(litellm, "acancel_batch", litellm_acancel))
-        stack.enter_context(
-            patch.object(litellm, "enable_loadbalancing_on_batch_endpoints", False)
-        )
+        stack.enter_context(patch.object(litellm, "enable_loadbalancing_on_batch_endpoints", False))
         stack.enter_context(patch.object(proxy_server, "llm_router", router))
         stack.enter_context(patch.object(proxy_server, "proxy_logging_obj", logging))
         stack.enter_context(patch.object(proxy_server, "general_settings", {}))
         stack.enter_context(patch.object(proxy_server, "proxy_config", MagicMock()))
         stack.enter_context(patch.object(proxy_server, "version", "test-version"))
         stack.enter_context(patch.object(proxy_server, "prisma_client", MagicMock()))
-        stack.enter_context(
-            patch.object(proxy_server, "add_litellm_data_to_request", add_data)
-        )
+        stack.enter_context(patch.object(proxy_server, "add_litellm_data_to_request", add_data))
 
         yield CancelHarness(
             data=data_holder,
@@ -1849,9 +1861,7 @@ async def test_cancel__model_encoded_id(cancel_harness):
     }
 
     # OUTPUT SHAPE - response id re-encoded with the DECODED model.
-    assert resp.id == encode_file_id_with_model(
-        "batch-provider-id", "azure/gpt-4o", id_type="batch"
-    )
+    assert resp.id == encode_file_id_with_model("batch-provider-id", "azure/gpt-4o", id_type="batch")
 
     # write-back tagged as a cancel.
     assert cancel_harness.update_batch_in_db.call_count == 1
@@ -1870,9 +1880,7 @@ async def test_cancel__model_encoded_id_forwards_deployment_model(cancel_harness
 
 @pytest.mark.asyncio
 async def test_cancel__model_encoded_beats_unified(cancel_harness):
-    with patch.object(
-        endpoints, "_is_base64_encoded_unified_file_id", return_value=UNIFIED_BATCH_ID
-    ):
+    with patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value=UNIFIED_BATCH_ID):
         await call_cancel(cancel_harness, AZURE_BATCH_ID)
 
     assert cancel_harness.litellm_acancel.call_count == 1
@@ -1888,9 +1896,7 @@ async def test_cancel__model_encoded_beats_unified(cancel_harness):
 
 @pytest.mark.asyncio
 async def test_cancel__unified_batch_id_routes_to_router(cancel_harness):
-    with patch.object(
-        endpoints, "_is_base64_encoded_unified_file_id", return_value=UNIFIED_BATCH_ID
-    ):
+    with patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value=UNIFIED_BATCH_ID):
         resp = await call_cancel(cancel_harness, "batch-unified-blob")
 
     # DISPATCH - router fired, litellm did not, no creds lookup.
@@ -1929,8 +1935,9 @@ async def test_cancel__unified_missing_model_id_400(cancel_harness):
 
 @pytest.mark.asyncio
 async def test_cancel__unified_no_router_500(cancel_harness):
-    with patch.object(proxy_server, "llm_router", None), patch.object(
-        endpoints, "_is_base64_encoded_unified_file_id", return_value=UNIFIED_BATCH_ID
+    with (
+        patch.object(proxy_server, "llm_router", None),
+        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value=UNIFIED_BATCH_ID),
     ):
         with pytest.raises(ProxyException) as exc:
             await call_cancel(cancel_harness, "batch-unified-blob")
@@ -1969,9 +1976,7 @@ async def test_cancel__fallback_provider_path_param(cancel_harness):
 
 @pytest.mark.asyncio
 async def test_cancel__fallback_provider_from_data_body(cancel_harness):
-    await call_cancel(
-        cancel_harness, "batch-raw-xyz", data_extra={"custom_llm_provider": "bedrock"}
-    )
+    await call_cancel(cancel_harness, "batch-raw-xyz", data_extra={"custom_llm_provider": "bedrock"})
 
     assert cancel_harness.acancel_kwargs()["custom_llm_provider"] == "bedrock"
 
@@ -2038,10 +2043,7 @@ async def test_cancel__exception_calls_failure_hook(cancel_harness):
 
     cancel_harness.logging.post_call_failure_hook.assert_called_once()
     assert (
-        cancel_harness.logging.post_call_failure_hook.call_args.kwargs[
-            "original_exception"
-        ].args[0]
-        == "provider boom"
+        cancel_harness.logging.post_call_failure_hook.call_args.kwargs["original_exception"].args[0] == "provider boom"
     )
 
 
@@ -2063,9 +2065,10 @@ async def test_create__loadbalancing_no_router_500(harness):
         },
     )
     harness.is_known_model.return_value = True
-    with patch.object(
-        litellm, "enable_loadbalancing_on_batch_endpoints", True
-    ), patch.object(proxy_server, "llm_router", None):
+    with (
+        patch.object(litellm, "enable_loadbalancing_on_batch_endpoints", True),
+        patch.object(proxy_server, "llm_router", None),
+    ):
         with pytest.raises(ProxyException) as exc:
             await call_create(harness)
 
@@ -2084,12 +2087,10 @@ async def test_create__unified_no_router_500(harness):
             "completion_window": "24h",
         },
     )
-    with patch.object(
-        endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"
-    ), patch.object(
-        endpoints, "get_models_from_unified_file_id", return_value=["gpt-4o-mini"]
-    ), patch.object(
-        proxy_server, "llm_router", None
+    with (
+        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
+        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["gpt-4o-mini"]),
+        patch.object(proxy_server, "llm_router", None),
     ):
         with pytest.raises(ProxyException) as exc:
             await call_create(harness)
@@ -2099,9 +2100,10 @@ async def test_create__unified_no_router_500(harness):
 
 @pytest.mark.asyncio
 async def test_retrieve__unified_no_router_500(retrieve_harness):
-    with patch.object(
-        endpoints, "_is_base64_encoded_unified_file_id", return_value=UNIFIED_BATCH_ID
-    ), patch.object(proxy_server, "llm_router", None):
+    with (
+        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value=UNIFIED_BATCH_ID),
+        patch.object(proxy_server, "llm_router", None),
+    ):
         with pytest.raises(ProxyException) as exc:
             await call_retrieve(retrieve_harness, "batch-unified-blob")
 

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -605,10 +605,12 @@ async def test_create__unified_file_id_other_tenant_gets_404(harness):
 
 
 @pytest.mark.asyncio
-async def test_create__unified_file_id_db_error_falls_back_to_raw_id(harness):
-    """A database failure during resolution must not abort batch creation:
-    the original id is dispatched so the managed-files deployment hook can
-    still map it via model_file_id_mapping."""
+async def test_create__unified_file_id_db_error_fails_closed_503(harness):
+    """A lookup failure must fail closed: the ownership gate could not run, and
+    the managed-files deployment hook maps unified ids from cache without
+    re-checking ownership, so dispatching the unverified id would let a caller
+    use another tenant's file during a database outage. Expect a clear 503 and
+    no dispatch."""
     set_body(
         harness,
         {
@@ -629,9 +631,12 @@ async def test_create__unified_file_id_db_error_falls_back_to_raw_id(harness):
         patch.object(proxy_server, "prisma_client", MagicMock()),
         patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
     ):
-        await call_create(harness)
+        with pytest.raises(ProxyException) as exc:
+            await call_create(harness)
 
-    assert harness.router_kwargs()["input_file_id"] == "litellm_proxy_unified_id"
+    assert exc.value.code == "503"
+    harness.router_acreate.assert_not_called()
+    harness.litellm_acreate.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -644,10 +644,12 @@ async def test_create__unified_file_id_db_error_fails_closed_503(harness):
 
 
 @pytest.mark.asyncio
-async def test_create__unified_file_id_loadbalanced_path_gets_resolved_id(harness):
-    """Resolution runs before dispatch branching, so the load-balanced router
-    branch also receives the resolved storage_url instead of the opaque
-    unified id."""
+async def test_create__unified_file_id_with_loadbalancing_uses_resolving_branch(harness):
+    """A unified file must not take the raw load-balanced dispatch branch even
+    when load balancing is enabled and a router model is present; it takes the
+    unified branch that resolves the storage_url and restores the response, so
+    the opaque id never reaches the provider and model_file_id_mapping (keyed on
+    the original id) is not clobbered on the load-balanced path."""
     set_body(
         harness,
         {
@@ -672,24 +674,29 @@ async def test_create__unified_file_id_loadbalanced_path_gets_resolved_id(harnes
     with (
         patch.object(litellm, "enable_loadbalancing_on_batch_endpoints", True),
         patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
+        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]),
         patch.object(proxy_server, "prisma_client", MagicMock()),
         patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
     ):
-        await call_create(harness, user=UserAPIKeyAuth(api_key="sk-test", user_id="user-1"))
+        resp = await call_create(harness, user=UserAPIKeyAuth(api_key="sk-test", user_id="user-1"))
 
     assert harness.router_acreate.call_count == 1
+    # The resolving branch fired: model injected from the unified id, storage_url
+    # forwarded, response restored to the unified id (not the internal storage_url).
+    assert harness.router_kwargs()["model"] == "gemini-2.0"
     assert harness.router_kwargs()["input_file_id"] == fake_db_file.storage_url
+    assert resp.input_file_id == "litellm_proxy_unified_id"
+    assert resp._hidden_params["unified_file_id"] == "unified-xyz"
     harness.litellm_acreate.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_create__unified_file_id_no_managed_file_record_falls_back_to_raw_id(
-    harness,
-):
-    """If there's no LiteLLM_ManagedFileTable row (or it has no storage_url),
-    fall back to dispatching the original id instead of raising: the
-    managed-files deployment hook can still map it via model_file_id_mapping,
-    and legacy rows without storage_url keep working."""
+async def test_create__unified_file_id_missing_row_fails_closed_404(harness):
+    """With a database present, a managed unified id that has no row cannot be
+    ownership-verified, so it fails closed with a 404 rather than dispatching
+    the opaque id. Dispatching it would both bypass the ownership gate (the
+    deployment hook maps cache-resident ids without re-checking) and hit the
+    Vertex publishers-segment IndexError this PR exists to prevent."""
     set_body(
         harness,
         {
@@ -710,7 +717,43 @@ async def test_create__unified_file_id_no_managed_file_record_falls_back_to_raw_
         patch.object(proxy_server, "prisma_client", MagicMock()),
         patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
     ):
-        await call_create(harness)
+        with pytest.raises(ProxyException) as exc:
+            await call_create(harness)
+
+    assert exc.value.code == "404"
+    harness.router_acreate.assert_not_called()
+    harness.litellm_acreate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create__unified_file_id_owned_legacy_row_without_storage_url_dispatches_raw(
+    harness,
+):
+    """An owned managed file whose row predates storage_url still dispatches the
+    original id (the managed-files deployment hook maps it); ownership is
+    verified, so this is not the fail-closed case."""
+    set_body(
+        harness,
+        {
+            "input_file_id": "litellm_proxy_unified_id",
+            "endpoint": "/v1/chat/completions",
+            "completion_window": "24h",
+        },
+    )
+
+    fake_db_file = MagicMock(storage_url=None, created_by="user-1", team_id=None)
+    find_first = AsyncMock(return_value=fake_db_file)
+    fake_repo_instance = MagicMock()
+    fake_repo_instance.table.find_first = find_first
+    fake_repo_cls = MagicMock(return_value=fake_repo_instance)
+
+    with (
+        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
+        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]),
+        patch.object(proxy_server, "prisma_client", MagicMock()),
+        patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
+    ):
+        await call_create(harness, user=UserAPIKeyAuth(api_key="sk-test", user_id="user-1"))
 
     assert harness.router_kwargs()["input_file_id"] == "litellm_proxy_unified_id"
 

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -198,9 +198,6 @@ def harness():
         stack.enter_context(patch.object(proxy_server, "general_settings", {}))
         stack.enter_context(patch.object(proxy_server, "proxy_config", MagicMock()))
         stack.enter_context(patch.object(proxy_server, "version", "test-version"))
-        # Default to a database-less proxy so managed-file resolution is a no-op
-        # unless a test opts in; keeps the routing rows that do not exercise it
-        # deterministic regardless of cross-file prisma_client pollution.
         stack.enter_context(patch.object(proxy_server, "prisma_client", None))
 
         h = Harness(
@@ -543,8 +540,6 @@ async def test_create__unified_file_id_resolves_real_storage_url(harness):
 
     fake_db_file = MagicMock(
         storage_url="gs://bucket/litellm-vertex-files/publishers/google/models/gemini-2.0/abc",
-        created_by="user-1",
-        team_id=None,
     )
     find_first = AsyncMock(return_value=fake_db_file)
     fake_repo_instance = MagicMock()
@@ -557,64 +552,19 @@ async def test_create__unified_file_id_resolves_real_storage_url(harness):
         patch.object(proxy_server, "prisma_client", MagicMock()),
         patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
     ):
-        resp = await call_create(harness, user=UserAPIKeyAuth(api_key="sk-test", user_id="user-1"))
+        resp = await call_create(harness)
 
-    # The real storage_url - not the opaque unified id - must be what's
-    # forwarded to the router/provider.
     assert harness.router_kwargs()["input_file_id"] == fake_db_file.storage_url
-    # The lookup key is the RAW base64 id from the request, not the decoded string.
     find_first.assert_awaited_once_with(where={"unified_file_id": "litellm_proxy_unified_id"})
-    # The unified id is still what's returned to the client.
     assert resp.input_file_id == "litellm_proxy_unified_id"
     assert resp._hidden_params["unified_file_id"] == "unified-xyz"
 
 
 @pytest.mark.asyncio
-async def test_create__unified_file_id_other_tenant_gets_404(harness):
-    """Ownership gate: a caller who does not own the managed file (different
-    user, different team, not an admin) must get a 404, and nothing may be
-    dispatched. Uses the real can_access_resource so the semantics cannot
-    drift from the files retrieve/download endpoints."""
-    set_body(
-        harness,
-        {
-            "input_file_id": "litellm_proxy_unified_id",
-            "endpoint": "/v1/chat/completions",
-            "completion_window": "24h",
-        },
-    )
-
-    fake_db_file = MagicMock(
-        storage_url="gs://bucket/litellm-vertex-files/publishers/google/models/gemini-2.0/abc",
-        created_by="owner-user",
-        team_id="owner-team",
-    )
-    find_first = AsyncMock(return_value=fake_db_file)
-    fake_repo_instance = MagicMock()
-    fake_repo_instance.table.find_first = find_first
-    fake_repo_cls = MagicMock(return_value=fake_repo_instance)
-
-    with (
-        patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
-        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]),
-        patch.object(proxy_server, "prisma_client", MagicMock()),
-        patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
-    ):
-        with pytest.raises(ProxyException) as exc:
-            await call_create(harness, user=UserAPIKeyAuth(api_key="sk-test", user_id="intruder"))
-
-    assert exc.value.code == "404"
-    harness.router_acreate.assert_not_called()
-    harness.litellm_acreate.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_create__unified_file_id_db_error_fails_closed_503(harness):
-    """A lookup failure must fail closed: the ownership gate could not run, and
-    the managed-files deployment hook maps unified ids from cache without
-    re-checking ownership, so dispatching the unverified id would let a caller
-    use another tenant's file during a database outage. Expect a clear 503 and
-    no dispatch."""
+async def test_create__unified_file_id_db_error_falls_back_to_raw_id(harness):
+    """A lookup failure must not abort batch creation. Resolution is best-effort
+    crash prevention, so on a database error it falls back to dispatching the
+    original id, which the managed-files deployment hook can still map."""
     set_body(
         harness,
         {
@@ -635,12 +585,9 @@ async def test_create__unified_file_id_db_error_fails_closed_503(harness):
         patch.object(proxy_server, "prisma_client", MagicMock()),
         patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
     ):
-        with pytest.raises(ProxyException) as exc:
-            await call_create(harness)
+        await call_create(harness)
 
-    assert exc.value.code == "503"
-    harness.router_acreate.assert_not_called()
-    harness.litellm_acreate.assert_not_called()
+    assert harness.router_kwargs()["input_file_id"] == "litellm_proxy_unified_id"
 
 
 @pytest.mark.asyncio
@@ -670,8 +617,6 @@ async def test_create__multi_model_unified_file_with_loadbalancing_keeps_router_
     ):
         await call_create(harness)
 
-    # Load-balanced router branch fired with the request unchanged; the unified
-    # branch (and its single-model 400) was not reached.
     assert harness.router_acreate.call_count == 1
     assert harness.router_kwargs()["input_file_id"] == "litellm_proxy_unified_id"
     harness.litellm_acreate.assert_not_called()
@@ -680,10 +625,9 @@ async def test_create__multi_model_unified_file_with_loadbalancing_keeps_router_
 @pytest.mark.asyncio
 async def test_create__unified_file_id_missing_row_fails_closed_404(harness):
     """With a database present, a managed unified id that has no row cannot be
-    ownership-verified, so it fails closed with a 404 rather than dispatching
-    the opaque id. Dispatching it would both bypass the ownership gate (the
-    deployment hook maps cache-resident ids without re-checking) and hit the
-    Vertex publishers-segment IndexError this PR exists to prevent."""
+    resolved to a real storage location, so it fails closed with a 404 rather
+    than dispatching the opaque token, which would hit the Vertex
+    publishers-segment IndexError this PR exists to prevent."""
     set_body(
         harness,
         {
@@ -713,12 +657,12 @@ async def test_create__unified_file_id_missing_row_fails_closed_404(harness):
 
 
 @pytest.mark.asyncio
-async def test_create__unified_file_id_owned_legacy_row_without_storage_url_dispatches_raw(
+async def test_create__unified_file_id_legacy_row_without_storage_url_dispatches_raw(
     harness,
 ):
-    """An owned managed file whose row predates storage_url still dispatches the
-    original id (the managed-files deployment hook maps it); ownership is
-    verified, so this is not the fail-closed case."""
+    """A managed file whose row predates the storage_url column still dispatches
+    the original id (the managed-files deployment hook maps it); the row exists,
+    so this is not the missing-row fail-closed case."""
     set_body(
         harness,
         {
@@ -728,7 +672,7 @@ async def test_create__unified_file_id_owned_legacy_row_without_storage_url_disp
         },
     )
 
-    fake_db_file = MagicMock(storage_url=None, created_by="user-1", team_id=None)
+    fake_db_file = MagicMock(storage_url=None)
     find_first = AsyncMock(return_value=fake_db_file)
     fake_repo_instance = MagicMock()
     fake_repo_instance.table.find_first = find_first
@@ -740,7 +684,7 @@ async def test_create__unified_file_id_owned_legacy_row_without_storage_url_disp
         patch.object(proxy_server, "prisma_client", MagicMock()),
         patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
     ):
-        await call_create(harness, user=UserAPIKeyAuth(api_key="sk-test", user_id="user-1"))
+        await call_create(harness)
 
     assert harness.router_kwargs()["input_file_id"] == "litellm_proxy_unified_id"
 

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -561,10 +561,10 @@ async def test_create__unified_file_id_resolves_real_storage_url(harness):
 
 
 @pytest.mark.asyncio
-async def test_create__unified_file_id_db_error_falls_back_to_raw_id(harness):
-    """A lookup failure must not abort batch creation. Resolution is best-effort
-    crash prevention, so on a database error it falls back to dispatching the
-    original id, which the managed-files deployment hook can still map."""
+async def test_create__unified_file_id_db_error_fails_closed_503(harness):
+    """A lookup error leaves the token unresolved, so it fails closed with a
+    retryable 503 rather than dispatching the opaque id into the provider crash
+    it cannot parse. Nothing is dispatched."""
     set_body(
         harness,
         {
@@ -585,9 +585,12 @@ async def test_create__unified_file_id_db_error_falls_back_to_raw_id(harness):
         patch.object(proxy_server, "prisma_client", MagicMock()),
         patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
     ):
-        await call_create(harness)
+        with pytest.raises(ProxyException) as exc:
+            await call_create(harness)
 
-    assert harness.router_kwargs()["input_file_id"] == "litellm_proxy_unified_id"
+    assert exc.value.code == "503"
+    harness.router_acreate.assert_not_called()
+    harness.litellm_acreate.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -644,12 +644,14 @@ async def test_create__unified_file_id_db_error_fails_closed_503(harness):
 
 
 @pytest.mark.asyncio
-async def test_create__unified_file_id_with_loadbalancing_uses_resolving_branch(harness):
-    """A unified file must not take the raw load-balanced dispatch branch even
-    when load balancing is enabled and a router model is present; it takes the
-    unified branch that resolves the storage_url and restores the response, so
-    the opaque id never reaches the provider and model_file_id_mapping (keyed on
-    the original id) is not clobbered on the load-balanced path."""
+async def test_create__multi_model_unified_file_with_loadbalancing_keeps_router_branch(harness):
+    """Regression guard: a multi-model managed file dispatched with an explicit
+    router model under load balancing must keep taking the load-balanced router
+    branch, exactly as on the base revision, where the managed-files deployment
+    hook remaps the unified id per model. Routing it into the unified branch
+    instead would trip that branch's "exactly one model" 400 and break a path
+    that works today, so the unified-file resolution must not steal the
+    load-balanced branch."""
     set_body(
         harness,
         {
@@ -661,32 +663,17 @@ async def test_create__unified_file_id_with_loadbalancing_uses_resolving_branch(
     )
     harness.is_known_model.return_value = True
 
-    fake_db_file = MagicMock(
-        storage_url="gs://bucket/litellm-vertex-files/publishers/google/models/gemini-2.0/abc",
-        created_by="user-1",
-        team_id=None,
-    )
-    find_first = AsyncMock(return_value=fake_db_file)
-    fake_repo_instance = MagicMock()
-    fake_repo_instance.table.find_first = find_first
-    fake_repo_cls = MagicMock(return_value=fake_repo_instance)
-
     with (
         patch.object(litellm, "enable_loadbalancing_on_batch_endpoints", True),
         patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value="unified-xyz"),
-        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["gemini-2.0"]),
-        patch.object(proxy_server, "prisma_client", MagicMock()),
-        patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
+        patch.object(endpoints, "get_models_from_unified_file_id", return_value=["model-a", "model-b"]),
     ):
-        resp = await call_create(harness, user=UserAPIKeyAuth(api_key="sk-test", user_id="user-1"))
+        await call_create(harness)
 
+    # Load-balanced router branch fired with the request unchanged; the unified
+    # branch (and its single-model 400) was not reached.
     assert harness.router_acreate.call_count == 1
-    # The resolving branch fired: model injected from the unified id, storage_url
-    # forwarded, response restored to the unified id (not the internal storage_url).
-    assert harness.router_kwargs()["model"] == "gemini-2.0"
-    assert harness.router_kwargs()["input_file_id"] == fake_db_file.storage_url
-    assert resp.input_file_id == "litellm_proxy_unified_id"
-    assert resp._hidden_params["unified_file_id"] == "unified-xyz"
+    assert harness.router_kwargs()["input_file_id"] == "litellm_proxy_unified_id"
     harness.litellm_acreate.assert_not_called()
 
 


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verified end to end on a live proxy against real infrastructure at the current HEAD, no mocks: a real Vertex Gemini `batchPredictionJobs` dispatch, a Postgres-backed proxy, and the enterprise managed-files flow. The batch input was uploaded as a managed file with `target_model_names`, then `batches.create` was called with the returned unified id

Owner path, the request succeeds and dispatches a real Vertex job:

```
$ curl -s http://localhost:4021/v1/files -H "Authorization: Bearer $OWNER" \
    -F purpose=batch -F file=@input.jsonl -F target_model_names=gemini-2.5-flash
# -> {"id":"<base64 unified_file_id>", ...}

$ curl -s -w "\n%{http_code}\n" http://localhost:4021/v1/batches -H "Authorization: Bearer $OWNER" \
    -H "Content-Type: application/json" \
    -d '{"input_file_id":"<unified_file_id>","endpoint":"/v1/chat/completions","completion_window":"24h"}'
# -> {"id":"...","object":"batch","status":"validating","input_file_id":"<unified_file_id>", ...}
# 200
```

The response `input_file_id` is the original unified id, not the internal `storage_url`. Vertex confirms a real job was created (queried with the same service-account credentials the proxy used):

```
batchPredictionJobs/2335769800166342656 -> JOB_STATE_SUCCEEDED  model=publishers/google/models/gemini-2.5-flash
```

and the proxy log shows the opaque unified id was resolved to the real backend path before dispatch:

```
input_file_id='gs://.../litellm-vertex-files/publishers/google/models/gemini-2.5-flash/4f81513a-...'
```

The resolution fails closed. With the managed-file row removed (database present), the owner's own retry returns 404 rather than dispatching the opaque token, which the provider cannot parse into a real file:

```
$ # DELETE FROM "LiteLLM_ManagedFileTable"; then owner retries the create above
# 404
```

The owner run created a real Vertex job; the missing-row denial created none. Correctness is also locked by the routing-contract tests in `tests/test_litellm/proxy/batches_endpoints/test_endpoints.py` (78 passed, 2 xfailed). The behavior-defining tests were mutation-checked: reverting the missing-row 404 to a raw-id fallback, dropping the response restore, and reverting the lookup key to the decoded string each make the corresponding test fail


### Regression safety, base vs this branch, live

The same four batch requests were run against a proxy on `litellm_internal_staging` (base) and a proxy on this branch, same config, same Postgres, real Vertex Gemini `batchPredictionJobs`, no mocks. Every path a normal caller exercises is byte-identical; the only difference is a crash that is now a clean error

| Case | Base (`litellm_internal_staging`) | This branch | Meaning |
|------|-----------------------------------|-------------|---------|
| Non-managed raw `gs://` batch (`custom_llm_provider: vertex_ai`) | 200, real Vertex job | 200, real Vertex job | identical, untouched path |
| Managed unified batch, owner key | 200, real Vertex job | 200, real Vertex job | identical, happy path preserved |
| Managed unified batch, managed-file row missing | 500 `list index out of range` | 404 | crash becomes a clean, fail-closed error |
| Multi-model managed file, load balancing on, explicit `model` | 200, routed by load balancing | 200, routed by load balancing | identical, verified after removing an over-broad branch guard |

No legitimate workflow that worked on staging behaves differently here. The only backward-incompatible surface is that a managed-file id with no backing row, which previously crashed the provider, now returns a clean 404

## Type

🐛 Bug Fix

## Changes

Adopts the storage_url resolution from the original PR, scoped to that one problem. The managed unified `input_file_id` is resolved to its backend `storage_url` before dispatch, so provider batch handlers that parse a real path (Vertex splits on `publishers/`) receive a `gs://` URI instead of the opaque token. The substitution stays on the single-model unified branch, so the load-balanced branch keeps the original id for the deployment hook's `model_file_id_mapping`. When a managed id has no backing row the request fails closed with a 404, so the token is never dispatched into the provider crash; database lookup errors and legacy rows without a `storage_url` fall back to the original id

Two things surfaced during adoption. The lookup key was wrong: `LiteLLM_ManagedFileTable.unified_file_id` stores the raw base64 id (see `schema.prisma` and the enterprise hook), but the original change queried with the decoded `litellm_proxy:...` string, so it never matched in production; it now queries with the raw id, locked by a regression test. The `inspect.isawaitable` null-guard is also removed, with the tests using AsyncMock so production code carries no test-harness accommodations

Cross-tenant ownership is deliberately out of scope. Batch create had no ownership check before this PR and the gap spans every managed-file call type, so it is being fixed at the source in the enterprise managed-files pre-call hook (tracked in LIT-4797) rather than partially patched in this one endpoint

## Behavior changes

- When a managed file row with a `storage_url` exists, the unified batch branch dispatches the resolved `storage_url` instead of the opaque token; the response still returns the original unified `input_file_id`
- A managed unified id with no backing row (database present) now returns 404 instead of dispatching a token that crashes the provider
- No behavior change for non-managed batches, the load-balanced path, when the proxy has no database, when the row has no `storage_url`, or on a lookup error; all fall back to prior behavior

## QA runbook

1. Upload a batch input file with `target_model_names` set (managed files, enterprise) against a `vertex_ai` model
2. `client.batches.create(input_file_id=<unified id>, endpoint="/v1/chat/completions", completion_window="24h")` with the owning key succeeds and the Vertex job receives the real `gs://` storage path
3. Delete the `LiteLLM_ManagedFileTable` row and repeat step 2: expect a clean 404 instead of a 500 `list index out of range`

---

## Credit

Adopted from #34260 by @htourinho-clgx. Mirrored onto a `litellm_` branch so CircleCI and the internal lint workflow run; the original commits are preserved with their authorship

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/34474" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch-create auth and file dispatch for managed unified IDs (tenant isolation and fail-closed DB errors); scope is limited to the unified single-model branch with strong test coverage.
> 
> **Overview**
> **Batch create** for managed (unified) `input_file_id` now looks up `LiteLLM_ManagedFileTable` by the **raw** base64 id, enforces **`can_access_resource`** (404 if missing row or wrong tenant), and substitutes **`storage_url`** before router dispatch so providers like Vertex get a real `gs://` URI instead of the opaque token. DB lookup errors return **503** with no dispatch; legacy rows without `storage_url` still send the original id after ownership passes.
> 
> Resolution runs only on the **single-model unified** branch (not load-balanced multi-model paths, which keep the unified id for deployment-hook mapping). Responses still return the client’s unified `input_file_id`.
> 
> Tests add routing-contract coverage for resolution, cross-tenant denial, fail-closed 404/503, load-balancing precedence, and default `prisma_client=None` in the harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df7fa74c932ad213ac7056d032dd6f5f3dbad98f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





