### PR TITLE
test: replace deprecated gpt-5-codex with gpt-5.3-codex

### DIFF
--- a/tests/llm_translation/test_openai.py
+++ b/tests/llm_translation/test_openai.py
@@ -838,7 +838,7 @@ def test_gpt_5_reasoning_streaming():
 def test_openai_gpt_5_codex_reasoning():
     litellm._turn_on_debug()
     completion_kwargs = {
-        "model": "gpt-5-codex",
+        "model": "gpt-5.3-codex",
         "messages": [
             {
                 "role": "system",


### PR DESCRIPTION
## TLDR

Problem this solves:

- test_openai_gpt_5_codex_reasoning fails on every run
- OpenAI deprecated gpt-5-codex, so the API rejects the request

How it solves it:

- points the test at gpt-5.3-codex, the newest codex model

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

The test itself is the end-to-end call: it streams a real chat completion against the live OpenAI API (no mocks, real $). Before, with the test file at the branch point 5e98e8f196 (model still gpt-5-codex):

```
pytest tests/llm_translation/test_openai.py::test_openai_gpt_5_codex_reasoning -x -q

E           litellm.exceptions.APIError: litellm.APIError: The model `gpt-5-codex` has been deprecated, learn more here: https://platform.openai.com/docs/deprecations
FAILED tests/llm_translation/test_openai.py::test_openai_gpt_5_codex_reasoning
1 failed in 1.04s
```

After, at d6fd9d8579 (this PR):

```
pytest tests/llm_translation/test_openai.py::test_openai_gpt_5_codex_reasoning -x -q

1 passed in 1.06s
```

gpt-5.3-codex is a drop-in replacement per model_prices_and_context_window.json: responses-only mode, streaming, function calling and reasoning, same as the old entry

## Type

✅ Test

## Changes

One line in tests/llm_translation/test_openai.py: the model string in test_openai_gpt_5_codex_reasoning goes from gpt-5-codex to gpt-5.3-codex

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
