### PR TITLE
fix(proxy): release max_parallel_requests slot when an MCP tool call completes (#34534)

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -4496,6 +4496,13 @@ class MCPServerManager:
         synthetic_llm_data = proxy_logging_obj._convert_mcp_to_llm_format(mcp_request_obj, pre_hook_kwargs)
 
         hook_result: dict[str, Any] = {}
+        # Hand the synthetic request dict back to call_tool: the parallel
+        # request limiter's pre-call hook stashes its slot acquisition into
+        # this dict's metadata channels, and no litellm completion callback
+        # ever fires for MCP tool calls — call_tool must explicitly release
+        # the slot when the tool call completes, or every MCP call leaks one
+        # max_parallel_requests slot until the key is fully locked out.
+        hook_result["_litellm_call_data"] = synthetic_llm_data
         try:
             # Use standard pre_call_hook
             modified_data = await proxy_logging_obj.pre_call_hook(
@@ -4516,6 +4523,16 @@ class MCPServerManager:
             GuardrailRaisedException,
             HTTPException,
         ) as e:
+            # Release the parallel-request slot if the rate limiter acquired
+            # one before a later hook in the chain raised — the exception
+            # never reaches call_tool's release, and async_post_call_failure_hook
+            # does not run for the MCP path. No-op when nothing was acquired
+            # (e.g. the limiter itself raised the 429: its check is
+            # all-or-nothing and stashes no acquisition on rejection).
+            if user_api_key_auth is not None:
+                await proxy_logging_obj._arelease_max_parallel_requests_on_disconnect(
+                    user_api_key_auth, synthetic_llm_data
+                )
             # Re-raise guardrail exceptions to properly fail the MCP call
             verbose_logger.error(f"Guardrail blocked MCP tool call pre call: {str(e)}")
             raise e
@@ -5135,82 +5152,111 @@ class MCPServerManager:
             if "arguments" in hook_result:
                 arguments = hook_result["arguments"]
 
-        # Prepare tasks for during hooks
-        tasks = []
-        if proxy_logging_obj:
-            during_hook_task = self._create_during_hook_task(
-                name=name,
-                arguments=arguments,
-                server_name_from_prefix=server_name,
-                user_api_key_auth=user_api_key_auth,
-                proxy_logging_obj=proxy_logging_obj,
-                start_time=start_time,
+        # The synthetic request dict pre_call_tool_check ran the hooks
+        # against. The parallel request limiter stashed its slot acquisition
+        # into this dict's metadata channels; MCP tool calls never fire the
+        # litellm completion callbacks that normally release the slot, so it
+        # must be released explicitly when the tool call finishes (success or
+        # error) — otherwise every MCP call leaks one max_parallel_requests
+        # slot and the key locks out after `limit` calls.
+        litellm_call_data: Optional[dict[str, Any]] = hook_result.pop("_litellm_call_data", None)
+
+        try:
+            # Prepare tasks for during hooks
+            tasks = []
+            if proxy_logging_obj:
+                during_hook_task = self._create_during_hook_task(
+                    name=name,
+                    arguments=arguments,
+                    server_name_from_prefix=server_name,
+                    user_api_key_auth=user_api_key_auth,
+                    proxy_logging_obj=proxy_logging_obj,
+                    start_time=start_time,
+                )
+                tasks.append(during_hook_task)
+
+            caller_oauth2_headers = oauth2_headers
+            oauth2_headers = await self._resolve_oauth2_headers_for_tool_call(
+                mcp_server, oauth2_headers, user_api_key_auth
             )
-            tasks.append(during_hook_task)
 
-        caller_oauth2_headers = oauth2_headers
-        oauth2_headers = await self._resolve_oauth2_headers_for_tool_call(mcp_server, oauth2_headers, user_api_key_auth)
+            # For OpenAPI servers, call the tool handler directly instead of via MCP client
+            if mcp_server.spec_path:
+                verbose_logger.debug("Calling OpenAPI tool %s directly via HTTP handler", name)
+                if hook_result.get("extra_headers"):
+                    verbose_logger.warning(
+                        "pre_mcp_call hook returned extra_headers for OpenAPI-backed "
+                        "MCP server '%s' — header injection is not supported for "
+                        "OpenAPI servers; headers will be ignored. Use SSE/HTTP "
+                        "transport to enable hook header injection.",
+                        server_name,
+                    )
 
-        # For OpenAPI servers, call the tool handler directly instead of via MCP client
-        if mcp_server.spec_path:
-            verbose_logger.debug("Calling OpenAPI tool %s directly via HTTP handler", name)
-            if hook_result.get("extra_headers"):
-                verbose_logger.warning(
-                    "pre_mcp_call hook returned extra_headers for OpenAPI-backed "
-                    "MCP server '%s' — header injection is not supported for "
-                    "OpenAPI servers; headers will be ignored. Use SSE/HTTP "
-                    "transport to enable hook header injection.",
-                    server_name,
+                auth_header_value = (
+                    _format_byok_openapi_auth_header(mcp_server, mcp_auth_header) if mcp_auth_header else None
+                )
+                resolved_auth_headers, forwarded_headers = await self.resolve_openapi_upstream_auth(
+                    mcp_server=mcp_server,
+                    oauth2_headers=caller_oauth2_headers,
+                    raw_headers=raw_headers,
+                    mcp_auth_header=mcp_auth_header,
+                    user_api_key_auth=user_api_key_auth,
+                    forwarded_headers=_openapi_forwarded_extra_headers(mcp_server, raw_headers, user_api_key_auth),
                 )
 
-            auth_header_value = (
-                _format_byok_openapi_auth_header(mcp_server, mcp_auth_header) if mcp_auth_header else None
-            )
-            resolved_auth_headers, forwarded_headers = await self.resolve_openapi_upstream_auth(
-                mcp_server=mcp_server,
-                oauth2_headers=caller_oauth2_headers,
-                raw_headers=raw_headers,
-                mcp_auth_header=mcp_auth_header,
-                user_api_key_auth=user_api_key_auth,
-                forwarded_headers=_openapi_forwarded_extra_headers(mcp_server, raw_headers, user_api_key_auth),
-            )
+                async def _call_openapi_via_handler():
+                    from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+                        _request_auth_header,
+                        _request_extra_headers,
+                        _request_resolved_auth_headers,
+                    )
 
-            async def _call_openapi_via_handler():
-                from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
-                    _request_auth_header,
-                    _request_extra_headers,
-                    _request_resolved_auth_headers,
+                    auth_token = _request_auth_header.set(auth_header_value)
+                    extra_token = _request_extra_headers.set(forwarded_headers)
+                    resolved_token = _request_resolved_auth_headers.set(resolved_auth_headers)
+                    try:
+                        async with self._limit_outbound_concurrency(mcp_server):
+                            return await self._call_openapi_tool_handler(mcp_server, name, arguments)
+                    finally:
+                        _request_auth_header.reset(auth_token)
+                        _request_extra_headers.reset(extra_token)
+                        _request_resolved_auth_headers.reset(resolved_token)
+
+                tasks.append(asyncio.create_task(_call_openapi_via_handler()))
+            else:
+                return await self._call_regular_mcp_tool(
+                    mcp_server=mcp_server,
+                    original_tool_name=name,
+                    arguments=arguments,
+                    tasks=tasks,
+                    mcp_auth_header=mcp_auth_header,
+                    mcp_server_auth_headers=mcp_server_auth_headers,
+                    oauth2_headers=oauth2_headers,
+                    raw_headers=raw_headers,
+                    proxy_logging_obj=proxy_logging_obj,
+                    host_progress_callback=host_progress_callback,
+                    hook_extra_headers=hook_result.get("extra_headers"),
+                    user_api_key_auth=user_api_key_auth,
                 )
 
-                auth_token = _request_auth_header.set(auth_header_value)
-                extra_token = _request_extra_headers.set(forwarded_headers)
-                resolved_token = _request_resolved_auth_headers.set(resolved_auth_headers)
+            return await self._gather_openapi_tool_tasks(tasks, proxy_logging_obj)
+        finally:
+            # Release the parallel-request slot acquired at pre-call. Runs on
+            # every exit path (return, guardrail raise during result check,
+            # upstream error, cancellation) and is idempotent: the release
+            # clears the acquisition marker and removing an absent slot id is
+            # a no-op, so a duplicate release can never free another
+            # request's slot. Guarded so a release failure never masks the
+            # tool call's own result/exception.
+            if proxy_logging_obj is not None and user_api_key_auth is not None and litellm_call_data is not None:
                 try:
-                    async with self._limit_outbound_concurrency(mcp_server):
-                        return await self._call_openapi_tool_handler(mcp_server, name, arguments)
-                finally:
-                    _request_auth_header.reset(auth_token)
-                    _request_extra_headers.reset(extra_token)
-                    _request_resolved_auth_headers.reset(resolved_token)
-
-            tasks.append(asyncio.create_task(_call_openapi_via_handler()))
-        else:
-            return await self._call_regular_mcp_tool(
-                mcp_server=mcp_server,
-                original_tool_name=name,
-                arguments=arguments,
-                tasks=tasks,
-                mcp_auth_header=mcp_auth_header,
-                mcp_server_auth_headers=mcp_server_auth_headers,
-                oauth2_headers=oauth2_headers,
-                raw_headers=raw_headers,
-                proxy_logging_obj=proxy_logging_obj,
-                host_progress_callback=host_progress_callback,
-                hook_extra_headers=hook_result.get("extra_headers"),
-                user_api_key_auth=user_api_key_auth,
-            )
-
-        return await self._gather_openapi_tool_tasks(tasks, proxy_logging_obj)
+                    await proxy_logging_obj._arelease_max_parallel_requests_on_disconnect(
+                        user_api_key_auth, litellm_call_data
+                    )
+                except Exception as release_error:  # noqa: BLE001 - never mask the tool call outcome
+                    verbose_logger.warning(
+                        f"Failed to release max_parallel_requests slot after MCP tool call: {str(release_error)}"
+                    )
 
     #########################################################
     # End of Methods that call the upstream MCP servers

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -4496,13 +4496,6 @@ class MCPServerManager:
         synthetic_llm_data = proxy_logging_obj._convert_mcp_to_llm_format(mcp_request_obj, pre_hook_kwargs)
 
         hook_result: dict[str, Any] = {}
-        # Hand the synthetic request dict back to call_tool: the parallel
-        # request limiter's pre-call hook stashes its slot acquisition into
-        # this dict's metadata channels, and no litellm completion callback
-        # ever fires for MCP tool calls — call_tool must explicitly release
-        # the slot when the tool call completes, or every MCP call leaks one
-        # max_parallel_requests slot until the key is fully locked out.
-        hook_result["_litellm_call_data"] = synthetic_llm_data
         try:
             # Use standard pre_call_hook
             modified_data = await proxy_logging_obj.pre_call_hook(
@@ -4510,6 +4503,16 @@ class MCPServerManager:
                 data=synthetic_llm_data,
                 call_type=CallTypes.call_mcp_tool.value,
             )
+            # Hand the request dict back to call_tool: the parallel request
+            # limiter's pre-call hook stashes its slot acquisition into this
+            # dict's metadata channels, and no litellm completion callback
+            # ever fires for MCP tool calls — call_tool must explicitly
+            # release the slot when the tool call completes, or every MCP
+            # call leaks one max_parallel_requests slot until the key is
+            # fully locked out. Captured from pre_call_hook's return value so
+            # the marker stays visible even if a callback ahead of the
+            # limiter replaced the dict object.
+            hook_result["_litellm_call_data"] = modified_data if modified_data is not None else synthetic_llm_data
             if modified_data:
                 # Convert response back to MCP format and apply modifications
                 modified_kwargs = proxy_logging_obj._convert_mcp_hook_response_to_kwargs(modified_data, pre_hook_kwargs)
@@ -5164,7 +5167,7 @@ class MCPServerManager:
         # must be released explicitly when the tool call finishes (success or
         # error) — otherwise every MCP call leaks one max_parallel_requests
         # slot and the key locks out after `limit` calls.
-        litellm_call_data: Optional[dict[str, Any]] = hook_result.pop("_litellm_call_data", None)
+        litellm_call_data: dict[str, Any] | None = hook_result.pop("_litellm_call_data", None)
 
         try:
             # Prepare tasks for during hooks

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -4529,9 +4529,14 @@ class MCPServerManager:
             # its check is all-or-nothing and stashes no acquisition on
             # rejection).
             if user_api_key_auth is not None:
-                await proxy_logging_obj._arelease_max_parallel_requests_on_disconnect(
-                    user_api_key_auth, synthetic_llm_data
-                )
+                try:
+                    await proxy_logging_obj._arelease_max_parallel_requests_on_disconnect(
+                        user_api_key_auth, synthetic_llm_data
+                    )
+                except Exception as release_error:  # noqa: BLE001 - never mask the original exception
+                    verbose_logger.warning(
+                        f"Failed to release max_parallel_requests slot in pre_call_tool_check: {str(release_error)}"
+                    )
             if isinstance(e, (BlockedPiiEntityError, GuardrailRaisedException, HTTPException)):
                 # Re-raise guardrail exceptions to properly fail the MCP call
                 verbose_logger.error(f"Guardrail blocked MCP tool call pre call: {str(e)}")

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -4518,24 +4518,24 @@ class MCPServerManager:
                 if modified_kwargs.get("extra_headers"):
                     hook_result["extra_headers"] = modified_kwargs["extra_headers"]
 
-        except (
-            BlockedPiiEntityError,
-            GuardrailRaisedException,
-            HTTPException,
-        ) as e:
+        except BaseException as e:
             # Release the parallel-request slot if the rate limiter acquired
             # one before a later hook in the chain raised — the exception
             # never reaches call_tool's release, and async_post_call_failure_hook
-            # does not run for the MCP path. No-op when nothing was acquired
-            # (e.g. the limiter itself raised the 429: its check is
-            # all-or-nothing and stashes no acquisition on rejection).
+            # does not run for the MCP path. Catches BaseException so an
+            # arbitrary custom-hook failure (or a cancellation) releases too,
+            # not just the expected guardrail exception types. No-op when
+            # nothing was acquired (e.g. the limiter itself raised the 429:
+            # its check is all-or-nothing and stashes no acquisition on
+            # rejection).
             if user_api_key_auth is not None:
                 await proxy_logging_obj._arelease_max_parallel_requests_on_disconnect(
                     user_api_key_auth, synthetic_llm_data
                 )
-            # Re-raise guardrail exceptions to properly fail the MCP call
-            verbose_logger.error(f"Guardrail blocked MCP tool call pre call: {str(e)}")
-            raise e
+            if isinstance(e, (BlockedPiiEntityError, GuardrailRaisedException, HTTPException)):
+                # Re-raise guardrail exceptions to properly fail the MCP call
+                verbose_logger.error(f"Guardrail blocked MCP tool call pre call: {str(e)}")
+            raise
 
         return hook_result
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_hook_extra_headers.py
@@ -118,7 +118,10 @@ class TestPreCallToolCheckReturnsHeaders:
                         server=server,
                     )
 
-        assert result == {}
+        # No hook-provided keys; "_litellm_call_data" is always present so
+        # call_tool can release the parallel-request slot on completion.
+        assert "arguments" not in result
+        assert "extra_headers" not in result
 
     @pytest.mark.asyncio
     async def test_returns_extra_headers_from_hook(self):
@@ -179,7 +182,10 @@ class TestPreCallToolCheckReturnsHeaders:
                         server=server,
                     )
 
