### PR TITLE
fix(guardrails): add /v1/messages support for Straiker plugin

### DIFF
--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -600,9 +600,15 @@ class AnthropicMessagesHandler(BaseTranslation):
                     guardrail_inputs["tool_calls"] = tool_calls_list
 
                 try:
+                    prepared_request_data = self._prepare_request_data(
+                        request_data,
+                        model_response,
+                        user_api_key_dict,
+                        key="response",
+                    )
                     _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                         inputs=guardrail_inputs,
-                        request_data=request_data if request_data is not None else {},
+                        request_data=prepared_request_data,
                         input_type="response",
                         logging_obj=litellm_logging_obj,
                     )

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -624,9 +624,15 @@ class AnthropicMessagesHandler(BaseTranslation):
 
         string_so_far = self.get_streaming_string_so_far(responses_so_far)
         try:
+            prepared_request_data = self._prepare_request_data(
+                request_data,
+                responses_so_far,
+                user_api_key_dict,
+                key="responses",
+            )
             _guardrailed_inputs = await guardrail_to_apply.apply_guardrail(
                 inputs={"texts": [string_so_far]},
-                request_data=request_data if request_data is not None else {},
+                request_data=prepared_request_data,
                 input_type="response",
                 logging_obj=litellm_logging_obj,
             )

--- a/litellm/proxy/guardrails/guardrail_hooks/straiker/straiker.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/straiker/straiker.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal, NoReturn
 from urllib.parse import urlsplit
 
 import httpx
-from pydantic import ValidationError
+from pydantic import BaseModel, TypeAdapter, ValidationError
 
 from litellm._logging import verbose_proxy_logger
 from litellm._version import version as litellm_version
@@ -24,11 +24,12 @@ from litellm.integrations.custom_guardrail import (
     log_guardrail_information,
 )
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+from litellm.litellm_core_utils.prompt_templates.factory import resolve_structured_messages
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
     httpxSpecialProvider,
 )
