### PR TITLE
fix(proxy): propagate Invoke cache-token counts to usage

### DIFF
--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -924,5 +924,13 @@ class AmazonAnthropicClaudeMessagesStreamDecoder(AWSEventStreamDecoder):
                 anthropic_usage["input_tokens"] = amazon_bedrock_invocation_metrics["inputTokenCount"]
             if "outputTokenCount" in amazon_bedrock_invocation_metrics:
                 anthropic_usage["output_tokens"] = amazon_bedrock_invocation_metrics["outputTokenCount"]
+            if "cacheReadInputTokenCount" in amazon_bedrock_invocation_metrics:
+                anthropic_usage["cache_read_input_tokens"] = amazon_bedrock_invocation_metrics[
+                    "cacheReadInputTokenCount"
+                ]
+            if "cacheWriteInputTokenCount" in amazon_bedrock_invocation_metrics:
+                anthropic_usage["cache_creation_input_tokens"] = amazon_bedrock_invocation_metrics[
+                    "cacheWriteInputTokenCount"
+                ]
             chunk_data["usage"] = anthropic_usage
         return chunk_data

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -966,5 +966,13 @@ class AmazonAnthropicClaudeMessagesStreamDecoder(AWSEventStreamDecoder):
                 anthropic_usage["input_tokens"] = amazon_bedrock_invocation_metrics["inputTokenCount"]
             if "outputTokenCount" in amazon_bedrock_invocation_metrics:
                 anthropic_usage["output_tokens"] = amazon_bedrock_invocation_metrics["outputTokenCount"]
+            if "cacheReadInputTokenCount" in amazon_bedrock_invocation_metrics:
+                anthropic_usage["cache_read_input_tokens"] = amazon_bedrock_invocation_metrics[
+                    "cacheReadInputTokenCount"
+                ]
+            if "cacheWriteInputTokenCount" in amazon_bedrock_invocation_metrics:
+                anthropic_usage["cache_creation_input_tokens"] = amazon_bedrock_invocation_metrics[
+                    "cacheWriteInputTokenCount"
+                ]
             chunk_data["usage"] = anthropic_usage
         return chunk_data

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -709,6 +709,8 @@ class AnthropicPassthroughLoggingHandler:
                             tool_search_requests = _stu.get("tool_search_requests")
                     if usage.get("cache_read_input_tokens") is not None:
                         cache_read = usage.get("cache_read_input_tokens")
+                    if usage.get("cache_creation_input_tokens") is not None:
+                        cache_creation = usage.get("cache_creation_input_tokens")
                     if usage.get("inference_geo") is not None:
                         inference_geo = usage.get("inference_geo")
                     found_usage = True

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -739,6 +739,8 @@ class AnthropicPassthroughLoggingHandler:
                             tool_search_requests = _stu.get("tool_search_requests")
                     if usage.get("cache_read_input_tokens") is not None:
                         cache_read = usage.get("cache_read_input_tokens")
+                    if usage.get("cache_creation_input_tokens") is not None:
+                        cache_creation = usage.get("cache_creation_input_tokens")
                     if usage.get("inference_geo") is not None:
                         inference_geo = usage.get("inference_geo")
                     found_usage = True

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -264,6 +264,103 @@ def test_chunk_parser_usage_transformation():
     assert parsed["usage"]["output_tokens"] == 5
 
 
