### PR TITLE
fix(vector-stores): paginate managed resource list by unified_resource_id cursor

### DIFF
--- a/litellm/llms/base_llm/managed_resources/base_managed_resource.py
+++ b/litellm/llms/base_llm/managed_resources/base_managed_resource.py
@@ -542,35 +542,39 @@ class BaseManagedResource(ABC, Generic[ResourceObjectType]):
         Returns:
             Dictionary with list of resources and pagination info
         """
+        from fastapi import HTTPException
+
         owner_filter = build_owner_filter(user_api_key_dict)
         if owner_filter is None:
             return build_list_page([])
 
-        where_clause: Dict[str, Any] = {**owner_filter}
+        where_clause: Dict[str, Any] = {**owner_filter, **(additional_filters or {})}
+
+        table = getattr(self.prisma_client.db, self.table_name)
 
         if after:
-            where_clause["id"] = {"gt": after}
+            cursor_row = await table.find_first(where={**where_clause, "unified_resource_id": after})
+            if cursor_row is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid 'after' cursor: no {self.resource_type} found with id '{after}'.",
+                )
 
-        # Add additional filters
-        if additional_filters:
-            where_clause.update(additional_filters)
+        page_size = limit or 20
+        cursor_args: Dict[str, Any] = {"cursor": {"unified_resource_id": after}, "skip": 1} if after else {}
 
-        # Fetch resources
-        fetch_limit = limit or 20
-        table = getattr(self.prisma_client.db, self.table_name)
         resources = await table.find_many(
             where=where_clause,
-            take=fetch_limit,
-            order={"created_at": "desc"},
+            take=page_size + 1,
+            order=[{"created_at": "desc"}, {"unified_resource_id": "desc"}],
+            **cursor_args,
         )
 
-        resource_objects: List[Any] = []
-        for resource in resources:
-            try:
-                # Stop once we have enough
-                if len(resource_objects) >= (limit or 20):
-                    break
+        has_more = len(resources) > page_size
 
+        resource_objects: List[Any] = []
+        for resource in resources[:page_size]:
+            try:
                 # Parse resource object
                 resource_data = resource.resource_object
                 if isinstance(resource_data, str):
@@ -590,4 +594,4 @@ class BaseManagedResource(ABC, Generic[ResourceObjectType]):
                 )
                 continue
 
-        return build_list_page(resource_objects, has_more=len(resource_objects) == (limit or 20))
+        return build_list_page(resource_objects, has_more=has_more)

--- a/litellm/llms/base_llm/managed_resources/isolation.py
+++ b/litellm/llms/base_llm/managed_resources/isolation.py
@@ -9,6 +9,7 @@ identifying ids are denied so an empty user_id can never select an
 unscoped query.
 """
 
