### PR TITLE
test(e2e): set reasoning_effort=none for gpt-5.6 chat tool calls

### DIFF
--- a/tests/e2e/llm_translation/test_chat_completions_regression_e2e.py
+++ b/tests/e2e/llm_translation/test_chat_completions_regression_e2e.py
@@ -473,6 +473,7 @@ class TestOpenAIChatCompletions:
                     tools=[_WEATHER_TOOL],
                     tool_choice="required",
                     max_tokens=128,
+                    reasoning_effort="none",
                 ),
             )
         )
@@ -620,6 +621,7 @@ class TestOpenAIChatCompletions:
                 tools=[_WEATHER_TOOL],
                 tool_choice="required",
                 max_tokens=128,
+                reasoning_effort="none",
                 stream=True,
             ),
         )


### PR DESCRIPTION
## TLDR

Both OpenAI tool-call tests failed with:

```
Function tools with reasoning_effort are not supported for gpt-5.6 in /v1/chat/completions.
To use function tools, use /v1/responses or set reasoning_effort to 'none'.
```

This is a provider constraint, not a litellm defect, so the tests now follow OpenAI's own instruction.

## Why not a product fix

gpt-5.6 applies a default reasoning effort, so the raw OpenAI API rejects tools **even when the request sets no `reasoning_effort` at all**; only an explicit `"none"` is accepted. litellm does not force that value when tools are present, and gpt-5.6 carries `supports_none_reasoning_effort: true` in the model map, so passing it through is the supported path and keeps this coverage on `/chat/completions` rather than moving it to `/v1/responses`.

## Proof

Raw OpenAI API with gpt-5.6 and a function tool:

```
tools only                  => 400 Function tools with reasoning_effort are not supported...
tools + reasoning_effort=low => 400 (same)
tools + reasoning_effort=none => 200 tool_calls=1
```

Through the proxy, before and after:

```
before fix (no effort)  : 400 litellm.BadRequestError: OpenAIException - Function tools with reasoning_effort...
after fix (effort=none) : 200 tool_calls=1
streaming (effort=none) : 200 tool_calls present in stream
```

## Type

✅ Test
