### PR TITLE
fix(proxy): hash caller-supplied key in key update audit log object_id

### DIFF
--- a/litellm/proxy/hooks/key_management_event_hooks.py
+++ b/litellm/proxy/hooks/key_management_event_hooks.py
@@ -18,6 +18,7 @@ from litellm.proxy._types import (
     UpdateKeyRequest,
     UserAPIKeyAuth,
 )
+from litellm.proxy.utils import _hash_token_if_needed
 
 # NOTE: This is the prefix for all virtual keys stored in AWS Secrets Manager
 LITELLM_PREFIX_STORED_VIRTUAL_KEYS = "litellm/"
@@ -124,7 +125,7 @@ class KeyManagementEventHooks:
                         ),
                         changed_by_api_key=user_api_key_dict.api_key,
                         table_name=LitellmTableNames.KEY_TABLE_NAME,
-                        object_id=data.key,
+                        object_id=_hash_token_if_needed(data.key),
                         action="updated",
                         updated_values=_updated_values,
                         before_value=_before_value,

--- a/tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py
+++ b/tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py
@@ -434,3 +434,71 @@ class TestRotateVirtualKeyInSecretManager:
 
         # Verify async_rotate_secret was NOT called
         mock_secret_manager.async_rotate_secret.assert_not_called()
+
+
+class TestKeyUpdatedAuditLogObjectId:
+    """Tests that /key/update audit logs never store the raw virtual key (issue #31620)."""
+
+    async def _run_updated_hook_and_capture_audit_log(self, request_key: str):
+        import asyncio
+
+        from litellm.proxy._types import (
+            LiteLLM_VerificationToken,
+            UpdateKeyRequest,
+            UserAPIKeyAuth,
+        )
+        from litellm.proxy.utils import hash_token
+
+        captured = []
+
+        async def capture_audit_log(request_data):
+            captured.append(request_data)
+
+        existing_key_row = LiteLLM_VerificationToken(
+            token=hash_token("sk-raw-test-key-31620"),
+            key_name="sk-...1620",
+        )
+
+        with (
+            patch("litellm.store_audit_logs", True),
+            patch(
+                "litellm.proxy.management_helpers.audit_logs.create_audit_log_for_update",
+                new=capture_audit_log,
+            ),
+        ):
+            await KeyManagementEventHooks.async_key_updated_hook(
+                data=UpdateKeyRequest(key=request_key, max_budget=2000.0),
+                existing_key_row=existing_key_row,
+                response=MagicMock(),
+                user_api_key_dict=UserAPIKeyAuth(api_key="sk-admin-key", user_id="admin"),
+            )
+            pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+            await asyncio.gather(*pending)
+
+        assert len(captured) == 1
+        return captured[0]
+
+    @pytest.mark.asyncio
+    async def test_update_audit_log_hashes_raw_key_in_object_id(self):
+        """A raw sk- key sent to /key/update must be stored hashed in object_id."""
+        from litellm.proxy.utils import hash_token
+
+        raw_key = "sk-raw-test-key-31620"
+
+        audit_row = await self._run_updated_hook_and_capture_audit_log(request_key=raw_key)
+
+        assert audit_row.object_id == hash_token(raw_key)
+        assert raw_key not in audit_row.object_id
+        assert raw_key not in str(audit_row.updated_values)
+        assert raw_key not in str(audit_row.before_value)
+
+    @pytest.mark.asyncio
+    async def test_update_audit_log_passes_through_hashed_key(self):
+        """An already-hashed token sent to /key/update is stored unchanged."""
+        from litellm.proxy.utils import hash_token
+
+        hashed_key = hash_token("sk-raw-test-key-31620")
+
+        audit_row = await self._run_updated_hook_and_capture_audit_log(request_key=hashed_key)
+
+        assert audit_row.object_id == hashed_key

--- a/tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py
+++ b/tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py
@@ -472,8 +472,10 @@ class TestKeyUpdatedAuditLogObjectId:
                 response=MagicMock(),
                 user_api_key_dict=UserAPIKeyAuth(api_key="sk-admin-key", user_id="admin"),
             )
