### PR TITLE
build: authorize pydantic-settings in the license check

### DIFF
--- a/tests/code_coverage_tests/liccheck.ini
+++ b/tests/code_coverage_tests/liccheck.ini
@@ -175,3 +175,4 @@ langgraph-prebuilt: >=1.0.8 # MIT License - https://github.com/langchain-ai/lang
 pytest-rerunfailures: >=15.1 # MPL 2.0 license
 pytest-recording: >=0.13.4 # MIT license
 expression: >=5.6.0 # MIT License - https://github.com/cognitedata/Expression/blob/main/LICENSE
+pydantic-settings: >=2.14.1 # MIT License - https://github.com/pydantic/pydantic-settings/blob/main/LICENSE


### PR DESCRIPTION
## TLDR

The license job fails with `pydantic-settings (2.14.1) - Unknown license`. This authorizes it with a verified license.

## Why it is unknown

`pydantic-settings` is a **direct** dependency (`pyproject.toml` constrains `>=2.14.1,<3.0`, added 2026-07-16 in #33222), and it is genuinely MIT. PyPI reports both a PEP 639 `license_expression: "MIT"` and the classifier `License :: OSI Approved :: MIT License`:

```
$ curl -s https://pypi.org/pypi/pydantic-settings/2.14.1/json | jq '.info | {license, license_expression, cls: [.classifiers[] | select(contains("License"))]}'
{
  "license": null,
  "license_expression": "MIT",
  "cls": ["License :: OSI Approved :: MIT License"]
}
```

The legacy `license` field is empty, and that is the field liccheck reads, so the package lands in the unknown bucket despite declaring MIT two other ways. Packages that publish their license only via PEP 639 will keep hitting this.

## Changes

One entry in `[Authorized Packages]` following the convention the rest of the file uses (pin, license, link):

```
pydantic-settings: >=2.14.1 # MIT License - https://github.com/pydantic/pydantic-settings/blob/main/LICENSE
```

Verified the config still parses and the entry is readable under `[Authorized Packages]`.

## Type

🚄 Infrastructure