-from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.guardrails import GuardrailEventHooks, Mode
 from litellm.types.proxy.guardrails.guardrail_hooks.straiker import (
     STRAIKER_WEBHOOK_SCHEMA_VERSION,
     StraikerGuardrailConfigModel,
@@ -57,6 +58,7 @@ RETRY_STATUS = frozenset({408, 429, 500, 502, 503, 504})
 UNREACHABLE_STATUS = frozenset({502, 503, 504})
 _APPLICATION_METADATA_KEYS = frozenset({"agent_id", "app_name"})
 _OPAQUE_METADATA_SCALAR_TYPES = (str, int, float, bool)
+_JSON_DICT_ADAPTER = TypeAdapter(dict[str, object])
 
 
 @dataclass(frozen=True, slots=True)
@@ -137,6 +139,24 @@ def _resolve_destination(request_data: dict) -> str | None:
         return None
 
 
+def _hook_name(value: object) -> str:
+    return value.value if isinstance(value, GuardrailEventHooks) else str(value)
+
+
+def _configured_modes(event_hook: object) -> list[str] | None:
+    if isinstance(event_hook, list):
+        names = [_hook_name(v) for v in event_hook]
+    elif isinstance(event_hook, (str, GuardrailEventHooks)):
+        names = [_hook_name(event_hook)]
+    elif isinstance(event_hook, Mode):
+        default = event_hook.default if isinstance(event_hook.default, list) else [event_hook.default]
+        tags = [v for value in event_hook.tags.values() for v in (value if isinstance(value, list) else [value])]
+        names = [_hook_name(v) for v in (*default, *tags) if v is not None]
+    else:
+        return None
+    return list(dict.fromkeys(names)) or None
+
+
 def _resolve_call_surface(logging_obj: LiteLLMLoggingObj | None, request_data: dict) -> str:
     call_type = (
         (getattr(logging_obj, "call_type", None) if logging_obj is not None else None)
@@ -146,13 +166,56 @@ def _resolve_call_surface(logging_obj: LiteLLMLoggingObj | None, request_data: d
     return call_type if isinstance(call_type, str) and call_type else "unknown"
 
 
+def _jsonable_dict(value: object) -> dict[str, object] | None:
+    if isinstance(value, BaseModel):
+        return _JSON_DICT_ADAPTER.validate_python(value.model_dump(mode="json", exclude_none=True))
+    if isinstance(value, dict):
+        return _JSON_DICT_ADAPTER.validate_python(value)
+    return None
+
+
+def _opaque_dict_list(value: object) -> list[dict[str, object]] | None:
+    if not isinstance(value, list):
+        return None
+    items = tuple(plain for item in value if (plain := _jsonable_dict(item)) is not None)
+    return list(items) if items else None
+
+
+def _choice_terminal_reason(choice: object) -> str | None:
+    if isinstance(choice, dict):
+        return _as_optional_str(choice.get("finish_reason")) or _as_optional_str(choice.get("stop_reason"))
+    return _as_optional_str(getattr(choice, "finish_reason", None)) or _as_optional_str(
+        getattr(choice, "stop_reason", None)
+    )
+
+
 def _response_finish_reason(response: Any) -> str | None:
+    if response is None:
+        return None
+    if isinstance(response, dict):
+        top = _as_optional_str(response.get("finish_reason")) or _as_optional_str(response.get("stop_reason"))
+        if top:
+            return top
+        choices = response.get("choices")
+        if not isinstance(choices, list):
+            return None
+        for choice in choices:
+            reason = _choice_terminal_reason(choice)
+            if reason:
+                return reason
+        return None
+
+    top = _as_optional_str(getattr(response, "finish_reason", None)) or _as_optional_str(
+        getattr(response, "stop_reason", None)
+    )
+    if top:
+        return top
     choices = getattr(response, "choices", None)
     if not isinstance(choices, list):
         return None
     for choice in choices:
-        reason = getattr(choice, "finish_reason", None)
-        if isinstance(reason, str) and reason:
+        reason = _choice_terminal_reason(choice)
+        if reason:
             return reason
     return None
 
@@ -234,6 +297,8 @@ class StraikerGuardrail(CustomGuardrail):
         kwargs.setdefault("supported_event_hooks", list(self.get_supported_event_hooks()))
         super().__init__(**kwargs)
 
+        self.configured_modes = _configured_modes(self.event_hook)
+
     def _webhook_url(self) -> str:
         return f"{self.api_base}{WEBHOOK_PATH}"
 
@@ -263,6 +328,7 @@ class StraikerGuardrail(CustomGuardrail):
     ) -> StraikerWebhookContext:
         return StraikerWebhookContext(
             call_surface=_resolve_call_surface(logging_obj, request_data),
+            mode=self.configured_modes,
             model=model,
             model_provider=_resolve_provider(request_data, model),
             destination=_resolve_destination(request_data),
@@ -287,9 +353,9 @@ class StraikerGuardrail(CustomGuardrail):
         content = StraikerWebhookContent(
             texts=list(inputs.get("texts") or []),
             images=list(inputs.get("images") or []),
-            structured_messages=inputs.get("structured_messages"),
-            tools=inputs.get("tools"),
-            tool_calls=inputs.get("tool_calls"),
+            structured_messages=_opaque_dict_list(inputs.get("structured_messages")),
+            tools=_opaque_dict_list(inputs.get("tools")),
+            tool_calls=_opaque_dict_list(inputs.get("tool_calls")),
         )
 
         if input_type == "request":
@@ -305,9 +371,10 @@ class StraikerGuardrail(CustomGuardrail):
 
         response_obj = request_data.get("response")
         content.finish_reason = _response_finish_reason(response_obj)
-        original_messages = request_data.get("messages")
         request_content = StraikerWebhookContent(
-            structured_messages=original_messages if isinstance(original_messages, list) else None,
+            structured_messages=_opaque_dict_list(
+                resolve_structured_messages(messages=request_data.get("messages"), request_kwargs=request_data)
+            ),
         )
         phase: Literal["none", "assembled"] = "assembled" if _is_streamed_request(request_data) else "none"
         event = StraikerWebhookEvent(type="post_call", id=event_id, stream=StraikerWebhookStream(phase=phase))

--- a/litellm/proxy/guardrails/guardrail_hooks/straiker/straiker.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/straiker/straiker.py
@@ -43,7 +43,7 @@ from litellm.types.proxy.guardrails.guardrail_hooks.straiker import (
     StraikerWebhookStream,
     StraikerWebhookUsage,
 )
-from litellm.types.utils import GenericGuardrailAPIInputs, Usage
+from litellm.types.utils import GenericGuardrailAPIInputs
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -139,6 +139,26 @@ def _resolve_destination(request_data: dict) -> str | None:
         return None
 
 
+def _route_has_translation(request_data: dict) -> bool:
+    from litellm.litellm_core_utils.api_route_to_call_types import get_call_types_for_route
+    from litellm.llms import load_guardrail_translation_mappings
+
+    route = _as_dict(request_data.get("litellm_metadata")).get("user_api_key_request_route")
+    if not isinstance(route, str) or not route:
+        return False
+    mappings = load_guardrail_translation_mappings()
+    return any(call_type in mappings for call_type in get_call_types_for_route(route) or ())
+
+
+def _request_structured_messages(request_data: dict) -> list[dict[str, Any]] | None:
+    messages = request_data.get("messages")
+    if messages:
+        return messages if isinstance(messages, list) else None
+    if not _route_has_translation(request_data):
+        return None
+    return resolve_structured_messages(messages=None, request_kwargs=request_data)
+
+
 def _hook_name(value: object) -> str:
     return value.value if isinstance(value, GuardrailEventHooks) else str(value)
 
@@ -220,12 +240,22 @@ def _response_finish_reason(response: Any) -> str | None:
     return None
 
 
+def _as_optional_int(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _usage_token_count(usage: object, openai_key: str, anthropic_key: str) -> int | None:
+    get = usage.get if isinstance(usage, dict) else lambda key: getattr(usage, key, None)
+    openai_count = _as_optional_int(get(openai_key))
+    return openai_count if openai_count is not None else _as_optional_int(get(anthropic_key))
+
+
 def _build_usage(response: object) -> StraikerWebhookUsage | None:
-    usage = getattr(response, "usage", None)
-    if not isinstance(usage, Usage):
+    usage = response.get("usage") if isinstance(response, dict) else getattr(response, "usage", None)
+    if usage is None:
         return None
-    input_tokens = usage.prompt_tokens
-    output_tokens = usage.completion_tokens
+    input_tokens = _usage_token_count(usage, "prompt_tokens", "input_tokens")
+    output_tokens = _usage_token_count(usage, "completion_tokens", "output_tokens")
     if input_tokens is None and output_tokens is None:
         return None
     return StraikerWebhookUsage(input_tokens=input_tokens, output_tokens=output_tokens)
@@ -372,9 +402,7 @@ class StraikerGuardrail(CustomGuardrail):
         response_obj = request_data.get("response")
         content.finish_reason = _response_finish_reason(response_obj)
         request_content = StraikerWebhookContent(
-            structured_messages=_opaque_dict_list(
-                resolve_structured_messages(messages=request_data.get("messages"), request_kwargs=request_data)
-            ),
+            structured_messages=_opaque_dict_list(_request_structured_messages(request_data)),
         )
         phase: Literal["none", "assembled"] = "assembled" if _is_streamed_request(request_data) else "none"
         event = StraikerWebhookEvent(type="post_call", id=event_id, stream=StraikerWebhookStream(phase=phase))

--- a/litellm/types/proxy/guardrails/guardrail_hooks/straiker.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/straiker.py
@@ -4,9 +4,6 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from litellm.types.llms.openai import AllMessageValues, ChatCompletionToolCallChunk
-from litellm.types.utils import ChatCompletionMessageToolCall
-
 from .base import GuardrailConfigModel
 
 StraikerWebhookEventType = Literal["pre_call", "post_call"]
@@ -32,9 +29,9 @@ class StraikerWebhookContent(BaseModel):
 
     texts: list[str] = Field(default_factory=list)
     images: list[str] = Field(default_factory=list)
-    structured_messages: list[AllMessageValues] | None = None
+    structured_messages: list[dict[str, object]] | None = None
     tools: list[dict[str, object]] | None = None
-    tool_calls: list[ChatCompletionToolCallChunk] | list[ChatCompletionMessageToolCall] | None = None
+    tool_calls: list[dict[str, object]] | None = None
     finish_reason: str | None = None
 
 
@@ -45,6 +42,7 @@ class StraikerWebhookUsage(BaseModel):
 
 class StraikerWebhookContext(BaseModel):
     call_surface: str
+    mode: list[str] | None = None
     model: str | None = None
     model_provider: str | None = None
     destination: str | None = None

--- a/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/guardrail_translation/test_anthropic_guardrail_handler.py
@@ -57,6 +57,98 @@ class MockDynamicGuardrail(CustomGuardrail):
         return inputs
 
 
+class MockRecordingGuardrail(CustomGuardrail):
+    """Mock guardrail that records the request_data it was handed."""
+
+    def __init__(self, guardrail_name: str):
+        super().__init__(guardrail_name=guardrail_name)
+        self.request_data: Optional[dict] = None
+
+    async def apply_guardrail(
+        self,
+        inputs: GenericGuardrailAPIInputs,
+        request_data: dict,
+        input_type: Literal["request", "response"],
+        logging_obj: Optional[Any] = None,
+    ) -> GenericGuardrailAPIInputs:
+        self.request_data = request_data
+        return inputs
+
+
+class TestAnthropicMessagesHandlerStreamingRequestData:
+    """Post-call guardrails on streaming /v1/messages receive the response and identity metadata"""
+
+    @pytest.mark.asyncio
+    async def test_terminal_chunk_passes_assembled_response_and_metadata(self):
+        from litellm.proxy._types import UserAPIKeyAuth
+        from litellm.types.utils import Choices, Message, ModelResponse
+
+        handler = AnthropicMessagesHandler()
+        guardrail = MockRecordingGuardrail(guardrail_name="test")
+        mock_response = ModelResponse(
+            id="msg_123",
+            created=1234567890,
+            model="claude-sonnet-4-5",
+            object="chat.completion",
+            choices=[
+                Choices(
+                    finish_reason="stop",
+                    index=0,
+                    message=Message(content="Hello world", role="assistant"),
+                )
+            ],
+        )
+
+        with (
+            patch.object(handler, "_check_streaming_has_ended", return_value=True),
+            patch(
+                "litellm.llms.anthropic.chat.guardrail_translation.handler.AnthropicPassthroughLoggingHandler._build_complete_streaming_response",
+                return_value=mock_response,
+            ),
+        ):
+            await handler.process_output_streaming_response(
+                responses_so_far=[b"data: some chunk"],
+                guardrail_to_apply=guardrail,
+                litellm_logging_obj=MagicMock(),
+                user_api_key_dict=UserAPIKeyAuth(user_id="u-1", team_id="t-1"),
+                request_data={"model": "claude-sonnet-4-5"},
+            )
+
+        assert guardrail.request_data is not None
+        assert guardrail.request_data["response"] is mock_response
+        assert (
+            guardrail.request_data["litellm_metadata"]["user_api_key_user_id"] == "u-1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mid_stream_chunk_passes_responses_so_far_and_metadata(self):
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        handler = AnthropicMessagesHandler()
+        guardrail = MockRecordingGuardrail(guardrail_name="test")
+        responses_so_far = [b"data: some chunk"]
+
+        with (
+            patch.object(handler, "_check_streaming_has_ended", return_value=False),
+            patch.object(
+                handler, "get_streaming_string_so_far", return_value="partial text"
+            ),
+        ):
+            await handler.process_output_streaming_response(
+                responses_so_far=responses_so_far,
+                guardrail_to_apply=guardrail,
+                litellm_logging_obj=MagicMock(),
+                user_api_key_dict=UserAPIKeyAuth(user_id="u-1", team_id="t-1"),
+                request_data={"model": "claude-sonnet-4-5"},
+            )
+
+        assert guardrail.request_data is not None
+        assert guardrail.request_data["responses"] is responses_so_far
+        assert (
+            guardrail.request_data["litellm_metadata"]["user_api_key_user_id"] == "u-1"
+        )
+
+
 class TestAnthropicMessagesHandlerStreamingOutputProcessing:
     """Test streaming output processing functionality"""
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_straiker.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_straiker.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -8,6 +9,7 @@ from litellm.exceptions import GuardrailRaisedException, ModifyResponseException
 from litellm.proxy.guardrails.guardrail_hooks.straiker import initialize_guardrail
 from litellm.proxy.guardrails.guardrail_hooks.straiker.straiker import (
     StraikerGuardrail,
+    _response_finish_reason,
 )
 from litellm.proxy.guardrails.guardrail_registry import (
     guardrail_class_registry,
@@ -17,7 +19,14 @@ from litellm.types.proxy.guardrails.guardrail_hooks.straiker import (
     StraikerGuardrailConfigModel,
     StraikerGuardrailConfigModelOptionalParams,
 )
-from litellm.types.utils import Choices, Message, ModelResponse, Usage
+from litellm.types.utils import (
+    ChatCompletionMessageToolCall,
+    Choices,
+    Function,
+    Message,
+    ModelResponse,
+    Usage,
+)
 
 
 def _mock_response(action: str, turn_id: str = "turn-1", schema_version: str = "1", **extra) -> MagicMock:
@@ -208,7 +217,9 @@ async def test_request_envelope_transport_and_shape():
         "metadata": {"user_api_key_alias": "team-key", "agent_id": "chatbot-app", "app_name": "Chatbot"},
     }
 
-    out = await g.apply_guardrail(inputs=inputs, request_data=request_data, input_type="request", logging_obj=_logging_obj())
+    out = await g.apply_guardrail(
+        inputs=inputs, request_data=request_data, input_type="request", logging_obj=_logging_obj()
+    )
 
     assert out is inputs
     url = g.async_handler.post.call_args.args[0]
@@ -230,6 +241,35 @@ async def test_request_envelope_transport_and_shape():
     assert "user_role" not in payload["application"]
     assert "response" not in payload
     assert "metadata" not in payload
+
+
+@pytest.mark.asyncio
+async def test_request_envelope_ignores_unsupported_opaque_items():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response("NONE")
+
+    await g.apply_guardrail(
+        inputs={
+            "texts": ["hello"],
+            "tools": [
+                object(),
+                {
+                    "type": "function",
+                    "function": {"name": "get_weather", "parameters": {"type": "object"}},
+                },
+            ],
+        },
+        request_data={"model": "m", "messages": [{"role": "user", "content": "hello"}]},
+        input_type="request",
+        logging_obj=_logging_obj(),
+    )
+
+    assert _posted_payload(g)["request"]["tools"] == [
+        {
+            "type": "function",
+            "function": {"name": "get_weather", "parameters": {"type": "object"}},
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -332,6 +372,64 @@ async def test_context_session_id_from_request_metadata():
 
 
 @pytest.mark.asyncio
+async def test_context_mode_from_string_event_hook():
+    g = _make_guardrail(event_hook="pre_call")
+    g.async_handler.post.return_value = _mock_response("NONE")
+    await g.apply_guardrail(
+        inputs={"texts": ["x"]},
+        request_data={"model": "m"},
+        input_type="request",
+        logging_obj=_logging_obj(),
+    )
+    assert _posted_payload(g)["context"]["mode"] == ["pre_call"]
+
+
+@pytest.mark.asyncio
+async def test_context_mode_from_list_event_hook():
+    from litellm.types.guardrails import GuardrailEventHooks
+
+    g = _make_guardrail(event_hook=[GuardrailEventHooks.pre_call, GuardrailEventHooks.post_call])
+    g.async_handler.post.return_value = _mock_response("NONE")
+    await g.apply_guardrail(
+        inputs={"texts": ["x"]},
+        request_data={"model": "m"},
+        input_type="request",
+        logging_obj=_logging_obj(),
+    )
+    assert _posted_payload(g)["context"]["mode"] == ["pre_call", "post_call"]
+
+
+@pytest.mark.asyncio
+async def test_context_mode_from_tagged_mode_is_flattened_and_deduped():
+    from litellm.types.guardrails import Mode
+
+    g = _make_guardrail(
+        event_hook=Mode(tags={"team-a": "pre_call", "team-b": ["post_call", "pre_call"]}, default="post_call")
+    )
+    g.async_handler.post.return_value = _mock_response("NONE")
+    await g.apply_guardrail(
+        inputs={"texts": ["x"]},
+        request_data={"model": "m"},
+        input_type="request",
+        logging_obj=_logging_obj(),
+    )
+    assert _posted_payload(g)["context"]["mode"] == ["post_call", "pre_call"]
+
+
+@pytest.mark.asyncio
+async def test_context_mode_omitted_when_event_hook_absent():
+    g = _make_guardrail(event_hook=None)
+    g.async_handler.post.return_value = _mock_response("NONE")
+    await g.apply_guardrail(
+        inputs={"texts": ["x"]},
+        request_data={"model": "m"},
+        input_type="request",
+        logging_obj=_logging_obj(),
+    )
+    assert "mode" not in _posted_payload(g)["context"]
+
+
+@pytest.mark.asyncio
 async def test_identity_key_and_team_coalesce_alias_over_id():
     g = _make_guardrail()
     g.async_handler.post.return_value = _mock_response("NONE")
@@ -425,6 +523,7 @@ async def test_application_source_from_agent_id():
         logging_obj=_logging_obj(),
     )
     assert _posted_payload(g)["application"] == {"source": "analytics-app", "name": "Analytics"}
+
 
 @pytest.mark.asyncio
 async def test_request_block_raises_guardrail_exception_with_reason():
@@ -558,6 +657,33 @@ async def test_response_envelope_and_block_replaces_response():
     assert payload["response"]["texts"] == ["secret"]
     assert payload["response"]["finish_reason"] == "stop"
     assert payload["request"]["structured_messages"] == [{"role": "user", "content": "original prompt"}]
+
+
+@pytest.mark.asyncio
+async def test_post_call_resolves_request_from_responses_input_when_messages_absent():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response("NONE")
+    response = ModelResponse(
+        choices=[Choices(finish_reason="stop", index=0, message=Message(content="answer", role="assistant"))],
+        model="gpt-4o-mini",
+    )
+    request_data = {
+        "model": "gpt-4o-mini",
+        "input": "responses-surface prompt",
+        "response": response,
+    }
+
+    await g.apply_guardrail(
+        inputs={"texts": ["answer"], "model": "gpt-4o-mini"},
+        request_data=request_data,
+        input_type="response",
+        logging_obj=_logging_obj(),
+    )
+
+    payload = _posted_payload(g)
+    assert payload["event"]["type"] == "post_call"
+    messages = payload["request"]["structured_messages"]
+    assert any(m.get("content") == "responses-surface prompt" for m in messages)
 
 
 @pytest.mark.asyncio
@@ -731,3 +857,135 @@ async def test_unreachable_http_status_fail_closed_blocks():
         await g.apply_guardrail(
             inputs={"texts": ["x"]}, request_data={"model": "m"}, input_type="request", logging_obj=_logging_obj()
         )
+
+
+@pytest.mark.asyncio
+async def test_post_call_preserves_anthropic_tool_blocks_in_request_messages():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response("NONE")
+    anthropic_messages = [
+        {"role": "user", "content": "What's the weather in Paris?"},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "get_weather",
+                    "input": {"city": "Paris"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": "18C, cloudy",
+                }
+            ],
+        },
+    ]
+    response = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Mild and cloudy."}],
+        "stop_reason": "end_turn",
+        "model": "claude-sonnet-5",
+    }
+    await g.apply_guardrail(
+        inputs={"texts": ["Mild and cloudy."], "model": "claude-sonnet-5"},
+        request_data={
+            "model": "claude-sonnet-5",
+            "messages": anthropic_messages,
+            "response": response,
+        },
+        input_type="response",
+        logging_obj=_logging_obj(),
+    )
+    payload = _posted_payload(g)
+    assert payload["request"]["structured_messages"] == anthropic_messages
+    assert payload["response"]["finish_reason"] == "end_turn"
+
+
+@pytest.mark.asyncio
+async def test_pre_call_preserves_anthropic_tool_blocks_in_structured_messages():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response("NONE")
+    anthropic_messages = [
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "get_weather",
+                    "input": {"city": "Paris"},
+                }
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": "18C",
+                }
+            ],
+        },
+    ]
+    await g.apply_guardrail(
+        inputs={"structured_messages": anthropic_messages, "model": "claude-sonnet-5"},
+        request_data={"model": "claude-sonnet-5", "messages": anthropic_messages},
+        input_type="request",
+        logging_obj=_logging_obj(),
+    )
+    assert _posted_payload(g)["request"]["structured_messages"] == anthropic_messages
+
+
+@pytest.mark.asyncio
+async def test_response_finish_reason_from_openai_choices_still_works():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response("NONE")
+    response = ModelResponse(
+        choices=[Choices(finish_reason="tool_calls", index=0, message=Message(content=None, role="assistant"))],
+        model="gpt-4o-mini",
+    )
+    await g.apply_guardrail(
+        inputs={
+            "texts": [],
+            "tool_calls": [
+                ChatCompletionMessageToolCall(
+                    id="c1",
+                    type="function",
+                    function=Function(name="f", arguments="{}"),
+                )
+            ],
+        },
+        request_data={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}], "response": response},
+        input_type="response",
+        logging_obj=_logging_obj(),
+    )
+    payload = _posted_payload(g)
+    assert payload["response"]["finish_reason"] == "tool_calls"
+    assert payload["response"]["tool_calls"] == [
+        {"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}
+    ]
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (None, None),
+        ({"choices": "invalid"}, None),
+        ({"choices": [{"finish_reason": "length"}]}, "length"),
+        ({"choices": [{"stop_reason": "end_turn"}]}, "end_turn"),
+        ({"choices": [{}]}, None),
+        (SimpleNamespace(stop_reason="end_turn"), "end_turn"),
+    ],
+)
+def test_response_finish_reason_handles_supported_shapes(response, expected):
+    assert _response_finish_reason(response) == expected

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_straiker.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_straiker.py
@@ -9,6 +9,8 @@ from litellm.exceptions import GuardrailRaisedException, ModifyResponseException
 from litellm.proxy.guardrails.guardrail_hooks.straiker import initialize_guardrail
 from litellm.proxy.guardrails.guardrail_hooks.straiker.straiker import (
     StraikerGuardrail,
+    _build_usage,
+    _request_structured_messages,
     _response_finish_reason,
 )
 from litellm.proxy.guardrails.guardrail_registry import (
@@ -671,6 +673,7 @@ async def test_post_call_resolves_request_from_responses_input_when_messages_abs
         "model": "gpt-4o-mini",
         "input": "responses-surface prompt",
         "response": response,
+        "litellm_metadata": {"user_api_key_request_route": "/v1/responses"},
     }
 
     await g.apply_guardrail(
@@ -989,3 +992,78 @@ async def test_response_finish_reason_from_openai_choices_still_works():
 )
 def test_response_finish_reason_handles_supported_shapes(response, expected):
     assert _response_finish_reason(response) == expected
