### PR TITLE
test(e2e): cover MCP access-group tool selection at key creation

### DIFF
--- a/tests/e2e/coverage_registry/mcp.yaml
+++ b/tests/e2e/coverage_registry/mcp.yaml
@@ -7,6 +7,14 @@
   assertions: [succeeds]
   source: "server.py:637"
   rationale: Core operation; most common auth path; high usage
+- id: mcp.list_tools.api_key.access_group_scoped
+  module: mcp
+  tier: P1
+  operation: list_tools
+  auth_family: api_key
+  assertions: [access_group_scoped]
+  source: "test_mcp_access_group_e2e.py"
+  rationale: "A key granted an MCP access group sees the tagged server's tools; a key with a different group does not. Access-group-scoped tool selection at key creation"
 - id: mcp.list_tools.api_key.denied_without_permission
   module: mcp
   tier: P0

--- a/tests/e2e/mcp/datadog_mcp.py
+++ b/tests/e2e/mcp/datadog_mcp.py
@@ -30,7 +30,12 @@ def assert_dd_mcp_creds() -> None:
         )
 
 
-def register_datadog_mcp(client: McpClient, resources: ResourceManager) -> str:
+def register_datadog_mcp(
+    client: McpClient,
+    resources: ResourceManager,
+    *,
+    mcp_access_groups: list[str] | None = None,
+) -> str:
     assert_dd_mcp_creds()
     name = f"e2e_dd_mcp_{unique_marker()}"
     server_id = client.register_server(
@@ -43,6 +48,7 @@ def register_datadog_mcp(client: McpClient, resources: ResourceManager) -> str:
             "DD-APPLICATION-KEY": _dd_app_key(),
         },
         allowed_tools=[SEARCH_LOGS_TOOL],
+        mcp_access_groups=mcp_access_groups,
     )
     resources.defer(lambda: client.delete_server(server_id))
     return server_id

--- a/tests/e2e/mcp/mcp_client.py
+++ b/tests/e2e/mcp/mcp_client.py
@@ -36,6 +36,7 @@ class McpServerNewBody(BaseModel):
     auth_type: str | None = None
     static_headers: dict[str, str] | None = None
     allowed_tools: list[str] | None = None
+    mcp_access_groups: list[str] | None = None
 
 
 class McpServerNewResponse(BaseModel):
@@ -155,6 +156,7 @@ class McpClient:
         auth_type: str | None = None,
         static_headers: dict[str, str] | None = None,
         allowed_tools: list[str] | None = None,
+        mcp_access_groups: list[str] | None = None,
     ) -> str:
         return unwrap(
             self.proxy.transport.post(
@@ -168,6 +170,7 @@ class McpClient:
                     auth_type=auth_type,
                     static_headers=static_headers,
                     allowed_tools=allowed_tools,
+                    mcp_access_groups=mcp_access_groups,
                 ),
                 response_type=McpServerNewResponse,
             )
@@ -196,10 +199,13 @@ class McpClient:
         *,
         user_id: str,
         mcp_servers: list[str] | None,
