### PR TITLE
fix(ui): keep team role and budget when the team ID is blank

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/DefaultUserSettings.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/DefaultUserSettings.test.tsx
@@ -150,4 +150,111 @@ describe("DefaultUserSettings", () => {
 
     expect(screen.getByText("Edit Settings")).toBeInTheDocument();
   });
+
+  describe("editable fields", () => {
+    const teamsOnlySettings = {
+      values: {
+        teams: [],
+      },
+      field_schema: {
+        description: "Default user settings",
+        properties: {
+          teams: {
+            type: "array",
+            description: "Teams",
+          },
+        },
+      },
+    };
+
+    const enterEditMode = async () => {
+      mockGetInternalUserSettings.mockResolvedValue(teamsOnlySettings);
+      mockUpdateInternalUserSettings.mockResolvedValue({ settings: {} });
+
+      render(<DefaultUserSettings {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Edit Settings")).toBeInTheDocument();
+      });
+
+      act(() => {
+        fireEvent.click(screen.getByText("Edit Settings"));
+      });
+    };
+
+    const savedPayload = () => mockUpdateInternalUserSettings.mock.calls[0][1] as Record<string, unknown>;
+
+    const selectUserRole = async (optionText: string) => {
+      act(() => {
+        fireEvent.mouseDown(document.querySelector(".ant-select-selector")!);
+      });
+
+      await waitFor(() => {
+        expect(document.querySelectorAll(".ant-select-item-option").length).toBeGreaterThan(0);
+      });
+
+      const option = Array.from(document.querySelectorAll(".ant-select-item-option")).find((el) =>
+        el.textContent?.includes(optionText),
+      );
+      expect(option).toBeTruthy();
+
+      act(() => {
+        fireEvent.click(option!);
+      });
+    };
+
+    it("keeps the stored role and max budget of a team saved without an ID", async () => {
+      mockGetInternalUserSettings.mockResolvedValue({
+        ...teamsOnlySettings,
+        values: { teams: [{ team_id: "", max_budget_in_team: 25, user_role: "admin" }] },
+      });
+      mockUpdateInternalUserSettings.mockResolvedValue({ settings: {} });
+
+      render(<DefaultUserSettings {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Edit Settings")).toBeInTheDocument();
+      });
+      act(() => {
+        fireEvent.click(screen.getByText("Edit Settings"));
+      });
+
+      expect(screen.getByPlaceholderText("Enter team ID")).toHaveValue("");
+      expect(screen.getByPlaceholderText("Optional")).toHaveValue("25.00");
+      expect(document.querySelector(".ant-select-selection-item")).toHaveTextContent("Admin");
+    });
+
+    it("keeps showing the selected role of a team whose ID has not been typed yet", async () => {
+      await enterEditMode();
+
+      act(() => {
+        fireEvent.click(screen.getByText("Add Team"));
+      });
+      await selectUserRole("Admin");
+
+      expect(document.querySelector(".ant-select-selection-item")).toHaveTextContent("Admin");
+    });
+
+    it("keeps the role and max budget of a team whose ID has not been typed yet", async () => {
+      await enterEditMode();
+
+      act(() => {
+        fireEvent.click(screen.getByText("Add Team"));
+      });
+
+      act(() => {
+        fireEvent.change(screen.getByPlaceholderText("Optional"), { target: { value: "25" } });
+      });
+      await selectUserRole("Admin");
+
+      act(() => {
+        fireEvent.click(screen.getByText("Save Changes"));
+      });
+
+      await waitFor(() => {
+        expect(mockUpdateInternalUserSettings).toHaveBeenCalled();
+      });
+      expect(savedPayload().teams).toEqual([{ team_id: "", max_budget_in_team: 25, user_role: "admin" }]);
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/DefaultUserSettings.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/DefaultUserSettings.tsx
@@ -115,7 +115,7 @@ const DefaultUserSettings: React.FC<DefaultUserSettingsProps> = ({
           team_id: team,
           user_role: "user" as const,
         };
-      } else if (typeof team === "object" && team.team_id) {
+      } else if (typeof team === "object" && team !== null && "team_id" in team) {
         return {
           team_id: team.team_id,
           max_budget_in_team: team.max_budget_in_team,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Team role/budget silently reset when the team ID is blank
- Editing a second field on that row drops the first

How it solves it:

- Guard the object branch on shape, not on a truthy team_id
- Regression tests pin the display and the save payload

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Steps to reproduce by hand, with the Admin UI dev server on :3000 pointed at a proxy on :4000:

1. Go to http://localhost:3000/?page=users and open the "Default User Settings" tab
2. Click "Edit Settings", then "Add Team"
3. Leave "Team ID" empty and change "User Role" to Admin

Before (b9b27c2beb): the dropdown snaps back to "User" as soon as it re-renders

After (7a718d19c2): the dropdown stays on Admin

4. Still leaving "Team ID" empty, type 25 into "Max Budget in Team", then set "User Role" to Admin

Before (b9b27c2beb): the budget you just typed is gone from the row

After (7a718d19c2): both the budget and the role survive, and "Save Changes" sends them

## Type

🐛 Bug Fix

## Changes

`normalizeTeams` guarded its object branch on the truthiness of `team.team_id`, so any entry whose ID is an empty string fell through to the branch that returns a bare `{ team_id: "", user_role: "user" }`, discarding `user_role` and `max_budget_in_team`

That normalized copy feeds both the rendered row and `updateTeam`, which is why the symptom shows up twice: the role dropdown re-renders as "User" even though the edited value holds "admin", and because `updateTeam` spreads the normalized copy, the next edit to that row also wipes whatever was set before it. It bites on load too, since a team saved with a blank ID comes back with its role reset

The guard now tests the shape of the entry (`typeof team === "object" && team !== null && "team_id" in team`) instead of the value, so a blank ID keeps its siblings. The bug predates the shadcn migration of this component and is unrelated to it

Three tests in the mapped `DefaultUserSettings.test.tsx` cover it: the role stays selected with a blank ID, a stored team with a blank ID keeps its role and budget on load, and the save payload carries both fields after two sequential edits. Reverting the guard fails all three; dropping `max_budget_in_team` or the `user_role` fallback each fails two

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