+from collections.abc import Mapping
 from typing import Any, Dict, List, Optional
 
 from litellm.proxy._types import (
@@ -17,15 +18,23 @@ from litellm.proxy._types import (
 )
 
 
+def _item_id(item: Any) -> str | None:
+    if isinstance(item, Mapping):
+        return item.get("id")
+    return getattr(item, "id", None)
+
+
 def build_list_page(items: List[Any], has_more: bool = False) -> Dict[str, Any]:
     """Build the OpenAI-style paginated list response shape used by managed
-    file/batch/vector-store listings. ``first_id`` and ``last_id`` are
-    sourced from each item's ``.id`` attribute."""
+    file/batch/vector-store listings. ``first_id`` and ``last_id`` are sourced
+    from each item's ``id``, which is an attribute on the pydantic objects the
+    file and batch listings build and a key on the plain dicts the vector-store
+    listing builds."""
     return {
         "object": "list",
         "data": items,
-        "first_id": items[0].id if items else None,
-        "last_id": items[-1].id if items else None,
+        "first_id": _item_id(items[0]) if items else None,
+        "last_id": _item_id(items[-1]) if items else None,
         "has_more": has_more,
     }
 

--- a/tests/test_litellm/llms/base_llm/test_base_managed_resource.py
+++ b/tests/test_litellm/llms/base_llm/test_base_managed_resource.py
@@ -108,6 +108,184 @@ async def test_list_identity_less_caller_returns_empty_without_query():
     resource.prisma_client.db.litellm_test_resource_table.find_many.assert_not_awaited()
 
 
+def _make_row(index: int, created_by: str = "alice"):
+    row = MagicMock()
+    row.id = f"pk-{index:03d}"
+    row.unified_resource_id = f"unified-resource-{index:03d}"
+    row.created_at = 1_000_000 + index
+    row.created_by = created_by
+    row.resource_object = {
+        "id": f"provider-vector-store-{index:03d}",
+        "object": "vector_store",
+        "name": f"store-{index:03d}",
+    }
+    return row
+
+
+def _row_matches(row, where) -> bool:
+    return all(
+        isinstance(value, dict) or getattr(row, field, None) == value
+        for field, value in where.items()
+    )
+
+
+def _make_paginating_resource(rows: List) -> _StubResource:
+    async def find_many(where, take, order, cursor=None, skip=0):
+        result = sorted(
+            rows, key=lambda r: (r.created_at, r.unified_resource_id), reverse=True
+        )
+        id_filter = where.get("id")
+        if isinstance(id_filter, dict) and "gt" in id_filter:
+            result = [r for r in result if r.id > id_filter["gt"]]
+        if cursor is not None:
+            (cur_field, cur_val), = cursor.items()
+            idx = next(
+                (i for i, r in enumerate(result) if getattr(r, cur_field) == cur_val),
+                None,
+            )
+            if idx is None:
+                return []
+            result = result[idx + skip:]
+        return result[:take]
+
+    async def find_first(where):
+        return next((r for r in rows if _row_matches(r, where)), None)
+
+    cache = MagicMock()
+    cache.async_get_cache = AsyncMock(return_value=None)
+
+    prisma = MagicMock()
+    table = MagicMock()
+    table.find_many = AsyncMock(side_effect=find_many)
+    table.find_first = AsyncMock(side_effect=find_first)
+    prisma.db = MagicMock()
+    setattr(prisma.db, "litellm_test_resource_table", table)
+
+    return _StubResource(internal_usage_cache=cache, prisma_client=prisma)
+
+
+@pytest.mark.asyncio
+async def test_list_resources_pagination_uses_unified_resource_id_cursor():
+    """The ``after`` cursor a client sends back is a resource's
+    ``unified_resource_id`` -- that is what the listing returns as each item's
+    ``id`` and as ``last_id``. Paginating must use a Prisma cursor on that
+    unique column, not a ``where id > after`` filter against the random-uuid
+    primary key, which compares the cursor to unrelated values and so loops or
+    silently drops resources.
+    """
+    rows = [_make_row(i) for i in range(3)]
+    resource = _make_paginating_resource(rows)
+
+    await resource.list_user_resources(
+        user_api_key_dict=UserAPIKeyAuth(user_id="alice"),
+        limit=2,
+        after=rows[2].unified_resource_id,
+    )
+
+    table = resource.prisma_client.db.litellm_test_resource_table
+    kwargs = table.find_many.await_args.kwargs
+    assert kwargs["cursor"] == {"unified_resource_id": rows[2].unified_resource_id}
+    assert kwargs["skip"] == 1
+    assert kwargs["order"] == [
+        {"created_at": "desc"},
+        {"unified_resource_id": "desc"},
+    ]
+    assert "id" not in kwargs["where"]
+
+
+@pytest.mark.asyncio
+async def test_list_resources_pagination_walks_all_pages_without_loops_or_gaps():
+    """Walking pages the way a client does -- feeding ``last_id`` back as
+    ``after`` -- must return every resource exactly once, newest first."""
+    rows = [_make_row(i) for i in range(5)]
+    resource = _make_paginating_resource(rows)
+    user = UserAPIKeyAuth(user_id="alice")
+
+    seen = []
+    after = None
+    for _ in range(len(rows) + 5):
+        page = await resource.list_user_resources(
+            user_api_key_dict=user, limit=2, after=after
+        )
+        seen.extend(item["id"] for item in page["data"])
+        if not page["has_more"]:
+            break
+        assert page["last_id"] is not None, "has_more was true but there is no cursor"
+        assert page["last_id"] != after, "cursor did not advance (pagination loop)"
+        after = page["last_id"]
+
+    assert seen == [r.unified_resource_id for r in reversed(rows)]
+    assert len(seen) == len(set(seen))
+
+
+@pytest.mark.asyncio
+async def test_list_resources_has_more_false_on_exactly_full_final_page():
+    """``has_more`` must mean "another row exists", not "this page is full",
+    so a resource count that is an exact multiple of ``limit`` does not cost
+    every client an extra empty request."""
+    rows = [_make_row(i) for i in range(4)]
+    resource = _make_paginating_resource(rows)
+    user = UserAPIKeyAuth(user_id="alice")
+
+    first = await resource.list_user_resources(user_api_key_dict=user, limit=2)
+    second = await resource.list_user_resources(
+        user_api_key_dict=user, limit=2, after=first["last_id"]
+    )
+
+    assert first["has_more"] is True
+    assert second["has_more"] is False
+    assert [item["id"] for item in second["data"]] == [
+        rows[1].unified_resource_id,
+        rows[0].unified_resource_id,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_resources_rejects_unknown_after_cursor():
+    """An ``after`` that does not resolve to a resource the caller can see is
+    a client error. Returning an empty page instead is indistinguishable from
+    the end of the list, so a stale cursor silently truncates the listing."""
+    from fastapi import HTTPException
+
+    resource = _make_paginating_resource([_make_row(0)])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await resource.list_user_resources(
+            user_api_key_dict=UserAPIKeyAuth(user_id="alice"),
+            limit=2,
+            after="does-not-exist-xyz",
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "does-not-exist-xyz" in str(exc_info.value.detail)
+    resource.prisma_client.db.litellm_test_resource_table.find_many.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_list_resources_cursor_lookup_is_scoped_to_the_caller():
+    """The cursor lookup must run against the rows the caller can list. A
+    Prisma cursor resolves by unique column regardless of the ``where``
+    filter, so an unscoped lookup would let one user anchor their page window
+    to another user's resource."""
+    from fastapi import HTTPException
+
+    resource = _make_paginating_resource([_make_row(0)])
+
+    with pytest.raises(HTTPException):
+        await resource.list_user_resources(
+            user_api_key_dict=UserAPIKeyAuth(user_id="alice"),
+            limit=2,
+            after="unified-resource-000",
+            additional_filters={"created_by": "bob"},
+        )
+
+    where = resource.prisma_client.db.litellm_test_resource_table.find_first.await_args.kwargs[
+        "where"
+    ]
+    assert where["created_by"] == "bob"
+    assert where["unified_resource_id"] == "unified-resource-000"
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "caller_team_id,expected",

--- a/tests/test_litellm/llms/base_llm/test_managed_resource_isolation.py
+++ b/tests/test_litellm/llms/base_llm/test_managed_resource_isolation.py
@@ -5,10 +5,51 @@ Tests for managed-resource tenant isolation helpers.
 import pytest
 
 from litellm.llms.base_llm.managed_resources.isolation import (
+    build_list_page,
     build_owner_filter,
     can_access_resource,
 )
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+
+
+# ---------------------------------------------------------------------------
+# build_list_page
+# ---------------------------------------------------------------------------
+
+
+def test_list_page_reads_ids_from_dict_items():
+    """The vector-store listing builds plain dicts, so sourcing the cursor ids
+    through attribute access alone raised AttributeError on every non-empty
+    page."""
+    page = build_list_page(
+        [{"id": "resource-a"}, {"id": "resource-b"}], has_more=True
+    )
+
+    assert page["first_id"] == "resource-a"
+    assert page["last_id"] == "resource-b"
+    assert page["has_more"] is True
+
+
+def test_list_page_reads_ids_from_object_items():
+    class _Item:
+        def __init__(self, id: str):
+            self.id = id
+
+    page = build_list_page([_Item("batch-a"), _Item("batch-b")])
+
+    assert page["first_id"] == "batch-a"
+    assert page["last_id"] == "batch-b"
+    assert page["has_more"] is False
+
+
+def test_list_page_empty():
+    assert build_list_page([]) == {
+        "object": "list",
+        "data": [],
+        "first_id": None,
+        "last_id": None,
+        "has_more": False,
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## TLDR

Problem this solves:

- Managed resource listing paginated on the wrong column
- `after` compared a base64 id against uuid primary keys
- Pages looped and dropped resources
- `build_list_page` raised AttributeError on dict items

How it solves it:

- Cursor on `unified_resource_id`, the id clients hold
- `unified_resource_id` added as a total-order tie-breaker
- Unresolvable `after` returns 400, not an empty page
- List page ids read from dicts and objects alike

## Relevant issues

Same bug class as #34192, in the sibling paginator

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

A note on how this is proven: `list_user_resources` has no HTTP surface today. `GET /v1/vector_stores` routes through `ProxyBaseLLMRequestProcessing` to `avector_store_list` on the router, so it never consults the managed vector store hook the way `GET /v1/batches` consults the managed files hook. There is therefore no curl that reaches this code. The runs below drive `alist_vector_stores`, the exact method that endpoint would call once it is wired up, against the real local Postgres through Prisma, with four managed vector stores seeded into `LiteLLM_ManagedVectorStoreTable` (`vs_000` oldest -> `vs_003` newest, random uuid primary keys as `@default(uuid())` produces) and a caller scoped to `user_id=lit-vs-proof-user`. A client walks with `limit=2`, feeding each response's `last_id` back as `after`. Labels are decoded from the base64 `unified_resource_id` returned as each item's `id`.

Before, at `7b019cf152` (the base commit):

```
page 1: after=none -> raised AttributeError detail='dict' object has no attribute 'id'
RESULT: 0/4 unique vector stores in 0 call(s)
```

Every non-empty page raised, because this listing builds plain dicts and `build_list_page` sourced `first_id` / `last_id` through attribute access.

Before, at `7b019cf152` with only the `build_list_page` part of this PR applied, so the cursor behaviour is observable:

```
page 1: after=none    -> ['vs_003', 'vs_002']  last_id=vs_002  has_more=True
page 2: after=vs_002  -> ['vs_002']            last_id=vs_002  has_more=False
RESULT: 2/4 unique vector stores in 2 call(s), duplicates=1
  -> last_id did not advance, vs_002 came back twice, vs_001 and vs_000 were never returned

unresolvable cursor:
  returned {"object": "list", "data": [], "first_id": null, "last_id": null, "has_more": false}
```

After, at `f913d42abb`:

```
page 1: after=none    -> ['vs_003', 'vs_002']  last_id=vs_002  has_more=True
page 2: after=vs_002  -> ['vs_001', 'vs_000']  last_id=vs_000  has_more=False
RESULT: 4/4 unique vector stores in 2 call(s), duplicates=0

unresolvable cursor:
  raised HTTPException status=400 detail=Invalid 'after' cursor: no vector_store found with id 'does-not-exist-xyz'.
```

The second page is also proof that Postgres accepts the new query shape: Prisma really does take a `cursor` on `unified_resource_id` together with `skip=1` and a two-key `order`, and returns the four rows in reverse-chronological order across exactly two round trips.

## Type

🐛 Bug Fix

## Changes

`list_user_resources` on `BaseManagedResource` backs the managed vector store listing (`alist_vector_stores`). It carried the same broken cursor that #34192 fixes for managed batches:

```python
if after:
    where_clause["id"] = {"gt": after}          # id is a random uuid() PK
...
order={"created_at": "desc"}                     # desc order, but gt cursor
```

The `after` value a client sends back is a resource's `unified_resource_id`, because that is what the listing returns as each item's `id` and as `last_id`. Comparing that base64 string against unrelated random uuids either re-selects the rows the previous page returned or excludes rows that should have come next, and ordering by `created_at desc` while filtering with `gt` points the two in opposite directions. The live run above shows both symptoms at once: a `last_id` that never advances and two of four resources that are never returned.

The fix is the same as #34192: a Prisma cursor on the unique `unified_resource_id` with `skip=1`, plus `unified_resource_id` as a secondary sort key so the ordering is total. A cursor is only well-defined when the ordering fully determines row order; `created_at` alone is not unique, so rows sharing a timestamp can come back in an order that shifts between requests and slip through the seam between pages.

Two related truncations are fixed with it. An `after` that does not resolve to a resource the caller can list returned an empty page, which a client cannot distinguish from the end of the list; it now returns 400 naming the cursor. The lookup runs against the caller's own rows, so the cursor cannot be anchored to a resource the caller cannot see: a Prisma cursor resolves by unique column regardless of the `where` filter. And `has_more` came from whether the page was full rather than whether another row exists, so an exact multiple of `limit` cost an extra empty request and a page shortened by an unparseable row looked like the end of the list. The listing now fetches `limit + 1` rows and reports `has_more` from the extra row.

Separately, `build_list_page` read `first_id` and `last_id` through attribute access only. The file and batch listings pass pydantic objects so they were fine, but this listing passes plain dicts, so every non-empty page raised AttributeError. It now reads the id from either shape.

Tests, all of which fail on the base commit and pass here: `test_list_resources_pagination_uses_unified_resource_id_cursor` pins the cursor, the `skip`, and the two-key order, and asserts no `id` filter leaks into the where clause; `test_list_resources_pagination_walks_all_pages_without_loops_or_gaps` walks every page the way a client does and asserts each resource comes back exactly once, newest first; `test_list_resources_has_more_false_on_exactly_full_final_page` covers the extra empty request; `test_list_resources_rejects_unknown_after_cursor` and `test_list_resources_cursor_lookup_is_scoped_to_the_caller` cover the 400 and the owner-scoped lookup; `test_list_page_reads_ids_from_dict_items` covers the AttributeError, alongside object-item and empty-page cases.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
