### PR TITLE
fix(guardrails): derive tokens_saved when Headroom compression service omits it

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -410,6 +410,19 @@ class HeadroomGuardrail(CustomGuardrail):
             )
             if key in body
         }
+        tokens_before = stats.get("tokens_before")
+        tokens_after = stats.get("tokens_after")
+        if (
+            "tokens_saved" not in stats
+            and isinstance(tokens_before, (int, float))
+            and not isinstance(tokens_before, bool)
+            and isinstance(tokens_after, (int, float))
+            and not isinstance(tokens_after, bool)
+        ):
+            # Spend tracking (extract_compression_saved_tokens) reads only
+            # tokens_saved, which the live compression service omits; derive it
+            # so savings are counted, but let a service-sent value win.
+            stats["tokens_saved"] = tokens_before - tokens_after
         return filtered, True, stats
 
     async def _call_retrieve(self, hash_value: str, query: str | None = None) -> str:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -11,6 +11,9 @@ Tests cover:
 - /v1/compress non-2xx surfaces as httpx.HTTPStatusError (raise_for_status),
   not a status_code check on the returned response -- both are handled
 - unreachable_fallback="fail_open" forwards the request uncompressed instead of raising
+- tokens_saved is derived from tokens_before/tokens_after when the compression
+  service omits it, passed through verbatim when present, and skipped (without
+  breaking compression) when the token counts are not numeric
 - CCR: headroom_retrieve tool injected when compressed messages contain hashes
 - CCR: async_should_run_agentic_loop returns True when response has headroom_retrieve tool calls
 - CCR: async_build_agentic_loop_plan calls retrieve endpoint and builds follow-up messages
@@ -31,6 +34,9 @@ from litellm.proxy.guardrails.guardrail_hooks.headroom.headroom import (
     extract_hashes_from_messages,
     has_headroom_retrieve_tool,
     HEADROOM_RETRIEVE_TOOL_NAME,
+)
+from litellm.proxy.spend_tracking.compression_savings import (
+    extract_compression_saved_tokens,
 )
 from litellm.types.utils import GenericGuardrailAPIInputs
 
@@ -136,6 +142,113 @@ async def test_apply_guardrail_compresses_and_returns_structured_messages(
             input_type="request",
         )
 
