### PR TITLE
fix(anthropic/adapter): copy input_schema so tool translation stops mutating caller's dict

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -768,7 +768,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 name=truncated_name,
             )
             if "input_schema" in tool:
-                function_chunk["parameters"] = tool["input_schema"]  # type: ignore
+                function_chunk["parameters"] = dict(tool["input_schema"] or {})  # type: ignore
             if "description" in tool:
                 function_chunk["description"] = tool["description"]  # type: ignore
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -767,7 +767,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 name=truncated_name,
             )
             if "input_schema" in tool:
-                function_chunk["parameters"] = tool["input_schema"]
+                function_chunk["parameters"] = dict(tool["input_schema"] or {})  # type: ignore
             if "description" in tool:
                 function_chunk["description"] = tool["description"]
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -3147,3 +3147,29 @@ def test_translate_anthropic_tools_to_openai_preserves_parameters_type():
     params = new_tools[0]["function"]["parameters"]
     assert params["type"] == "object"
     assert new_tools[0]["type"] == "function"
+
+
+def test_translate_anthropic_tools_to_openai_does_not_mutate_input_schema():
+    """The caller's input_schema must not be mutated: extra top-level tool keys
+    (e.g. computer-tool display_* kwargs) are merged into the OpenAI parameters
+    but must never leak back into the source tool dict, which callers reuse."""
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    input_schema = {"type": "object", "properties": {"action": {"type": "string"}}}
+    tool = {
+        "name": "computer",
+        "type": "computer_20241022",
+        "input_schema": input_schema,
+        "display_width_px": 1024,
+        "display_height_px": 768,
+    }
+
+    new_tools, _ = adapter.translate_anthropic_tools_to_openai(tools=[tool])
+
+    params = new_tools[0]["function"]["parameters"]
+    # vendor kwargs land in the translated parameters ...
+    assert params["display_width_px"] == 1024
+    assert params["display_height_px"] == 768
+    # ... but the caller's schema is untouched
+    assert input_schema == {"type": "object", "properties": {"action": {"type": "string"}}}
+    assert "display_width_px" not in input_schema
+    assert tool["input_schema"] is input_schema

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -3508,3 +3508,29 @@ def test_translate_anthropic_tools_to_openai_preserves_parameters_type():
     params = new_tools[0]["function"]["parameters"]
     assert params["type"] == "object"
     assert new_tools[0]["type"] == "function"
+
+
+def test_translate_anthropic_tools_to_openai_does_not_mutate_input_schema():
+    """The caller's input_schema must not be mutated: extra top-level tool keys
+    (e.g. computer-tool display_* kwargs) are merged into the OpenAI parameters
+    but must never leak back into the source tool dict, which callers reuse."""
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    input_schema = {"type": "object", "properties": {"action": {"type": "string"}}}
+    tool = {
+        "name": "computer",
+        "type": "computer_20241022",
+        "input_schema": input_schema,
+        "display_width_px": 1024,
+        "display_height_px": 768,
+    }
+
+    new_tools, _ = adapter.translate_anthropic_tools_to_openai(tools=[tool])
+
+    params = new_tools[0]["function"]["parameters"]
+    # vendor kwargs land in the translated parameters ...
+    assert params["display_width_px"] == 1024
+    assert params["display_height_px"] == 768
+    # ... but the caller's schema is untouched
+    assert input_schema == {"type": "object", "properties": {"action": {"type": "string"}}}
+    assert "display_width_px" not in input_schema
+    assert tool["input_schema"] is input_schema


### PR DESCRIPTION
## TLDR

Problem this solves:

- Anthropic→OpenAI tool translation mutates the caller's `input_schema` in place
- Reused tool lists get polluted with non-schema keys on the second translation

How it solves it:

- Shallow-copy `input_schema` before assigning it to `parameters`
- The vendor-kwargs loop now writes to the copy, never the source

## Relevant issues

Fixes #34510

## Linear ticket

<!-- external contributor: none -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

`translate_anthropic_tools_to_openai` assigned the caller's `input_schema` dict to `function_chunk["parameters"]` by reference, then the trailing "pass additional kwargs" loop mutated it in place — merging non-schema top-level tool keys (e.g. a `computer` tool's `display_width_px` / `display_height_px`) back into the caller's original `input_schema`. Callers reuse the same in-memory tool list across translations (the Anthropic-passthrough guardrail pre-call hook translates once, the real request translates again), so the second pass forwards a polluted schema — which schema-validating providers can reject.

Fix: shallow-copy the schema before assigning, so the source tool is never touched.

```python
function_chunk["parameters"] = dict(tool["input_schema"] or {})
```

This mirrors the existing in-file precedent in `translate_anthropic_output_format_to_openai`, which already `copy.deepcopy`s the schema "to avoid mutating the original schema". A shallow copy is sufficient here because the mutation only adds top-level keys.

Note: #29669 proposed the same copy fix bundled with a `type`-into-`parameters` change; the `type` half has since landed on `main`, so this PR isolates the still-unfixed aliasing/mutation half.

## Screenshots / Proof of Fix

Test proves the fix (added in this PR):

- **Without the fix** — `test_translate_anthropic_tools_to_openai_does_not_mutate_input_schema` FAILS: the caller's `input_schema` gains `display_width_px` / `display_height_px`.
- **With the fix** — PASSES: vendor kwargs land in the translated `parameters`, the source `input_schema` is unchanged.

```
$ python -m pytest tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py::test_translate_anthropic_tools_to_openai_does_not_mutate_input_schema -q
.                                                                        [100%]
1 passed
```
