### PR TITLE
fix(responses): expose aclose() so abandoned streams release their connection

### DIFF
--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -106,6 +106,13 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._accumulated_provider_specific_fields: dict[str, Any] = {}
         self._custom_tool_names: set[str] = extract_custom_tool_names(self.responses_api_request.get("tools"))
 
+    async def aclose(self) -> None:
+        self.finished = True
+        await self.litellm_custom_stream_wrapper.aclose()
+
+    def close(self) -> None:
+        self.finished = True
+
     def _get_or_assign_tool_output_index(self, call_id: str) -> int:
         existing = self._tool_output_index_by_call_id.get(call_id)
         if existing is not None:

--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -1,3 +1,4 @@
+from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
 
 from litellm._logging import verbose_logger
@@ -322,6 +323,12 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         self._stream_error: Exception | None = None
         self._error_event_emitted = False
         self._last_sequence_number = 0
+
+    async def aclose(self) -> None:
+        self.finished = True
+        base_close: Callable[[], Awaitable[None]] | None = getattr(self.base_iterator, "aclose", None)
+        if base_close is not None:
+            await base_close()
 
     def _extract_mcp_headers_from_params(self) -> None:
         """Extract MCP headers from original request params to pass to tool calls"""

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from functools import lru_cache
 from typing import Any, Dict, List, Literal, Optional
 
+import anyio
 import httpx
 from openai._streaming import SSEDecoder
 
@@ -143,9 +144,13 @@ class BaseResponsesAPIStreamingIterator:
         )  # GUARANTEE OPENAI HEADERS IN RESPONSE
 
     async def aclose(self) -> None:
-        closer: asyncio.Task[None] = asyncio.ensure_future(self.response.aclose())
+        self.finished = True
+        response: httpx.Response | None = getattr(self, "response", None)
+        if response is None:
+            return
+        closer: asyncio.Task[None] = asyncio.ensure_future(response.aclose())
         interrupted = False
-        try:
+        with anyio.CancelScope(shield=True):
             while not closer.done():
                 try:
                     await asyncio.shield(closer)
@@ -155,12 +160,10 @@ class BaseResponsesAPIStreamingIterator:
                     interrupted = True
                 except BaseException:
                     break
-        finally:
-            self.finished = True
-        error: Optional[BaseException] = None if closer.cancelled() else closer.exception()
+        error: BaseException | None = None if closer.cancelled() else closer.exception()
         if isinstance(error, RuntimeError):
             try:
-                self.response.close()
+                response.close()
                 error = None
             except Exception as sync_close_error:
                 error = sync_close_error
@@ -170,12 +173,14 @@ class BaseResponsesAPIStreamingIterator:
             raise asyncio.CancelledError
 
     def close(self) -> None:
+        self.finished = True
+        response: httpx.Response | None = getattr(self, "response", None)
+        if response is None:
+            return
         try:
-            self.response.close()
+            response.close()
         except Exception as e:
             verbose_logger.debug("BaseResponsesAPIStreamingIterator.close: error closing response: %s", e)
-        finally:
-            self.finished = True
 
     def _check_max_streaming_duration(self) -> None:
         """Raise litellm.Timeout if the stream has exceeded LITELLM_MAX_STREAMING_DURATION_SECONDS."""

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from functools import lru_cache
 from typing import Any, Dict, List, Literal, Optional
 
+import anyio
 import httpx
 from openai._streaming import SSEDecoder
 
@@ -141,6 +142,18 @@ class BaseResponsesAPIStreamingIterator:
         self._hidden_params["additional_headers"] = process_response_headers(
             self.response.headers or {}
         )  # GUARANTEE OPENAI HEADERS IN RESPONSE
+
+    async def aclose(self) -> None:
+        with anyio.CancelScope(shield=True):
+            try:
+                await self.response.aclose()
+            except BaseException as e:
+                verbose_logger.debug(
+                    "BaseResponsesAPIStreamingIterator.aclose: error closing response: %s",
+                    e,
+                )
+            finally:
+                self.finished = True
 
     def _check_max_streaming_duration(self) -> None:
         """Raise litellm.Timeout if the stream has exceeded LITELLM_MAX_STREAMING_DURATION_SECONDS."""

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -9,7 +9,6 @@ from datetime import datetime
 from functools import lru_cache
 from typing import Any, Dict, List, Literal, Optional
 
-import anyio
 import httpx
 from openai._streaming import SSEDecoder
 
