### PR TITLE
fix(bedrock-mantle): restore namespace on function calls

### DIFF
--- a/litellm/llms/bedrock_mantle/responses/transformation.py
+++ b/litellm/llms/bedrock_mantle/responses/transformation.py
@@ -17,6 +17,7 @@ BaseAWSLLM._sign_request after the request body is finalized.
 
 from typing import Any, Dict, List, Optional
 
+import httpx
 import litellm
 from litellm._logging import verbose_logger
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
@@ -24,11 +25,16 @@ from litellm.llms.bedrock_mantle.common_utils import (
     MANTLE_HOST_RE,
     BedrockMantleAuthMixin,
 )
-from litellm.llms.openai.responses.transformation import OpenAIResponsesAPIConfig
+from litellm.llms.openai.responses.transformation import (
+    LiteLLMLoggingObj,
+    OpenAIResponsesAPIConfig,
+)
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.llms.openai import (
     ResponseInputParam,
     ResponsesAPIOptionalRequestParams,
+    ResponsesAPIResponse,
+    ResponsesAPIStreamingResponse,
 )
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
@@ -172,6 +178,121 @@ class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPI
             response_api_optional_request_params=request_params,
             litellm_params=litellm_params,
             headers=headers,
+        )
+
+    @staticmethod
+    def _namespace_by_tool_name(logging_obj: LiteLLMLoggingObj) -> dict[str, str]:
+        model_call_details = getattr(logging_obj, "model_call_details", {})
+        if not isinstance(model_call_details, dict):
+            return {}
+        additional_args = model_call_details.get("additional_args")
+        if not isinstance(additional_args, dict):
+            return {}
+        complete_input_dict = additional_args.get("complete_input_dict")
+        if not isinstance(complete_input_dict, dict):
+            return {}
+        tools = complete_input_dict.get("tools")
+        if not isinstance(tools, list):
+            return {}
+
+        namespaces_by_tool_name: dict[str, set[str]] = {}
+        for namespace_tool in tools:
+            if not isinstance(namespace_tool, dict) or namespace_tool.get("type") != "namespace":
+                continue
+            namespace = namespace_tool.get("name")
+            nested_tools = namespace_tool.get("tools")
+            if not isinstance(namespace, str) or not isinstance(nested_tools, list):
+                continue
+            for nested_tool in nested_tools:
+                if not isinstance(nested_tool, dict):
+                    continue
+                tool_name = nested_tool.get("name")
+                if isinstance(tool_name, str):
+                    namespaces_by_tool_name.setdefault(tool_name, set()).add(namespace)
+
+        return {
+            tool_name: next(iter(namespaces))
+            for tool_name, namespaces in namespaces_by_tool_name.items()
+            if len(namespaces) == 1
+        }
+
+    @classmethod
+    def _restore_function_call_namespaces(
+        cls,
+        value: Any,
+        namespace_by_tool_name: dict[str, str],
+    ) -> Any:
+        if isinstance(value, list):
+            return [cls._restore_function_call_namespaces(item, namespace_by_tool_name) for item in value]
+        if not isinstance(value, dict):
+            return value
+
+        restored = {
+            key: cls._restore_function_call_namespaces(item, namespace_by_tool_name) for key, item in value.items()
+        }
+        if (
+            restored.get("type") == "function_call"
+            and restored.get("namespace") is None
+            and isinstance(restored.get("name"), str)
+        ):
+            namespace = namespace_by_tool_name.get(restored["name"])
+            if namespace is not None:
+                restored["namespace"] = namespace
+        return restored
+
+    def transform_response_api_response(
+        self,
+        model: str,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> ResponsesAPIResponse:
+        namespace_by_tool_name = self._namespace_by_tool_name(logging_obj)
+        if not namespace_by_tool_name:
+            return super().transform_response_api_response(
+                model=model,
+                raw_response=raw_response,
+                logging_obj=logging_obj,
+            )
+
+        try:
+            response_payload = raw_response.json()
+        except ValueError:
+            return super().transform_response_api_response(
+                model=model,
+                raw_response=raw_response,
+                logging_obj=logging_obj,
+            )
+        restored_payload = self._restore_function_call_namespaces(
+            response_payload,
+            namespace_by_tool_name,
+        )
+        restored_response = httpx.Response(
+            status_code=raw_response.status_code,
+            headers=raw_response.headers,
+            json=restored_payload,
+            request=raw_response.request,
+            extensions=raw_response.extensions,
+        )
+        return super().transform_response_api_response(
+            model=model,
+            raw_response=restored_response,
+            logging_obj=logging_obj,
+        )
+
+    def transform_streaming_response(
+        self,
+        model: str,
+        parsed_chunk: dict,
+        logging_obj: LiteLLMLoggingObj,
+    ) -> ResponsesAPIStreamingResponse:
+        restored_chunk = self._restore_function_call_namespaces(
+            parsed_chunk,
+            self._namespace_by_tool_name(logging_obj),
+        )
+        return super().transform_streaming_response(
+            model=model,
+            parsed_chunk=restored_chunk,
+            logging_obj=logging_obj,
         )
 
     @staticmethod

--- a/litellm/llms/bedrock_mantle/responses/transformation.py
+++ b/litellm/llms/bedrock_mantle/responses/transformation.py
@@ -196,6 +196,11 @@ class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPI
             return {}
 
         namespaces_by_tool_name: dict[str, set[str]] = {}
+        top_level_function_names = frozenset(
+            tool["name"]
+            for tool in tools
+            if isinstance(tool, dict) and tool.get("type") == "function" and isinstance(tool.get("name"), str)
+        )
         for namespace_tool in tools:
             if not isinstance(namespace_tool, dict) or namespace_tool.get("type") != "namespace":
                 continue
@@ -213,7 +218,7 @@ class BedrockMantleResponsesAPIConfig(BedrockMantleAuthMixin, OpenAIResponsesAPI
         return {
             tool_name: next(iter(namespaces))
             for tool_name, namespaces in namespaces_by_tool_name.items()
-            if len(namespaces) == 1
+            if len(namespaces) == 1 and tool_name not in top_level_function_names
         }
 
     @classmethod

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -10,9 +10,11 @@ gate, the URL construction for both paths, and the shared Bearer auth.
 import copy
 import os
 import sys
+from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.abspath("../../../../.."))
 
+import httpx
 import pytest
 from botocore.exceptions import (
     ConnectTimeoutError,
@@ -630,6 +632,142 @@ class TestBedrockMantleCodexAdditionalTools:
             )
         assert mock_debug.call_count == 1
         assert "additional_tools" in str(mock_debug.call_args)
+
+
+class TestBedrockMantleNamespaceRestoration:
+    _NAMESPACE_TOOLS = [
+        {
+            "type": "namespace",
+            "name": "collaboration",
+            "tools": [
+                {"type": "function", "name": "spawn_agent"},
+                {"type": "function", "name": "wait_agent"},
+            ],
+        }
+    ]
+
+    @staticmethod
+    def _logging_obj(tools):
+        logging_obj = MagicMock()
+        logging_obj.model_call_details = {
+            "additional_args": {"complete_input_dict": {"tools": tools}}
+        }
+        return logging_obj
+
+    @staticmethod
+    def _function_call(name="spawn_agent", namespace=None):
+        item = {
+            "type": "function_call",
+            "id": "fc_123",
+            "call_id": "call_123",
+            "name": name,
+            "arguments": "{}",
+            "status": "completed",
+        }
+        if namespace is not None:
+            item["namespace"] = namespace
+        return item
+
+    def test_non_stream_response_restores_namespace(self):
+        cfg = BedrockMantleResponsesAPIConfig()
+        response = httpx.Response(
+            200,
+            request=httpx.Request("POST", "https://example.com/v1/responses"),
+            json={
+                "id": "resp_123",
+                "object": "response",
+                "created_at": 1700000000,
+                "status": "completed",
+                "model": "openai.gpt-5.6-luna",
+                "output": [self._function_call()],
+            },
+        )
+
+        parsed = cfg.transform_response_api_response(
+            model="openai.gpt-5.6-luna",
+            raw_response=response,
+            logging_obj=self._logging_obj(self._NAMESPACE_TOOLS),
+        )
+
+        assert parsed.output[0].namespace == "collaboration"
+
+    @pytest.mark.parametrize(
+        "chunk",
+        [
+            {
+                "type": "response.output_item.added",
+                "sequence_number": 1,
+                "output_index": 0,
+                "item": _function_call(),
+            },
+            {
+                "type": "response.output_item.done",
+                "sequence_number": 2,
+                "output_index": 0,
+                "item": _function_call(),
+            },
+            {
+                "type": "response.completed",
+                "sequence_number": 3,
+                "response": {
+                    "id": "resp_123",
+                    "object": "response",
+                    "created_at": 1700000000,
+                    "status": "completed",
+                    "model": "openai.gpt-5.6-luna",
+                    "output": [_function_call()],
+                },
+            },
+        ],
+    )
+    def test_streaming_response_restores_namespace(self, chunk):
+        cfg = BedrockMantleResponsesAPIConfig()
+
+        parsed = cfg.transform_streaming_response(
+            model="openai.gpt-5.6-luna",
+            parsed_chunk=chunk,
+            logging_obj=self._logging_obj(self._NAMESPACE_TOOLS),
+        )
+
+        payload = parsed.model_dump(exclude_none=True)
+        function_call = (
+            payload["item"] if "item" in payload else payload["response"]["output"][0]
+        )
+        assert function_call["namespace"] == "collaboration"
+
+    def test_existing_namespace_is_preserved(self):
+        cfg = BedrockMantleResponsesAPIConfig()
+        restored = cfg._restore_function_call_namespaces(
+            self._function_call(namespace="existing"),
+            {"spawn_agent": "collaboration"},
+        )
+        assert restored["namespace"] == "existing"
+
+    def test_non_namespaced_function_call_is_unchanged(self):
+        cfg = BedrockMantleResponsesAPIConfig()
+        function_call = self._function_call(name="standalone")
+        restored = cfg._restore_function_call_namespaces(
+            function_call,
+            {"spawn_agent": "collaboration"},
+        )
+        assert restored == function_call
+
+    def test_ambiguous_tool_name_is_not_assigned_a_namespace(self):
+        cfg = BedrockMantleResponsesAPIConfig()
+        tools = [
+            *self._NAMESPACE_TOOLS,
+            {
+                "type": "namespace",
+                "name": "other_namespace",
+                "tools": [{"type": "function", "name": "spawn_agent"}],
+            },
+        ]
+        namespace_by_tool_name = cfg._namespace_by_tool_name(self._logging_obj(tools))
+        restored = cfg._restore_function_call_namespaces(
+            self._function_call(),
+            namespace_by_tool_name,
+        )
+        assert "namespace" not in restored
 
 
 class TestBedrockMantleResponsesRegistry:

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -769,6 +769,53 @@ class TestBedrockMantleNamespaceRestoration:
         )
         assert "namespace" not in restored
 
