### PR TITLE
fix(guardrails): add /v1/messages support for Straiker plugin

### DIFF
--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -600,9 +600,15 @@ class AnthropicMessagesHandler(BaseTranslation):
                     guardrail_inputs["tool_calls"] = tool_calls_list
 
                 try:
+                    prepared_request_data = self._prepare_request_data(
+                        request_data,
+                        model_response,
+                        user_api_key_dict,
+                        key="response",
+                    )
                     _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                         inputs=guardrail_inputs,
-                        request_data=request_data if request_data is not None else {},
+                        request_data=prepared_request_data,
                         input_type="response",
                         logging_obj=litellm_logging_obj,
                     )

--- a/litellm/proxy/guardrails/guardrail_hooks/straiker/straiker.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/straiker/straiker.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal, NoReturn
 from urllib.parse import urlsplit
 
 import httpx
-from pydantic import ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from litellm._logging import verbose_proxy_logger
 from litellm._version import version as litellm_version
@@ -24,11 +24,12 @@ from litellm.integrations.custom_guardrail import (
     log_guardrail_information,
 )
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+from litellm.litellm_core_utils.prompt_templates.factory import resolve_structured_messages
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
 )
-from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.guardrails import GuardrailEventHooks, Mode
 from litellm.types.proxy.guardrails.guardrail_hooks.straiker import (
     STRAIKER_WEBHOOK_SCHEMA_VERSION,
     StraikerGuardrailConfigModel,
@@ -57,6 +58,7 @@ RETRY_STATUS = frozenset({408, 429, 500, 502, 503, 504})
 UNREACHABLE_STATUS = frozenset({502, 503, 504})
 _APPLICATION_METADATA_KEYS = frozenset({"agent_id", "app_name"})
 _OPAQUE_METADATA_SCALAR_TYPES = (str, int, float, bool)
+_JSON_DICT_ADAPTER = TypeAdapter(dict[str, object])
 
 
 @dataclass(frozen=True, slots=True)
@@ -137,6 +139,24 @@ def _resolve_destination(request_data: dict) -> str | None:
         return None
 
 
+def _hook_name(value: object) -> str:
+    return value.value if isinstance(value, GuardrailEventHooks) else str(value)
+
+
+def _configured_modes(event_hook: object) -> list[str] | None:
+    if isinstance(event_hook, list):
+        names = [_hook_name(v) for v in event_hook]
+    elif isinstance(event_hook, (str, GuardrailEventHooks)):
+        names = [_hook_name(event_hook)]
+    elif isinstance(event_hook, Mode):
+        default = event_hook.default if isinstance(event_hook.default, list) else [event_hook.default]
+        tags = [v for value in event_hook.tags.values() for v in (value if isinstance(value, list) else [value])]
+        names = [_hook_name(v) for v in (*default, *tags) if v is not None]
+    else:
+        return None
+    return list(dict.fromkeys(names)) or None
+
+
 def _resolve_call_surface(logging_obj: LiteLLMLoggingObj | None, request_data: dict) -> str:
     call_type = (
         (getattr(logging_obj, "call_type", None) if logging_obj is not None else None)
@@ -146,13 +166,56 @@ def _resolve_call_surface(logging_obj: LiteLLMLoggingObj | None, request_data: d
     return call_type if isinstance(call_type, str) and call_type else "unknown"
 
 
+def _jsonable_dict(value: object) -> dict[str, object] | None:
+    if isinstance(value, BaseModel):
+        return _JSON_DICT_ADAPTER.validate_python(value.model_dump(mode="json", exclude_none=True))
+    if isinstance(value, dict):
+        return _JSON_DICT_ADAPTER.validate_python(value)
+    return None
+
+
+def _opaque_dict_list(value: object) -> list[dict[str, object]] | None:
+    if not isinstance(value, list):
+        return None
+    items = tuple(plain for item in value if (plain := _jsonable_dict(item)) is not None)
+    return list(items) if items else None
+
+
+def _choice_terminal_reason(choice: object) -> str | None:
+    if isinstance(choice, dict):
+        return _as_optional_str(choice.get("finish_reason")) or _as_optional_str(choice.get("stop_reason"))
+    return _as_optional_str(getattr(choice, "finish_reason", None)) or _as_optional_str(
+        getattr(choice, "stop_reason", None)
+    )
+
+
 def _response_finish_reason(response: Any) -> str | None:
+    if response is None:
+        return None
+    if isinstance(response, dict):
+        top = _as_optional_str(response.get("finish_reason")) or _as_optional_str(response.get("stop_reason"))
+        if top:
+            return top
+        choices = response.get("choices")
+        if not isinstance(choices, list):
+            return None
+        for choice in choices:
+            reason = _choice_terminal_reason(choice)
+            if reason:
+                return reason
+        return None
+
+    top = _as_optional_str(getattr(response, "finish_reason", None)) or _as_optional_str(
+        getattr(response, "stop_reason", None)
+    )
+    if top:
+        return top
     choices = getattr(response, "choices", None)
     if not isinstance(choices, list):
         return None
     for choice in choices:
-        reason = getattr(choice, "finish_reason", None)
-        if isinstance(reason, str) and reason:
+        reason = _choice_terminal_reason(choice)
+        if reason:
             return reason
     return None
 
@@ -234,6 +297,8 @@ class StraikerGuardrail(CustomGuardrail):
         kwargs.setdefault("supported_event_hooks", list(self.get_supported_event_hooks()))
         super().__init__(**kwargs)
 
+        self.configured_modes = _configured_modes(self.event_hook)
+
     def _webhook_url(self) -> str:
         return f"{self.api_base}{WEBHOOK_PATH}"
 
@@ -263,6 +328,7 @@ class StraikerGuardrail(CustomGuardrail):
     ) -> StraikerWebhookContext:
         return StraikerWebhookContext(
             call_surface=_resolve_call_surface(logging_obj, request_data),
+            mode=self.configured_modes,
             model=model,
             model_provider=_resolve_provider(request_data, model),
             destination=_resolve_destination(request_data),
@@ -287,9 +353,9 @@ class StraikerGuardrail(CustomGuardrail):
         content = StraikerWebhookContent(
             texts=list(inputs.get("texts") or []),
             images=list(inputs.get("images") or []),
-            structured_messages=inputs.get("structured_messages"),
-            tools=inputs.get("tools"),
-            tool_calls=inputs.get("tool_calls"),
+            structured_messages=_opaque_dict_list(inputs.get("structured_messages")),
+            tools=_opaque_dict_list(inputs.get("tools")),
+            tool_calls=_opaque_dict_list(inputs.get("tool_calls")),
         )
 
         if input_type == "request":
@@ -305,9 +371,10 @@ class StraikerGuardrail(CustomGuardrail):
 
         response_obj = request_data.get("response")
         content.finish_reason = _response_finish_reason(response_obj)
-        original_messages = request_data.get("messages")
         request_content = StraikerWebhookContent(
-            structured_messages=original_messages if isinstance(original_messages, list) else None,
+            structured_messages=_opaque_dict_list(
+                resolve_structured_messages(messages=request_data.get("messages"), request_kwargs=request_data)
+            ),
         )
         phase: Literal["none", "assembled"] = "assembled" if _is_streamed_request(request_data) else "none"
         event = StraikerWebhookEvent(type="post_call", id=event_id, stream=StraikerWebhookStream(phase=phase))

--- a/litellm/types/proxy/guardrails/guardrail_hooks/straiker.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/straiker.py
@@ -4,9 +4,6 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolCallChunk
-from litellm.types.utils import ChatCompletionMessageToolCall
-
 from .base import GuardrailConfigModel
 
 StraikerWebhookEventType = Literal["pre_call", "post_call"]
@@ -32,9 +29,9 @@ class StraikerWebhookContent(BaseModel):
 
     texts: list[str] = Field(default_factory=list)
     images: list[str] = Field(default_factory=list)
-    structured_messages: list[AllMessageValues] | None = None
+    structured_messages: list[dict[str, object]] | None = None
     tools: list[dict[str, object]] | None = None
-    tool_calls: list[ChatCompletionToolCallChunk] | list[ChatCompletionMessageToolCall] | None = None
+    tool_calls: list[dict[str, object]] | None = None
     finish_reason: str | None = None
 
 
@@ -45,6 +42,7 @@ class StraikerWebhookUsage(BaseModel):
 
 class StraikerWebhookContext(BaseModel):
     call_surface: str
+    mode: list[str] | None = None
     model: str | None = None
     model_provider: str | None = None
     destination: str | None = None

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_straiker.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_straiker.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -8,6 +9,7 @@ from litellm.exceptions import GuardrailRaisedException, ModifyResponseException
 from litellm.proxy.guardrails.guardrail_hooks.straiker import initialize_guardrail
 from litellm.proxy.guardrails.guardrail_hooks.straiker.straiker import (
     StraikerGuardrail,
+    _response_finish_reason,
 )
 from litellm.proxy.guardrails.guardrail_registry import (
     guardrail_class_registry,
@@ -17,7 +19,14 @@ from litellm.types.proxy.guardrails.guardrail_hooks.straiker import (
     StraikerGuardrailConfigModel,
     StraikerGuardrailConfigModelOptionalParams,
 )
-from litellm.types.utils import Choices, Message, ModelResponse, Usage
+from litellm.types.utils import (
+    ChatCompletionMessageToolCall,
+    Choices,
+    Function,
+    Message,
+    ModelResponse,
+    Usage,
+)
 
 
 def _mock_response(action: str, turn_id: str = "turn-1", schema_version: str = "1", **extra) -> MagicMock:
@@ -208,7 +217,9 @@ async def test_request_envelope_transport_and_shape():
         "metadata": {"user_api_key_alias": "team-key", "agent_id": "chatbot-app", "app_name": "Chatbot"},
     }
 
-    out = await g.apply_guardrail(inputs=inputs, request_data=request_data, input_type="request", logging_obj=_logging_obj())
+    out = await g.apply_guardrail(
+        inputs=inputs, request_data=request_data, input_type="request", logging_obj=_logging_obj()
+    )
 
     assert out is inputs
     url = g.async_handler.post.call_args.args[0]
@@ -230,6 +241,35 @@ async def test_request_envelope_transport_and_shape():
     assert "user_role" not in payload["application"]
     assert "response" not in payload
     assert "metadata" not in payload
+
+
+@pytest.mark.asyncio
+async def test_request_envelope_ignores_unsupported_opaque_items():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response("NONE")
+
+    await g.apply_guardrail(
+        inputs={
+            "texts": ["hello"],
+            "tools": [
+                object(),
+                {
+                    "type": "function",
+                    "function": {"name": "get_weather", "parameters": {"type": "object"}},
+                },
+            ],
+        },
+        request_data={"model": "m", "messages": [{"role": "user", "content": "hello"}]},
+        input_type="request",
+        logging_obj=_logging_obj(),
+    )
+
+    assert _posted_payload(g)["request"]["tools"] == [
+        {
+            "type": "function",
+            "function": {"name": "get_weather", "parameters": {"type": "object"}},
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -332,6 +372,64 @@ async def test_context_session_id_from_request_metadata():
 
 
 @pytest.mark.asyncio
+async def test_context_mode_from_string_event_hook():
+    g = _make_guardrail(event_hook="pre_call")
+    g.async_handler.post.return_value = _mock_response("NONE")
+    await g.apply_guardrail(
+        inputs={"texts": ["x"]},
+        request_data={"model": "m"},
+        input_type="request",
+        logging_obj=_logging_obj(),
+    )
+    assert _posted_payload(g)["context"]["mode"] == ["pre_call"]
+
+
+@pytest.mark.asyncio
+async def test_context_mode_from_list_event_hook():
+    from litellm.types.guardrails import GuardrailEventHooks
+
+    g = _make_guardrail(event_hook=[GuardrailEventHooks.pre_call, GuardrailEventHooks.post_call])
+    g.async_handler.post.return_value = _mock_response("NONE")
+    await g.apply_guardrail(
+        inputs={"texts": ["x"]},
+        request_data={"model": "m"},
+        input_type="request",
+        logging_obj=_logging_obj(),
+    )
+    assert _posted_payload(g)["context"]["mode"] == ["pre_call", "post_call"]
+
+
+@pytest.mark.asyncio
+async def test_context_mode_from_tagged_mode_is_flattened_and_deduped():
+    from litellm.types.guardrails import Mode
+
+    g = _make_guardrail(
+        event_hook=Mode(tags={"team-a": "pre_call", "team-b": ["post_call", "pre_call"]}, default="post_call")
+    )
+    g.async_handler.post.return_value = _mock_response("NONE")
+    await g.apply_guardrail(
+        inputs={"texts": ["x"]},
+        request_data={"model": "m"},
+        input_type="request",
+        logging_obj=_logging_obj(),
+    )
+    assert _posted_payload(g)["context"]["mode"] == ["post_call", "pre_call"]
+
+
+@pytest.mark.asyncio
+async def test_context_mode_omitted_when_event_hook_absent():
+    g = _make_guardrail(event_hook=None)
+    g.async_handler.post.return_value = _mock_response("NONE")
+    await g.apply_guardrail(
+        inputs={"texts": ["x"]},
+        request_data={"model": "m"},
+        input_type="request",
+        logging_obj=_logging_obj(),
+    )
+    assert "mode" not in _posted_payload(g)["context"]
+
+
+@pytest.mark.asyncio
 async def test_identity_key_and_team_coalesce_alias_over_id():
     g = _make_guardrail()
     g.async_handler.post.return_value = _mock_response("NONE")
@@ -425,6 +523,7 @@ async def test_application_source_from_agent_id():
         logging_obj=_logging_obj(),
     )
     assert _posted_payload(g)["application"] == {"source": "analytics-app", "name": "Analytics"}
+
 
 @pytest.mark.asyncio
 async def test_request_block_raises_guardrail_exception_with_reason():
@@ -558,6 +657,33 @@ async def test_response_envelope_and_block_replaces_response():
     assert payload["response"]["texts"] == ["secret"]
     assert payload["response"]["finish_reason"] == "stop"
     assert payload["request"]["structured_messages"] == [{"role": "user", "content": "original prompt"}]
+
+
+@pytest.mark.asyncio
+async def test_post_call_resolves_request_from_responses_input_when_messages_absent():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response("NONE")
+    response = ModelResponse(
+        choices=[Choices(finish_reason="stop", index=0, message=Message(content="answer", role="assistant"))],
+        model="gpt-4o-mini",
+    )
+    request_data = {
+        "model": "gpt-4o-mini",
+        "input": "responses-surface prompt",
+        "response": response,
+    }
+
+    await g.apply_guardrail(
+        inputs={"texts": ["answer"], "model": "gpt-4o-mini"},
+        request_data=request_data,
+        input_type="response",
+        logging_obj=_logging_obj(),
+    )
+
+    payload = _posted_payload(g)
+    assert payload["event"]["type"] == "post_call"
+    messages = payload["request"]["structured_messages"]
+    assert any(m.get("content") == "responses-surface prompt" for m in messages)
 
 
 @pytest.mark.asyncio
@@ -731,3 +857,135 @@ async def test_unreachable_http_status_fail_closed_blocks():
         await g.apply_guardrail(
             inputs={"texts": ["x"]}, request_data={"model": "m"}, input_type="request", logging_obj=_logging_obj()
         )
+
+
+@pytest.mark.asyncio
+async def test_post_call_preserves_anthropic_tool_blocks_in_request_messages():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response("NONE")
+    anthropic_messages = [
+        {"role": "user", "content": "What's the weather in Paris?"},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "get_weather",
+                    "input": {"city": "Paris"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": "18C, cloudy",
+                }
+            ],
+        },
+    ]
+    response = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Mild and cloudy."}],
+        "stop_reason": "end_turn",
+        "model": "claude-sonnet-5",
+    }
+    await g.apply_guardrail(
+        inputs={"texts": ["Mild and cloudy."], "model": "claude-sonnet-5"},
+        request_data={
+            "model": "claude-sonnet-5",
+            "messages": anthropic_messages,
+            "response": response,
+        },
+        input_type="response",
+        logging_obj=_logging_obj(),
+    )
+    payload = _posted_payload(g)
+    assert payload["request"]["structured_messages"] == anthropic_messages
+    assert payload["response"]["finish_reason"] == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_preserves_anthropic_tool_blocks_in_structured_messages():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response("NONE")
+    anthropic_messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "get_weather",
+                    "input": {"city": "Paris"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": "18C",
+                }
+            ],
+        },
+    ]
+    await g.apply_guardrail(
+        inputs={"structured_messages": anthropic_messages, "model": "claude-sonnet-5"},
+        request_data={"model": "claude-sonnet-5", "messages": anthropic_messages},
+        input_type="request",
+        logging_obj=_logging_obj(),
+    )
+    assert _posted_payload(g)["request"]["structured_messages"] == anthropic_messages
+
+
+@pytest.mark.asyncio
+async def test_response_finish_reason_from_openai_choices_still_works():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response("NONE")
+    response = ModelResponse(
+        choices=[Choices(finish_reason="tool_calls", index=0, message=Message(content=None, role="assistant"))],
+        model="gpt-4o-mini",
+    )
+    await g.apply_guardrail(
+        inputs={
+            "texts": [],
+            "tool_calls": [
+                ChatCompletionMessageToolCall(
+                    id="c1",
+                    type="function",
+                    function=Function(name="f", arguments="{}"),
+                )
+            ],
+        },
+        request_data={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}], "response": response},
+        input_type="response",
+        logging_obj=_logging_obj(),
+    )
+    payload = _posted_payload(g)
+    assert payload["response"]["finish_reason"] == "tool_calls"
+    assert payload["response"]["tool_calls"] == [
+        {"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+    ]
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (None, None),
+        ({"choices": "invalid"}, None),
+        ({"choices": [{"finish_reason": "length"}]}, "length"),
+        ({"choices": [{"stop_reason": "end_turn"}]}, "end_turn"),
+        ({"choices": [{}]}, None),
+        (SimpleNamespace(stop_reason="end_turn"), "end_turn"),
+    ],
+)
+def test_response_finish_reason_handles_supported_shapes(response, expected):
+    assert _response_finish_reason(response) == expected


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/messages` streaming post-call hooks omitted prepared response metadata
- Responses post-call webhooks could lose the original request context
- Straiker payload types assumed chat-completion-specific message shapes

How it solves it:

- Prepare Anthropic streaming response data before applying post-call guardrails
- Normalize Straiker request, tool, finish-reason, and mode fields

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
<img width="1376" height="842" alt="Screenshot 2026-07-24 at 2 52 43 PM" src="https://github.com/user-attachments/assets/cf7f8dd8-d7c5-4609-af11-efc8c7e9799e" />

- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Before (`bd753aecf3`):

TODO: add the live proxy command and output showing the missing request context on `/v1/responses`

After (`52c75749e9`):

A real-provider matrix run covered OpenAI, Anthropic, Gemini, and Bedrock through `/v1/chat/completions`, `/v1/messages`, and `/v1/responses`

The native Responses post-call webhook preserves the original request:

```json
{
  "context": {
    "call_surface": "aresponses",
    "mode": ["pre_call", "post_call"]
  },
  "request": {
    "structured_messages": [
      {
        "role": "user",
        "content": "What's the weather in Paris right now?"
      }
    ]
  }
}
```

The Anthropic Messages post-call webhook preserves the terminal reason:

```json
{
  "context": {
    "call_surface": "anthropic_messages"
  },
  "response": {
    "finish_reason": "end_turn"
  }
}
```

## Type

Bug Fix

## Changes

The Anthropic Messages streaming post-call path now prepares request data before invoking guardrails, matching the non-streaming path and preserving the assembled response and LiteLLM metadata

The Straiker plugin now resolves request messages across API formats, preserves opaque JSON message and tool structures, extracts OpenAI and Anthropic terminal reasons, and includes configured guardrail modes in webhook context

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
