### PR TITLE
fix(mcp): use a toolset row's stored tool name as written

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -121,7 +121,6 @@ from litellm.proxy._experimental.mcp_server.utils import (
     normalize_server_name,
     parse_admin_env_vars,
     split_server_prefix_from_name,
-    strip_known_server_prefix,
     validate_mcp_server_name,
 )
 from litellm.proxy._types import (
@@ -2492,6 +2491,13 @@ class MCPServerManager:
         the given toolsets.  Results are cached via ``user_api_key_cache`` (a
         Redis-backed ``DualCache`` in production) so that cache entries are
         shared across workers and cold-cache DB hits are minimised.
+
+        A row names a tool on the server identified by ``server_id``, so the
+        stored name is the tool's own name and is used as written.  It is never
+        reduced by the server's wire prefix: that prefix is added on the way out
+        and is not part of any tool's identity, so treating a leading segment as
+        one silently renames the tool when a native name happens to begin with
+        it (``greyhound_internal_events`` on a server prefixed ``greyhound``).
         """
         from litellm.proxy._experimental.mcp_server.toolset_db import list_mcp_toolsets
         from litellm.proxy.proxy_server import prisma_client, user_api_key_cache
@@ -2509,12 +2515,9 @@ class MCPServerManager:
             tool_permissions: dict[str, list[str]] = {}
             for toolset in toolsets:
                 for tool in toolset.tools:
-                    raw_name = tool["tool_name"]
-                    server = self.get_mcp_server_by_id(tool["server_id"])
-                    unprefixed = strip_known_server_prefix(raw_name, server)
-                    tool_permissions.setdefault(tool["server_id"], [])
-                    if unprefixed not in tool_permissions[tool["server_id"]]:
-                        tool_permissions[tool["server_id"]].append(unprefixed)
+                    allowed_names = tool_permissions.setdefault(tool["server_id"], [])
+                    if tool["tool_name"] not in allowed_names:
+                        allowed_names.append(tool["tool_name"])
             await user_api_key_cache.async_set_cache(
                 key=cache_key,
                 value=tool_permissions,

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
@@ -238,11 +238,12 @@ class TestFetchMCPToolsetsAccess:
 class TestToolsetPrefixResolution:
     """Regression for LIT-3419.
 
-    Toolsets store bare tool names; the live tools come back prefixed with the
-    server's own prefix. Reconciling them must strip exactly that prefix, not
-    chop at the first separator, otherwise tools on a server whose prefix
-    contains the separator (a hyphenated alias, or the UUID server_id used when
-    a server has no alias) are silently dropped from the toolset.
+    A toolset row names a tool on the server given by its ``server_id``, so the
+    stored name is the tool's own name. The live tools come back carrying the
+    server's wire prefix, so reconciling them strips that prefix from the LIVE
+    name only; the stored name is matched as written. Reducing the stored name
+    too renames the tool whenever a native name begins with its own server's
+    prefix, which resolves the row to a different tool on the same server.
     """
 
     # alias, server_name, server_id; the clean-alias row worked before the fix,
@@ -316,31 +317,52 @@ class TestToolsetPrefixResolution:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("alias, server_name, server_id", PREFIX_CASES)
-    async def test_resolve_unprefixes_stored_names_with_separator_prefix(
+    async def test_resolve_uses_the_stored_name_as_written(
         self, alias, server_name, server_id
     ):
-        from types import SimpleNamespace
+        """The row names a tool; resolution must not rewrite that name.
 
-        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
-            global_mcp_server_manager,
-        )
+        A name that merely looks prefixed is still the tool's own name, and the
+        server is already identified by ``server_id``, so there is nothing for a
+        prefix to disambiguate.
+        """
+        server = self._server(alias, server_name, server_id)
+        stored = "read_wiki_contents"
+
+        assert await self._resolve(server, server_id, stored) == {server_id: [stored]}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("alias, server_name, server_id", PREFIX_CASES)
+    async def test_resolve_keeps_a_name_that_looks_like_its_own_server_prefix(
+        self, alias, server_name, server_id
+    ):
         from litellm.proxy._experimental.mcp_server.utils import (
             add_server_prefix_to_name,
             get_server_prefix,
         )
 
         server = self._server(alias, server_name, server_id)
-        # A caller (e.g. the management API) may persist already-prefixed names;
-        # resolution must reduce them to the true bare name regardless of prefix.
+        # A native tool whose own name begins with what the gateway would use as
+        # this server's wire prefix.
         stored = add_server_prefix_to_name(
             "read_wiki_contents", get_server_prefix(server)
         )
+
+        assert await self._resolve(server, server_id, stored) == {server_id: [stored]}
+
+    @staticmethod
+    async def _resolve(server, server_id, stored):
+        from types import SimpleNamespace
+
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            global_mcp_server_manager,
+        )
+
         toolset = SimpleNamespace(tools=[{"server_id": server_id, "tool_name": stored}])
         cache = MagicMock(
             async_get_cache=AsyncMock(return_value=None),
             async_set_cache=AsyncMock(),
         )
-
         with (
             patch(
                 "litellm.proxy._experimental.mcp_server.mcp_server_manager."
@@ -354,11 +376,138 @@ class TestToolsetPrefixResolution:
                 new=AsyncMock(return_value=[toolset]),
             ),
         ):
-            result = await global_mcp_server_manager.resolve_toolset_tool_permissions(
+            return await global_mcp_server_manager.resolve_toolset_tool_permissions(
                 toolset_ids=["ts-1"]
             )
 
-        assert result == {server_id: ["read_wiki_contents"]}
+    @pytest.mark.asyncio
+    async def test_bare_stored_name_starting_with_server_prefix_stays_granted(self):
+        """A native tool whose own name starts with ``{prefix}{separator}``.
+
+        The dashboard persists the bare native name, so resolution must not read
+        that leading segment as the server prefix and strip it. Doing so resolves
+        the row to a different tool on the same server: the granted tool vanishes
+        from the toolset and an ungranted sibling is served under its wire name.
+        """
+        from mcp.types import Tool as MCPTool
+
+        from litellm.proxy._experimental.mcp_server.server import (
+            filter_tools_by_key_team_permissions,
+        )
+        from litellm.proxy._experimental.mcp_server.utils import (
+            add_server_prefix_to_name,
+            get_server_prefix,
+            strip_known_server_prefix,
+        )
+
+        server = self._server("deepwiki", None, "srv-collide")
+        prefix = get_server_prefix(server)
+        granted = add_server_prefix_to_name("contents", prefix)
+        assert strip_known_server_prefix(granted, server) != granted, (
+            "fixture must exercise the collision: the bare native name has to "
+            "start with the server's own prefix plus the separator"
+        )
+
+        resolved = await self._resolve(server, "srv-collide", granted)
+
+        sibling = "contents"
+        live_tools = [
+            MCPTool(
+                name=add_server_prefix_to_name(name, prefix),
+                inputSchema={"type": "object"},
+            )
+            for name in (granted, sibling)
+        ]
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.server."
+                "MCPRequestHandler.get_allowed_tools_for_server",
+                new=AsyncMock(return_value=resolved["srv-collide"]),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.server."
+                "global_mcp_server_manager.get_mcp_server_by_id",
+                return_value=server,
+            ),
+        ):
+            kept = await filter_tools_by_key_team_permissions(
+                tools=live_tools,
+                server_id="srv-collide",
+                user_api_key_auth=_make_auth(),
+            )
+
+        # Exactly the granted tool. ``sibling`` is a different tool on the same
+        # server and was never selected, so it must not be reachable through
+        # this row even though the stored name is its wire name.
+        assert [t.name for t in kept] == [add_server_prefix_to_name(granted, prefix)]
+
+    @pytest.mark.asyncio
+    async def test_collision_row_grants_only_the_named_tool_when_no_sibling_exists(
+        self,
+    ):
+        """Without the stripped sibling in the catalog there is nothing to widen.
+
+        Resolution emits both readings of an ambiguous row, but a reading only
+        grants a tool that actually exists on the server. A server exposing only
+        the self-named tool therefore yields exactly that tool, which is the case
+        that used to resolve to nothing at all.
+        """
+        from mcp.types import Tool as MCPTool
+
+        from litellm.proxy._experimental.mcp_server.server import (
+            filter_tools_by_key_team_permissions,
+        )
+        from litellm.proxy._experimental.mcp_server.utils import (
+            add_server_prefix_to_name,
+            get_server_prefix,
+        )
+
+        server = self._server("deepwiki", None, "srv-lonely")
+        prefix = get_server_prefix(server)
+        granted = add_server_prefix_to_name("contents", prefix)
+
+        resolved = await self._resolve(server, "srv-lonely", granted)
+
+        live_tools = [
+            MCPTool(
+                name=add_server_prefix_to_name(granted, prefix),
+                inputSchema={"type": "object"},
+            )
+        ]
+
+        with (
+            patch(
+                "litellm.proxy._experimental.mcp_server.server."
+                "MCPRequestHandler.get_allowed_tools_for_server",
+                new=AsyncMock(return_value=resolved["srv-lonely"]),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.server."
+                "global_mcp_server_manager.get_mcp_server_by_id",
+                return_value=server,
+            ),
+        ):
+            kept = await filter_tools_by_key_team_permissions(
+                tools=live_tools,
+                server_id="srv-lonely",
+                user_api_key_auth=_make_auth(),
+            )
+
+        assert [t.name for t in kept] == [add_server_prefix_to_name(granted, prefix)]
+
+    @pytest.mark.asyncio
+    async def test_bare_stored_name_without_collision_grants_only_that_tool(self):
+        """The ordinary row must stay exact; accepting both readings of an
+        ambiguous row must not widen an unambiguous one."""
+        from litellm.proxy._experimental.mcp_server.utils import get_server_prefix
+
+        server = self._server("deepwiki", None, "srv-clean")
+        assert get_server_prefix(server) == "deepwiki"
+
+        resolved = await self._resolve(server, "srv-clean", "read_wiki_contents")
+
+        assert resolved == {"srv-clean": ["read_wiki_contents"]}
 
 
 class TestMCPActiveToolsetContextVar:


### PR DESCRIPTION
## TLDR

Problem this solves:

- A toolset row could resolve to a different tool on the same server, so the selected tool disappeared from `/toolset/<name>/mcp` and an unselected sibling was served, and executed, under the selected tool's wire name
- It fires whenever a native tool name happens to begin with what the gateway uses as that server's wire prefix followed by `MCP_TOOL_PREFIX_SEPARATOR`, so it reaches the default `-` separator too: a server aliased `deepwiki` serving a native `deepwiki-contents` reduces to `contents`
- Toolsets are the tool-level permission boundary, so the row granted access to a tool that was never selected, while `tools/list` still returned the expected count under the expected name

How it solves it:

- A row already carries `server_id`, so the stored `tool_name` is the tool's own name and is matched as written; only the live name coming off the server still has the wire prefix stripped

## Relevant issues

- Stops a toolset row from resolving to a different tool on the same MCP server, which listed and executed something the admin never selected
- Removes the prefix reduction applied to stored names in `resolve_toolset_tool_permissions`, the single producer of the allowlist, so the MCP `tools/list` filter, the `tools/call` permission check, the REST listing and the Responses API path are all corrected without touching them
- Net removal of logic, no schema change, no new field, and no behavior change for a row whose stored name does not begin with its server's prefix

## Linear ticket

LIT-3419

Not marked as auto-closing: the reported deployment's effective `MCP_TOOL_PREFIX_SEPARATOR` has not been confirmed yet, and the dashboard renders the prefix with a hardcoded `-` (`MCPToolsetTableColumns.tsx`), so the reporter's screenshot cannot reveal it. This diff fixes the defect described in the ticket; whether it is the whole of what that deployment hit needs the env var plus the raw `LiteLLM_MCPToolsetTable` row from the running container.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests); `osv-scan` is red, and it is red identically on every open PR checked (34586, 34588, 34589, 34590, 34591, 34592), so it is repo-wide and not this diff
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (5/5, and the earlier security finding is resolved)

## Screenshots / Proof of Fix

Live proxy on `127.0.0.1:4419` against a real streamable-HTTP MCP upstream on a server prefixed `greyhound`, exposing two native tools: `inspect_events` and `greyhound_inspect_events`. The second name is what triggers the bug, since it begins with the server's own prefix.

Steps 1 to 5 run with `MCP_TOOL_PREFIX_SEPARATOR=_`, which is why the wire names below read `greyhound_greyhound_inspect_events`. Under the default `-` the same row lists as `greyhound-greyhound_inspect_events`; step 6 covers that separator.

1. What each surface sees, with the separator set to `_`

```bash
curl -s "http://127.0.0.1:4419/mcp-rest/tools/list?server_id=$SID" -H 'Authorization: Bearer sk-1234'
#  picker tool_name: inspect_events
#  picker tool_name: greyhound_inspect_events     <- the tool's own name, what the dashboard persists

curl -s -X POST http://127.0.0.1:4419/mcp/ -H 'x-litellm-api-key: Bearer sk-1234' \
  -H 'Accept: application/json, text/event-stream' -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
#  wire name: greyhound_inspect_events
#  wire name: greyhound_greyhound_inspect_events
```

2. Grant exactly one tool, the native `greyhound_inspect_events`, as the dashboard writes it

```bash
curl -s -X POST http://127.0.0.1:4419/v1/mcp/toolset -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d "{\"toolset_name\":\"ts-ui\",\"tools\":[{\"server_id\":\"$SID\",\"tool_name\":\"greyhound_inspect_events\"}]}"

psql -h localhost -U tin -d litellm_lit3419 -At -c 'select toolset_name, tools from "LiteLLM_MCPToolsetTable";'
# ts-ui|[{"server_id": "a8947b6b...", "tool_name": "greyhound_inspect_events"}]
```

3. Before. One tool is listed and the count looks right, but calling it runs the tool that was never granted

```bash
# tools/list
#  tools returned: 1
#    - greyhound_inspect_events

# tools/call greyhound_inspect_events
#  upstream ran: inspect_events ran with X | isError: False
#  ^ the unselected sibling executed, and the selected tool was unreachable
```

Note that the count and the displayed name are both correct here. Nothing on the listing surface indicates a problem, which is why this reads as working and is why the defect is an authorization one rather than a visibility one.

4. After. The selected tool resolves, and the sibling is refused

```bash
# tools/list
#  tools returned: 1
#    - greyhound_greyhound_inspect_events

# tools/call greyhound_greyhound_inspect_events
#  upstream ran: greyhound_inspect_events ran with X | isError: False

# tools/call greyhound_inspect_events        (the sibling, never selected)
#  Error: Tool 'inspect_events' is not allowed for your key/team on server 'greyhound'
```

5. An ordinary row is unaffected

```bash
# toolset holding the row "inspect_events"
#  tools returned: 1
#    - greyhound_inspect_events
# tools/call greyhound_inspect_events  ->  inspect_events ran with Y
```

6. Default separator, after the change

```bash
# MCP_TOOL_PREFIX_SEPARATOR=- , same ts-ui row
#  tools returned: 1
#    - greyhound-greyhound_inspect_events
# unchanged from before the fix, so this row is unregressed on the default separator
```

This row is unregressed on `-` because `greyhound_inspect_events` does not start with `greyhound-`, so the old reduction was already a no-op for it. The default separator is not immune in general: `strip_known_server_prefix` strips `{known_prefix}{separator}` for any of the server's registered prefixes, so a native name such as `deepwiki-contents` on a server aliased `deepwiki` was reduced to `contents` on stock defaults.

7. The one behavior this removes: a row storing an already-prefixed name

```bash
# MCP_TOOL_PREFIX_SEPARATOR=- , row stores "greyhound-inspect_events" while the native tool is "inspect_events"
#  tools returned: 0
```

This is acceptable because the dashboard picker reads the REST listing with `add_prefix=False` and therefore only ever persists bare native names, so it cannot create such a row.

## Type

🐛 Bug Fix

## Changes

- `resolve_toolset_tool_permissions` uses `tool_name` as stored instead of reducing it by the server's wire prefix, which also drops the per-row server lookup and the `strip_known_server_prefix` import
- Documents the contract on the method: a row names a tool on the server given by `server_id`, so the stored name is the tool's own name and the wire prefix is never treated as part of it
- Reworks the LIT-3419 regression class in `test_mcp_toolset_scope.py` around the new contract: the stored name survives verbatim, a name that looks like its own server prefix still resolves end to end through the listing filter, and the unselected sibling is not reachable
- Replaces the test that asserted a stored prefixed name is reduced, since that is the behavior being removed

## QA runbook

Point an MCP client at `/toolset/<name>/mcp` with a key granted that toolset. Add a tool through the dashboard whose native name begins with the server's alias followed by the configured `MCP_TOOL_PREFIX_SEPARATOR`, and confirm `tools/list` offers it, `tools/call` reaches the upstream function of that name, and a sibling tool that was not added is refused. Repeat with an ordinary tool name and confirm it is unchanged. Check the sibling explicitly rather than the listed count, since the pre-fix behavior returns the correct count under the correct name.
