### PR TITLE
test: stop bedrock tool acompletion tests from making real network calls

### DIFF
--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -1093,53 +1093,57 @@ def test_transform_response_with_structured_response_calling_tool():
     )
 
 
+def _mock_converse_response() -> MagicMock:
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.headers = {}
+    mock_response.json.return_value = {
+        "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+        "stopReason": "end_turn",
+        "usage": {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15},
+    }
+    mock_response.text = json.dumps(mock_response.json.return_value)
+    return mock_response
+
+
+async def _acompletion_captured_request_body(tools: list, messages: list) -> dict:
+    from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
+
+    client = AsyncHTTPHandler()
+    with patch.object(client, "post", return_value=_mock_converse_response()) as mock_post:
+        response = await litellm.acompletion(
+            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+            messages=messages,
+            tools=tools,
+            aws_access_key_id="fake-access-key",
+            aws_secret_access_key="fake-secret-key",
+            aws_region_name="us-west-2",
+            client=client,
+        )
+
+    assert response.choices[0].message.content == "ok"
+    mock_post.assert_called_once()
+    assert mock_post.call_args.kwargs["url"].endswith("/converse")
+    return json.loads(mock_post.call_args.kwargs["data"])
+
+
 @pytest.mark.asyncio
 async def test_bedrock_bash_tool_acompletion():
-    """Test Bedrock with bash tool for ls command using acompletion."""
-
-    # Test with bash tool instead of computer tool
+    """Bash tool rides acompletion into the converse request body without any network call."""
     tools = [
         {
             "type": "bash_20241022",
             "name": "bash",
         }
     ]
-
     messages = [{"role": "user", "content": "run ls command and find all python files"}]
 
-    try:
-        response = await litellm.acompletion(
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            messages=messages,
-            tools=tools,
-            # Using dummy API key - test should fail with auth error, proving request formatting works
-            api_key="dummy-key-for-testing",
-        )
-        # If we get here, something's wrong - we expect an auth error
-        assert False, "Expected authentication error but got successful response"
-    except Exception as e:
-        error_str = str(e).lower()
+    request_body = await _acompletion_captured_request_body(tools=tools, messages=messages)
 
-        # Check if it's an expected authentication/credentials error
-        auth_error_indicators = [
-            "credentials",
-            "authentication",
-            "unauthorized",
-            "access denied",
-            "aws",
-            "region",
-            "profile",
-            "token",
-            "invalid",
-            "signature",
-        ]
-
-        if any(auth_error in error_str for auth_error in auth_error_indicators):
-            # This is expected - request formatting succeeded, auth failed as expected
-            assert True
-        else:
-            # Unexpected error - might be tool handling issue
-            pytest.fail(f"Unexpected error (might be tool handling issue): {e}")
+    additional_fields = request_body["additionalModelRequestFields"]
+    assert additional_fields["tools"] == [{"type": "bash_20241022", "name": "bash"}]
+    assert "anthropic_beta" in additional_fields
+    assert request_body["messages"][0]["content"][0]["text"] == "run ls command and find all python files"
 
 
 @pytest.mark.asyncio
@@ -1172,39 +1176,16 @@ async def test_bedrock_computer_use_acompletion():
         }
     ]
 
-    try:
-        response = await litellm.acompletion(
-            model="bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
-            messages=messages,
-            tools=tools,
-            # Using dummy API key - test should fail with auth error, proving request formatting works
-            api_key="dummy-key-for-testing",
-        )
-        # If we get here, something's wrong - we expect an auth error
-        assert False, "Expected authentication error but got successful response"
-    except Exception as e:
-        error_str = str(e).lower()
+    request_body = await _acompletion_captured_request_body(tools=tools, messages=messages)
 
-        # Check if it's an expected authentication/credentials error
-        auth_error_indicators = [
-            "credentials",
-            "authentication",
-            "unauthorized",
-            "access denied",
-            "aws",
-            "region",
-            "profile",
-            "token",
-            "invalid",
-            "signature",
-        ]
-
-        if any(auth_error in error_str for auth_error in auth_error_indicators):
-            # This is expected - request formatting succeeded, auth failed as expected
-            assert True
-        else:
-            # Unexpected error - might be tool handling issue
-            pytest.fail(f"Unexpected error (might be tool handling issue): {e}")
+    additional_fields = request_body["additionalModelRequestFields"]
+    assert additional_fields["anthropic_beta"] == ["computer-use-2025-01-24"]
+    computer_tools = [tool for tool in additional_fields["tools"] if tool.get("type") == "computer_20250124"]
+    assert computer_tools[0]["display_height_px"] == 768
+    assert computer_tools[0]["display_width_px"] == 1024
+    image_blocks = [block for block in request_body["messages"][0]["content"] if "image" in block]
+    assert image_blocks[0]["image"]["format"] == "png"
+    assert image_blocks[0]["image"]["source"]["bytes"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Two bedrock unit tests call the real AWS API
- Network stalls hang CI until the 20 minute job cap

How it solves it:

- Inject a mocked HTTP client, no wire traffic
- Assert the actual converse request body instead of an auth error

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR only changes unit tests, so the failure and the fix both live in test execution rather than proxy behavior. Before: on run [30168575662](https://github.com/BerriAI/litellm/actions/runs/30168575662) (PR #33082, unrelated auth change, commit 77e5aca) the "All Other Providers" job log shows `test_bedrock_bash_tool_acompletion` stalling for 153s on its first attempt at 18:07, entering `RERUN` at 18:09:34, then 358s of silence until the 20 minute cap cancelled the job; the shard normally finishes in about 10 minutes. After (this branch): the full file runs in under a second with no sockets opened, because the only HTTP client involved is an injected mock

```
$ pytest tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py -q
165 passed, 2 warnings in 0.69s
```

## Type

✅ Test

## Changes

`test_bedrock_bash_tool_acompletion` and `test_bedrock_computer_use_acompletion` in `tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py` sent real HTTPS requests to bedrock-runtime with `api_key="dummy-key-for-testing"` and treated any auth-flavored error string as proof that request formatting worked. Under network stalls the call blocks for minutes, and the `--reruns 2` CI flag re-runs the hang, which is how the provider transformation job blew through its 20 minute cap

Both tests now pass an `AsyncHTTPHandler` into `litellm.acompletion` with its `post` patched to return a canned converse response. They assert stronger things than before: the request went to the `/converse` endpoint, the bash and computer tools land in `additionalModelRequestFields.tools` with their display parameters, `anthropic_beta` carries `computer-use-2025-01-24`, the data URI image is transformed into a converse image block with png format and raw bytes, and the mocked response parses back into a normal completion. The old version only checked that some error string contained words like "aws" or "invalid", which could pass even if tool formatting broke, and could never distinguish a formatting regression from a network blip

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
