### PR TITLE
fix(vertex_ai): forward function_call id on Vertex Gemini 3+ tool turns

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -1266,7 +1266,7 @@ def _get_dummy_thought_signature() -> str:
 def convert_to_gemini_tool_call_invoke(
     message: ChatCompletionAssistantMessage,
     model: Optional[str] = None,
-    custom_llm_provider: Optional[str] = None,
+    forward_function_call_id: bool = False,
 ) -> List[VertexPartType]:
     """
     OpenAI tool invokes:
@@ -1316,16 +1316,12 @@ def convert_to_gemini_tool_call_invoke(
             VertexGeminiConfig,
         )
 
-        forward_tool_call_id = bool(
-            model and VertexGeminiConfig._forward_gemini_function_call_id(model, custom_llm_provider)
-        )
-
         if tool_calls is not None:
             for idx, tool in enumerate(tool_calls):
                 if "function" in tool:
                     gemini_function_call: Optional[VertexFunctionCall] = _gemini_tool_call_invoke_helper(
                         function_call_params=tool["function"],
-                        tool_call_id=(tool.get("id") if forward_tool_call_id else None),
+                        tool_call_id=(tool.get("id") if forward_function_call_id else None),
                     )
                     if gemini_function_call is not None:
                         part_dict: VertexPartType = {"function_call": gemini_function_call}
@@ -1377,8 +1373,7 @@ def convert_to_gemini_tool_call_invoke(
 def convert_to_gemini_tool_call_result(
     message: Union[ChatCompletionToolMessage, ChatCompletionFunctionMessage],
     last_message_with_tool_calls: Optional[dict],
-    model: Optional[str] = None,
-    custom_llm_provider: Optional[str] = None,
+    forward_function_call_id: bool = False,
 ) -> Union[VertexPartType, List[VertexPartType]]:
     """
     OpenAI message with a tool result looks like:
@@ -1500,14 +1495,8 @@ def convert_to_gemini_tool_call_result(
                 name = tool.get("function", {}).get("name", "")
 
     # Echo the OpenAI tool_call_id on functionResponse (strip thought-signature suffix).
-    # Only Google AI Studio Gemini 3+ accepts `id` on function_response parts.
-    # Vertex AI and older Gemini models reject the field with HTTP 400.
-    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
-        VertexGeminiConfig,
-    )
-
     gemini_call_id: Optional[str] = None
