### PR TITLE
fix(proxy): attribute org spend for team-linked credentials minted without org_id

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -2320,6 +2320,9 @@ async def _run_centralized_common_checks(
         None if isinstance(global_spend_result, BaseException) else global_spend_result
     )
 
+    if user_api_key_auth_obj.org_id is None and team_object is not None and team_object.organization_id is not None:
+        user_api_key_auth_obj.org_id = team_object.organization_id
+
     # common_checks identifies admin via user_object, not the token
     # (non_proxy_admin_allowed_routes_check). JWT admin shortcut and
     # master_key tokens get admin from the token; the DB row for the

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -3797,6 +3797,109 @@ async def test_centralized_common_checks_user_http_exception_isolates_to_user_on
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "key_org_id,team_org_id,expected_org_id",
+    [
+        (None, "org-from-team", "org-from-team"),
+        ("org-pinned-on-key", "org-from-team", "org-pinned-on-key"),
+        (None, None, None),
+    ],
+)
+async def test_centralized_common_checks_backfills_org_id_from_team(key_org_id, team_org_id, expected_org_id):
+    """LIT-4688 regression: a key minted without an organization_id but attached
+    to an org-linked team must leave auth with org_id set from the team, so the
+    spend writer (which reads user_api_key_dict.org_id, no team fallback)
+    credits the org and the org budget cap can actually trip. A key with an
+    explicitly pinned org_id must win over the team's org."""
+    import litellm.proxy.proxy_server as _proxy_server_mod
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    from litellm.proxy._types import LiteLLM_TeamTableCachedObj
+
+    token = UserAPIKeyAuth(api_key="sk-test", user_id="u", team_id="t1", org_id=key_org_id)
+    request = Request(scope={"type": "http"})
+    request._url = URL(url="/chat/completions")
+
+    fetched_team = LiteLLM_TeamTableCachedObj(team_id="t1", organization_id=team_org_id)
+
+    attrs = _proxy_attrs_for_centralized_checks(user_custom_auth=None)
+    originals = {a: getattr(_proxy_server_mod, a, None) for a in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+        org_id_seen_by_common_checks = []
+        with (
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_team_object",
+                new_callable=AsyncMock,
+                return_value=fetched_team,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.common_checks",
+                new_callable=AsyncMock,
+                side_effect=lambda **kw: org_id_seen_by_common_checks.append(kw["valid_token"].org_id),
+            ) as mock_checks,
+        ):
+            await _run_centralized_common_checks(
+                user_api_key_auth_obj=token,
+                request=request,
+                request_data={"model": "gpt-4o"},
+                route="/chat/completions",
+            )
+
+        mock_checks.assert_awaited_once()
+        assert token.org_id == expected_org_id
+        assert org_id_seen_by_common_checks == [expected_org_id]
+    finally:
+        for k, v in originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
+async def test_centralized_common_checks_org_backfill_survives_team_fetch_failure():
+    """When the team DB fetch fails, the token-derived fallback team carries no
+    organization_id, so the backfill must leave org_id as None rather than
+    crash or mis-attribute."""
+    import litellm.proxy.proxy_server as _proxy_server_mod
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    token = UserAPIKeyAuth(api_key="sk-test", user_id="u", team_id="t1")
+    request = Request(scope={"type": "http"})
+    request._url = URL(url="/chat/completions")
+
+    attrs = _proxy_attrs_for_centralized_checks(user_custom_auth=None)
+    originals = {a: getattr(_proxy_server_mod, a, None) for a in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+        with (
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_team_object",
+                new_callable=AsyncMock,
+                side_effect=Exception("DB down"),
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.common_checks",
+                new_callable=AsyncMock,
+            ) as mock_checks,
+        ):
+            await _run_centralized_common_checks(
+                user_api_key_auth_obj=token,
+                request=request,
+                request_data={"model": "gpt-4o"},
+                route="/chat/completions",
+            )
+
+        mock_checks.assert_awaited_once()
+        assert token.org_id is None
+    finally:
+        for k, v in originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
 async def test_master_key_auth_substitutes_alias_for_api_key():
     """
     When the master key authenticates a request, the resulting

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -3857,6 +3857,64 @@ async def test_centralized_common_checks_backfills_org_id_from_team(key_org_id, 
 
 
 @pytest.mark.asyncio
+async def test_cli_session_token_org_backfilled_from_team(monkeypatch):
+    """LIT-4688 root cause: CLI session tokens (from /sso/cli/poll) are minted
+    with a real team_id but no org_id, and their auth path decrypts the blob
+    without the combined_view team join, so their spend never reached the org.
+    The centralized-checks backfill must complete the credential from the team
+    the same way the SQL view does for DB keys."""
+    import litellm.proxy.proxy_server as _proxy_server_mod
+    from fastapi import Request
+    from starlette.datastructures import URL
+
+    from litellm.proxy._types import LiteLLM_TeamTableCachedObj, LiteLLM_UserTable
+    from litellm.proxy.auth.auth_checks import ExperimentalUIJWTToken
+
+    monkeypatch.setenv("LITELLM_SALT_KEY", "sk-test-salt-lit4688")
+
+    cli_user = LiteLLM_UserTable(user_id="cli-user", user_role="internal_user", teams=["t-cli"], models=[])
+    blob = ExperimentalUIJWTToken.get_cli_jwt_auth_token(user_info=cli_user, team_id="t-cli", team_alias="cli-team")
+    token = ExperimentalUIJWTToken.get_key_object_from_ui_hash_key(blob)
+    assert token is not None
+    assert token.is_session_token is True
+    assert token.team_id == "t-cli"
+    assert token.org_id is None
+
+    request = Request(scope={"type": "http"})
+    request._url = URL(url="/chat/completions")
+
+    org_linked_team = LiteLLM_TeamTableCachedObj(team_id="t-cli", organization_id="org-infoops")
+
+    attrs = _proxy_attrs_for_centralized_checks(user_custom_auth=None)
+    originals = {a: getattr(_proxy_server_mod, a, None) for a in attrs}
+    try:
+        for k, v in attrs.items():
+            setattr(_proxy_server_mod, k, v)
+        with (
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.get_team_object",
+                new_callable=AsyncMock,
+                return_value=org_linked_team,
+            ),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.common_checks",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await _run_centralized_common_checks(
+                user_api_key_auth_obj=token,
+                request=request,
+                request_data={"model": "gpt-4o"},
+                route="/chat/completions",
+            )
+
+        assert token.org_id == "org-infoops"
+    finally:
+        for k, v in originals.items():
+            setattr(_proxy_server_mod, k, v)
+
+
+@pytest.mark.asyncio
 async def test_centralized_common_checks_org_backfill_survives_team_fetch_failure():
     """When the team DB fetch fails, the token-derived fallback team carries no
     organization_id, so the backfill must leave org_id as None rather than


