### PR TITLE
fix(guardrails): compress content-parts messages in headroom guardrail (Anthropic traffic)

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -28,6 +28,11 @@ from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,  # pyright: ignore[reportUnknownVariableType]
     httpxSpecialProvider,
 )
+from litellm.proxy.guardrails.guardrail_hooks.content_text import (
+    content_to_text,
+    is_all_text_parts,
+    merge_rewritten_text_parts,
+)
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.guardrails import GuardrailEventHooks, Mode
 from litellm.types.integrations.custom_logger import AgenticLoopPlan, AgenticLoopRequestPatch
@@ -49,6 +54,60 @@ def _is_str_object_dict(value: object) -> TypeGuard[dict[str, object]]:  # guard
 
 def _is_object_list(value: object) -> TypeGuard[list[object]]:  # guard-ok: isinstance narrows correctly; predicate is trivially correct  # fmt: skip
     return isinstance(value, list)
+
+
+def _flatten_messages_for_compression(messages: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Collapse all-text list-of-parts content to plain strings for /v1/compress.
+
+    The compression service's transforms only rewrite string content and skip
+    the OpenAI list-of-parts shape, which is what every Anthropic-format
+    request translates to. Only rows whose parts are ALL text are flattened:
+    cache_control breakpoints are positional (each caches the prefix ending
+    at its part), so merging text across a non-text part would move a later
+    breakpoint to the other side of it. Rows with non-text parts are sent
+    unchanged and pass through the service untouched.
+    """
+    flattened: list[dict[str, object]] = []
+    for msg in messages:
+        content = msg.get("content")
+        if is_all_text_parts(content):
+            text = content_to_text(content)
+            if text:
+                flattened.append({**msg, "content": text})
+                continue
+        flattened.append(msg)
+    return flattened
+
+
+def _restore_content_shapes(
+    originals: list[dict[str, object]], returned: list[dict[str, object]]
+) -> list[dict[str, object]]:
+    """Write compressed text back into each original row's content shape.
+
+    Rows are matched positionally; the pairing is only trusted when the
+    service kept the row count and every role lines up. If it restructured
+    the conversation (e.g. dropped rows), its output is adopted as-is, which
+    is the pre-flattening behavior.
+    """
+    if len(returned) != len(originals):
+        return returned
+    for orig, ret in zip(originals, returned):
+        if orig.get("role") != ret.get("role"):
+            return returned
+    restored: list[dict[str, object]] = []
+    for orig, ret in zip(originals, returned):
+        orig_content = orig.get("content")
+        ret_content = ret.get("content")
+        if isinstance(orig_content, list) and isinstance(ret_content, str):
+            if ret_content == content_to_text(orig_content):
+                # Untouched row: keep the exact original parts, including
+                # per-part fields like cache_control on later text parts.
+                restored.append({**ret, "content": orig_content})
+            else:
+                restored.append({**ret, "content": merge_rewritten_text_parts(orig_content, ret_content)})
+        else:
+            restored.append(ret)
+    return restored
 
 
 def extract_hashes_from_messages(messages: list[dict[str, object]]) -> list[str]:
@@ -491,10 +550,11 @@ class HeadroomGuardrail(CustomGuardrail):
         model = self.headroom_model or request_data.get("model")
         start_time = time.time()
         compressed, compression_succeeded, stats = await self._call_compress(
-            messages=messages,
+            messages=_flatten_messages_for_compression(messages),
             model=model if isinstance(model, str) else None,
         )
         end_time = time.time()
+        compressed = _restore_content_shapes(originals=messages, returned=compressed)
 
         from litellm.proxy.common_utils.callback_utils import (
             add_guardrail_to_applied_guardrails_header,

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -1551,3 +1551,234 @@ async def test_apply_guardrail_litellm_timeout_fail_open_forwards_uncompressed()
         )
 
     assert result["structured_messages"] == ORIGINAL_MESSAGES
+
+
+
+
+# ---------------------------------------------------------------------------
+# Content-parts flattening (LIT-4795)
+#
+# Anthropic-format requests translate to messages whose content is a list of
+# part dicts. The compression service only rewrites string content, so the
+# guardrail flattens ALL-TEXT part lists on the wire and restores the
+# original shapes afterwards. Rows with non-text parts are never flattened:
+# cache_control breakpoints are positional, and merging text across a
+# non-text part would move a later breakpoint to the other side of it.
+# ---------------------------------------------------------------------------
+
+PARTS_MESSAGES = [
+    {
+        "role": "system",
+        "content": [
+            {"type": "text", "text": "You are Claude Code.", "cache_control": {"type": "ephemeral"}},
+            {
+                "type": "text",
+                "text": "Second system block. " + "B" * 5000,
+                "cache_control": {"type": "ephemeral", "ttl": "1h"},
+            },
+        ],
+    },
+    {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Mixed row text."},
+            {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+        ],
+    },
+    {"role": "tool", "content": "tool output " + "C" * 500},
+]
+
+FLATTENED_SYSTEM_TEXT = "You are Claude Code.\n\nSecond system block. " + "B" * 5000
+
+
+def _parts_copy() -> list:
+    return json.loads(json.dumps(PARTS_MESSAGES))
+
+
+def _echo_wire_view() -> list:
+    """What the service receives (and echoes back when it changes nothing)."""
+    return [
+        {"role": "system", "content": FLATTENED_SYSTEM_TEXT},
+        json.loads(json.dumps(PARTS_MESSAGES[1])),
+        {"role": "tool", "content": "tool output " + "C" * 500},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_flattens_all_text_rows_only(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["B" * 5000],
+        structured_messages=_parts_copy(),
+    )
+    mock_response = _make_compress_response(_echo_wire_view())
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_post:
+        await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "claude-fable-5"},
+            input_type="request",
+        )
+
+    wire_messages = mock_post.call_args.kwargs["json"]["messages"]
+    assert wire_messages[0]["content"] == FLATTENED_SYSTEM_TEXT
+    # Mixed text+image row is never flattened: merging its text would move a
+    # later cache_control breakpoint across the image part.
+    assert isinstance(wire_messages[1]["content"], list)
+    assert wire_messages[2]["content"] == "tool output " + "C" * 500
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_restores_rewritten_all_text_row(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["B" * 5000],
+        structured_messages=_parts_copy(),
+    )
+    compressed = _echo_wire_view()
+    compressed[0]["content"] = "compressed system. Retrieve more: hash=b573993006976af767214fac"
+    mock_response = _make_compress_response(compressed)
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "claude-fable-5"},
+            input_type="request",
+        )
+
+    messages = result["structured_messages"]
+    system_content = messages[0]["content"]
+    # Rewritten all-text row collapses to one part carrying the LAST declared
+    # breakpoint: an Anthropic breakpoint caches the prefix ending at its
+    # part, so after the merge the last one (and its TTL) still describes the
+    # row.
+    assert isinstance(system_content, list)
+    assert len(system_content) == 1
+    assert system_content[0]["text"] == "compressed system. Retrieve more: hash=b573993006976af767214fac"
+    assert system_content[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    # Mixed row passes through byte-identical.
+    assert messages[1]["content"] == PARTS_MESSAGES[1]["content"]
+    # Hashes inside restored parts still drive retrieve-tool injection.
+    assert has_headroom_retrieve_tool(result.get("tools") or [])
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_keeps_originals_when_service_echoes_unchanged(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["B" * 5000],
+        structured_messages=_parts_copy(),
+    )
+    mock_response = _make_compress_response(_echo_wire_view())
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "claude-fable-5"},
+            input_type="request",
+        )
+
+    messages = result["structured_messages"]
+    assert [m["content"] for m in messages] == [m["content"] for m in PARTS_MESSAGES]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_adopts_service_output_when_rows_dropped(
+    guardrail: HeadroomGuardrail,
+):
+    inputs = GenericGuardrailAPIInputs(
+        texts=["B" * 5000],
+        structured_messages=_parts_copy(),
+    )
+    dropped = [
+        {"role": "system", "content": FLATTENED_SYSTEM_TEXT},
+        {"role": "user", "content": "B" * 50},
+    ]
+    mock_response = _make_compress_response(dropped)
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "claude-fable-5"},
+            input_type="request",
+        )
+
+    assert result["structured_messages"] == dropped
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_sends_textless_parts_rows_unflattened(
+    guardrail: HeadroomGuardrail,
+):
+    image_only = [
+        {"role": "user", "content": [{"type": "image_url", "image_url": {"url": "https://example.com/x.png"}}]},
+        {"role": "user", "content": "D" * 5000},
+    ]
+    inputs = GenericGuardrailAPIInputs(
+        texts=["D" * 5000],
+        structured_messages=json.loads(json.dumps(image_only)),
+    )
+    mock_response = _make_compress_response(json.loads(json.dumps(image_only)))
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_post:
+        await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={"model": "claude-fable-5"},
+            input_type="request",
+        )
+
+    wire_messages = mock_post.call_args.kwargs["json"]["messages"]
+    assert isinstance(wire_messages[0]["content"], list)
+    assert wire_messages[1]["content"] == "D" * 5000
+
+
+@pytest.mark.asyncio
+async def test_fail_open_returns_original_parts_shapes():
+    guardrail = _make_guardrail(unreachable_fallback="fail_open")
+    inputs = GenericGuardrailAPIInputs(
+        texts=["B" * 5000],
+        structured_messages=_parts_copy(),
+    )
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        side_effect=httpx.ConnectError("boom"),
+    ):
+        result = await guardrail.apply_guardrail(
+            inputs=inputs,
+            request_data={},
+            input_type="request",
+        )
+
+    messages = result["structured_messages"]
+    assert [m["content"] for m in messages] == [m["content"] for m in PARTS_MESSAGES]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Headroom compression never fired for Anthropic clients (claude-cli, Anthropic SDKs)
- Compression silently skipped any message whose content is a list of parts

How it solves it:

- Flatten text-bearing content-part lists to strings before calling /v1/compress
- Restore original shapes (images, cache_control) from the service response

## Relevant issues

- Headroom compression appeared to run only on OpenAI models and never on Anthropic models; the real discriminator is the message content shape, not the model or route
- Anthropic-format requests always translate to list-of-parts content, which the compression service's transforms skip via `isinstance(content, str)` gates, so the request was forwarded uncompressed while the guardrail still reported itself as applied
- Fix flattens text-bearing parts on the wire and restores the original content shapes afterwards, sharing the content/text helpers compresr already owned

## Linear ticket

Resolves LIT-4795

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Changes

- `headroom.py`: flatten ALL-TEXT list-of-parts content to plain strings in the /v1/compress request, then write returned text back; rows the service returned unchanged keep their exact original parts (all `cache_control` breakpoints intact), a rewritten all-text row collapses to one part carrying the LAST declared breakpoint (a breakpoint caches the prefix ending at its part, so after the merge the last one and its TTL still describe the row); rows with any non-text part are never flattened, because merging text across a non-text part would move a later breakpoint to the other side of it; if the service restructures the conversation (row count or roles change) its output is adopted as-is, which is the previous behavior
- Flattening and write-back use the shared `content_text.py` helpers (`content_to_text`, `is_all_text_parts`, `merge_rewritten_text_parts`) that the compresr breakpoint fix (LIT-4804, #34660) already landed on staging
- What does NOT change: OpenAI plain-string traffic sends the identical wire payload as before; this PR no longer touches compresr or content_text.py at all (both are owned by the merged #34660); `compression_interception` compresses in-process without the service and is unaffected

## Root cause

The headroom service's transforms only rewrite string content (`smart_crusher.py`, `code_compressor.py`, `kompress_compressor.py` all gate on `isinstance(content, str)`) and pass list-of-parts content through untouched. Every Anthropic `/v1/messages` request translates to parts-list content in `structured_messages`, so compression was a silent no-op for all Anthropic client traffic. OpenAI clients mostly send plain strings, which made the bug look model-scoped. A `/v1/chat/completions` request with content-parts skipped compression the same way, and a `/v1/messages` request with plain-string content compressed fine, confirming content shape as the discriminator (matrix below, run against a live proxy).

| content shape | /v1/chat/completions | /v1/messages |
|---|---|---|
| plain string | compressed (29k -> 908 tokens) | compressed (906) |
| content-parts list | not compressed (28,937) | not compressed (28,944) |

## Proof of fix (live proxy + string-only compress mock + mock upstream)

Before, claude-cli-shaped `/v1/messages` request (parts content, cache_control, tools):

```
[compress] model=claude-fable-5 messages=2 chars 47603 -> 47603
[anthropic-upstream] RECEIVED messages_chars=47390 tools=['Bash'] cache_control_count=3
```

After, same request on fixed code:

```
[compress] model=claude-fable-5 messages=2 chars 47401 -> 359
[anthropic-upstream] RECEIVED messages_chars=348 tools=['Bash', 'headroom_retrieve'] cache_control_count=3
```

Negative control on fixed code, plain-string `/v1/chat/completions` still compresses:

```
[compress] model=gpt-test messages=1 chars 47320 -> 279
[openai-upstream] RECEIVED messages_chars=279 tools=['headroom_retrieve']
```

Mutation check: reverting the flatten/restore wiring fails the three new shape tests; full suite is 145 passed.

## Things a reviewer will ask about

- Why fix in the guardrail rather than the anthropic translation handler: the same skip hits `/v1/chat/completions` when a caller sends content-parts, so the invariant ("the compress service only rewrites strings") belongs at the litellm-to-service boundary where it covers every route
- Positional row matching in `_restore_content_shapes` is only trusted when the row count and every role line up; on any mismatch the service output is adopted wholesale, which is exactly the pre-flattening behavior, so alignment can never make a request worse than today
- Rows with ANY non-text part (e.g. text plus an image) are sent unflattened and pass through the service untouched: `cache_control` breakpoints are positional, so merging text across a non-text part would silently cache a shorter prefix than the caller configured; image bytes therefore never round-trip through the compression service

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request shaping for a guardrail on the proxy path; mistakes could alter `cache_control` or multimodal rows, though scope is limited to all-text flattening with positional restore guards and broad tests.
> 
> **Overview**
> **Headroom compression now works for Anthropic-style list-of-parts message content**, which previously skipped `/v1/compress` because the service only rewrites string `content`.
> 
> Before calling compress, the guardrail **flattens rows whose parts are all text** into plain strings (via shared `content_text` helpers), then **restores the original shapes** after the response. Unchanged compressed text keeps the exact original parts (including `cache_control`); rewritten all-text rows merge back into a single part with the last breakpoint. **Rows with any non-text part** (e.g. images) stay unflattened so positional cache breakpoints are not shifted.
> 
> If the service changes message count or roles, its output is used as-is (unchanged fallback). New unit tests cover wire flattening, restore, row drops, and fail-open behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33fadd70a3b6d5711baaa86a31081710540f38e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

