### PR TITLE
fix(bedrock): drop toolSpec.strict for Haiku 4.5 and Sonnet 4.6 on Converse

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -747,7 +747,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "anthropic.claude-haiku-4-5@20251001": {
         "cache_creation_input_token_cost": 1.25e-06,
@@ -773,7 +774,8 @@
         "supports_native_streaming": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "anthropic.claude-3-5-sonnet-20240620-v1:0": {
         "input_cost_per_token": 3e-06,
@@ -2220,7 +2222,8 @@
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "bedrock_converse_supports_strict_tools": false
     },
     "global.anthropic.claude-sonnet-4-6": {
         "supports_adaptive_thinking": true,
@@ -2252,7 +2255,8 @@
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "bedrock_converse_supports_strict_tools": false
     },
     "us.anthropic.claude-sonnet-4-6": {
         "supports_adaptive_thinking": true,
@@ -2284,7 +2288,8 @@
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "bedrock_converse_supports_strict_tools": false
     },
     "eu.anthropic.claude-sonnet-4-6": {
         "supports_adaptive_thinking": true,
@@ -2316,7 +2321,8 @@
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "bedrock_converse_supports_strict_tools": false
     },
     "au.anthropic.claude-sonnet-4-6": {
         "supports_adaptive_thinking": true,
@@ -2348,7 +2354,8 @@
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "bedrock_converse_supports_strict_tools": false
     },
     "jp.anthropic.claude-sonnet-4-6": {
         "supports_adaptive_thinking": true,
@@ -2380,7 +2387,8 @@
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "bedrock_converse_supports_strict_tools": false
     },
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -2697,7 +2705,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "apac.anthropic.claude-3-sonnet-20240229-v1:0": {
         "input_cost_per_token": 3e-06,
@@ -15900,7 +15909,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "eu.anthropic.claude-3-5-sonnet-20240620-v1:0": {
         "input_cost_per_token": 3e-06,
@@ -21805,7 +21815,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "global.amazon.nova-2-lite-v1:0": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -26183,7 +26194,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "crusoe/deepseek-ai/DeepSeek-R1-0528": {
         "input_cost_per_token": 3e-06,
@@ -34837,7 +34849,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "us.anthropic.claude-3-5-sonnet-20240620-v1:0": {
         "input_cost_per_token": 3e-06,
@@ -35052,7 +35065,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "us.anthropic.claude-opus-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 1.875e-05,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -747,7 +747,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "anthropic.claude-haiku-4-5@20251001": {
         "cache_creation_input_token_cost": 1.25e-06,
@@ -773,7 +774,8 @@
         "supports_native_streaming": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "anthropic.claude-3-5-sonnet-20240620-v1:0": {
         "input_cost_per_token": 3e-06,
@@ -2220,7 +2222,8 @@
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "bedrock_converse_supports_strict_tools": false
     },
     "global.anthropic.claude-sonnet-4-6": {
         "supports_adaptive_thinking": true,
@@ -2252,7 +2255,8 @@
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "bedrock_converse_supports_strict_tools": false
     },
     "us.anthropic.claude-sonnet-4-6": {
         "supports_adaptive_thinking": true,
@@ -2284,7 +2288,8 @@
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "bedrock_converse_supports_strict_tools": false
     },
     "eu.anthropic.claude-sonnet-4-6": {
         "supports_adaptive_thinking": true,
@@ -2316,7 +2321,8 @@
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "bedrock_converse_supports_strict_tools": false
     },
     "au.anthropic.claude-sonnet-4-6": {
         "supports_adaptive_thinking": true,
@@ -2348,7 +2354,8 @@
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "bedrock_converse_supports_strict_tools": false
     },
     "jp.anthropic.claude-sonnet-4-6": {
         "supports_adaptive_thinking": true,
@@ -2380,7 +2387,8 @@
         "supports_native_structured_output": true,
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 1024
+        "prompt_cache_min_tokens": 1024,
+        "bedrock_converse_supports_strict_tools": false
     },
     "anthropic.claude-sonnet-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 3.75e-06,
@@ -2697,7 +2705,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "apac.anthropic.claude-3-sonnet-20240229-v1:0": {
         "input_cost_per_token": 3e-06,
@@ -15900,7 +15909,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "eu.anthropic.claude-3-5-sonnet-20240620-v1:0": {
         "input_cost_per_token": 3e-06,
@@ -21880,7 +21890,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "global.amazon.nova-2-lite-v1:0": {
         "cache_read_input_token_cost": 7.5e-08,
@@ -26258,7 +26269,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "crusoe/deepseek-ai/DeepSeek-R1-0528": {
         "input_cost_per_token": 3e-06,
@@ -34928,7 +34940,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "us.anthropic.claude-3-5-sonnet-20240620-v1:0": {
         "input_cost_per_token": 3e-06,
@@ -35143,7 +35156,8 @@
         "supports_vision": true,
         "supports_native_structured_output": true,
         "supports_parallel_tool_use_config": true,
-        "prompt_cache_min_tokens": 4096
+        "prompt_cache_min_tokens": 4096,
+        "bedrock_converse_supports_strict_tools": false
     },
     "us.anthropic.claude-opus-4-20250514-v1:0": {
         "cache_creation_input_token_cost": 1.875e-05,

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
@@ -1,9 +1,9 @@
 """Regression tests for Bedrock Converse ``toolSpec.strict`` forwarding.
 
-Bedrock Converse routes Claude Opus 4.7/4.8 and Claude Sonnet 4 through an
-Anthropic-compatible validator that rejects ``toolSpec.strict`` even though
-Anthropic's native API accepts ``strict`` as a top-level tool field. See
-BerriAI/litellm#31582.
+Bedrock Converse routes several Claude model families through a validator that
+rejects ``toolSpec.strict`` (and can hang on large strict MCP tool sets via
+compiled-grammar limits) even though Anthropic's native API accepts ``strict``.
+See BerriAI/litellm#31582 (Opus), #31943 (Sonnet 4), #34388 (Haiku 4.5 / Sonnet 4.6).
 """
 
 import pytest
@@ -48,12 +48,20 @@ _STRICT_TOOL = [
         "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
         "bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0",
         "bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0",
+        # Haiku 4.5 / Sonnet 4.6: grammar-size hang / strict rejection (#34388)
+        "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "anthropic.claude-haiku-4-5-20251001-v1:0",
+        "bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "bedrock/us.anthropic.claude-sonnet-4-6",
+        "anthropic.claude-sonnet-4-6",
+        "bedrock/global.anthropic.claude-sonnet-4-6",
+        "bedrock/eu.anthropic.claude-sonnet-4-6",
     ],
 )
 def test_bedrock_tools_pt_strict_dropped_for_strict_unsupported_models(
     model_id: str,
 ) -> None:
-    """Opus 4.7/4.8 and Sonnet 4 reject toolSpec.strict and additionalProperties."""
+    """Models with bedrock_converse_supports_strict_tools:false drop strict fields."""
     result = _bedrock_tools_pt(_STRICT_TOOL, model=model_id)
     tool_spec = result[0]["toolSpec"]
     assert (
@@ -68,13 +76,12 @@ def test_bedrock_tools_pt_strict_dropped_for_strict_unsupported_models(
     "model_id",
     [
         "anthropic.claude-sonnet-4-5-20250929-v1:0",
-        "bedrock/us.anthropic.claude-sonnet-4-6",
         "bedrock/us.anthropic.claude-opus-4-6",
         "bedrock/us.anthropic.claude-opus-4-5",
     ],
 )
 def test_bedrock_tools_pt_strict_kept_for_other_anthropic(model_id: str) -> None:
-    """Sonnet 4.5/4.6 and Opus <=4.6 accept toolSpec.strict — keep forwarding it."""
+    """Sonnet 4.5 and Opus <=4.6 still accept toolSpec.strict — keep forwarding it."""
     result = _bedrock_tools_pt(_STRICT_TOOL, model=model_id)
     assert (
         result[0]["toolSpec"]["strict"] is True
@@ -129,6 +136,17 @@ def test_bedrock_converse_supports_strict_tools_helper() -> None:
         )
         is False
     )
+    # #34388 Haiku 4.5 / Sonnet 4.6
+    assert (
+        bedrock_converse_supports_strict_tools(
+            "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+        )
+        is False
+    )
+    assert (
+        bedrock_converse_supports_strict_tools("bedrock/us.anthropic.claude-sonnet-4-6")
+        is False
+    )
 
 
 @pytest.mark.parametrize(
@@ -143,6 +161,12 @@ def test_bedrock_converse_supports_strict_tools_helper() -> None:
         "us.anthropic.claude-sonnet-4-20250514-v1:0",
         "eu.anthropic.claude-sonnet-4-20250514-v1:0",
         "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+        # #34388
+        "anthropic.claude-haiku-4-5-20251001-v1:0",
+        "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "anthropic.claude-sonnet-4-6",
+        "us.anthropic.claude-sonnet-4-6",
+        "global.anthropic.claude-sonnet-4-6",
     ],
 )
 def test_strict_tools_flag_set_in_model_cost_map(cost_map_key: str) -> None:


### PR DESCRIPTION
## Summary
- Set `bedrock_converse_supports_strict_tools: false` for all `bedrock_converse` cost-map entries of Claude **Haiku 4.5** and **Sonnet 4.6** (regional prefixes included).
- Extend the existing Bedrock Converse strict-tools regression suite so those models drop `toolSpec.strict` / `additionalProperties` like Opus 4.7/4.8 and Sonnet 4.
- Leaves Sonnet 4.5 / older Opus paths that still accept strict unchanged.

## Context
Fixes https://github.com/BerriAI/litellm/issues/34388

PydanticAI/MCP tool definitions often set `strict: true`. Since LiteLLM began forwarding `strict` to Bedrock Converse, Haiku 4.5 / Sonnet 4.6 can hit compiled-grammar limits or hang until gateway timeout. The same cost-map gate already exists for Opus 4.7/4.8 (#31923) and Sonnet 4 (#31943). Sonnet 5 is covered by separate open PRs — this change does **not** re-implement those.

## Test plan
- [x] Local: `pytest -q tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py` → **39 passed**
- [x] Helper smoke: `bedrock_converse_supports_strict_tools` is False for Haiku 4.5 / Sonnet 4.6 and True for Sonnet 4.5
- [ ] CI: full upstream suite on this PR