### PR TITLE
fix(mcp): authorize UI sessions as live users

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -845,6 +845,10 @@ class MCPRequestHandler:
                 prisma_client=prisma_client,
                 user_api_key_cache=user_api_key_cache,
                 user_id_upsert=False,
+                # Interactive MCP subjects must observe grants, revocations,
+                # and offboarding on the next request. Do not authorize from a
+                # cached pre-reconciliation user row.
+                check_db_only=True,
             )
             # Resolve the user's own MCP object permission (get_user_object does not load it) so the shared
             # get_allowed_mcp_servers can grant the user their litellm-granted servers. Reuses the same
@@ -2117,6 +2121,10 @@ class MCPRequestHandler:
                 prisma_client=prisma_client,
                 user_api_key_cache=user_api_key_cache,
                 user_id_upsert=False,
+                # Team fan-out is part of the admitted subject's live
+                # authorization boundary, so stale membership must never
+                # preserve or delay access.
+                check_db_only=True,
                 parent_otel_span=user_api_key_auth.parent_otel_span,
                 proxy_logging_obj=proxy_logging_obj,
             )

--- a/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
@@ -76,9 +76,22 @@ async def resolve_ui_session_team_ids(
 async def build_effective_auth_contexts(
     user_api_key_auth: UserAPIKeyAuth,
 ) -> List[UserAPIKeyAuth]:
-    """Return auth contexts that reflect the actual teams for UI session tokens."""
+    """Return the live admitted-user context behind a UI session token.
 
-    resolved_team_ids = await resolve_ui_session_team_ids(user_api_key_auth)
-    if resolved_team_ids:
-        return [clone_user_api_key_auth_with_team(user_api_key_auth, team_id) for team_id in resolved_team_ids]
+    A UI session key is intentionally not granted MCP servers itself. Treating
+    it like an ordinary virtual key after only swapping in an employee team id
+    therefore applies the key-level MCP ceiling and hides every team server
+    when ``require_key_mcp_access_defined`` is enabled.
+
+    Reuse the same server-only admitted-user path as DCR bridge credentials so
+    discovery and tool execution apply the employee's current direct and team
+    grants, roster membership, organization ceilings, and rate limits.
+    """
+
+    if user_api_key_auth.team_id == UI_SESSION_TOKEN_TEAM_ID and user_api_key_auth.user_id:
+        from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+            MCPRequestHandler,
+        )
+
+        return [await MCPRequestHandler._reload_admitted_user(user_api_key_auth.user_id)]
     return [user_api_key_auth]

--- a/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
@@ -48,6 +48,11 @@ async def resolve_ui_session_team_ids(
             prisma_client=prisma_client,
             user_api_key_cache=user_api_key_cache,
             user_id_upsert=False,
+            # UI-session authorization must observe grants, revocations, and
+            # offboarding on the next request. A cached user row can retain a
+            # pre-login or pre-reconciliation team list until its management
+            # TTL expires, which makes both grants and revocations stale.
+            check_db_only=True,
             parent_otel_span=user_api_key_auth.parent_otel_span,
             proxy_logging_obj=proxy_logging_obj,
         )

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -6399,6 +6399,7 @@ class TestGatewaySessionAdmission:
                 self._scope(token)
             )
         assert get_user_object.await_args.kwargs["user_id"] == "sso-user-42"
+        assert get_user_object.await_args.kwargs["check_db_only"] is True
         assert auth_result.user_id == "sso-user-42"
         mock_auth.assert_not_called()
         # Identity-only admission injects no per-server upstream credential (unlike the
@@ -6528,8 +6529,10 @@ class TestUserSubjectTeamUnion:
         async def _get_team_object(team_id, **kw):
             return teams_by_id.get(team_id)
 
-        async def _get_user_object(user_id, **kw):
+        async def _get_user_object_impl(user_id, **kw):
             return MagicMock(user_id=user_id, teams=user_teams or [])
+
+        get_user_object = AsyncMock(side_effect=_get_user_object_impl)
 
         async def _get_org_object(org_id, **kw):
             return (orgs_by_id or {}).get(org_id)
@@ -6541,7 +6544,7 @@ class TestUserSubjectTeamUnion:
 
         with (
             patch("litellm.proxy.auth.auth_checks.get_team_object", _get_team_object),
-            patch("litellm.proxy.auth.auth_checks.get_user_object", _get_user_object),
+            patch("litellm.proxy.auth.auth_checks.get_user_object", get_user_object),
             patch("litellm.proxy.auth.auth_checks.get_org_object", _get_org_object),
             patch("litellm.proxy.auth.auth_checks._get_mcp_server_ids_from_access_groups", AsyncMock(return_value=[])),
             patch("litellm.proxy.proxy_server.get_current_spend", _spend_from_fallback),
@@ -6549,7 +6552,7 @@ class TestUserSubjectTeamUnion:
             patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
             patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
         ):