-    if model and VertexGeminiConfig._forward_gemini_function_call_id(model, custom_llm_provider):
+    if forward_function_call_id:
         raw_tool_call_id = message.get("tool_call_id")
         if raw_tool_call_id and isinstance(raw_tool_call_id, str):
             stripped_id = raw_tool_call_id.split(THOUGHT_SIGNATURE_SEPARATOR, 1)[0]

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -661,6 +661,10 @@ def _gemini_convert_messages_with_history(
         vertex_project = litellm_params.get("vertex_project") or litellm_params.get("vertex_ai_project")
         vertex_credentials = litellm_params.get("vertex_credentials") or litellm_params.get("vertex_ai_credentials")
 
+    from .vertex_and_google_ai_studio_gemini import VertexGeminiConfig
+
+    forward_function_call_id = VertexGeminiConfig._forward_gemini_function_call_id(model or "")
+
     try:
         while msg_i < len(messages):
             user_content: List[PartType] = []
@@ -910,7 +914,7 @@ def _gemini_convert_messages_with_history(
                     gemini_tool_call_parts = convert_to_gemini_tool_call_invoke(
                         assistant_msg,
                         model=model,
-                        custom_llm_provider=custom_llm_provider,
+                        forward_function_call_id=forward_function_call_id,
                     )
                     ## check if gemini_tool_call already exists in assistant_content
                     for gemini_tool_call_part in gemini_tool_call_parts:
@@ -973,8 +977,7 @@ def _gemini_convert_messages_with_history(
                 _part = convert_to_gemini_tool_call_result(
                     messages[msg_i],  # type: ignore
                     last_message_with_tool_calls,  # type: ignore
-                    model=model,
-                    custom_llm_provider=custom_llm_provider,
+                    forward_function_call_id=forward_function_call_id,
                 )
                 msg_i += 1
                 # Handle both single part and list of parts (for Computer Use with images)

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -289,15 +289,13 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         return False
 
     @staticmethod
-    def _forward_gemini_function_call_id(model: str, custom_llm_provider: Optional[str] = None) -> bool:
+    def _forward_gemini_function_call_id(model: str) -> bool:
         """
         Whether to include `id` on function_call / function_response parts.
 
-        Gemini 3+ on Google AI Studio accepts (and returns) `id` for strict
-        tool-call matching. Vertex AI rejects the field with HTTP 400.
+        Gemini 3+ accepts (and returns) `id` for strict tool-call matching, on Vertex AI and
+        Google AI Studio alike. Older Gemini models reject the field with HTTP 400.
         """
-        if custom_llm_provider != "gemini":
-            return False
         return VertexGeminiConfig._is_gemini_3_or_newer(model)
 
     def _supports_penalty_parameters(self, model: str) -> bool:

--- a/litellm/types/llms/vertex_ai.py
+++ b/litellm/types/llms/vertex_ai.py
@@ -16,7 +16,7 @@ GeminiEmbeddingInput = Union[EmbeddingInput, List[List[str]]]
 
 class FunctionResponse(TypedDict, total=False):
     # `id` correlates this response with the originating `functionCall` part.
-    # Supported on Google AI Studio Gemini 3.5+; Vertex AI rejects this field.
+    # Supported on Gemini 3+; older Gemini models reject this field.
     id: str
     name: Required[str]
     response: Optional[dict]
@@ -24,8 +24,8 @@ class FunctionResponse(TypedDict, total=False):
 
 
 class FunctionCall(TypedDict, total=False):
-    # `id` correlates the corresponding `functionResponse` on Google AI Studio
-    # Gemini 3.5+. Vertex AI and older Gemini models omit/reject this field.
+    # `id` correlates the corresponding `functionResponse` on Gemini 3+.
+    # Older Gemini models omit/reject this field.
     id: str
     name: Required[str]
     args: Optional[dict]
@@ -58,8 +58,8 @@ class PartType(TypedDict, total=False):
 
 
 class HttpxFunctionCall(TypedDict, total=False):
-    # `id` correlates the corresponding `functionResponse` on Google AI Studio
-    # Gemini 3.5+. Vertex AI and older Gemini models omit/reject this field.
+    # `id` correlates the corresponding `functionResponse` on Gemini 3+.
+    # Older Gemini models omit/reject this field.
     id: str
     name: Required[str]
     args: dict

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -2273,82 +2273,8 @@ def test_is_gemini_3_or_newer():
     assert VertexGeminiConfig._is_gemini_3_or_newer("") == False
 
 
-def test_forward_gemini_function_call_id_vertex_vs_google_ai_studio():
-    """Vertex AI rejects `id` on function_call/function_response; Google AI Studio accepts it on Gemini 3.5+."""
-    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
-        VertexGeminiConfig,
-    )
-
-    model = "gemini-3.5-flash"
-    assert (
-        VertexGeminiConfig._forward_gemini_function_call_id(model, "vertex_ai") is False
-    )
-    assert (
-        VertexGeminiConfig._forward_gemini_function_call_id(model, "vertex_ai_beta")
-        is False
-    )
-    assert VertexGeminiConfig._forward_gemini_function_call_id(model, "gemini") is True
-    assert VertexGeminiConfig._forward_gemini_function_call_id(model, None) is False
-    assert (
-        VertexGeminiConfig._forward_gemini_function_call_id(
-            "gemini-2.5-flash", "gemini"
-        )
-        is False
-    )
-
-
-def test_vertex_ai_gemini_35_tool_calls_omit_function_call_id():
-    """Regression: Vertex must not send OpenAI tool_call id inside Gemini function_call parts."""
-    from litellm.llms.vertex_ai.gemini.transformation import (
-        _gemini_convert_messages_with_history,
-    )
-
-    messages = [
-        {"role": "user", "content": "Explore this directory"},
-        {
-            "role": "assistant",
-            "content": "",
-            "tool_calls": [
-                {
-                    "id": "call_50e7e0fe0989464a89f188eda443",
-                    "type": "function",
-                    "function": {
-                        "name": "read",
-                        "arguments": '{"filePath": "/tmp"}',
-                    },
-                }
-            ],
-        },
-        {
-            "role": "tool",
-            "tool_call_id": "call_50e7e0fe0989464a89f188eda443",
-            "content": "ok",
-        },
-    ]
-
-    contents = _gemini_convert_messages_with_history(
-        messages=messages,
-        model="gemini-3.5-flash",
-        custom_llm_provider="vertex_ai",
-    )
-
-    for content in contents:
-        for part in content.get("parts", []):
-            fc = part.get("function_call")
-            if fc is not None:
-                assert "id" not in fc, f"Vertex payload must not include id: {fc}"
-            fr = part.get("function_response")
-            if fr is not None:
-                assert "id" not in fr, f"Vertex payload must not include id: {fr}"
-
-
-def test_google_ai_studio_gemini_35_tool_calls_include_function_call_id():
-    from litellm.llms.vertex_ai.gemini.transformation import (
-        _gemini_convert_messages_with_history,
-    )
-
-    tool_call_id = "call_50e7e0fe0989464a89f188eda443"
-    messages = [
+def _tool_call_messages(tool_call_id: str):
+    return [
         {"role": "user", "content": "hi"},
         {
             "role": "assistant",
@@ -2371,12 +2297,8 @@ def test_google_ai_studio_gemini_35_tool_calls_include_function_call_id():
         },
     ]
 
-    contents = _gemini_convert_messages_with_history(
-        messages=messages,
-        model="gemini-3.5-flash",
-        custom_llm_provider="gemini",
-    )
 
+def _collect_function_call_ids(contents):
     function_call_ids = []
     function_response_ids = []
     for content in contents:
@@ -2387,9 +2309,120 @@ def test_google_ai_studio_gemini_35_tool_calls_include_function_call_id():
             fr = part.get("function_response")
             if fr is not None:
                 function_response_ids.append(fr.get("id"))
+    return function_call_ids, function_response_ids
 
-    assert function_call_ids == [tool_call_id]
-    assert function_response_ids == [tool_call_id]
+
+def test_forward_gemini_function_call_id_is_gated_on_model_version_only():
+    """Gemini 3+ takes `id` on Vertex AI and Google AI Studio alike; older models reject it."""
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    assert VertexGeminiConfig._forward_gemini_function_call_id("gemini-3.5-flash") is True
+    assert VertexGeminiConfig._forward_gemini_function_call_id("gemini-3-pro") is True
+    assert VertexGeminiConfig._forward_gemini_function_call_id("gemini-2.5-flash") is False
+    assert VertexGeminiConfig._forward_gemini_function_call_id("gemini-2.0-flash") is False
+
+
+@pytest.mark.parametrize("custom_llm_provider", ["vertex_ai", "vertex_ai_beta", "gemini"])
+def test_gemini_35_tool_calls_include_function_call_id(custom_llm_provider):
+    """Vertex AI accepts `id` on Gemini 3+, so it must be sent there and not just on AI Studio.
+
+    Both parts are asserted together: Vertex pairs a result to its call by id, so emitting one
+    side without the other would break strict tool-call matching.
+    """
+    from litellm.llms.vertex_ai.gemini.transformation import (
+        _gemini_convert_messages_with_history,
+    )
+
+    tool_call_id = "call_50e7e0fe0989464a89f188eda443"
+    contents = _gemini_convert_messages_with_history(
+        messages=_tool_call_messages(tool_call_id),
+        model="gemini-3.5-flash",
+        custom_llm_provider=custom_llm_provider,
+    )
+
+    assert _collect_function_call_ids(contents) == ([tool_call_id], [tool_call_id])
+
+
+@pytest.mark.parametrize("custom_llm_provider", ["vertex_ai", "gemini"])
+def test_gemini_25_tool_calls_omit_function_call_id(custom_llm_provider):
+    """Regression: models older than Gemini 3 reject `id`, so the key must be absent entirely."""
+    from litellm.llms.vertex_ai.gemini.transformation import (
+        _gemini_convert_messages_with_history,
+    )
+
+    contents = _gemini_convert_messages_with_history(
+        messages=_tool_call_messages("call_50e7e0fe0989464a89f188eda443"),
+        model="gemini-2.5-flash",
+        custom_llm_provider=custom_llm_provider,
+    )
+
+    for content in contents:
+        for part in content.get("parts", []):
+            fc = part.get("function_call")
+            if fc is not None:
+                assert "id" not in fc, f"gemini-2.5 payload must not include id: {fc}"
+            fr = part.get("function_response")
+            if fr is not None:
+                assert "id" not in fr, f"gemini-2.5 payload must not include id: {fr}"
+
+
+def test_vertex_ai_forwarded_function_call_id_strips_thought_signature_suffix():
+    """The thought signature rides along on the OpenAI id but must not reach Vertex.
+
+    Vertex now sees this code path for the first time, so the suffix has to be stripped here too.
+    """
+    from litellm.llms.vertex_ai.gemini.transformation import (
+        _gemini_convert_messages_with_history,
+    )
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        THOUGHT_SIGNATURE_SEPARATOR,
+    )
+
+    bare_id = "call_50e7e0fe0989464a89f188eda443"
+    contents = _gemini_convert_messages_with_history(
+        messages=_tool_call_messages(f"{bare_id}{THOUGHT_SIGNATURE_SEPARATOR}sig123"),
+        model="gemini-3.5-flash",
+        custom_llm_provider="vertex_ai",
+    )
+
+    _, function_response_ids = _collect_function_call_ids(contents)
+    assert function_response_ids == [bare_id]
+
+
+@pytest.mark.parametrize("model", ["gemini-3.5-flash", "gemini-2.5-flash"])
+def test_tool_response_without_matching_tool_call_is_rejected(model):
+    """An unpairable tool result must raise, not ship a functionResponse with no matching call."""
+    from litellm.llms.vertex_ai.gemini.transformation import (
+        _gemini_convert_messages_with_history,
+    )
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_50e7e0fe0989464a89f188eda443",
+                    "type": "function",
+                    "function": {
+                        "name": "read",
+                        "arguments": '{"filePath": "/tmp"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "content": "ok"},
+    ]
+
+    with pytest.raises(Exception, match="Missing corresponding tool call"):
+        _gemini_convert_messages_with_history(
+            messages=messages,
+            model=model,
+            custom_llm_provider="vertex_ai",
+        )
 
 
 def test_reasoning_effort_maps_to_thinking_level_gemini_3():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex AI Gemini 3+ tool calls lose their `id`. LiteLLM strips it from both `functionCall` and `functionResponse` on every Vertex request, so Gemini cannot do strict tool-call matching and has to fall back to matching by function name
- The user-visible symptom is an empty assistant message after the final tool result. Gemini 3 returns a unique `id` on every `functionCall` and expects it echoed back on the matching `functionResponse`; when the `id` is missing, `generateContent` does not reject the request, it returns an empty response with `finish_reason: STOP`. A tool-calling agent looks like it silently gave up on the last turn, which is hard to attribute to a missing field several layers down
- The gate that does this was added in #28324 on the premise that "Vertex AI rejects `id` on function_call/function_response parts". Google has since shipped the field to the `v1` aiplatform endpoint, so the premise no longer holds and the workaround is now the bug
- Anyone running Gemini 3+ through `vertex_ai/` with parallel tool calls is affected. Google AI Studio users are not, because #28324 left that path alone

How it solves it:

- Gate the `id` on model version alone, which is what the code did before #28324 and what Google AI Studio already does today
- Drop `custom_llm_provider` from `_forward_gemini_function_call_id` and from both Gemini tool-call converters, since the provider branch was its only reader
- Resolve the decision once in `_gemini_convert_messages_with_history` and pass it down as a bool, instead of re-deriving it independently in each converter

This brings LiteLLM back in line with what Vertex documents for Gemini 3. Google's migration guide covers it under [function calling strict response matching](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/migrate#function_calling_strict_response_matching): the `id`, `name` and response count on every `functionResponse` must match the `functionCall` parts that preceded it, and adding `id` to all function response parts is listed as a required migration step. The Interactions API errors outright on a mismatch. `generateContent` does not, which is why this surfaces as degraded output rather than a 400, and why it went unnoticed after #28324 landed

Echoing the `id` is also the only thing that makes parallel tool calls unambiguous. Name-based matching works as long as each turn calls a distinct function, and breaks as soon as a model issues two calls to the same function with different arguments, which is common for search and lookup tools

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against real Vertex AI, no mocks. Config (`vertex_fc_id_test_config.yaml`):

```yaml
model_list:
  - model_name: vertex-gemini-3
    litellm_params:
      model: vertex_ai/gemini-3.6-flash
      vertex_project: os.environ/VERTEX_PROJECT
      vertex_location: global

  - model_name: vertex-gemini-25
    litellm_params:
      model: vertex_ai/gemini-2.5-flash
      vertex_project: os.environ/VERTEX_PROJECT
      vertex_location: global

general_settings:
  master_key: sk-1234
```

```bash
python litellm/proxy/proxy_cli.py --config vertex_fc_id_test_config.yaml --detailed_debug 2>&1 | tee litellm.log
```

**Turn 1**, get a real tool call back from Vertex:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{
    "model": "vertex-gemini-3",
    "messages": [{"role": "user", "content": "What is the weather in Boston, MA? Use the tool."}],
    "tools": [{"type": "function", "function": {
      "name": "get_current_weather",
      "description": "Get the current weather in a given location",
      "parameters": {"type": "object",
        "properties": {"location": {"type": "string", "description": "City and state"}},
        "required": ["location"]}}}]
  }' | jq '.choices[0].message.tool_calls[0] | {id, function}'
```

```json
{
  "id": "ZX9IviSb__thought__AY89a18/oeibAN3n5I8cD...<truncated>",
  "function": {
    "arguments": "{\"location\": \"Boston, MA\"}",
    "name": "get_current_weather"
  }
}
```

`ZX9IviSb` is Vertex's own `functionCall.id`, returned by the `v1` endpoint; the `__thought__` suffix is LiteLLM's existing thought-signature packing. Vertex returning an id here is the response-side confirmation that `v1` now supports the field.

**Turn 2**, feed that tool call and its result back:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d @turn2.json | jq -r '.choices[0].message.content'
```

```
The current weather in Boston, MA is 42°F and cloudy.
```

Outbound request LiteLLM built for Google, from `litellm.log`. **Before this PR**, on `vertex_ai/gemini-3.6-flash`, no id on either part:

```
POST https://aiplatform.googleapis.com/v1/projects/your-project/locations/global/publishers/google/models/gemini-3.6-flash:generateContent

'contents': [
  {'role': 'user',  'parts': [{'text': 'What is the weather in Boston, MA? Use the tool.'}]},
  {'role': 'model', 'parts': [{'function_call': {'name': 'get_current_weather', 'args': {'location': 'Boston, MA'}},
                               'thoughtSignature': '<redacted>'}]},
  {'role': 'user',  'parts': [{'function_response': {'name': 'get_current_weather',
                                                     'response': {'temp_f': 42, 'conditions': 'cloudy'}}}]}
]
```

**After this PR**, same request, same model, id present on both parts and stripped of the thought-signature suffix:

```
POST https://aiplatform.googleapis.com/v1/projects/your-project/locations/global/publishers/google/models/gemini-3.6-flash:generateContent

'contents': [
  {'role': 'user',  'parts': [{'text': 'What is the weather in Boston, MA? Use the tool.'}]},
  {'role': 'model', 'parts': [{'function_call': {'name': 'get_current_weather', 'args': {'location': 'Boston, MA'},
                                                 'id': 'ZX9IviSb'},
                               'thoughtSignature': '<redacted>'}]},
  {'role': 'user',  'parts': [{'function_response': {'name': 'get_current_weather',
                                                     'response': {'temp_f': 42, 'conditions': 'cloudy'},
                                                     'id': 'ZX9IviSb'}}]}
]
```

Both returned 200 with the correct answer.

Older models are unaffected. Same turn-2 request against `vertex-gemini-25` (`vertex_ai/gemini-2.5-flash`) still sends no id, which is required since those models reject the field:

```
POST https://aiplatform.googleapis.com/v1/projects/your-project/locations/global/publishers/google/models/gemini-2.5-flash:generateContent

'contents': [
  {'role': 'user',  'parts': [{'text': 'What is the weather in Boston, MA? Use the tool.'}]},
  {'role': 'model', 'parts': [{'function_call': {'name': 'get_current_weather', 'args': {'location': 'Boston, MA'}},
                               'thoughtSignature': '<redacted>'}]},
  {'role': 'user',  'parts': [{'function_response': {'name': 'get_current_weather',
                                                     'response': {'temp_f': 42, 'conditions': 'cloudy'}}}]}
]
```

```
The weather in Boston, MA is cloudy with a temperature of 42 degrees Fahrenheit.
```

### Reviewer QA: context caching (`cachedContents`) also carries the id

The one Vertex surface this PR changes without direct coverage is explicit context caching: `transform_openai_messages_to_gemini_context_caching` runs through the same converters, so cached tool turns now embed the id. Verified live against real Vertex AI on `vertex_ai/gemini-3.6-flash` (location `global`), same proxy config as above. Turn 1 as above returned a real Vertex tool-call id (`hH89Idyy__thought__...`). Turn 2 marks a contiguous block of messages (a padded user question of about 7.7k tokens, the assistant tool call, the tool result, and a closing user note) with `cache_control: {"type": "ephemeral"}`, followed by an uncached user question, with the same weather tool passed

**After** (this PR, acd414f), the cachedContents create body carries the id on both parts and Vertex accepts it:

```
POST https://aiplatform.googleapis.com/v1/projects/your-project/locations/global/cachedContents

'contents': [
  {'role': 'user',  'parts': [{'text': '<7.7k-token padded question>'}]},
  {'role': 'model', 'parts': [{'function_call': {'name': 'get_current_weather', 'args': {'location': 'Boston, MA'},
                                                 'id': 'hH89Idyy'},
                               'thoughtSignature': '<redacted>'}]},
  {'role': 'user',  'parts': [{'function_response': {'name': 'get_current_weather',
                                                     'response': {'temp_f': 42, 'conditions': 'cloudy'},
                                                     'id': 'hH89Idyy'}}]},
  {'role': 'user',  'parts': [{'text': 'The tool result above is authoritative and final.'}]}
]
```

The create returned 200 (`cachedContents/8953872159109808128`), the follow-up generateContent referenced that cache and answered correctly, and usage confirms the cache was read:

```
"content": "The current weather in Boston, MA is cloudy with a temperature of 42°F."
"cache_read_input_tokens": 7711
```

**Before** (base litellm_internal_staging, 0a6b372), the identical request also succeeds, with both tool parts present and no `id` anywhere in the create body. The id fields are therefore the only behavioral delta on this endpoint, and the v1 `cachedContents` endpoint accepts them

One shared behavior surfaced while testing, identical on base and on this PR head and therefore pre-existing and unrelated to the id: if the cached block ends on the tool-result turn (no trailing user text message), Vertex rejects the create with `Requests ending with a model turn are not supported`

## Type

🐛 Bug Fix

## Changes

`VertexGeminiConfig._forward_gemini_function_call_id` drops its `custom_llm_provider` parameter and returns `_is_gemini_3_or_newer(model)`. That parameter existed only to hold the `!= "gemini"` short-circuit, and nothing else read it.

`convert_to_gemini_tool_call_invoke` and `convert_to_gemini_tool_call_result` now take `forward_function_call_id: bool` in place of `custom_llm_provider` (and, for the result converter, `model`, whose only reader was the same gate). `_gemini_convert_messages_with_history` resolves the flag once and passes it to both. This removes the duplicated derivation and lets the result converter drop the function-local `VertexGeminiConfig` import that existed to dodge a circular import.

The `id` field comments on `FunctionCall`, `FunctionResponse` and `HttpxFunctionCall` in `types/llms/vertex_ai.py` came from #28324 and stated that Vertex rejects the field, which is no longer true; they now describe the version gate.

`custom_llm_provider` on `_gemini_convert_messages_with_history` itself is left in place. It is unused after this change, but it has three production call sites and a long tail of test callers, none of which have anything to do with this bug. Worth removing as a follow-up.

Out of scope and unchanged: `countTokens` strips `functionResponse.id` unconditionally in `llms/gemini/count_tokens/handler.py`, which shifts token counts slightly but never correctness; the realtime transformation has its own `_include_function_response_id` returning `False` and no seam to thread this through.

## QA runbook

Point a `vertex_ai/` deployment at any Gemini 3+ model and run a two-turn tool-calling exchange, as in the proof of fix above. With `--detailed_debug`, the outbound `generateContent` body should carry the same `id` on the `function_call` part and on the matching `function_response` part, and the call should return 200. Repeat against a Gemini 2.5 deployment and confirm neither part carries an `id`. Google AI Studio (`gemini/`) behaviour should be byte-identical to before.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Tests live in `tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py`. The two tests that encoded the old "Vertex must omit the id" contract are rewritten to the new one, and the Google AI Studio test is unchanged in meaning. Coverage: the gate is version-gated only; Gemini 3+ emits the id on both parts across `vertex_ai`, `vertex_ai_beta` and `gemini`; Gemini 2.5 emits the key on neither; a `<id>__thought__<sig>` tool-call id forwards stripped; and an unpairable tool result raises rather than shipping a half-formed payload.

Mutation-checked against five mutants, all killed: the gate forced to `False`, to `True`, and back to the old provider branch, plus each converter call site independently forced to `False`. That last pair is what makes a one-sided implementation impossible to pass, since `functionCall.id` without a matching `functionResponse.id` is exactly the shape that would break strict matching on Google's side.

