### PR TITLE
fix(anthropic): preserve Kimi K2 tool_use ids on non-Anthropic dispatch

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -1063,7 +1063,7 @@ def _sanitize_tool_use_id_content_block(block: Any, *, preserve_kimi_k2_ids: boo
     return block
 
 
-def sanitize_tool_use_ids_in_anthropic_messages(messages: list[Any], model: Optional[str] = None) -> list[Any]:
+def sanitize_tool_use_ids_in_anthropic_messages(messages: list[Any], model: str | None = None) -> list[Any]:
     """
     Return a new message list with ``tool_use`` / ``server_tool_use`` ``id`` and
     ``tool_result`` ``tool_use_id`` values rewritten to satisfy Anthropic's

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -1001,39 +1001,69 @@ def _is_empty_text_block(block: Any) -> bool:
     return not isinstance(text, str) or not text.strip()
 
 
-def normalize_anthropic_tool_use_id(raw_id: str) -> str:
+_KIMI_K2_TOOL_CALL_ID_PATTERN = re.compile(r"^functions\.[^:]+:\d+$")
+
+
+def is_anthropic_family_model(model: str) -> bool:
+    """
+    True for models that dispatch to a real Anthropic-compatible backend
+    (Anthropic API, Bedrock Claude, Vertex Claude), where a tool_use id must
+    satisfy Anthropic's literal ``^[a-zA-Z0-9_-]+$`` pattern or the request is
+    rejected outright.
+    """
+    model_lower = model.lower()
+    if "anthropic" in model_lower or "claude" in model_lower:
+        return True
+    return "arn:" in model_lower and ":bedrock:" in model_lower
+
+
+def normalize_anthropic_tool_use_id(raw_id: str, *, preserve_kimi_k2_ids: bool = True) -> str:
     """
     Normalize a tool_use / tool_result id for Anthropic's ``^[a-zA-Z0-9_-]+$``
     pattern.
 
     Strips Gemini thought-signature suffixes (``__thought__``) first, then
     replaces any remaining invalid characters with underscores.
+
+    ``preserve_kimi_k2_ids`` leaves Kimi K2's ``functions.{name}:{index}`` ids
+    untouched: vLLM's and SGLang's ``kimi_k2`` tool parsers, and Kimi's own
+    chat template, derive the next tool-call index by parsing that exact id
+    format out of replayed conversation history. Rewriting it (e.g. to
+    ``functions_Bash_0``) breaks that parsing on the model's next turn, which
+    silently drops the tool call instead of raising, so a Claude Code session
+    routed through Kimi stops mid-task with no visible error. Callers that
+    know the id is about to be replayed to a real Anthropic-compatible
+    backend (see ``is_anthropic_family_model``) should pass
+    ``preserve_kimi_k2_ids=False`` so the id is sanitized as usual -- real
+    Anthropic rejects ``functions.Bash:0`` regardless of its origin.
     """
+    if preserve_kimi_k2_ids and _KIMI_K2_TOOL_CALL_ID_PATTERN.match(raw_id):
+        return raw_id
     base_id = raw_id.split(THOUGHT_SIGNATURE_SEPARATOR, 1)[0] if THOUGHT_SIGNATURE_SEPARATOR in raw_id else raw_id
     sanitized = re.sub(r"[^a-zA-Z0-9_-]", "_", base_id)
     return sanitized or "tool_use_id"
 
 
-def _sanitize_tool_use_id_content_block(block: Any) -> Any:
+def _sanitize_tool_use_id_content_block(block: Any, *, preserve_kimi_k2_ids: bool) -> Any:
     if not isinstance(block, dict):
         return block
     block_type = block.get("type")
     if block_type in ("tool_use", "server_tool_use"):
         raw_id = block.get("id")
         if isinstance(raw_id, str):
-            normalized = normalize_anthropic_tool_use_id(raw_id)
+            normalized = normalize_anthropic_tool_use_id(raw_id, preserve_kimi_k2_ids=preserve_kimi_k2_ids)
             if normalized != raw_id:
                 return {**block, "id": normalized}
     elif block_type == "tool_result":
         raw_id = block.get("tool_use_id")
         if isinstance(raw_id, str):
-            normalized = normalize_anthropic_tool_use_id(raw_id)
+            normalized = normalize_anthropic_tool_use_id(raw_id, preserve_kimi_k2_ids=preserve_kimi_k2_ids)
             if normalized != raw_id:
                 return {**block, "tool_use_id": normalized}
     return block
 
 
-def sanitize_tool_use_ids_in_anthropic_messages(messages: list[Any]) -> list[Any]:
+def sanitize_tool_use_ids_in_anthropic_messages(messages: list[Any], model: Optional[str] = None) -> list[Any]:
     """
     Return a new message list with ``tool_use`` / ``server_tool_use`` ``id`` and
     ``tool_result`` ``tool_use_id`` values rewritten to satisfy Anthropic's
@@ -1043,14 +1073,24 @@ def sanitize_tool_use_ids_in_anthropic_messages(messages: list[Any]) -> list[Any
     conversation history containing ids like ``functions.Bash:0`` with ``.``
     and ``:`` — valid on the upstream provider but rejected by Anthropic when
     the session is switched to a native Anthropic deployment.
+
+    ``functions.{name}:{index}`` ids are preserved unless ``model`` resolves
+    to a real Anthropic-compatible backend (``is_anthropic_family_model``):
+    Kimi K2's own tool parser depends on that exact format surviving replay,
+    so mangling it on every dispatch (including back to Kimi itself) breaks
+    tool calling for the much more common same-provider case. See
+    ``normalize_anthropic_tool_use_id``.
     """
+    preserve_kimi_k2_ids = not (model is not None and is_anthropic_family_model(model))
     out: list[Any] = []
     for m in messages:
         if not isinstance(m, dict) or not isinstance(m.get("content"), list):
             out.append(m)
             continue
         content = m["content"]
-        new_content = [_sanitize_tool_use_id_content_block(b) for b in content]
+        new_content = [
+            _sanitize_tool_use_id_content_block(b, preserve_kimi_k2_ids=preserve_kimi_k2_ids) for b in content
+        ]
         if new_content == content:
             out.append(m)
         else:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -230,8 +230,12 @@ async def anthropic_messages(
     # Anthropic Messages path here for the same guarantee.  See #22930.
     messages = strip_empty_text_blocks_from_anthropic_messages(messages)
     # Replay of cross-provider tool history (e.g. kimi -> Anthropic) may carry
-    # ids like ``functions.Bash:0`` that violate Anthropic's id pattern.
-    messages = sanitize_tool_use_ids_in_anthropic_messages(messages)
+    # ids like ``functions.Bash:0`` that violate Anthropic's id pattern. Only
+    # sanitize them away when the destination is actually Anthropic-family:
+    # Kimi K2's own tool parser depends on that exact id format surviving
+    # replay, so mangling it on a same-provider round trip breaks tool
+    # calling. See ``sanitize_tool_use_ids_in_anthropic_messages``.
+    messages = sanitize_tool_use_ids_in_anthropic_messages(messages, model=model)
 
     from litellm.integrations.anthropic_cache_control_hook import (
         AnthropicCacheControlHook,
@@ -422,7 +426,7 @@ def anthropic_messages_handler(
     # full-messages scan. Pop it so it never leaks into provider params.
     if not kwargs.pop("_litellm_messages_presanitized", False):
         messages = strip_empty_text_blocks_from_anthropic_messages(messages)
-        messages = sanitize_tool_use_ids_in_anthropic_messages(messages)
+        messages = sanitize_tool_use_ids_in_anthropic_messages(messages, model=model)
 
     from litellm.integrations.anthropic_cache_control_hook import (
         AnthropicCacheControlHook,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -520,7 +520,39 @@ def test_translate_openai_content_to_anthropic_strips_gemini_thought_from_tool_c
 
 
 def test_translate_openai_content_to_anthropic_sanitizes_colon_dot_tool_call_ids():
-    """Cross-provider ids like ``functions.Bash:0`` must be normalized for Anthropic replay."""
+    """Cross-provider ids with invalid characters must be normalized for Anthropic replay."""
+    openai_choices = [
+        Choices(
+            message=Message(
+                role="assistant",
+                content=None,
+                tool_calls=[
+                    ChatCompletionAssistantToolCall(
+                        id="tool call#0",
+                        type="function",
+                        function=Function(
+                            name="Bash",
+                            arguments='{"command": "ls"}',
+                        ),
+                    )
+                ],
+            )
+        )
+    ]
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result = adapter._translate_openai_content_to_anthropic(choices=openai_choices)
+
+    assert len(result) == 1
+    assert result[0]["type"] == "tool_use"
+    assert result[0]["id"] == "tool_call_0"
+
+
+def test_translate_openai_content_to_anthropic_preserves_kimi_k2_tool_call_ids():
+    """Kimi K2 tool call ids (``functions.{name}:{index}``) must survive translation
+    unchanged. vLLM/SGLang's ``kimi_k2`` tool parser derives the next tool-call index
+    by parsing this exact format out of replayed conversation history, so rewriting it
+    (e.g. to ``functions_Bash_0``) breaks tool calling on the model's next turn."""
     openai_choices = [
         Choices(
             message=Message(
@@ -545,7 +577,7 @@ def test_translate_openai_content_to_anthropic_sanitizes_colon_dot_tool_call_ids
 
     assert len(result) == 1
     assert result[0]["type"] == "tool_use"
-    assert result[0]["id"] == "functions_Bash_0"
+    assert result[0]["id"] == "functions.Bash:0"
 
 
 def test_translate_openai_response_to_anthropic_text_and_tool_calls():

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -147,6 +147,57 @@ async def test_anthropic_messages_sanitizes_tool_use_ids_before_dispatch():
     assert msgs[0]["content"][0]["id"] == "functions.Bash:0"
 
 
+@pytest.mark.asyncio
+async def test_anthropic_messages_preserves_kimi_k2_tool_use_ids_for_non_anthropic_model():
+    """Kimi K2's ``functions.{name}:{index}`` tool_use ids must survive
+    dispatch unchanged when the destination is NOT a real Anthropic-family
+    backend. vLLM/SGLang's ``kimi_k2`` tool parser derives the next tool-call
+    index by parsing that exact format out of replayed history; mangling it
+    (e.g. to ``functions_Bash_0``) breaks tool calling on the model's next
+    turn, which surfaces as Claude Code silently stopping mid-task instead of
+    an explicit error. Contrast with
+    ``test_anthropic_messages_sanitizes_tool_use_ids_before_dispatch``, which
+    covers the real-Anthropic-destination case where sanitization must still
+    happen."""
+    from litellm.llms.anthropic.experimental_pass_through.messages import handler
+
+    msgs = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "functions.Bash:0",
+                    "name": "Bash",
+                    "input": {},
+                }
+            ],
+        }
+    ]
+    captured = {}
+
+    def fake_handler(*args, **kwargs):
+        captured["messages"] = kwargs.get("messages")
+        return "stub"
+
+    fake_loop = MagicMock()
+    fake_loop.run_in_executor = lambda _e, func: _async_return(func())
+
+    with (
+        patch.object(handler, "anthropic_messages_handler", side_effect=fake_handler),
+        patch("asyncio.get_event_loop", return_value=fake_loop),
+    ):
+        await handler.anthropic_messages(
+            max_tokens=100,
+            messages=msgs,
+            model="moonshot/kimi-k2-0905-preview",
+            custom_llm_provider="moonshot",
+            api_key="k",
+        )
+
+    assert captured["messages"][0]["content"][0]["id"] == "functions.Bash:0"
+
+
 async def _async_return(value):
     return value
 

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1468,6 +1468,43 @@ class TestAnthropicThinkingSignatureSelfHeal:
                 "content": [
                     {
                         "type": "tool_use",
+                        "id": "tool call#0",
+                        "name": "Bash",
+                        "input": {},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool call#0",
+                        "content": "ok",
+                    }
+                ],
+            },
+        ]
+        out = sanitize_tool_use_ids_in_anthropic_messages(msgs)
+        assert out[0]["content"][0]["id"] == "tool_call_0"
+        assert out[1]["content"][0]["tool_use_id"] == "tool_call_0"
+        assert msgs[0]["content"][0]["id"] == "tool call#0"
+
+    def test_sanitize_tool_use_ids_in_anthropic_messages_preserves_kimi_k2_ids(self):
+        """Kimi K2's ``functions.{name}:{index}`` ids must survive sanitization
+        unchanged: vLLM/SGLang's ``kimi_k2`` tool parser derives the next tool-call
+        index by parsing this exact format out of replayed history, so rewriting
+        it (e.g. to ``functions_Bash_0``) breaks tool calling on the next turn."""
+        from litellm.llms.anthropic.common_utils import (
+            sanitize_tool_use_ids_in_anthropic_messages,
+        )
+
+        msgs = [
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
                         "id": "functions.Bash:0",
                         "name": "Bash",
                         "input": {},
@@ -1486,9 +1523,9 @@ class TestAnthropicThinkingSignatureSelfHeal:
             },
         ]
         out = sanitize_tool_use_ids_in_anthropic_messages(msgs)
