### PR TITLE
chore(deps): bump postcss to 8.5.18 to fix GHSA-r28c-9q8g-f849

### DIFF
--- a/ui/litellm-dashboard/package-lock.json
+++ b/ui/litellm-dashboard/package-lock.json
@@ -67,7 +67,7 @@
         "jsdom": "27.4.0",
         "knip": "5.83.1",
         "openapi-typescript": "7.13.0",
-        "postcss": "8.5.13",
+        "postcss": "8.5.18",
         "prettier": "3.2.5",
         "tailwindcss": "4.3.2",
         "tw-animate-css": "1.4.0",
@@ -2717,23 +2717,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@playwright/test": {
-      "version": "1.58.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
-      "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "playwright": "1.58.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
@@ -7427,6 +7410,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11009,40 +10993,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/playwright": {
-      "version": "1.58.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
-      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "playwright-core": "1.58.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.58.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
-      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -11064,9 +11014,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -11083,7 +11033,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -79,7 +79,7 @@
     "jsdom": "27.4.0",
     "knip": "5.83.1",
     "openapi-typescript": "7.13.0",
-    "postcss": "8.5.13",
+    "postcss": "8.5.18",
     "prettier": "3.2.5",
     "tailwindcss": "4.3.2",
     "tw-animate-css": "1.4.0",
@@ -96,7 +96,7 @@
     "ws": "8.21.0",
     "braces": "3.0.3",
     "axios": "1.13.6",
-    "postcss": "8.5.13",
+    "postcss": "8.5.18",
     "esbuild": "0.28.1",
     "date-fns": "^4.4.0",
     "sharp": "^0.35.0"


### PR DESCRIPTION
Fixes half of #34530 (postcss CVE only — see comment on that issue re: the gitpython bump, which is blocked by a genuine dependency conflict with mlflow)

## Problem
postcss <=8.5.17 has GHSA-r28c-9q8g-f849, a path traversal vulnerability in source map auto-loading that can leak arbitrary .map file contents.

## Fix
Bumped postcss to 8.5.18 via the existing npm `overrides` mechanism (both the direct devDependency and the overrides entry). This means `@tailwindcss/postcss`, `next`, and `vitest`/`vite` all resolve to the patched version through the shared override — no breaking changes to any of those packages themselves.

## Verification
`npm audit` now reports 0 vulnerabilities (previously 4 high severity, all stemming from this single postcss version).