### PR TITLE
fix(cost): drop stale web search pricing from gpt-4o-mini-2024-07-18

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -22318,11 +22318,6 @@
         "mode": "chat",
         "output_cost_per_token": 6e-07,
         "output_cost_per_token_batches": 3e-07,
-        "search_context_cost_per_query": {
-            "search_context_size_high": 0.03,
-            "search_context_size_low": 0.025,
-            "search_context_size_medium": 0.0275
-        },
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_pdf_input": true,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -22393,11 +22393,6 @@
         "mode": "chat",
         "output_cost_per_token": 6e-07,
         "output_cost_per_token_batches": 3e-07,
-        "search_context_cost_per_query": {
-            "search_context_size_high": 0.03,
-            "search_context_size_low": 0.025,
-            "search_context_size_medium": 0.0275
-        },
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
         "supports_pdf_input": true,

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -1,5 +1,7 @@
+import json
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -600,6 +602,70 @@ def test_web_search_provider_prefix_fallback_does_not_misprice_non_gemini_model(
         "A non-Gemini provider-prefixed model with no web search pricing must not be charged "
         f"the vertex_ai per_prompt default via the prefix fallback, got ${cost}"
     )
+
+
+@pytest.mark.parametrize(
+    "web_search_options",
+    [
+        None,
+        WebSearchOptions(search_context_size="low"),
+        WebSearchOptions(search_context_size="medium"),
+        WebSearchOptions(search_context_size="high"),
+    ],
+)
+def test_gpt_4o_mini_snapshot_bills_web_search_like_its_alias(
+    web_search_options, local_model_cost_map
+):
+    """
+    gpt-4o-mini-2024-07-18 is the dated snapshot of gpt-4o-mini and must bill web search
+    identically. It kept a search_context_cost_per_query from the March 2025 launch tiers that the
+    May 2025 cleanup missed, because that sweep selected on supports_web_search and the snapshot
+    never carried the flag. The result was $0.0275 per query on one name and nothing on the other
+    for the same underlying model. Neither entry declares web search support, so both resolve to $0
+    at every search context size.
+    """
+    alias_info = litellm.get_model_info("gpt-4o-mini")
+    snapshot_info = litellm.get_model_info("gpt-4o-mini-2024-07-18")
+
+    assert not alias_info.get("supports_web_search")
+    assert not snapshot_info.get("supports_web_search")
+    assert not snapshot_info.get("search_context_cost_per_query")
+
+    snapshot_cost = StandardBuiltInToolCostTracking.get_cost_for_web_search(
+        web_search_options=web_search_options, model_info=snapshot_info
+    )
+    alias_cost = StandardBuiltInToolCostTracking.get_cost_for_web_search(
+        web_search_options=web_search_options, model_info=alias_info
+    )
+
+    assert snapshot_cost == alias_cost == 0.0, (
+        f"gpt-4o-mini-2024-07-18 must not carry a web search fee its alias does not: "
+        f"got ${snapshot_cost} vs ${alias_cost} on gpt-4o-mini"
+    )
+
+
+def test_gpt_4o_mini_snapshot_web_search_price_absent_from_both_cost_maps():
+    """
+    The fixture above only sees the bundled backup, but the map served to running deployments is
+    the canonical file fetched from the repo, so the removal has to hold in both. They already
+    differ in a handful of unrelated entries, which is how one name kept a price its alias had lost.
+    """
+    repo_root = Path(__file__).parents[4]
+    entries = tuple(
+        json.loads((repo_root / path).read_text(encoding="utf-8"))[
+            "gpt-4o-mini-2024-07-18"
+        ]
+        for path in (
+            "model_prices_and_context_window.json",
+            "litellm/model_prices_and_context_window_backup.json",
+        )
+    )
+
+    canonical, backup = entries
+    assert "search_context_cost_per_query" not in canonical
+    assert (
+        canonical == backup
+    ), "gpt-4o-mini-2024-07-18 differs between the two cost maps"
 
 
 # Note: File search integration test removed due to complex annotation detection logic


### PR DESCRIPTION
## Relevant issues

Related context: #31316 tracks the missing per call web search fee on GA OpenAI models (gpt-5.x, gpt-4.1, o3, o4-mini currently bill it at $0). This PR does not close it; it only removes the one orphaned price that made two names for the same model bill differently. Restoring a correct flat price for the whole family belongs with that issue

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both runs use a live proxy built from this branch (tree identical to 8c0110326e) with a single model_list entry for gpt-4o-mini-2024-07-18. The defect is a cost map data entry, so the customer visible surface is /model/info and the fee the cost tracker attaches; no provider call behavior changes

Before (default behavior: the proxy fetches the cost map from main at runtime, so this is what any running deployment serves today):

```
$ curl -s http://localhost:4000/v1/model/info -H "Authorization: Bearer sk-1234" \
    | jq '.data[] | select(.model_name=="gpt-4o-mini-2024-07-18") | .model_info.search_context_cost_per_query'
{
  "search_context_size_high": 0.03,
  "search_context_size_low": 0.025,
  "search_context_size_medium": 0.0275
}
```

After (same proxy code at 8c0110326e with LITELLM_LOCAL_MODEL_COST_MAP=True so it serves this branch's map):

```
$ curl -s http://localhost:4000/v1/model/info -H "Authorization: Bearer sk-1234" \
    | jq '.data[] | select(.model_name=="gpt-4o-mini-2024-07-18") | .model_info.search_context_cost_per_query'
null
```

The alias gpt-4o-mini already returns null here, so the two names now agree

## Type

🐛 Bug Fix

## Changes

The gpt-4o-mini-2024-07-18 entry carries a tiered search_context_cost_per_query while declaring no supports_web_search, so the dated snapshot bills a web search fee ($0.0275 per query at the default tier) that its own alias gpt-4o-mini bills at $0. The values are the March 2025 search preview launch tiers; OpenAI moved to flat per call pricing in June 2025

Provenance: commit 06484f6e5a (PR #11251) deliberately stripped this field from 9 OpenAI entries including gpt-4o-mini, with the policy spelled out in its commit message. That sweep selected entries by the supports_web_search flag, which baa2bdb762 had added to the alias but never to the snapshot, so the snapshot kept a price every sibling had lost. This PR completes that documented cleanup rather than making a new pricing judgement

Why remove the price instead of adding the flag plus a flat price, the way #33920 does for Claude models: the Anthropic cost calculator consumes its price via usage.server_tool_use, so there the flag is the missing half. Here the price is the half with no counterpart, on a snapshot whose alias was deliberately stripped; adding a price to the snapshot alone would deepen the split, and pricing the whole family correctly is #31316

Billing impact stated plainly: a web search call on this model name moves from arbitrarily over billed to consistently unbilled, matching gpt-4o-mini, gpt-4o and every GA OpenAI entry. Nobody gets billed more

Tests, both appended to the mapped test file and verified to fail before the data edit and pass after: one behavioral test asserting the snapshot and alias produce identical (zero) web search cost at every search_context_size, and one data guard asserting the field is absent from the canonical map and that the entry is identical in both cost map files, since the two files are synced by hand and their drift is exactly how this bug survived

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