-        assert out[0]["content"][0]["id"] == "functions_Bash_0"
-        assert out[1]["content"][0]["tool_use_id"] == "functions_Bash_0"
-        assert msgs[0]["content"][0]["id"] == "functions.Bash:0"
+        assert out[0]["content"][0]["id"] == "functions.Bash:0"
+        assert out[1]["content"][0]["tool_use_id"] == "functions.Bash:0"
+        assert out[0] is msgs[0] and out[1] is msgs[1]
 
     def test_normalize_anthropic_tool_use_id_strips_thought_signature(self):
         from litellm.litellm_core_utils.prompt_templates.factory import (
@@ -1502,6 +1539,37 @@ class TestAnthropicThinkingSignatureSelfHeal:
             normalize_anthropic_tool_use_id(f"{base}{THOUGHT_SIGNATURE_SEPARATOR}{sig}")
             == base
         )
+
+    @pytest.mark.parametrize(
+        "kimi_id",
+        [
+            "functions.Bash:0",
+            "functions.Bash:12",
+            "functions.mcp__server__tool:3",
+        ],
+    )
+    def test_normalize_anthropic_tool_use_id_preserves_kimi_k2_format(self, kimi_id):
+        from litellm.llms.anthropic.common_utils import normalize_anthropic_tool_use_id
+
+        assert normalize_anthropic_tool_use_id(kimi_id) == kimi_id
+
+    @pytest.mark.parametrize(
+        "near_miss_id,expected",
+        [
+            ("functions.Bash", "functions_Bash"),  # missing ":{index}" suffix
+            ("functions.Bash:", "functions_Bash_"),  # missing index digits
+            ("functions.Bash:x", "functions_Bash_x"),  # non-numeric index
+            ("function.Bash:0", "function_Bash_0"),  # missing trailing "s"
+        ],
+    )
+    def test_normalize_anthropic_tool_use_id_still_sanitizes_non_kimi_ids(
+        self, near_miss_id, expected
+    ):
+        """Ids that merely resemble Kimi's format but don't match it exactly
+        must still go through the normal character-sanitization path."""
+        from litellm.llms.anthropic.common_utils import normalize_anthropic_tool_use_id
+
+        assert normalize_anthropic_tool_use_id(near_miss_id) == expected
 
     def test_anthropic_messages_config_http_retry_helpers(self):
         import httpx


