### PR TITLE
fix(model_cost): resync backup cost map with canonical and guard against drift

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -17670,6 +17670,46 @@
         "tpm": 8000000,
         "supports_image_size": false
     },
+    "gemini-3-pro-image": {
+        "input_cost_per_image": 0.0011,
+        "input_cost_per_token": 2e-06,
+        "input_cost_per_token_batches": 1e-06,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.134,
+        "output_cost_per_image_token": 0.00012,
+        "output_cost_per_token": 1.2e-05,
+        "output_cost_per_token_batches": 6e-06,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3-pro-image",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query"
+    },
     "gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
         "input_cost_per_token": 2e-06,
@@ -17684,6 +17724,44 @@
         "output_cost_per_token": 1.2e-05,
         "output_cost_per_token_batches": 6e-06,
         "source": "https://ai.google.dev/gemini-api/docs/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_response_schema": true,
+        "supports_system_messages": true,
+        "supports_vision": true,
+        "supports_web_search": true,
+        "search_context_cost_per_query": {
+            "search_context_size_low": 0.014,
+            "search_context_size_medium": 0.014,
+            "search_context_size_high": 0.014
+        },
+        "web_search_billing_unit": "per_query"
+    },
+    "gemini-3.1-flash-image": {
+        "input_cost_per_image": 0.00056,
+        "input_cost_per_token": 5e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0672,
+        "output_cost_per_image_token": 6e-05,
+        "output_cost_per_token": 3e-06,
+        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models",
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/completions",
@@ -19264,7 +19342,6 @@
         ],
         "supports_function_calling": false,
         "supports_prompt_caching": true,
-        "supports_reasoning": false,
         "supports_response_schema": true,
         "supports_system_messages": true,
         "supports_vision": true,
@@ -19274,7 +19351,8 @@
             "search_context_size_medium": 0.014,
             "search_context_size_high": 0.014
         },
-        "web_search_billing_unit": "per_query"
+        "web_search_billing_unit": "per_query",
+        "supports_reasoning": false
     },
     "gemini/gemini-3-pro-image-preview": {
         "input_cost_per_image": 0.0011,
@@ -24239,7 +24317,7 @@
         "input_cost_per_token_batches": 3.75e-07,
         "input_cost_per_token_priority": 1.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -24285,7 +24363,7 @@
         "input_cost_per_token_batches": 3.75e-07,
         "input_cost_per_token_priority": 1.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -24329,7 +24407,7 @@
         "input_cost_per_token_flex": 1e-07,
         "input_cost_per_token_batches": 1e-07,
         "litellm_provider": "openai",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -24372,7 +24450,7 @@
         "input_cost_per_token_flex": 1e-07,
         "input_cost_per_token_batches": 1e-07,
         "litellm_provider": "openai",
-        "max_input_tokens": 272000,
+        "max_input_tokens": 1050000,
         "max_output_tokens": 128000,
         "max_tokens": 128000,
         "mode": "chat",
@@ -24412,9 +24490,9 @@
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 272000,
-        "max_tokens": 272000,
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
         "mode": "responses",
         "output_cost_per_token": 0.00012,
         "output_cost_per_token_batches": 6e-05,
@@ -24448,9 +24526,9 @@
         "input_cost_per_token": 1.5e-05,
         "input_cost_per_token_batches": 7.5e-06,
         "litellm_provider": "openai",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 272000,
-        "max_tokens": 272000,
+        "max_input_tokens": 400000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
         "mode": "responses",
         "output_cost_per_token": 0.00012,
         "output_cost_per_token_batches": 6e-05,
@@ -31810,6 +31888,22 @@
         "output_cost_per_token": 2.56e-06,
         "source": "https://openrouter.ai/z-ai/glm-5",
         "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "openrouter/z-ai/glm-5.1": {
+        "input_cost_per_token": 1.05e-06,
+        "output_cost_per_token": 3.5e-06,
+        "cache_read_input_token_cost": 5.25e-07,
+        "cache_creation_input_token_cost": 0.0,
+        "litellm_provider": "openrouter",
+        "max_input_tokens": 202752,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "chat",
+        "source": "https://openrouter.ai/z-ai/glm-5.1",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
@@ -40086,6 +40180,21 @@
         "supports_tool_choice": true,
         "source": "https://docs.z.ai/guides/overview/pricing"
     },
