### PR TITLE
feat(ui): migrate the Create Organization form to shadcn and react-hook-form

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -1088,11 +1088,6 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/app/(dashboard)/playground/components/chat_ui/A2AMetrics.tsx": {
     "no-restricted-imports": {
       "count": 1

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
@@ -1,19 +1,14 @@
 import { organizationKeys, useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 import { useUserModels } from "@/app/(dashboard)/hooks/models/useModels";
 import OrganizationFilters, { FilterState } from "@/app/(dashboard)/organizations/OrganizationFilters";
-import { InfoCircleOutlined } from "@ant-design/icons";
-import { Form, Input, Modal, Select as Select2, Tooltip } from "antd";
 import { useQueryClient } from "@tanstack/react-query";
 import React, { useState } from "react";
 import DeleteResourceModal from "@/components/common_components/DeleteResourceModal";
-import MCPServerSelector from "@/components/mcp_server_management/MCPServerSelector";
-import { ModelSelect } from "@/components/ModelSelect/ModelSelect";
 import NotificationsManager from "@/components/molecules/notifications_manager";
-import { organizationCreateCall, organizationDeleteCall } from "@/components/networking";
+import { organizationDeleteCall } from "@/components/networking";
+import { OrgCreateDialog } from "@/components/organization/org-create/OrgCreateDialog";
 import OrganizationInfoView from "@/components/organization/organization_view";
-import NumericalInput from "@/components/shared/numerical_input";
 import { Button } from "@/components/ui/button";
-import VectorStoreSelector from "@/components/vector_store_management/VectorStoreSelector";
 
 import OrganizationsTable from "./OrganizationsTable";
 
@@ -30,7 +25,6 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
   const [orgToDelete, setOrgToDelete] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isOrgModalVisible, setIsOrgModalVisible] = useState(false);
-  const [form] = Form.useForm();
   const [showFilters, setShowFilters] = useState(false);
   const [filters, setFilters] = useState<FilterState>({ org_id: "", org_alias: "" });
 
@@ -81,48 +75,6 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
   const cancelDelete = () => {
     setIsDeleteModalOpen(false);
     setOrgToDelete(null);
-  };
-
-  const handleCreate = async (values: any) => {
-    try {
-      if (!accessToken) return;
-
-      // Transform allowed_vector_store_ids and allowed_mcp_servers_and_groups into object_permission
-      if (
-        (values.allowed_vector_store_ids && values.allowed_vector_store_ids.length > 0) ||
-        (values.allowed_mcp_servers_and_groups &&
-          (values.allowed_mcp_servers_and_groups.servers?.length > 0 ||
-            values.allowed_mcp_servers_and_groups.accessGroups?.length > 0))
-      ) {
-        values.object_permission = {};
-        if (values.allowed_vector_store_ids && values.allowed_vector_store_ids.length > 0) {
-          values.object_permission.vector_stores = values.allowed_vector_store_ids;
-          delete values.allowed_vector_store_ids;
-        }
-        if (values.allowed_mcp_servers_and_groups) {
-          if (values.allowed_mcp_servers_and_groups.servers?.length > 0) {
-            values.object_permission.mcp_servers = values.allowed_mcp_servers_and_groups.servers;
-          }
-          if (values.allowed_mcp_servers_and_groups.accessGroups?.length > 0) {
-            values.object_permission.mcp_access_groups = values.allowed_mcp_servers_and_groups.accessGroups;
-          }
-          delete values.allowed_mcp_servers_and_groups;
-        }
-      }
-
-      await organizationCreateCall(accessToken, values);
-      NotificationsManager.success("Organization created successfully");
-      setIsOrgModalVisible(false);
-      form.resetFields();
-      await refetchOrganizations();
-    } catch (error) {
-      console.error("Error creating organization:", error);
-    }
-  };
-
-  const handleCancel = () => {
-    setIsOrgModalVisible(false);
-    form.resetFields();
   };
 
   if (!premiumUser) {
@@ -190,97 +142,7 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
         </>
       )}
 