+
+
+@pytest.mark.parametrize(
+    "request_data",
+    [
+        {"input": ["ssn 123-45-6789"], "litellm_metadata": {"user_api_key_request_route": "/vllm/v1/embeddings"}},
+        {"input": [[1, 2, 3]], "litellm_metadata": {}},
+        {"input": "confidential memo", "litellm_metadata": {}},
+        {"input": "confidential memo"},
+    ],
+)
+def test_request_messages_not_resolved_for_unmapped_surfaces(request_data):
+    """Bodies from surfaces without a translation handler yield no messages, and never raise."""
+    assert _request_structured_messages(request_data) is None
+
+
+@pytest.mark.parametrize(
+    ("request_data", "expected"),
+    [
+        (
+            {"messages": [{"role": "user", "content": "hi"}], "litellm_metadata": {}},
+            [{"role": "user", "content": "hi"}],
+        ),
+        (
+            {
+                "input": [{"role": "user", "content": "weather in Paris?"}],
+                "litellm_metadata": {"user_api_key_request_route": "/v1/responses"},
+            },
+            [{"role": "user", "content": "weather in Paris?"}],
+        ),
+    ],
+)
+def test_request_messages_resolved_for_mapped_surfaces(request_data, expected):
+    assert _request_structured_messages(request_data) == expected
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        ({"usage": {"input_tokens": 10, "output_tokens": 5}}, (10, 5)),
+        ({"usage": {"prompt_tokens": 7, "completion_tokens": 3}}, (7, 3)),
+        (SimpleNamespace(usage=Usage(prompt_tokens=7, completion_tokens=3)), (7, 3)),
+        ({"usage": {"prompt_tokens": 0, "input_tokens": 99}}, (0, None)),
+        ({"usage": {}}, None),
+        ({}, None),
+    ],
+)
+def test_build_usage_handles_openai_and_anthropic_shapes(response, expected):
+    usage = _build_usage(response)
+    if expected is None:
+        assert usage is None
+    else:
+        assert (usage.input_tokens, usage.output_tokens) == expected
+
+
+@pytest.mark.asyncio
+async def test_anthropic_non_streaming_response_reports_usage():
+    g = _make_guardrail()
+    g.async_handler.post.return_value = _mock_response("NONE")
+    await g.apply_guardrail(
+        inputs={"texts": ["hello"]},
+        request_data={
+            "model": "claude-sonnet-4-5",
+            "messages": [{"role": "user", "content": "hi"}],
+            "response": {
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 10, "output_tokens": 5},
+            },
+        },
+        input_type="response",
+        logging_obj=_logging_obj(),
+    )
+    payload = _posted_payload(g)
+    assert payload["usage"] == {"input_tokens": 10, "output_tokens": 5}
+    assert payload["response"]["finish_reason"] == "end_turn"