+    def test_non_stream_top_level_function_collision_is_not_assigned_namespace(self):
+        cfg = BedrockMantleResponsesAPIConfig()
+        tools = [
+            {"type": "function", "name": "spawn_agent"},
+            *self._NAMESPACE_TOOLS,
+        ]
+        response = httpx.Response(
+            200,
+            request=httpx.Request("POST", "https://example.com/v1/responses"),
+            json={
+                "id": "resp_123",
+                "object": "response",
+                "created_at": 1700000000,
+                "status": "completed",
+                "model": "openai.gpt-5.6-luna",
+                "output": [self._function_call()],
+            },
+        )
+
+        parsed = cfg.transform_response_api_response(
+            model="openai.gpt-5.6-luna",
+            raw_response=response,
+            logging_obj=self._logging_obj(tools),
+        )
+
+        assert "namespace" not in parsed.output[0].model_dump(exclude_none=True)
+
+    def test_streaming_top_level_function_collision_is_not_assigned_namespace(self):
+        cfg = BedrockMantleResponsesAPIConfig()
+        tools = [
+            {"type": "function", "name": "spawn_agent"},
+            *self._NAMESPACE_TOOLS,
+        ]
+
+        parsed = cfg.transform_streaming_response(
+            model="openai.gpt-5.6-luna",
+            parsed_chunk={
+                "type": "response.output_item.added",
+                "sequence_number": 1,
+                "output_index": 0,
+                "item": self._function_call(),
+            },
+            logging_obj=self._logging_obj(tools),
+        )
+
+        assert "namespace" not in parsed.model_dump(exclude_none=True)["item"]
+
 
 class TestBedrockMantleResponsesRegistry:
     def test_registry_returns_config_for_gpt_5_5(self, local_cost_map):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mantle omits namespace from namespaced function calls