-            pending = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
-            await asyncio.gather(*pending)
+            for _ in range(100):
+                if captured:
+                    break
+                await asyncio.sleep(0.01)
 
         assert len(captured) == 1
         return captured[0]


### PR DESCRIPTION
## TLDR

Problem this solves:

- With audit logging enabled, `/key/update` wrote the caller-supplied raw `sk-` virtual key into `LiteLLM_AuditLog.object_id`, storing the full secret in plaintext in the audit table and forwarding it to external audit sinks
- Every other key audit path already stores the hashed token (`created` uses `response.token_id`, `rotated`/`deleted` use the DB `token`, `/key/block` and `/key/unblock` hash before logging); the update hook was the one remaining leak

How it solves it:

- `async_key_updated_hook` now runs the caller-supplied key through `_hash_token_if_needed` before storing it as `object_id`, the same helper `/key/block`, `/key/unblock`, the DB lookup, and the cache invalidation on this exact request path already use
- A raw `sk-` key is hashed to the key's token id; an already-hashed token (what the dashboard sends) passes through unchanged, so `object_id` is now always the hashed token for key `updated` rows
- The fix lands at `LiteLLM_AuditLogs` construction time, so both the DB row and the audit-log callback sinks receive the hashed value, and all callers of the hook are covered (`/key/update`, temp budget increases, `/key/bulk_update`, team bulk key updates)

`updated_values` and `before_value` were already masked by the `mask_api_keys` validator on `LiteLLM_AuditLogs` (the reporter observed the same); `object_id` was the only field storing the full raw key

## Relevant issues

Fixes #31620

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Admin UI on this branch's live proxy, after changing the key's Max Budget from the Keys page. The Audit Logs table shows both worlds at once: the row written before this fix (10:02:34) has the raw `sk-ZKNNr...` key in the Object ID column, while every row written after the fix, including the one produced by the UI edit (10:28:35), shows the 64-char hashed token that matches the Key ID on the key's Settings page. All keys shown are throwaway keys on a disposable local DB