### PR DESCRIPTION
## TLDR

Problem this solves:

- CLI session tokens carry a real team_id but never an org_id
- Their auth path skips the combined_view team join DB keys get
- Spend from these tokens reaches the team but never the org
- Org budget caps have nothing to trip on and get exceeded

How it solves it:

- Backfill org_id from the fetched team at the centralized auth seam
- Every credential type now leaves auth with the same complete identity
- Spend writer and org budget check read the same derived org

## Relevant issues

## Linear ticket

Resolves LIT-4688

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A customer ran an org with a hard budget cap and watched it get exceeded: 96% of their spend was logged with an empty organization_id even though every credential carried a real, org-linked team. Their traffic authenticates with CLI session tokens from `/sso/cli/poll`, which `get_cli_jwt_auth_token` mints with `team_id` set and `org_id` never set; at request time the token blob is decrypted and used as-is, so the combined_view SQL join that fills org from team for DB virtual keys never runs. Team spend and team budgets worked the whole time, which made the gap invisible

Proof against a live proxy on localhost:4141 (groq, real spend), same CLI session token, same org (max_budget $0.00001) and org-linked team both runs. Seed steps: `POST /organization/new` with the cap, `POST /team/new` with that organization_id, `POST /user/new` with that team, then mint the session token the same way `/sso/cli/poll` does

