### PR TITLE
fix(proxy): replace per-chunk asyncio.to_thread with bounded queue for sync-iterator streams

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -263,6 +263,10 @@ REDIS_DAILY_TAG_SPEND_UPDATE_BUFFER_KEY = "litellm_daily_tag_spend_update_buffer
 MAX_REDIS_BUFFER_DEQUEUE_COUNT = int(os.getenv("MAX_REDIS_BUFFER_DEQUEUE_COUNT", 100))
 # Bounds asyncio.Queue() instances (log queues, spend update queues, etc.) to prevent unbounded memory growth
 LITELLM_ASYNCIO_QUEUE_MAXSIZE = int(os.getenv("LITELLM_ASYNCIO_QUEUE_MAXSIZE", 1000))
+# Bounds the dedicated thread pool for bridging synchronous provider streams (e.g. boto3 Bedrock)
+# into async consumers, separate from the general-purpose executor so a burst of concurrent
+# streams cannot starve unrelated background work.
+MAX_SYNC_STREAM_PRODUCER_THREADS = int(os.getenv("MAX_SYNC_STREAM_PRODUCER_THREADS", 100))
 TOOL_POLICY_CACHE_TTL_SECONDS = int(os.getenv("TOOL_POLICY_CACHE_TTL_SECONDS", 60))
 GUARDRAIL_SCANNED_MESSAGES_CACHE_TTL_SECONDS = int(
     os.getenv("GUARDRAIL_SCANNED_MESSAGES_CACHE_TTL_SECONDS", 24 * 60 * 60)

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -119,15 +119,31 @@ class _SyncToAsyncQueueIterator:
             raise item
         return item
 
-    async def aclose(self) -> None:
-        self._exhausted = True
-        self._closed.set()
-        await asyncio.to_thread(self._done.wait)
+    def _drain_queue_nowait(self) -> None:
         while not self._queue.empty():
             try:
                 self._queue.get_nowait()
             except asyncio.QueueEmpty:
                 break
+
+    async def aclose(self) -> None:
+        self._exhausted = True
+        self._closed.set()
+
+        async def _drain_until_done() -> None:
+            while True:
+                await self._queue.get()
+
+        drain_task = asyncio.ensure_future(_drain_until_done())
+        try:
+            await asyncio.to_thread(self._done.wait)
+        finally:
+            drain_task.cancel()
+            try:
+                await drain_task
+            except asyncio.CancelledError:
+                pass
+        self._drain_queue_nowait()
 
 
 def is_async_iterable(obj: Any) -> bool:

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -65,18 +65,19 @@ _GCHUNK_FIELDS: frozenset = frozenset(GChunk.__annotations__)
 
 
 class _SyncToAsyncQueueIterator:
-    __slots__ = ("_sync_iter", "_queue", "_thread", "_loop", "_exhausted", "_closed")
+    __slots__ = ("_sync_iter", "_queue", "_loop", "_exhausted", "_closed", "_done")
 
     def __init__(self, sync_iter: Any) -> None:
         from litellm.constants import LITELLM_ASYNCIO_QUEUE_MAXSIZE
+        from litellm.litellm_core_utils.thread_pool_executor import executor
 
         self._sync_iter = sync_iter
         self._loop = asyncio.get_running_loop()
         self._queue: asyncio.Queue = asyncio.Queue(maxsize=LITELLM_ASYNCIO_QUEUE_MAXSIZE)
         self._exhausted = False
-        self._closed = False
-        self._thread = threading.Thread(target=self._producer, daemon=True)
-        self._thread.start()
+        self._closed = threading.Event()
+        self._done = threading.Event()
+        executor.submit(self._producer)
 
     def _producer(self) -> None:
         def _put(item: Any) -> None:
@@ -90,14 +91,20 @@ class _SyncToAsyncQueueIterator:
 
         try:
             for item in self._sync_iter:
-                if self._closed:
+                if self._closed.is_set():
                     break
                 _put(item)
         except Exception as exc:
-            if not self._closed:
+            if not self._closed.is_set():
                 _put(exc)
         finally:
+            if self._closed.is_set() and hasattr(self._sync_iter, "close"):
+                try:
+                    self._sync_iter.close()
+                except Exception:
+                    pass
             _put(_SYNC_ITER_EXHAUSTED)
+            self._done.set()
 
     async def __anext__(self) -> Any:
         if self._exhausted:
@@ -111,10 +118,9 @@ class _SyncToAsyncQueueIterator:
         return item
 
     async def aclose(self) -> None:
-        self._closed = True
         self._exhausted = True
-        if hasattr(self._sync_iter, "close"):
-            self._sync_iter.close()
+        self._closed.set()
+        await asyncio.to_thread(self._done.wait, 5)
         while not self._queue.empty():
             try:
                 self._queue.get_nowait()

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -100,14 +100,14 @@ class _SyncToAsyncQueueIterator:
                 if self._closed.is_set():
                     break
                 _put(item)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - forwarded to the async consumer, not swallowed
             if not self._closed.is_set():
                 _put(exc)
         finally:
             if self._closed.is_set() and hasattr(self._sync_iter, "close"):
                 try:
                     self._sync_iter.close()
-                except Exception:
+                except Exception:  # noqa: BLE001 - best-effort cleanup must not mask the real exhaustion signal
                     pass
             _put(_SYNC_ITER_EXHAUSTED)
             self._done.set()
@@ -141,7 +141,7 @@ class _SyncToAsyncQueueIterator:
             if hasattr(self._sync_iter, "close"):
                 try:
                     self._sync_iter.close()
-                except Exception:
+                except Exception:  # noqa: BLE001 - best-effort cleanup, aclose() must not raise
                     pass
             self._done.set()
 

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -69,7 +69,9 @@ class _SyncToAsyncQueueIterator:
 
     def __init__(self, sync_iter: Any) -> None:
         from litellm.constants import LITELLM_ASYNCIO_QUEUE_MAXSIZE
-        from litellm.litellm_core_utils.thread_pool_executor import executor
+        from litellm.litellm_core_utils.sync_stream_producer_executor import (
+            sync_stream_producer_executor,
+        )
 
         self._sync_iter = sync_iter
         self._loop = asyncio.get_running_loop()
@@ -77,7 +79,7 @@ class _SyncToAsyncQueueIterator:
         self._exhausted = False
         self._closed = threading.Event()
         self._done = threading.Event()
-        executor.submit(self._producer)
+        sync_stream_producer_executor.submit(self._producer)
 
     def _producer(self) -> None:
         def _put(item: Any) -> None:
@@ -120,7 +122,7 @@ class _SyncToAsyncQueueIterator:
     async def aclose(self) -> None:
         self._exhausted = True
         self._closed.set()
-        await asyncio.to_thread(self._done.wait, 5)
+        await asyncio.to_thread(self._done.wait)
         while not self._queue.empty():
             try:
                 self._queue.get_nowait()

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections.abc
+import concurrent.futures
 import datetime
 import json
 import logging
@@ -63,18 +64,62 @@ _SYNC_ITER_EXHAUSTED = object()
 _GCHUNK_FIELDS: frozenset = frozenset(GChunk.__annotations__)
 
 
-def _next_sync_or_exhausted(it: Any) -> Any:
-    """
-    Call next(it) from a thread and return _SYNC_ITER_EXHAUSTED on StopIteration.
+class _SyncToAsyncQueueIterator:
+    __slots__ = ("_sync_iter", "_queue", "_thread", "_loop", "_exhausted", "_closed")
 
-    asyncio.to_thread re-raises thread exceptions inside a coroutine, where PEP 479
-    converts StopIteration to RuntimeError before any except clause can catch it.
-    Returning a sentinel instead keeps StopIteration out of the coroutine boundary.
-    """
-    try:
-        return next(it)
-    except StopIteration:
-        return _SYNC_ITER_EXHAUSTED
+    def __init__(self, sync_iter: Any) -> None:
+        from litellm.constants import LITELLM_ASYNCIO_QUEUE_MAXSIZE
+
+        self._sync_iter = sync_iter
+        self._loop = asyncio.get_running_loop()
+        self._queue: asyncio.Queue = asyncio.Queue(maxsize=LITELLM_ASYNCIO_QUEUE_MAXSIZE)
+        self._exhausted = False
+        self._closed = False
+        self._thread = threading.Thread(target=self._producer, daemon=True)
+        self._thread.start()
+
+    def _producer(self) -> None:
+        def _put(item: Any) -> None:
+            try:
+                future = asyncio.run_coroutine_threadsafe(self._queue.put(item), self._loop)
+                future.result()
+            except RuntimeError:
+                pass
+            except concurrent.futures.CancelledError:
+                pass
+
+        try:
+            for item in self._sync_iter:
+                if self._closed:
+                    break
+                _put(item)
+        except Exception as exc:
+            if not self._closed:
+                _put(exc)
+        finally:
+            _put(_SYNC_ITER_EXHAUSTED)
+
+    async def __anext__(self) -> Any:
+        if self._exhausted:
+            raise StopAsyncIteration
+        item = await self._queue.get()
+        if item is _SYNC_ITER_EXHAUSTED:
+            self._exhausted = True
+            raise StopAsyncIteration
+        if isinstance(item, BaseException):
+            raise item
+        return item
+
+    async def aclose(self) -> None:
+        self._closed = True
+        self._exhausted = True
+        if hasattr(self._sync_iter, "close"):
+            self._sync_iter.close()
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
 
 
 def is_async_iterable(obj: Any) -> bool:
@@ -1982,9 +2027,9 @@ class CustomStreamWrapper:
                     if isinstance(self.completion_stream, str) or isinstance(self.completion_stream, bytes):
                         chunk = self.completion_stream
                     else:
-                        chunk = await asyncio.to_thread(_next_sync_or_exhausted, self.completion_stream)  # type: ignore[arg-type]
-                        if chunk is _SYNC_ITER_EXHAUSTED:
-                            raise StopAsyncIteration
+                        if not isinstance(self.completion_stream, _SyncToAsyncQueueIterator):
+                            self.completion_stream = _SyncToAsyncQueueIterator(self.completion_stream)
+                        chunk = await self.completion_stream.__anext__()
                     if chunk is not None and chunk != b"":
                         processed_chunk = self.chunk_creator(chunk=chunk)
                         if processed_chunk is None:

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -135,8 +135,14 @@ class _SyncToAsyncQueueIterator:
         self._closed.set()
 
         if self._producer_future.cancel():
-            # The producer was still queued behind other work on the shared
-            # executor and never started, so it will never set _done itself.
+            # The producer task never ran, so it never touched the sync
+            # iterator - safe to close it directly here, no other thread
+            # is executing it.
+            if hasattr(self._sync_iter, "close"):
+                try:
+                    self._sync_iter.close()
+                except Exception:
+                    pass
             self._done.set()
 
         async def _drain_until_done() -> None:

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -65,7 +65,7 @@ _GCHUNK_FIELDS: frozenset = frozenset(GChunk.__annotations__)
 
 
 class _SyncToAsyncQueueIterator:
-    __slots__ = ("_sync_iter", "_queue", "_loop", "_exhausted", "_closed", "_done")
+    __slots__ = ("_sync_iter", "_queue", "_loop", "_exhausted", "_closed", "_done", "_producer_future")
 
     def __init__(self, sync_iter: Any) -> None:
         from litellm.constants import LITELLM_ASYNCIO_QUEUE_MAXSIZE
@@ -79,7 +79,7 @@ class _SyncToAsyncQueueIterator:
         self._exhausted = False
         self._closed = threading.Event()
         self._done = threading.Event()
-        sync_stream_producer_executor.submit(self._producer)
+        self._producer_future = sync_stream_producer_executor.submit(self._producer)
 
     def _producer(self) -> None:
         def _put(item: Any) -> None:
@@ -90,6 +90,10 @@ class _SyncToAsyncQueueIterator:
                 pass
             except concurrent.futures.CancelledError:
                 pass
+
+        if self._closed.is_set():
+            self._done.set()
+            return
 
         try:
             for item in self._sync_iter:
@@ -129,6 +133,11 @@ class _SyncToAsyncQueueIterator:
     async def aclose(self) -> None:
         self._exhausted = True
         self._closed.set()
+
+        if self._producer_future.cancel():
+            # The producer was still queued behind other work on the shared
+            # executor and never started, so it will never set _done itself.
+            self._done.set()
 
         async def _drain_until_done() -> None:
             while True:

--- a/litellm/litellm_core_utils/sync_stream_producer_executor.py
+++ b/litellm/litellm_core_utils/sync_stream_producer_executor.py
@@ -1,0 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from litellm.constants import MAX_SYNC_STREAM_PRODUCER_THREADS
+
+sync_stream_producer_executor = ThreadPoolExecutor(max_workers=MAX_SYNC_STREAM_PRODUCER_THREADS)

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -3638,6 +3638,69 @@ async def test_sync_to_async_queue_iterator_aclose_cancels_queued_producer():
     assert wrapper._producer_future.cancelled()
 
 
+def test_sync_to_async_queue_iterator_producer_exits_early_if_already_closed():
+    """
+    Regression: if _closed is already set by the time _producer() actually
+    starts running (e.g. cancel() raced and lost against the task starting),
+    the producer must not touch the sync iterator at all - just signal done.
+    """
+
+    class NeverCalledIter:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise AssertionError("producer must not iterate once _closed is set")
+
+    wrapper = object.__new__(_SyncToAsyncQueueIterator)
+    wrapper._sync_iter = NeverCalledIter()
+    wrapper._loop = asyncio.new_event_loop()
+    wrapper._queue = asyncio.Queue()
+    wrapper._exhausted = False
+    wrapper._closed = threading.Event()
+    wrapper._closed.set()
+    wrapper._done = threading.Event()
+
+    wrapper._producer()
+
+    assert wrapper._done.is_set()
+    wrapper._loop.close()
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_producer_swallows_close_exception_on_exhaustion():
+    """
+    Regression: when the producer itself closes the sync iterator after being
+    signalled to stop (the producer-was-already-running path, not the
+    cancelled-before-start one), a close() failure must not prevent the
+    exhaustion sentinel and _done from being set.
+    """
+    entered_next = threading.Event()
+    release_producer = threading.Event()
+
+    class ExplodingCloseSlowIter:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            entered_next.set()
+            release_producer.wait(timeout=2)
+            return "chunk"
+
+        def close(self):
+            raise RuntimeError("close failed")
+
+    wrapper = _SyncToAsyncQueueIterator(ExplodingCloseSlowIter())
+    await asyncio.to_thread(entered_next.wait, 2)
+
+    close_task = asyncio.create_task(wrapper.aclose())
+    await asyncio.sleep(0.05)
+    release_producer.set()
+    await close_task
+
+    assert wrapper._done.is_set()
+
+
 @pytest.mark.asyncio
 async def test_sync_to_async_queue_iterator_aclose_swallows_close_exception():
     class ExplodingCloseIter:

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -20,6 +20,7 @@ from litellm.litellm_core_utils.streaming_handler import (
     CustomStreamWrapper,
     _ProviderChunkEarlyReturn,
     _ProviderChunkParsed,
+    _SyncToAsyncQueueIterator,
 )
 from litellm.types.utils import (
     CompletionTokensDetailsWrapper,
@@ -3355,3 +3356,182 @@ async def test_transport_read_error_before_finish_reason_raises(logging_obj: Log
         if chunk.choices and chunk.choices[0].finish_reason
     ]
     assert fabricated_finish_reasons == []
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_delivers_items_in_order():
+    items = [1, 2, 3, 4, 5]
+    wrapper = _SyncToAsyncQueueIterator(iter(items))
+    received = []
+    try:
+        while True:
+            received.append(await wrapper.__anext__())
+    except StopAsyncIteration:
+        pass
+    assert received == items
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_raises_stop_async_iteration_when_exhausted():
+    wrapper = _SyncToAsyncQueueIterator(iter([42]))
+    assert await wrapper.__anext__() == 42
+    with pytest.raises(StopAsyncIteration):
+        await wrapper.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_propagates_sync_iterator_exceptions():
+    def _exploding_iter():
+        yield 1
+        raise ValueError("upstream failure")
+
+    wrapper = _SyncToAsyncQueueIterator(_exploding_iter())
+    assert await wrapper.__anext__() == 1
+    with pytest.raises(ValueError, match="upstream failure"):
+        await wrapper.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_does_not_block_event_loop():
+    class SlowIter:
+        def __init__(self):
+            self._done = False
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self._done:
+                raise StopIteration
+            self._done = True
+            time.sleep(0.2)  # simulate blocking I/O
+            return "chunk"
+
+    wrapper = _SyncToAsyncQueueIterator(SlowIter())
+    tick_ran = asyncio.Event()
+
+    async def background_tick():
+        await asyncio.sleep(0.05)
+        tick_ran.set()
+
+    start = asyncio.get_event_loop().time()
+    item, _ = await asyncio.gather(wrapper.__anext__(), background_tick())
+    elapsed = asyncio.get_event_loop().time() - start
+
+    assert item == "chunk"
+    assert tick_ran.is_set(), "Background coroutine never ran — event loop was blocked"
+    assert elapsed < 0.4, f"Took too long ({elapsed:.2f}s), event loop likely blocked"
+
+
+@pytest.mark.asyncio
+async def test_custom_stream_wrapper_bedrock_path_uses_queue_iterator(
+    logging_obj: Logging,
+):
+    class FakeSyncIter:
+        def __init__(self, chunks):
+            self._it = iter(chunks)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self._it)
+
+    chunk = ModelResponseStream(
+        id="chatcmpl-bedrock-test",
+        created=int(time.time()),
+        model="test-model",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(
+                    provider_specific_fields=None,
+                    content="hello",
+                    role="assistant",
+                    function_call=None,
+                    tool_calls=None,
+                    audio=None,
+                ),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields={},
+        usage=None,
+    )
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=FakeSyncIter([chunk]),
+        model="test-model",
+        logging_obj=logging_obj,
+        custom_llm_provider="cached_response",
+    )
+
+    try:
+        while True:
+            await wrapper.__anext__()
+    except StopAsyncIteration:
+        pass
+
+    assert isinstance(wrapper.completion_stream, _SyncToAsyncQueueIterator)
+
+
+@pytest.mark.asyncio
+async def test_custom_stream_wrapper_aclose_closes_upgraded_sync_iterator(
+    logging_obj: Logging,
+):
+    close_calls = []
+
+    class FakeSyncIter:
+        def __init__(self, chunks):
+            self._it = iter(chunks)
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            return next(self._it)
+
+        def close(self):
+            close_calls.append(True)
+
+    chunk = ModelResponseStream(
+        id="chatcmpl-bedrock-test-close",
+        created=int(time.time()),
+        model="test-model",
+        object="chat.completion.chunk",
+        system_fingerprint=None,
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(
+                    provider_specific_fields=None,
+                    content="hello",
+                    role="assistant",
+                    function_call=None,
+                    tool_calls=None,
+                    audio=None,
+                ),
+                logprobs=None,
+            )
+        ],
+        provider_specific_fields={},
+        usage=None,
+    )
+
+    wrapper = CustomStreamWrapper(
+        completion_stream=FakeSyncIter([chunk, chunk, chunk]),
+        model="test-model",
+        logging_obj=logging_obj,
+        custom_llm_provider="cached_response",
+    )
+
+    await wrapper.__anext__()
+    assert isinstance(wrapper.completion_stream, _SyncToAsyncQueueIterator)
+
+    await wrapper.aclose()
+
+    assert close_calls == [True]

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -10,6 +10,7 @@ sys.path.insert(
     0, os.path.abspath("../../..")
 )  # Adds the parent directory to the system path
 import asyncio