-      <Modal title="Create Organization" visible={isOrgModalVisible} width={800} footer={null} onCancel={handleCancel}>
-        <Form form={form} onFinish={handleCreate} labelCol={{ span: 8 }} wrapperCol={{ span: 16 }} labelAlign="left">
-          <Form.Item
-            label="Organization Name"
-            name="organization_alias"
-            rules={[
-              {
-                required: true,
-                message: "Please input an organization name",
-              },
-            ]}
-          >
-            <Input placeholder="" />
-          </Form.Item>
-          <Form.Item label="Models" name="models">
-            <ModelSelect
-              options={{ showAllProxyModelsOverride: true, includeSpecialOptions: true }}
-              value={form.getFieldValue("models")}
-              onChange={(values) => form.setFieldValue("models", values)}
-              context="organization"
-            />
-          </Form.Item>
-
-          <Form.Item label="Max Budget (USD)" name="max_budget">
-            <NumericalInput step={0.01} precision={2} width={200} />
-          </Form.Item>
-          <Form.Item label="Reset Budget" name="budget_duration">
-            <Select2 defaultValue={null} placeholder="n/a">
-              <Select2.Option value="24h">daily</Select2.Option>
-              <Select2.Option value="7d">weekly</Select2.Option>
-              <Select2.Option value="30d">monthly</Select2.Option>
-            </Select2>
-          </Form.Item>
-          <Form.Item label="Tokens per minute Limit (TPM)" name="tpm_limit">
-            <NumericalInput step={1} width={400} />
-          </Form.Item>
-          <Form.Item label="Requests per minute Limit (RPM)" name="rpm_limit">
-            <NumericalInput step={1} width={400} />
-          </Form.Item>
-
-          <Form.Item
-            label={
-              <span>
-                Allowed Vector Stores{" "}
-                <Tooltip title="Select which vector stores this organization can access by default. Leave empty for access to all vector stores">
-                  <InfoCircleOutlined style={{ marginLeft: "4px" }} />
-                </Tooltip>
-              </span>
-            }
-            name="allowed_vector_store_ids"
-            className="mt-4"
-            help="Select vector stores this organization can access. Leave empty for access to all vector stores"
-          >
-            <VectorStoreSelector
-              onChange={(values) => form.setFieldValue("allowed_vector_store_ids", values)}
-              value={form.getFieldValue("allowed_vector_store_ids")}
-              accessToken={accessToken || ""}
-              placeholder="Select vector stores (optional)"
-            />
-          </Form.Item>
-
-          <Form.Item
-            label={
-              <span>
-                Allowed MCP Servers{" "}
-                <Tooltip title="Select which MCP servers and access groups this organization can access by default.">
-                  <InfoCircleOutlined style={{ marginLeft: "4px" }} />
-                </Tooltip>
-              </span>
-            }
-            name="allowed_mcp_servers_and_groups"
-            className="mt-4"
-            help="Select MCP servers and access groups this organization can access."
-          >
-            <MCPServerSelector
-              onChange={(values) => form.setFieldValue("allowed_mcp_servers_and_groups", values)}
-              value={form.getFieldValue("allowed_mcp_servers_and_groups")}
-              accessToken={accessToken || ""}
-              placeholder="Select MCP servers and access groups (optional)"
-            />
-          </Form.Item>
-
-          <Form.Item label="Metadata" name="metadata">
-            <Input.TextArea rows={4} />
-          </Form.Item>
-
-          <div style={{ textAlign: "right", marginTop: "10px" }}>
-            <Button type="submit">Create Organization</Button>
-          </div>
-        </Form>
-      </Modal>
+      <OrgCreateDialog open={isOrgModalVisible} onOpenChange={setIsOrgModalVisible} accessToken={accessToken || ""} />
 
       <DeleteResourceModal
         isOpen={isDeleteModalOpen}

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1184,35 +1184,6 @@ export const organizationInfoCall = async (accessToken: string, organizationID: 
   }
 };
 
