### PR TITLE
fix(anthropic-adapter): translate stop_sequences and disabled thinking for non-Claude targets

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -331,6 +331,7 @@ class LiteLLMAnthropicMessagesAdapter:
             "thinking",
             "output_format",
             "output_config",
+            "stop_sequences",
         ]
 
     def _is_web_search_tool(self, tool: Dict[str, Any]) -> bool:
@@ -615,7 +616,7 @@ class LiteLLMAnthropicMessagesAdapter:
         thinking_type = thinking.get("type", "disabled")
 
         if thinking_type == "disabled":
-            return None
+            return "none"
         elif thinking_type == "enabled":
             return reasoning_effort_from_thinking_budget(thinking.get("budget_tokens", 0))
         elif thinking_type == "adaptive":
@@ -919,6 +920,18 @@ class LiteLLMAnthropicMessagesAdapter:
             tool_choice=cast(AnthropicMessagesToolChoice, tool_choice)
         )
 
+    def _translate_stop_sequences_to_openai(
+        self,
+        anthropic_message_request: AnthropicMessagesRequest,
+        new_kwargs: ChatCompletionRequest,
+    ) -> None:
+        if "stop_sequences" not in anthropic_message_request:
+            return
+        stop_sequences = anthropic_message_request["stop_sequences"]
+        if not stop_sequences:
+            return
+        new_kwargs["stop"] = stop_sequences
+
     def _translate_tools_to_openai(
         self,
         anthropic_message_request: AnthropicMessagesRequest,
@@ -1095,6 +1108,11 @@ class LiteLLMAnthropicMessagesAdapter:
         )
         ## CONVERT THINKING
         self._translate_thinking_to_openai(
+            anthropic_message_request=anthropic_message_request,
+            new_kwargs=new_kwargs,
+        )
+        ## CONVERT STOP_SEQUENCES
+        self._translate_stop_sequences_to_openai(
             anthropic_message_request=anthropic_message_request,
             new_kwargs=new_kwargs,
         )

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -710,9 +710,9 @@ class LiteLLMAnthropicMessagesAdapter:
 
         summary = thinking.get("summary") if isinstance(thinking, dict) else None
         if summary:
-            return cast(Any, {"effort": reasoning_effort, "summary": summary})
+            return {"effort": reasoning_effort, "summary": summary}
         if is_reasoning_auto_summary_enabled():
-            return cast(Any, {"effort": reasoning_effort, "summary": "detailed"})
+            return {"effort": reasoning_effort, "summary": "detailed"}
         return reasoning_effort
 
     def translate_anthropic_tool_choice_to_openai(

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -989,11 +989,17 @@ class LiteLLMAnthropicMessagesAdapter:
         if not reasoning_effort:
             return
 
+        thinking_type = thinking.get("type") if isinstance(thinking, dict) else None
+
         # For adaptive thinking, override with output_config.effort if available
-        if isinstance(thinking, dict) and thinking.get("type") == "adaptive":
+        if thinking_type == "adaptive":
             output_config = anthropic_message_request.get("output_config")
             if isinstance(output_config, dict) and output_config.get("effort"):
                 reasoning_effort = output_config["effort"]
+
+        if thinking_type == "disabled":
+            new_kwargs["reasoning_effort"] = reasoning_effort
+            return
 
         summary = thinking.get("summary") if isinstance(thinking, dict) else None
         auto_summary = is_reasoning_auto_summary_enabled()

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -684,24 +684,36 @@ class LiteLLMAnthropicMessagesAdapter:
                 thinking
             )
             if reasoning_effort:
