### PR TITLE
feat(proxy): add include_model_table flag to /v2/team/list

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -4580,6 +4580,10 @@ async def list_team_v2(
     ),
     sort_order: str = fastapi.Query(default="asc", description="Sort order ('asc' or 'desc')"),
     status: str | None = fastapi.Query(default=None, description="Filter by status (e.g. 'deleted')"),
+    include_model_table: bool = fastapi.Query(
+        default=False,
+        description="Include the team's litellm_model_table relation (team-level model aliases) in each result.",
+    ),
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ):
     """
@@ -4604,6 +4608,9 @@ async def list_team_v2(
             Sort order ('asc' or 'desc')
         status: Optional[str]
             Filter by status. Currently supports "deleted" to query deleted teams.
+        include_model_table: bool
+            When True, load each team's litellm_model_table relation (team-level
+            model aliases). Defaults to False, leaving the response unchanged.
     """
     from litellm.proxy.proxy_server import (
         prisma_client,
@@ -4682,11 +4689,13 @@ async def list_team_v2(
         # Get total count for pagination
         total_count = await _deleted_team_db(prisma_client).count(where=where_conditions)
     else:
+        model_table_include: dict[str, bool] | None = {"litellm_model_table": True} if include_model_table else None
         teams = await _team_db(prisma_client).find_many(
             where=where_conditions,
             skip=skip,
             take=page_size,
             order=order_by if order_by else {"created_at": "desc"},  # Default sort
+            include=model_table_include,
         )
         # Get total count for pagination
         total_count = await _team_db(prisma_client).count(where=where_conditions)

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -10936,3 +10936,98 @@ def test_validate_member_user_id_provisioning_caps_the_ids_it_echoes_back():
     assert f"u{_MAX_REPORTED_UNKNOWN_USER_IDS}" not in detail
     assert f"and {500 - _MAX_REPORTED_UNKNOWN_USER_IDS} more" in detail
     assert len(detail) < 1000
+
+
+def _list_team_v2_mock_ctx(mock_repo_instance):
+    """Patches shared by the include_model_table tests: bypass auth/where/keys
+    aggregation and route the paginated fetch through mock_repo_instance."""
+    from litellm.proxy.management_endpoints import team_endpoints
+
+    return (
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch.object(team_endpoints, "TeamRepository", return_value=mock_repo_instance),
+        patch.object(
+            team_endpoints,
+            "_enforce_list_team_v2_access",
+            AsyncMock(return_value=(None, None)),
+        ),
+        patch.object(
+            team_endpoints,
+            "_build_team_list_where_conditions",
+            AsyncMock(return_value={}),
+        ),
+        patch.object(team_endpoints, "_get_keys_count_by_team", AsyncMock(return_value={})),
+    )
+
+
+async def _call_list_team_v2(*, include_model_table: bool):
+    from fastapi import Request
+
+    from litellm.proxy.management_endpoints.team_endpoints import list_team_v2
+
+    return await list_team_v2(
+        http_request=MagicMock(spec=Request),
+        user_id=None,
+        organization_id=None,
+        team_id=None,
+        team_alias=None,
+        search=None,
+        page=1,
+        page_size=10,
+        sort_by=None,
+        sort_order="asc",
+        status=None,
+        include_model_table=include_model_table,
+        user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN),
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_team_v2_include_model_table_true_loads_relation():
+    """
+    include_model_table=True must fetch the litellm_model_table relation and
+    surface it in each result, matching legacy /team/list behaviour.
+    """
+    team_row = LiteLLM_TeamTable(
+        team_id="team-1",
+        litellm_model_table=LiteLLM_ModelTable(
+            created_by="u",
+            updated_by="u",
+            model_aliases={"gpt-4o": "openai/gpt-4o"},
+        ),
+    )
+
+    mock_repo_instance = MagicMock()
+    mock_repo_instance.table.find_many = AsyncMock(return_value=[team_row])
+    mock_repo_instance.table.count = AsyncMock(return_value=1)
+
+    ctx = _list_team_v2_mock_ctx(mock_repo_instance)
+    with ctx[0], ctx[1], ctx[2], ctx[3], ctx[4], ctx[5], ctx[6]:
+        response = await _call_list_team_v2(include_model_table=True)
+
+    assert mock_repo_instance.table.find_many.await_args.kwargs["include"] == {"litellm_model_table": True}
+    returned_team = response["teams"][0]
+    assert returned_team.litellm_model_table is not None
+    assert returned_team.litellm_model_table.model_aliases == {"gpt-4o": "openai/gpt-4o"}
+
+
+@pytest.mark.asyncio
+async def test_list_team_v2_include_model_table_defaults_off():
+    """
+    Default (include_model_table=False) must not request the relation, so the
+    response is unchanged from before the flag existed (relation stays null).
+    """
+    team_row = LiteLLM_TeamTable(team_id="team-1")
+
+    mock_repo_instance = MagicMock()
+    mock_repo_instance.table.find_many = AsyncMock(return_value=[team_row])
+    mock_repo_instance.table.count = AsyncMock(return_value=1)
+
+    ctx = _list_team_v2_mock_ctx(mock_repo_instance)
+    with ctx[0], ctx[1], ctx[2], ctx[3], ctx[4], ctx[5], ctx[6]:
+        response = await _call_list_team_v2(include_model_table=False)
+
+    assert mock_repo_instance.table.find_many.await_args.kwargs["include"] is None
+    assert response["teams"][0].litellm_model_table is None

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -19500,6 +19500,9 @@ export interface paths {
          *             Sort order ('asc' or 'desc')
          *         status: Optional[str]
          *             Filter by status. Currently supports "deleted" to query deleted teams.
+         *         include_model_table: bool
+         *             When True, load each team's litellm_model_table relation (team-level
+         *             model aliases). Defaults to False, leaving the response unchanged.
          */
         get: operations["list_team_v2_v2_team_list_get"];
         put?: never;
@@ -60079,6 +60082,8 @@ export interface operations {
                 sort_order?: string;
                 /** @description Filter by status (e.g. 'deleted') */
                 status?: string | null;
+                /** @description Include the team's litellm_model_table relation (team-level model aliases) in each result. */
+                include_model_table?: boolean;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## TLDR

Problem this solves:

- /v2/team/list omitted the litellm_model_table relation that the legacy /team/list loads, so team-level model aliases came back null.

How it solves it:

- Add an opt-in include_model_table query param (default false, so existing behaviour is unchanged) that hydrates the relation on the active-teams fetch when set to true

## Relevant issues

https://github.com/BerriAI/litellm/issues/34394

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix



## Type

🆕 New Feature

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

After adding tests before adding implementation:
<img width="1515" height="118" alt="Screenshot 2026-07-24 at 16 38 40" src="https://github.com/user-attachments/assets/0b61fc10-ccb1-4d78-ad5a-a26a20691459" />

After adding implementation:
<img width="652" height="73" alt="Screenshot 2026-07-24 at 16 40 33" src="https://github.com/user-attachments/assets/2782dde3-745a-4453-9e82-dc96b8f2c4aa" />