@@ -144,16 +143,39 @@ class BaseResponsesAPIStreamingIterator:
         )  # GUARANTEE OPENAI HEADERS IN RESPONSE
 
     async def aclose(self) -> None:
-        with anyio.CancelScope(shield=True):
+        closer: asyncio.Task[None] = asyncio.ensure_future(self.response.aclose())
+        interrupted = False
+        try:
+            while not closer.done():
+                try:
+                    await asyncio.shield(closer)
+                except asyncio.CancelledError:
+                    if closer.cancelled():
+                        break
+                    interrupted = True
+                except BaseException:
+                    break
+        finally:
+            self.finished = True
+        error: Optional[BaseException] = None if closer.cancelled() else closer.exception()
+        if isinstance(error, RuntimeError):
             try:
-                await self.response.aclose()
-            except BaseException as e:
-                verbose_logger.debug(
-                    "BaseResponsesAPIStreamingIterator.aclose: error closing response: %s",
-                    e,
-                )
-            finally:
-                self.finished = True
+                self.response.close()
+                error = None
+            except Exception as sync_close_error:
+                error = sync_close_error
+        if error is not None:
+            verbose_logger.debug("BaseResponsesAPIStreamingIterator.aclose: error closing response: %s", error)
+        if interrupted:
+            raise asyncio.CancelledError
+
+    def close(self) -> None:
+        try:
+            self.response.close()
+        except Exception as e:
+            verbose_logger.debug("BaseResponsesAPIStreamingIterator.close: error closing response: %s", e)
+        finally:
+            self.finished = True
 
     def _check_max_streaming_duration(self) -> None:
         """Raise litellm.Timeout if the stream has exceeded LITELLM_MAX_STREAMING_DURATION_SECONDS."""
@@ -702,6 +724,8 @@ class ResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
         return self
 
     async def __anext__(self) -> Any:
+        if self.finished:
+            raise StopAsyncIteration
         try:
             self._check_max_streaming_duration()
             while True:
@@ -784,6 +808,8 @@ class SyncResponsesAPIStreamingIterator(BaseResponsesAPIStreamingIterator):
         return self
 
     def __next__(self):
+        if self.finished:
+            raise StopIteration
         try:
             self._check_max_streaming_duration()
             while True:

--- a/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
+++ b/tests/test_litellm/responses/litellm_completion_transformation/test_tool_call_streaming_transformation.py
@@ -10,6 +10,8 @@ before response.completed.
 
 from unittest.mock import AsyncMock
 
+import pytest
+
 from litellm.responses.litellm_completion_transformation.streaming_iterator import (
     LiteLLMCompletionStreamingIterator,
 )
@@ -397,3 +399,23 @@ def test_reused_index_with_new_call_id_marks_fallback_ambiguous():
     assert arguments_by_call_id["call_b"] == '{"b":'
     assert arguments_by_call_id["call_a"] != '{"a":1}'
     assert arguments_by_call_id["call_b"] != '{"b":1}'
+
+
+@pytest.mark.asyncio
+async def test_aclose_delegates_to_custom_stream_wrapper():
+    """The iterator owns no ``response``; its ``aclose`` must delegate to the
+    wrapped ``CustomStreamWrapper`` (which releases the HTTP connection) and mark
+    itself finished."""
+    wrapper = AsyncMock()
+    wrapper.aclose = AsyncMock()
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=wrapper,
+        request_input="Test input",
+        responses_api_request={},
+    )
+
+    await iterator.aclose()
+
+    wrapper.aclose.assert_awaited_once()
+    assert iterator.finished is True

--- a/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
+++ b/tests/test_litellm/responses/mcp/test_mcp_streaming_iterator.py
@@ -257,3 +257,31 @@ async def test_initial_call_failure_is_stashed_for_eager_reraise(monkeypatch):
 
     assert iterator._initial_creation_error is not None
     assert "initial boom" in str(iterator._initial_creation_error)
