### PR TITLE
feat(ui): deep-link virtual key detail view via ?key= query param

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/api-keys/detailNavigation.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/api-keys/detailNavigation.test.ts
@@ -1,0 +1,53 @@
+/* @vitest-environment jsdom */
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useKeyDetailRouting } from "./detailNavigation";
+
+vi.mock("next/navigation", () => ({ useSearchParams: () => new URLSearchParams(window.location.search) }));
+
+describe("useKeyDetailRouting", () => {
+  beforeEach(() => {
+    window.history.pushState(null, "", "/api-keys/");
+  });
+
+  it("openKey sets ?key= via history.pushState (no full navigation)", () => {
+    const spy = vi.spyOn(window.history, "pushState");
+    const { result } = renderHook(() => useKeyDetailRouting());
+    act(() => result.current.openKey("88a145505dd6"));
+    expect(spy).toHaveBeenCalledWith(null, "", expect.stringContaining("key=88a145505dd6"));
+    spy.mockRestore();
+  });
+
+  it("openKey preserves unrelated query params like the legacy ?page=", () => {
+    window.history.pushState(null, "", "/?page=api-keys");
+    const spy = vi.spyOn(window.history, "pushState");
+    const { result } = renderHook(() => useKeyDetailRouting());
+    act(() => result.current.openKey("88a145505dd6"));
+    const url = spy.mock.calls.at(-1)?.[2] as string;
+    expect(url).toContain("page=api-keys");
+    expect(url).toContain("key=88a145505dd6");
+    spy.mockRestore();
+  });
+
+  it("close removes only the key param", () => {
+    window.history.pushState(null, "", "/?page=api-keys&key=88a145505dd6");
+    const spy = vi.spyOn(window.history, "pushState");
+    const { result } = renderHook(() => useKeyDetailRouting());
+    act(() => result.current.close());
+    const url = spy.mock.calls.at(-1)?.[2] as string;
+    expect(url).toContain("page=api-keys");
+    expect(url).not.toContain("key=");
+    spy.mockRestore();
+  });
+
+  it("exposes keyId from ?key=", () => {
+    window.history.pushState(null, "", "/api-keys/?key=88a145505dd6");
+    const { result } = renderHook(() => useKeyDetailRouting());
+    expect(result.current.keyId).toBe("88a145505dd6");
+  });
+
+  it("keyId is null when no key param is present", () => {
+    const { result } = renderHook(() => useKeyDetailRouting());
+    expect(result.current.keyId).toBeNull();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/api-keys/detailNavigation.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/api-keys/detailNavigation.ts
@@ -1,0 +1,32 @@
+import { useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+import { navigateWithParams } from "../navigateWithParams";
+
+export interface KeyDetailRouting {
+  keyId: string | null;
+  openKey: (id: string) => void;
+  close: () => void;
+}
+
+export function useKeyDetailRouting(): KeyDetailRouting {
+  const searchParams = useSearchParams();
+
+  const openKey = useCallback((id: string) => {
+    navigateWithParams((params) => {
+      params.set("key", id);
+    });
+  }, []);
+
+  const close = useCallback(() => {
+    navigateWithParams((params) => {
+      params.delete("key");
+    });
+  }, []);
+
+  return {
+    keyId: searchParams?.get("key") ?? null,
+    openKey,
+    close,
+  };
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeyInfo.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeyInfo.ts
@@ -1,0 +1,25 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import { KeyResponse } from "@/components/key_team_helpers/key_list";
+import { keyInfoV1Call } from "@/components/networking";
+
+import { keyKeys } from "./useKeys";
+
+export function useKeyInfo(keyId: string | null, options?: { enabled?: boolean }): UseQueryResult<KeyResponse> {
+  const { accessToken } = useAuthorized();
+
+  return useQuery<KeyResponse>({
+    queryKey: [...keyKeys.detail(keyId ?? ""), accessToken],
+    queryFn: async () => {
+      if (!accessToken || !keyId) throw new Error("Missing access token or key id");
+      const keyData = await keyInfoV1Call(accessToken, keyId);
+      return {
+        ...keyData["info"],
+        token: keyId,
+        api_key: keyId,
+      };
+    },
+    enabled: Boolean(accessToken && keyId) && (options?.enabled ?? true),
+  });
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/detailNavigation.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/detailNavigation.ts
@@ -1,20 +1,14 @@
 import { useSearchParams } from "next/navigation";
 import { useCallback } from "react";
 
+import { navigateWithParams } from "../navigateWithParams";
+
 export interface ModelDetailRouting {
   modelId: string | null;
   teamId: string | null;
   openModel: (id: string) => void;
   openTeam: (id: string) => void;
   close: () => void;
-}
-
-function navigateWithParams(mutate: (params: URLSearchParams) => void): void {
-  const params = new URLSearchParams(window.location.search);
-  mutate(params);
-  const qs = params.toString();
-  const url = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
-  window.history.pushState(null, "", url);
 }
 
 export function useModelDetailRouting(): ModelDetailRouting {

--- a/ui/litellm-dashboard/src/app/(dashboard)/navigateWithParams.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/navigateWithParams.ts
@@ -1,0 +1,7 @@
+export function navigateWithParams(mutate: (params: URLSearchParams) => void): void {
+  const params = new URLSearchParams(window.location.search);
+  mutate(params);
+  const qs = params.toString();
+  const url = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
+  window.history.pushState(null, "", url);
+}

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -4,8 +4,11 @@ import { vi, it, expect, beforeEach, describe, MockedFunction } from "vitest";
 import { renderWithProviders } from "../../../tests/test-utils";
 import { VirtualKeysTable } from "./VirtualKeysTable";
 import { KeyResponse, Team } from "../key_team_helpers/key_list";
+import { useKeyInfo } from "@/app/(dashboard)/hooks/keys/useKeyInfo";
 import { KeysResponse, useKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
 import useTeams from "@/app/(dashboard)/hooks/useTeams";
+
+vi.mock("next/navigation", () => ({ useSearchParams: () => new URLSearchParams(window.location.search) }));
 
 // Resolve debounced values synchronously so an applied filter lands in the useKeys query within the test tick.
 vi.mock("@tanstack/react-pacer/debouncer", async () => {
@@ -41,6 +44,10 @@ vi.mock("@/app/(dashboard)/hooks/teams/useTeams", () => ({
 vi.mock("@/app/(dashboard)/hooks/keys/useKeys", () => ({
   useKeys: vi.fn(),
   keyKeys: { lists: () => ["keys", "list"] },
+}));
+
+vi.mock("@/app/(dashboard)/hooks/keys/useKeyInfo", () => ({
+  useKeyInfo: vi.fn(),
 }));
 
 vi.mock("@/app/(dashboard)/hooks/useTeams", () => ({
@@ -139,6 +146,10 @@ const mockTeam: Team = {
 
 const mockUseKeys = useKeys as MockedFunction<typeof useKeys>;
 const mockUseTeams = useTeams as MockedFunction<typeof useTeams>;
+const mockUseKeyInfo = useKeyInfo as MockedFunction<typeof useKeyInfo>;
+
+const keyInfoResult = (data: KeyResponse | undefined, isError = false) =>
+  ({ data, isError }) as ReturnType<typeof useKeyInfo>;
 
 const keysResult = (keys: KeyResponse[], data: Partial<KeysResponse> = {}, extra: Record<string, unknown> = {}) =>
   ({
@@ -161,7 +172,10 @@ const openFilters = () => fireEvent.click(screen.getByRole("button", { name: "Fi
 beforeEach(() => {
   vi.clearAllMocks();
 
+  window.history.pushState(null, "", "/");
+
   mockUseKeys.mockReturnValue(keysResult([mockKey]));
+  mockUseKeyInfo.mockReturnValue(keyInfoResult(undefined));
 
   mockUseTeams.mockReturnValue({
     teams: [mockTeam],
@@ -344,22 +358,67 @@ it("sorts by spend ascending when 'Spend ascending' is chosen from the Spend / B
   });
 });
 
-it("should open KeyInfoView when clicking the key cell", async () => {
+it("clicking the key cell deep-links via ?key=", async () => {
   renderWithProviders(<VirtualKeysTable />);
 
   await waitFor(() => {
     expect(screen.getByText("Test Key Alias")).toBeInTheDocument();
   });
 
-  expect(screen.getByTestId("pagination-range")).toBeInTheDocument();
-
   fireEvent.click(screen.getByText("Test Key Alias"));
+
+  expect(window.location.search).toContain(`key=${encodeURIComponent(mockKey.token)}`);
+});
+
+it("renders KeyInfoView when the URL has ?key= for a key on the current page, without refetching it", async () => {
+  window.history.pushState(null, "", `/?key=${encodeURIComponent(mockKey.token)}`);
+
+  renderWithProviders(<VirtualKeysTable />);
 
   await waitFor(() => {
     expect(screen.getByText("Back to Keys")).toBeInTheDocument();
   });
-
   expect(screen.queryByTestId("pagination-range")).not.toBeInTheDocument();
+  expect(mockUseKeyInfo).toHaveBeenLastCalledWith(mockKey.token, { enabled: false });
+
+  fireEvent.click(screen.getByText("Back to Keys"));
+
+  expect(window.location.search).not.toContain("key=");
+});
+
+it("fetches the key by id when the URL has ?key= for a key not in the loaded page", async () => {
+  window.history.pushState(null, "", "/?key=other-key-hash");
+  mockUseKeyInfo.mockReturnValue(
+    keyInfoResult({ ...mockKey, token: "other-key-hash", key_alias: "Fetched Key Alias" }),
+  );
+
+  renderWithProviders(<VirtualKeysTable />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Back to Keys")).toBeInTheDocument();
+  });
+  expect(mockUseKeyInfo).toHaveBeenLastCalledWith("other-key-hash", { enabled: true });
+  expect(screen.getAllByText("Fetched Key Alias").length).toBeGreaterThan(0);
+});
+
+it("shows a loading state while a deep-linked key is being fetched", () => {
+  window.history.pushState(null, "", "/?key=other-key-hash");
+
+  renderWithProviders(<VirtualKeysTable />);
+
+  expect(screen.getByText("Loading key...")).toBeInTheDocument();
+  expect(screen.queryByTestId("pagination-range")).not.toBeInTheDocument();
+});
+
+it("shows 'Key not found' when the deep-linked key fails to load", async () => {
+  window.history.pushState(null, "", "/?key=missing-key-hash");
+  mockUseKeyInfo.mockReturnValue(keyInfoResult(undefined, true));
+
+  renderWithProviders(<VirtualKeysTable />);
+
+  await waitFor(() => {
+    expect(screen.getByText("Key not found")).toBeInTheDocument();
+  });
 });
 
 it("should display 'Default Proxy Admin' for user_id when value is 'default_user_id'", async () => {

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -66,7 +66,7 @@ vi.mock("@/app/(dashboard)/hooks/organizations/useOrganizations", () => ({
 }));
 
 const mockKey: KeyResponse = {
-  token: "sk-1234567890abcdef",
+  token: "88a145505dd6e87e2ea166fcef1e4b53948dbdb32af6431dfd05ec06b571ee52",
   token_id: "key-1",
   key_name: "test-key",
   key_alias: "Test Key Alias",
@@ -115,7 +115,7 @@ const mockKey: KeyResponse = {
   end_user_rpm_limit: 10,
   end_user_max_budget: 10,
   last_refreshed_at: Date.now(),
-  api_key: "sk-1234567890abcdef",
+  api_key: "88a145505dd6e87e2ea166fcef1e4b53948dbdb32af6431dfd05ec06b571ee52",
   user_role: "user",
   rpm_limit_per_model: {},
   tpm_limit_per_model: {},

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useKeyDetailRouting } from "@/app/(dashboard)/api-keys/detailNavigation";
+import { useKeyInfo } from "@/app/(dashboard)/hooks/keys/useKeyInfo";
 import { useKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
 import { useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 import { useAllTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
@@ -18,7 +20,7 @@ import { ColumnFiltersState, OnChangeFn, PaginationState, SortingState } from "@
 import { KeyRound } from "lucide-react";
 import React, { useCallback, useMemo, useState } from "react";
 
-import { KeyResponse, Team } from "../key_team_helpers/key_list";
+import { Team } from "../key_team_helpers/key_list";
 import KeyInfoView from "../templates/key_info_view";
 import { getKeyTableColumns, KEY_TABLE_HIDDEN_COLUMNS } from "./keyTableColumns";
 
@@ -47,7 +49,7 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
   const { data: fetchedTeams } = useAllTeams();
   const allTeams = useMemo<Team[]>(() => fetchedTeams ?? [], [fetchedTeams]);
 
-  const [selectedKey, setSelectedKey] = useState<KeyResponse | null>(null);
+  const { keyId: selectedKeyId, openKey, close: closeKeyDetail } = useKeyDetailRouting();
   const [sorting, setSorting] = useState<SortingState>(DEFAULT_SORTING);
   const [tablePagination, setTablePagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 50 });
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -103,9 +105,18 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
   }, []);
 
   const columns = useMemo(
-    () => getKeyTableColumns({ allTeams, organizations, onSelectKey: setSelectedKey }),
-    [allTeams, organizations],
+    () => getKeyTableColumns({ allTeams, organizations, onSelectKey: (key) => openKey(key.token) }),
+    [allTeams, organizations, openKey],
   );
+
+  const selectedKeyFromList = useMemo(
+    () => keyList.find((key) => key.token === selectedKeyId),
+    [keyList, selectedKeyId],
+  );
+  const { data: fetchedSelectedKey, isError: selectedKeyLoadFailed } = useKeyInfo(selectedKeyId, {
+    enabled: !selectedKeyFromList,
+  });
+  const selectedKey = selectedKeyFromList ?? fetchedSelectedKey;
 
   const teamOptions = useMemo(
     () =>
@@ -142,12 +153,15 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
     [allTeams, organizations],
   );
 
-  if (selectedKey) {
+  if (selectedKeyId) {
+    if (!selectedKey && !selectedKeyLoadFailed) {
+      return <div className="p-4 text-sm text-muted-foreground">Loading key...</div>;
+    }
     return (
       <div className="w-full h-full overflow-hidden">
         <KeyInfoView
-          keyId={selectedKey.token}
-          onClose={() => setSelectedKey(null)}
+          keyId={selectedKeyId}
+          onClose={closeKeyDetail}
           keyData={selectedKey}
           teams={allTeams}
           onDelete={refetch}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Virtual key detail view lives only in component state
- Reloading or sharing a URL loses the opened key
- Models page already deep-links via ?model=, keys page does not

How it solves it:

- Clicking a key now sets ?key=<token> via history.pushState
- On load, ?key= restores the detail view, fetching /key/info if needed
- Extracts the models page pushState helper for reuse

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Screenshots to follow. To reproduce: start the proxy and the dashboard dev server, open http://localhost:3000/?page=api-keys, click any key row and confirm the URL gains key=<hash> while the detail view opens, reload the page and confirm the same key's detail view comes back (including for a key beyond the first table page, which is fetched from /key/info), then click "Back to Keys" and confirm the param clears and the table returns. Browser back/forward also toggles between table and detail

## Type

🆕 New Feature

## Changes

The Virtual Keys table previously kept the selected key in useState, so the detail view vanished on reload and could not be linked. This wires it to the URL the same way the models page wires ?model=

New useKeyDetailRouting hook (src/app/(dashboard)/api-keys/detailNavigation.ts) exposes keyId, openKey, and close on top of a navigateWithParams helper extracted from the models page's detailNavigation.ts into src/app/(dashboard)/navigateWithParams.ts. It uses history.pushState because a router.push with a query-only change is a no-op under the /ui static mount, matching the existing models implementation

VirtualKeysTable resolves the selected key from the currently loaded table page when possible; otherwise a new useKeyInfo hook (src/app/(dashboard)/hooks/keys/useKeyInfo.ts) hydrates it from /key/info, the same pattern the request logs panel already uses. A failed lookup falls through to KeyInfoView's existing "Key not found" state. TeamVirtualKeysTable keeps its local-state selection on purpose so team drawers do not touch the URL

Tests cover the hook (sets ?key=, preserves unrelated params like the legacy ?page=, clears only its own param) and the table (click writes the param, deep link renders the detail view without refetching when the key is on the loaded page, fetches by id when it is not, loading and not-found states)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