+        mcp_access_groups: list[str] | None = None,
         models: list[str] | None = None,
     ) -> str:
         object_permission = (
-            ObjectPermission(mcp_servers=mcp_servers) if mcp_servers is not None else None
+            ObjectPermission(mcp_servers=mcp_servers, mcp_access_groups=mcp_access_groups)
+            if mcp_servers is not None or mcp_access_groups is not None
+            else None
         )
         return self.proxy.generate_key(
             KeyGenerateBody(

--- a/tests/e2e/mcp/test_mcp_access_group_e2e.py
+++ b/tests/e2e/mcp/test_mcp_access_group_e2e.py
@@ -1,0 +1,58 @@
+"""Live e2e: MCP tool selection via access group at key creation.
+
+An admin registers the Datadog remote MCP server tagged with a server-side
+access group (`mcp_access_groups`). A key minted with that access group
+(`object_permission.mcp_access_groups`) sees the server's tools; a key minted
+with a different group does not. This exercises access-group-scoped tool
+selection, the enterprise MCP surface where keys are granted tool access groups
+rather than explicit server ids.
+
+A tools/list that leaks the server across the access-group boundary fails hard.
+Requires DD_API_KEY + DD_APP_KEY (the suite's real MCP upstream).
+"""
+
+import pytest
+
+from datadog_mcp import SEARCH_LOGS_TOOL, register_datadog_mcp
+from e2e_config import unique_marker
+from e2e_http import unwrap
+from lifecycle import ResourceManager
+from mcp_client import McpClient
+
+pytestmark = pytest.mark.e2e
+
+
+class TestMcpAccessGroupToolSelection:
+    @pytest.mark.covers("mcp.list_tools.api_key.access_group_scoped")
+    def test_access_group_scopes_tool_selection(
+        self, client: McpClient, resources: ResourceManager
+    ) -> None:
+        group = f"e2e-mcp-grp-{unique_marker()}"
+        server_id = register_datadog_mcp(client, resources, mcp_access_groups=[group])
+
+        granted = client.generate_key(
+            user_id=f"e2e-mcp-ag-granted-{unique_marker()}",
+            mcp_servers=None,
+            mcp_access_groups=[group],
+        )
+        resources.defer(lambda: client.proxy.delete_key(granted))
+
+        other = client.generate_key(
+            user_id=f"e2e-mcp-ag-other-{unique_marker()}",
+            mcp_servers=None,
+            mcp_access_groups=[f"e2e-mcp-grp-absent-{unique_marker()}"],
+        )
+        resources.defer(lambda: client.proxy.delete_key(other))
+
+        granted_tools = unwrap(client.list_tools(granted))
+        assert granted_tools.tool_name_containing(server_id, SEARCH_LOGS_TOOL) is not None, (
+            f"key granted access group {group} did not see the tagged server's tool "
+            f"(upstream dead or access-group grant not applied): "
+            f"{granted_tools.tool_names_for_server(server_id)}"
+        )
+
+        other_tools = unwrap(client.list_tools(other)).tool_names_for_server(server_id)
+        assert other_tools == frozenset(), (
+            f"key with a different access group saw the server's tools; access-group tool "
+            f"selection leaked across the boundary: {other_tools}"
+        )

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -47,6 +47,7 @@ class KeyMetadata(BaseModel):
 
 class ObjectPermission(BaseModel):
     mcp_servers: list[str] | None = None
+    mcp_access_groups: list[str] | None = None
 
 
 class KeyGenerateBody(BaseModel):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Enterprise MCP users mint virtual keys against tool access groups rather than explicit server ids (a confirmed customer pattern), and nothing exercised access-group-scoped tool selection end to end. A regression that ignored the key's access group, or leaked a server across the access-group boundary, would go uncaught

How it solves it:

- Registers the upstream MCP server tagged with a server-side access group (`mcp_access_groups`), then mints one key granted that group and one granted a different group
- Asserts the granted key sees the tagged server's tools on `tools/list`, and the other key sees none

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Proof comes from the stage e2e run (requires `DD_API_KEY` + `DD_APP_KEY`, the suite's real MCP upstream). The flow the test drives, as an operator would: register a server tagged with an access group, mint a key with that group, and list tools:

```
curl -sS http://<proxy>/v1/mcp/server -H "Authorization: Bearer $MASTER_KEY" \
  -d '{"server_name":"...","alias":"...","url":"<dd-mcp-url>","transport":"http","allowed_tools":["search_datadog_logs"],"mcp_access_groups":["grpA"]}'
# mint a key with object_permission.mcp_access_groups=["grpA"], then:
curl -sS http://<proxy>/mcp-rest/tools/list -H "x-litellm-api-key: <granted-key>" | jq '.tools[].name'
```

The granted key lists the server's tool; a key minted with a different group lists none

## Type

✅ Test

## Changes

- Adds `test_mcp_access_group_e2e.py` with `TestMcpAccessGroupToolSelection`
- Adds `mcp_access_groups` support to the e2e MCP client: server registration body, `register_server`, `generate_key`, the Datadog register helper, and `ObjectPermission`
- Adds the registry cell `mcp.list_tools.api_key.access_group_scoped`

## QA runbook

On stage, once merged, the test registers the Datadog MCP server tagged with a unique access group, mints granted + other-group keys, and asserts tool visibility is scoped to the access group. A leak across the boundary (other key seeing the server's tools) fails the test

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