-        assert result == {}
+        # No hook-provided keys; "_litellm_call_data" is always present so
+        # call_tool can release the parallel-request slot on completion.
+        assert "arguments" not in result
+        assert "extra_headers" not in result
 
     @pytest.mark.asyncio
     async def test_returns_modified_arguments_from_hook(self):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_parallel_slot_release.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_parallel_slot_release.py
@@ -1,0 +1,202 @@
+"""
+Regression tests: MCP tool calls must release the max_parallel_requests slot.
+
+Field failure being prevented: every MCP tool call runs the parallel request
+limiter's pre-call hook (+1) via ``pre_call_tool_check``, but MCP tool calls
+never fire the litellm completion callbacks that normally release the slot
+(``async_log_success_event`` / ``async_log_failure_event``). Without an
+explicit release, every MCP tool call — including fully successful sequential
+ones — leaks one slot, and a key with ``max_parallel_requests: N`` wedges
+permanently after N calls until the proxy restarts.
+
+Covers:
+1. Sequential successful tool calls on a limit-1 key never 429 and leave the
+   in-flight gauge at 0 (the exact field repro).
+2. A tool call that raises still releases its slot (finally path).
+3. A downstream pre-call hook raising after the limiter acquired a slot
+   releases the slot before the exception propagates (guardrail-block path).
+"""
+
+import asyncio
+from typing import Any, Dict, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+import litellm
+from litellm.caching.caching import DualCache
+from litellm.integrations.custom_logger import CustomLogger
+from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServerManager
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.hooks.parallel_request_limiter_v3 import (
+    _PROXY_MaxParallelRequestsHandler_v3,
+)
+from litellm.proxy.utils import ProxyLogging, hash_token
+from litellm.types.mcp import MCPAuth, MCPTransport
+from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+
+def _make_server(name: str = "test_server") -> MCPServer:
+    return MCPServer(
+        server_id="test-id",
+        name=name,
+        server_name=name,
+        url="https://example.com",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.none,
+    )
+
+
+def _wire_proxy_logging(monkeypatch, extra_callbacks: Optional[list] = None):
+    """
+    Real ProxyLogging + real v3 limiter registered the same way the proxy
+    does: in ``litellm.callbacks`` (walked by ``pre_call_hook``) and in
+    ``proxy_hook_mapping`` (resolved by the slot release).
+    """
+    proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
+    limiter = _PROXY_MaxParallelRequestsHandler_v3(
+        internal_usage_cache=proxy_logging.internal_usage_cache
+    )
+    proxy_logging.proxy_hook_mapping["parallel_request_limiter"] = limiter
+    monkeypatch.setattr(litellm, "callbacks", [limiter] + (extra_callbacks or []))
+    return proxy_logging, limiter
+
+
+async def _in_flight_gauge(proxy_logging: ProxyLogging, limiter, api_key_hash: str) -> int:
+    counter_key = f"{{api_key:{api_key_hash}}}:max_parallel_requests"
+    raw = await proxy_logging.internal_usage_cache.dual_cache.async_get_cache(key=counter_key)
+    return limiter._gauge_in_flight_from_cache_value(raw)
+
+
+def _call_tool_patches(manager: MCPServerManager, server: MCPServer, tool_result: Any):
+    """Patch everything network-facing; hook plumbing stays real."""
+    if isinstance(tool_result, Exception):
+        call_mock = AsyncMock(side_effect=tool_result)
+    else:
+        call_mock = AsyncMock(return_value=tool_result)
+    return [
+        patch(
+            "litellm.proxy._experimental.mcp_server.mcp_server_manager._resolve_byok_mcp_auth_header",
+            new=AsyncMock(return_value=None),
+        ),
+        patch.object(manager, "_resolve_mcp_server_for_tool_call", return_value=server),
+        patch.object(manager, "check_allowed_or_banned_tools", return_value=True),
+        patch.object(manager, "check_tool_permission_for_key_team", new_callable=AsyncMock),
+        patch.object(manager, "validate_allowed_params"),
+        patch.object(
+            manager,
+            "_resolve_oauth2_headers_for_tool_call",
+            new=AsyncMock(return_value=None),
+        ),
+        patch.object(manager, "_create_during_hook_task", side_effect=lambda **_: asyncio.sleep(0)),
+        patch.object(manager, "_call_regular_mcp_tool", call_mock),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sequential_mcp_tool_calls_do_not_exhaust_parallel_slots(monkeypatch):
+    """
+    The field repro: a key with ``max_parallel_requests: 1`` making strictly
+    sequential MCP tool calls (true concurrency never exceeds 1) must never
+    be rate limited. Before the fix, call 1 leaked its slot and call 2
+    rejected with a 429 — the key wedged permanently at its limit.
+    """
+    proxy_logging, limiter = _wire_proxy_logging(monkeypatch)
+    manager = MCPServerManager()
+    server = _make_server()
+    _api_key = hash_token("sk-mcp-sequential")
+    user_api_key_auth = UserAPIKeyAuth(api_key=_api_key, max_parallel_requests=1)
+
+    patches = _call_tool_patches(manager, server, tool_result=MagicMock())
+    for p in patches:
+        p.start()
+    try:
+        for _ in range(3):
+            await manager.call_tool(
+                server_name="test_server",
+                name="test_tool",
+                arguments={"key": "val"},
+                user_api_key_auth=user_api_key_auth,
+                proxy_logging_obj=proxy_logging,
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert await _in_flight_gauge(proxy_logging, limiter, _api_key) == 0
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_call_error_releases_parallel_slot(monkeypatch):
+    """A tool call that raises must still release its slot (finally path)."""
+    proxy_logging, limiter = _wire_proxy_logging(monkeypatch)
+    manager = MCPServerManager()
+    server = _make_server()
+    _api_key = hash_token("sk-mcp-error")
+    user_api_key_auth = UserAPIKeyAuth(api_key=_api_key, max_parallel_requests=1)
+
+    patches = _call_tool_patches(manager, server, tool_result=RuntimeError("upstream MCP server exploded"))
+    for p in patches:
+        p.start()
+    try:
+        with pytest.raises(RuntimeError):
+            await manager.call_tool(
+                server_name="test_server",
+                name="test_tool",
+                arguments={"key": "val"},
+                user_api_key_auth=user_api_key_auth,
+                proxy_logging_obj=proxy_logging,
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert await _in_flight_gauge(proxy_logging, limiter, _api_key) == 0
+
+
+class _BlockingPreCallHook(CustomLogger):
+    """Simulates a guardrail rejecting the call after the limiter ran."""
+
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: UserAPIKeyAuth,
+        cache: DualCache,
+        data: dict,
+        call_type: str,
+    ) -> Optional[Dict[str, Any]]:
+        raise HTTPException(status_code=400, detail={"error": "blocked by guardrail"})
+
+
+@pytest.mark.asyncio
+async def test_pre_call_guardrail_block_releases_parallel_slot(monkeypatch):
+    """
+    A downstream hook raising after the limiter's +1 must not strand the
+    slot: ``async_post_call_failure_hook`` never runs for the MCP path, so
+    ``pre_call_tool_check`` itself has to release before re-raising.
+    """
+    proxy_logging, limiter = _wire_proxy_logging(
+        monkeypatch, extra_callbacks=[_BlockingPreCallHook()]
+    )
+    manager = MCPServerManager()
+    server = _make_server()
+    _api_key = hash_token("sk-mcp-blocked")
+    user_api_key_auth = UserAPIKeyAuth(api_key=_api_key, max_parallel_requests=1)
+
+    patches = _call_tool_patches(manager, server, tool_result=MagicMock())
+    for p in patches:
+        p.start()
+    try:
+        with pytest.raises(HTTPException):
+            await manager.call_tool(
+                server_name="test_server",
+                name="test_tool",
+                arguments={"key": "val"},
+                user_api_key_auth=user_api_key_auth,
+                proxy_logging_obj=proxy_logging,
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert await _in_flight_gauge(proxy_logging, limiter, _api_key) == 0

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_parallel_slot_release.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_parallel_slot_release.py
@@ -13,8 +13,10 @@ Covers:
 1. Sequential successful tool calls on a limit-1 key never 429 and leave the
    in-flight gauge at 0 (the exact field repro).
 2. A tool call that raises still releases its slot (finally path).
-3. A downstream pre-call hook raising after the limiter acquired a slot
-   releases the slot before the exception propagates (guardrail-block path).
+3. An arbitrary (non-guardrail) exception from a custom pre-call hook after
+   the limiter's +1 releases the slot before the exception propagates.
+4. A downstream pre-call hook raising a guardrail exception after the limiter
+   acquired a slot releases the slot before the exception propagates.
 """
 
 import asyncio
@@ -55,9 +57,7 @@ def _wire_proxy_logging(monkeypatch, extra_callbacks: Optional[list] = None):
     ``proxy_hook_mapping`` (resolved by the slot release).
     """
     proxy_logging = ProxyLogging(user_api_key_cache=DualCache())
-    limiter = _PROXY_MaxParallelRequestsHandler_v3(
-        internal_usage_cache=proxy_logging.internal_usage_cache
-    )
+    limiter = _PROXY_MaxParallelRequestsHandler_v3(internal_usage_cache=proxy_logging.internal_usage_cache)
     proxy_logging.proxy_hook_mapping["parallel_request_limiter"] = limiter
     monkeypatch.setattr(litellm, "callbacks", [limiter] + (extra_callbacks or []))
     return proxy_logging, limiter
@@ -168,6 +168,53 @@ class _BlockingPreCallHook(CustomLogger):
         raise HTTPException(status_code=400, detail={"error": "blocked by guardrail"})
 
 
+class _CrashingPreCallHook(CustomLogger):
+    """Simulates a custom hook failing with an arbitrary (non-guardrail) error."""
+
+    async def async_pre_call_hook(
+        self,
+        user_api_key_dict: UserAPIKeyAuth,
+        cache: DualCache,
+        data: dict,
+        call_type: str,
+    ) -> Optional[Dict[str, Any]]:
+        raise RuntimeError("custom hook exploded")
+
+
+@pytest.mark.asyncio
+async def test_pre_call_arbitrary_hook_error_releases_parallel_slot(monkeypatch):
+    """
+    An arbitrary (non-guardrail) exception from a custom pre-call hook after
+    the limiter's +1 must also release the slot: the exception escapes before
+    call_tool enters its release-protected try/finally, so the release has to
+    happen in pre_call_tool_check itself — for any exception type, not just
+    the expected guardrail ones.
+    """
+    proxy_logging, limiter = _wire_proxy_logging(monkeypatch, extra_callbacks=[_CrashingPreCallHook()])
+    manager = MCPServerManager()
+    server = _make_server()
+    _api_key = hash_token("sk-mcp-hook-crash")
+    user_api_key_auth = UserAPIKeyAuth(api_key=_api_key, max_parallel_requests=1)
+
+    patches = _call_tool_patches(manager, server, tool_result=MagicMock())
+    for p in patches:
+        p.start()
+    try:
+        with pytest.raises(RuntimeError):
+            await manager.call_tool(
+                server_name="test_server",
+                name="test_tool",
+                arguments={"key": "val"},
+                user_api_key_auth=user_api_key_auth,
+                proxy_logging_obj=proxy_logging,
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert await _in_flight_gauge(proxy_logging, limiter, _api_key) == 0
+
+
 @pytest.mark.asyncio
 async def test_pre_call_guardrail_block_releases_parallel_slot(monkeypatch):
     """
@@ -175,9 +222,7 @@ async def test_pre_call_guardrail_block_releases_parallel_slot(monkeypatch):
     slot: ``async_post_call_failure_hook`` never runs for the MCP path, so
     ``pre_call_tool_check`` itself has to release before re-raising.
     """
-    proxy_logging, limiter = _wire_proxy_logging(
-        monkeypatch, extra_callbacks=[_BlockingPreCallHook()]
-    )
+    proxy_logging, limiter = _wire_proxy_logging(monkeypatch, extra_callbacks=[_BlockingPreCallHook()])
     manager = MCPServerManager()
     server = _make_server()
     _api_key = hash_token("sk-mcp-blocked")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every MCP tool call permanently leaks one max_parallel_requests slot
- Keys wedge at their limit after N sequential MCP calls
- Only a proxy restart un-wedges the key

How it solves it:

- call_tool releases the pre-call slot acquisition in a finally
- pre_call_tool_check releases the slot when a downstream hook blocks
- Reuses the idempotent disconnect release added in #30020

## Relevant issues

Fixes #34534

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live repro against a real deployment (`main-latest` image built 2026-07-18, v3 limiter active, no Redis, Graphiti MCP server behind the proxy, key with `max_parallel_requests: 20`):

**Before (live proxy, strictly sequential `tools/call`, concurrency = 1):**

```
call 5: ok
call 10: ok
call 15: FIRST 429 -> Error: Rate limit exceeded for api_key: bc31c458... Limit type: max_parallel_requests. Current limit: 20, Remaining: 0
call 20: 429
call 25: 429
call 30: 429
total 429s: 16
```

`ss -tn state established '( sport = :4000 )'` on the proxy host at the same moment: **0 connections** — the gauge is pure leak. The key stays wedged across the per-minute "resets at" window and only recovers on proxy restart.

**After the fix (same flow re-verified): 40 sequential MCP calls, 0 429s, in-flight gauge back to 0.**

**Root cause:** `pre_call_tool_check` runs the full `pre_call_hook` chain with `call_type="call_mcp_tool"`, so `_PROXY_MaxParallelRequestsHandler_v3.async_pre_call_hook` acquires a slot (+1) and stashes the acquisition into the synthetic request dict. MCP tool calls never fire `async_log_success_event`/`async_log_failure_event` (litellm completion-level callbacks), `async_post_call_failure_hook` doesn't run for the MCP path, and the synthetic dict was a local discarded on return — no release path existed. Same increment-without-decrement shape as #27955, different route; the #30020 fix is active in the same build but only covers cancelled streams.

**Changes:**

- `pre_call_tool_check` hands the synthetic request dict back to `call_tool` under the internal `"_litellm_call_data"` key, and releases the slot before re-raising when a downstream pre-call hook (guardrail) blocks the call after the limiter's +1
- `call_tool` releases the slot in a `finally` on every exit path (return, upstream error, guardrail raise during result check, cancellation), via the existing idempotent `_arelease_max_parallel_requests_on_disconnect` — the release clears the acquisition marker and slot removal is a no-op ZREM on a duplicate, so a double release can never free another request's slot
- Release failures are logged, never masking the tool call's own outcome

**Tests** (`tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_parallel_slot_release.py`, real ProxyLogging + real v3 limiter, only network calls mocked):

- `test_sequential_mcp_tool_calls_do_not_exhaust_parallel_slots` — limit-1 key, 3 sequential calls, no 429, gauge back to 0 (exact field repro; fails without the fix)
- `test_mcp_tool_call_error_releases_parallel_slot` — tool raises, slot still released
- `test_pre_call_guardrail_block_releases_parallel_slot` — downstream hook raises after limiter +1, slot released before propagation

All 3 fail on main and pass with the fix. Existing suites pass: `test_mcp_hook_extra_headers.py` + `test_mcp_max_concurrent_requests.py` (58 passed) and `test_parallel_request_limiter_v3.py` (93 passed, 1 skipped). Two assertions in `test_mcp_hook_extra_headers.py` updated from `result == {}` to key-absence checks since `pre_call_tool_check` now always carries the internal `"_litellm_call_data"` entry.