### PR TITLE
fix(bedrock): guard empty choices in mistral get_outputText

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_mistral_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_mistral_transformation.py
@@ -99,7 +99,7 @@ class AmazonMistralConfig(AmazonInvokeConfig, BaseConfig):
             A string with the response of the LLM
 
         """
-        if "choices" in completion_response:
+        if "choices" in completion_response and len(completion_response["choices"]) > 0:
             outputText = completion_response["choices"][0]["message"]["content"]
             model_response.choices[0].finish_reason = completion_response["choices"][0]["finish_reason"]
         elif "outputs" in completion_response:

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_mistral_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_mistral_transformation.py
@@ -102,7 +102,7 @@ class AmazonMistralConfig(AmazonInvokeConfig, BaseConfig):
         if "choices" in completion_response and len(completion_response["choices"]) > 0:
             outputText = completion_response["choices"][0]["message"]["content"]
             model_response.choices[0].finish_reason = completion_response["choices"][0]["finish_reason"]
-        elif "outputs" in completion_response:
+        elif "outputs" in completion_response and len(completion_response["outputs"]) > 0:
             outputText = completion_response["outputs"][0]["text"]
             model_response.choices[0].finish_reason = completion_response["outputs"][0]["stop_reason"]
         else:

--- a/tests/test_litellm/llms/bedrock/chat/test_mistral_config.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_mistral_config.py
@@ -1,6 +1,9 @@
+import pytest
+
 from litellm.llms.bedrock.chat.invoke_transformations.amazon_mistral_transformation import (
     AmazonMistralConfig,
 )
+from litellm.llms.bedrock.common_utils import BedrockError
 from litellm.types.utils import ModelResponse
 
 
@@ -30,3 +33,12 @@ def test_mistral_get_outputText():
 
     assert outputText == "Hi!"
     assert model_response.choices[0].finish_reason == "finish"
+
+
+def test_mistral_get_outputText_empty_choices():
+    model_response = ModelResponse()
+
+    with pytest.raises(BedrockError):
+        AmazonMistralConfig.get_outputText(
+            completion_response={"choices": []}, model_response=model_response
+        )

--- a/tests/test_litellm/llms/bedrock/chat/test_mistral_config.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_mistral_config.py
@@ -42,3 +42,12 @@ def test_mistral_get_outputText_empty_choices():
         AmazonMistralConfig.get_outputText(
             completion_response={"choices": []}, model_response=model_response
         )
+
+
+def test_mistral_get_outputText_empty_outputs():
+    model_response = ModelResponse()
+
+    with pytest.raises(BedrockError):
+        AmazonMistralConfig.get_outputText(
+            completion_response={"outputs": []}, model_response=model_response
+        )


### PR DESCRIPTION
`AmazonMistralConfig.get_outputText` guards `choices` and `outputs` by key presence only, so a present-but-empty list reaches `[0]` and raises `IndexError`.

The caller wraps that: `BaseAWSLLM` catches it at `base_invoke_transformation.py:363` and re-raises as `BedrockError(status_code=422)`. So this is not a crash, it is a bad error. The caller sees `Received error=list index out of range`, which says nothing about what the provider returned. After this change the same request reports `Received error=Unexpected mistral completion response`, and the status code is unchanged.

Two branches are affected, not one:

- `{"choices": []}` reached `completion_response["choices"][0]`.
- `{"outputs": []}` reached `completion_response["outputs"][0]`. This one became easier to hit once `choices` was length-guarded, because a payload carrying both keys empty stops short-circuiting on the first branch and falls into the second.

Both now require a non-empty list, so either shape falls through to the existing `else` and raises `BedrockError` directly. This mirrors the guard the sibling OpenAI-format handler already uses in `invoke_handler.py:574` (`"choices" in completion_response and len(...) > 0`).

Regression tests feed `{"choices": []}` and `{"outputs": []}` through `get_outputText` and assert `BedrockError`; both raised `IndexError` before their respective commits.