+    "zai/glm-5.1": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 2.6e-07,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
     "zai/glm-5-code": {
         "cache_creation_input_token_cost": 0,
         "cache_read_input_token_cost": 3e-07,
@@ -40106,6 +40215,21 @@
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 6e-07,
         "output_cost_per_token": 2.2e-06,
+        "litellm_provider": "zai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "source": "https://docs.z.ai/guides/overview/pricing"
+    },
+    "zai/glm-4.7-flash": {
+        "cache_creation_input_token_cost": 0,
+        "cache_read_input_token_cost": 0,
+        "input_cost_per_token": 0,
+        "output_cost_per_token": 0,
         "litellm_provider": "zai",
         "max_input_tokens": 200000,
         "max_output_tokens": 128000,
@@ -45527,6 +45651,7 @@
         "supports_response_schema": true
     },
     "snowflake/claude-sonnet-4-6": {
+        "supports_adaptive_thinking": true,
         "max_tokens": 16384,
         "max_input_tokens": 200000,
         "max_output_tokens": 16384,
@@ -45945,40 +46070,6 @@
         "supports_tool_choice": true,
         "supports_vision": false
     },
-    "darkbloom/gemma-4-26b": {
-        "input_cost_per_token": 3e-08,
-        "litellm_provider": "darkbloom",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 1.65e-07,
-        "source": "https://www.darkbloom.dev/",
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true
-    },
-    "darkbloom/gpt-oss-20b": {
-        "input_cost_per_token": 1.45e-08,
-        "litellm_provider": "darkbloom",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 32768,
-        "max_tokens": 32768,
-        "mode": "chat",
-        "output_cost_per_token": 7e-08,
-        "source": "https://www.darkbloom.dev/",
-        "supported_endpoints": [
-            "/v1/chat/completions"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true
-    },
     "deepseek/deepseek-v4-pro": {
         "cache_creation_input_token_cost": 0.0,
         "cache_read_input_token_cost": 3.625e-09,
@@ -46133,6 +46224,40 @@
         "supports_assistant_prefill": true,
         "supports_reasoning": false,
         "source": "https://pinstripes.io/pricing"
+    },
+    "darkbloom/gemma-4-26b": {
+        "input_cost_per_token": 3e-08,
+        "litellm_provider": "darkbloom",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-07,
+        "source": "https://www.darkbloom.dev/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
+    },
+    "darkbloom/gpt-oss-20b": {
+        "input_cost_per_token": 1.45e-08,
+        "litellm_provider": "darkbloom",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 7e-08,
+        "source": "https://www.darkbloom.dev/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true
     },
     "fallback_generalizations": {
         "rules": [

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -20957,7 +20957,8 @@
         "max_tokens": 16000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/v1/chat/completions",
+            "/v1/messages"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -20970,7 +20971,8 @@
         "max_tokens": 16000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/v1/chat/completions",
+            "/v1/messages"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -21022,7 +21024,8 @@
         "max_tokens": 16000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/v1/chat/completions",
+            "/v1/messages"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,

--- a/tests/test_litellm/test_model_cost_map_sync.py
+++ b/tests/test_litellm/test_model_cost_map_sync.py
@@ -1,0 +1,84 @@
+"""The two shipped model cost maps must stay in lockstep.
+
+``model_prices_and_context_window.json`` (repo root) is the canonical map that gets
+published and fetched at runtime. ``litellm/model_prices_and_context_window_backup.json``
+is bundled into the package and is what LiteLLM falls back to when the remote fetch
+fails or when ``LITELLM_LOCAL_MODEL_COST_MAP=True``. If they drift, the same model
+silently resolves to different metadata depending on whether the remote fetch
+succeeded -- wrong context windows, missing models, missing endpoints.
+
+``ci_cd/check_files_match.py`` was written to enforce exactly this, but it is wired
+into nothing (it used to be a pre-commit hook, and the pre-commit config was removed),
+so drift accumulated unnoticed. Existing per-model checks such as
+``test_gpt_5_6_backup_matches_main`` only cover the handful of models each was written
+for, so they cannot catch drift in any other entry.
+
+These tests assert the invariant globally.
+"""
+
+import filecmp
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[2]
+MAIN_PATH = REPO_ROOT / "model_prices_and_context_window.json"
+BACKUP_PATH = REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json"
+
+_RESYNC_HINT = "Run `python ci_cd/check_files_match.py` after updating the canonical map."
+
+
+def _load(path: Path) -> dict:
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _describe_drift(main_map: dict, backup_map: dict, limit: int = 20) -> str:
+    only_main = sorted(set(main_map) - set(backup_map))
+    only_backup = sorted(set(backup_map) - set(main_map))
+
+    field_diffs = []
+    for key in sorted(set(main_map) & set(backup_map)):
+        main_entry, backup_entry = main_map[key], backup_map[key]
+        if not isinstance(main_entry, dict) or not isinstance(backup_entry, dict):
+            if main_entry != backup_entry:
+                field_diffs.append(f"{key}: {main_entry!r} != {backup_entry!r}")
+            continue
+        for field in sorted(set(main_entry) | set(backup_entry)):
+            main_value = main_entry.get(field, "<absent>")
+            backup_value = backup_entry.get(field, "<absent>")
+            if main_value != backup_value:
+                field_diffs.append(f"{key}.{field}: main={main_value!r} backup={backup_value!r}")
+
+    lines = []
+    if only_main:
+        lines.append(f"{len(only_main)} entries missing from backup: {only_main[:limit]}")
+    if only_backup:
+        lines.append(f"{len(only_backup)} entries missing from main: {only_backup[:limit]}")
+    if field_diffs:
+        lines.append(f"{len(field_diffs)} field differences:")
+        lines.extend(f"  {diff}" for diff in field_diffs[:limit])
+        if len(field_diffs) > limit:
+            lines.append(f"  ... and {len(field_diffs) - limit} more")
+    return "\n".join(lines)
+
+
+def test_backup_cost_map_has_same_contents_as_canonical():
+    """Every entry and field must resolve identically from either map."""
+    main_map = _load(MAIN_PATH)
+    backup_map = _load(BACKUP_PATH)
+
+    if main_map != backup_map:
+        raise AssertionError(
+            "model cost maps have drifted.\n" + _describe_drift(main_map, backup_map) + "\n" + _RESYNC_HINT
+        )
+
+
+def test_backup_cost_map_is_byte_identical_to_canonical():
+    """The two files are kept byte-identical, which is the contract ci_cd/check_files_match.py enforces.
+
+    Separate from the parsed-content check so a pure formatting divergence reports as
+    a formatting problem rather than as missing or wrong model metadata.
+    """
+    assert filecmp.cmp(MAIN_PATH, BACKUP_PATH, shallow=False), (
+        f"{MAIN_PATH.name} and {BACKUP_PATH.name} differ byte-for-byte. " + _RESYNC_HINT
+    )


### PR DESCRIPTION
## TLDR

Problem this solves:

- The two shipped cost maps have drifted apart
- Same model resolves to different metadata depending on which one loaded

How it solves it:

- Resolve each divergence against the commit that introduced it
- Add a CI test so the maps can't drift again

## Relevant issues

None open for this — found while auditing the cost maps.

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

On the CI checkbox: the only red check is `osv-scan`, and it fails independently of this PR. It scans `uv.lock` and `ui/litellm-dashboard/package-lock.json`; this branch touches neither, and both are byte-identical to the base branch. Running the same osv-scanner v2.3.8 command locally reports 5 advisories against the already-pinned `gitpython` 3.1.52 (GHSA-3rp5-jjmw-4wv2, GHSA-6p8h-3wgx-97gf, GHSA-fjr4-x663-mwxc, GHSA-r9mr-m37c-5fr3) and `postcss` 8.5.13 (GHSA-r28c-9q8g-f849). It was still green on PRs that ran a couple of hours before this one, so the advisories look freshly published. `guard-fork-dependencies.yml` blocks fork PRs from touching lockfiles, so the bump (or an `osv-scanner.toml` entry) has to happen in the canonical repo.

## Screenshots / Proof of Fix

`LITELLM_LOCAL_MODEL_COST_MAP=True` makes litellm load the bundled backup instead of the canonical map, so the drift is observable as real library behaviour. This reads `litellm.model_cost` at runtime and compares it against the canonical file in the repo — no mocks, no test framework.

**Before**, at base commit `f6a1050cbf`:

```
commit under test: f6a1050cbf
litellm.model_cost entries loaded at runtime: 2978
canonical file entries: 2984

model                                    field                        runtime (bundled)              canonical                      ok
--------------------------------------------------------------------------------------------------------------------------------------
gpt-5.4-mini                             max_input_tokens             272000                         1050000                        MISMATCH
gpt-5.4-nano                             max_input_tokens             272000                         1050000                        MISMATCH
gpt-5-pro                                max_input_tokens             128000                         400000                         MISMATCH
gpt-5-pro                                max_output_tokens            272000                         128000                         MISMATCH
github_copilot/claude-sonnet-4.5         supported_endpoints          [.../v1/messages]              ['/v1/chat/completions']       MISMATCH
snowflake/claude-sonnet-4-6              supports_adaptive_thinking   <absent>                       True                           MISMATCH

entries present in the canonical map but not resolvable at runtime:
    gemini-3-pro-image                       MISSING at runtime
    gemini-3.1-flash-image                   MISSING at runtime
    openrouter/z-ai/glm-5.1                  MISSING at runtime
    zai/glm-4.7-flash                        MISSING at runtime
    zai/glm-5.1                              MISSING at runtime

TOTAL PROBLEMS: 11
```

**After**, at `94897ad8a8`:

```
commit under test: 94897ad8a8
litellm.model_cost entries loaded at runtime: 2983
canonical file entries: 2984

gpt-5.4-mini                             max_input_tokens             1050000                        1050000                        OK
gpt-5.4-nano                             max_input_tokens             1050000                        1050000                        OK
gpt-5-pro                                max_input_tokens             400000                         400000                         OK
gpt-5-pro                                max_output_tokens            128000                         128000                         OK
github_copilot/claude-sonnet-4.5         supported_endpoints          [.../v1/messages]              [.../v1/messages]              OK
snowflake/claude-sonnet-4-6              supports_adaptive_thinking   True                           True                           OK

(all five previously-missing entries now resolvable)

TOTAL PROBLEMS: 0
```

The remaining 2983 vs 2984 gap is `fallback_generalizations`, a config key rather than a model, which `litellm.model_cost` excludes by design.

Supporting test runs:

- `pytest tests/test_litellm/test_model_cost_map_sync.py` — 2 passed. Both fail at `f6a1050cbf`, so they are load-bearing.
- Every top-level test file that reads the cost map — 738 passed. The 16 failures are identical on base and on this branch (Azure AD / GCP IAM token and router access-group tests, unrelated to the cost map).
- `pytest tests/test_litellm/llms/openai/test_gpt5_transformation.py tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py tests/test_litellm/completion_extras/test_litellm_responses_transformation_transformation.py tests/test_litellm/test_gpt_5_6_model_metadata.py tests/test_litellm/test_gpt_5_5_model_metadata.py tests/test_litellm/test_deepseek_model_metadata.py` — 235 passed.
- `python ci_cd/check_files_match.py` — exits 0.

## Type

🐛 Bug Fix

## Changes

`model_prices_and_context_window.json` is the canonical map. `litellm/model_prices_and_context_window_backup.json` is bundled into the package and is what gets used when the remote fetch fails or `LITELLM_LOCAL_MODEL_COST_MAP=True`. They had drifted, so model metadata depended on which one happened to load.

The divergences, and which side each was resolved to:

| Entry | Field | Resolved to | Why |
|---|---|---|---|
| `gpt-5.4-mini` / `-nano` (+dated) | `max_input_tokens` | canonical (1050000) | sibling `gpt-5.4` uses 1050000; the backup's 272000 is a stale gpt-5-generation value |
| `gpt-5-pro` (+dated) | `max_input_tokens`, `max_output_tokens`, `max_tokens` | canonical | the backup's values are transposed — its input window (128000) was smaller than base `gpt-5`'s 272000 |
| `github_copilot/claude-{haiku,opus,sonnet}-4.5` | `supported_endpoints` | **backup** | `0b0fd6a4d1` (#31802) added `/v1/messages` to the backup only |
| `snowflake/claude-sonnet-4-6` | `supports_adaptive_thinking` | canonical | `98ced0ae43` added the flag to the canonical map only |
| 5 entries (gemini image, zai/glm) | whole entry | canonical | added to the canonical map only |

The drift runs in **both** directions — 124 commits touched only the canonical map and 124 touched only the backup — so this doesn't just copy one file over the other. The `/v1/messages` endpoints are added to the canonical map first, since that's the one place the backup was ahead; everything else is already correct there, so the backup is then regenerated from it with the existing `ci_cd/check_files_match.py`.

Because every value here already exists in the canonical map, callers on the normal remote-fetch path see no change at all. What changes is that the bundled-backup path now agrees with them.

**Why it went unnoticed:** `ci_cd/check_files_match.py` exists to enforce exactly this, but nothing references it — `git grep check_files_match` returns nothing. It ran as a pre-commit hook until `51af6fedb3` removed `.pre-commit-config.yaml` when hooks moved to `make pre-commit`, and it wasn't carried over. The existing per-model checks like `test_gpt_5_6_backup_matches_main` only assert the specific models each was written for, so none of them could catch drift elsewhere.

`tests/test_litellm/test_model_cost_map_sync.py` asserts the invariant globally instead, and prints the actual divergences on failure rather than a bare byte-compare.

One note for reviewers: I resolved `gpt-5-pro` and the `gpt-5.4` minis from family conventions in the map itself, since neither value had a commit message explaining it. If you have the authoritative numbers, those two rows are the ones worth a second look.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<sub>Investigated and prepared with AI assistance.</sub>