### PR TITLE
fix(proxy): sign with S3SigV4Auth to stop 403 SignatureDoesNotMatch on object keys with reserved characters

### DIFF
--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -9,8 +9,11 @@ NOTE 1: S3 does not provide a BATCH PUT API endpoint, so we create tasks to uplo
 import asyncio
 import time
 from datetime import datetime
-from typing import List, Optional, cast
+from typing import TYPE_CHECKING, Dict, List, Optional, cast
 from urllib.parse import quote
+
+if TYPE_CHECKING:
+    from botocore.credentials import Credentials
 
 import litellm
 from litellm._logging import print_verbose, verbose_logger
@@ -279,13 +282,13 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
 
     def _sign_s3_request(
         self,
-        credentials,
+        credentials: "Credentials",
         method: str,
         url: str,
-        headers: dict,
+        headers: Dict[str, str],
         region: str,
         data: Optional[str] = None,
-    ) -> dict:
+    ) -> Dict[str, str]:
         try:
             from botocore.auth import S3SigV4Auth
             from botocore.awsrequest import AWSRequest

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -309,11 +309,9 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         return dict(aws_request.headers.items())
 
     async def async_upload_data_to_s3(self, batch_logging_element: s3BatchLoggingElement):
-        try:
-            import base64
-            import hashlib
-        except ImportError:
-            raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
+        import base64
+        import hashlib
+
         try:
             from litellm.litellm_core_utils.asyncify import asyncify
 
