### PR TITLE
fix(ui): resolve tab slug against the last base-segment match

### DIFF
--- a/ui/litellm-dashboard/src/utils/tabRoutes.test.ts
+++ b/ui/litellm-dashboard/src/utils/tabRoutes.test.ts
@@ -25,6 +25,11 @@ describe("createTabRoutes.slugFromPathname", () => {
   it("returns empty string when the base segment is not in the path", () => {
     expect(routes.slugFromPathname("/teams")).toBe("");
   });
+
+  it("reads the route base after a server-root prefix that repeats the segment name", () => {
+    expect(routes.slugFromPathname("/logs/ui/logs/audit/")).toBe("audit");
+    expect(routes.slugFromPathname("/logs/ui/logs/")).toBe("");
+  });
 });
 
 describe("createTabRoutes.tabHref", () => {

--- a/ui/litellm-dashboard/src/utils/tabRoutes.ts
+++ b/ui/litellm-dashboard/src/utils/tabRoutes.ts
@@ -15,7 +15,7 @@ export function createTabRoutes<Slug extends string>(baseSegment: string, slugs:
 
   const slugFromPathname = (pathname: string): string => {
     const parts = pathname.split("/").filter(Boolean);
-    const idx = parts.indexOf(baseSegment);
+    const idx = parts.lastIndexOf(baseSegment);
     if (idx === -1) {
       return "";
     }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Nested tab routes redirect-loop when SERVER_ROOT_PATH repeats a route segment name

How it solves it:

- Match the last occurrence of the route base segment, not the first

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Unit-level fix; the regression test in `src/utils/tabRoutes.test.ts` encodes the failing case. To see it against a live proxy, start the proxy with `SERVER_ROOT_PATH=/logs`, open `http://localhost:4000/logs/ui/logs/audit/`, and confirm the Audit Logs tab loads instead of looping back to the base path.

## Type

🐛 Bug Fix

## Changes

`createTabRoutes.slugFromPathname` (the shared tab-routing helper) parsed the active tab by matching the **first** occurrence of the route base segment in the pathname. When `SERVER_ROOT_PATH` is set to a value that repeats a route segment name, the server-root copy wins. Concretely, `SERVER_ROOT_PATH=/logs` mounts the UI at `/logs/ui`, so the Audit Logs tab lives at `/logs/ui/logs/audit/`; the parser matched the leading `logs` and returned `ui` instead of `audit`. The layout then treats `ui` as an unknown tab and hard-redirects to `/logs/ui/logs/`, which misparses the same way, producing a reload loop. Greptile flagged this as a P1 on the Logs per-tab-routing PR.

The fix matches the **last** occurrence of the base segment. The route base always comes after any server-root prefix in the path, and no tab slug equals the base, so the last match is always the real route base. This hardens every page that uses the shared helper (Caching, Cost Optimization, Router Settings, Logs) at once. `legacyKeyForPathname` already avoided this by stripping the `uiBase()` prefix first; this brings the tab parser in line. A regression test covers `/logs/ui/logs/audit/` and `/logs/ui/logs/`.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR