### PR TITLE
refactor(ui): migrate cost-optimization to shadcn

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -215,17 +215,7 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/app/(dashboard)/cost-optimization/_components/PromptCompressionTab.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
-  "src/app/(dashboard)/cost-optimization/_components/UsageTab.tsx": {
     "no-restricted-imports": {
       "count": 1
     }

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.test.tsx
@@ -20,6 +20,16 @@ describe("CostOptimizationView", () => {
     expect(getByText("Prompt Caching")).toBeInTheDocument();
   });
 
+  it("surfaces the experimental-dashboard notice and links to the discussion", () => {
+    const { getByText, getByRole } = renderView();
+
+    expect(getByText("This is an experimental dashboard")).toBeInTheDocument();
+    expect(getByRole("link", { name: "here" })).toHaveAttribute(
+      "href",
+      "https://github.com/BerriAI/litellm/discussions/32172",
+    );
+  });
+
   it("defaults to the Usage tab and switches the active tab on click", () => {
     const { getByRole } = renderView();
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import React from "react";
-import { PiggyBank } from "lucide-react";
-import { Alert, Tabs } from "antd";
+import { Info, PiggyBank } from "lucide-react";
 
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useVisitedTabs } from "@/hooks/useVisitedTabs";
 import UsageTab from "./UsageTab";
 import PromptCompressionTab from "./PromptCompressionTab";
 import AutorouterTab from "./AutorouterTab";
@@ -18,29 +19,7 @@ interface CostOptimizationViewProps {
 
 const CostOptimizationView: React.FC<CostOptimizationViewProps> = ({ accessToken, userId, userRole }) => {
   const activity = useDailyActivityRange(accessToken, userId, userRole);
-
-  const items = [
-    {
-      key: "usage",
-      label: "Usage",
-      children: <UsageTab accessToken={accessToken} activity={activity} />,
-    },
-    {
-      key: "compression",
-      label: "Prompt Compression",
-      children: <PromptCompressionTab accessToken={accessToken} />,
-    },
-    {
-      key: "autorouter",
-      label: "Autorouter",
-      children: <AutorouterTab accessToken={accessToken} userId={userId} userRole={userRole} />,
-    },
-    {
-      key: "caching",
-      label: "Prompt Caching",
-      children: <PromptCachingTab accessToken={accessToken} activity={activity} />,
-    },
-  ];
+  const { onTabChange, hasVisited } = useVisitedTabs("usage");
 
   return (
     <div className="w-full space-y-6 p-6">
@@ -54,26 +33,53 @@ const CostOptimizationView: React.FC<CostOptimizationViewProps> = ({ accessToken
         </p>
       </div>
 
-      <Alert
-        type="info"
-        showIcon
-        message="This is an experimental dashboard"
-        description={
-          <span>
+      <div role="alert" className="flex gap-2.5 rounded-lg border bg-card px-4 py-3 text-sm">
+        <Info className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+        <div>
+          <p className="font-medium text-foreground">This is an experimental dashboard</p>
+          <p className="mt-0.5 text-muted-foreground">
             Have feedback? Join the discussion{" "}
             <a
               href="https://github.com/BerriAI/litellm/discussions/32172"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-600 underline"
+              className="underline underline-offset-4 hover:text-foreground"
             >
               here
             </a>
-          </span>
-        }
-      />
+          </p>
+        </div>
+      </div>
 
-      <Tabs defaultActiveKey="usage" items={items} />
+      <Tabs defaultValue="usage" onValueChange={onTabChange}>
+        <TabsList variant="line" className="h-auto w-full justify-start rounded-none border-b p-0">
+          <TabsTrigger value="usage" className="flex-none rounded-none px-4 py-2">
+            Usage
+          </TabsTrigger>
+          <TabsTrigger value="compression" className="flex-none rounded-none px-4 py-2">
+            Prompt Compression
+          </TabsTrigger>
+          <TabsTrigger value="autorouter" className="flex-none rounded-none px-4 py-2">
+            Autorouter
+          </TabsTrigger>
+          <TabsTrigger value="caching" className="flex-none rounded-none px-4 py-2">
+            Prompt Caching
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent keepMounted={hasVisited("usage")} value="usage" className="pt-4">
+          <UsageTab accessToken={accessToken} activity={activity} />
+        </TabsContent>
+        <TabsContent keepMounted={hasVisited("compression")} value="compression" className="pt-4">
+          <PromptCompressionTab accessToken={accessToken} />
+        </TabsContent>
+        <TabsContent keepMounted={hasVisited("autorouter")} value="autorouter" className="pt-4">
+          <AutorouterTab accessToken={accessToken} userId={userId} userRole={userRole} />
+        </TabsContent>
+        <TabsContent keepMounted={hasVisited("caching")} value="caching" className="pt-4">
+          <PromptCachingTab accessToken={accessToken} activity={activity} />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 };

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
@@ -1,4 +1,5 @@
 import { render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import type { ToolSpendResponse } from "@/components/networking";
 
@@ -93,6 +94,18 @@ describe("UsageTab", () => {
     expect(getByText("$0.1400")).toBeInTheDocument();
     expect(getByText("$0.0160")).toBeInTheDocument();
     expect(getByText("140,000 tokens compressed")).toBeInTheDocument();
+  });
+
+  it("keeps the savings methodology collapsed until its disclosure is opened", async () => {
+    const user = userEvent.setup();
+    const { getByText, queryByText, findByText } = renderWith([day("2026-07-12", {})]);
+
+    expect(getByText("How savings are calculated")).toBeInTheDocument();
+    expect(queryByText(/Savings are computed for each request when it is logged/)).not.toBeInTheDocument();
+
+    await user.click(getByText("How savings are calculated"));
+
+    expect(await findByText(/Savings are computed for each request when it is logged/)).toBeInTheDocument();
   });
 
   it("builds a per-day time series and per-driver donut from the daily rows", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
-import { Collapse } from "antd";
+import { ChevronRight } from "lucide-react";
 
 import { AreaChart, BarChart, DonutChart, DEFAULT_COLOR_CYCLE } from "@/components/shared/charts";
 import AdvancedDatePicker from "@/components/shared/advanced_date_picker";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { getToolSpend, ToolSpendResponse } from "@/components/networking";
 import { SpendMetrics } from "@/components/UsagePage/types";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
@@ -35,38 +36,35 @@ const cachingOf = (m: SpendMetrics): number => m.prompt_caching_savings_spend ??
 const savedTokensOf = (m: SpendMetrics): number => m.compression_saved_tokens ?? 0;
 
 const MethodologyNote = () => (
-  <Collapse
-    ghost
-    items={[
-      {
-        key: "methodology",
-        label: <span className="text-sm font-medium">How savings are calculated</span>,
-        children: (
-          <div className="space-y-3 text-sm text-muted-foreground">
-            <p>
-              Savings are computed for each request when it is logged, using the provider&apos;s reported usage and the
-              model&apos;s pricing, then summed into a daily rollup. Totals below are read from that rollup over the
-              selected date range, so the numbers never require a scan of raw request logs.
-            </p>
-            <p>
-              Compression savings are the tokens Headroom removed before the call, priced at the model&apos;s input
-              rate: <code>compression_saved_tokens * input_cost_per_token</code>
-            </p>
-            <p>
-              Prompt caching savings are the tokens the provider served from cache (Anthropic{" "}
-              <code>cache_read_input_tokens</code>, or OpenAI-style <code>prompt_tokens_details.cached_tokens</code>),
-              priced at the discount between the normal input rate and the cache-read rate:{" "}
-              <code>cache_read_input_tokens * max(input_cost_per_token - cache_read_input_token_cost, 0)</code>
-            </p>
-            <p>
-              Total saved is the sum of both drivers. Models without a separate cache-read price in the pricing map
-              contribute zero caching savings rather than erroring.
-            </p>
-          </div>
-        ),
-      },
-    ]}
-  />
+  <Collapsible>
+    <CollapsibleTrigger className="group flex items-center gap-1.5 rounded-md py-1 text-sm font-medium text-foreground hover:text-muted-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none">
+      <ChevronRight className="size-4 shrink-0 transition-transform group-data-[panel-open]:rotate-90" />
+      How savings are calculated
+    </CollapsibleTrigger>
+    <CollapsibleContent>
+      <div className="space-y-3 pt-2 pl-[22px] text-sm text-muted-foreground">
+        <p>
+          Savings are computed for each request when it is logged, using the provider&apos;s reported usage and the
+          model&apos;s pricing, then summed into a daily rollup. Totals below are read from that rollup over the
+          selected date range, so the numbers never require a scan of raw request logs.
+        </p>
+        <p>
+          Compression savings are the tokens Headroom removed before the call, priced at the model&apos;s input rate:{" "}
+          <code>compression_saved_tokens * input_cost_per_token</code>
+        </p>
+        <p>
+          Prompt caching savings are the tokens the provider served from cache (Anthropic{" "}
+          <code>cache_read_input_tokens</code>, or OpenAI-style <code>prompt_tokens_details.cached_tokens</code>),
+          priced at the discount between the normal input rate and the cache-read rate:{" "}
+          <code>cache_read_input_tokens * max(input_cost_per_token - cache_read_input_token_cost, 0)</code>
+        </p>
+        <p>
+          Total saved is the sum of both drivers. Models without a separate cache-read price in the pricing map
+          contribute zero caching savings rather than erroring.
+        </p>
+      </div>
+    </CollapsibleContent>
+  </Collapsible>
 );
 
 const SummaryCard = ({ label, value, hint }: { label: string; value: string; hint?: string }) => (


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cost Optimization page still rendered antd Tabs, Alert and Collapse
- Those files held two `no-restricted-imports` suppressions

How it solves it:

- Swap them for shadcn tabs, collapsible, and a token-styled notice
- Markup only; no behaviour, data-fetching or API change
- Visited tab panels keep state, matching what antd Tabs did

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The visual blast-radius gate re-baselined `cost-optimization` and re-ran every other dashboard route against its existing baseline: 35 of 35 passed, so `cost-optimization` is the only route whose pixels moved and the other 34 are byte-identical. Tolerance is `maxDiffPixels: 0`. Baselines were calibrated on the clean tree first (2 in-boot runs plus a fresh-boot run, 35 routes stable, 0 unstable) before anything was touched

The two visible differences on the page are the notice and the tab strip. The notice moves from antd's blue-tinted info alert to the neutral bordered callout with a lucide icon, and the "here" link loses its hardcoded `text-blue-600` for the token-driven underline. The tab strip moves from antd's blue underline to the same line-tab treatment the already-migrated routes use. Content below the tabs is unchanged

Steps to reproduce by hand against a local proxy on port 4000, with the dashboard dev server on port 3000:

1. Go to http://localhost:4000/ui/?page=cost-optimization
2. Expect the "This is an experimental dashboard" notice with an info icon, and "here" linking to the discussion thread
3. Click "How savings are calculated"; expect the chevron to rotate and the four methodology paragraphs to expand, then click again to collapse
4. Click through Prompt Compression, Autorouter and Prompt Caching; expect each panel to render its own content and only one panel to be visible at a time
5. Set a date range on Usage, switch to Autorouter and back; expect Usage to still show the range you picked rather than resetting

I drove steps 2 through 5 against a live seeded stack. All four panels mount and render, inactive panels carry `hidden`/`inert` with zero height, and the disclosure toggles `aria-expanded` with the chevron rotating from 0 to 90 degrees. At a 1280x600 viewport the shell still scrolls the full page with no horizontal overflow and nothing clipped

## Type

🧹 Refactoring

## Changes

Migrated, both route-exclusive to `cost-optimization`:

- `_components/CostOptimizationView.tsx`: antd `Tabs` to `ui/tabs`, antd `Alert` to a composed notice using border, card and muted-foreground tokens plus a lucide `Info`. Panels use `useVisitedTabs` with `keepMounted` so a visited panel keeps its state across tab switches, which is what antd `Tabs` did and what Base UI otherwise drops by unmounting the inactive panel
- `_components/UsageTab.tsx`: antd `Collapse` to `ui/collapsible` for the savings-methodology disclosure

`eslint-suppressions.json` loses the two `no-restricted-imports` entries these files held, via `eslint . --prune-suppressions`, so the baseline ratchets down rather than keeping stale headroom

Not touched, quoting the analyzer's buckets:

- DEFERRED, "contains an antd Form -- do not touch until forms unblock": `AutorouterTab.tsx`, `PromptCompressionTab.tsx`, `add_auto_router_tab.tsx`, `check_openapi_schema.tsx`, `RoutingGroupModal.tsx`
- SHARED, "reached by another page -- REFUSE to edit; Track A owns these": 25 files including `advanced_date_picker.tsx` (3 pages), `general_settings.tsx` (2 pages), the `Settings/RouterSettings/Fallbacks/*` and `router_settings/*` trees (11 pages each), and `notifications_manager.tsx` / `message_manager.tsx` (54 pages each)

Because those two buckets stay put, the Cost Optimization route still imports antd through its deferred and shared children after this PR. Only the two files above changed

No shadcn primitive was added. `npx shadcn add alert` writes a base-vega file importing `cva` from `class-variance-authority`, which this project does not depend on since its primitives use the `cva({ base, variants })` form from `@/lib/cva.config`, so the notice is composed from tokens instead

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

The regression net was established in a separate commit that changes no component. The existing tab tests already queried by role and `aria-selected`, and the two antd surfaces with no coverage got characterisation tests: the notice with its discussion link, and the methodology disclosure asserting the body is absent until the trigger is clicked. Both were proven green against the antd components first, and the migration commit does not touch any test file. The full dashboard suite is green at 553 files and 5527 tests, along with eslint, prettier and knip
