### PR TITLE
fix(mcp): exclude OpenAPI header/cookie params from generated MCP tool schema

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
+++ b/litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py
@@ -261,6 +261,8 @@ def build_input_schema(operation: Dict[str, Any]) -> Dict[str, Any]:
         for param in operation["parameters"]:
             if "name" not in param:
                 continue
+            if param.get("in") in ("header", "cookie"):
+                continue
             param_name = param["name"]
             param_schema = param.get("schema", {})
             param_type = param_schema.get("type", "string")

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_to_mcp_generator.py
@@ -411,6 +411,37 @@ class TestBuildInputSchema:
         # Required should include original names
         assert "repository-id" in schema["required"]
 
+    def test_header_and_cookie_params_excluded(self):
+        """Regression for LIT-1420: header/cookie OpenAPI params must not leak into
+        the MCP tool input schema. They are HTTP-transport concerns forwarded from
+        the MCP client's header config, not arguments the model should fill. Before
+        the fix, an auth header param was exposed as a tool arg and passed as a
+        function kwarg, breaking tool invocation."""
+        operation = {
+            "parameters": [
+                {"name": "orderId", "in": "path", "required": True, "schema": {"type": "string"}},
+                {"name": "expand", "in": "query", "required": False, "schema": {"type": "string"}},
+                {"name": "accessss-Token", "in": "header", "required": False, "schema": {"type": "string"}},
+                {"name": "session", "in": "cookie", "required": False, "schema": {"type": "string"}},
+            ],
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "schema": {"type": "object", "properties": {"note": {"type": "string"}}}
+                    }
+                },
+            },
+        }
+
+        schema = build_input_schema(operation)
+
+        assert "accessss-Token" not in schema["properties"]
+        assert "session" not in schema["properties"]
+        assert "accessss-Token" not in schema["required"]
+        assert "orderId" in schema["properties"]
+        assert "expand" in schema["properties"]
+        assert "body" in schema["properties"]
+
 
 class TestExtractParameters:
     """Test parameter extraction from OpenAPI operations."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- When an MCP server is generated from an OpenAPI spec, `build_input_schema` copied every operation parameter into the tool's input schema, including params declared `in: header` or `in: cookie`. The model was then prompted to fill an auth header (e.g. an access token) and it was passed as a tool function keyword argument, breaking tool invocation for any backend that requires custom auth headers

How it solves it:

- Header and cookie params are HTTP-transport concerns, not model-facing arguments. `extract_parameters` already ignores them (only path/query/body reach the outgoing request) and header values are forwarded from the MCP client's configured headers. So the fix skips `in: header` and `in: cookie` params in `build_input_schema`, matching `extract_parameters`

## Relevant issues

## Linear ticket

Resolves LIT-1420

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Point the proxy at an MCP server generated from an OpenAPI spec whose operation has a header parameter, then list the tools and confirm the header no longer appears in the tool's `inputSchema`:

```
curl -sS http://localhost:4000/v1/mcp/tools/list \
  -H "Authorization: Bearer $LITELLM_KEY" \
  | jq '.tools[] | select(.name=="getOrderDetails") | .inputSchema.properties | keys'
```

Before this change the array includes the header param (e.g. `"accessss-Token"`); after, it contains only the path/query/body properties. The added unit test pins this: it fails on the pre-fix code (header + cookie present in the schema) and passes after

## Type

🐛 Bug Fix

## Changes

- `build_input_schema` in `litellm/proxy/_experimental/mcp_server/openapi_to_mcp_generator.py` skips params with `in: header` or `in: cookie`
- Adds `test_header_and_cookie_params_excluded` to the existing generator test, asserting header + cookie params are absent from the schema while path, query, and body remain

## QA runbook

Configure an OpenAPI-backed MCP server with an operation that declares a header parameter, list its tools through the gateway, and verify the header key is absent from the tool `inputSchema.properties` (the curl above). Tool calls that previously failed with an unexpected keyword argument for the header now succeed, with the header supplied from the MCP client's configured headers

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

## Coordination note

This touches `openapi_to_mcp_generator.py`, which has several PRs in flight (e.g. #30138 "fix OpenAPI generator param/body handling" and a cluster forwarding OpenAPI headers on MCP tool calls). This change is deliberately narrow: it only stops `in: header` / `in: cookie` params from entering the model-facing input schema, matching what `extract_parameters` already does, and adds the regression test. If a maintainer would rather fold the header/cookie skip into one of those PRs, close this and keep the test; the test is the part that must survive either way.