-export const organizationCreateCall = async (
-  accessToken: string,
-  formValues: Record<string, any>, // Assuming formValues is an object
-) => {
-  try {
-    if (formValues.metadata) {
-      // if there's an exception JSON.parse, show it in the message
-      try {
-        formValues.metadata = JSON.parse(formValues.metadata);
-      } catch (error) {
-        console.error("Failed to parse metadata:", error);
-        throw new Error("Failed to parse metadata: " + error);
-      }
-    }
-
-    const data = await apiClient.post(`/organization/new`, {
-      accessToken,
-      body: {
-        ...formValues, // Include formValues in the request body
-      },
-    });
-    return data;
-    // Handle success - you might want to update some state or UI based on the created key
-  } catch (error) {
-    console.error("Failed to create key:", error);
-    throw error;
-  }
-};
-
 export const organizationUpdateCall = async (
   accessToken: string,
   formValues: Record<string, any>, // Assuming formValues is an object

--- a/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.test.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.test.tsx
@@ -145,4 +145,37 @@ describe("OrgCreateDialog", () => {
     await user.click(screen.getByRole("button", { name: "reopen" }));
     expect(screen.getByLabelText("Organization Name")).toHaveValue("");
   });
+
+  it("resets the form when the dialog is dismissed with Escape and reopened", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByLabelText("Organization Name"), "abandoned");
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByLabelText("Organization Name")).not.toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "reopen" }));
+    expect(screen.getByLabelText("Organization Name")).toHaveValue("");
+  });
+
+  it("does not fire a second create while one is pending", async () => {
+    const user = userEvent.setup();
+    let resolveCreate: (value: unknown) => void = () => {};
+    const createOrganization = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+    renderDialog({ createOrganization });
+
+    await user.type(screen.getByLabelText("Organization Name"), "new-org");
+    await user.keyboard("{Enter}");
+    await waitFor(() => expect(createOrganization).toHaveBeenCalledTimes(1));
+    await user.keyboard("{Enter}");
+
+    expect(createOrganization).toHaveBeenCalledTimes(1);
+    resolveCreate({});
+    await waitFor(() => expect(screen.queryByLabelText("Organization Name")).not.toBeInTheDocument());
+  });
 });

--- a/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.test.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.test.tsx
@@ -1,0 +1,148 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/molecules/notifications_manager", () => ({
+  __esModule: true,
+  default: { success: vi.fn(), fromBackend: vi.fn() },
+}));
+vi.mock("@/components/ModelSelect/ModelSelect", () => ({
+  ModelSelect: ({ onChange }: { onChange: (values: string[]) => void }) => (
+    <button type="button" onClick={() => onChange(["gpt-5.2"])}>
+      set-models
+    </button>
+  ),
+}));
+vi.mock("@/components/vector_store_management/VectorStoreSelector", () => ({
+  __esModule: true,
+  default: ({ onChange }: { onChange: (values: string[]) => void }) => (
+    <button type="button" onClick={() => onChange(["vs-1"])}>
+      set-vector-stores
+    </button>
+  ),
+}));
+vi.mock("@/components/mcp_server_management/MCPServerSelector", () => ({
+  __esModule: true,
+  default: ({
+    onChange,
+  }: {
+    onChange: (values: { servers: string[]; accessGroups: string[]; toolsets: string[] }) => void;
+  }) => (
+    <button type="button" onClick={() => onChange({ servers: ["srv-1"], accessGroups: [], toolsets: ["ts-1"] })}>
+      set-mcp
+    </button>
+  ),
+}));
+
+import { OrgCreateDialog } from "./OrgCreateDialog";
+
+const Harness = ({ createOrganization }: { createOrganization: (body: unknown) => Promise<unknown> }) => {
+  const [open, setOpen] = React.useState(true);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        reopen
+      </button>
+      <OrgCreateDialog open={open} onOpenChange={setOpen} accessToken="token" createOrganization={createOrganization} />
+    </>
+  );
+};
+
+const renderDialog = (overrides?: { createOrganization?: ReturnType<typeof vi.fn> }) => {
+  const createOrganization = overrides?.createOrganization ?? vi.fn().mockResolvedValue({});
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <Harness createOrganization={createOrganization} />
+    </QueryClientProvider>,
+  );
+  return { createOrganization };
+};
+
+describe("OrgCreateDialog", () => {
+  it("blocks submit and shows an error when the name is missing", async () => {
+    const user = userEvent.setup();
+    const { createOrganization } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "Create Organization" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Please input an organization name");
+    expect(createOrganization).not.toHaveBeenCalled();
+  });
+
+  it("sends only alias and models for a minimal create and closes the dialog", async () => {
+    const user = userEvent.setup();
+    const { createOrganization } = renderDialog();
+
+    await user.type(screen.getByLabelText("Organization Name"), "new-org");
+    await user.click(screen.getByRole("button", { name: "Create Organization" }));
+
+    await waitFor(() => expect(createOrganization).toHaveBeenCalledTimes(1));
+    expect(createOrganization.mock.calls[0][0]).toStrictEqual({ organization_alias: "new-org", models: [] });
+    await waitFor(() => expect(screen.queryByLabelText("Organization Name")).not.toBeInTheDocument());
+  });
+
+  it("maps selectors and limits into the create body", async () => {
+    const user = userEvent.setup();
+    const { createOrganization } = renderDialog();
+
+    await user.type(screen.getByLabelText("Organization Name"), "new-org");
+    await user.click(screen.getByRole("button", { name: "set-models" }));
+    await user.type(screen.getByLabelText("Tokens per minute Limit (TPM)"), "1000");
+    await user.click(screen.getByRole("button", { name: "set-vector-stores" }));
+    await user.click(screen.getByRole("button", { name: "set-mcp" }));
+    await user.click(screen.getByRole("button", { name: "Create Organization" }));
+
+    await waitFor(() => expect(createOrganization).toHaveBeenCalledTimes(1));
+    const expectedBody = {
+      organization_alias: "new-org",
+      models: ["gpt-5.2"],
+      tpm_limit: 1000,
+      object_permission: {
+        vector_stores: ["vs-1"],
+        mcp_servers: ["srv-1"],
+        mcp_toolsets: ["ts-1"],
+      },
+    };
+    expect(createOrganization.mock.calls[0][0]).toStrictEqual(expectedBody);
+  });
+
+  it("blocks submit and shows an error for invalid metadata JSON", async () => {
+    const user = userEvent.setup();
+    const { createOrganization } = renderDialog();
+
+    await user.type(screen.getByLabelText("Organization Name"), "new-org");
+    await user.type(screen.getByLabelText("Metadata"), "not json");
+    await user.click(screen.getByRole("button", { name: "Create Organization" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Metadata must be a valid JSON object");
+    expect(createOrganization).not.toHaveBeenCalled();
+  });
+
+  it("keeps the dialog open with the entered values when the create fails", async () => {
+    const user = userEvent.setup();
+    const { createOrganization } = renderDialog({
+      createOrganization: vi.fn().mockRejectedValue(new Error("boom")),
+    });
+
+    await user.type(screen.getByLabelText("Organization Name"), "new-org");
+    await user.click(screen.getByRole("button", { name: "Create Organization" }));
+
+    await waitFor(() => expect(createOrganization).toHaveBeenCalledTimes(1));
+    expect(screen.getByLabelText("Organization Name")).toHaveValue("new-org");
+  });
+
+  it("resets the form when the dialog is cancelled and reopened", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(screen.getByLabelText("Organization Name"), "abandoned");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.queryByLabelText("Organization Name")).not.toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "reopen" }));
+    expect(screen.getByLabelText("Organization Name")).toHaveValue("");
+  });
+});

