### PR TITLE
fix(bedrock): stop toolless requests leaking tool_choice and parallel-tool-use config

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1573,15 +1573,17 @@ class AmazonConverseConfig(BaseConfig):
                     bedrock_tools.append(ToolBlock(cachePoint=cache_point))
                     break
 
+        tool_choice_values: ToolChoiceValuesBlock | None = inference_params.pop("tool_choice", None)
         bedrock_tool_config: ToolConfigBlock | None = None
         if len(bedrock_tools) > 0:
-            tool_choice_values: Final[ToolChoiceValuesBlock] = inference_params.pop("tool_choice", None)
             bedrock_tool_config = ToolConfigBlock(
                 tools=bedrock_tools,
             )
             if tool_choice_values is not None:
                 bedrock_tool_config["toolChoice"] = tool_choice_values
                 self._drop_tool_choice_type_conflicting_with_tool_config(additional_request_params)
+        else:
+            additional_request_params.pop("tool_choice", None)
 
         data: Final[CommonRequestObject] = {
             "inferenceConfig": self._transform_inference_params(inference_params=inference_params),

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -618,9 +618,23 @@ def test_parallel_tool_calls_config_kept_for_sonnet_5():
     litellm.model_cost = litellm.get_model_cost_map(url="")
     try:
         config = AmazonConverseConfig()
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                },
+            }
+        ]
         optional_params = config.map_openai_params(
             model="anthropic.claude-sonnet-5",
-            non_default_params={"parallel_tool_calls": False},
+            non_default_params={"parallel_tool_calls": False, "tools": tools},
             optional_params={},
             drop_params=False,
         )
@@ -632,6 +646,7 @@ def test_parallel_tool_calls_config_kept_for_sonnet_5():
             messages=None,
         )
 
+        assert "toolConfig" in data
         assert data["additionalModelRequestFields"]["tool_choice"] == {
             "type": "auto",
             "disable_parallel_tool_use": True,
@@ -5934,3 +5949,81 @@ def test_adaptive_thinking_dropped_when_max_tokens_too_small_converse():
     )
 
     assert "thinking" not in optional_params