-            yield
+            yield get_user_object
 
     async def test_keyless_user_unions_servers_across_all_their_teams(self):
         teams = {"team-a": _make_team("team-a", ["srv1", "srv2"]), "team-b": _make_team("team-b", ["srv2", "srv3"])}
@@ -6557,6 +6560,17 @@ class TestUserSubjectTeamUnion:
         with self._patch(teams_by_id=teams, user_teams=["team-a", "team-b"]):
             result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
         assert set(result) == {"srv1", "srv2", "srv3"}
+
+    async def test_admitted_subject_team_membership_is_loaded_from_db(self):
+        auth = _make_admitted_subject("sso-user")
+        with self._patch(
+            teams_by_id={"team-a": _make_team("team-a", ["srv1"])},
+            user_teams=["team-a"],
+        ) as get_user_object:
+            result = await MCPRequestHandler.get_allowed_mcp_servers(auth)
+
+        assert set(result) == {"srv1"}
+        assert get_user_object.await_args.kwargs["check_db_only"] is True
 
     async def test_key_based_caller_uses_single_team_only(self):
         """A key-based caller (api_key set) with a team_id sees ONLY that team, even though the

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
@@ -1,4 +1,3 @@
-import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -31,9 +30,7 @@ async def test_resolve_ui_session_team_ids_returns_unique_ids(monkeypatch):
         user_id="user-1",
     )
 
-    fake_user = SimpleNamespace(
-        teams=["team-a", "team-b", "team-a", "", None, "team-c"]
-    )
+    fake_user = SimpleNamespace(teams=["team-a", "team-b", "team-a", "", None, "team-c"])
 
     get_user_object = AsyncMock(return_value=fake_user)
     monkeypatch.setattr(
@@ -81,10 +78,7 @@ async def test_resolve_ui_session_team_ids_observes_next_call_revocation(monkeyp
     assert await resolve_ui_session_team_ids(user_auth) == ["team-a"]
     assert await resolve_ui_session_team_ids(user_auth) == []
     assert get_user_object.await_count == 2
-    assert all(
-        call.kwargs["check_db_only"] is True
-        for call in get_user_object.await_args_list
-    )
+    assert all(call.kwargs["check_db_only"] is True for call in get_user_object.await_args_list)
 
 
 @pytest.mark.asyncio
@@ -97,62 +91,51 @@ async def test_resolve_ui_session_team_ids_short_circuits_when_not_ui_session():
 
 
 @pytest.mark.asyncio
-async def test_build_effective_auth_contexts_returns_cloned_contexts(monkeypatch):
+async def test_build_effective_auth_contexts_reloads_ui_session_as_admitted_user(
+    monkeypatch,
+):
     user_auth = UserAPIKeyAuth(team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="user-42")
+    admitted = UserAPIKeyAuth(user_id="user-42")
+    admitted.mcp_admitted_user_subject = True
 
-    mock_resolve = AsyncMock(return_value=["team-one", "team-two"])
+    reload_user = AsyncMock(return_value=admitted)
     monkeypatch.setattr(
-        "litellm.proxy._experimental.mcp_server.ui_session_utils.resolve_ui_session_team_ids",
-        mock_resolve,
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        reload_user,
     )
 
     contexts = await build_effective_auth_contexts(user_auth)
 
-    assert [ctx.team_id for ctx in contexts] == ["team-one", "team-two"]
-    assert all(ctx is not user_auth for ctx in contexts)
-    mock_resolve.assert_awaited_once_with(user_auth)
+    assert contexts == [admitted]
+    assert contexts[0].mcp_admitted_user_subject is True
+    reload_user.assert_awaited_once_with("user-42")
 
 
 @pytest.mark.asyncio
-async def test_build_effective_auth_contexts_returns_original_when_no_resolution(
+async def test_build_effective_auth_contexts_returns_non_ui_context_unchanged(
     monkeypatch,
 ):
     user_auth = UserAPIKeyAuth(team_id="existing-team", user_id="user-7")
 
-    mock_resolve = AsyncMock(return_value=[])
-    monkeypatch.setattr(
-        "litellm.proxy._experimental.mcp_server.ui_session_utils.resolve_ui_session_team_ids",
-        mock_resolve,
-    )
-
     contexts = await build_effective_auth_contexts(user_auth)
 
     assert contexts == [user_auth]
-    mock_resolve.assert_awaited_once_with(user_auth)
 
 
 @pytest.mark.asyncio
-async def test_build_effective_auth_contexts_handles_unpicklable_parent_span(
+async def test_build_effective_auth_contexts_propagates_reload_failure_closed(
     monkeypatch,
 ):
-    class DummySpan:
-        def __init__(self) -> None:
-            self._lock = threading.RLock()
-
-    parent_span = DummySpan()
     user_auth = UserAPIKeyAuth(
         team_id=UI_SESSION_TOKEN_TEAM_ID,
-        user_id="user-span",
-        parent_otel_span=parent_span,
+        user_id="offboarded-user",
     )
 
-    mock_resolve = AsyncMock(return_value=["team-span"])
+    reload_user = AsyncMock(side_effect=RuntimeError("live user unavailable"))
     monkeypatch.setattr(
-        "litellm.proxy._experimental.mcp_server.ui_session_utils.resolve_ui_session_team_ids",
-        mock_resolve,
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        reload_user,
     )
 
-    contexts = await build_effective_auth_contexts(user_auth)
-
-    assert contexts[0].team_id == "team-span"
-    assert contexts[0].parent_otel_span is parent_span
+    with pytest.raises(RuntimeError, match="live user unavailable"):
+        await build_effective_auth_contexts(user_auth)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
@@ -35,9 +35,10 @@ async def test_resolve_ui_session_team_ids_returns_unique_ids(monkeypatch):
         teams=["team-a", "team-b", "team-a", "", None, "team-c"]
     )
 
+    get_user_object = AsyncMock(return_value=fake_user)
     monkeypatch.setattr(
         "litellm.proxy.auth.auth_checks.get_user_object",
-        AsyncMock(return_value=fake_user),
+        get_user_object,
     )
 
     import litellm.proxy.proxy_server as proxy_server
@@ -49,6 +50,41 @@ async def test_resolve_ui_session_team_ids_returns_unique_ids(monkeypatch):
     team_ids = await resolve_ui_session_team_ids(user_auth)
 
     assert team_ids == ["team-a", "team-b", "team-c"]
+    get_user_object.assert_awaited_once()
+    assert get_user_object.await_args.kwargs["check_db_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_resolve_ui_session_team_ids_observes_next_call_revocation(monkeypatch):
+    user_auth = UserAPIKeyAuth(
+        team_id=UI_SESSION_TOKEN_TEAM_ID,
+        user_id="user-revoked",
+    )
+
+    get_user_object = AsyncMock(
+        side_effect=[
+            SimpleNamespace(teams=["team-a"]),
+            SimpleNamespace(teams=[]),
+        ]
+    )
+    monkeypatch.setattr(
+        "litellm.proxy.auth.auth_checks.get_user_object",
+        get_user_object,
+    )
+
+    import litellm.proxy.proxy_server as proxy_server
+
+    monkeypatch.setattr(proxy_server, "prisma_client", object())
+    monkeypatch.setattr(proxy_server, "proxy_logging_obj", None)
+    monkeypatch.setattr(proxy_server, "user_api_key_cache", None)
+
+    assert await resolve_ui_session_team_ids(user_auth) == ["team-a"]
+    assert await resolve_ui_session_team_ids(user_auth) == []
+    assert get_user_object.await_count == 2
+    assert all(
+        call.kwargs["check_db_only"] is True
+        for call in get_user_object.await_args_list
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- resolve MCP discovery for a UI session through the existing admitted-user authorization path instead of treating the dashboard key as an ordinary virtual key
- force interactive user and team-membership authorization to read the current user row from the database
- preserve team grants, roster checks, organization ceilings, tool permissions, rate limits, revocation, and offboarding on the next request

## Why
With `require_key_mcp_access_defined: true`, cloning a `litellm-dashboard` UI session into an employee team still applies the ordinary virtual-key ceiling. Because that session key intentionally has no key-level MCP object permission, every team server is hidden even when the employee is correctly provisioned. The DCR bridge already has a server-only admitted-user path that resolves the signed-in employee against live policy; UI discovery should use the same path.

This also closes the stale-user-cache portion of #34566 by using database-only user loads at initial admission and team fan-out.

## Tests
- `pytest -q tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py` (302 passed)
- Ruff check and format check pass on all changed files

Closes the remaining UI-session authorization portion of #34566.