![Audit Logs table showing pre-fix raw key row and post-fix hashed rows](https://raw.githubusercontent.com/yucheng-berri/litellm/assets-pr34632/31620-ui-2-audit-logs-table.png)

![Editing the key's max budget in the Admin UI](https://raw.githubusercontent.com/yucheng-berri/litellm/assets-pr34632/31620-ui-1-edit-budget.png)

![Audit log drawer for the post-fix update row](https://raw.githubusercontent.com/yucheng-berri/litellm/assets-pr34632/31620-ui-3-audit-drawer.png)

Live proxy (this branch's worktree) + real Postgres, `litellm_settings.store_audit_logs: true`, premium enabled. Raw keys below are redacted; both were throwaway keys on a disposable local DB

Before the fix (staging HEAD 57894b5b5e):

```
$ curl -sS -X POST http://127.0.0.1:20620/key/generate \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"key_alias":"audit-repro-31620","max_budget":100}'
{"key":"sk-ZKNNr...", ...}

$ curl -sS -X POST http://127.0.0.1:20620/key/update \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"key":"sk-ZKNNr...","max_budget":2000}'
HTTP 200

$ docker exec litfix-pg-31620 psql -U llmproxy -d litellm -c \
    'SELECT action, object_id FROM "LiteLLM_AuditLog" ORDER BY updated_at;'
 created | 13b3a824523f7bca3c103f757c4a9c21ffb0767adf6b9112f47f81f7efd315a3
 updated | sk-ZKNNr...                    <- full raw key stored in plaintext

$ ... SELECT action, object_id = '<raw key>' FROM "LiteLLM_AuditLog";
 created | f
 updated | t                              <- exact raw key match
```

After the fix (same flow, new key `sk-0K3k8...`, hashed token `a8eeef82f238...`):

```
$ curl -sS -X POST http://127.0.0.1:20620/key/update \
    -d '{"key":"sk-0K3k8...","max_budget":2000}'          # raw key sent
HTTP 200
$ curl -sS -X POST http://127.0.0.1:20620/key/delete -d '{"keys":["sk-0K3k8..."]}'
HTTP 200

$ ... SELECT action, object_id FROM "LiteLLM_AuditLog" ORDER BY updated_at;
 created | a8eeef82f2388518a0e12a23da48fb39d18632d3f4591d555fb62ec5c891f83c
 updated | a8eeef82f2388518a0e12a23da48fb39d18632d3f4591d555fb62ec5c891f83c
 deleted | a8eeef82f2388518a0e12a23da48fb39d18632d3f4591d555fb62ec5c891f83c

$ ... SELECT count(*) FROM "LiteLLM_AuditLog" WHERE object_id = '<raw key>';
 0
```

Dashboard-style update (caller sends the hashed token `f18e6778a171...`) stores it unchanged:

```
$ curl -sS -X POST http://127.0.0.1:20620/key/update \
    -d '{"key":"f18e6778a171...","max_budget":500}'
HTTP 200
 created | f18e6778a171d8dff286fb298c31c3283b3a0946003e9c154ac23359baf41752
 updated | f18e6778a171d8dff286fb298c31c3283b3a0946003e9c154ac23359baf41752
```

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/hooks/key_management_event_hooks.py`: `async_key_updated_hook` stores `_hash_token_if_needed(data.key)` as `object_id` instead of the raw caller-supplied key; `_hash_token_if_needed` is now imported at module top (import verified cycle-free in all orders)
- `tests/test_litellm/proxy/hooks/test_key_management_event_hooks.py`: new `TestKeyUpdatedAuditLogObjectId` regression tests; the raw-key test fails on unfixed code (asserts `object_id == hash_token(raw_key)` and that the raw key appears nowhere in the audit row), the second test pins the hashed-token passthrough

## Behavior changes

- Key `updated` audit rows now store the hashed token in `object_id` (matching `created`, `rotated`, `deleted`, `blocked`, `unblocked` rows) instead of whatever string the caller sent. Anyone filtering the enterprise `GET /audit` endpoint's `object_id` param by a raw `sk-` key will no longer match new rows; filtering by the hashed token (or the existing `object_key_hash` param, which was already hash-based) is the supported path and is now consistent across all key actions
- Audit-log callback sinks (S3, Datadog, etc.) receive the hashed token in `StandardAuditLogPayload.object_id` for key updates; they previously received the raw key, which was the same leak in a second location
- Existing audit rows written before this fix keep the raw key in `object_id`; this PR does not migrate them. Deployments that had `store_audit_logs` enabled should treat historical key `updated` rows as containing live secrets and clean or rotate accordingly

## QA runbook

1. Run a proxy with a `LITELLM_LICENSE`, a Postgres `DATABASE_URL`, and `litellm_settings.store_audit_logs: true`
2. `curl -X POST :4000/key/generate -H "Authorization: Bearer $MASTER_KEY" -d '{"key_alias":"qa-31620"}'` and keep the returned raw `sk-` key
3. `curl -X POST :4000/key/update -H "Authorization: Bearer $MASTER_KEY" -d '{"key":"<raw key>","max_budget":2000}'`
4. `SELECT action, object_id FROM "LiteLLM_AuditLog" ORDER BY updated_at;` and confirm the `updated` row's `object_id` is the 64-char hashed token (identical to the `created` row), with no `sk-` value anywhere in `object_id`
5. Repeat the update sending the hashed token as `key` (what the Admin UI sends from the Keys page, Edit Settings, change Max Budget, Save) and confirm the row is identical

UI flow (verified end to end against this branch's live proxy with the bundled dashboard):

1. Log in at `http://localhost:4000/ui` (admin / master key)
2. Virtual Keys, click the key, Settings tab, Edit Settings, change Max Budget, Save Changes
3. Logs, Audit Logs tab: the new `Updated` / `Keys` row's Object ID column shows the 64-char hashed token, identical to the `Created` row and to the Key ID shown on the key's Settings page; rows written before this fix still show the raw `sk-` key in the same column, which is the leak this PR stops

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
