### PR TITLE
feat(ui): add OCR support to Playground

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -921,14 +921,8 @@
     }
   },
   "src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx": {
-    "local/no-complex-jsx-arrow": {
-      "count": 1
-    },
     "max-lines": {
       "count": 1
-    },
-    "no-nested-ternary": {
-      "count": 6
     },
     "react-hooks/set-state-in-effect": {
       "count": 4

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
@@ -375,6 +375,64 @@ describe("ChatUI", () => {
     expect(customProxyInput).toHaveValue(testProxyUrl);
   });
 
+  it("revokes the active OCR preview URL on unmount", async () => {
+    const createObjectURL = vi.fn(() => "blob:http://localhost/ocr-preview");
+    const revokeObjectURL = vi.fn();
+    URL.createObjectURL = createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL;
+
+    const { getByText, unmount } = render(
+      <ChatUI
+        accessToken="1234567890"
+        token="1234567890"
+        userRole="user"
+        userID="1234567890"
+        disabledPersonalKeyCreation={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByText("Test Key")).toBeInTheDocument();
+    });
+
+    const endpointTypeText = getByText("Endpoint Type");
+    const endpointSelect = endpointTypeText.parentElement?.querySelector(".ant-select-selector");
+    expect(endpointSelect).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.mouseDown(endpointSelect!);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("/v1/ocr")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("/v1/ocr"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Click or drag a document or image to upload")).toBeInTheDocument();
+    });
+
+    const uploadInput = document.querySelector('input[type="file"]') as HTMLInputElement | null;
+    expect(uploadInput).not.toBeNull();
+
+    const imageFile = new File(["ocr"], "ocr.png", { type: "image/png" });
+    await act(async () => {
+      fireEvent.change(uploadInput!, { target: { files: [imageFile] } });
+    });
+
+    await waitFor(() => {
+      expect(createObjectURL).toHaveBeenCalledWith(imageFile);
+      expect(screen.getByAltText("Upload preview")).toBeInTheDocument();
+    });
+
+    unmount();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:http://localhost/ocr-preview");
+  });
+
   it("should enable search functionality for MCP server selector", async () => {
     render(
       <ChatUI

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
@@ -441,6 +441,49 @@ describe("ChatUI", () => {
     expect(customProxyInput).toHaveValue(testProxyUrl);
   });
 
+  it("revokes the active OCR preview URL on unmount", async () => {
+    const createObjectURL = vi.fn(() => "blob:http://localhost/ocr-preview");
+    const revokeObjectURL = vi.fn();
+    URL.createObjectURL = createObjectURL;
+    URL.revokeObjectURL = revokeObjectURL;
+
+    const { getByText, unmount } = render(
+      <ChatUI
+        accessToken="1234567890"
+        token="1234567890"
+        userRole="user"
+        userID="1234567890"
+        disabledPersonalKeyCreation={false}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByText("Test Key")).toBeInTheDocument();
+    });
+
+    await selectComboboxOption("Select an endpoint", "/v1/ocr");
+
+    await waitFor(() => {
+      expect(screen.getByText("Click or drag a document or image to upload")).toBeInTheDocument();
+    });
+
+    const uploadInput = screen.getByLabelText(/Click or drag a document or image to upload/);
+
+    const imageFile = new File(["ocr"], "ocr.png", { type: "image/png" });
+    await act(async () => {
+      fireEvent.change(uploadInput, { target: { files: [imageFile] } });
+    });
+
+    await waitFor(() => {
+      expect(createObjectURL).toHaveBeenCalledWith(imageFile);
+      expect(screen.getByAltText("Upload preview")).toBeInTheDocument();
+    });
+
+    unmount();
+
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:http://localhost/ocr-preview");
+  });
+
   it("should enable search functionality for MCP server selector", async () => {
     const user = userEvent.setup();
     render(

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -48,6 +48,7 @@ import { Agent, fetchAvailableAgents } from "../../llm_calls/fetch_agents";
 import { fetchAvailableModels, ModelGroup } from "@/components/llm_calls/fetch_models";
 import { makeOpenAIImageEditsRequest } from "../../llm_calls/image_edits";
 import { makeOpenAIImageGenerationRequest } from "../../llm_calls/image_generation";
+import { makeOpenAIOcrRequest } from "../../llm_calls/OcrApi";
 import { makeOpenAIResponsesRequest } from "@/components/llm_calls/responses_api";
 import { makeInteractionsRequest } from "../../llm_calls/interactions_api";
 import A2AMetrics from "./A2AMetrics";
@@ -254,6 +255,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
   const [chatUploadedImage, setChatUploadedImage] = useState<File | null>(null);
   const [chatImagePreviewUrl, setChatImagePreviewUrl] = useState<string | null>(null);
   const [uploadedAudio, setUploadedAudio] = useState<File | null>(null);
+  const [uploadedOcrFile, setUploadedOcrFile] = useState<File | null>(null);
+  const [ocrFilePreviewUrl, setOcrFilePreviewUrl] = useState<string | null>(null);
   const [isGetCodeModalVisible, setIsGetCodeModalVisible] = useState(false);
   const [generatedCode, setGeneratedCode] = useState("");
   const [selectedSdk, setSelectedSdk] = useState<"openai" | "azure">("openai");
@@ -565,8 +568,27 @@ const ChatUI: React.FC<ChatUIProps> = ({
     setUploadedAudio(null);
   };
 
+  const handleOcrFileUpload = (file: File): false => {
+    setUploadedOcrFile(file);
+    setOcrFilePreviewUrl(file.type.startsWith("image/") ? URL.createObjectURL(file) : null);
+    return false;
+  };
+
+  const handleRemoveOcrFile = () => {
+    if (ocrFilePreviewUrl) {
+      URL.revokeObjectURL(ocrFilePreviewUrl);
+    }
+    setUploadedOcrFile(null);
+    setOcrFilePreviewUrl(null);
+  };
+
   const handleSendMessage = async () => {
-    if (inputMessage.trim() === "" && endpointType !== EndpointType.TRANSCRIPTION && endpointType !== EndpointType.MCP)
+    if (
+      inputMessage.trim() === "" &&
+      endpointType !== EndpointType.TRANSCRIPTION &&
+      endpointType !== EndpointType.MCP &&
+      endpointType !== EndpointType.OCR
+    )
       return;
 
     // For image edits, require both image and prompt
@@ -578,6 +600,11 @@ const ChatUI: React.FC<ChatUIProps> = ({
     // For audio transcriptions, require audio file
     if (endpointType === EndpointType.TRANSCRIPTION && !uploadedAudio) {
       NotificationsManager.fromBackend("Please upload an audio file for transcription");
+      return;
+    }
+
+    if (endpointType === EndpointType.OCR && !uploadedOcrFile) {
+      NotificationsManager.fromBackend("Please upload a document or image for OCR");
       return;
     }
 
@@ -638,6 +665,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
       EndpointType.ANTHROPIC_MESSAGES,
       EndpointType.EMBEDDINGS,
       EndpointType.TRANSCRIPTION,
+      EndpointType.OCR,
       EndpointType.INTERACTIONS,
     ];
 
@@ -650,7 +678,11 @@ const ChatUI: React.FC<ChatUIProps> = ({
       return;
     }
 
-    const effectiveApiKey = simplified ? accessToken : apiKeySource === "session" ? accessToken : apiKey;
+    const effectiveApiKey = (() => {
+      if (simplified) return accessToken;
+      if (apiKeySource === "session") return accessToken;
+      return apiKey;
+    })();
 
     if (!effectiveApiKey) {
       NotificationsManager.fromBackend("Please provide a Virtual Key or select Current UI Session");
@@ -713,6 +745,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
         ? `🎵 Audio file: ${uploadedAudio.name}\nPrompt: ${inputMessage}`
         : `🎵 Audio file: ${uploadedAudio.name}`;
       displayMessage = createDisplayMessage(audioMessage, false);
+    } else if (endpointType === EndpointType.OCR && uploadedOcrFile) {
+      displayMessage = createDisplayMessage(`OCR file: ${uploadedOcrFile.name}`, false);
     } else if (endpointType === EndpointType.MCP && selectedMCPDirectTool) {
       // For MCP direct mode, show tool name and arguments from form
       const mcpMessage = `🔧 MCP Tool: ${selectedMCPDirectTool}\nArguments: ${JSON.stringify(mcpToolArguments, null, 2)}`;
@@ -907,6 +941,18 @@ const ChatUI: React.FC<ChatUIProps> = ({
               customProxyBaseUrl || undefined,
             );
           }
+        } else if (endpointType === EndpointType.OCR) {
+          if (uploadedOcrFile) {
+            await makeOpenAIOcrRequest({
+              file: uploadedOcrFile,
+              updateUI: (text, model) => updateTextUI("assistant", text, model),
+              selectedModel,
+              accessToken: effectiveApiKey,
+              tags: selectedTags,
+              signal,
+              customBaseUrl: customProxyBaseUrl || undefined,
+            });
+          }
         } else if (endpointType === EndpointType.INTERACTIONS) {
           await makeInteractionsRequest(
             inputMessage,
@@ -992,6 +1038,9 @@ const ChatUI: React.FC<ChatUIProps> = ({
       if (endpointType === EndpointType.TRANSCRIPTION && uploadedAudio) {
         handleRemoveAudio();
       }
+      if (endpointType === EndpointType.OCR && uploadedOcrFile) {
+        handleRemoveOcrFile();
+      }
     }
 
     setInputMessage("");
@@ -1003,6 +1052,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
     handleRemoveResponsesImage();
     handleRemoveChatImage();
     handleRemoveAudio();
+    handleRemoveOcrFile();
     NotificationsManager.success("Chat history cleared.");
   };
 
@@ -1036,6 +1086,61 @@ const ChatUI: React.FC<ChatUIProps> = ({
   };
 
   const antIcon = <LoadingOutlined style={{ fontSize: 24 }} spin />;
+
+  const getMcpServerSelectValue = () => {
+    if (endpointType !== EndpointType.MCP) {
+      return selectedMCPServers;
+    }
+    if (selectedMCPServers[0] !== "__all__" && selectedMCPServers.length === 1) {
+      return selectedMCPServers[0];
+    }
+    return undefined;
+  };
+
+  const getInputPlaceholder = () => {
+    const messageEndpoints = [
+      EndpointType.CHAT,
+      EndpointType.EMBEDDINGS,
+      EndpointType.RESPONSES,
+      EndpointType.ANTHROPIC_MESSAGES,
+      EndpointType.INTERACTIONS,
+    ];
+    if (messageEndpoints.includes(endpointType as EndpointType)) {
+      return "Type your message... (Shift+Enter for new line)";
+    }
+    if (endpointType === EndpointType.A2A_AGENTS) {
+      return "Send a message to the A2A agent...";
+    }
+    if (endpointType === EndpointType.IMAGE_EDITS) {
+      return "Describe how you want to edit the image...";
+    }
+    if (endpointType === EndpointType.SPEECH) {
+      return "Enter text to convert to speech...";
+    }
+    if (endpointType === EndpointType.TRANSCRIPTION) {
+      return "Optional: Add context or prompt for transcription...";
+    }
+    if (endpointType === EndpointType.OCR) {
+      return "Upload a document or image to run OCR";
+    }
+    return "Describe the image you want to generate...";
+  };
+
+  const isSendDisabled = () => {
+    if (isLoading) {
+      return true;
+    }
+    if (endpointType === EndpointType.MCP) {
+      return !(selectedMCPServers.length === 1 && selectedMCPServers[0] !== "__all__" && selectedMCPDirectTool);
+    }
+    if (endpointType === EndpointType.TRANSCRIPTION) {
+      return !uploadedAudio;
+    }
+    if (endpointType === EndpointType.OCR) {
+      return !uploadedOcrFile;
+    }
+    return !inputMessage.trim();
+  };
 
   return (
     <div className={`w-full bg-white ${simplified ? "h-full flex flex-col" : "p-4 pb-0"}`}>
@@ -1352,13 +1457,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     mode={endpointType === EndpointType.MCP ? undefined : "multiple"}
                     style={{ width: "100%" }}
                     placeholder={endpointType === EndpointType.MCP ? "Select MCP server" : "Select MCP servers"}
-                    value={
-                      endpointType === EndpointType.MCP
-                        ? selectedMCPServers[0] !== "__all__" && selectedMCPServers.length === 1
-                          ? selectedMCPServers[0]
-                          : undefined
-                        : selectedMCPServers
-                    }
+                    value={getMcpServerSelectValue()}
                     onChange={(value) => {
                       if (endpointType === EndpointType.MCP) {
                         const serverId = value as string | undefined;
@@ -1902,6 +2001,22 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     </div>
                   )}
 
+                  {endpointType === EndpointType.OCR && !uploadedOcrFile && (
+                    <div className="mb-4">
+                      <Dragger
+                        beforeUpload={handleOcrFileUpload}
+                        accept="image/*,application/pdf"
+                        showUploadList={false}
+                      >
+                        <p className="ant-upload-drag-icon">
+                          <FilePdfOutlined style={{ fontSize: "24px", color: "#666" }} />
+                        </p>
+                        <p className="ant-upload-text text-sm">Click or drag a document or image to upload</p>
+                        <p className="ant-upload-hint text-xs text-gray-500">Support for PDF and image files.</p>
+                      </Dragger>
+                    </div>
+                  )}
+
                   {/* Show file previews above input when files are uploaded */}
                   {endpointType === EndpointType.RESPONSES && responsesUploadedImage && (
                     <FilePreviewCard
@@ -1916,6 +2031,14 @@ const ChatUI: React.FC<ChatUIProps> = ({
                       file={chatUploadedImage}
                       previewUrl={chatImagePreviewUrl}
                       onRemove={handleRemoveChatImage}
+                    />
+                  )}
+
+                  {endpointType === EndpointType.OCR && uploadedOcrFile && (
+                    <FilePreviewCard
+                      file={uploadedOcrFile}
+                      previewUrl={ocrFilePreviewUrl}
+                      onRemove={handleRemoveOcrFile}
                     />
                   )}
 
@@ -2067,24 +2190,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
                           value={inputMessage}
                           onChange={(e) => setInputMessage(e.target.value)}
                           onKeyDown={handleKeyDown}
-                          placeholder={
-                            endpointType === EndpointType.CHAT ||
-                            endpointType === EndpointType.EMBEDDINGS ||
-                            endpointType === EndpointType.RESPONSES ||
-                            endpointType === EndpointType.ANTHROPIC_MESSAGES ||
-                            endpointType === EndpointType.INTERACTIONS
-                              ? "Type your message... (Shift+Enter for new line)"
-                              : endpointType === EndpointType.A2A_AGENTS
-                                ? "Send a message to the A2A agent..."
-                                : endpointType === EndpointType.IMAGE_EDITS
-                                  ? "Describe how you want to edit the image..."
-                                  : endpointType === EndpointType.SPEECH
-                                    ? "Enter text to convert to speech..."
-                                    : endpointType === EndpointType.TRANSCRIPTION
-                                      ? "Optional: Add context or prompt for transcription..."
-                                      : "Describe the image you want to generate..."
-                          }
-                          disabled={isLoading}
+                          placeholder={getInputPlaceholder()}
+                          disabled={isLoading || endpointType === EndpointType.OCR}
                           className="flex-1"
                           autoSize={{ minRows: 1, maxRows: 4 }}
                           style={{
@@ -2102,18 +2209,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                       {/* Right: send button - matching blue theme */}
                       <TremorButton
                         onClick={handleSendMessage}
-                        disabled={
-                          isLoading ||
-                          (endpointType === EndpointType.MCP
-                            ? !(
-                                selectedMCPServers.length === 1 &&
-                                selectedMCPServers[0] !== "__all__" &&
-                                selectedMCPDirectTool
-                              )
-                            : endpointType === EndpointType.TRANSCRIPTION
-                              ? !uploadedAudio
-                              : !inputMessage.trim())
-                        }
+                        disabled={isSendDisabled()}
                         className="shrink-0 ml-2 w-8! h-8! min-w-8! p-0! rounded-full! bg-blue-600! hover:bg-blue-700! disabled:bg-gray-300! border-none! text-white! disabled:text-gray-500! flex! items-center! justify-center!"
                       >
                         <ArrowUpOutlined style={{ fontSize: "14px" }} />

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -269,6 +269,24 @@ const ChatUI: React.FC<ChatUIProps> = ({
   const codeInterpreter = useCodeInterpreter();
 
   const chatEndRef = useRef<HTMLDivElement>(null);
+  const ocrFilePreviewUrlRef = useRef<string | null>(null);
+
+  const revokeOcrFilePreviewUrl = () => {
+    if (ocrFilePreviewUrlRef.current) {
+      URL.revokeObjectURL(ocrFilePreviewUrlRef.current);
+    }
+    ocrFilePreviewUrlRef.current = null;
+    setOcrFilePreviewUrl(null);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (ocrFilePreviewUrlRef.current) {
+        URL.revokeObjectURL(ocrFilePreviewUrlRef.current);
+        ocrFilePreviewUrlRef.current = null;
+      }
+    };
+  }, []);
 
   // Fetch MCP servers and toolsets
   const loadMCPServers = async () => {
@@ -569,17 +587,17 @@ const ChatUI: React.FC<ChatUIProps> = ({
   };
 
   const handleOcrFileUpload = (file: File): false => {
+    revokeOcrFilePreviewUrl();
     setUploadedOcrFile(file);
-    setOcrFilePreviewUrl(file.type.startsWith("image/") ? URL.createObjectURL(file) : null);
+    const previewUrl = file.type.startsWith("image/") ? URL.createObjectURL(file) : null;
+    ocrFilePreviewUrlRef.current = previewUrl;
+    setOcrFilePreviewUrl(previewUrl);
     return false;
   };
 
   const handleRemoveOcrFile = () => {
-    if (ocrFilePreviewUrl) {
-      URL.revokeObjectURL(ocrFilePreviewUrl);
-    }
     setUploadedOcrFile(null);
-    setOcrFilePreviewUrl(null);
+    revokeOcrFilePreviewUrl();
   };
 
   const handleSendMessage = async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -275,6 +275,24 @@ const ChatUI: React.FC<ChatUIProps> = ({
   const codeInterpreter = useCodeInterpreter();
 
   const chatEndRef = useRef<HTMLDivElement>(null);
+  const ocrFilePreviewUrlRef = useRef<string | null>(null);
+
+  const revokeOcrFilePreviewUrl = () => {
+    if (ocrFilePreviewUrlRef.current) {
+      URL.revokeObjectURL(ocrFilePreviewUrlRef.current);
+    }
+    ocrFilePreviewUrlRef.current = null;
+    setOcrFilePreviewUrl(null);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (ocrFilePreviewUrlRef.current) {
+        URL.revokeObjectURL(ocrFilePreviewUrlRef.current);
+        ocrFilePreviewUrlRef.current = null;
+      }
+    };
+  }, []);
 
   // Fetch MCP servers and toolsets
   const loadMCPServers = async () => {
@@ -704,8 +722,11 @@ const ChatUI: React.FC<ChatUIProps> = ({
   };
 
   const handleOcrFileUpload = (file: File): false => {
+    revokeOcrFilePreviewUrl();
     setUploadedOcrFile(file);
-    setOcrFilePreviewUrl(file.type.startsWith("image/") ? URL.createObjectURL(file) : null);
+    const previewUrl = file.type.startsWith("image/") ? URL.createObjectURL(file) : null;
+    ocrFilePreviewUrlRef.current = previewUrl;
+    setOcrFilePreviewUrl(previewUrl);
     return false;
   };
 
@@ -718,11 +739,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
   };
 
   const handleRemoveOcrFile = () => {
-    if (ocrFilePreviewUrl) {
-      URL.revokeObjectURL(ocrFilePreviewUrl);
-    }
     setUploadedOcrFile(null);
-    setOcrFilePreviewUrl(null);
+    revokeOcrFilePreviewUrl();
   };
 
   const handleSendMessage = async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -43,6 +43,7 @@ import { Agent, fetchAvailableAgents } from "../../llm_calls/fetch_agents";
 import { fetchAvailableModels, ModelGroup } from "@/components/llm_calls/fetch_models";
 import { makeOpenAIImageEditsRequest } from "../../llm_calls/image_edits";
 import { makeOpenAIImageGenerationRequest } from "../../llm_calls/image_generation";
+import { makeOpenAIOcrRequest } from "../../llm_calls/OcrApi";
 import { makeOpenAIResponsesRequest } from "@/components/llm_calls/responses_api";
 import { makeInteractionsRequest } from "../../llm_calls/interactions_api";
 import AdditionalModelSettings from "./AdditionalModelSettings";
@@ -255,6 +256,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
   const [chatUploadedImage, setChatUploadedImage] = useState<File | null>(null);
   const [chatImagePreviewUrl, setChatImagePreviewUrl] = useState<string | null>(null);
   const [uploadedAudio, setUploadedAudio] = useState<File | null>(null);
+  const [uploadedOcrFile, setUploadedOcrFile] = useState<File | null>(null);
+  const [ocrFilePreviewUrl, setOcrFilePreviewUrl] = useState<string | null>(null);
   const [isGetCodeModalVisible, setIsGetCodeModalVisible] = useState(false);
   const [generatedCode, setGeneratedCode] = useState("");
   const [selectedSdk, setSelectedSdk] = useState<"openai" | "azure">("openai");
@@ -700,8 +703,35 @@ const ChatUI: React.FC<ChatUIProps> = ({
     setUploadedAudio(null);
   };
 
+  const handleOcrFileUpload = (file: File): false => {
+    setUploadedOcrFile(file);
+    setOcrFilePreviewUrl(file.type.startsWith("image/") ? URL.createObjectURL(file) : null);
+    return false;
+  };
+
+  const handleOcrFileInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      handleOcrFileUpload(file);
+    }
+    event.target.value = "";
+  };
+
+  const handleRemoveOcrFile = () => {
+    if (ocrFilePreviewUrl) {
+      URL.revokeObjectURL(ocrFilePreviewUrl);
+    }
+    setUploadedOcrFile(null);
+    setOcrFilePreviewUrl(null);
+  };
+
   const handleSendMessage = async () => {
-    if (inputMessage.trim() === "" && endpointType !== EndpointType.TRANSCRIPTION && endpointType !== EndpointType.MCP)
+    if (
+      inputMessage.trim() === "" &&
+      endpointType !== EndpointType.TRANSCRIPTION &&
+      endpointType !== EndpointType.MCP &&
+      endpointType !== EndpointType.OCR
+    )
       return;
 
     // For image edits, require both image and prompt
@@ -713,6 +743,11 @@ const ChatUI: React.FC<ChatUIProps> = ({
     // For audio transcriptions, require audio file
     if (endpointType === EndpointType.TRANSCRIPTION && !uploadedAudio) {
       toast.fromError("Please upload an audio file for transcription");
+      return;
+    }
+
+    if (endpointType === EndpointType.OCR && !uploadedOcrFile) {
+      toast.fromError("Please upload a document or image for OCR");
       return;
     }
 
@@ -771,6 +806,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
       EndpointType.ANTHROPIC_MESSAGES,
       EndpointType.EMBEDDINGS,
       EndpointType.TRANSCRIPTION,
+      EndpointType.OCR,
       EndpointType.INTERACTIONS,
     ];
 
@@ -783,7 +819,11 @@ const ChatUI: React.FC<ChatUIProps> = ({
       return;
     }
 
-    const effectiveApiKey = simplified ? accessToken : apiKeySource === "session" ? accessToken : apiKey;
+    const effectiveApiKey = (() => {
+      if (simplified) return accessToken;
+      if (apiKeySource === "session") return accessToken;
+      return apiKey;
+    })();
 
     if (!effectiveApiKey) {
       toast.fromError("Please provide a Virtual Key or select Current UI Session");
@@ -846,6 +886,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
         ? `🎵 Audio file: ${uploadedAudio.name}\nPrompt: ${inputMessage}`
         : `🎵 Audio file: ${uploadedAudio.name}`;
       displayMessage = createDisplayMessage(audioMessage, false);
+    } else if (endpointType === EndpointType.OCR && uploadedOcrFile) {
+      displayMessage = createDisplayMessage(`OCR file: ${uploadedOcrFile.name}`, false);
     } else if (endpointType === EndpointType.MCP && selectedMCPDirectTool) {
       // For MCP direct mode, show tool name and arguments from form
       const mcpMessage = `🔧 MCP Tool: ${selectedMCPDirectTool}\nArguments: ${JSON.stringify(mcpToolArguments, null, 2)}`;
@@ -1043,6 +1085,18 @@ const ChatUI: React.FC<ChatUIProps> = ({
               customProxyBaseUrl || undefined,
             );
           }
+        } else if (endpointType === EndpointType.OCR) {
+          if (uploadedOcrFile) {
+            await makeOpenAIOcrRequest({
+              file: uploadedOcrFile,
+              updateUI: (text, model) => updateTextUI("assistant", text, model),
+              selectedModel,
+              accessToken: effectiveApiKey,
+              tags: selectedTags,
+              signal,
+              customBaseUrl: customProxyBaseUrl || undefined,
+            });
+          }
         } else if (endpointType === EndpointType.INTERACTIONS) {
           await makeInteractionsRequest(
             inputMessage,
@@ -1128,6 +1182,9 @@ const ChatUI: React.FC<ChatUIProps> = ({
       if (endpointType === EndpointType.TRANSCRIPTION && uploadedAudio) {
         handleRemoveAudio();
       }
+      if (endpointType === EndpointType.OCR && uploadedOcrFile) {
+        handleRemoveOcrFile();
+      }
     }
 
     setInputMessage("");
@@ -1139,6 +1196,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
     handleRemoveResponsesImage();
     handleRemoveChatImage();
     handleRemoveAudio();
+    handleRemoveOcrFile();
     toast.success("Chat history cleared.");
   };
 
@@ -1194,7 +1252,9 @@ const ChatUI: React.FC<ChatUIProps> = ({
             ? "Enter text to convert to speech..."
             : endpointType === EndpointType.TRANSCRIPTION
               ? "Optional: Add context or prompt for transcription..."
-              : "Describe the image you want to generate...";
+              : endpointType === EndpointType.OCR
+                ? "Upload a document or image to run OCR"
+                : "Describe the image you want to generate...";
 
   const sendDisabled =
     isLoading ||
@@ -1202,7 +1262,9 @@ const ChatUI: React.FC<ChatUIProps> = ({
       ? !(selectedMCPServers.length === 1 && selectedMCPServers[0] !== "__all__" && selectedMCPDirectTool)
       : endpointType === EndpointType.TRANSCRIPTION
         ? !uploadedAudio
-        : !inputMessage.trim());
+        : endpointType === EndpointType.OCR
+          ? !uploadedOcrFile
+          : !inputMessage.trim());
 
   return (
     <div className={`min-h-0 min-w-0 bg-white ${simplified ? "flex h-full w-full flex-col" : "h-full w-full p-3"}`}>
@@ -1927,6 +1989,31 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     </div>
                   )}
 
+                  {endpointType === EndpointType.OCR && !uploadedOcrFile && (
+                    <div className="mb-4">
+                      <label
+                        className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 px-4 py-8 text-center hover:border-gray-400"
+                        onDragOver={(event) => event.preventDefault()}
+                        onDrop={(event) => {
+                          event.preventDefault();
+                          const file = event.dataTransfer.files[0];
+                          if (file) {
+                            handleOcrFileUpload(file);
+                          }
+                        }}
+                      >
+                        <ImageIcon className="mb-2 size-6 text-gray-500" aria-hidden="true" />
+                        <p className="text-sm">Click or drag a document or image to upload</p>
+                        <p className="text-xs text-gray-500">Support for PDF and image files.</p>
+                        <input
+                          type="file"
+                          accept="image/*,application/pdf"
+                          className="sr-only"
+                          onChange={handleOcrFileInputChange}
+                        />
+                      </label>
+                    </div>
+                  )}
                   {endpointType === EndpointType.RESPONSES && responsesUploadedImage && (
                     <FilePreviewCard
                       file={responsesUploadedImage}
@@ -1943,6 +2030,13 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     />
                   )}
 
+                  {endpointType === EndpointType.OCR && uploadedOcrFile && (
+                    <FilePreviewCard
+                      file={uploadedOcrFile}
+                      previewUrl={ocrFilePreviewUrl}
+                      onRemove={handleRemoveOcrFile}
+                    />
+                  )}
                   {endpointType === EndpointType.RESPONSES && codeInterpreter.enabled && (
                     <div className="mb-2 space-y-2">
                       <div className="flex items-center justify-between rounded-lg border border-blue-200 bg-linear-to-r from-blue-50 to-purple-50 px-3 py-2">
@@ -1994,10 +2088,15 @@ const ChatUI: React.FC<ChatUIProps> = ({
                     onSubmit={handleSendMessage}
                     onCancel={handleCancelRequest}
                     placeholder={inputPlaceholder}
-                    disabled={isLoading}
+                    disabled={isLoading || endpointType === EndpointType.OCR}
                     isLoading={isLoading}
                     submitDisabled={sendDisabled}
-                    showSuggestions={chatHistory.length === 0 && !isLoading && endpointType !== EndpointType.MCP}
+                    showSuggestions={
+                      chatHistory.length === 0 &&
+                      !isLoading &&
+                      endpointType !== EndpointType.MCP &&
+                      endpointType !== EndpointType.OCR
+                    }
                     suggestions={
                       endpointType === EndpointType.A2A_AGENTS
                         ? ["What can you help me with?", "Tell me about yourself", "What tasks can you perform?"]

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -109,6 +109,63 @@ const MCP_SUPPORTED_ENDPOINTS = new Set<EndpointType>([
 
 const CUSTOM_MODEL_DEBOUNCE_WAIT_MS = 500;
 
+interface SendDisabledOptions {
+  endpointType: EndpointType;
+  inputMessage: string;
+  isLoading: boolean;
+  selectedMCPDirectTool: string | undefined;
+  selectedMCPServers: readonly string[];
+  uploadedAudio: File | null;
+  uploadedOcrFile: File | null;
+}
+
+const getInputPlaceholder = (endpointType: EndpointType): string => {
+  switch (endpointType) {
+    case EndpointType.CHAT:
+    case EndpointType.EMBEDDINGS:
+    case EndpointType.RESPONSES:
+    case EndpointType.ANTHROPIC_MESSAGES:
+    case EndpointType.INTERACTIONS:
+      return "Type your message... (Shift+Enter for new line)";
+    case EndpointType.A2A_AGENTS:
+      return "Send a message to the A2A agent...";
+    case EndpointType.IMAGE_EDITS:
+      return "Describe how you want to edit the image...";
+    case EndpointType.SPEECH:
+      return "Enter text to convert to speech...";
+    case EndpointType.TRANSCRIPTION:
+      return "Optional: Add context or prompt for transcription...";
+    case EndpointType.OCR:
+      return "Upload a document or image to run OCR";
+    default:
+      return "Describe the image you want to generate...";
+  }
+};
+
+const getSendDisabled = ({
+  endpointType,
+  inputMessage,
+  isLoading,
+  selectedMCPDirectTool,
+  selectedMCPServers,
+  uploadedAudio,
+  uploadedOcrFile,
+}: SendDisabledOptions): boolean => {
+  if (isLoading) {
+    return true;
+  }
+  if (endpointType === EndpointType.MCP) {
+    return !(selectedMCPServers.length === 1 && selectedMCPServers[0] !== "__all__" && selectedMCPDirectTool);
+  }
+  if (endpointType === EndpointType.TRANSCRIPTION) {
+    return !uploadedAudio;
+  }
+  if (endpointType === EndpointType.OCR) {
+    return !uploadedOcrFile;
+  }
+  return !inputMessage.trim();
+};
+
 const ChatUI: React.FC<ChatUIProps> = ({
   accessToken,
   token,
@@ -659,6 +716,14 @@ const ChatUI: React.FC<ChatUIProps> = ({
     event.target.value = "";
   };
 
+  const handleAudioFileDrop = (event: React.DragEvent<HTMLLabelElement>) => {
+    event.preventDefault();
+    const file = event.dataTransfer.files[0];
+    if (file) {
+      handleAudioUpload(file);
+    }
+  };
+
   const mcpServerOptions = useMemo((): MultiSelectOption[] => {
     const options: MultiSelectOption[] = [];
     if (endpointType !== EndpointType.MCP) {
@@ -736,6 +801,14 @@ const ChatUI: React.FC<ChatUIProps> = ({
       handleOcrFileUpload(file);
     }
     event.target.value = "";
+  };
+
+  const handleOcrFileDrop = (event: React.DragEvent<HTMLLabelElement>) => {
+    event.preventDefault();
+    const file = event.dataTransfer.files[0];
+    if (file) {
+      handleOcrFileUpload(file);
+    }
   };
 
   const handleRemoveOcrFile = () => {
@@ -1255,34 +1328,16 @@ const ChatUI: React.FC<ChatUIProps> = ({
     modelEmptyText = "No models available for this endpoint";
   }
 
-  const inputPlaceholder =
-    endpointType === EndpointType.CHAT ||
-    endpointType === EndpointType.EMBEDDINGS ||
-    endpointType === EndpointType.RESPONSES ||
-    endpointType === EndpointType.ANTHROPIC_MESSAGES ||
-    endpointType === EndpointType.INTERACTIONS
-      ? "Type your message... (Shift+Enter for new line)"
-      : endpointType === EndpointType.A2A_AGENTS
-        ? "Send a message to the A2A agent..."
-        : endpointType === EndpointType.IMAGE_EDITS
-          ? "Describe how you want to edit the image..."
-          : endpointType === EndpointType.SPEECH
-            ? "Enter text to convert to speech..."
-            : endpointType === EndpointType.TRANSCRIPTION
-              ? "Optional: Add context or prompt for transcription..."
-              : endpointType === EndpointType.OCR
-                ? "Upload a document or image to run OCR"
-                : "Describe the image you want to generate...";
-
-  const sendDisabled =
-    isLoading ||
-    (endpointType === EndpointType.MCP
-      ? !(selectedMCPServers.length === 1 && selectedMCPServers[0] !== "__all__" && selectedMCPDirectTool)
-      : endpointType === EndpointType.TRANSCRIPTION
-        ? !uploadedAudio
-        : endpointType === EndpointType.OCR
-          ? !uploadedOcrFile
-          : !inputMessage.trim());
+  const inputPlaceholder = getInputPlaceholder(endpointType as EndpointType);
+  const sendDisabled = getSendDisabled({
+    endpointType: endpointType as EndpointType,
+    inputMessage,
+    isLoading,
+    selectedMCPDirectTool,
+    selectedMCPServers,
+    uploadedAudio,
+    uploadedOcrFile,
+  });
 
   return (
     <div className={`min-h-0 min-w-0 bg-white ${simplified ? "flex h-full w-full flex-col" : "h-full w-full p-3"}`}>
@@ -1963,13 +2018,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                         <label
                           className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 px-4 py-8 text-center hover:border-gray-400"
                           onDragOver={(event) => event.preventDefault()}
-                          onDrop={(event) => {
-                            event.preventDefault();
-                            const file = event.dataTransfer.files[0];
-                            if (file) {
-                              handleAudioUpload(file);
-                            }
-                          }}
+                          onDrop={handleAudioFileDrop}
                         >
                           <Volume2 className="mb-2 size-6 text-gray-500" aria-hidden="true" />
                           <p className="text-sm">Click or drag audio file to upload</p>
@@ -2012,13 +2061,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                       <label
                         className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50 px-4 py-8 text-center hover:border-gray-400"
                         onDragOver={(event) => event.preventDefault()}
-                        onDrop={(event) => {
-                          event.preventDefault();
-                          const file = event.dataTransfer.files[0];
-                          if (file) {
-                            handleOcrFileUpload(file);
-                          }
-                        }}
+                        onDrop={handleOcrFileDrop}
                       >
                         <ImageIcon className="mb-2 size-6 text-gray-500" aria-hidden="true" />
                         <p className="text-sm">Click or drag a document or image to upload</p>

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointSelector.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointSelector.test.tsx
@@ -27,4 +27,17 @@ describe("EndpointSelector", () => {
     expect(await screen.findByText("/v1/audio/speech")).toBeInTheDocument();
     expect(await screen.findByText("/v1/audio/transcriptions")).toBeInTheDocument();
   });
+
+  it("should filter and show the OCR endpoint when user inputs 'ocr'", async () => {
+    const user = userEvent.setup();
+    render(<EndpointSelector endpointType={ENDPOINT_OPTIONS[0].value} onEndpointChange={() => {}} />);
+
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+
+    const input = await screen.findByRole("combobox");
+    await user.type(input, "ocr");
+
+    expect(await screen.findByText("/v1/ocr")).toBeInTheDocument();
+  });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointSelector.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointSelector.test.tsx
@@ -26,4 +26,17 @@ describe("EndpointSelector", () => {
     expect(await screen.findByText("/v1/audio/speech")).toBeInTheDocument();
     expect(await screen.findByText("/v1/audio/transcriptions")).toBeInTheDocument();
   });
+
+  it("should filter and show the OCR endpoint when user inputs 'ocr'", async () => {
+    const user = userEvent.setup();
+    render(<EndpointSelector endpointType={ENDPOINT_OPTIONS[0].value} onEndpointChange={() => {}} />);
+
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+
+    const input = await screen.findByRole("combobox");
+    await user.type(input, "ocr");
+
+    expect(await screen.findByText("/v1/ocr")).toBeInTheDocument();
+  });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointSelector.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointSelector.test.tsx
@@ -35,6 +35,7 @@ describe("EndpointSelector", () => {
     await user.click(combobox);
 
     const input = await screen.findByRole("combobox");
+    await user.clear(input);
     await user.type(input, "ocr");
 
     expect(await screen.findByText("/v1/ocr")).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/EndpointUtils.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@/components/chat_ui/mode_endpoint_mapping", () => ({
     EMBEDDINGS: "embeddings",
     SPEECH: "speech",
     TRANSCRIPTION: "transcription",
+    OCR: "ocr",
     A2A_AGENTS: "a2a_agents",
   },
   getEndpointType: vi.fn(),
@@ -28,6 +29,7 @@ vi.mock("@/components/chat_ui/mode_endpoint_mapping", () => ({
     IMAGE_EDITS: "image_edits",
     ANTHROPIC_MESSAGES: "anthropic_messages",
     EMBEDDING: "embedding",
+    OCR: "ocr",
   },
 }));
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/chatConstants.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/chatConstants.ts
@@ -42,6 +42,7 @@ export const ENDPOINT_OPTIONS = [
   { value: EndpointType.EMBEDDINGS, label: "/v1/embeddings" },
   { value: EndpointType.SPEECH, label: "/v1/audio/speech" },
   { value: EndpointType.TRANSCRIPTION, label: "/v1/audio/transcriptions" },
+  { value: EndpointType.OCR, label: "/v1/ocr" },
   { value: EndpointType.A2A_AGENTS, label: "/v1/a2a/message/send" },
   { value: EndpointType.MCP, label: "/mcp-rest/tools/call" },
   { value: EndpointType.REALTIME, label: "/v1/realtime" },

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/OcrApi.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/OcrApi.test.tsx
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeOpenAIOcrRequest } from "./OcrApi";
+
+vi.mock("@/components/networking", () => ({
+  getProxyBaseUrl: vi.fn(() => "https://example.com"),
+  getGlobalLitellmHeaderName: vi.fn(() => "Authorization"),
+}));
+
+describe("ocr_api", () => {
+  const mockUpdateUI = vi.fn();
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    const responseBody = JSON.stringify({
+      pages: [
+        {
+          index: 0,
+          markdown: "# Extracted text",
+        },
+      ],
+      model: "mistral-ocr-latest",
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      text: async () => responseBody,
+    } as Response);
+
+    global.fetch = mockFetch;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("posts OCR uploads to /v1/ocr with model and file multipart fields", async () => {
+    const file = new File(["document data"], "invoice.pdf", { type: "application/pdf" });
+
+    await makeOpenAIOcrRequest({
+      file,
+      updateUI: mockUpdateUI,
+      selectedModel: "mistral-ocr-latest",
+      accessToken: "sk-1234567890",
+      tags: ["tag1", "tag2"],
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith("https://example.com/v1/ocr", {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer sk-1234567890",
+        "x-litellm-tags": "tag1,tag2",
+      },
+      body: expect.any(FormData),
+      signal: undefined,
+    });
+
+    const formData = mockFetch.mock.calls[0][1].body as FormData;
+    expect(formData.get("model")).toBe("mistral-ocr-latest");
+    expect(formData.get("file")).toBe(file);
+    expect(mockUpdateUI).toHaveBeenCalledWith("# Extracted text", "mistral-ocr-latest");
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/OcrApi.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/OcrApi.tsx
@@ -1,0 +1,66 @@
+import NotificationManager from "@/components/molecules/notifications_manager";
+import { getGlobalLitellmHeaderName, getProxyBaseUrl } from "@/components/networking";
+import { createApiClient } from "@/lib/http/client";
+
+interface OcrRequestParams {
+  file: File;
+  updateUI: (text: string, model: string) => void;
+  selectedModel: string;
+  accessToken: string;
+  tags?: string[];
+  signal?: AbortSignal;
+  customBaseUrl?: string;
+}
+
+const formatOcrResponse = (response: unknown): string => {
+  if (typeof response !== "object" || response === null || !("pages" in response)) {
+    return JSON.stringify(response, null, 2);
+  }
+
+  const pages = (response as { pages?: unknown }).pages;
+  if (!Array.isArray(pages)) {
+    return JSON.stringify(response, null, 2);
+  }
+
+  const markdown = pages
+    .map((page) =>
+      typeof page === "object" && page !== null && "markdown" in page
+        ? (page as { markdown?: unknown }).markdown
+        : undefined,
+    )
+    .filter((pageMarkdown): pageMarkdown is string => typeof pageMarkdown === "string" && pageMarkdown.length > 0)
+    .join("\n\n");
+
+  return markdown || JSON.stringify(response, null, 2);
+};
+
+export async function makeOpenAIOcrRequest({
+  file,
+  updateUI,
+  selectedModel,
+  accessToken,
+  tags,
+  signal,
+  customBaseUrl,
+}: OcrRequestParams) {
+  const client = createApiClient({
+    getBaseUrl: () => customBaseUrl || getProxyBaseUrl(),
+    getAuthHeaderName: getGlobalLitellmHeaderName,
+    onError: (message) => NotificationManager.fromBackend(`OCR failed: ${message}`),
+  });
+  const formData = new FormData();
+  formData.append("model", selectedModel);
+  formData.append("file", file);
+
+  const responseJson = await client.post<unknown>("/v1/ocr", {
+    accessToken,
+    rawBody: formData,
+    headers: {
+      ...(tags && tags.length > 0 ? { "x-litellm-tags": tags.join(",") } : {}),
+    },
+    signal,
+  });
+
+  updateUI(formatOcrResponse(responseJson), selectedModel);
+  NotificationManager.success("OCR completed successfully");
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/OcrApi.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/llm_calls/OcrApi.tsx
@@ -1,4 +1,4 @@
-import NotificationManager from "@/components/molecules/notifications_manager";
+import { toast } from "@/lib/toast";
 import { getGlobalLitellmHeaderName, getProxyBaseUrl } from "@/components/networking";
 import { createApiClient } from "@/lib/http/client";
 
@@ -46,7 +46,7 @@ export async function makeOpenAIOcrRequest({
   const client = createApiClient({
     getBaseUrl: () => customBaseUrl || getProxyBaseUrl(),
     getAuthHeaderName: getGlobalLitellmHeaderName,
-    onError: (message) => NotificationManager.fromBackend(`OCR failed: ${message}`),
+    onError: (message) => toast.fromError(`OCR failed: ${message}`),
   });
   const formData = new FormData();
   formData.append("model", selectedModel);
@@ -62,5 +62,5 @@ export async function makeOpenAIOcrRequest({
   });
 
   updateUI(formatOcrResponse(responseJson), selectedModel);
-  NotificationManager.success("OCR completed successfully");
+  toast.success("OCR completed successfully");
 }

--- a/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.test.ts
+++ b/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { EndpointType, getEndpointType, litellmModeMapping, ModelMode } from "./mode_endpoint_mapping";
+
+describe("mode_endpoint_mapping", () => {
+  it("maps OCR model mode to the OCR endpoint", () => {
+    expect(getEndpointType("ocr")).toBe(EndpointType.OCR);
+    expect(litellmModeMapping[ModelMode.OCR]).toBe(EndpointType.OCR);
+  });
+
+  it("preserves existing model mode mappings", () => {
+    expect(getEndpointType("chat")).toBe(EndpointType.CHAT);
+    expect(getEndpointType("responses")).toBe(EndpointType.RESPONSES);
+    expect(getEndpointType("image_generation")).toBe(EndpointType.IMAGE);
+    expect(getEndpointType("audio_transcription")).toBe(EndpointType.TRANSCRIPTION);
+  });
+});

--- a/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.tsx
@@ -11,6 +11,7 @@ export enum ModelMode {
   IMAGE_EDITS = "image_edits",
   ANTHROPIC_MESSAGES = "anthropic_messages",
   EMBEDDING = "embedding",
+  OCR = "ocr",
   // add additional modes as needed
 }
 
@@ -25,6 +26,7 @@ export enum EndpointType {
   EMBEDDINGS = "embeddings",
   SPEECH = "speech",
   TRANSCRIPTION = "transcription",
+  OCR = "ocr",
   A2A_AGENTS = "a2a_agents",
   MCP = "mcp",
   REALTIME = "realtime",
@@ -42,6 +44,7 @@ export const litellmModeMapping: Record<ModelMode, EndpointType> = {
   [ModelMode.AUDIO_SPEECH]: EndpointType.SPEECH,
   [ModelMode.AUDIO_TRANSCRIPTION]: EndpointType.TRANSCRIPTION,
   [ModelMode.EMBEDDING]: EndpointType.EMBEDDINGS,
+  [ModelMode.OCR]: EndpointType.OCR,
 };
 
 export const getEndpointType = (mode: string): EndpointType => {

--- a/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.tsx
+++ b/ui/litellm-dashboard/src/components/chat_ui/mode_endpoint_mapping.tsx
@@ -12,6 +12,7 @@ export enum ModelMode {
   ANTHROPIC_MESSAGES = "anthropic_messages",
   EMBEDDING = "embedding",
   REALTIME = "realtime",
+  OCR = "ocr",
 }
 
 // Define an enum for the endpoint types your UI calls
@@ -25,6 +26,7 @@ export enum EndpointType {
   EMBEDDINGS = "embeddings",
   SPEECH = "speech",
   TRANSCRIPTION = "transcription",
+  OCR = "ocr",
   A2A_AGENTS = "a2a_agents",
   MCP = "mcp",
   REALTIME = "realtime",
@@ -43,6 +45,7 @@ export const litellmModeMapping: Record<ModelMode, EndpointType> = {
   [ModelMode.AUDIO_TRANSCRIPTION]: EndpointType.TRANSCRIPTION,
   [ModelMode.EMBEDDING]: EndpointType.EMBEDDINGS,
   [ModelMode.REALTIME]: EndpointType.REALTIME,
+  [ModelMode.OCR]: EndpointType.OCR,
 };
 
 export const getEndpointType = (mode: string): EndpointType => {


### PR DESCRIPTION
## Summary

- add `/v1/ocr` to the Dashboard Playground endpoint selector and mode mapping
- add an OCR upload/request flow that sends `model` and `file` as multipart form data through the shared API client
- render OCR page markdown (or the JSON response fallback) and cover the endpoint, mapping, request helper, and adjacent ChatUI behavior with focused tests
- revoke OCR image preview blob URLs on file replacement/removal, request completion, history clearing, and component unmount

Fixes #34461

## Validation

- `NODE_ENV=test npm test -- ChatUI.test.tsx -t "revokes the active OCR preview URL on unmount" --run` (baseline RED, patched GREEN)
- `NODE_ENV=test npm test -- ChatUI.test.tsx OcrApi.test.tsx FilePreviewCard.test.tsx EndpointSelector.test.tsx EndpointUtils.test.tsx --run` (5 files, 43 tests passed)
- changed-file ESLint with `--pass-on-unpruned-suppressions` (0 errors; existing warnings only)
- changed-file Prettier check
- `git diff --check`

Repository-wide `tsc --noEmit` is not listed as passing because it currently reports unrelated pre-existing Dashboard errors. A narrowed production check reached only an existing `MCPEventsDisplay.tsx` `style jsx` typing error and did not identify a new OCR cleanup error.

## Duplicate Check

Rechecked the live `litellm_internal_staging` head and issue #34461 before this update. Searches by issue number, `OCR Playground`, `revokeObjectURL OCR ChatUI`, and the affected symbols found no active or merged equivalent Dashboard Playground fix. PR #34190 cleans up existing upload preview refs but does not cover the OCR preview state introduced here.

## Browser/Playwright status

Not run. The Dashboard package does not provide a Playwright/Cypress configuration, and no real OCR provider credentials were available. The jsdom/Vitest coverage verifies endpoint search, mode mapping, multipart request construction, response formatting, OCR image preview creation, and component-unmount cleanup; no real provider call is claimed.