+    assert result.get("structured_messages") == COMPRESSED_MESSAGES
+
+
+def _recorded_guardrail_response(request_data: dict) -> dict:
+    entries = request_data["metadata"]["standard_logging_guardrail_information"]
+    assert len(entries) == 1
+    return entries[0]["guardrail_response"]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_derives_tokens_saved_when_service_omits_it(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["A" * 5000],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+    # _make_compress_response omits tokens_saved, matching the live service.
+    mock_response = _make_compress_response(COMPRESSED_MESSAGES)
+    request_data: dict = {"model": "gpt-4o"}
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+
+    stats = _recorded_guardrail_response(request_data)
+    assert stats["tokens_saved"] == 900
+
+    # Spend tracking reads the entry under the spend-log metadata key.
+    entry = request_data["metadata"]["standard_logging_guardrail_information"][0]
+    assert extract_compression_saved_tokens({"guardrail_information": [entry]}) == 900
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_passes_through_service_sent_tokens_saved(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["A" * 5000],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+    mock_response = _make_compress_response(COMPRESSED_MESSAGES)
+    # Deliberately different from tokens_before - tokens_after (900): the
+    # service-sent value must win over the derived one.
+    mock_response.json.return_value["tokens_saved"] = 123
+    request_data: dict = {"model": "gpt-4o"}
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+
+    assert _recorded_guardrail_response(request_data)["tokens_saved"] == 123
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tokens_before, tokens_after",
+    [
+        ("1000", "100"),
+        (True, False),
+        (None, None),
+    ],
+)
+async def test_apply_guardrail_skips_derivation_for_non_numeric_token_counts(
+    guardrail: HeadroomGuardrail,
+    tokens_before,
+    tokens_after,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["A" * 5000],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+    mock_response = _make_compress_response(COMPRESSED_MESSAGES)
+    mock_response.json.return_value["tokens_before"] = tokens_before
+    mock_response.json.return_value["tokens_after"] = tokens_after
+    request_data: dict = {"model": "gpt-4o"}
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data=request_data,
+            input_type="request",
+        )
+
+    assert "tokens_saved" not in _recorded_guardrail_response(request_data)
+    # Compression itself is unaffected by the skipped derivation.
     assert result.get("structured_messages") == COMPRESSED_MESSAGES
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Headroom-compressed requests always show 0 saved tokens on the Cost Optimization dashboard
- The live compression service omits `tokens_saved`, the one key spend tracking reads

How it solves it:

- Derive `tokens_saved = tokens_before - tokens_after` in the Headroom stats when the service omits it
- A service-sent `tokens_saved` still wins; non-numeric token counts skip derivation

## Relevant issues

- Headroom guardrail records compression stats as a filtered pass-through of the service response, so `tokens_saved` was silently absent
- `extract_compression_saved_tokens` (feeding `compression_saved_tokens` on the daily spend tables, #33810) keys exclusively on that field, so every compressed request rolled up as 0 saved tokens
- The sibling writers already derive the field themselves (`compresr.py`, `compression_interception/handler.py`); this brings Headroom in line

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy on :4000 against Postgres, real Anthropic `claude-haiku-4-5` calls, and a stub compression service
returning the live-service response shape (`tokens_before`, `tokens_after`, `compression_ratio`, no `tokens_saved`).
Spend tables truncated, then the identical request sent twice: once at `3eaf7b1c0a` (the commit this branch
forked from) and once at `9bd89290cb` (this PR's head).

```bash
# both runs
curl -s -X POST localhost:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' \
  -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"Say hi. filler context ..."}],"max_tokens":20}'
```

Spend logs, both requests in the same DB:

```
psql> select "startTime", metadata->'guardrail_information'->0->'guardrail_response' from "LiteLLM_SpendLogs" order by "startTime";

 2026-07-25 00:14:43.482 | {"tokens_after": 50, "tokens_before": 1502, "compression_ratio": 0.5}                        <- 3eaf7b1c0a
 2026-07-25 00:17:52.811 | {"tokens_after": 50, "tokens_saved": 1452, "tokens_before": 1502, "compression_ratio": 0.5}  <- 9bd89290cb
```

Daily rollup after both requests; only the second one contributed savings:

```
psql> select date, model, prompt_tokens, compression_saved_tokens from "LiteLLM_DailyUserSpend";

    date    |      model       | prompt_tokens | compression_saved_tokens
------------+------------------+---------------+--------------------------
 2026-07-25 | claude-haiku-4-5 |            98 |                     1452
```

What the Cost Optimization dashboard reads:

```bash
curl -s "localhost:4000/user/daily/activity?start_date=2026-07-25&end_date=2026-07-25" -H 'Authorization: Bearer sk-1234'
# metadata: total_compression_saved_tokens: 1452, total_compression_savings_spend: 0.001452
```

Cost Optimization > Usage went from "$0.00, 0 tokens compressed" at `3eaf7b1c0a` to "$0.0015, 1,452 tokens
compressed" at `9bd89290cb` for the same request.

What does NOT change: compression behavior, the guardrail entry shape on failure paths, and requests where the
service already sends `tokens_saved` (value passes through verbatim, pinned by test).

## Type

🐛 Bug Fix

## Changes

`HeadroomGuardrail._call_compress` fills in `tokens_saved` from `tokens_before - tokens_after` when the compress
response omits it and both counts are numeric (bools excluded); an explicit `tokens_saved` from the service is
left untouched.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/0d31832db9304091abb35ac959078559