+
+
+_PARALLEL_TOOL_USE_MODEL = "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+_WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get the weather",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}
+
+
+def _converse_request(non_default_params: dict) -> dict:
+    config = AmazonConverseConfig()
+    optional_params = config.map_openai_params(
+        non_default_params=dict(non_default_params),
+        optional_params={},
+        model=_PARALLEL_TOOL_USE_MODEL,
+        drop_params=False,
+    )
+    return config.transform_request(
+        model=_PARALLEL_TOOL_USE_MODEL,
+        messages=[{"role": "user", "content": "hi"}],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+
+def test_toolless_request_does_not_leak_tool_choice_into_inference_config():
+    """
+    Regression for https://github.com/BerriAI/litellm/issues/34420 (leak 1).
+
+    tool_choice was only popped when tools were present, so a request with no
+    tools left tool_choice in inference_params and it leaked into inferenceConfig,
+    which Bedrock Converse rejects with a 400.
+    """
+    result = _converse_request({"tool_choice": "auto"})
+
+    assert "toolConfig" not in result
+    assert "toolChoice" not in result.get("inferenceConfig", {})
+    assert "tool_choice" not in result.get("inferenceConfig", {})
+    assert "tool_choice" not in result.get("additionalModelRequestFields", {})
+
+
+def test_toolless_request_does_not_leak_parallel_tool_use_block():
+    """
+    Regression for https://github.com/BerriAI/litellm/issues/34420 (leak 2).
+
+    parallel_tool_calls=False injects a disable_parallel_tool_use tool_choice
+    block into additionalModelRequestFields, gated only on model capability. On a
+    toolless request that produced a tool_choice block with no toolConfig, which
+    Bedrock rejects with a 400. Agent frameworks send parallel_tool_calls=False on
+    every turn, including toolless ones.
+    """
+    result = _converse_request({"parallel_tool_calls": False})
+
+    assert "toolConfig" not in result
+    assert "tool_choice" not in result.get("additionalModelRequestFields", {})
+
+
+def test_tool_request_still_carries_tool_config_and_parallel_block():
+    """
+    Guard: the fix for #34420 must not change requests that DO carry tools. A
+    tool-bearing request with parallel_tool_calls=False still emits toolConfig and
+    keeps the disable_parallel_tool_use block in additionalModelRequestFields.
+    """
+    result = _converse_request({"tools": [_WEATHER_TOOL], "parallel_tool_calls": False})
+
+    assert "toolConfig" in result
+    assert len(result["toolConfig"]["tools"]) >= 1
+    assert result["additionalModelRequestFields"]["tool_choice"]["disable_parallel_tool_use"] is True


### PR DESCRIPTION
## Relevant issues

Fixes #34420

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

On Bedrock Converse, a request with no tools that sets `parallel_tool_calls` or `tool_choice` gets a 400 from Bedrock. Agent frameworks like n8n send `parallel_tool_calls=false` on every turn, including toolless chat turns, so ordinary completions fail. Two leaks in `AmazonConverseConfig._transform_request_helper` caused it: `tool_choice` was popped from the inference params only inside `if len(bedrock_tools) > 0`, so on a toolless request it leaked into `inferenceConfig`; and the `disable_parallel_tool_use` block derived from `parallel_tool_calls` was injected into `additionalModelRequestFields` gated only on model capability, with no tools-presence check, producing a `tool_choice` block with no `toolConfig`

The leak is in the request LiteLLM emits, so the proof captures the outgoing Converse body a live proxy sends upstream (`--detailed_debug`). Config: one `bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0` deployment with dummy AWS creds, so the request builds and is logged, then AWS returns 403; the point is the shape of what LiteLLM sends

Reproduce (the n8n case, toolless with `parallel_tool_calls=false`):

```bash
curl -s -X POST http://127.0.0.1:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-proof-1234' -H 'Content-Type: application/json' \
  -d '{"model":"bedrock-haiku","messages":[{"role":"user","content":"hi"}],"parallel_tool_calls":false}'
```

Before, at base `5d4c4d0fce` (fix absent), the outgoing body carries a `tool_choice` block with no `toolConfig`, which Bedrock rejects:

```
{"messages": [{"role": "user", "content": [{"text": "hi"}]}],
 "inferenceConfig": {},
 "additionalModelRequestFields": {"tool_choice": {"disable_parallel_tool_use": true}}}
```

After, with this PR (head `fd653dec98`), the toolless request is clean:

```
{"messages": [{"role": "user", "content": [{"text": "hi"}]}],
 "inferenceConfig": {}}
```

The `tool_choice`-into-`inferenceConfig` leak (leak 1, e.g. a toolless request with `tool_choice="auto"`) is covered by a separate regression test that fails on the base commit and passes with the fix. A third test guards that tool-bearing requests are unchanged: they still emit `toolConfig` and keep the `disable_parallel_tool_use` block in `additionalModelRequestFields`

## Type

🐛 Bug Fix

## Changes

In `_transform_request_helper`, `tool_choice` is now popped from the inference params unconditionally so it can never reach `inferenceConfig`, and it is only attached to `toolConfig.toolChoice` when tools are present. When there are no tools, the `disable_parallel_tool_use` block that `parallel_tool_calls` produced is dropped from `additionalModelRequestFields`. Tool-bearing requests keep both behaviors unchanged. One pre-existing test that asserted a toolless request keeps the `disable_parallel_tool_use` block was updated to use a tool-bearing request, since keeping that block with no `toolConfig` is exactly the 400 this fixes

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

---

Disclosure: still finding my feet in this codebase, and I paired with Claude Code to locate the two leaks and run the before/after proxy capture above. I read through the transform path and confirmed the fix against the issue's repro myself; happy to adjust