+import threading
 import traceback
 from typing import Optional
 
@@ -3535,3 +3536,33 @@ async def test_custom_stream_wrapper_aclose_closes_upgraded_sync_iterator(
     await wrapper.aclose()
 
     assert close_calls == [True]
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_aclose_while_producer_blocked_in_next():
+    close_calls = []
+    release_producer = threading.Event()
+
+    class SlowSyncIter:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            release_producer.wait(timeout=2)
+            return "chunk"
+
+        def close(self):
+            close_calls.append(threading.current_thread())
+
+    wrapper = _SyncToAsyncQueueIterator(SlowSyncIter())
+
+    close_task = asyncio.create_task(wrapper.aclose())
+    await asyncio.sleep(0.05)
+    release_producer.set()
+    await close_task
+
+    assert len(close_calls) == 1
+    assert close_calls[0] is not threading.current_thread(), (
+        "close() must run on the producer thread, not the event-loop thread, "
+        "to avoid 'generator already executing' when the producer is mid-next()"
+    )

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -3601,6 +3601,37 @@ async def test_sync_to_async_queue_iterator_aclose_does_not_deadlock_on_full_que
 
 
 @pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_aclose_cancels_queued_producer():
+    """
+    Regression: if the shared producer executor is saturated, the producer task
+    can still be queued (not yet started) when aclose() runs. In that case the
+    task's own _closed check never executes, so _done would never be set unless
+    aclose() cancels the still-queued future itself.
+    """
+    import concurrent.futures
+
+    class NeverCalledIter:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise AssertionError("producer must not run once its future is cancelled")
+
+    wrapper = object.__new__(_SyncToAsyncQueueIterator)
+    wrapper._sync_iter = NeverCalledIter()
+    wrapper._loop = asyncio.get_running_loop()
+    wrapper._queue = asyncio.Queue()
+    wrapper._exhausted = False
+    wrapper._closed = threading.Event()
+    wrapper._done = threading.Event()
+    wrapper._producer_future = concurrent.futures.Future()  # never started, still cancellable
+
+    await asyncio.wait_for(wrapper.aclose(), timeout=2)
+
+    assert wrapper._producer_future.cancelled()
+
+
+@pytest.mark.asyncio
 async def test_sync_to_async_queue_iterator_aclose_swallows_close_exception():
     class ExplodingCloseIter:
         def __iter__(self):

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -3569,6 +3569,38 @@ async def test_sync_to_async_queue_iterator_aclose_while_producer_blocked_in_nex
 
 
 @pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_aclose_does_not_deadlock_on_full_queue():
+    """
+    Regression: a producer blocked in queue.put() (bounded queue full because the
+    consumer stopped reading) must not deadlock against aclose() waiting for the
+    producer to finish before draining the queue. aclose() must drain concurrently.
+    """
+    import litellm.constants as litellm_constants
+
+    monkeypatch_maxsize = litellm_constants.LITELLM_ASYNCIO_QUEUE_MAXSIZE
+    litellm_constants.LITELLM_ASYNCIO_QUEUE_MAXSIZE = 2
+    try:
+        produced = []
+
+        class FastSyncIter:
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                produced.append(1)
+                if len(produced) > 10:
+                    raise StopIteration
+                return "chunk"
+
+        wrapper = _SyncToAsyncQueueIterator(FastSyncIter())
+        await asyncio.sleep(0.05)  # let the producer fill the bounded queue and block on put()
+
+        await asyncio.wait_for(wrapper.aclose(), timeout=2)
+    finally:
+        litellm_constants.LITELLM_ASYNCIO_QUEUE_MAXSIZE = monkeypatch_maxsize
+
+
+@pytest.mark.asyncio
 async def test_sync_to_async_queue_iterator_aclose_swallows_close_exception():
     class ExplodingCloseIter:
         def __iter__(self):
@@ -3585,8 +3617,8 @@ async def test_sync_to_async_queue_iterator_aclose_swallows_close_exception():
 
 
 @pytest.mark.asyncio
-async def test_sync_to_async_queue_iterator_aclose_drains_queue_race():
-    """Cover the QueueEmpty branch of aclose()'s drain loop, which guards
+async def test_sync_to_async_queue_iterator_drain_queue_nowait_handles_race():
+    """Cover the QueueEmpty branch of _drain_queue_nowait(), which guards
     against get_nowait() racing ahead of empty() reporting a non-empty queue."""
 
     class NeverYieldsIter:
@@ -3600,16 +3632,13 @@ async def test_sync_to_async_queue_iterator_aclose_drains_queue_race():
     wrapper._queue.empty = lambda: False
     wrapper._queue.get_nowait = Mock(side_effect=asyncio.QueueEmpty())
 
-    await wrapper.aclose()
+    wrapper._drain_queue_nowait()
 
 
 def test_sync_to_async_queue_iterator_producer_survives_cancelled_put():
     import concurrent.futures
 
-    from litellm.litellm_core_utils.streaming_handler import (
-        _SYNC_ITER_EXHAUSTED,
-        _SyncToAsyncQueueIterator,
-    )
+    from litellm.litellm_core_utils.streaming_handler import _SyncToAsyncQueueIterator
 
     class DummyLoop:
         pass

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -3566,3 +3566,69 @@ async def test_sync_to_async_queue_iterator_aclose_while_producer_blocked_in_nex
         "close() must run on the producer thread, not the event-loop thread, "
         "to avoid 'generator already executing' when the producer is mid-next()"
     )
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_aclose_swallows_close_exception():
+    class ExplodingCloseIter:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise StopIteration
+
+        def close(self):
+            raise RuntimeError("close failed")
+
+    wrapper = _SyncToAsyncQueueIterator(ExplodingCloseIter())
+    await wrapper.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sync_to_async_queue_iterator_aclose_drains_queue_race():
+    """Cover the QueueEmpty branch of aclose()'s drain loop, which guards
+    against get_nowait() racing ahead of empty() reporting a non-empty queue."""
+
+    class NeverYieldsIter:
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise StopIteration
+
+    wrapper = _SyncToAsyncQueueIterator(NeverYieldsIter())
+    wrapper._queue.empty = lambda: False
+    wrapper._queue.get_nowait = Mock(side_effect=asyncio.QueueEmpty())
+
+    await wrapper.aclose()
+
+
+def test_sync_to_async_queue_iterator_producer_survives_cancelled_put():
+    import concurrent.futures
+
+    from litellm.litellm_core_utils.streaming_handler import (
+        _SYNC_ITER_EXHAUSTED,
+        _SyncToAsyncQueueIterator,
+    )
+
+    class DummyLoop:
+        pass
+
+    wrapper = object.__new__(_SyncToAsyncQueueIterator)
+    wrapper._sync_iter = iter(["chunk"])
+    wrapper._loop = DummyLoop()
+    wrapper._queue = asyncio.Queue()
+    wrapper._closed = threading.Event()
+    wrapper._done = threading.Event()
+    put_calls = []
+
+    def _raise_cancelled(coro, loop):
+        put_calls.append(coro)
+        coro.close()
+        raise concurrent.futures.CancelledError()
+
+    with patch("asyncio.run_coroutine_threadsafe", side_effect=_raise_cancelled):
+        wrapper._producer()
+
+    assert len(put_calls) == 2  # the chunk, then the exhaustion sentinel
+    assert wrapper._done.is_set()

--- a/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
+++ b/tests/test_litellm/litellm_core_utils/test_streaming_handler.py
@@ -3541,6 +3541,7 @@ async def test_custom_stream_wrapper_aclose_closes_upgraded_sync_iterator(
 @pytest.mark.asyncio
 async def test_sync_to_async_queue_iterator_aclose_while_producer_blocked_in_next():
     close_calls = []
+    entered_next = threading.Event()
     release_producer = threading.Event()
 
     class SlowSyncIter:
@@ -3548,6 +3549,7 @@ async def test_sync_to_async_queue_iterator_aclose_while_producer_blocked_in_nex
             return self
 
         def __next__(self):
+            entered_next.set()
             release_producer.wait(timeout=2)
             return "chunk"
 
@@ -3555,6 +3557,11 @@ async def test_sync_to_async_queue_iterator_aclose_while_producer_blocked_in_nex
             close_calls.append(threading.current_thread())
 
     wrapper = _SyncToAsyncQueueIterator(SlowSyncIter())
+
+    # Wait for the producer to actually be inside next() before closing, so
+    # this test exercises "producer mid-next()" rather than racing against
+    # the executor not having started the task yet.
+    await asyncio.to_thread(entered_next.wait, 2)
 
     close_task = asyncio.create_task(wrapper.aclose())
     await asyncio.sleep(0.05)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock (sync-iterator) streams deliver chunks in bursts
- Caused by a fresh asyncio.to_thread dispatch per chunk

How it solves it:

- Replace per-chunk dispatch with one producer thread + a queue
- Bound the queue for real backpressure, no dropped chunks

## Relevant issues

Fixes #34502

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproduced and measured against real AWS Bedrock (`bedrock/converse/us.anthropic.claude-3-haiku-20240307-v1:0`, `us-east-1`), calling the SDK directly and synchronously (`litellm.completion(..., stream=True)`, the code path that hits the sync-iterator branch):

```python
import time
import litellm

response = litellm.completion(
    model="bedrock/converse/us.anthropic.claude-3-haiku-20240307-v1:0",
    messages=[{"role": "user", "content": "Count slowly from 1 to 200, one number per line, nothing else."}],
    stream=True,
    aws_region_name="us-east-1",
)

times = []
for chunk in response:
    times.append(time.time())

gaps_ms = [(times[i + 1] - times[i]) * 1000 for i in range(len(times) - 1)]
under_1ms = sum(1 for g in gaps_ms if g < 1)
print(f"{under_1ms}/{len(gaps_ms)} gaps under 1ms")
```

Before this PR, commit `42aba4f32a4238de6686d2a62c410d4eb6e5cdb4` (current `litellm_internal_staging` tip):

```
77/201 gaps under 1ms
```

201 chunks, 38.3% arriving under 1ms apart, interleaved with normal-length gaps: `[15.326, 23.467, 0.596, 16.793, 21.014, 1.335, 20.138, 21.278, 0.835, 47.276, 0.24, 0.664, 3.937, 10.24, 0.374, 19.309, 0.212, 20.186, 0.78, 20.92]` (first 20 gaps, ms) — the bursty pattern.

After this PR, same commit hash for this branch's HEAD:

```
0/103 gaps under 1ms
```

103 chunks, every gap in the normal ~20-25ms range: `[20.191, 43.129, 22.731, 23.522, 22.322, 21.722, 21.398, 22.653, 21.891, 23.453, 20.488, 23.326, 22.743, 24.301, 20.834, 20.516, 23.607, 21.181, 23.148, 24.389]` (first 20 gaps, ms) — matches direct (non-litellm) boto3 streaming cadence.

Note: this bug only reproduces via the direct synchronous SDK call (`litellm.completion(stream=True)`, no `a` prefix). It does not reproduce through the `litellm` proxy server or `litellm.acompletion(...)`, since those always route through Bedrock's async streaming branch and never construct a `CustomStreamWrapper` around a genuinely synchronous iterator.

## Type

🐛 Bug Fix

## Changes

- `litellm/litellm_core_utils/streaming_handler.py`: replace the per-chunk `asyncio.to_thread(_next_sync_or_exhausted, ...)` dispatch in `CustomStreamWrapper.__anext__`'s sync-iterator branch with a `_SyncToAsyncQueueIterator` wrapper. One daemon producer thread iterates the sync stream continuously and pushes items into a bounded `asyncio.Queue` (bounded via the existing `LITELLM_ASYNCIO_QUEUE_MAXSIZE` constant, previously unwired in this path) using `run_coroutine_threadsafe(queue.put(item), loop).result()` for real backpressure. The wrapper intentionally omits `__aiter__` so `is_async_iterable()` keeps routing chunks through the same branch instead of switching to the async-for path partway through a stream. `aclose()` closes the underlying sync iterator and drains the queue so cancellation still releases the connection.
- `tests/test_litellm/litellm_core_utils/test_streaming_handler.py`: unit tests for ordering, exhaustion, exception propagation, non-blocking behavior, the Bedrock lazy-upgrade path, and `aclose()` closing the wrapped sync iterator.

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
