### PR TITLE
fix(anthropic): stop tool translation from mutating caller input_schema

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -768,7 +768,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 name=truncated_name,
             )
             if "input_schema" in tool:
-                function_chunk["parameters"] = tool["input_schema"]  # type: ignore
+                function_chunk["parameters"] = copy.deepcopy(tool["input_schema"])  # type: ignore
             if "description" in tool:
                 function_chunk["description"] = tool["description"]  # type: ignore
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import sys
 from typing import Any, cast
@@ -1805,6 +1806,38 @@ def test_translate_anthropic_tools_to_openai_fills_missing_tool_name():
     result, _ = adapter.translate_anthropic_tools_to_openai(tools=tools, model=None)
     assert result[0]["function"]["name"] == "litellm_unnamed_tool_0"
     assert result[1]["function"]["name"] == "litellm_unnamed_tool_1"
+
+
+def test_translate_anthropic_tools_to_openai_does_not_mutate_caller_input_schema():
+    """Translation must be a pure read: the caller's ``input_schema`` must not be mutated.
+
+    Regression test for the tool-translation path aliasing the caller's ``input_schema``
+    dict and then merging extra top-level tool kwargs (e.g. a ``computer`` tool's
+    ``display_width_px``) into it in place. Because callers reuse the same in-memory tool
+    list (a pre-call guardrail translates the tools, then the real call translates them
+    again), the second pass forwarded a schema polluted with non-schema keys.
+    """
+    tool = {
+        "name": "computer",
+        "type": "computer_20241022",
+        "input_schema": {"type": "object", "properties": {"action": {"type": "string"}}},
+        "display_width_px": 1024,
+        "display_height_px": 768,
+    }
+    input_schema_before = copy.deepcopy(tool["input_schema"])
+
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    result, _ = adapter.translate_anthropic_tools_to_openai(tools=[tool], model="claude-3-5-sonnet")
+
+    assert tool["input_schema"] == input_schema_before
+    assert "display_width_px" not in tool["input_schema"]
+    assert "display_height_px" not in tool["input_schema"]
+
+    translated_parameters = result[0]["function"]["parameters"]
+    assert translated_parameters["display_width_px"] == 1024
+    assert translated_parameters["display_height_px"] == 768
+    assert translated_parameters["properties"] == {"action": {"type": "string"}}
+    assert translated_parameters is not tool["input_schema"]
 
 
 def test_translate_openai_content_to_anthropic_reasoning_content_without_thinking_blocks():


### PR DESCRIPTION
## TLDR

Problem this solves:

- `translate_anthropic_tools_to_openai` assigned the caller's `input_schema` dict to the translated `parameters` by reference, then the "pass additional computer kwargs" loop merged extra top-level tool keys (e.g. a `computer` tool's `display_width_px`) into that shared dict in place
- Callers reuse the same in-memory tool list (a pre-call guardrail translates the tools, then the real call translates them again), so the second pass forwarded a schema polluted with non-schema keys, and providers that validate the tool `parameters` JSON schema can reject the request. The corruption is silent

How it solves it:

- Deep-copy `input_schema` before assigning it to `function_chunk["parameters"]`, so translation is a pure read and later kwarg merges land only on the copy
- This mirrors the sibling `translate_anthropic_output_format_to_openai` in the same file, which already `copy.deepcopy`s its schema for the same reason; `copy` is already imported

## Relevant issues

Fixes #34510

## Linear ticket

## Type

🐛 Bug Fix

## Changes

`litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py`: deep-copy `input_schema` before it becomes the translated OpenAI `parameters`

Added a regression test `test_translate_anthropic_tools_to_openai_does_not_mutate_caller_input_schema` that asserts the caller's `input_schema` is untouched after translation and that the vendor kwargs still reach the translated `parameters`. It fails on the pre-fix code and passes after

## QA runbook

Pure translation logic, so it reproduces with no provider credentials

```
from litellm.llms.anthropic.experimental_pass_through.adapters.transformation import LiteLLMAnthropicMessagesAdapter
import copy
adapter = LiteLLMAnthropicMessagesAdapter()
tool = {
    "name": "computer",
    "type": "computer_20241022",
    "input_schema": {"type": "object", "properties": {"action": {"type": "string"}}},
    "display_width_px": 1024,
    "display_height_px": 768,
}
before = copy.deepcopy(tool["input_schema"])
adapter.translate_anthropic_tools_to_openai(tools=[tool], model="claude-3-5-sonnet")
print("mutated:", tool["input_schema"] != before)
```

Before this PR prints `mutated: True` (the caller's schema now contains `display_width_px` / `display_height_px`); after, it prints `mutated: False`
