### PR TITLE
feat(pricing): add groq/qwen/qwen3.6-27b to model cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -25692,6 +25692,21 @@
         "supports_response_schema": false,
         "supports_tool_choice": true
     },
+    "groq/qwen/qwen3.6-27b": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "groq/whisper-large-v3": {
         "input_cost_per_second": 3.083e-05,
         "litellm_provider": "groq",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27189,6 +27189,21 @@
         "supports_response_schema": false,
         "supports_tool_choice": true
     },
+    "groq/qwen/qwen3.6-27b": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "groq/whisper-large-v3": {
         "input_cost_per_second": 3.083e-05,
         "litellm_provider": "groq",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -25767,6 +25767,21 @@
         "supports_response_schema": false,
         "supports_tool_choice": true
     },
+    "groq/qwen/qwen3.6-27b": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "groq/whisper-large-v3": {
         "input_cost_per_second": 3.083e-05,
         "litellm_provider": "groq",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27189,6 +27189,21 @@
         "supports_response_schema": false,
         "supports_tool_choice": true
     },
+    "groq/qwen/qwen3.6-27b": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "groq/whisper-large-v3": {
         "input_cost_per_second": 3.083e-05,
         "litellm_provider": "groq",

--- a/tests/test_litellm/llms/groq/test_groq_qwen3_6_27b_metadata.py
+++ b/tests/test_litellm/llms/groq/test_groq_qwen3_6_27b_metadata.py
@@ -1,0 +1,60 @@
+"""
+Test Groq qwen3.6-27b model metadata in the cost map.
+"""
+
+import json
+from importlib.resources import files
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def use_local_model_cost_map():
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+    import litellm
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+
+    original_model_cost = litellm.model_cost
+    litellm.model_cost = json.loads(
+        files("litellm").joinpath("model_prices_and_context_window_backup.json").read_text(encoding="utf-8")
+    )
+    litellm.get_model_info.cache_clear()
+    _invalidate_model_cost_lowercase_map()
+    try:
+        yield litellm
+    finally:
+        litellm.model_cost = original_model_cost
+        litellm.get_model_info.cache_clear()
+        _invalidate_model_cost_lowercase_map()
+        monkeypatch.undo()
+
+
+def test_groq_qwen3_6_27b_model_info(use_local_model_cost_map):
+    model_info = use_local_model_cost_map.get_model_info(model="groq/qwen/qwen3.6-27b")
+
+    assert model_info["litellm_provider"] == "groq"
+    assert model_info["mode"] == "chat"
+    assert model_info["max_input_tokens"] == 131072
+    assert model_info["max_output_tokens"] == 16384
+    assert model_info["max_tokens"] == 16384
+    assert model_info["input_cost_per_token"] == pytest.approx(6e-07)
+    assert model_info["output_cost_per_token"] == pytest.approx(3e-06)
+    assert model_info["cache_read_input_token_cost"] == pytest.approx(3e-07)
+    assert model_info["supports_function_calling"] is True
+    assert model_info["supports_reasoning"] is True
+    assert model_info["supports_response_schema"] is True
+    assert model_info["supports_tool_choice"] is True
+    assert model_info["supports_vision"] is True
+
+
+def test_groq_qwen3_6_27b_raw_model_cost_entry(use_local_model_cost_map):
+    model_info = use_local_model_cost_map.model_cost["groq/qwen/qwen3.6-27b"]
+
+    assert model_info["litellm_provider"] == "groq"
+    assert model_info["mode"] == "chat"
+    assert model_info["input_cost_per_token"] == pytest.approx(6e-07)
+    assert model_info["output_cost_per_token"] == pytest.approx(3e-06)
+    assert model_info["cache_read_input_token_cost"] == pytest.approx(3e-07)
+    assert model_info["supports_vision"] is True


### PR DESCRIPTION
## TLDR

Problem this solves:

- groq/qwen/qwen3.6-27b is served by Groq but missing from the cost map
- cost tracking for it silently returns 0 and get_model_info raises

How it solves it:

- add the model entry with pricing and capability flags from Groq's API
- add a regression test so the values cannot silently drift

## Relevant issues

No open issue tracks this; the model is simply absent from the cost map

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Captured at commit ca070277b0 against a live proxy hitting the real Groq API

Before: on any commit without this entry, get_model_info("groq/qwen/qwen3.6-27b") raises "This model isn't mapped yet" and the proxy logs "not in built-in cost map ... cost fields will default to 0", so x-litellm-response-cost comes back 0

After (this commit), config points qwen3.6-27b at groq/qwen/qwen3.6-27b:

```
curl -sS -D - http://localhost:4001/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"qwen3.6-27b","messages":[{"role":"user","content":"Reply with exactly: pricing works"}],"max_tokens":15}'

HTTP/1.1 200 OK
x-litellm-model-id: 532b52a7c9b7174177e97790238d75e2a45b6bfd6acf5c7aac9bd41cd2f44d14
x-litellm-response-cost: 5.46e-05
```

usage was 16 prompt + 15 completion tokens, and 16 * 6e-07 + 15 * 3e-06 = 5.46e-05, which matches the header exactly

## Type

🆕 New Feature

## Changes

Adds groq/qwen/qwen3.6-27b to model_prices_and_context_window.json and the bundled backup, with input 0.60 USD/1M, output 3.00 USD/1M, cached input 0.30 USD/1M, a 131072 context window, 16384 max output tokens, and function calling, tool choice, JSON schema, reasoning and vision flags, all sourced from Groq's models API

Adds tests/test_litellm/llms/groq/test_groq_qwen3_6_27b_metadata.py asserting the resolved model info and the raw cost-map entry so the pricing and capability flags are regression covered

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