### PR DESCRIPTION
## Relevant issues

Fixes #34522

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I don't have a live vLLM + Kimi K2 deployment to curl against for this PR, so the fix is verified with targeted unit tests instead (see Changes below). The failure mode itself was diagnosed by tracing `normalize_anthropic_tool_use_id` through both call sites and confirming Kimi K2's tool-call id format against vLLM's own writeup of the `kimi_k2` tool parser:

- https://vllm.ai/blog/2025-10-28-kimi-k2-accuracy
- https://github.com/sgl-project/sglang/issues/10600

## Type

🐛 Bug Fix

## Changes

`normalize_anthropic_tool_use_id()` (`litellm/llms/anthropic/common_utils.py`) rewrites any `tool_use`/`tool_result` id containing characters outside `[a-zA-Z0-9_-]` to satisfy Anthropic's id pattern. Kimi K2's tool call ids look like `functions.Bash:0`; vLLM's and SGLang's `kimi_k2` tool parsers, and Kimi's own chat template, derive the next tool-call index by parsing that exact format back out of replayed conversation history. Rewriting the id (e.g. to `functions_Bash_0`) before it reaches the client, and again on the next turn before it's replayed back to the same Kimi backend, breaks that parsing. The failure is silent: vLLM logs a tool-call conversion warning but still returns `finish_reason: stop` instead of `tool_calls`, so a client like Claude Code just ends its turn mid-task with no visible error.