+
+
+@pytest.mark.asyncio
+async def test_aclose_delegates_to_base_iterator():
+    """When the wrapped base iterator owns the HTTP stream, ``aclose`` must
+    forward to it so the connection is released, and mark itself finished."""
+    iterator = _make_iterator([])
+    base = MagicMock()
+    base.aclose = AsyncMock()
+    iterator.base_iterator = base
+
+    await iterator.aclose()
+
+    base.aclose.assert_awaited_once()
+    assert iterator.finished is True
+
+
+@pytest.mark.asyncio
+async def test_aclose_without_base_iterator_marks_finished():
+    """A base iterator that is ``None`` (LLM call never created one) or a plain
+    ``ResponsesAPIResponse`` has no ``aclose``; delegation must be skipped
+    without raising, and ``finished`` still set."""
+    iterator = _make_iterator([])
+    iterator.base_iterator = None
+
+    await iterator.aclose()
+
+    assert iterator.finished is True

--- a/tests/test_litellm/responses/test_streaming_iterator.py
+++ b/tests/test_litellm/responses/test_streaming_iterator.py
@@ -3,6 +3,7 @@ completion_start_time on the first chunk so downstream TTFT consumers
 (Prometheus, OTEL, SpendLogs completionStartTime) do not fall back to
 completion_start_time = end_time."""
 
+import asyncio
 import json
 from datetime import datetime
 from typing import Optional
@@ -132,6 +133,103 @@ async def test_responses_streaming_aclose_marks_finished_when_close_fails():
     await iterator.aclose()
 
     iterator.response.aclose.assert_awaited_once()
+    assert iterator.finished is True
+
+
+@pytest.mark.asyncio
+async def test_responses_streaming_aclose_finishes_cleanup_under_native_cancellation():
+    """A native ``asyncio.Task.cancel()`` mid-close must not abandon the httpx
+    connection: the inner ``response.aclose()`` still runs to completion, the
+    cancellation is honored (re-raised, not swallowed), and ``finished`` is set."""
+    iterator = _make_iterator(
+        sse_events=_COMPLETE_STREAM_EVENTS,
+        logging_obj=_logging_obj_stub(),
+    )
+    started = asyncio.Event()
+    release = asyncio.Event()
+    inner_completed = False
+
+    async def blocking_aclose() -> None:
+        nonlocal inner_completed
+        started.set()
+        await release.wait()
+        inner_completed = True
+
+    iterator.response.aclose = blocking_aclose
+
+    task = asyncio.ensure_future(iterator.aclose())
+    await started.wait()
+    task.cancel()
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert inner_completed is True
+    assert iterator.finished is True
+
+
+@pytest.mark.asyncio
+async def test_responses_streaming_aclose_is_idempotent():
+    iterator = _make_iterator(
+        sse_events=_COMPLETE_STREAM_EVENTS,
+        logging_obj=_logging_obj_stub(),
+    )
+    iterator.response.aclose = AsyncMock()
+
+    await iterator.aclose()
+    await iterator.aclose()
+
+    assert iterator.finished is True
+
+
+@pytest.mark.asyncio
+async def test_responses_streaming_aclose_falls_back_to_sync_close_on_runtime_error():
+    """httpx raises ``RuntimeError`` when ``aclose()`` hits a sync stream; the
+    iterator must fall back to the sync ``close()`` so the connection is released."""
+    iterator = _make_iterator(
+        sse_events=_COMPLETE_STREAM_EVENTS,
+        logging_obj=_logging_obj_stub(),
+    )
+    iterator.response.aclose = AsyncMock(
+        side_effect=RuntimeError("Attempted to call an async close on an sync stream.")
+    )
+    iterator.response.close = Mock()
+
+    await iterator.aclose()
+
+    iterator.response.close.assert_called_once()
+    assert iterator.finished is True
+
+
+@pytest.mark.asyncio
+async def test_responses_streaming_iteration_after_aclose_stops_without_failure():
+    """Iterating a closed stream must end cleanly with ``StopAsyncIteration``
+    instead of surfacing ``httpx.StreamClosed`` through the failure handler."""
+    iterator = _make_iterator(
+        sse_events=_COMPLETE_STREAM_EVENTS,
+        logging_obj=_logging_obj_stub(),
+    )
+    iterator.response.aclose = AsyncMock()
+
+    await iterator.aclose()
+
+    with pytest.raises(StopAsyncIteration):
+        await iterator.__anext__()
+
+    assert iterator._failure_handled is False
+
+
+def test_sync_responses_streaming_close_releases_response():
+    iterator = _make_sync_iterator(
+        sse_events=_COMPLETE_STREAM_EVENTS,
+        logging_obj=_logging_obj_stub(),
+    )
+    iterator.response.close = Mock()
+
+    iterator.close()
+
+    iterator.response.close.assert_called_once()
     assert iterator.finished is True
 
 

--- a/tests/test_litellm/responses/test_streaming_iterator.py
+++ b/tests/test_litellm/responses/test_streaming_iterator.py
@@ -6,7 +6,7 @@ completion_start_time = end_time."""
 import json
 from datetime import datetime
 from typing import Optional
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import httpx
 import pytest