@@ -582,10 +580,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         Returns:
             Optional[dict]: The parsed JSON object or None if not found/error
         """
-        try:
-            import hashlib
-        except ImportError:
-            raise ImportError("Missing boto3 to call S3. Run 'pip install boto3'.")
+        import hashlib
 
         try:
             from litellm.litellm_core_utils.asyncify import asyncify

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -9,7 +9,7 @@ NOTE 1: S3 does not provide a BATCH PUT API endpoint, so we create tasks to uplo
 import asyncio
 import time
 from datetime import datetime
-from typing import TYPE_CHECKING, Dict, List, Optional, cast
+from typing import TYPE_CHECKING, List, Optional, cast
 from urllib.parse import quote
 
 if TYPE_CHECKING:
@@ -280,15 +280,24 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             verbose_logger.exception(f"s3 Layer Error - {str(e)}")
             self.handle_callback_failure(callback_name="S3Logger")
 
+    @staticmethod
+    def _encode_s3_object_key(s3_object_key: str) -> str:
+        encoded_segments = []
+        for segment in quote(s3_object_key, safe="/").split("/"):
+            if segment in (".", ".."):
+                segment = segment.replace(".", "%2E")
+            encoded_segments.append(segment)
+        return "/".join(encoded_segments)
+
     def _sign_s3_request(
         self,
         credentials: "Credentials",
         method: str,
         url: str,
-        headers: Dict[str, str],
+        headers: "dict[str, str]",
         region: str,
-        data: Optional[str] = None,
-    ) -> Dict[str, str]:
+        data: "str | None" = None,
+    ) -> "dict[str, str]":
         try:
             from botocore.auth import S3SigV4Auth
             from botocore.awsrequest import AWSRequest
@@ -324,7 +333,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             verbose_logger.debug(f"s3_v2 logger - uploading data to s3 - {batch_logging_element.s3_object_key}")
             verbose_logger.debug(f"s3_v2 logger - s3_verify setting: {self.s3_verify}")
 
-            object_key_encoded = quote(batch_logging_element.s3_object_key, safe="/")
+            object_key_encoded = self._encode_s3_object_key(batch_logging_element.s3_object_key)
 
             # Prepare the URL
             url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{object_key_encoded}"
@@ -491,7 +500,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 aws_region_name=self.s3_region_name,
             )
 
-            object_key_encoded = quote(batch_logging_element.s3_object_key, safe="/")
+            object_key_encoded = self._encode_s3_object_key(batch_logging_element.s3_object_key)
 
             # Prepare the URL
             url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{object_key_encoded}"
@@ -597,7 +606,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
 
             verbose_logger.debug(f"s3_v2 logger - downloading data from s3 - {s3_object_key}")
 
-            object_key_encoded = quote(s3_object_key, safe="/")
+            object_key_encoded = self._encode_s3_object_key(s3_object_key)
 
             # Prepare the URL
             url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{object_key_encoded}"

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -10,6 +10,7 @@ import asyncio
 import time
 from datetime import datetime
 from typing import List, Optional, cast
+from urllib.parse import quote
 
 import litellm
 from litellm._logging import print_verbose, verbose_logger
@@ -276,14 +277,29 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             verbose_logger.exception(f"s3 Layer Error - {str(e)}")
             self.handle_callback_failure(callback_name="S3Logger")
 
+    def _sign_s3_request(
+        self,
+        credentials,
+        method: str,
+        url: str,
+        headers: dict,
+        region: str,
+        data: Optional[str] = None,
+    ) -> dict:
+        try:
+            from botocore.auth import S3SigV4Auth
+            from botocore.awsrequest import AWSRequest
+        except ImportError:
+            raise ImportError("Missing boto3 to call S3. Run 'pip install boto3'.")
+
+        aws_request = AWSRequest(method=method, url=url, data=data, headers=headers)
+        S3SigV4Auth(credentials, "s3", region).add_auth(aws_request)
+        return dict(aws_request.headers.items())
+
     async def async_upload_data_to_s3(self, batch_logging_element: s3BatchLoggingElement):
         try:
             import base64
             import hashlib
-
-            import requests
-            from botocore.auth import SigV4Auth
-            from botocore.awsrequest import AWSRequest
         except ImportError:
             raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
         try:
@@ -305,18 +321,20 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             verbose_logger.debug(f"s3_v2 logger - uploading data to s3 - {batch_logging_element.s3_object_key}")
             verbose_logger.debug(f"s3_v2 logger - s3_verify setting: {self.s3_verify}")
 
+            object_key_encoded = quote(batch_logging_element.s3_object_key, safe="/")
+
             # Prepare the URL
-            url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{batch_logging_element.s3_object_key}"
+            url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{object_key_encoded}"
 
             if self.s3_endpoint_url and self.s3_bucket_name:
                 if self.s3_use_virtual_hosted_style:
                     # Virtual-hosted-style: bucket.endpoint/key
                     endpoint_host = self.s3_endpoint_url.replace("https://", "").replace("http://", "")
                     protocol = "https://" if self.s3_endpoint_url.startswith("https://") else "http://"
-                    url = f"{protocol}{self.s3_bucket_name}.{endpoint_host}/{batch_logging_element.s3_object_key}"
+                    url = f"{protocol}{self.s3_bucket_name}.{endpoint_host}/{object_key_encoded}"
                 else:
                     # Path-style: endpoint/bucket/key
-                    url = self.s3_endpoint_url + "/" + self.s3_bucket_name + "/" + batch_logging_element.s3_object_key
+                    url = self.s3_endpoint_url + "/" + self.s3_bucket_name + "/" + object_key_encoded
 
             # Convert JSON to string
             json_string = safe_dumps(batch_logging_element.payload)
@@ -341,24 +359,17 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                     else {}
                 ),
             }
-            req = requests.Request("PUT", url, data=json_string, headers=headers)
-            prepped = req.prepare()
-
-            # Sign the request
-            aws_request = AWSRequest(
-                method=prepped.method,
-                url=prepped.url,
-                data=prepped.body,
-                headers=prepped.headers,
-            )
             aws_region_name = self.get_aws_region_name_for_non_llm_api_calls(aws_region_name=self.s3_region_name)
-            SigV4Auth(credentials, "s3", aws_region_name).add_auth(aws_request)
+            signed_headers = self._sign_s3_request(
+                credentials=credentials,
+                method="PUT",
+                url=url,
+                headers=headers,
+                region=aws_region_name,
+                data=json_string,
+            )
 
-            # Prepare the signed headers
-            signed_headers = dict(aws_request.headers.items())
-
-            # Use prepared URL so path segments match SigV4 canonical request (e.g. %20 for spaces).
-            request_url = prepped.url or url
+            request_url = url
 
             # Make the request with retry for transient S3 errors (500/503)
             max_retries = 3
@@ -465,9 +476,6 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             import base64
             import hashlib
 
-            import requests
-            from botocore.auth import SigV4Auth
-            from botocore.awsrequest import AWSRequest
             from botocore.credentials import Credentials
         except ImportError:
             raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
@@ -480,18 +488,20 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 aws_region_name=self.s3_region_name,
             )
 
+            object_key_encoded = quote(batch_logging_element.s3_object_key, safe="/")
+
             # Prepare the URL
-            url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{batch_logging_element.s3_object_key}"
+            url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{object_key_encoded}"
 
             if self.s3_endpoint_url and self.s3_bucket_name:
                 if self.s3_use_virtual_hosted_style:
                     # Virtual-hosted-style: bucket.endpoint/key
                     endpoint_host = self.s3_endpoint_url.replace("https://", "").replace("http://", "")
                     protocol = "https://" if self.s3_endpoint_url.startswith("https://") else "http://"
-                    url = f"{protocol}{self.s3_bucket_name}.{endpoint_host}/{batch_logging_element.s3_object_key}"
+                    url = f"{protocol}{self.s3_bucket_name}.{endpoint_host}/{object_key_encoded}"
                 else:
                     # Path-style: endpoint/bucket/key
-                    url = self.s3_endpoint_url + "/" + self.s3_bucket_name + "/" + batch_logging_element.s3_object_key
+                    url = self.s3_endpoint_url + "/" + self.s3_bucket_name + "/" + object_key_encoded
 
             # Convert JSON to string
             json_string = safe_dumps(batch_logging_element.payload)
@@ -516,24 +526,17 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                     else {}
                 ),
             }
-            req = requests.Request("PUT", url, data=json_string, headers=headers)
-            prepped = req.prepare()
-
-            # Sign the request
-            aws_request = AWSRequest(
-                method=prepped.method,
-                url=prepped.url,
-                data=prepped.body,
-                headers=prepped.headers,
-            )
             aws_region_name = self.get_aws_region_name_for_non_llm_api_calls(aws_region_name=self.s3_region_name)
-            SigV4Auth(credentials, "s3", aws_region_name).add_auth(aws_request)
+            signed_headers = self._sign_s3_request(
+                credentials=credentials,
+                method="PUT",
+                url=url,
+                headers=headers,
+                region=aws_region_name,
+                data=json_string,
+            )
 
-            # Prepare the signed headers
-            signed_headers = dict(aws_request.headers.items())
-
-            # Use prepared URL so path segments match SigV4 canonical request (e.g. %20 for spaces).
-            request_url = prepped.url or url
+            request_url = url
 
             httpx_client = _get_httpx_client(
                 params=({"ssl_verify": self.s3_verify} if self.s3_verify is not None else None)
@@ -569,10 +572,6 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         """
         try:
             import hashlib