Both id-mangling call sites funnel through `normalize_anthropic_tool_use_id()`:
- the `anthropic_messages` request-history sanitizer (`experimental_pass_through/messages/handler.py`), reachable from *any* backend
- the OpenAI-to-Anthropic streaming/non-streaming adapter (`experimental_pass_through/adapters/transformation.py`), only ever reached for non-Anthropic-family backends

This PR adds a `preserve_kimi_k2_ids` flag to `normalize_anthropic_tool_use_id()` (default `True`) and threads it through `sanitize_tool_use_ids_in_anthropic_messages()` via a new `model` parameter. The request-history sanitizer is also reachable when a session's history is replayed into a genuine Anthropic-family model (e.g. a session switched from Kimi to Claude mid-conversation), where the id truly must be sanitized or the real Anthropic API 400s — so it derives the flag from the resolved `model` string via a new `is_anthropic_family_model()` helper (mirrors the existing `is_anthropic_claude_model`/`is_bedrock_arn_model` heuristics already used elsewhere in this file). The adapter path is only ever reached for non-Anthropic-family backends (confirmed by the routing logic in `handler.py`: native Anthropic-family dispatch never reaches `LiteLLMMessagesToCompletionTransformationHandler`), so it keeps the default (preserve) and required no call-site change.

Test changes:
- `tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py`: updated the existing `test_sanitize_tool_use_ids_in_anthropic_messages` to use a generic invalid-character id (it previously hardcoded the exact Kimi id shape as its example of "any invalid id", which is what made the old behavior look correct). Added `test_sanitize_tool_use_ids_in_anthropic_messages_preserves_kimi_k2_ids`, `test_normalize_anthropic_tool_use_id_preserves_kimi_k2_format` (parametrized), and `test_normalize_anthropic_tool_use_id_still_sanitizes_non_kimi_ids` (parametrized, covers near-miss ids that resemble but don't match Kimi's format, to guard against an overly broad regex).
- `tests/.../adapters/test_anthropic_experimental_pass_through_adapters_transformation.py`: updated `test_translate_openai_content_to_anthropic_sanitizes_colon_dot_tool_call_ids` to use a generic invalid id; added `test_translate_openai_content_to_anthropic_preserves_kimi_k2_tool_call_ids`.
- `tests/.../messages/test_anthropic_experimental_pass_through_messages_handler.py`: added `test_anthropic_messages_preserves_kimi_k2_tool_use_ids_for_non_anthropic_model`, which dispatches with `model="moonshot/kimi-k2-0905-preview"` and asserts the id survives; the existing `test_anthropic_messages_sanitizes_tool_use_ids_before_dispatch` (dispatches with `model="anthropic/claude-sonnet-4-5-20250929"`) needed no change and continues to assert sanitization still happens for real Anthropic-family destinations.