--- a/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.test.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.test.tsx
@@ -158,6 +158,28 @@ describe("OrgCreateDialog", () => {
     expect(screen.getByLabelText("Organization Name")).toHaveValue("");
   });
 
+  it("cannot be dismissed while a create is pending, then closes once on success", async () => {
+    const user = userEvent.setup();
+    let resolveCreate: (value: unknown) => void = () => {};
+    const createOrganization = vi.fn().mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCreate = resolve;
+        }),
+    );
+    renderDialog({ createOrganization });
+
+    await user.type(screen.getByLabelText("Organization Name"), "new-org");
+    await user.keyboard("{Enter}");
+    await waitFor(() => expect(createOrganization).toHaveBeenCalledTimes(1));
+
+    await user.keyboard("{Escape}");
+    expect(screen.getByLabelText("Organization Name")).toHaveValue("new-org");
+
+    resolveCreate({});
+    await waitFor(() => expect(screen.queryByLabelText("Organization Name")).not.toBeInTheDocument());
+  });
+
   it("does not fire a second create while one is pending", async () => {
     const user = userEvent.setup();
     let resolveCreate: (value: unknown) => void = () => {};

--- a/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.tsx
@@ -103,6 +103,7 @@ export const OrgCreateDialog = ({
             <FormField control={form.control} name="budget_duration" label="Reset Budget">
               {({ id, value, onChange, "aria-invalid": ariaInvalid, "aria-describedby": ariaDescribedBy }) => (
                 <Select
+                  items={BUDGET_DURATION_OPTIONS}
                   value={value === "" ? NO_RESET : value}
                   onValueChange={(selected) => onChange(selected === NO_RESET ? "" : selected)}
                 >

--- a/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import * as React from "react";
+
+import { organizationKeys } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
+import { ModelSelect } from "@/components/ModelSelect/ModelSelect";
+import MCPServerSelector from "@/components/mcp_server_management/MCPServerSelector";
+import NotificationsManager from "@/components/molecules/notifications_manager";
+import { FieldGroup } from "@/components/shared/form/field";
+import { FormField } from "@/components/shared/form/FormField";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import VectorStoreSelector from "@/components/vector_store_management/VectorStoreSelector";
+import { useZodForm } from "@/lib/forms/useZodForm";
+import { fetchClient } from "@/lib/http/api";
+
+import { BUDGET_DURATION_OPTIONS, NO_RESET } from "../org-settings/OrgSettingsForm";
+import { orgSettingsSchema } from "../org-settings/schema";
+import { buildOrgCreateBody, emptyOrgFormValues, type OrgCreateBody } from "./mapper";
+
+const defaultCreateOrganization = async (body: OrgCreateBody): Promise<unknown> => {
+  const { data } = await fetchClient.POST("/organization/new", { body });
+  return data;
+};
+
+interface OrgCreateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  accessToken: string;
+  createOrganization?: (body: OrgCreateBody) => Promise<unknown>;
+}
+
+export const OrgCreateDialog = ({
+  open,
+  onOpenChange,
+  accessToken,
+  createOrganization = defaultCreateOrganization,
+}: OrgCreateDialogProps) => {
+  const queryClient = useQueryClient();
+  const form = useZodForm(orgSettingsSchema, { defaultValues: emptyOrgFormValues });
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      form.reset(emptyOrgFormValues);
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const mutation = useMutation({
+    mutationFn: (body: OrgCreateBody) => createOrganization(body),
+    onSuccess: () => {
+      NotificationsManager.success("Organization created successfully");
+      queryClient.invalidateQueries({ queryKey: organizationKeys.all });
+      handleOpenChange(false);
+    },
+    onError: (error: unknown) =>
+      NotificationsManager.fromBackend(error instanceof Error ? error.message : "Failed to create organization"),
+  });
+
+  const onSubmit = form.handleSubmit((values) => {
+    mutation.mutate(buildOrgCreateBody(values));
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Create Organization</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={onSubmit}>
+          <FieldGroup>
+            <FormField control={form.control} name="organization_alias" label="Organization Name">
+              {({ ref, ...field }) => <Input {...field} ref={ref} />}
+            </FormField>
+
+            <FormField control={form.control} name="models" label="Models">
+              {(field) => (
+                <ModelSelect
+                  value={field.value}
+                  onChange={field.onChange}
+                  context="organization"
+                  options={{ includeSpecialOptions: true, showAllProxyModelsOverride: true }}
+                />
+              )}
+            </FormField>
+
+            <FormField control={form.control} name="max_budget" label="Max Budget (USD)">
+              {({ ref, ...field }) => <Input {...field} ref={ref} type="number" step={0.01} min={0} />}
+            </FormField>
+
+            <FormField control={form.control} name="budget_duration" label="Reset Budget">
+              {({ id, value, onChange, "aria-invalid": ariaInvalid, "aria-describedby": ariaDescribedBy }) => (
+                <Select
+                  value={value === "" ? NO_RESET : value}
+                  onValueChange={(selected) => onChange(selected === NO_RESET ? "" : selected)}
+                >
+                  <SelectTrigger id={id} aria-invalid={ariaInvalid} aria-describedby={ariaDescribedBy}>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {BUDGET_DURATION_OPTIONS.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </FormField>
+
+            <FormField control={form.control} name="tpm_limit" label="Tokens per minute Limit (TPM)">
+              {({ ref, ...field }) => <Input {...field} ref={ref} type="number" step={1} min={0} />}
+            </FormField>
+
+            <FormField control={form.control} name="rpm_limit" label="Requests per minute Limit (RPM)">
+              {({ ref, ...field }) => <Input {...field} ref={ref} type="number" step={1} min={0} />}
+            </FormField>
+
+            <FormField
+              control={form.control}
+              name="vector_stores"
+              label="Allowed Vector Stores"
+              description="Select vector stores this organization can access. Leave empty for access to all vector stores"
+            >
+              {(field) => (
+                <VectorStoreSelector
+                  value={field.value}
+                  onChange={field.onChange}
+                  accessToken={accessToken}
+                  placeholder="Select vector stores (optional)"
+                />
+              )}
+            </FormField>
+
+            <FormField
+              control={form.control}
+              name="mcp"
+              label="Allowed MCP Servers"
+              description="Select MCP servers, access groups, and toolsets this organization can access. Leave empty for access to all"
+            >
+              {(field) => (
+                <MCPServerSelector
+                  value={field.value}
+                  onChange={field.onChange}
+                  accessToken={accessToken}
+                  placeholder="Select MCP servers and access groups (optional)"
+                />
+              )}
+            </FormField>
+
+            <FormField control={form.control} name="metadata" label="Metadata">
+              {({ ref, ...field }) => <Textarea {...field} ref={ref} rows={4} />}
+            </FormField>
+          </FieldGroup>
+
+          <DialogFooter className="mt-6">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={mutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? "Creating..." : "Create Organization"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.tsx
@@ -43,11 +43,9 @@ export const OrgCreateDialog = ({
   const queryClient = useQueryClient();
   const form = useZodForm(orgSettingsSchema, { defaultValues: emptyOrgFormValues });
 
-  const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen) {
-      form.reset(emptyOrgFormValues);
-    }
-    onOpenChange(nextOpen);
+  const closeAndReset = () => {
+    form.reset(emptyOrgFormValues);
+    onOpenChange(false);
   };
 
   const mutation = useMutation({
@@ -55,11 +53,19 @@ export const OrgCreateDialog = ({
     onSuccess: () => {
       NotificationsManager.success("Organization created successfully");
       queryClient.invalidateQueries({ queryKey: organizationKeys.all });
-      handleOpenChange(false);
+      closeAndReset();
     },
     onError: (error: unknown) =>
       NotificationsManager.fromBackend(error instanceof Error ? error.message : "Failed to create organization"),
   });
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && mutation.isPending) return;
+    if (!nextOpen) {
+      form.reset(emptyOrgFormValues);
+    }
+    onOpenChange(nextOpen);
+  };
 
   const onSubmit = form.handleSubmit((values) => {
     if (mutation.isPending) return;

--- a/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.tsx
@@ -62,6 +62,7 @@ export const OrgCreateDialog = ({
   });
 
   const onSubmit = form.handleSubmit((values) => {
+    if (mutation.isPending) return;
     mutation.mutate(buildOrgCreateBody(values));
   });
 

--- a/ui/litellm-dashboard/src/components/organization/org-create/mapper.test.ts
+++ b/ui/litellm-dashboard/src/components/organization/org-create/mapper.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { buildOrgCreateBody, emptyOrgFormValues } from "./mapper";
+
+describe("buildOrgCreateBody", () => {
+  it("sends only alias and models for a minimal form", () => {
+    expect(buildOrgCreateBody({ ...emptyOrgFormValues, organization_alias: "acme" })).toStrictEqual({
+      organization_alias: "acme",
+      models: [],
+    });
+  });
+
+  it("maps every field when the whole form is filled", () => {
+    const filledForm = {
+      organization_alias: "acme",
+      models: ["gpt-5.2"],
+      max_budget: "12.5",
+      budget_duration: "30d",
+      tpm_limit: "1000",
+      rpm_limit: "50",
+      vector_stores: ["vs-1"],
+      mcp: { servers: ["srv-1"], accessGroups: ["ag-1"], toolsets: ["ts-1"] },
+      metadata: '{"env": "prod"}',
+    };
+    const expectedBody = {
+      organization_alias: "acme",
+      models: ["gpt-5.2"],
+      max_budget: 12.5,
+      budget_duration: "30d",
+      tpm_limit: 1000,
+      rpm_limit: 50,
+      metadata: { env: "prod" },
+      object_permission: {
+        vector_stores: ["vs-1"],
+        mcp_servers: ["srv-1"],
+        mcp_access_groups: ["ag-1"],
+        mcp_toolsets: ["ts-1"],
+      },
+    };
+
+    expect(buildOrgCreateBody(filledForm)).toStrictEqual(expectedBody);
+  });
+
+  it("includes only the non-empty grant lists in object_permission", () => {
+    expect(
+      buildOrgCreateBody({
+        ...emptyOrgFormValues,
+        organization_alias: "acme",
+        mcp: { servers: [], accessGroups: [], toolsets: ["ts-1"] },
+      }).object_permission,
+    ).toStrictEqual({ mcp_toolsets: ["ts-1"] });
+  });
+
+  it("parses metadata into an object instead of sending the raw string", () => {
+    expect(
+      buildOrgCreateBody({ ...emptyOrgFormValues, organization_alias: "acme", metadata: '{"a": 1}' }).metadata,
+    ).toStrictEqual({ a: 1 });
+  });
+});

--- a/ui/litellm-dashboard/src/components/organization/org-create/mapper.ts
+++ b/ui/litellm-dashboard/src/components/organization/org-create/mapper.ts
@@ -1,0 +1,45 @@
+import { z } from "zod/v4";
+
+import type { components } from "@/lib/http/schema";
+
+import type { OrgSettingsFormValues } from "../org-settings/schema";
+
+export type OrgCreateBody = components["schemas"]["NewOrganizationRequest"];
+
+export const emptyOrgFormValues: OrgSettingsFormValues = {
+  organization_alias: "",
+  models: [],
+  max_budget: "",
+  budget_duration: "",
+  tpm_limit: "",
+  rpm_limit: "",
+  vector_stores: [],
+  mcp: { servers: [], accessGroups: [], toolsets: [] },
+  metadata: "",
+};
+
+const metadataRecordSchema = z.record(z.string(), z.unknown());
+
+const objectPermissionFromValues = (values: OrgSettingsFormValues): OrgCreateBody["object_permission"] => {
+  const grants = {
+    ...(values.vector_stores.length > 0 && { vector_stores: values.vector_stores }),
+    ...(values.mcp.servers.length > 0 && { mcp_servers: values.mcp.servers }),
+    ...(values.mcp.accessGroups.length > 0 && { mcp_access_groups: values.mcp.accessGroups }),
+    ...(values.mcp.toolsets.length > 0 && { mcp_toolsets: values.mcp.toolsets }),
+  };
+  return Object.keys(grants).length > 0 ? grants : undefined;
+};
+
+export const buildOrgCreateBody = (values: OrgSettingsFormValues): OrgCreateBody => {
+  const objectPermission = objectPermissionFromValues(values);
+  return {
+    organization_alias: values.organization_alias,
+    models: values.models,
+    ...(values.max_budget.trim() !== "" && { max_budget: Number(values.max_budget) }),
+    ...(values.tpm_limit.trim() !== "" && { tpm_limit: Number(values.tpm_limit) }),
+    ...(values.rpm_limit.trim() !== "" && { rpm_limit: Number(values.rpm_limit) }),
+    ...(values.budget_duration !== "" && { budget_duration: values.budget_duration }),
+    ...(values.metadata.trim() !== "" && { metadata: metadataRecordSchema.parse(JSON.parse(values.metadata)) }),
+    ...(objectPermission !== undefined && { object_permission: objectPermission }),
+  };
+};

--- a/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.tsx
@@ -22,9 +22,9 @@ import { fetchClient } from "@/lib/http/api";
 import { buildOrgPatch, orgToForm, type OrgPatchBody } from "./mapper";
 import { orgSettingsSchema } from "./schema";
 
-const NO_RESET = "never";
+export const NO_RESET = "never";
 
-const BUDGET_DURATION_OPTIONS = [
+export const BUDGET_DURATION_OPTIONS = [
   { value: NO_RESET, label: "No reset" },
   { value: "24h", label: "daily" },
   { value: "7d", label: "weekly" },

--- a/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.tsx
@@ -102,6 +102,7 @@ export const OrgSettingsForm = ({
         <FormField control={form.control} name="budget_duration" label="Reset Budget">
           {({ id, value, onChange, "aria-invalid": ariaInvalid, "aria-describedby": ariaDescribedBy }) => (
             <Select
+              items={BUDGET_DURATION_OPTIONS}
               value={value === "" ? NO_RESET : value}
               onValueChange={(selected) => onChange(selected === NO_RESET ? "" : selected)}
             >


### PR DESCRIPTION
## TLDR

Problem this solves:

- Create Organization modal is still antd Form
- Old form silently dropped selected MCP toolsets
- Failed creates only logged to console; users saw nothing

How it solves it:

- Rebuilds it on the shadcn + react-hook-form + zod pattern
- Reuses the merged org-settings schema and form kit
- Typed body via fetchClient POST /organization/new

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at commit 35959a6da5 against a live proxy (`proxy_cli.py --config litellm/proxy/dev_config.yaml`) with the dashboard dev server (`npm run dev`), logged in as the proxy admin

### Before (antd modal on litellm_internal_staging)

<img src="https://raw.githubusercontent.com/BerriAI/litellm/litellm_org_create_rhf_assets/before-create-org-modal.png" width="720" alt="antd Create Organization modal before the migration">

### After (shadcn dialog on this branch)

<img src="https://raw.githubusercontent.com/BerriAI/litellm/litellm_org_create_rhf_assets/after-create-org-dialog.png" width="720" alt="shadcn Create Organization dialog after the migration">

Submitting with an empty name and invalid metadata JSON now blocks with inline field errors instead of silently doing nothing

<img src="https://raw.githubusercontent.com/BerriAI/litellm/litellm_org_create_rhf_assets/after-create-org-validation.png" width="720" alt="inline validation errors for missing name and invalid metadata JSON">

Live end-to-end create through the new dialog (name, max budget 25, TPM 1000, metadata `{"env": "demo"}`): the wire request was `POST /organization/new` with body `{"organization_alias":"demo-org-pr34552","models":[],"max_budget":25,"tpm_limit":1000,"metadata":{"env":"demo"}}`; note metadata arrives as a parsed object, untouched fields are omitted, and there is no object_permission key since no vector stores or MCP servers were selected. The proxy returned 200 with the created org and its linked budget row, the dialog closed, and the list refreshed to show the new row

<img src="https://raw.githubusercontent.com/BerriAI/litellm/litellm_org_create_rhf_assets/after-create-org-created.png" width="720" alt="created organization appearing in the organizations table">

## Type

🧹 Refactoring

## Changes

Second consumer of the forms pattern established in #34170/#34324, and the create-form half of the recipe (the merged org-settings form covers the edit half). The antd Modal + Form block inside OrganizationsPanel is replaced by `org-create/OrgCreateDialog.tsx`, built on the shared kit (`useZodForm`, `FormField`, shadcn Dialog/Input/Select/Textarea) with the same field widgets as the edit form (ModelSelect, VectorStoreSelector, MCPServerSelector)

The create form reuses `org-settings/schema.ts` unchanged since the two forms have identical fields; only the mapper differs. `org-create/mapper.ts` builds a full `NewOrganizationRequest` body (typed against schema.d.ts) instead of a dirty-field patch: empty widget values are omitted from the body entirely, and `object_permission` is only sent when at least one grant list is non-empty, preserving the "leave empty for access to all" semantics of the old form. The request goes through the typed `fetchClient.POST("/organization/new")` instead of the untyped `organizationCreateCall`, which also removes that helper's mutate-the-form-values metadata parsing

Three behavior fixes ride along. Selected MCP toolsets are now sent as `object_permission.mcp_toolsets`; the old transform only copied servers and access groups, so toolsets picked in the selector were silently dropped. A failed create now surfaces the backend error as a toast; the old handler swallowed it with console.error, leaving the modal open with no feedback. Invalid metadata JSON is now blocked at validation time with an inline field error instead of throwing inside the networking helper mid-submit

`NO_RESET` and `BUDGET_DURATION_OPTIONS` are exported from OrgSettingsForm so both org forms share the same Reset Budget options; the create form's "n/a" placeholder becomes an explicit "No reset" option with identical wire behavior (nothing sent). The antd suppression for OrganizationsPanel is pruned from eslint-suppressions.json since the file no longer imports antd, and `organizationCreateCall` is removed from networking.tsx since this was its last caller

An adversarial review pass found no blockers and three worthwhile hardenings that are included: the submit handler ignores re-entry while a create is in flight (Enter in a text input could previously fire a duplicate POST during the round-trip), a test pinning that an Escape dismissal resets the form the same way Cancel does, and a test pinning the single-flight submit behavior

Greptile's review then caught a real stale-closure bug on top of that: the dialog could be dismissed via Escape, the close button, or the backdrop while a create was still in flight (only the Cancel button was disabled), and if the user reopened the dialog before the request settled, the earlier mutation's success callback would reset and close the freshly reopened form. The fix makes the dialog non-dismissable while a create is pending, matching the disabled Cancel button, and routes the success-path close through an unguarded helper since the pending flag read inside onSuccess is a stale render snapshot. A test pins that Escape during a pending create is a no-op and the dialog still closes exactly once on success

Taking the screenshots surfaced one more cosmetic bug that also existed in the merged org-settings form: the Base UI Select renders the raw value in its trigger unless the root receives `items`, so Reset Budget displayed "never" or "30d" instead of "No reset" or "monthly". Both org forms now pass `items={BUDGET_DURATION_OPTIONS}`

Tests: `mapper.test.ts` pins the minimal body (alias + models only, nothing else), the full-form body including all four grant lists, grant-list omission rules, and metadata parsing, all with toStrictEqual so an accidentally added or dropped key fails. `OrgCreateDialog.test.tsx` covers required-name validation blocking the request, the exact minimal and mapped bodies reaching the injected create function, invalid-JSON blocking, a failed create keeping the dialog open with values intact, cancel-then-reopen and Escape-then-reopen resetting the form, no dismissal while a create is pending, and no duplicate create on double submit

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