-                summary = thinking.get("summary") if isinstance(thinking, dict) else None
-                auto_summary = is_reasoning_auto_summary_enabled()
-                if summary:
-                    return {
-                        "reasoning_effort": {
-                            "effort": reasoning_effort,
-                            "summary": summary,
-                        }
-                    }
-                elif auto_summary:
-                    return {
-                        "reasoning_effort": {
-                            "effort": reasoning_effort,
-                            "summary": "detailed",
-                        }
-                    }
-                return {"reasoning_effort": reasoning_effort}
+                return {
+                    "reasoning_effort": LiteLLMAnthropicMessagesAdapter._apply_reasoning_summary_wrapping(
+                        reasoning_effort, thinking
+                    )
+                }
             return {}
+
+    @staticmethod
+    def _apply_reasoning_summary_wrapping(
+        reasoning_effort: str,
+        thinking: Dict[str, Any],
+    ) -> Any:
+        """
+        Apply the reasoning_effort/summary wrapping rules shared by every
+        thinking->reasoning_effort translation path.
+
+        Disabled thinking always stays a plain string - there's no reasoning
+        trace to summarize, and non-Claude providers (e.g. Fireworks) expect
+        reasoning_effort as a plain string, not a summary dict.
+        """
+        thinking_type = thinking.get("type") if isinstance(thinking, dict) else None
+        if thinking_type == "disabled":
+            return reasoning_effort
+
+        summary = thinking.get("summary") if isinstance(thinking, dict) else None
+        if summary:
+            return cast(Any, {"effort": reasoning_effort, "summary": summary})
+        if is_reasoning_auto_summary_enabled():
+            return cast(Any, {"effort": reasoning_effort, "summary": "detailed"})
+        return reasoning_effort
 
     def translate_anthropic_tool_choice_to_openai(
         self, tool_choice: AnthropicMessagesToolChoice
@@ -997,30 +1009,9 @@ class LiteLLMAnthropicMessagesAdapter:
             if isinstance(output_config, dict) and output_config.get("effort"):
                 reasoning_effort = output_config["effort"]
 
-        if thinking_type == "disabled":
-            new_kwargs["reasoning_effort"] = reasoning_effort
-            return
-
-        summary = thinking.get("summary") if isinstance(thinking, dict) else None
-        auto_summary = is_reasoning_auto_summary_enabled()
-        if summary:
-            new_kwargs["reasoning_effort"] = cast(
-                Any,
-                {
-                    "effort": reasoning_effort,
-                    "summary": summary,
-                },
-            )
-        elif auto_summary:
-            new_kwargs["reasoning_effort"] = cast(
-                Any,
-                {
-                    "effort": reasoning_effort,
-                    "summary": "detailed",
-                },
-            )
-        else:
-            new_kwargs["reasoning_effort"] = reasoning_effort
+        new_kwargs["reasoning_effort"] = self._apply_reasoning_summary_wrapping(
+            reasoning_effort, cast(Dict[str, Any], thinking)
+        )
 
     def _translate_output_format_to_openai(
         self,

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1593,6 +1593,23 @@ def test_thinking_disabled_translated_to_reasoning_effort_none_for_non_claude_mo
     assert new_kwargs["reasoning_effort"] == "none"
 
 
+def test_thinking_disabled_stays_plain_string_when_auto_summary_enabled():
+    import litellm
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    thinking = {"type": "disabled"}
+
+    original = litellm.reasoning_auto_summary
+    try:
+        litellm.reasoning_auto_summary = True
+        new_kwargs = {"model": CACHE_CONTROL_NON_ANTHROPIC_MODEL}
+        adapter._translate_thinking_to_openai(cast(Any, {"thinking": thinking}), cast(Any, new_kwargs))
+    finally:
+        litellm.reasoning_auto_summary = original
+
+    assert new_kwargs["reasoning_effort"] == "none"
+
+
 def test_stop_sequences_translated_to_stop_for_non_claude_model():
     from litellm.types.llms.anthropic import AnthropicMessagesRequest
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1627,6 +1627,22 @@ def test_stop_sequences_translated_to_stop_for_non_claude_model():
     assert "stop_sequences" not in openai_request
 
 
+def test_empty_stop_sequences_does_not_set_stop():
+    from litellm.types.llms.anthropic import AnthropicMessagesRequest
+
+    anthropic_request = AnthropicMessagesRequest(
+        model=CACHE_CONTROL_NON_ANTHROPIC_MODEL,
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "hi"}],
+        stop_sequences=[],
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    openai_request, _ = adapter.translate_anthropic_to_openai(anthropic_message_request=anthropic_request)
+
+    assert "stop" not in openai_request
+
+
 def test_cache_control_preserved_in_image_content_for_claude():
     """Cache control should be preserved in image content for Claude models."""
     anthropic_messages = [

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1582,6 +1582,34 @@ def test_thinking_still_translated_to_reasoning_effort_for_non_claude_model():
     assert new_kwargs["reasoning_effort"] == "low"
 
 
+def test_thinking_disabled_translated_to_reasoning_effort_none_for_non_claude_model():
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    thinking = {"type": "disabled"}
+
+    new_kwargs = {"model": CACHE_CONTROL_NON_ANTHROPIC_MODEL}
+    adapter._translate_thinking_to_openai(cast(Any, {"thinking": thinking}), cast(Any, new_kwargs))
+
+    assert "thinking" not in new_kwargs
+    assert new_kwargs["reasoning_effort"] == "none"
+
+
+def test_stop_sequences_translated_to_stop_for_non_claude_model():
+    from litellm.types.llms.anthropic import AnthropicMessagesRequest
+
+    anthropic_request = AnthropicMessagesRequest(
+        model=CACHE_CONTROL_NON_ANTHROPIC_MODEL,
+        max_tokens=1024,
+        messages=[{"role": "user", "content": "hi"}],
+        stop_sequences=["</block>"],
+    )
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    openai_request, _ = adapter.translate_anthropic_to_openai(anthropic_message_request=anthropic_request)
+
+    assert openai_request["stop"] == ["</block>"]
+    assert "stop_sequences" not in openai_request
+
+
 def test_cache_control_preserved_in_image_content_for_claude():
     """Cache control should be preserved in image content for Claude models."""
     anthropic_messages = [

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_experimental_pass_through_messages_handler.py
@@ -651,6 +651,26 @@ class TestThinkingSummaryPreservation:
             "reasoning_effort": {"effort": "high", "summary": "concise"}
         }
 
+    def test_translate_thinking_for_model_disabled_stays_plain_string_when_auto_summary_enabled(self):
+        """Disabled thinking must stay a plain string even when reasoning_auto_summary is on."""
+        import litellm
+        from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import (
+            LiteLLMAnthropicMessagesAdapter,
+        )
+
+        original = litellm.reasoning_auto_summary
+        try:
+            litellm.reasoning_auto_summary = True
+            thinking = {"type": "disabled"}
+            result = LiteLLMAnthropicMessagesAdapter.translate_thinking_for_model(
+                thinking=thinking,
+                model="openai/gpt-5.2",
+            )
+        finally:
+            litellm.reasoning_auto_summary = original
+
+        assert result == {"reasoning_effort": "none"}
+
 
 # ---------------------------------------------------------------------------
 # Parity tests: redundant empty-text-block sanitization scan removal.


### PR DESCRIPTION
## TLDR

Problem this solves:

- Claude Code's classifier sends `/v1/messages` with `stop_sequences` to non-Claude targets (e.g. Fireworks GLM)
- Fireworks rejects `stop_sequences` outright (HTTP 400), since its OpenAI-compatible API only accepts `stop`
- `thinking: {type: "disabled"}` not mapped to `reasoning_effort: "none"`, so the model still burns budget reasoning

How it solves it:

- Adapter now translates `stop_sequences` -> `stop` for all non-Anthropic-native targets (mirrors how `thinking` is already handled)
- `thinking: {type: "disabled"}` now maps to `reasoning_effort: "none"` instead of `None`
- Guarded the `reasoning_auto_summary` wrapping so a disabled-thinking `"none"` stays a plain string instead of becoming `{"effort": "none", "summary": "detailed"}` (there's no reasoning trace to summarize when thinking is disabled, and non-Claude providers expect a plain string)

## Relevant issues

- Adapter's translatable-param list omitted `stop_sequences`, so it fell through to verbatim copy-through instead of translation
- `translate_anthropic_thinking_to_reasoning_effort` returned `None` for the `"disabled"` case instead of `"none"`
- Making `"disabled"` truthy surfaced a latent second issue: it now reaches the `reasoning_auto_summary` wrapping logic, which needed an explicit guard

## Linear ticket

Resolves LIT-4798

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy against a local stub standing in for Fireworks (no Fireworks credentials in this environment; stub enforces the same strict "extra field" rejection Fireworks applies).

**Before fix** (commit `78348fd1c7`):

```
$ curl .../v1/messages -d '{"model":"glm-classifier","max_tokens":100,"messages":[...],"stop_sequences":["</block>"]}'
{"error":{"message":"litellm.BadRequestError: Fireworks_aiException - {\"error\":{\"message\":\"Extra inputs are not permitted: stop_sequences=['</block>']\" ...}}"}}
HTTP_STATUS:400

$ curl .../v1/messages -d '{"model":"glm-classifier","max_tokens":100,"messages":[...],"thinking":{"type":"disabled"}}'
{"content":[{"type":"text","text":"stop=None reasoning_effort=None"}]}
HTTP_STATUS:200
```

**After fix** (commit `adeb46b157`, stop_sequences + disabled-thinking core fix):

```
$ curl .../v1/messages -d '{"model":"glm-classifier","max_tokens":100,"messages":[...],"stop_sequences":["</block>"]}'
{"content":[{"type":"text","text":"stop=['</block>'] reasoning_effort=None"}]}
HTTP_STATUS:200

$ curl .../v1/messages -d '{"model":"glm-classifier","max_tokens":100,"messages":[...],"thinking":{"type":"disabled"}}'
{"content":[{"type":"text","text":"stop=None reasoning_effort='none'"}]}
HTTP_STATUS:200
```

**Follow-up fix** (commit `a6ce7b10f9`, mutation-tested unit repro/verify since it's an interaction with a global opt-in flag rather than a Fireworks-specific wire issue):

```python
# reasoning_auto_summary=True, thinking={"type": "disabled"}
# before: {"effort": "none", "summary": "detailed"}   <- would be rejected as reasoning_effort by non-Claude providers
# after:  "none"
```

## Type

🐛 Bug Fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the experimental Anthropic→OpenAI adapter and covered by new unit tests; behavior change is intentional for non-Claude routing with no auth or data-path impact.
> 
> **Overview**
> Fixes Anthropic `/v1/messages` pass-through when the upstream target is OpenAI-compatible (e.g. Fireworks) instead of native Claude.
> 
> **Stop sequences:** `stop_sequences` is now a translatable param and is mapped to OpenAI `stop` during `translate_anthropic_to_openai`, so providers that reject unknown `stop_sequences` no longer get a verbatim copy-through. Empty lists are ignored.
> 
> **Disabled thinking:** `thinking: {type: "disabled"}` now becomes `reasoning_effort: "none"` for non-Claude models (previously dropped as `None`), so reasoning can actually be turned off.
> 
> **Reasoning summary wrapping:** Duplicated summary/auto-summary logic is centralized in `_apply_reasoning_summary_wrapping`. When thinking is disabled, `"none"` stays a **plain string** even if `reasoning_auto_summary` is on—avoiding `{"effort": "none", "summary": "detailed"}` that non-Claude backends reject.
> 
> Unit tests cover stop translation, disabled thinking, and the auto-summary interaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d478b9955e2fcd0baaf7e40eb6f5b35e805a918c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->