- Codex cannot dispatch calls without the namespace

How it solves it:

- Derives namespaces from the submitted tool definitions
- Restores unambiguous namespaces across all response event shapes

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Tested against the real Amazon Bedrock Mantle Responses API with `bedrock_mantle/xai.grok-4.3`, AWS login credentials, `store: false`, streaming enabled, and a forced `collaboration.spawn_agent` call

```bash
curl -N http://localhost:4000/v1/responses \
  -H 'Content-Type: application/json' \
  -d '{"model":"bedrock-mantle-grok-4.3","input":"Call the requested tool.","store":false,"stream":true,"tools":[{"type":"namespace","name":"collaboration","description":"Agent collaboration tools","tools":[{"type":"function","name":"spawn_agent","description":"Spawn an agent","parameters":{"type":"object","properties":{"task_name":{"type":"string"},"message":{"type":"string"}},"required":["task_name","message"],"additionalProperties":false},"strict":true}]}],"tool_choice":{"type":"function","name":"spawn_agent"},"max_output_tokens":1000}'
```

Before at `bd753aecf37ae55bf086b010acfaf5731ae3d9f1`

```text
response.output_item.added  function_call spawn_agent namespace=null
response.output_item.done   function_call spawn_agent namespace=null
response.completed          function_call spawn_agent namespace=null
```

After at `803f90035a1ae3f0301beff0ea652184e6d665d9`

```text
response.output_item.added  function_call spawn_agent namespace=collaboration
response.output_item.done   function_call spawn_agent namespace=collaboration
response.completed          function_call spawn_agent namespace=collaboration
```

## Codex CLI E2E

Verified with `codex-cli 0.145.0`, `multi_agent` enabled, and the patched LiteLLM proxy at commit `803f90035a1ae3f0301beff0ea652184e6d665d9`

```text
collab_tool_call spawn_agent completed
receiver_thread_ids=[019f93c0-c259-7602-9c63-8114dcbb83ac]
collab_tool_call wait completed
child message=SUBAGENT_OK
agent message=CODEX_NAMESPACE_E2E_OK
turn completed
```

## Type

Bug Fix

## Changes

- Build a unique function-to-namespace index from request tools
- Restore missing namespaces recursively before response model validation
- Preserve upstream namespaces and skip names that collide across namespaces or with top-level functions
- Cover non-streaming and every relevant streaming event shape, including top-level collisions

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR