### PR TITLE
feat(proxy): filter /key/list by user email

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -5176,7 +5176,31 @@ async def get_member_team_ids(
 
 
 VALID_EXPIRES_FILTER_VALUES = frozenset({"active", "expired"})
-USER_EMAIL_KEY_FILTER_MAX_USERS = 1000
+USER_EMAIL_KEY_FILTER_MAX_USERS = 50_000
+
+
+async def _resolve_user_ids_for_email_filter(prisma_client: PrismaClient, user_email: str) -> List[str]:
+    """Resolve a user_email fragment to the complete set of matching user IDs.
+
+    Raw SQL keeps this bounded: only the user_id column is fetched (find_many
+    materializes full rows), and LIKE wildcards in the fragment are escaped so
+    user input cannot widen the match. Matching more than
+    USER_EMAIL_KEY_FILTER_MAX_USERS users is refused rather than truncated:
+    a silently partial id list would make /key/list drop visible keys.
+    """
+    escaped = user_email.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    rows = await prisma_client.db.query_raw(
+        'SELECT user_id FROM "LiteLLM_UserTable" WHERE user_email ILIKE $1 LIMIT $2',
+        f"%{escaped}%",
+        USER_EMAIL_KEY_FILTER_MAX_USERS + 1,
+    )
+    user_ids = [row["user_id"] for row in rows]
+    if len(user_ids) > USER_EMAIL_KEY_FILTER_MAX_USERS:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "user_email filter matched too many users; use a more specific email fragment"},
+        )
+    return user_ids
 
 
 @router.get(
@@ -5196,7 +5220,7 @@ async def list_keys(
     ),
     user_email: str | None = Query(
         None,
-        description="Filter keys by the owning user's email. Case-insensitive substring match against the user table, capped at the first 1000 matching users; only keys whose user_id belongs to a matching user are returned.",
+        description="Filter keys by the owning user's email. Case-insensitive substring match against the user table; only keys whose user_id belongs to a matching user are returned. Fragments matching more than 50,000 users are rejected with a 400.",
     ),
     team_id: Optional[str] = Query(None, description="Filter keys by team ID"),
     organization_id: Optional[str] = Query(None, description="Filter keys by organization ID"),
@@ -5327,13 +5351,7 @@ async def list_keys(
             user_id = user_api_key_dict.user_id
 
         user_ids_for_email = (
-            [
-                user.user_id
-                for user in await UserRepository(prisma_client).table.find_many(
-                    where={"user_email": {"contains": user_email, "mode": "insensitive"}},
-                    take=USER_EMAIL_KEY_FILTER_MAX_USERS,
-                )
-            ]
+            await _resolve_user_ids_for_email_filter(prisma_client, user_email)
             if user_email and isinstance(user_email, str)
             else None
         )

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -5176,6 +5176,7 @@ async def get_member_team_ids(
 
 
 VALID_EXPIRES_FILTER_VALUES = frozenset({"active", "expired"})
+USER_EMAIL_KEY_FILTER_MAX_USERS = 1000
 
 
 @router.get(
@@ -5195,7 +5196,7 @@ async def list_keys(
     ),
     user_email: str | None = Query(
         None,
-        description="Filter keys by the owning user's email. Case-insensitive substring match against the user table; only keys whose user_id belongs to a matching user are returned.",
+        description="Filter keys by the owning user's email. Case-insensitive substring match against the user table, capped at the first 1000 matching users; only keys whose user_id belongs to a matching user are returned.",
     ),
     team_id: Optional[str] = Query(None, description="Filter keys by team ID"),
     organization_id: Optional[str] = Query(None, description="Filter keys by organization ID"),
@@ -5329,7 +5330,8 @@ async def list_keys(
             [
                 user.user_id
                 for user in await UserRepository(prisma_client).table.find_many(
-                    where={"user_email": {"contains": user_email, "mode": "insensitive"}}
+                    where={"user_email": {"contains": user_email, "mode": "insensitive"}},
+                    take=USER_EMAIL_KEY_FILTER_MAX_USERS,
                 )
             ]
             if user_email and isinstance(user_email, str)

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -5193,6 +5193,10 @@ async def list_keys(
         None,
         description="Filter keys by user ID. Exact match by default; set substring_matching=true (admin only) for case-insensitive substring matching.",
     ),
+    user_email: str | None = Query(
+        None,
+        description="Filter keys by the owning user's email. Case-insensitive substring match against the user table; only keys whose user_id belongs to a matching user are returned.",
+    ),
     team_id: Optional[str] = Query(None, description="Filter keys by team ID"),
     organization_id: Optional[str] = Query(None, description="Filter keys by organization ID"),
     key_hash: Optional[str] = Query(None, description="Filter keys by key hash"),
@@ -5321,6 +5325,17 @@ async def list_keys(
         if not user_id and not is_proxy_admin:
             user_id = user_api_key_dict.user_id
 
+        user_ids_for_email = (
+            [
+                user.user_id
+                for user in await UserRepository(prisma_client).table.find_many(
+                    where={"user_email": {"contains": user_email, "mode": "insensitive"}}
+                )
+            ]
+            if user_email and isinstance(user_email, str)
+            else None
+        )
+
         response = await _list_key_helper(
             prisma_client=prisma_client,
             page=page,
@@ -5343,6 +5358,7 @@ async def list_keys(
             agent_id=agent_id,
             use_substring_matching=use_substring_matching,
             expires_filter=expires if isinstance(expires, str) else None,
+            user_ids_for_email=user_ids_for_email,
         )
 
         verbose_proxy_logger.debug("Successfully prepared response")
@@ -5571,6 +5587,7 @@ def _build_key_filter_conditions(
     agent_id: Optional[str] = None,
     use_substring_matching: bool = False,
     expires_filter: str | None = None,
+    user_ids_for_email: List[str] | None = None,
 ) -> Dict[str, Union[str, Dict[str, Any], List[Dict[str, Any]]]]:
     """Build filter conditions for key listing.
 
@@ -5678,6 +5695,8 @@ def _build_key_filter_conditions(
         where = {"AND": [where, {"access_group_ids": {"hasSome": [access_group_id]}}]}
     if agent_id and isinstance(agent_id, str):
         where = {"AND": [where, {"agent_id": agent_id}]}
+    if user_ids_for_email is not None:
+        where = {"AND": [where, {"user_id": {"in": user_ids_for_email}}]}
     if expires_filter is not None and expires_filter in VALID_EXPIRES_FILTER_VALUES:
         where = {"AND": [where, _build_expires_where_clause(expires_filter, datetime.now(timezone.utc))]}
 
@@ -5710,6 +5729,7 @@ async def _list_key_helper(
     agent_id: Optional[str] = None,
     use_substring_matching: bool = False,
     expires_filter: str | None = None,
+    user_ids_for_email: List[str] | None = None,
 ) -> KeyListResponseObject:
     """
     Helper function to list keys
@@ -5748,6 +5768,7 @@ async def _list_key_helper(
         agent_id=agent_id,
         use_substring_matching=use_substring_matching,
         expires_filter=expires_filter,
+        user_ids_for_email=user_ids_for_email,
     )
 
     # Calculate skip for pagination

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6354,6 +6354,9 @@ async def test_list_keys_user_email_resolves_to_user_ids():
         assert mock_find_many.call_args.kwargs["where"] == {
             "user_email": {"contains": "alias@example.com", "mode": "insensitive"}
         }
+        assert mock_find_many.call_args.kwargs["take"] == 1000, (
+            "user lookup must be bounded; a broad substring like '@' matches every user"
+        )
         assert mock_list_key_helper.call_args.kwargs["user_ids_for_email"] == ["user-1", "user-2"]
 
         mock_find_many.return_value = []

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6255,6 +6255,130 @@ def test_build_key_filter_conditions_agent_id_narrows_visibility():
     assert "agent_id" not in json.dumps(where_without)
 
 
+def test_build_key_filter_conditions_user_email_ids_narrow_visibility():
+    """
+    Filtering /key/list by user_email resolves to a list of user IDs which must
+    be ANDed on top of the caller's visibility conditions (narrow, never widen).
+    An email that matches no users must produce a match-nothing filter rather
+    than being dropped (dropping it would return every visible key).
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _build_key_filter_conditions,
+    )
+
+    where = _build_key_filter_conditions(
+        user_id="some-user",
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=["team-a"],
+        member_team_ids=None,
+        include_created_by_keys=False,
+        user_ids_for_email=["user-1", "user-2"],
+    )
+    assert where.get("AND"), f"expected top-level AND, got: {where}"
+    assert {"user_id": {"in": ["user-1", "user-2"]}} in where["AND"], f"user_id in-filter not ANDed: {where}"
+
+    where_no_match = _build_key_filter_conditions(
+        user_id=None,
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=None,
+        member_team_ids=None,
+        include_created_by_keys=False,
+        user_ids_for_email=[],
+    )
+    assert {"user_id": {"in": []}} in where_no_match["AND"], (
+        f"an email matching no users must match nothing, got: {where_no_match}"
+    )
+
+    where_without = _build_key_filter_conditions(
+        user_id="some-user",
+        team_id=None,
+        organization_id=None,
+        key_alias=None,
+        key_hash=None,
+        exclude_team_id=None,
+        admin_team_ids=None,
+        member_team_ids=None,
+        include_created_by_keys=False,
+    )
+    assert '"in"' not in json.dumps(where_without)
+
+
+@pytest.mark.asyncio
+async def test_list_keys_user_email_resolves_to_user_ids():
+    """
+    list_keys must resolve the user_email filter to user IDs via a
+    case-insensitive substring lookup on the user table and pass them to
+    _list_key_helper. No email filter (including the Query default object
+    from direct calls) must skip the lookup entirely.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+
+    mock_prisma_client = AsyncMock()
+    mock_find_many = AsyncMock(
+        return_value=[SimpleNamespace(user_id="user-1"), SimpleNamespace(user_id="user-2")]
+    )
+    mock_prisma_client.db.litellm_usertable.find_many = mock_find_many
+    mock_list_key_helper = AsyncMock(
+        return_value={"keys": [], "total_count": 0, "current_page": 1, "total_pages": 0}
+    )
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.validate_key_list_check",
+            return_value=None,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints._list_key_helper",
+            mock_list_key_helper,
+        ),
+    ):
+        admin = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin")
+
+        await list_keys(
+            request=Mock(),
+            user_api_key_dict=admin,
+            user_email="alias@example.com",
+            include_team_keys=False,
+            include_created_by_keys=False,
+            status=None,
+        )
+        assert mock_find_many.call_args.kwargs["where"] == {
+            "user_email": {"contains": "alias@example.com", "mode": "insensitive"}
+        }
+        assert mock_list_key_helper.call_args.kwargs["user_ids_for_email"] == ["user-1", "user-2"]
+
+        mock_find_many.return_value = []
+        await list_keys(
+            request=Mock(),
+            user_api_key_dict=admin,
+            user_email="nobody@example.com",
+            include_team_keys=False,
+            include_created_by_keys=False,
+            status=None,
+        )
+        assert mock_list_key_helper.call_args.kwargs["user_ids_for_email"] == []
+
+        mock_find_many.reset_mock()
+        await list_keys(
+            request=Mock(),
+            user_api_key_dict=admin,
+            include_team_keys=False,
+            include_created_by_keys=False,
+            status=None,
+        )
+        mock_find_many.assert_not_called()
+        assert mock_list_key_helper.call_args.kwargs["user_ids_for_email"] is None
+
+
 @pytest.mark.asyncio
 async def test_generate_key_negative_max_budget():
     """

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -6314,19 +6314,16 @@ def test_build_key_filter_conditions_user_email_ids_narrow_visibility():
 @pytest.mark.asyncio
 async def test_list_keys_user_email_resolves_to_user_ids():
     """
-    list_keys must resolve the user_email filter to user IDs via a
-    case-insensitive substring lookup on the user table and pass them to
-    _list_key_helper. No email filter (including the Query default object
-    from direct calls) must skip the lookup entirely.
+    list_keys must resolve the user_email filter to user IDs via a raw
+    id-only case-insensitive substring lookup on the user table and pass
+    them to _list_key_helper. No email filter (including the Query default
+    object from direct calls) must skip the lookup entirely.
     """
-    from types import SimpleNamespace
     from unittest.mock import Mock
 
     mock_prisma_client = AsyncMock()
-    mock_find_many = AsyncMock(
-        return_value=[SimpleNamespace(user_id="user-1"), SimpleNamespace(user_id="user-2")]
-    )
-    mock_prisma_client.db.litellm_usertable.find_many = mock_find_many
+    mock_query_raw = AsyncMock(return_value=[{"user_id": "user-1"}, {"user_id": "user-2"}])
+    mock_prisma_client.db.query_raw = mock_query_raw
     mock_list_key_helper = AsyncMock(
         return_value={"keys": [], "total_count": 0, "current_page": 1, "total_pages": 0}
     )
@@ -6351,15 +6348,13 @@ async def test_list_keys_user_email_resolves_to_user_ids():
             include_created_by_keys=False,
             status=None,
         )
-        assert mock_find_many.call_args.kwargs["where"] == {
-            "user_email": {"contains": "alias@example.com", "mode": "insensitive"}
-        }
-        assert mock_find_many.call_args.kwargs["take"] == 1000, (
-            "user lookup must be bounded; a broad substring like '@' matches every user"
-        )
+        sql, pattern, limit = mock_query_raw.call_args.args
+        assert "ILIKE" in sql and 'FROM "LiteLLM_UserTable"' in sql
+        assert pattern == "%alias@example.com%"
+        assert limit == 50_001, "lookup must be bounded so an over-broad fragment cannot fetch the whole table"
         assert mock_list_key_helper.call_args.kwargs["user_ids_for_email"] == ["user-1", "user-2"]
 
-        mock_find_many.return_value = []
+        mock_query_raw.return_value = []
         await list_keys(
             request=Mock(),
             user_api_key_dict=admin,
@@ -6370,7 +6365,7 @@ async def test_list_keys_user_email_resolves_to_user_ids():
         )
         assert mock_list_key_helper.call_args.kwargs["user_ids_for_email"] == []
 
-        mock_find_many.reset_mock()
+        mock_query_raw.reset_mock()
         await list_keys(
             request=Mock(),
             user_api_key_dict=admin,
@@ -6378,8 +6373,35 @@ async def test_list_keys_user_email_resolves_to_user_ids():
             include_created_by_keys=False,
             status=None,
         )
-        mock_find_many.assert_not_called()
+        mock_query_raw.assert_not_called()
         assert mock_list_key_helper.call_args.kwargs["user_ids_for_email"] is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_ids_for_email_filter_escapes_wildcards_and_refuses_overflow():
+    """
+    LIKE wildcards typed by the user must match literally, and a fragment
+    matching more than the ceiling must 400 instead of silently truncating
+    the id list (truncation would make /key/list drop visible keys).
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        USER_EMAIL_KEY_FILTER_MAX_USERS,
+        _resolve_user_ids_for_email_filter,
+    )
+
+    mock_prisma_client = AsyncMock()
+    mock_query_raw = AsyncMock(return_value=[{"user_id": "user-1"}])
+    mock_prisma_client.db.query_raw = mock_query_raw
+
+    result = await _resolve_user_ids_for_email_filter(mock_prisma_client, "50%_off\\weird")
+    assert result == ["user-1"]
+    assert mock_query_raw.call_args.args[1] == "%50\\%\\_off\\\\weird%"
+
+    mock_query_raw.return_value = [{"user_id": f"user-{i}"} for i in range(USER_EMAIL_KEY_FILTER_MAX_USERS + 1)]
+    with pytest.raises(HTTPException) as exc_info:
+        await _resolve_user_ids_for_email_filter(mock_prisma_client, "@")
+    assert exc_info.value.status_code == 400
+    assert "too many users" in str(exc_info.value.detail)
 
 
 @pytest.mark.asyncio

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.ts
@@ -32,6 +32,7 @@ export interface KeyListCallOptions {
   agentID?: string | null;
   selectedKeyAlias?: string | null;
   userID?: string | null;
+  userEmail?: string | null;
   keyHash?: string | null;
   sortBy?: string | null;
   sortOrder?: string | null;
@@ -55,6 +56,7 @@ const keyListCall = async (accessToken: string, page: number, pageSize: number, 
         key_alias: options.selectedKeyAlias,
         key_hash: options.keyHash,
         user_id: options.userID,
+        user_email: options.userEmail,
         page,
         size: pageSize,
         sort_by: options.sortBy,

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -38,6 +38,7 @@ const FILTER_LABELS: Record<string, string> = {
   team_id: "Team",
   org_id: "Organization",
   user_id: "User ID",
+  user_email: "User Email",
   key_hash: "Key ID",
 };
 
@@ -71,6 +72,7 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
     organizationID: getFilterValue("org_id"),
     selectedKeyAlias: searchQuery.trim() || undefined,
     userID: getFilterValue("user_id"),
+    userEmail: getFilterValue("user_email"),
     keyHash: getFilterValue("key_hash"),
     sortBy,
     sortOrder,
@@ -231,6 +233,13 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
                       value={(get("user_id") as string) ?? ""}
                       onChange={(event) => set("user_id", event.target.value)}
                       placeholder="Enter User ID…"
+                    />
+                  </DataTableFilterField>
+                  <DataTableFilterField label="User Email">
+                    <Input
+                      value={(get("user_email") as string) ?? ""}
+                      onChange={(event) => set("user_email", event.target.value)}
+                      placeholder="Enter User Email…"
                     />
                   </DataTableFilterField>
                   <DataTableFilterField label="Key ID">

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -42813,7 +42813,7 @@ export interface operations {
                 size?: number;
                 /** @description Filter keys by user ID. Exact match by default; set substring_matching=true (admin only) for case-insensitive substring matching. */
                 user_id?: string | null;
-                /** @description Filter keys by the owning user's email. Case-insensitive substring match against the user table; only keys whose user_id belongs to a matching user are returned. */
+                /** @description Filter keys by the owning user's email. Case-insensitive substring match against the user table, capped at the first 1000 matching users; only keys whose user_id belongs to a matching user are returned. */
                 user_email?: string | null;
                 /** @description Filter keys by team ID */
                 team_id?: string | null;

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -42813,6 +42813,8 @@ export interface operations {
                 size?: number;
                 /** @description Filter keys by user ID. Exact match by default; set substring_matching=true (admin only) for case-insensitive substring matching. */
                 user_id?: string | null;
+                /** @description Filter keys by the owning user's email. Case-insensitive substring match against the user table; only keys whose user_id belongs to a matching user are returned. */
+                user_email?: string | null;
                 /** @description Filter keys by team ID */
                 team_id?: string | null;
                 /** @description Filter keys by organization ID */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -42813,7 +42813,7 @@ export interface operations {
                 size?: number;
                 /** @description Filter keys by user ID. Exact match by default; set substring_matching=true (admin only) for case-insensitive substring matching. */
                 user_id?: string | null;
-                /** @description Filter keys by the owning user's email. Case-insensitive substring match against the user table, capped at the first 1000 matching users; only keys whose user_id belongs to a matching user are returned. */
+                /** @description Filter keys by the owning user's email. Case-insensitive substring match against the user table; only keys whose user_id belongs to a matching user are returned. Fragments matching more than 50,000 users are rejected with a 400. */
                 user_email?: string | null;
                 /** @description Filter keys by team ID */
                 team_id?: string | null;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Admins can't find a user's keys by email on the Virtual Keys page
- /key/list only filters by user_id, which nobody remembers

How it solves it:

- New user_email param on /key/list, case-insensitive substring match
- Email resolves via raw id-only SQL, complete match set, wildcards escaped
- Email resolves to user IDs, ANDed into the existing where-clause
- Virtual Keys filter drawer gains a User Email field

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at 139dc60e5b against a live proxy running this branch, seeded with two fresh users each owning one key:

```
$ curl -s 'http://localhost:4093/user/new' -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"user_email":"qa-alice-20463@example.com","auto_create_key":false}'   # and same for qa-bob-20463
c2481c13-2037-4e9b-9279-5c1971496925 qa-alice-20463@example.com
9e48342f-659e-4149-82cf-adb3370eab67 qa-bob-20463@example.com

$ curl -s 'http://localhost:4093/key/list?user_email=qa-alice-20463&return_full_object=true' -H 'Authorization: Bearer sk-1234'
total: 1
qa-key-alice-20463 c2481c13-2037-4e9b-9279-5c1971496925

$ curl -s 'http://localhost:4093/key/list?user_email=QA-ALICE-20463@EXAMPLE&return_full_object=true' -H 'Authorization: Bearer sk-1234'
total: 1
qa-key-alice-20463 c2481c13-2037-4e9b-9279-5c1971496925

$ curl -s 'http://localhost:4093/key/list?user_email=-20463@example.com&return_full_object=true' -H 'Authorization: Bearer sk-1234'
total: 2
qa-key-bob-20463 9e48342f-659e-4149-82cf-adb3370eab67
qa-key-alice-20463 c2481c13-2037-4e9b-9279-5c1971496925

$ curl -s 'http://localhost:4093/key/list?user_email=nobody-99999@nowhere.test&return_full_object=true' -H 'Authorization: Bearer sk-1234'
total: 0 keys: 0

$ curl -s 'http://localhost:4093/key/list?return_full_object=true&size=100' -H 'Authorization: Bearer sk-1234'
total without filter: 8
```

Re-run at 45f3ac556b after moving the lookup to raw id-only SQL, same seeded users:

```
$ curl -s 'http://localhost:4093/key/list?user_email=qa-alice-20463&return_full_object=true' -H 'Authorization: Bearer sk-1234'
total: 1
qa-key-alice-20463 c2481c13-2037-4e9b-9279-5c1971496925

$ curl -s 'http://localhost:4093/key/list?user_email=QA-ALICE-20463@EXAMPLE&return_full_object=true' -H 'Authorization: Bearer sk-1234'
total: 1

$ curl -s 'http://localhost:4093/key/list?user_email=qa-%25lice&return_full_object=true' -H 'Authorization: Bearer sk-1234'
total: 0 (typed % must not act as a LIKE wildcard)

$ curl -s 'http://localhost:4093/key/list?user_email=qa-alice_20463&return_full_object=true' -H 'Authorization: Bearer sk-1234'
total: 0 (typed _ must not match the - in qa-alice-20463)

$ curl -s 'http://localhost:4093/key/list?user_email=@&return_full_object=true&size=100' -H 'Authorization: Bearer sk-1234'
total: 2

$ curl -s 'http://localhost:4093/key/list?return_full_object=true&size=100' -H 'Authorization: Bearer sk-1234'
total: 8 (no filter, unchanged)
```

(key/list output piped through python to print total_count and key_alias/user_id per key)

For the UI half: open http://localhost:3000/?page=api-keys, click the filter icon in the Virtual Keys toolbar, type an email fragment into the new User Email field, and the table narrows to that user's keys; a User Email chip appears in the toolbar. UI screenshots to be posted below

## Type

🆕 New Feature

## Changes

Backend: /key/list accepts user_email. list_keys resolves it to user IDs with a case-insensitive substring lookup on LiteLLM_UserTable, then _build_key_filter_conditions ANDs a user_id in-filter on top of the caller's visibility conditions, so the filter can only narrow what the caller could already see. An email matching no users yields an empty in-list and therefore zero keys rather than silently dropping the filter. The email-to-id resolution is a raw SQL query selecting only user_id (find_many materializes full rows), with LIKE wildcards in the fragment escaped so user input cannot widen the match. It returns the complete match set, so the filter never silently drops visible keys; a fragment matching more than 50,000 users gets a 400 asking for a more specific fragment instead of building an IN clause that large. Visibility scoping stays entirely in the existing Prisma where-builder, so there is a single implementation of the key-visibility contract

Frontend: the Virtual Keys filter drawer gains a User Email input wired through useKeys to the new param, plus the toolbar chip label. schema.d.ts regenerated

Tests: unit tests pin the AND-narrowing semantics (including the empty-match case, where dropping the filter would return every visible key) and the email-to-user-id resolution in list_keys, including that omitting the param skips the lookup

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
