### PR TITLE
fix(ui): logout no longer reloads the current page before redirecting to login

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxySettings/useProxySettings.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxySettings/useProxySettings.ts
@@ -1,5 +1,5 @@
 import { fetchProxySettings } from "@/utils/proxyUtils";
-import { useQuery } from "@tanstack/react-query";
+import { QueryClient, useQuery } from "@tanstack/react-query";
 import { createQueryKeys } from "../common/queryKeysFactory";
 
 export const proxySettingsKeys = createQueryKeys("proxySettings");
@@ -23,4 +23,14 @@ export default function useProxySettings(accessToken: string | null): ProxySetti
     enabled: Boolean(accessToken),
   });
   return data ?? EMPTY_PROXY_SETTINGS;
+}
+
+export function ensureProxySettings(
+  queryClient: QueryClient,
+  accessToken: string | null,
+): Promise<ProxySettings | null> {
+  return queryClient.ensureQueryData({
+    queryKey: [...proxySettingsKeys.all, accessToken],
+    queryFn: () => fetchProxySettings(accessToken),
+  });
 }

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.test.ts
@@ -243,6 +243,39 @@ describe("useAuthorized", () => {
     expect(result.current.token).toBeNull();
   });
 
+  it("should redirect immediately when token is missing, without waiting for the UI config fetch", async () => {
+    getUiConfigMock.mockReturnValue(new Promise(() => {}));
+
+    decodeTokenMock.mockReturnValue(null);
+    checkTokenValidityMock.mockReturnValue(false);
+
+    const { result } = renderHook(() => useAuthorized(), { wrapper });
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login/");
+    });
+
+    expect(clearTokenCookiesMock).not.toHaveBeenCalled();
+    expect(result.current.token).toBeNull();
+  });
+
+  it("should clear cookies and redirect immediately when token is expired, without waiting for the UI config fetch", async () => {
+    getUiConfigMock.mockReturnValue(new Promise(() => {}));
+
+    decodeTokenMock.mockReturnValue({ key: "api-key-123", user_id: "user-1" });
+    checkTokenValidityMock.mockReturnValue(false);
+
+    document.cookie = "token=expired-token; path=/;";
+
+    renderHook(() => useAuthorized(), { wrapper });
+
+    await waitFor(() => {
+      expect(clearTokenCookiesMock).toHaveBeenCalled();
+    });
+
+    expect(replaceMock).toHaveBeenCalledWith("http://proxy.example/ui/login/");
+  });
+
   it("should clear cookies and redirect when token is expired", async () => {
     getUiConfigMock.mockResolvedValue({
       server_root_path: "/",

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useAuthorized.ts
@@ -28,15 +28,14 @@ const useAuthorized = () => {
 
   // Single useEffect for all redirect logic
   useEffect(() => {
-    if (isLoading) return;
+    if (isTokenValid && isLoading) return;
+    if (isAuthorized) return;
 
-    if (!isAuthorized) {
-      if (token) {
-        clearTokenCookies();
-      }
-      redirectToLogin();
+    if (token) {
+      clearTokenCookies();
     }
-  }, [isLoading, isAuthorized, token, redirectToLogin]);
+    redirectToLogin();
+  }, [isLoading, isTokenValid, isAuthorized, token, redirectToLogin]);
 
   return {
     isLoading,

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useLogout.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useLogout.ts
@@ -13,11 +13,11 @@ export function useLogout(accessToken: string | null): () => Promise<void> {
   useProxySettings(accessToken);
 
   return async () => {
-    const settings = await ensureProxySettings(queryClient, accessToken).catch(() => null);
     clearTokenCookies();
     clearStoredReturnUrl();
     localStorage.removeItem("litellm_selected_worker_id");
     localStorage.removeItem("litellm_worker_url");
+    const settings = await ensureProxySettings(queryClient, accessToken).catch(() => null);
     window.location.replace(settings?.PROXY_LOGOUT_URL || getLoginUrl(getProxyBaseUrl()));
   };
 }

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useLogout.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useLogout.ts
@@ -1,19 +1,23 @@
+import { getProxyBaseUrl } from "@/components/networking";
 import { clearTokenCookies } from "@/utils/cookieUtils";
-import { clearStoredReturnUrl } from "@/utils/returnUrlUtils";
-import useProxySettings from "@/app/(dashboard)/hooks/proxySettings/useProxySettings";
+import { clearStoredReturnUrl, getLoginUrl } from "@/utils/returnUrlUtils";
+import { useQueryClient } from "@tanstack/react-query";
+import useProxySettings, { ensureProxySettings } from "@/app/(dashboard)/hooks/proxySettings/useProxySettings";
 
 /**
  * Shared sign-out handler. Used by both the top navbar and the sidebar footer so
  * the two entry points can never drift on which client state gets cleared.
  */
-export function useLogout(accessToken: string | null): () => void {
-  const proxySettings = useProxySettings(accessToken);
+export function useLogout(accessToken: string | null): () => Promise<void> {
+  const queryClient = useQueryClient();
+  useProxySettings(accessToken);
 
-  return () => {
+  return async () => {
+    const settings = await ensureProxySettings(queryClient, accessToken).catch(() => null);
     clearTokenCookies();
     clearStoredReturnUrl();
     localStorage.removeItem("litellm_selected_worker_id");
     localStorage.removeItem("litellm_worker_url");
-    window.location.href = proxySettings.PROXY_LOGOUT_URL || "";
+    window.location.replace(settings?.PROXY_LOGOUT_URL || getLoginUrl(getProxyBaseUrl()));
   };
 }

--- a/ui/litellm-dashboard/src/components/navbar.test.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.test.tsx
@@ -132,9 +132,17 @@ vi.mock("@/utils/cookieUtils", () => ({
   clearTokenCookies: vi.fn(),
 }));
 
-// Mock window.location.href for logout testing
+vi.mock("@/utils/returnUrlUtils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/returnUrlUtils")>();
+  return {
+    ...actual,
+    clearStoredReturnUrl: vi.fn(),
+  };
+});
+
+// Mock window.location for logout testing
 Object.defineProperty(window, "location", {
-  value: { href: "" },
+  value: { href: "", replace: vi.fn() },
   writable: true,
 });
 
@@ -285,6 +293,7 @@ describe("Navbar", () => {
 
   it("should handle logout functionality", async () => {
     const user = userEvent.setup();
+    vi.mocked(window.location.replace).mockClear();
 
     renderWithProviders(<Navbar {...defaultProps} />);
 
@@ -298,9 +307,36 @@ describe("Navbar", () => {
     await user.click(screen.getByText("Logout"));
 
     const cookieUtils = vi.mocked(await import("@/utils/cookieUtils"));
+    const returnUrlUtils = vi.mocked(await import("@/utils/returnUrlUtils"));
     expect(cookieUtils.clearTokenCookies).toHaveBeenCalled();
+    expect(returnUrlUtils.clearStoredReturnUrl).toHaveBeenCalled();
     await waitFor(() => {
-      expect(window.location.href).toBe("https://example.com/logout");
+      expect(window.location.replace).toHaveBeenCalledWith("https://example.com/logout");
+    });
+  });
+
+  it("should redirect to the login page on logout when PROXY_LOGOUT_URL is not configured", async () => {
+    const user = userEvent.setup();
+    vi.mocked(window.location.replace).mockClear();
+
+    const proxyUtils = vi.mocked(await import("@/utils/proxyUtils"));
+    proxyUtils.fetchProxySettings.mockResolvedValueOnce({
+      PROXY_BASE_URL: "",
+      PROXY_LOGOUT_URL: "",
+    });
+
+    renderWithProviders(<Navbar {...defaultProps} accessToken="test-token-no-logout-url" />);
+
+    await user.click(screen.getByRole("button", { name: /open account menu/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("test-user")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Logout"));
+
+    await waitFor(() => {
+      expect(window.location.replace).toHaveBeenCalledWith("http://localhost:4000/ui/login/");
     });
   });
 

--- a/ui/litellm-dashboard/src/components/navbar.test.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.test.tsx
@@ -344,6 +344,11 @@ describe("Navbar", () => {
     const user = userEvent.setup();
     vi.mocked(window.location.replace).mockClear();
 
+    const cookieUtils = vi.mocked(await import("@/utils/cookieUtils"));
+    const returnUrlUtils = vi.mocked(await import("@/utils/returnUrlUtils"));
+    cookieUtils.clearTokenCookies.mockClear();
+    returnUrlUtils.clearStoredReturnUrl.mockClear();
+
     const proxyUtils = vi.mocked(await import("@/utils/proxyUtils"));
     let resolveSettings!: (value: { PROXY_BASE_URL: string; PROXY_LOGOUT_URL: string }) => void;
     proxyUtils.fetchProxySettings.mockImplementationOnce(
@@ -364,6 +369,8 @@ describe("Navbar", () => {
     await user.click(screen.getByText("Logout"));
 
     expect(window.location.replace).not.toHaveBeenCalled();
+    expect(cookieUtils.clearTokenCookies).toHaveBeenCalled();
+    expect(returnUrlUtils.clearStoredReturnUrl).toHaveBeenCalled();
 
     resolveSettings({ PROXY_BASE_URL: "", PROXY_LOGOUT_URL: "https://sso.example.com/logout" });
 

--- a/ui/litellm-dashboard/src/components/navbar.test.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.test.tsx
@@ -340,6 +340,38 @@ describe("Navbar", () => {
     });
   });
 
+  it("should wait for an in-flight proxy settings fetch so a configured logout URL is not skipped", async () => {
+    const user = userEvent.setup();
+    vi.mocked(window.location.replace).mockClear();
+
+    const proxyUtils = vi.mocked(await import("@/utils/proxyUtils"));
+    let resolveSettings!: (value: { PROXY_BASE_URL: string; PROXY_LOGOUT_URL: string }) => void;
+    proxyUtils.fetchProxySettings.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSettings = resolve;
+        }),
+    );
+
+    renderWithProviders(<Navbar {...defaultProps} accessToken="test-token-pending-settings" />);
+
+    await user.click(screen.getByRole("button", { name: /open account menu/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("test-user")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Logout"));
+
+    expect(window.location.replace).not.toHaveBeenCalled();
+
+    resolveSettings({ PROXY_BASE_URL: "", PROXY_LOGOUT_URL: "https://sso.example.com/logout" });
+
+    await waitFor(() => {
+      expect(window.location.replace).toHaveBeenCalledWith("https://sso.example.com/logout");
+    });
+  });
+
   it("should not render dark mode toggle slider", () => {
     renderWithProviders(<Navbar {...defaultProps} />);
 

--- a/ui/litellm-dashboard/src/components/navbar.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.tsx
@@ -46,9 +46,10 @@ const Navbar: React.FC<NavbarProps> = ({
 
   const handleLogout = () => {
     clearTokenCookies();
+    clearStoredReturnUrl();
     localStorage.removeItem("litellm_selected_worker_id");
     localStorage.removeItem("litellm_worker_url");
-    window.location.href = proxySettings.PROXY_LOGOUT_URL || "";
+    window.location.replace(proxySettings.PROXY_LOGOUT_URL || getLoginUrl(baseUrl));
   };
 
   const handleWorkerSwitch = (workerId: string) => {

--- a/ui/litellm-dashboard/src/components/navbar.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.tsx
@@ -6,7 +6,7 @@ import { getProxyBaseUrl } from "@/components/networking";
 import { useTheme } from "@/contexts/ThemeContext";
 import { clearTokenCookies } from "@/utils/cookieUtils";
 import { clearStoredReturnUrl, getLoginUrl } from "@/utils/returnUrlUtils";
-import useProxySettings from "@/app/(dashboard)/hooks/proxySettings/useProxySettings";
+import { useLogout } from "@/app/(dashboard)/hooks/useLogout";
 import { DownOutlined, MenuFoldOutlined, MenuUnfoldOutlined } from "@ant-design/icons";
 import { Tag } from "antd";
 import Link from "next/link";
@@ -33,7 +33,7 @@ const Navbar: React.FC<NavbarProps> = ({
   onToggleSidebar,
 }) => {
   const baseUrl = getProxyBaseUrl();
-  const proxySettings = useProxySettings(accessToken);
+  const handleLogout = useLogout(accessToken);
   const { logoUrl } = useTheme();
   const { data: healthData } = useHealthReadinessDetails(accessToken);
   const version = healthData?.litellm_version;
@@ -43,14 +43,6 @@ const Navbar: React.FC<NavbarProps> = ({
   const showWorkerSwitch = isControlPlane && selectedWorker !== null;
 
   const imageUrl = logoUrl || `${baseUrl}/get_image`;
-
-  const handleLogout = () => {
-    clearTokenCookies();
-    clearStoredReturnUrl();
-    localStorage.removeItem("litellm_selected_worker_id");
-    localStorage.removeItem("litellm_worker_url");
-    window.location.replace(proxySettings.PROXY_LOGOUT_URL || getLoginUrl(baseUrl));
-  };
 
   const handleWorkerSwitch = (workerId: string) => {
     clearTokenCookies();


### PR DESCRIPTION
## TLDR

Problem this solves:

- Logout reloads the current page instead of going to login
- Old page stays visible for seconds with 401ing calls
- Reported as regression after upgrading v1.85.0 -> v1.92.0

How it solves it:

- Logout falls back to the login URL when PROXY_LOGOUT_URL is unset
- Logout awaits in-flight proxy settings so SSO logout is never skipped
- useAuthorized redirects immediately on missing/invalid token, no uiConfig wait
- Navbar and sidebar logout share one hook; return URL cookie cleared

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (commit 8177230a29): with no PROXY_LOGOUT_URL configured, `handleLogout` runs `window.location.href = ""`, which reloads the page the user is on. The route's auth guard then waits for the async `/get_ui_config` fetch before redirecting, so the old page (for example Teams) renders for a few seconds with its data calls returning 401, and only then does the browser land on `/ui/login`

After (commit 1b6cee9b12): clicking logout navigates directly to `/ui/login/` via `location.replace`, with no intermediate page and no 401ing requests in the network tab

Repro steps for screenshots (I will post before/after captures):

1. Run the proxy with the built UI: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug`
2. Log in at http://localhost:4000/ui and navigate to the Teams page
3. Open devtools, Network tab, enable "Preserve log"
4. Click the account menu in the top right, then Logout
5. Before the fix: the Teams page reloads, team/model calls return 401, then after a delay the login page appears. After the fix: the browser goes straight to `/ui/login/` with no Teams reload and no 401s
6. Log back in and confirm you land on the default landing page, not the pre-logout Teams page (the `litellm_return_url` cookie is now cleared on logout)

## Type

🐛 Bug Fix

## Changes

Logout previously navigated to `PROXY_LOGOUT_URL || ""`; an empty string makes the browser reload the current URL, so logging out from any dashboard page reloaded that page with the token already cleared. The shared `useLogout` hook now clears the token cookies, the stored return URL (so a later login cannot bounce back to the pre-logout page), and worker localStorage synchronously on click (per Veria's review, so a stalled settings request can never leave the session alive after logout), then resolves the proxy settings through `queryClient.ensureQueryData` (instant when cached, awaits the in-flight request otherwise, per Greptile's review so a configured SSO logout endpoint is never skipped during the settings race; the request authenticates via the captured accessToken, not the cookie), and finally navigates with `window.location.replace` falling back to `getLoginUrl(getProxyBaseUrl())`. `replace` keeps the dead authenticated page out of browser history. Behavior when `PROXY_LOGOUT_URL` is configured is unchanged

The navbar had drifted from `useLogout` (which the sidebar footer uses) into its own copy of the logic, despite the hook's docstring saying both entry points share it. The navbar now uses the hook, so both logout buttons carry the fix and cannot drift again

`useAuthorized` gated its redirect-to-login behind the async `getUiConfig()` query, so any unauthenticated hard load of a per-page route (logout reload, expired session, bookmarked URL) rendered the page body until that network call resolved. The token check is synchronous, so the hook now redirects immediately when the token is missing or invalid and only waits for uiConfig when a valid token needs the `admin_ui_disabled` check

Tests: the navbar tests assert logout uses `location.replace` with the configured logout URL, clears the return URL cookie, falls back to the login page when `PROXY_LOGOUT_URL` is empty (previously it navigated to `""`), and waits for an in-flight settings fetch before navigating (previously it went to the fallback immediately) while having already cleared the token cookies and return URL before that fetch resolves. The new `useAuthorized` tests pin the uiConfig fetch as never resolving and assert the redirect still fires for missing and expired tokens. All of these fail on the pre-fix code

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
