### PR TITLE
fix: stop sending invalid num_generations to Cohere chat API

### DIFF
--- a/litellm/llms/cohere/chat/transformation.py
+++ b/litellm/llms/cohere/chat/transformation.py
@@ -164,7 +164,11 @@ class CohereChatConfig(BaseConfig):
             if param == "max_completion_tokens":
                 optional_params["max_tokens"] = value
             if param == "n":
-                optional_params["num_generations"] = value
+                if value is not None and value > 1 and not (litellm.drop_params or drop_params):
+                    raise litellm.utils.UnsupportedParamsError(
+                        message="Cohere's chat API does not support n > 1. Call the API multiple times to generate multiple completions. To drop this param, set `litellm.drop_params = True`",
+                        status_code=400,
+                    )
             if param == "top_p":
                 optional_params["p"] = value
             if param == "frequency_penalty":

--- a/litellm/llms/cohere/chat/v2_transformation.py
+++ b/litellm/llms/cohere/chat/v2_transformation.py
@@ -149,7 +149,11 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
             if param == "max_completion_tokens":
                 optional_params["max_tokens"] = value
             if param == "n":
-                optional_params["num_generations"] = value
+                if value is not None and value > 1 and not (litellm.drop_params or drop_params):
+                    raise litellm.utils.UnsupportedParamsError(
+                        message="Cohere's chat API does not support n > 1. Call the API multiple times to generate multiple completions. To drop this param, set `litellm.drop_params = True`",
+                        status_code=400,
+                    )
             if param == "top_p":
                 optional_params["p"] = value
             if param == "frequency_penalty":

--- a/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
+++ b/tests/test_litellm/llms/cohere/chat/test_cohere_transformation.py
@@ -2,6 +2,8 @@ import os
 import sys
 from unittest.mock import MagicMock
 
+import pytest
+
 sys.path.insert(
     0, os.path.abspath("../../../../..")
 )  # Adds the parent directory to the system path
@@ -117,3 +119,40 @@ class TestCohereV2Transform:
         )
 
         assert optional_params["max_tokens"] == 256
+
+    @pytest.mark.parametrize("config", [CohereChatConfig(), CohereV2ChatConfig()])
+    def test_n_equals_one_does_not_send_num_generations(self, config):
+        """Regression for https://github.com/BerriAI/litellm/issues/34111
+
+        Cohere's chat API rejects num_generations ("unknown field"). n=1 is a
+        no-op, so it must be accepted without forwarding num_generations.
+        """
+        result = config.map_openai_params(
+            non_default_params={"n": 1},
+            optional_params={},
+            model="command-r7b-12-2024",
+            drop_params=False,
+        )
+
+        assert "num_generations" not in result
+
+    @pytest.mark.parametrize("config", [CohereChatConfig(), CohereV2ChatConfig()])
+    def test_n_greater_than_one_raises_without_drop_params(self, config):
+        with pytest.raises(litellm.utils.UnsupportedParamsError):
+            config.map_openai_params(
+                non_default_params={"n": 3},
+                optional_params={},
+                model="command-r7b-12-2024",
+                drop_params=False,
+            )
+
+    @pytest.mark.parametrize("config", [CohereChatConfig(), CohereV2ChatConfig()])
+    def test_n_greater_than_one_dropped_with_drop_params(self, config):
+        result = config.map_openai_params(
+            non_default_params={"n": 3},
+            optional_params={},
+            model="command-r7b-12-2024",
+            drop_params=True,
+        )
+
+        assert "num_generations" not in result


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cohere chat calls that set n fail with a 400
- n maps to num_generations, which Cohere chat rejects
- Even the common no-op n=1 breaks every request

How it solves it:

- Never forward num_generations to Cohere chat
- n=1 is a no-op and is accepted silently
- n > 1 raises UnsupportedParamsError unless drop_params

## Relevant issues

Fixes #34111

## Screenshots / Proof of Fix

Cohere's chat API does not support num_generations; per Cohere's own migration guide the field is not available on Chat and multiple generations require calling the API n times (https://docs.cohere.com/v1/docs/migrating-from-cogenerate-to-cochat).

Before, at commit 86eee8bd05, n=1 is turned into the invalid field that Cohere rejects:

```
$ python -c "
from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
print(CohereV2ChatConfig().map_openai_params({'n': 1}, {}, 'command-r7b-12-2024', drop_params=False))
"
{'num_generations': 1}
```

After, at commit 59c1df6ab6, n=1 is a no-op and n > 1 is surfaced locally:

```
$ python -c "
from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
print(CohereV2ChatConfig().map_openai_params({'n': 1}, {}, 'command-r7b-12-2024', drop_params=False))
"
{}

$ python -c "
import litellm
from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
try:
    CohereV2ChatConfig().map_openai_params({'n': 3}, {}, 'command-r7b-12-2024', drop_params=False)
except litellm.utils.UnsupportedParamsError as e:
    print('UnsupportedParamsError:', e.message)
"
UnsupportedParamsError: Cohere's chat API does not support n > 1. ...
```

## Type

🐛 Bug Fix

## Changes

Removed the n to num_generations mapping in both the v1 and v2 Cohere chat transformations. n=1 is a no-op so it is accepted without forwarding anything to Cohere; n > 1 cannot be honored by the chat API, so it raises UnsupportedParamsError locally unless drop_params is set, matching how the gpt-5 and o-series configs handle params the provider rejects. Added regression tests covering n=1, n > 1, and n > 1 with drop_params across both configs