-
-            import requests
-            from botocore.auth import SigV4Auth
-            from botocore.awsrequest import AWSRequest
         except ImportError:
             raise ImportError("Missing boto3 to call S3. Run 'pip install boto3'.")
 
@@ -595,40 +594,36 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
 
             verbose_logger.debug(f"s3_v2 logger - downloading data from s3 - {s3_object_key}")
 
+            object_key_encoded = quote(s3_object_key, safe="/")
+
             # Prepare the URL
-            url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{s3_object_key}"
+            url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{object_key_encoded}"
 
             if self.s3_endpoint_url and self.s3_bucket_name:
                 if self.s3_use_virtual_hosted_style:
                     # Virtual-hosted-style: bucket.endpoint/key
                     endpoint_host = self.s3_endpoint_url.replace("https://", "").replace("http://", "")
                     protocol = "https://" if self.s3_endpoint_url.startswith("https://") else "http://"
-                    url = f"{protocol}{self.s3_bucket_name}.{endpoint_host}/{s3_object_key}"
+                    url = f"{protocol}{self.s3_bucket_name}.{endpoint_host}/{object_key_encoded}"
                 else:
                     # Path-style: endpoint/bucket/key
-                    url = self.s3_endpoint_url + "/" + self.s3_bucket_name + "/" + s3_object_key
+                    url = self.s3_endpoint_url + "/" + self.s3_bucket_name + "/" + object_key_encoded
 
-            # Prepare the request for GET operation
             # For GET requests, we need x-amz-content-sha256 with hash of empty string
             empty_string_hash = hashlib.sha256(b"").hexdigest()
             headers = {
                 "x-amz-content-sha256": empty_string_hash,
             }
