### PR TITLE
fix(bedrock): stop replaying expired Google OIDC tokens to STS on guardrail auth

### DIFF
--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -78,8 +78,10 @@ class BaseAWSLLM:
     # Storage is in-process memory only: default ``DualCache()`` has no Redis backend unless attached
     # elsewhere. Entry TTL: static access-key + secret + region use ``_get_default_ttl_for_boto3_credentials``
     # (~59 minutes); ambient env (``_auth_with_env_vars`` returns ``ttl=None``) uses ``InMemoryCache``'s
-    # ``default_ttl`` (600 seconds / 10 minutes). AssumeRole, web identity, profiles, and explicit
-    # session-token tuples are not cached — see ``get_credentials`` and ``_get_or_set_cached_credentials``.
+    # ``default_ttl`` (600 seconds / 10 minutes); web identity STS credentials use
+    # ``_get_default_ttl_for_boto3_credentials`` (~59 minutes), keyed on all aws_* credential args
+    # plus ssl_verify. AssumeRole, profiles, and explicit session-token tuples are not cached — see
+    # ``get_credentials`` and ``_get_or_set_cached_credentials``.
     _shared_iam_cache: ClassVar[DualCache] = DualCache()
 
     def __init__(self) -> None:
@@ -136,11 +138,12 @@ class BaseAWSLLM:
         which ``InMemoryCache.set_cache`` resolves to ``default_ttl`` (600 seconds / 10 minutes by
         default).
 
-        Used only for static access-key credentials and ambient credentials from
+        Used for static access-key credentials, ambient credentials from
         ``_auth_with_env_vars`` (including when skipping AssumeRole because the runtime identity
-        already matches ``aws_role_name``).
+        already matches ``aws_role_name``), and web identity STS credentials (plain
+        non-refreshable ``Credentials`` cached ~59 min, inside the 3600s STS session).
 