### PR DESCRIPTION
## Credit

Original work by @cs-mehta in BerriAI/litellm#34485. This branch mirrors that PR onto a `litellm_` prefixed branch so CircleCI and the internal lint workflow run against it, plus follow-up commits addressing review findings.

## TLDR

Problem this solves:

- `/v1/messages` streaming post-call hooks omitted prepared response metadata
- Responses post-call webhooks could lose the original request context
- Straiker payload types assumed chat-completion-specific message shapes

How it solves it:

- Prepare Anthropic streaming response data before applying post-call guardrails, on both the terminal and mid-stream branches
- Normalize Straiker request, tool, finish-reason, and mode fields

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

Bug Fix

## Changes

The Anthropic Messages streaming post-call path prepares request data before invoking guardrails, matching the non-streaming path and preserving the assembled response and LiteLLM metadata

The Straiker plugin resolves request messages across API formats, preserves opaque JSON message and tool structures, extracts OpenAI and Anthropic terminal reasons, and includes configured guardrail modes in webhook context

## Behavior changes

None for existing chat-completions traffic. Straiker post-call webhooks on `/v1/messages` and `/v1/responses` now carry `request.structured_messages`, `response.finish_reason` and `response.usage` where they were previously absent

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/34548" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches guardrail request_data on the Anthropic streaming path and Straiker post-call webhook assembly; behavior changes for /v1/messages and /v1/responses but chat-completions paths are largely unchanged.
> 
> **Overview**
> **Anthropic `/v1/messages` streaming post-call guardrails** now call `_prepare_request_data` before `apply_guardrail`, same as non-streaming. End-of-stream hooks get the assembled `response` and user `litellm_metadata`; mid-stream hooks get `responses` plus metadata instead of a bare request dict.
> 
> **Straiker webhooks** are generalized for non–chat-completions surfaces. Post-call `request.structured_messages` comes from `messages` when present, otherwise from `resolve_structured_messages` only on routes with guardrail translation (e.g. `/v1/responses`). Payload fields use opaque JSON dicts; finish reason and usage work on dict/Anthropic shapes (`stop_reason`, `input_tokens`/`output_tokens`). Webhook `context.mode` lists configured guardrail event hooks.
> 
> Straiker webhook types drop chat-specific message/tool types in favor of generic dict lists. Tests cover streaming request_data handoff and Straiker envelope behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b36b24af2b201e8bc948d1ad0b8dd05b49c31d3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->