-            req = requests.Request("GET", url, headers=headers)
-            prepped = req.prepare()
-
-            # Sign the request
-            aws_request = AWSRequest(
-                method=prepped.method,
-                url=prepped.url,
-                headers=prepped.headers,
+            aws_region_name = self.get_aws_region_name_for_non_llm_api_calls(aws_region_name=self.s3_region_name)
+            signed_headers = self._sign_s3_request(
+                credentials=credentials,
+                method="GET",
+                url=url,
+                headers=headers,
+                region=aws_region_name,
             )
-            SigV4Auth(credentials, "s3", self.s3_region_name).add_auth(aws_request)
 
-            # Prepare the signed headers
-            signed_headers = dict(aws_request.headers.items())
-
-            request_url = prepped.url or url
+            request_url = url
             response = await self.async_httpx_client.get(request_url, headers=signed_headers)
 
             if response.status_code != 200:

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1564,3 +1564,39 @@ def test_download_signature_matches_wire_url_special_chars(
     _assert_signature_valid_for_wire_url(
         request_url, None, signed_headers, access_key, secret_key, method="GET"
     )
+
+
+@patch("asyncio.create_task")
+@patch("litellm.integrations.s3_v2.CustomBatchLogger.periodic_flush")
+def test_sign_s3_request_raises_when_botocore_missing(
+    mock_periodic_flush, mock_create_task
+):
+    import builtins
+
+    mock_periodic_flush.return_value = None
+    mock_create_task.return_value = None
+
+    logger = S3Logger(
+        s3_bucket_name="test-bucket",
+        s3_aws_access_key_id="k",
+        s3_aws_secret_access_key="s",
+        s3_region_name="us-east-1",
+    )
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "botocore.auth":
+            raise ImportError("no botocore")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=fake_import):
+        with pytest.raises(ImportError, match="Missing boto3"):
+            logger._sign_s3_request(
+                credentials=MagicMock(),
+                method="PUT",
+                url="https://test-bucket.s3.us-east-1.amazonaws.com/x.json",
+                headers={"x-amz-content-sha256": "abc"},
+                region="us-east-1",
+                data="{}",
+            )

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1388,3 +1388,171 @@ def test_s3_server_side_encryption_read_from_callback_params():
         assert logger.s3_server_side_encryption == "aws:kms"
     finally:
         litellm.s3_callback_params = original
+
+
+SPECIAL_CHAR_OBJECT_KEYS = [
+    "My Team/2025-09-14/test-key.json",
+    "R&D + Ops/2025-09-14/test-key.json",
+    "tёam#1/2025-09-14/test-key.json",
+    "a@b/2025-09-14/test-key.json",
+]
+
+
+def _assert_signature_valid_for_wire_url(
+    request_url,
+    data,
+    signed_headers,
+    access_key,
+    secret_key,
+    region="us-east-1",
+    method="PUT",
+):
+    from botocore.auth import S3SigV4Auth
+    from botocore.awsrequest import AWSRequest
+    from botocore.credentials import Credentials
+
+    assert "Authorization" in signed_headers, "request was not signed"
+    assert " " not in request_url, "raw space leaked onto the wire URL"
+
+    verify_headers = {
+        k: v for k, v in signed_headers.items() if k.lower() != "authorization"
+    }
+    verify_req = AWSRequest(
+        method=method, url=request_url, data=data, headers=verify_headers
+    )
+    verify_req.context["timestamp"] = signed_headers["X-Amz-Date"]
+    S3SigV4Auth(Credentials(access_key, secret_key), "s3", region).add_auth(verify_req)
+
+    assert verify_req.headers["Authorization"] == signed_headers["Authorization"], (
+        "SigV4 signature does not match the URL actually sent on the wire; "
+        "S3 would reject this with 403 SignatureDoesNotMatch.\n"
+        f"  wire url  : {request_url}\n"
+        f"  sent sig  : {signed_headers['Authorization']}\n"
+        f"  valid sig : {verify_req.headers['Authorization']}"
+    )
+
+
+@pytest.mark.parametrize("s3_object_key", SPECIAL_CHAR_OBJECT_KEYS)
+@patch("asyncio.create_task")
+@patch("litellm.integrations.s3_v2.CustomBatchLogger.periodic_flush")
+def test_async_upload_signature_matches_wire_url_special_chars(
+    mock_periodic_flush, mock_create_task, s3_object_key
+):
+    from unittest.mock import AsyncMock
+
+    from litellm.types.integrations.s3_v2 import s3BatchLoggingElement
+
+    mock_periodic_flush.return_value = None
+    mock_create_task.return_value = None
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+
+    access_key, secret_key = "test-access-key", "test-secret-key"
+    logger = S3Logger(
+        s3_bucket_name="test-bucket",
+        s3_aws_access_key_id=access_key,
+        s3_aws_secret_access_key=secret_key,
+        s3_region_name="us-east-1",
+    )
+    logger.async_httpx_client = AsyncMock()
+    logger.async_httpx_client.put.return_value = mock_response
+
+    element = s3BatchLoggingElement(
+        s3_object_key=s3_object_key,
+        payload={"test": "data"},
+        s3_object_download_filename="test-file.json",
+    )
+    asyncio.run(logger.async_upload_data_to_s3(element))
+
+    call_args = logger.async_httpx_client.put.call_args
+    assert call_args is not None
+    request_url = call_args[0][0]
+    signed_headers = call_args[1]["headers"]
+    data = call_args[1]["data"]
+    _assert_signature_valid_for_wire_url(
+        request_url, data, signed_headers, access_key, secret_key
+    )
+
+
+@pytest.mark.parametrize("s3_object_key", SPECIAL_CHAR_OBJECT_KEYS)
+@patch("asyncio.create_task")
+@patch("litellm.integrations.s3_v2.CustomBatchLogger.periodic_flush")
+def test_sync_upload_signature_matches_wire_url_special_chars(
+    mock_periodic_flush, mock_create_task, s3_object_key
+):
+    from litellm.types.integrations.s3_v2 import s3BatchLoggingElement
+
+    mock_periodic_flush.return_value = None
+    mock_create_task.return_value = None
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+
+    access_key, secret_key = "test-access-key", "test-secret-key"
+    logger = S3Logger(
+        s3_bucket_name="test-bucket",
+        s3_aws_access_key_id=access_key,
+        s3_aws_secret_access_key=secret_key,
+        s3_region_name="us-east-1",
+    )
+
+    mock_sync_client = MagicMock()
+    mock_sync_client.put.return_value = mock_response
+
+    element = s3BatchLoggingElement(
+        s3_object_key=s3_object_key,
+        payload={"test": "data"},
+        s3_object_download_filename="test-file.json",
+    )
+    with patch(
+        "litellm.integrations.s3_v2._get_httpx_client", return_value=mock_sync_client
+    ):
+        logger.upload_data_to_s3(element)
+
+    call_args = mock_sync_client.put.call_args
+    assert call_args is not None
+    request_url = call_args[0][0]
+    signed_headers = call_args[1]["headers"]
+    data = call_args[1]["data"]
+    _assert_signature_valid_for_wire_url(
+        request_url, data, signed_headers, access_key, secret_key
+    )
+
+
+@pytest.mark.parametrize("s3_object_key", SPECIAL_CHAR_OBJECT_KEYS)
+@patch("asyncio.create_task")
+@patch("litellm.integrations.s3_v2.CustomBatchLogger.periodic_flush")
+def test_download_signature_matches_wire_url_special_chars(
+    mock_periodic_flush, mock_create_task, s3_object_key
+):
+    from unittest.mock import AsyncMock
+
+    mock_periodic_flush.return_value = None
+    mock_create_task.return_value = None
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json = MagicMock(return_value={"test": "data"})
+
+    access_key, secret_key = "test-access-key", "test-secret-key"
+    logger = S3Logger(
+        s3_bucket_name="test-bucket",
+        s3_aws_access_key_id=access_key,
+        s3_aws_secret_access_key=secret_key,
+        s3_region_name="us-east-1",
+    )
+    logger.async_httpx_client = AsyncMock()
+    logger.async_httpx_client.get.return_value = mock_response
+
+    asyncio.run(logger._download_object_from_s3(s3_object_key))
+
+    call_args = logger.async_httpx_client.get.call_args
+    assert call_args is not None
+    request_url = call_args[0][0]
+    signed_headers = call_args[1]["headers"]
+    _assert_signature_valid_for_wire_url(
+        request_url, None, signed_headers, access_key, secret_key, method="GET"
+    )

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1395,6 +1395,10 @@ SPECIAL_CHAR_OBJECT_KEYS = [
     "R&D + Ops/2025-09-14/test-key.json",
     "tёam#1/2025-09-14/test-key.json",
     "a@b/2025-09-14/test-key.json",
+    "./2025-09-14/test-key.json",
+    "../2025-09-14/test-key.json",
+    "a/./b/2025-09-14/test-key.json",
+    "a/../b/2025-09-14/test-key.json",
 ]
 
 
@@ -1407,6 +1411,7 @@ def _assert_signature_valid_for_wire_url(
     region="us-east-1",
     method="PUT",
 ):
+    import httpx
     from botocore.auth import S3SigV4Auth
     from botocore.awsrequest import AWSRequest
     from botocore.credentials import Credentials
@@ -1414,11 +1419,13 @@ def _assert_signature_valid_for_wire_url(
     assert "Authorization" in signed_headers, "request was not signed"
     assert " " not in request_url, "raw space leaked onto the wire URL"
 
+    wire_url = str(httpx.Request(method, request_url).url)
+
     verify_headers = {
         k: v for k, v in signed_headers.items() if k.lower() != "authorization"
     }
     verify_req = AWSRequest(
-        method=method, url=request_url, data=data, headers=verify_headers
+        method=method, url=wire_url, data=data, headers=verify_headers
     )
     verify_req.context["timestamp"] = signed_headers["X-Amz-Date"]
     S3SigV4Auth(Credentials(access_key, secret_key), "s3", region).add_auth(verify_req)
@@ -1426,9 +1433,10 @@ def _assert_signature_valid_for_wire_url(
     assert verify_req.headers["Authorization"] == signed_headers["Authorization"], (
         "SigV4 signature does not match the URL actually sent on the wire; "
         "S3 would reject this with 403 SignatureDoesNotMatch.\n"
-        f"  wire url  : {request_url}\n"
-        f"  sent sig  : {signed_headers['Authorization']}\n"
-        f"  valid sig : {verify_req.headers['Authorization']}"
+        f"  passed url : {request_url}\n"
+        f"  wire url   : {wire_url}\n"
+        f"  sent sig   : {signed_headers['Authorization']}\n"
+        f"  valid sig  : {verify_req.headers['Authorization']}"
     )
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- s3_v2 logs vanish with 403 SignatureDoesNotMatch for keys with reserved chars
- Hits every team/key whose alias has a space, #, +, & or unicode

How it solves it:

- Percent-encode the object key once, sign with S3SigV4Auth (no re-quote)
- Signed canonical URI now matches the URL sent on the wire

## Relevant issues

Fixes #34490

## Linear ticket

<!-- external contributor: intentionally blank -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

**Root cause:** `s3_v2.py` built the S3 URL from the raw object key and signed it with botocore's generic `SigV4Auth`, whose `_normalize_url_path()` re-quotes the path (`quote(normalize_url_path(path), safe='/~')`): a single-encoded `%20` becomes double-encoded `%2520` in the signed canonical request, while httpx sends `%20` on the wire → S3 recomputes over `%20`, signatures differ → `403 SignatureDoesNotMatch`. `S3SigV4Auth._normalize_url_path()` returns the path unchanged, so signing with it makes the signed URI match the wire URI.

A related variant: `.` / `..` object-key segments are collapsed by httpx when building the wire URL, so those must also be percent-encoded before signing or the signed path drifts from the wire path (an authenticated caller controlling a team/key alias could otherwise force 403s under that prefix). Handled in `_encode_s3_object_key`.

**Deterministic before/after (models S3's own server-side verification):** the added tests re-derive the SigV4 signature over the exact URL httpx puts on the wire (reusing the client's `X-Amz-Date`) and assert it equals the `Authorization` header the client produced. This is precisely what S3 does to accept/reject a request.

Before the fix (upstream base) the added signature tests fail (async + sync + download × special-char / unicode / dot-segment keys); after the fix they pass:

```
$ python -m pytest tests/test_litellm/integrations/test_s3_v2.py -k signature_matches_wire_url -q
24 passed
$ python -m pytest tests/test_litellm/integrations/test_s3_v2.py -q
64 passed
```

Additionally validated by running the real `S3Logger.async_upload_data_to_s3` inside a running proxy container and confirming S3 would accept the signed request for every reserved-character / unicode / dot-segment key:

<img width="1209" height="1211" alt="image" src="https://github.com/user-attachments/assets/4b9a55ce-dc6f-4eb9-9fb0-46ea5777f184" />

## Type

🐛 Bug Fix

## Changes

- Add `_encode_s3_object_key` — percent-encode the object key exactly once with `quote(key, safe="/")` (preserving `/` separators), and percent-encode `.` / `..` segments so httpx does not collapse them off the signed path.
- Add `_sign_s3_request(credentials, method, url, headers, region, data=None)` — builds the `AWSRequest`, signs with `botocore.auth.S3SigV4Auth`, and returns the signed headers.
- Use both across `async_upload_data_to_s3`, `upload_data_to_s3`, and `_download_object_from_s3`; sign and send the same already-encoded URL, dropping the `requests.Request(...).prepare()` indirection (also removes the `requests` dependency from these paths).
- No behavior change for keys containing only unreserved characters: `quote()` is a no-op and `S3SigV4Auth` produces an identical signature when there is nothing to re-encode.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