@@ -105,6 +105,34 @@ def _logging_obj_stub() -> Mock:
     logging_obj.completion_start_time = None
     logging_obj.model_call_details = {"litellm_params": {}}
     return logging_obj
+
+
+@pytest.mark.asyncio
+async def test_responses_streaming_aclose_releases_response():
+    iterator = _make_iterator(
+        sse_events=_COMPLETE_STREAM_EVENTS,
+        logging_obj=_logging_obj_stub(),
+    )
+    iterator.response.aclose = AsyncMock()
+
+    await iterator.aclose()
+
+    iterator.response.aclose.assert_awaited_once()
+    assert iterator.finished is True
+
+
+@pytest.mark.asyncio
+async def test_responses_streaming_aclose_marks_finished_when_close_fails():
+    iterator = _make_iterator(
+        sse_events=_COMPLETE_STREAM_EVENTS,
+        logging_obj=_logging_obj_stub(),
+    )
+    iterator.response.aclose = AsyncMock(side_effect=RuntimeError("close failed"))
+
+    await iterator.aclose()
+
+    iterator.response.aclose.assert_awaited_once()
+    assert iterator.finished is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/responses/test_streaming_iterator.py
+++ b/tests/test_litellm/responses/test_streaming_iterator.py
@@ -9,12 +9,14 @@ from datetime import datetime
 from typing import Optional
 from unittest.mock import AsyncMock, Mock
 
+import anyio
 import httpx
 import pytest
 
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
 from litellm.responses.streaming_iterator import (
+    BaseResponsesAPIStreamingIterator,
     ResponsesAPIStreamingIterator,
     SyncResponsesAPIStreamingIterator,
 )
@@ -123,12 +125,15 @@ async def test_responses_streaming_aclose_releases_response():
 
 
 @pytest.mark.asyncio
-async def test_responses_streaming_aclose_marks_finished_when_close_fails():
+async def test_responses_streaming_aclose_suppresses_genuine_cleanup_failure():
+    """A non-RuntimeError failure in ``response.aclose()`` does not hit the sync
+    fallback, so this exercises the real cleanup-failure path: the exception is
+    swallowed (aclose does not raise) and ``finished`` is still set."""
     iterator = _make_iterator(
         sse_events=_COMPLETE_STREAM_EVENTS,
         logging_obj=_logging_obj_stub(),
     )
-    iterator.response.aclose = AsyncMock(side_effect=RuntimeError("close failed"))
+    iterator.response.aclose = AsyncMock(side_effect=ValueError("cleanup boom"))
 
     await iterator.aclose()
 
@@ -231,6 +236,94 @@ def test_sync_responses_streaming_close_releases_response():
 
     iterator.response.close.assert_called_once()
     assert iterator.finished is True