Before, at 7257d0fc89 (base):

```
$ curl -s http://localhost:4141/v1/chat/completions -H "Authorization: Bearer $CLI_TOKEN" \
    -d '{"model":"qa-groq-llama","messages":[{"role":"user","content":"say BEFORE"}],"max_tokens":5}'
BEFORE

$ curl -s "http://localhost:4141/spend/logs?user_id=$CLI_USER" -H 'Authorization: Bearer sk-1234'
{'team': '0d9bd741-95dc-49d5-b6b0-6b01b20456c0', 'org': 'EMPTY', 'spend': 2.42e-05}

$ curl -s "http://localhost:4141/organization/info?organization_id=$ORG_ID" -H 'Authorization: Bearer sk-1234'
org spend: 0.0
```

After, at 22607bf801 (this PR):

```
$ curl -s http://localhost:4141/v1/chat/completions -H "Authorization: Bearer $CLI_TOKEN" \
    -d '{"model":"qa-groq-llama","messages":[{"role":"user","content":"say AFTER"}],"max_tokens":5}'
AFTER

$ curl -s "http://localhost:4141/spend/logs?user_id=$CLI_USER" -H 'Authorization: Bearer sk-1234'
{'team': '0d9bd741-95d', 'org': 'a4612ad4-808f-4f73-b80f-0746621186bb', 'spend': 2.42e-05}

$ curl -s "http://localhost:4141/organization/info?organization_id=$ORG_ID" -H 'Authorization: Bearer sk-1234'
2.42e-05

$ curl -s -w "\nHTTP %{http_code}" http://localhost:4141/v1/chat/completions -H "Authorization: Bearer $CLI_TOKEN" \
    -d '{"model":"qa-groq-llama","messages":[{"role":"user","content":"say AFTER2"}],"max_tokens":5}'
{"error":{"message":"Budget has been exceeded! Organization=a4612ad4-808f-4f73-b80f-0746621186bb Current cost: 2.42e-05, Max budget: 1e-05","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
```

Restart durability, which is what the customer actually observed in production: on the base commit the org budget check reads an in-memory counter fed by nothing durable, so a single pod can throw one transient 429 at the threshold, and a restart (or any other pod) reseeds from the DB's 0.0 and serves traffic again. Reproduced both ways

```
base 7257d0fc89: call over cap -> 429 (in-memory counter), restart proxy, same call -> HTTP 200
this PR 22607bf801: call over cap -> 429, restart proxy, same call -> still HTTP 429
```

The fix makes the DB org spend real, so enforcement survives restarts and is consistent across pods

## Type

🐛 Bug Fix

## Changes

`_run_centralized_common_checks` now sets `user_api_key_auth_obj.org_id` from `team_object.organization_id` when the credential has no org of its own. The mutation is per-request only, on the UserAPIKeyAuth built for this request, never the cached key row, so a team moving to a different org is honored on the next auth once the team cache refreshes. A credential with an explicitly pinned org_id always wins

This is the same derivation combined_view already does in SQL for DB virtual keys, applied at the one seam every auth path flows through, so CLI session tokens, JWT team tokens, and any future credential type get the same complete identity that keys get. The org budget check's local team fallback keeps working as before; the difference is the spend writer now sees the same org the check sees

Tests: a parametrized regression test for the backfill (backfills from team, pinned key org wins, no org anywhere stays None), a team-fetch-failure test asserting the backfill fails safe, and a CLI session-token test that mints a real token via `get_cli_jwt_auth_token`, decrypts it like the auth path does, and asserts it leaves the centralized checks with the team's org. The backfill test and the session-token test both fail without the fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