+def test_chunk_parser_maps_cache_token_counts():
+    """Bedrock Invoke reports prompt-cache usage on the final chunk as
+    cacheReadInputTokenCount / cacheWriteInputTokenCount inside
+    amazon-bedrock-invocationMetrics. Map them onto the synthesized usage so
+    downstream cost tracking sees cached tokens instead of billing every
+    request as fresh input."""
+
+    decoder = AmazonAnthropicClaudeMessagesStreamDecoder(
+        model="bedrock/invoke/anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+
+    chunk = {
+        "type": "message_delta",
+        "amazon-bedrock-invocationMetrics": {
+            "inputTokenCount": 1,
+            "outputTokenCount": 162,
+            "cacheReadInputTokenCount": 421714,
+            "cacheWriteInputTokenCount": 1139,
+        },
+    }
+
+    parsed = decoder._chunk_parser(chunk.copy())
+
+    assert "amazon-bedrock-invocationMetrics" not in parsed
+    assert parsed["usage"]["input_tokens"] == 1
+    assert parsed["usage"]["output_tokens"] == 162
+    assert parsed["usage"]["cache_read_input_tokens"] == 421714
+    assert parsed["usage"]["cache_creation_input_tokens"] == 1139
+
+
+def test_chunk_parser_omits_cache_fields_when_absent():
+    """Cache fields stay absent on the synthesized usage when the
+    invocationMetrics block does not report them (no cache activity)."""
+
+    decoder = AmazonAnthropicClaudeMessagesStreamDecoder(
+        model="bedrock/invoke/anthropic.claude-3-sonnet-20240229-v1:0"
+    )
+
+    chunk = {
+        "type": "message_delta",
+        "amazon-bedrock-invocationMetrics": {
+            "inputTokenCount": 14,
+            "outputTokenCount": 67,
+        },
+    }
+
+    parsed = decoder._chunk_parser(chunk.copy())
+
+    assert parsed["usage"]["input_tokens"] == 14
+    assert parsed["usage"]["output_tokens"] == 67
+    assert "cache_read_input_tokens" not in parsed["usage"]
+    assert "cache_creation_input_tokens" not in parsed["usage"]
+
+
+@pytest.mark.parametrize(
+    "invocation_metrics, present_key, present_value, absent_key",
+    [
+        # cache hit: read tokens reported, no write
+        (
+            {"inputTokenCount": 2, "outputTokenCount": 9, "cacheReadInputTokenCount": 500},
+            "cache_read_input_tokens",
+            500,
+            "cache_creation_input_tokens",
+        ),
+        # cold request: write tokens reported, no read
+        (
+            {"inputTokenCount": 3, "outputTokenCount": 7, "cacheWriteInputTokenCount": 42},
+            "cache_creation_input_tokens",
+            42,
+            "cache_read_input_tokens",
+        ),
+        # zero-valued count is still mapped (membership check, not truthiness)
+        (
+            {"inputTokenCount": 4, "outputTokenCount": 8, "cacheReadInputTokenCount": 0},
+            "cache_read_input_tokens",
+            0,
+            "cache_creation_input_tokens",
+        ),
+    ],
+)
+def test_chunk_parser_maps_cache_fields_independently(invocation_metrics, present_key, present_value, absent_key):
+    """Each cache field maps on its own guard: a cache-read-only (hit) or
+    cache-write-only (cold) chunk maps the reported field without requiring
+    the other, and a zero count is preserved rather than dropped."""
+
+    decoder = AmazonAnthropicClaudeMessagesStreamDecoder(
+        model="bedrock/invoke/anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+
+    chunk = {"type": "message_delta", "amazon-bedrock-invocationMetrics": invocation_metrics}
+
+    parsed = decoder._chunk_parser(chunk.copy())
+
+    assert parsed["usage"][present_key] == present_value
+    assert absent_key not in parsed["usage"]
+
+
 def test_remove_ttl_from_cache_control():
     """Ensure ttl field is removed from cache_control in messages."""
 

--- a/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py
@@ -265,6 +265,103 @@ def test_chunk_parser_usage_transformation():
     assert parsed["usage"]["output_tokens"] == 5
 
 
+def test_chunk_parser_maps_cache_token_counts():
+    """Bedrock Invoke reports prompt-cache usage on the final chunk as
+    cacheReadInputTokenCount / cacheWriteInputTokenCount inside
+    amazon-bedrock-invocationMetrics. Map them onto the synthesized usage so
+    downstream cost tracking sees cached tokens instead of billing every
+    request as fresh input."""
+
+    decoder = AmazonAnthropicClaudeMessagesStreamDecoder(
+        model="bedrock/invoke/anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+
+    chunk = {
+        "type": "message_delta",
+        "amazon-bedrock-invocationMetrics": {
+            "inputTokenCount": 1,
+            "outputTokenCount": 162,
+            "cacheReadInputTokenCount": 421714,
+            "cacheWriteInputTokenCount": 1139,
+        },
+    }
+
+    parsed = decoder._chunk_parser(chunk.copy())
+
+    assert "amazon-bedrock-invocationMetrics" not in parsed
+    assert parsed["usage"]["input_tokens"] == 1
+    assert parsed["usage"]["output_tokens"] == 162
+    assert parsed["usage"]["cache_read_input_tokens"] == 421714
+    assert parsed["usage"]["cache_creation_input_tokens"] == 1139
+
+
+def test_chunk_parser_omits_cache_fields_when_absent():
+    """Cache fields stay absent on the synthesized usage when the
+    invocationMetrics block does not report them (no cache activity)."""
+
+    decoder = AmazonAnthropicClaudeMessagesStreamDecoder(
+        model="bedrock/invoke/anthropic.claude-3-sonnet-20240229-v1:0"
+    )
+
+    chunk = {
+        "type": "message_delta",
+        "amazon-bedrock-invocationMetrics": {
+            "inputTokenCount": 14,
+            "outputTokenCount": 67,
+        },
+    }
+
+    parsed = decoder._chunk_parser(chunk.copy())
+
+    assert parsed["usage"]["input_tokens"] == 14
+    assert parsed["usage"]["output_tokens"] == 67
+    assert "cache_read_input_tokens" not in parsed["usage"]
+    assert "cache_creation_input_tokens" not in parsed["usage"]
+
+
+@pytest.mark.parametrize(
+    "invocation_metrics, present_key, present_value, absent_key",
+    [
+        # cache hit: read tokens reported, no write
+        (
+            {"inputTokenCount": 2, "outputTokenCount": 9, "cacheReadInputTokenCount": 500},
+            "cache_read_input_tokens",
+            500,
+            "cache_creation_input_tokens",
+        ),
+        # cold request: write tokens reported, no read
+        (
+            {"inputTokenCount": 3, "outputTokenCount": 7, "cacheWriteInputTokenCount": 42},
+            "cache_creation_input_tokens",
+            42,
+            "cache_read_input_tokens",
+        ),
+        # zero-valued count is still mapped (membership check, not truthiness)
+        (
+            {"inputTokenCount": 4, "outputTokenCount": 8, "cacheReadInputTokenCount": 0},
+            "cache_read_input_tokens",
+            0,
+            "cache_creation_input_tokens",
+        ),
+    ],
+)
+def test_chunk_parser_maps_cache_fields_independently(invocation_metrics, present_key, present_value, absent_key):
+    """Each cache field maps on its own guard: a cache-read-only (hit) or
+    cache-write-only (cold) chunk maps the reported field without requiring
+    the other, and a zero count is preserved rather than dropped."""
+
+    decoder = AmazonAnthropicClaudeMessagesStreamDecoder(
+        model="bedrock/invoke/anthropic.claude-3-5-sonnet-20241022-v2:0"
+    )
+
+    chunk = {"type": "message_delta", "amazon-bedrock-invocationMetrics": invocation_metrics}
+
+    parsed = decoder._chunk_parser(chunk.copy())
+
+    assert parsed["usage"][present_key] == present_value
+    assert absent_key not in parsed["usage"]
+
+
 def test_remove_ttl_from_cache_control():
     """Ensure ttl field is removed from cache_control in messages."""
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
@@ -1939,6 +1939,42 @@ class TestAnthropicUsageOnlyFallback:
         assert usage.prompt_tokens_details.cached_tokens == 40
         assert usage.server_tool_use.web_search_requests == 2
 
+    def test_build_usage_only_recovers_cache_creation_from_message_delta(self):
+        # Bedrock Invoke reports the cache breakdown on the final chunk (the
+        # decoder lands invocationMetrics-derived usage on message_delta), while
+        # message_start carries no cache tokens. The fallback must recover both
+        # cache_read and cache_creation from the delta, not just cache_read.
+        chunks = [
+            _sse_bytes(
+                {
+                    "type": "message_start",
+                    "message": {
+                        "model": "claude-3-5-sonnet-20241022",
+                        "usage": {"input_tokens": 5, "output_tokens": 1},
+                    },
+                }
+            ),
+            _sse_bytes(
+                {
+                    "type": "message_delta",
+                    "usage": {
+                        "output_tokens": 30,
+                        "cache_read_input_tokens": 4000,
+                        "cache_creation_input_tokens": 120,
+                    },
+                }
+            ),
+        ]
+        response = AnthropicPassthroughLoggingHandler._build_usage_only_response_from_chunks(
+            all_chunks=chunks, model="claude-3-5-sonnet-20241022"
+        )
+        assert response is not None
+        usage = response.usage
+        assert usage._cache_read_input_tokens == 4000
+        assert usage._cache_creation_input_tokens == 120
+        # prompt_tokens must be cache-inclusive: input + cache_read + cache_creation
+        assert usage.prompt_tokens == 5 + 4000 + 120
+
     def test_build_usage_only_returns_none_without_usage_events(self):
         chunks = [_sse_bytes({"type": "content_block_delta", "delta": {"text": "hi"}})]
         assert (

--- a/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py
@@ -2066,6 +2066,42 @@ class TestAnthropicUsageOnlyFallback:
         assert usage.prompt_tokens_details.cached_tokens == 40
         assert usage.server_tool_use.web_search_requests == 2
 
+    def test_build_usage_only_recovers_cache_creation_from_message_delta(self):
+        # Bedrock Invoke reports the cache breakdown on the final chunk (the
+        # decoder lands invocationMetrics-derived usage on message_delta), while
+        # message_start carries no cache tokens. The fallback must recover both
+        # cache_read and cache_creation from the delta, not just cache_read.
+        chunks = [
+            _sse_bytes(
+                {
+                    "type": "message_start",
+                    "message": {
+                        "model": "claude-3-5-sonnet-20241022",
+                        "usage": {"input_tokens": 5, "output_tokens": 1},
+                    },
+                }
+            ),
+            _sse_bytes(
+                {
+                    "type": "message_delta",
+                    "usage": {
+                        "output_tokens": 30,
+                        "cache_read_input_tokens": 4000,
+                        "cache_creation_input_tokens": 120,
+                    },
+                }
+            ),
+        ]
+        response = AnthropicPassthroughLoggingHandler._build_usage_only_response_from_chunks(
+            all_chunks=chunks, model="claude-3-5-sonnet-20241022"
+        )
+        assert response is not None
+        usage = response.usage
+        assert usage._cache_read_input_tokens == 4000
+        assert usage._cache_creation_input_tokens == 120
+        # prompt_tokens must be cache-inclusive: input + cache_read + cache_creation
+        assert usage.prompt_tokens == 5 + 4000 + 120
+
     def test_build_usage_only_returns_none_without_usage_events(self):
         chunks = [_sse_bytes({"type": "content_block_delta", "delta": {"text": "hi"}})]
         assert (


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Invoke streaming drops `cacheRead`/`cacheWrite` token counts from usage → cache-heavy Claude traffic billed as fresh input (4–7× over-report)
- The usage-only recovery fallback also drops cache-write tokens on large/agentic streams

How it solves it:

- Map the two cache fields in the Invoke decoder, and read `cache_creation` from `message_delta` in the fallback — only when reported, no double-count

## Relevant issues

Fixes #34497

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduction: route an Anthropic Claude model over the Bedrock **Invoke** streaming path (`bedrock/invoke/…`) with a large cache-eligible prompt + `cache_control`. Pre-fix the returned `usage` has `input_tokens`/`output_tokens` but no `cache_read_input_tokens`/`cache_creation_input_tokens`, even though Bedrock reported `cacheReadInputTokenCount`/`cacheWriteInputTokenCount` in `amazon-bedrock-invocationMetrics` — so the cost calculator bills every request as fresh input.

```
$ pytest tests/test_litellm/llms/bedrock/messages/invoke_transformations/test_anthropic_claude3_transformation.py \
         tests/test_litellm/proxy/pass_through_endpoints/llm_provider_handlers/test_anthropic_passthrough_logging_handler.py \
         -k "chunk_parser_maps_cache or chunk_parser_omits_cache or recovers_cache_creation_from_message_delta"
6 passed
```

The fallback test is a negative control: it asserts `cache_creation_input_tokens == 120`; reverting only the handler change fails it at `assert 0 == 120`, confirming the fix is load-bearing.

_Live proof on a running proxy to be added._

<img width="1204" height="504" alt="image" src="https://github.com/user-attachments/assets/a3a63ff9-a9d4-4281-b9bc-6fb02b90bb98" />

## Type

🐛 Bug Fix

## Changes

For Anthropic Claude models on the Bedrock **Invoke** streaming path, the final chunk reports token usage in `amazon-bedrock-invocationMetrics`. The decoder mapped only `inputTokenCount`/`outputTokenCount` and dropped `cacheReadInputTokenCount`/`cacheWriteInputTokenCount`, so prompt-cache usage never reached `cache_read_input_tokens`/`cache_creation_input_tokens` and cache-heavy traffic was billed as fresh input.

- `AmazonAnthropicClaudeMessagesStreamDecoder._chunk_parser` (`litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py`) now maps `cacheReadInputTokenCount → cache_read_input_tokens` and `cacheWriteInputTokenCount → cache_creation_input_tokens` when present.
- `_build_usage_only_response_from_chunks` (`litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py`) read `cache_read_input_tokens` from `message_delta` but read `cache_creation_input_tokens` only from `message_start`; the `message_delta` branch now reads `cache_creation_input_tokens` too.

Notes for review:
- Distinct from `_promote_message_stop_usage`: that runs one stage later on fields already in snake_case on `message_start`/`message_stop`. On the Invoke path the cache counts exist only in the camelCase `invocationMetrics` block, so they were dropped before that step could see them — the two are complementary, not redundant.
- No double-count: the promote step is last-wins (assignment, not addition), and `inputTokenCount` is exclusive of cached tokens (a real chunk shows `inputTokenCount: 1` alongside `cacheReadInputTokenCount: 421714`), so `input_tokens` does not overlap the cache counts downstream.
- The fallback gap matters because the decoder lands cache usage on the final delta; on large/agentic streams that `stream_chunk_builder` cannot reassemble, cache-write tokens were silently priced at zero. Regression test covers exactly that recovery path.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