-        AssumeRole, web identity exchange, profiles, and explicit session-token tuples are not
+        AssumeRole, profiles, and explicit session-token tuples are not
         cached here — shared ``Credentials`` / refresh state must not span logical sessions.
         """
         cache_key = self.get_cache_key(credential_args)
@@ -266,23 +269,26 @@ class BaseAWSLLM:
         #   Credentials - boto3.Credentials
         #   cache ttl - Optional[int]. If None, the credentials are not cached. Some auth flows have no expiry time.
         #
-        # iam_cache: static keys and ambient env only (including skip-AssumeRole path).
-        # Do not cache AssumeRole / web identity / profile / explicit session-token paths here.
+        # iam_cache: static keys, ambient env (including skip-AssumeRole path), and web identity.
+        # Do not cache AssumeRole / profile / explicit session-token paths here.
         #########################################################
         if self._is_auth_with_web_identity_token(
             aws_web_identity_token,
             aws_role_name,
             aws_session_name,
         ):
-            credentials, _cache_ttl = self._auth_with_web_identity_token(
-                aws_web_identity_token=cast(str, aws_web_identity_token),
-                aws_role_name=cast(str, aws_role_name),
-                aws_session_name=cast(str, aws_session_name),
-                aws_region_name=aws_region_name,
-                aws_sts_endpoint=aws_sts_endpoint,
-                aws_external_id=aws_external_id,
+            return self._get_or_set_cached_credentials(
+                args,
+                lambda: self._auth_with_web_identity_token(
+                    aws_web_identity_token=cast(str, aws_web_identity_token),
+                    aws_role_name=cast(str, aws_role_name),
+                    aws_session_name=cast(str, aws_session_name),
+                    aws_region_name=aws_region_name,
+                    aws_sts_endpoint=aws_sts_endpoint,
+                    aws_external_id=aws_external_id,
+                    ssl_verify=ssl_verify,
+                ),
             )
-            return credentials
         elif self._is_auth_with_aws_role(aws_role_name):
             # Same role (IRSA/ECS/EC2): ambient creds via _get_or_set_cached_credentials like the
             # default env branch; never pre-read cache (must run _is_already_running_as_role first).

--- a/litellm/secret_managers/main.py
+++ b/litellm/secret_managers/main.py
@@ -1,9 +1,12 @@
 import ast
+import base64
 import os
+import time
 import traceback
 from typing import Optional, Union
 
 import httpx
+from pydantic import BaseModel, ValidationError
 
 import litellm
 from litellm._logging import verbose_logger
@@ -15,6 +18,33 @@ from litellm.secret_managers.get_azure_ad_token_provider import (
 from litellm.secret_managers.secret_manager_handler import get_secret_from_manager
 
 oidc_cache = DualCache()
+
+
+_OIDC_TOKEN_EXPIRY_MARGIN_SECONDS = 60
+
+
+class _OidcTokenClaims(BaseModel):
+    exp: float | None = None
+
+
+def _oidc_token_cache_ttl(oidc_token: str, max_ttl: int) -> int:
+    """Cache TTL for a fetched OIDC token: ``max_ttl``, capped so the cache entry
+    never outlives the token's own ``exp`` claim (minus a safety margin).
+    Falls back to ``max_ttl`` when the token carries no readable ``exp``."""
+    segments = oidc_token.split(".")
+    if len(segments) != 3:
+        return max_ttl
+    payload = segments[1]
+    try:
+        decoded = base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
+        claims = _OidcTokenClaims.model_validate_json(decoded)
+        if claims.exp is None:
+            return max_ttl
+        exp = int(claims.exp)
+    except (ValueError, OverflowError, ValidationError):
+        return max_ttl
+    return min(max_ttl, exp - int(time.time()) - _OIDC_TOKEN_EXPIRY_MARGIN_SECONDS)
+
 
 _DEFAULT_OIDC_ALLOWED_CREDENTIAL_DIRS = ("/var/run/secrets", "/run/secrets")
 
@@ -187,7 +217,15 @@ def get_secret(
             )
             if response.status_code == 200:
                 oidc_token = response.text
-                oidc_cache.set_cache(key=secret_name, value=oidc_token, ttl=3600 - 60)
+                ttl = _oidc_token_cache_ttl(oidc_token, 3600 - 60)
+                if ttl > 0:
+                    oidc_cache.set_cache(key=secret_name, value=oidc_token, ttl=ttl)
+                else:
+                    verbose_logger.warning(
+                        "Google OIDC token for %s is already expired or expires within %ss; not caching it",
+                        secret_name,
+                        _OIDC_TOKEN_EXPIRY_MARGIN_SECONDS,
+                    )
                 return oidc_token
             else:
                 raise ValueError("Google OIDC provider failed")

--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -292,21 +292,55 @@ def test_web_identity_token_oidc_reference_still_resolved():
     assert exc.value.status_code == 401
 
 
-def test_web_identity_path_not_cached_in_iam_cache():
+def test_web_identity_credentials_cached_in_iam_cache():
+    """
+    Web identity STS credentials are cached for their STS lifetime, so repeated
+    get_credentials calls (e.g. per-request guardrail auth) reuse the assumed-role
+    credentials instead of replaying the OIDC token to STS on every request.
+    """
     base = BaseAWSLLM()
     with patch.object(
         base,
         "_auth_with_web_identity_token",
-        return_value=(Credentials("wi-ak", "wi-sk", "wi-tok"), None),
+        return_value=(Credentials("wi-ak", "wi-sk", "wi-tok"), 3540),
     ) as mock_wi:
         kwargs = dict(
-            aws_web_identity_token="jwt-token",
+            aws_web_identity_token="oidc/google/https://example.com/",
             aws_role_name="arn:aws:iam::123456789012:role/WebIdentity",
             aws_session_name="web-id-session",
         )
-        base.get_credentials(**kwargs)
-        base.get_credentials(**kwargs)
+        first = base.get_credentials(**kwargs)
+        second = base.get_credentials(**kwargs)
+        assert mock_wi.call_count == 1
+        assert first is second
+
+
+def test_web_identity_cache_is_keyed_on_credential_args():
+    """
+    Two web identity configs that differ in any credential arg (here the role)
+    must not share cached credentials.
+    """
+    base = BaseAWSLLM()
+    with patch.object(
+        base,
+        "_auth_with_web_identity_token",
+        side_effect=[
+            (Credentials("wi-ak-a", "wi-sk-a", "wi-tok-a"), 3540),
+            (Credentials("wi-ak-b", "wi-sk-b", "wi-tok-b"), 3540),
+        ],
+    ) as mock_wi:
+        first = base.get_credentials(
+            aws_web_identity_token="oidc/google/https://example.com/",
+            aws_role_name="arn:aws:iam::123456789012:role/RoleA",
+            aws_session_name="web-id-session",
+        )
+        second = base.get_credentials(
+            aws_web_identity_token="oidc/google/https://example.com/",
+            aws_role_name="arn:aws:iam::123456789012:role/RoleB",
+            aws_session_name="web-id-session",
+        )
         assert mock_wi.call_count == 2
+        assert first.access_key != second.access_key
 
 
 def test_boto3_init_tracer_wrapping():

--- a/tests/test_litellm/secret_managers/test_secret_managers_main.py
+++ b/tests/test_litellm/secret_managers/test_secret_managers_main.py
@@ -1,5 +1,8 @@
+import base64
+import json
 import logging
 import os
+import time
 from unittest.mock import Mock, patch
 
 import pytest
@@ -93,6 +96,100 @@ def test_oidc_google_cached():
     assert result == "cached_token", f"Expected cached token, got {result}"
     mock_oidc_cache.get_cache.assert_called_with(key=secret_name)
     mock_get_http_handler.assert_not_called()
+
+
+def _jwt_with_exp(exp: int) -> str:
+    header = base64.urlsafe_b64encode(json.dumps({"alg": "RS256"}).encode()).rstrip(b"=").decode()
+    payload = base64.urlsafe_b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=").decode()
+    return f"{header}.{payload}.signature"
+
+
+def test_oidc_google_cache_ttl_capped_by_token_exp():
+    """A token the metadata server returns near its expiry must not be cached past
+    its exp claim; the cached-entry TTL is exp - now - 60s, not the 59m default."""
+    secret_name = "oidc/google/https://example.com/api"
+    mock_handler = MockHTTPHandler(timeout=600.0)
+    mock_handler.text = _jwt_with_exp(int(time.time()) + 300)
+    mock_get_http_handler = Mock(return_value=mock_handler)
+    mock_oidc_cache = Mock()
+    mock_oidc_cache.get_cache.return_value = None
+
+    with patch("litellm.secret_managers.main.oidc_cache", mock_oidc_cache):
+        with patch(
+            "litellm.secret_managers.main._get_oidc_http_handler",
+            mock_get_http_handler,
+        ):
+            result = get_secret(secret_name)
+
+    assert result == mock_handler.text
+    mock_oidc_cache.set_cache.assert_called_once()
+    ttl = mock_oidc_cache.set_cache.call_args.kwargs["ttl"]
+    assert 0 < ttl <= 240
+
+
+def test_oidc_google_expired_token_not_cached():
+    """An already-expired token is returned (STS gives the authoritative error) but
+    never cached, so the next call fetches a fresh token instead of replaying it."""
+    secret_name = "oidc/google/https://example.com/api"
+    mock_handler = MockHTTPHandler(timeout=600.0)
+    mock_handler.text = _jwt_with_exp(int(time.time()) - 10)
+    mock_get_http_handler = Mock(return_value=mock_handler)
+    mock_oidc_cache = Mock()
+    mock_oidc_cache.get_cache.return_value = None
+
+    with patch("litellm.secret_managers.main.oidc_cache", mock_oidc_cache):
+        with patch(
+            "litellm.secret_managers.main._get_oidc_http_handler",
+            mock_get_http_handler,
+        ):
+            result = get_secret(secret_name)
+
+    assert result == mock_handler.text
+    mock_oidc_cache.set_cache.assert_not_called()
+
+
+def test_oidc_google_long_lived_token_still_capped_at_default_ttl():
+    """A token expiring far in the future must not extend the cache past the
+    59m policy ceiling; exp only ever shortens the TTL."""
+    secret_name = "oidc/google/https://example.com/api"
+    mock_handler = MockHTTPHandler(timeout=600.0)
+    mock_handler.text = _jwt_with_exp(int(time.time()) + 7200)
+    mock_get_http_handler = Mock(return_value=mock_handler)
+    mock_oidc_cache = Mock()
+    mock_oidc_cache.get_cache.return_value = None
+
+    with patch("litellm.secret_managers.main.oidc_cache", mock_oidc_cache):
+        with patch(
+            "litellm.secret_managers.main._get_oidc_http_handler",
+            mock_get_http_handler,
+        ):
+            result = get_secret(secret_name)
+
+    assert result == mock_handler.text
+    mock_oidc_cache.set_cache.assert_called_once_with(
+        key=secret_name, value=mock_handler.text, ttl=3540
+    )
+
+
+def test_oidc_google_non_jwt_token_keeps_default_ttl():
+    """A token without a readable exp claim falls back to the 59m default TTL."""
+    secret_name = "oidc/google/https://example.com/api"
+    mock_handler = MockHTTPHandler(timeout=600.0)
+    mock_get_http_handler = Mock(return_value=mock_handler)
+    mock_oidc_cache = Mock()
+    mock_oidc_cache.get_cache.return_value = None
+
+    with patch("litellm.secret_managers.main.oidc_cache", mock_oidc_cache):
+        with patch(
+            "litellm.secret_managers.main._get_oidc_http_handler",
+            mock_get_http_handler,
+        ):
+            result = get_secret(secret_name)
+
+    assert result == "mocked_token"
+    mock_oidc_cache.set_cache.assert_called_once_with(
+        key=secret_name, value="mocked_token", ttl=3540
+    )
 
 
 def test_oidc_google_failure():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock guardrails authenticating with `aws_web_identity_token: oidc/google/<audience>` (proxy hosted on GCP, federating into AWS) fail with `AWS STS rejected the web identity token: An error occurred (InvalidIdentityToken) when calling the AssumeRoleWithWebIdentity operation: The web identity token provided could not be validated` and stay broken for up to 59 minutes at a stretch. Reported by a customer after upgrading; a blocker because every Bedrock guardrail call fails while the window lasts
- Two stacked causes. `get_secret` caches the Google OIDC token for a flat 59 minutes keyed on fetch time, ignoring the token's own `exp` claim, and the GCE metadata server serves cached identity tokens that can arrive with only minutes of validity left. Since #27125 (v1.85.0) web identity STS credentials are no longer cached, so every guardrail request replays that cached token to STS; the moment the token's real expiry passes inside the 59 minute window, every guardrail call fails until the cache rolls

How it solves it:

- `oidc/google` tokens are now cached for `min(59min, exp - now - 60s)`, derived from the token's own `exp` claim; a token already expired or within 60s of expiry is returned for immediate use but never cached, with a warning logged. An expired token can therefore never be replayed from cache
- The web identity branch of `BaseAWSLLM.get_credentials` routes through `_get_or_set_cached_credentials` again with the ~59 minute TTL that `_auth_with_web_identity_token` already returns, restoring the pre-v1.85.0 behavior. STS is exchanged roughly once an hour per credential config instead of on every request

## Relevant issues

## Linear ticket

Resolves LIT-4803

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

![Unfixed: expired cached OIDC token replayed to STS, exact reported error](https://raw.githubusercontent.com/yucheng-berri/litellm/assets-pr34637/shot1_unfixed_repro.png)

![Fixed: same timeline all green, one STS exchange, block still enforced](https://raw.githubusercontent.com/yucheng-berri/litellm/assets-pr34637/shot2_fixed_verify.png)

![Real GCP-to-AWS federation soak: unfixed fails persistently at token expiry, fixed 34/34 green](https://raw.githubusercontent.com/yucheng-berri/litellm/assets-pr34637/shot3_real_soak.png)

Verified on a live proxy (real Postgres, real Anthropic completions, real AWS Bedrock ApplyGuardrail evaluating and blocking content). The two external trust pieces that cannot exist outside a customer's GCP+AWS federation, the GCE metadata endpoint and the AWS-side OIDC trust, are stood in by a local rig that mints Google-format JWTs with a 90s validity and an STS endpoint that validates the token `exp` exactly as AWS does (returning AWS's `InvalidIdentityToken` XML for expired tokens) and otherwise vends real temporary AWS credentials, so the entire litellm code path and the real guardrail evaluation run unmodified. Two guardrails `bedrock-pre-a` and `bedrock-pre-b` share the token reference but use distinct roles

Request used throughout:

```bash
curl -sS http://127.0.0.1:20803/v1/chat/completions \
  -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"hi, what is 2+2?"}],"guardrails":["bedrock-pre-a"]}'
```

Before (staging tip, unfixed). t=0 succeeds, and the same request 125s later fails on every guardrail with the exact reported error, persistently:

```text
17:38:11Z t=0    guardrail bedrock-pre-a  ->  200  "Four."
17:40:18Z t=+125s guardrail bedrock-pre-a ->  500
{"error":{"message":"Bedrock guardrail failed: AWS STS rejected the web identity token: An error occurred (InvalidIdentityToken) when calling the AssumeRoleWithWebIdentity operation: The web identity token provided could not be validated. See the AssumeRoleWithWebIdentity documentation for requirements.. Token aud='https://demo-proxy.example/', iss='https://accounts.google.com'", ...}}
17:40:19Z t=+125s guardrail bedrock-pre-b ->  500  (same error)
17:40:20Z t=+125s guardrail bedrock-pre-a ->  500  (same error, every request keeps failing)
stub counters: metadata fetches did not move (expired token replayed from cache), STS hit on every request: {"meta_calls": 4, "sts_calls": 9, "sts_expired": 3}
```

After (this branch). Same timeline, same rig:

```text
17:40:54Z t=0     guardrail bedrock-pre-a -> 200  "Four."
          5 more requests through bedrock-pre-a -> 200 200 200 200 200  (one STS exchange total; credentials served from cache)
17:43:07Z t=+125s guardrail bedrock-pre-a -> 200  (cached STS credentials, zero STS traffic)
17:43:08Z t=+125s guardrail bedrock-pre-b -> 200  (token cache honored exp and had rolled; a fresh token was fetched instead of replaying the expired one)
17:43:09Z t=+125s blocked-word request through bedrock-pre-b -> 400 "Violated guardrail policy" (real ApplyGuardrail still enforcing)
stub counters: {"sts_expired": 3} unchanged; no expired token was ever sent to STS after the fix
```

Mutation check: the three behavior tests fail on the unfixed tree (`3 failed`) and pass with the fix (150 passed across both touched test files)

### Real-environment soak (GCE VM, real Google tokens, real STS federation, real Bedrock)

A second verification ran on a real GCE VM with genuine GCP-to-AWS federation: real Google-signed identity tokens from the metadata server, exchanged at real AWS STS through an `accounts.google.com` IAM OIDC provider and a role scoped to the VM's service account, calling the real Bedrock guardrail. Unfixed (staging tip) and fixed proxies ran side by side for 67 minutes on the same token, probed every 2 minutes. The only simulated piece was a thin cache in front of the metadata server that re-serves the same real token until its true exp; plain GCE and current GKE Workload Identity both mint fresh tokens per fetch (observed: 14/14 fresh over 70 min on a real Autopilot cluster), so the aged-token behavior that customers hit comes from a caching layer in their own serving stack, which the thin cache reproduces with real tokens

```text
21:57:43Z T0        both proxies fetch the same real token (exp 22:57:43Z); both 200
21:57..22:56        32 probes green on both; fixed proxy does exactly 1 STS exchange (credentials cached), unfixed does 1 per request
22:56:49Z           59min cache boundary: metadata layer re-serves the real token with 54s left
                    unfixed: re-caches it for another 59min (the bug)
                    fixed:   logs "Google OIDC token ... is already expired or expires within 60s; not caching it",
                             uses it once while still valid, real STS accepts, credentials cached
23:02:56Z onward    unfixed: every probe 500, real STS rejects the replayed token
                    ("An error occurred (ExpiredTokenException) ... Token expired: current date/time ... must be before the expiration")
                    fixed:   still 200, zero failures across all 34 probes
```

Real STS rejected the minutes-stale replay with `ExpiredTokenException`; the reported production error was `InvalidIdentityToken ... could not be validated`, which is the signature-validation failure an even staler replay produces once the signing key rotates out of Google's JWKS. Both are the same defect class (replaying a cached token past its exp), and the fix removes the class: a token is never served from cache past its own expiry

## Type

🐛 Bug Fix

## Changes

- `litellm/secret_managers/main.py`: new `_oidc_token_cache_ttl` helper (unverified decode of the JWT `exp` claim via a small pydantic model) caps the `oidc/google` cache TTL at `exp - now - 60s`; skips caching entirely when that is non-positive and logs a warning
- `litellm/llms/bedrock/base_aws_llm.py`: the web identity branch of `get_credentials` uses `_get_or_set_cached_credentials` with the TTL the auth helper already returned (previously discarded); `ssl_verify` is now forwarded to the STS client on this path; stale comments updated
- tests: flipped `test_web_identity_path_not_cached_in_iam_cache` to assert caching (the uncached behavior is the regression this PR fixes), added a cache-keying test, and four `oidc/google` TTL tests (near-expiry capped, expired never cached, far-future capped at 59m, non-JWT falls back)

Behavior changes:

- web identity STS credentials are cached again in the process-wide IAM cache for ~59 minutes, keyed on all `aws_*` credential args plus `ssl_verify`; this restores the pre-v1.85.0 behavior that #27125 removed. Distinct token/role/session configs never share an entry, and the cached object is a plain non-refreshable `Credentials` whose TTL sits inside the 3600s STS session
- Google OIDC tokens are never cached past their own `exp`; a proxy fetching near-expiry tokens from the GCE metadata server will refetch more often than the previous flat 59 minutes
- `ssl_verify` now reaches the web identity STS client; previously it participated in the cache key but was silently dropped for the STS call itself

Deferred, tracked in the Linear ticket: the `oidc/github` branch has the same flat-TTL shape (295s cache vs a ~300s token) and can reuse `_oidc_token_cache_ttl`; the unverified-JWT decode duplicated between this helper and `_unverified_web_identity_audience` belongs in a shared `litellm_core_utils` helper; the `InvalidIdentityToken` diagnostic could also print the token's remaining lifetime

## QA runbook

1. Run a Postgres and the proxy off this branch with a config containing a Bedrock guardrail using `aws_web_identity_token: oidc/google/<your audience>`, `aws_role_name`, `aws_session_name` (and optionally `aws_sts_endpoint`)
2. On a GCP host with real federation: send a chat completion with `"guardrails": ["<guardrail_name>"]` once an hour for a few hours; every request must return 200 and the log must never show `AWS STS rejected the web identity token`
3. Off GCP, reproduce with the rig described above (fake metadata via `HTTP_PROXY`, STS stub via `aws_sts_endpoint`, 90s token validity): request at t=0, then at t=+125s; before this PR the second request returns 500 `InvalidIdentityToken`, after it both return 200
4. Confirm credential caching: N back-to-back requests through the same guardrail produce exactly one `AssumeRoleWithWebIdentity` exchange
5. `uv run pytest tests/test_litellm/secret_managers/test_secret_managers_main.py tests/test_litellm/llms/bedrock/test_base_aws_llm.py`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
