### PR TITLE
fix(proxy/batches): make managed-file resolution additive, restore fall-back for missing-row and lookup errors

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -49,12 +49,11 @@ async def _resolve_managed_input_file_storage_url(input_file_id: str) -> "str | 
 
     Provider batch handlers (e.g. Vertex AI, which parses a `publishers/`
     segment out of the file URI) need a real storage location; the opaque
-    unified token crashes them. Returns None only when there is no database or
-    the row has no storage_url yet, so callers fall back to the original id
-    (which the managed-files deployment hook can still map). Fails closed
-    rather than dispatch a token that cannot be resolved: 404 when no
-    managed-file row exists, 503 when the lookup itself errors so the caller
-    can retry.
+    unified token crashes them. Returns None whenever a storage_url cannot be
+    produced (no database, lookup error, no managed-file row, or a row without
+    a storage_url yet) so callers fall back to dispatching the original id,
+    which the managed-files deployment hook still maps. This adds resolution
+    without changing behavior on any path that did not resolve before.
     """
     from litellm.proxy.proxy_server import prisma_client
 
@@ -64,15 +63,9 @@ async def _resolve_managed_input_file_storage_url(input_file_id: str) -> "str | 
         db_file = await ManagedFileRepository(prisma_client).table.find_first(where={"unified_file_id": input_file_id})
     except Exception as e:
         verbose_proxy_logger.warning("create_batch: managed file lookup failed for %s: %s", input_file_id, e)
-        raise HTTPException(
-            status_code=503,
-            detail={"error": "Could not resolve managed file; please retry"},
-        )
+        return None
     if db_file is None:
-        raise HTTPException(
-            status_code=404,
-            detail={"error": f"Managed file not found: {input_file_id}"},
-        )
+        return None
     return db_file.storage_url or None
 
 

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -561,10 +561,11 @@ async def test_create__unified_file_id_resolves_real_storage_url(harness):
 
 
 @pytest.mark.asyncio
-async def test_create__unified_file_id_db_error_fails_closed_503(harness):
-    """A lookup error leaves the token unresolved, so it fails closed with a
-    retryable 503 rather than dispatching the opaque id into the provider crash
-    it cannot parse. Nothing is dispatched."""
+async def test_create__unified_file_id_db_error_falls_back_to_raw_id(harness):
+    """Resolution is additive and best-effort: a lookup error leaves the id
+    unresolved and dispatch falls back to the original id, exactly as before
+    this change (the managed-files deployment hook still maps it). No new
+    failure mode is introduced."""
     set_body(
         harness,
         {
@@ -585,12 +586,9 @@ async def test_create__unified_file_id_db_error_fails_closed_503(harness):
         patch.object(proxy_server, "prisma_client", MagicMock()),
         patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
     ):
-        with pytest.raises(ProxyException) as exc:
-            await call_create(harness)
+        await call_create(harness)
 
-    assert exc.value.code == "503"
-    harness.router_acreate.assert_not_called()
-    harness.litellm_acreate.assert_not_called()
+    assert harness.router_kwargs()["input_file_id"] == "litellm_proxy_unified_id"
 
 
 @pytest.mark.asyncio
@@ -626,11 +624,11 @@ async def test_create__multi_model_unified_file_with_loadbalancing_keeps_router_
 
 
 @pytest.mark.asyncio
-async def test_create__unified_file_id_missing_row_fails_closed_404(harness):
-    """With a database present, a managed unified id that has no row cannot be
-    resolved to a real storage location, so it fails closed with a 404 rather
-    than dispatching the opaque token, which would hit the Vertex
-    publishers-segment IndexError this PR exists to prevent."""
+async def test_create__unified_file_id_missing_row_falls_back_to_raw_id(harness):
+    """Resolution is additive: when no managed-file row exists there is nothing
+    to substitute, so dispatch falls back to the original id exactly as before
+    this change (the managed-files deployment hook still maps it). No new
+    failure mode is introduced for this case."""
     set_body(
         harness,
         {
@@ -651,12 +649,9 @@ async def test_create__unified_file_id_missing_row_fails_closed_404(harness):
         patch.object(proxy_server, "prisma_client", MagicMock()),
         patch.object(endpoints, "ManagedFileRepository", fake_repo_cls),
     ):
-        with pytest.raises(ProxyException) as exc:
-            await call_create(harness)
+        await call_create(harness)
 
-    assert exc.value.code == "404"
-    harness.router_acreate.assert_not_called()
-    harness.litellm_acreate.assert_not_called()
+    assert harness.router_kwargs()["input_file_id"] == "litellm_proxy_unified_id"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Relevant issues

Follow-up to #34474

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`#34474` resolved a managed (unified) batch `input_file_id` to its backend `storage_url` before dispatch so providers like Vertex AI receive a real `gs://` path instead of the opaque token. Alongside that it added two fail-closed responses that were not in the original change and were not present before it: a 404 when the managed-file row is missing and a 503 when the lookup errors. Those two are backward-incompatible against the prior behavior, where the same requests fell through and dispatched the original id (the managed-files deployment hook maps it)

Verified live, base vs the merged `#34474` behavior, real Vertex Gemini `batchPredictionJobs`, no mocks: the missing-row case returns 200 on the prior behavior when the deployment hook serves the mapping from cache, and 404 after `#34474`. This PR restores the prior response for that case

This change keeps the resolution and removes only the two added fail-closed responses, so the managed-file handling becomes strictly additive: when a row with a `storage_url` exists it is substituted, and every other path (no database, lookup error, missing row, row without a `storage_url`) falls back to dispatching the original id exactly as before `#34474`

## Type

🧹 Refactoring

## Changes

`_resolve_managed_input_file_storage_url` now returns None on a lookup error and on a missing row instead of raising 503 and 404, matching the no-database and no-storage_url paths. The result: resolution is applied when it can be, and no request that previously dispatched now fails. The two mapped tests assert the fall-back for the missing-row and lookup-error cases; the resolution, legacy-row, and load-balancing tests are unchanged

## Behavior changes

- A managed unified id whose managed-file row is missing now dispatches the original id again (as before #34474) instead of returning 404
- A managed-file lookup error now dispatches the original id again instead of returning 503
- No change to the resolved-storage_url path, non-managed batches, or the load-balanced path

## QA runbook

1. Upload a batch input file with `target_model_names` set (managed files, enterprise) against a `vertex_ai` model, create a batch with the owning key: the Vertex job still receives the resolved `gs://` path
2. Delete the `LiteLLM_ManagedFileTable` row and repeat: the request dispatches the original id (deployment-hook mapping) rather than returning 404, matching the behavior before #34474

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/34584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch-create behavior for unified file ids when the DB lookup fails or the row is missing—requests proceed instead of failing fast, which restores compatibility but may send opaque ids to providers if the deployment hook does not map them.
> 
> **Overview**
> Follow-up to managed-file `storage_url` resolution for batch create: **substitution when a row has `storage_url` is unchanged**, but **503 (DB lookup error) and 404 (missing row) are removed** so those cases behave like before #34474.
> 
> `_resolve_managed_input_file_storage_url` now returns `None` on lookup exceptions and when no managed-file row exists, instead of raising. Batch create then dispatches the **original unified `input_file_id`**, relying on the managed-files deployment hook as before. Tests were updated to assert router dispatch with the raw id for DB errors and missing rows rather than expecting fail-closed HTTP errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf71afd3fe5f59894f7d6d5f519255fd3b24e19a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->