+
+
+def _base_iterator_without_response() -> BaseResponsesAPIStreamingIterator:
+    iterator = object.__new__(BaseResponsesAPIStreamingIterator)
+    iterator.finished = False
+    return iterator
+
+
+@pytest.mark.asyncio
+async def test_aclose_without_response_attribute_marks_finished():
+    """Subclasses that skip the base ``__init__`` never set ``self.response``;
+    the inherited ``aclose`` must not raise ``AttributeError`` for them."""
+    iterator = _base_iterator_without_response()
+
+    await iterator.aclose()
+
+    assert iterator.finished is True
+
+
+def test_close_without_response_attribute_marks_finished():
+    iterator = _base_iterator_without_response()
+
+    iterator.close()
+
+    assert iterator.finished is True
+
+
+@pytest.mark.asyncio
+async def test_aclose_marks_finished_before_awaiting_response_close():
+    """``finished`` must flip True at ``aclose`` entry so a concurrent
+    ``__anext__`` stops immediately instead of iterating (and possibly
+    failure-logging) the stream that is being deliberately closed."""
+    iterator = _make_iterator(
+        sse_events=_COMPLETE_STREAM_EVENTS,
+        logging_obj=_logging_obj_stub(),
+    )
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocking_aclose() -> None:
+        entered.set()
+        await release.wait()
+
+    iterator.response.aclose = blocking_aclose
+
+    close_task = asyncio.ensure_future(iterator.aclose())
+    await entered.wait()
+
+    assert iterator.finished is True
+    with pytest.raises(StopAsyncIteration):
+        await iterator.__anext__()
+    assert iterator._failure_handled is False
+
+    release.set()
+    await close_task
+    assert iterator.finished is True
+
+
+@pytest.mark.asyncio
+async def test_aclose_completes_cleanup_and_preserves_persistent_anyio_cancellation():
+    """Under a persistently cancelled anyio scope the shield lets cleanup run to
+    completion (no spin, no hang) and returns normally, yet the cancellation is
+    not lost: the caller's next checkpoint still raises ``CancelledError``."""
+    iterator = _base_iterator_without_response()
+    cleanup_done = asyncio.Event()
+
+    async def slow_aclose() -> None:
+        await asyncio.sleep(0.2)
+        cleanup_done.set()
+
+    response = Mock()
+    response.aclose = slow_aclose
+    iterator.response = response
+
+    async def scenario() -> None:
+        async with anyio.create_task_group() as tg:
+
+            async def worker() -> None:
+                tg.cancel_scope.cancel()
+                await iterator.aclose()
+                assert cleanup_done.is_set() is True
+                assert iterator.finished is True
+                with pytest.raises(asyncio.CancelledError):
+                    await anyio.lowlevel.checkpoint()
+
+            tg.start_soon(worker)
+
+    await asyncio.wait_for(scenario(), timeout=5)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Abandoned Responses API streams never release their httpx connection
- Callers had no aclose() to deterministically close a stream
- Leaked connections eventually exhaust the upstream connection pool

How it solves it:

- Adds aclose() and sync close() to the streaming iterator base
- Cleanup survives task cancellation and never masks the original error
- Existing proxy disconnect cleanup picks it up via hasattr

## Relevant issues

Fixes #26250

Supersedes #26273 and #26292 (closed unmerged). Those PRs took the same approach but wrapped the teardown in `anyio.CancelScope(shield=True)`, which shields against anyio task group cancellation only; a native `asyncio.Task.cancel()` still interrupts the inner await, so the cleanup could be abandoned halfway while the swallowed `CancelledError` made it look successful. The `asyncio.shield` re-await loop here survives both cancellation regimes, and the cancellation test in this PR fails against the `CancelScope` variant

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs below hit a live OpenAI-compatible LiteLLM gateway at `127.0.0.1:4000` which routes model `deepseek` to `openrouter/deepseek/deepseek-v4-pro`, so every stream is real provider traffic costing real $

### SDK caller: before vs after

This is the exact scenario from #26250: a caller opens streams, reads one event, abandons them, and tries to close deterministically. Script (`proof_sdk.py`, run with `LITELLM_SRC` pointing at each checkout):

```python
import asyncio
import os
import subprocess
import sys

sys.path.insert(0, os.environ["LITELLM_SRC"])
import litellm

litellm.register_model({
    "deepseek": {
        "litellm_provider": "openai",
        "mode": "chat",
        "supports_native_streaming": True,
    }
})


def upstream_conns() -> int:
    out = subprocess.run(
        ["ss", "-tnp", "state", "established", "( dport = 4000 )"],
        capture_output=True, text=True,
    ).stdout
    return out.count(f"pid={os.getpid()}")


async def main() -> None:
    streams = []
    for _ in range(5):
        s = await litellm.aresponses(
            model="openai/deepseek",
            api_base="http://127.0.0.1:4000/v1",
            api_key=os.environ["UPSTREAM_GATEWAY_KEY"],
            input="Count from 1 to 1000, one number per line.",
            stream=True,
        )
        await s.__anext__()
        streams.append(s)
    print(f"iterator class: {type(streams[0]).__name__}")
    print(f"5 streams opened, first event read from each, then abandoned")
    print(f"established connections to upstream: {upstream_conns()}")
    try:
        for s in streams:
            await s.aclose()
        print("aclose() called on all 5 streams")
    except AttributeError as e:
        print(f"aclose() unavailable: {e}")
    await asyncio.sleep(2)
    print(f"established connections to upstream after cleanup attempt: {upstream_conns()}")


asyncio.run(main())
```

Output:

```
== BEFORE @ bd753aecf3 ==
iterator class: ResponsesAPIStreamingIterator
5 streams opened, first event read from each, then abandoned
established connections to upstream: 5
aclose() unavailable: 'ResponsesAPIStreamingIterator' object has no attribute 'aclose'
established connections to upstream after cleanup attempt: 5

== AFTER @ 0cf21d345d ==
iterator class: ResponsesAPIStreamingIterator
5 streams opened, first event read from each, then abandoned
established connections to upstream: 5
aclose() called on all 5 streams
established connections to upstream after cleanup attempt: 0
```

### Proxy end to end (after, at 0cf21d345d)

Proxy started from this branch with `python litellm/proxy/proxy_cli.py --config proof_config.yaml --port 4010 --detailed_debug`, where the config maps `deepseek` to the same live gateway (`model: openai/deepseek`, `api_base: http://127.0.0.1:4000/v1`). Clients stream `/v1/responses` and disconnect mid-flight; established connections from the proxy process to the upstream are counted with `ss -tnp state established '( dport = 4000 )'`

```
1. baseline established connections proxy->upstream: 0

2. one stream held open in background, counted mid-flight:
   during stream: 1
   2s after client killed: 0

3. abort 8 streams mid-flight (--max-time 3):
   req 1 aborted, 13135 bytes streamed
   req 2 aborted, 13504 bytes streamed
   req 3 aborted, 10973 bytes streamed
   req 4 aborted, 11712 bytes streamed
   req 5 aborted, 14266 bytes streamed
   req 6 aborted, 11928 bytes streamed
   req 7 aborted, 13489 bytes streamed
   req 8 aborted, 25260 bytes streamed

4. connections right after aborts: 0
   3s later (no leaked connections may remain): 0

5. follow-up request completes normally:
   "type":"response.completed"
```

One honest caveat on the proxy path: when a client disconnect cancels a pending upstream read, httpcore already closes that transport connection, so the proxy scenario alone does not visibly leak sockets before this change. What this PR adds on the proxy side is deterministic iterator cleanup through the existing `hasattr(response, "aclose")` hook in `_finalize_streaming_generator_cleanup`, which previously found no method to call. The deterministic leak and its fix are demonstrated by the SDK run above

## Type

🐛 Bug Fix

## Changes

`BaseResponsesAPIStreamingIterator` gains an async `aclose()` and a sync `close()`. `aclose()` closes the underlying `httpx.Response` through an `asyncio.shield` re-await loop, so cleanup runs to completion under both native `asyncio.Task.cancel()` and anyio task group cancellation; a cancellation that arrives mid-close is re-raised once cleanup finishes, so it is never swallowed. Close errors are logged at debug level instead of propagating, so calling `aclose()` from an except or finally block cannot mask the original failure. If closing raises the httpx sync-stream `RuntimeError` (the sync iterator and the Mock/Cached subclasses hold sync-stream responses), it falls back to `response.close()`. The iterator is always marked `finished`, and both calls are idempotent

`ResponsesAPIStreamingIterator.__anext__` and `SyncResponsesAPIStreamingIterator.__next__` now stop immediately once `finished` is set, so iterating a closed stream raises `StopAsyncIteration`/`StopIteration` instead of surfacing `httpx.StreamClosed` and firing the failure handler on a stream that did not fail

Follow-up hardening after review: `finished` is set at the top of `aclose()`/`close()` so concurrent iteration stops immediately once closing starts instead of racing the teardown; the base `aclose()`/`close()` no-op safely on iterators that never set `self.response`; `LiteLLMCompletionStreamingIterator` overrides `aclose()` to delegate to its `CustomStreamWrapper.aclose()` (the #21213 cleanup), so the completion-bridge path now releases its underlying stream too, and `MCPEnhancedStreamingIterator` delegates to `base_iterator.aclose()` when present; the wait loop is additionally wrapped in `anyio.CancelScope(shield=True)` so anyio-managed cancellation does not re-deliver during the close window (native `task.cancel()` is still handled by the inner shield loop)

Tests: 14 new unit tests across `tests/test_litellm/responses/` covering release on aclose, genuine cleanup failure suppression, cancellation survival plus propagation under both native and persistent anyio cancellation, idempotency, the sync-stream fallback, iteration during and after close, sync `close()`, the missing-response guard, and both subclass delegations. The native cancellation test was mutation-verified: it fails against a plain `anyio.CancelScope(shield=True)` implementation, which native task cancellation interrupts

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
