### PR TITLE
fix(redis): use inspect.signature so redis-py v7+ keeps parsing env config

### DIFF
--- a/.github/workflows/test-redis-compat.yml
+++ b/.github/workflows/test-redis-compat.yml
@@ -1,0 +1,74 @@
+name: "Unit Tests: Redis Client Version Compatibility"
+
+on:
+  pull_request:
+    branches:
+      - main
+      - litellm_internal_staging
+      - litellm_oss_staging
+      - "litellm_**"
+    paths:
+      - "litellm/_redis.py"
+      - "litellm/_redis_credential_provider.py"
+      - "tests/test_litellm/test_redis.py"
+      - ".github/workflows/test-redis-compat.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  redis-compat:
+    name: "redis-py ${{ matrix.redis-version }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # 5.3.1 is the version pinned in uv.lock (redisvl caps it below 6); the
+        # newer legs prove the inspect.signature introspection in litellm/_redis.py
+        # keeps extracting kwargs on the redis-py releases people actually run now.
+        # Only the exact release 6.0.0 is skipped: rq (pulled by the proxy extra)
+        # specifies `redis != 6`, which excludes 6.0.0 alone, so 6.4.0 stands in
+        # for the 6.x line.
+        redis-version: ["5.3.1", "6.4.0", "7.4.1", "8.0.1"]
+
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: ./.github/actions/setup-uv-with-retries
+        with:
+          version: "0.10.9"
+
+      - name: Install dependencies
+        run: |
+          .github/scripts/uv_sync_with_retries.sh --frozen --group ci --group proxy-dev --extra google --extra proxy --extra semantic-router
+
+      - name: Pin redis-py to the matrix version
+        env:
+          REDIS_VERSION: ${{ matrix.redis-version }}
+        run: |
+          uv pip install "redis==${REDIS_VERSION:?}"
+          uv run --no-sync python -c "import redis; assert redis.__version__ == '${REDIS_VERSION:?}', redis.__version__; print('redis-py', redis.__version__)"
+
+      - name: Run redis unit tests
+        run: |
+          uv run --no-sync pytest tests/test_litellm/test_redis.py \
+            --tb=short -vv \
+            --reruns 2 \
+            --reruns-delay 1 \
+            --durations=20

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -80,19 +80,19 @@ def _get_redis_url_kwargs(client=None):
 
     include_args = ["url"]
 
-    available_args = [x for x in _get_signature_arg_names(redis.Redis.from_url) if x not in exclude_args] + include_args
+    available_args = [x for x in _get_signature_arg_names(client) if x not in exclude_args] + include_args
 
     return available_args
 
 
 def _get_redis_cluster_kwargs(client=None):
     if client is None:
-        client = redis.Redis.from_url
+        client = redis.RedisCluster
 
     # Only allow primitive arguments
     exclude_args = {"self", "connection_pool", "retry", "host", "port", "startup_nodes"}
 
-    available_args = {x for x in _get_signature_arg_names(redis.RedisCluster) if x not in exclude_args}
+    available_args = {x for x in _get_signature_arg_names(client) if x not in exclude_args}
     available_args |= {
         "password",
         "username",
@@ -571,7 +571,7 @@ def get_redis_async_client(
     if "startup_nodes" in redis_kwargs:
         from redis.cluster import ClusterNode
 
-        args = _get_redis_cluster_kwargs()
+        args = _get_redis_cluster_kwargs(client=async_redis.RedisCluster)
         cluster_kwargs = {}
         for arg in redis_kwargs:
             if arg in args:

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -35,9 +35,15 @@ from ._logging import verbose_logger
 AZURE_REDIS_SCOPE = "https://redis.azure.com/.default"
 
 
-def _get_redis_kwargs():
-    arg_spec = inspect.getfullargspec(redis.Redis)
+def _get_signature_arg_names(obj: Callable) -> List[str]:
+    return [
+        name
+        for name, param in inspect.signature(obj).parameters.items()
+        if param.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+    ]
 
+
+def _get_redis_kwargs():
     # Only allow primitive arguments
     exclude_args = {
         "self",
@@ -56,7 +62,7 @@ def _get_redis_kwargs():
         "azure_client_secret",
     }
 
-    available_args = {x for x in arg_spec.args if x not in exclude_args} | include_args
+    available_args = {x for x in _get_signature_arg_names(redis.Redis) if x not in exclude_args} | include_args
 
     return available_args
 
@@ -64,7 +70,6 @@ def _get_redis_kwargs():
 def _get_redis_url_kwargs(client=None):
     if client is None:
         client = redis.Redis.from_url
-    arg_spec = inspect.getfullargspec(redis.Redis.from_url)
 
     # Only allow primitive arguments
     exclude_args = {
@@ -75,7 +80,7 @@ def _get_redis_url_kwargs(client=None):
 
     include_args = ["url"]
 
-    available_args = [x for x in arg_spec.args if x not in exclude_args] + include_args
+    available_args = [x for x in _get_signature_arg_names(redis.Redis.from_url) if x not in exclude_args] + include_args
 
     return available_args
 
@@ -83,12 +88,11 @@ def _get_redis_url_kwargs(client=None):
 def _get_redis_cluster_kwargs(client=None):
     if client is None:
         client = redis.Redis.from_url
-    arg_spec = inspect.getfullargspec(redis.RedisCluster)
 
     # Only allow primitive arguments
     exclude_args = {"self", "connection_pool", "retry", "host", "port", "startup_nodes"}
 
-    available_args = {x for x in arg_spec.args if x not in exclude_args}
+    available_args = {x for x in _get_signature_arg_names(redis.RedisCluster) if x not in exclude_args}
     available_args |= {
         "password",
         "username",

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -548,7 +548,7 @@ class ProxyLogging:
 
         for hook in PROXY_HOOKS:
             proxy_hook = get_proxy_hook(hook)
-            expected_args = inspect.getfullargspec(proxy_hook).args
+            expected_args = list(inspect.signature(proxy_hook).parameters.keys())
             passed_in_args: Dict[str, Any] = {}
             if "internal_usage_cache" in expected_args:
                 passed_in_args["internal_usage_cache"] = self.internal_usage_cache

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -744,11 +744,11 @@ class Router:
         """
         Returns a list of valid arguments for the Router.__init__ method.
         """
-        arg_spec = inspect.getfullargspec(Router.__init__)
-        valid_args = arg_spec.args + arg_spec.kwonlyargs
-        if "self" in valid_args:
-            valid_args.remove("self")
-        return valid_args
+        return [
+            name
+            for name, param in inspect.signature(Router.__init__).parameters.items()
+            if name != "self" and param.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        ]
 
     def apply_default_settings(self):
         """

--- a/tests/documentation_tests/test_router_settings.py
+++ b/tests/documentation_tests/test_router_settings.py
@@ -26,10 +26,10 @@ def get_init_params(cls: Type) -> list[str]:
         )
 
     init_method = cls.__init__
-    argspec = inspect.getfullargspec(init_method)
+    sig = inspect.signature(init_method)
 
     # The first argument is usually 'self', so we exclude it
-    return argspec.args[1:]  # Exclude 'self'
+    return [x for x in sig.parameters.keys() if x != 'self']
 
 
 router_init_params = set(get_init_params(litellm.router.Router))

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -4,9 +4,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 import redis
 import redis.asyncio as async_redis
+import inspect
 
 from litellm._redis import (
     _get_redis_cluster_kwargs,
+    _get_redis_kwargs,
+    _get_redis_url_kwargs,
+    _get_signature_arg_names,
     get_redis_async_client,
     get_redis_client,
     get_redis_connection_pool,
@@ -133,10 +137,7 @@ def test_get_redis_url_from_environment_missing_host_port(monkeypatch):
         get_redis_url_from_environment()
 
     # Check the error message
-    assert (
-        "Either 'REDIS_URL' or both 'REDIS_HOST' and 'REDIS_PORT' must be specified"
-        in str(excinfo.value)
-    )
+    assert "Either 'REDIS_URL' or both 'REDIS_HOST' and 'REDIS_PORT' must be specified" in str(excinfo.value)
 
 
 def test_get_redis_url_from_environment_missing_port(monkeypatch):
@@ -151,18 +152,28 @@ def test_get_redis_url_from_environment_missing_port(monkeypatch):
         get_redis_url_from_environment()
 
     # Check the error message
-    assert (
-        "Either 'REDIS_URL' or both 'REDIS_HOST' and 'REDIS_PORT' must be specified"
-        in str(excinfo.value)
-    )
+    assert "Either 'REDIS_URL' or both 'REDIS_HOST' and 'REDIS_PORT' must be specified" in str(excinfo.value)
+
+
+def test_get_signature_arg_names_strips_var_args_and_kwargs():
+    """The introspection helper must drop *args/**kwargs so a catch-all signature
+    like Redis.from_url(url, **kwargs) never leaks a bogus 'kwargs' entry into the
+    allow-list. Regression for redis-py v7 where from_url/RedisCluster expose **kwargs."""
+
+    def fn(url, host="localhost", *args, timeout=None, **kwargs):
+        return None
+
+    names = _get_signature_arg_names(fn)
+
+    assert names == ["url", "host", "timeout"]
+    assert "args" not in names
+    assert "kwargs" not in names
 
 
 def test_max_connections_in_cluster_kwargs():
     """Test that max_connections is included in Redis cluster kwargs"""
     kwargs = _get_redis_cluster_kwargs()
-    assert (
-        "max_connections" in kwargs
-    ), "max_connections should be in available Redis cluster kwargs"
+    assert "max_connections" in kwargs, "max_connections should be in available Redis cluster kwargs"
 
 
 def test_socket_timeouts_in_cluster_kwargs():
@@ -212,6 +223,164 @@ def test_async_cluster_reconnect_defaults_are_overridable(mock_cluster_cls):
     assert call_kwargs["socket_keepalive"] is False
 
 
+def test_signature_vs_getfullargspec_with_redis_decorator():
+    """
+    Regression test for Redis 7.1+ compatibility.
+
+    Redis-py 7.1 introduced a @deprecated_args decorator on Redis.__init__ that wraps
+    the method. Even though it uses functools.wraps, inspect.getfullargspec() cannot
+    properly introspect through the wrapper and returns an empty args list, while
+    inspect.signature() correctly unwraps and returns all parameters.
+
+    This test replicates the exact decorator pattern to document why we migrated
+    from getfullargspec() to signature().
+    """
+    from functools import wraps
+    from typing import Callable, TypeVar
+
+    C = TypeVar("C", bound=Callable)
+
+    # Replicate redis-py's @deprecated_args decorator pattern
+    def deprecated_args(args_to_warn=None, reason="", version=""):
+        def decorator(func: C) -> C:
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                return func(*args, **kwargs)
+
+            return wrapper
+
+        return decorator
+
+    # Create a mock Redis class with the decorator (like redis-py 7.1+)
+    class MockRedisWithDecorator:
+        @deprecated_args(args_to_warn=["retry_on_timeout"], version="6.0.0")
+        def __init__(self, host="localhost", port=6379, db=0, password=None):
+            self.host = host
+            self.port = port
+
+    # Test getfullargspec - it fails to see through the wrapper
+    spec = inspect.getfullargspec(MockRedisWithDecorator.__init__)
+    getfullargspec_args = spec.args
+
+    # Test signature - it properly unwraps and sees the real parameters
+    sig = inspect.signature(MockRedisWithDecorator.__init__)
+    signature_params = list(sig.parameters.keys())
+
+    # Document the issue: getfullargspec sees only the wrapper's (*args, **kwargs)
+    # which results in 0 named args, while signature sees the original 5 parameters
+    assert len(getfullargspec_args) == 0, "getfullargspec incorrectly returns 0 args for decorated function"
+    assert len(signature_params) == 5, "signature correctly returns 5 parameters"
+    assert "self" in signature_params, "signature finds 'self' parameter"
+    assert "host" in signature_params, "signature finds 'host' parameter"
+    assert "port" in signature_params, "signature finds 'port' parameter"
+    assert "host" not in getfullargspec_args, "getfullargspec fails to find 'host' parameter"
+
+    # This is why we use signature() instead of getfullargspec() in:
+    # - _get_redis_kwargs()
+    # - _get_redis_url_kwargs()
+    # - _get_redis_cluster_kwargs()
+
+
+def test_get_redis_kwargs_works_with_actual_redis_class():
+    """
+    Integration test: Verify _get_redis_kwargs() works with real redis.Redis class.
+
+    This catches regressions when redis-py library updates add decorators or
+    change class structure that might break our introspection.
+    """
+    import redis
+
+    # Get kwargs from the actual Redis class
+    kwargs = _get_redis_kwargs()
+
+    # Critical: Should NOT be empty
+    assert len(kwargs) > 0, (
+        "CRITICAL: _get_redis_kwargs() returned empty list! "
+        "This likely means redis-py updated their decorators/class structure. "
+        f"Redis version: {redis.__version__}"
+    )
+
+    # Should have at least these common Redis parameters
+    expected_params = ["host", "port", "db", "password"]
+    for param in expected_params:
+        assert param in kwargs, (
+            f"Expected parameter '{param}' missing from Redis kwargs. "
+            f"Redis version: {redis.__version__}. "
+            "This may indicate redis-py structural changes."
+        )
+
+    # Excluded params should NOT be present
+    excluded_params = ["self", "connection_pool", "retry"]
+    for param in excluded_params:
+        assert param not in kwargs, f"Parameter '{param}' should be excluded but was found in kwargs"
+
+
+def test_get_redis_url_kwargs_works_with_actual_redis_class():
+    """
+    Integration test: Verify _get_redis_url_kwargs() works with real redis.Redis.from_url.
+
+    This catches regressions when redis-py library updates might break our introspection.
+    """
+    import redis
+
+    # Get kwargs from the actual Redis.from_url method
+    kwargs = _get_redis_url_kwargs()
+
+    # Critical: Should NOT be empty
+    assert len(kwargs) > 0, (
+        "CRITICAL: _get_redis_url_kwargs() returned empty list! "
+        "This likely means redis-py updated their decorators/class structure. "
+        f"Redis version: {redis.__version__}"
+    )
+
+    # Should definitely include 'url' parameter
+    assert "url" in kwargs, f"'url' parameter missing from Redis.from_url kwargs. Redis version: {redis.__version__}"
+
+    # Excluded params should NOT be present
+    excluded_params = ["self", "connection_pool", "retry", "kwargs"]
+    for param in excluded_params:
+        assert param not in kwargs, f"Parameter '{param}' should be excluded but was found in kwargs"
+
+
+def test_get_redis_cluster_kwargs_works_with_actual_redis_class():
+    """
+    Integration test: Verify _get_redis_cluster_kwargs() works with real redis.RedisCluster.
+
+    This catches regressions when redis-py library updates might break our introspection.
+    """
+    import redis
+
+    # Get kwargs from the actual RedisCluster class
+    kwargs = _get_redis_cluster_kwargs()
+
+    # Critical: Should NOT be empty
+    assert len(kwargs) > 0, (
+        "CRITICAL: _get_redis_cluster_kwargs() returned empty list! "
+        "This likely means redis-py updated their decorators/class structure. "
+        f"Redis version: {redis.__version__}"
+    )
+
+    # Should have these cluster-specific parameters we explicitly add
+    expected_custom_params = [
+        "max_connections",
+        "password",
+        "username",
+        "ssl",
+        "ssl_cert_reqs",
+        "ssl_check_hostname",
+        "ssl_ca_certs",
+    ]
+    for param in expected_custom_params:
+        assert param in kwargs, (
+            f"Expected parameter '{param}' missing from RedisCluster kwargs. Redis version: {redis.__version__}"
+        )
+
+    # Excluded params should NOT be present
+    excluded_params = ["self", "connection_pool", "retry", "host", "port", "startup_nodes", "kwargs"]
+    for param in excluded_params:
+        assert param not in kwargs, f"Parameter '{param}' should be excluded but was found in kwargs"
+
+
 def test_get_redis_async_client_with_connection_pool():
     """Test that connection_pool parameter is properly passed to Redis client"""
     # Create a mock connection pool
@@ -222,7 +391,6 @@ def test_get_redis_async_client_with_connection_pool():
         patch("litellm._redis.async_redis.Redis") as mock_redis,
         patch("litellm._redis._get_redis_client_logic") as mock_logic,
     ):
-
         # Configure mock to return basic redis kwargs
         mock_logic.return_value = {"host": "localhost", "port": 6379, "db": 0}
 
@@ -231,12 +399,8 @@ def test_get_redis_async_client_with_connection_pool():
 
         # Verify Redis was called with connection_pool in kwargs
         call_kwargs = mock_redis.call_args[1]
-        assert (
-            "connection_pool" in call_kwargs
-        ), "connection_pool should be passed to Redis client"
-        assert (
-            call_kwargs["connection_pool"] == mock_pool
-        ), "connection_pool should match the provided pool"
+        assert "connection_pool" in call_kwargs, "connection_pool should be passed to Redis client"
+        assert call_kwargs["connection_pool"] == mock_pool, "connection_pool should match the provided pool"
 
 
 def test_get_redis_async_client_without_connection_pool():
@@ -245,7 +409,6 @@ def test_get_redis_async_client_without_connection_pool():
         patch("litellm._redis.async_redis.Redis") as mock_redis,
         patch("litellm._redis._get_redis_client_logic") as mock_logic,
     ):
-
         # Configure mock to return basic redis kwargs
         mock_logic.return_value = {"host": "localhost", "port": 6379, "db": 0}
 
@@ -254,9 +417,7 @@ def test_get_redis_async_client_without_connection_pool():
 
         # Verify Redis was called without connection_pool in kwargs
         call_kwargs = mock_redis.call_args[1]
-        assert (
-            "connection_pool" not in call_kwargs
-        ), "connection_pool should not be in kwargs when not provided"
+        assert "connection_pool" not in call_kwargs, "connection_pool should not be in kwargs when not provided"
 
 
 def test_gcp_iam_credential_provider_get_credentials():
@@ -328,9 +489,7 @@ def test_gcp_iam_credential_provider_cache_shared_across_instances():
     share one cached token so concurrent Redis connections don't each trigger
     a blocking IAM round-trip.
     """
-    service_account = (
-        "projects/-/serviceAccounts/shared@project.iam.gserviceaccount.com"
-    )
+    service_account = "projects/-/serviceAccounts/shared@project.iam.gserviceaccount.com"
 
     with patch(
         "litellm._redis_credential_provider._generate_gcp_iam_access_token",
@@ -355,9 +514,7 @@ def test_get_redis_async_client_gcp_cluster_uses_credential_provider():
     startup_nodes = [{"host": "redis-node-1", "port": 6379}]
 
     mock_connect_func = MagicMock()
-    mock_connect_func._gcp_service_account = (
-        "projects/-/serviceAccounts/sa@project.iam.gserviceaccount.com"
-    )
+    mock_connect_func._gcp_service_account = "projects/-/serviceAccounts/sa@project.iam.gserviceaccount.com"
 
     redis_kwargs = {
         "startup_nodes": startup_nodes,
@@ -374,15 +531,11 @@ def test_get_redis_async_client_gcp_cluster_uses_credential_provider():
     cluster_call_kwargs = mock_cluster.call_args[1]
 
     # Must use credential_provider, not a static password
-    assert (
-        "credential_provider" in cluster_call_kwargs
-    ), "async GCP cluster must use credential_provider for per-connection token refresh"
-    assert isinstance(
-        cluster_call_kwargs["credential_provider"], GCPIAMCredentialProvider
+    assert "credential_provider" in cluster_call_kwargs, (
+        "async GCP cluster must use credential_provider for per-connection token refresh"
     )
-    assert (
-        "password" not in cluster_call_kwargs
-    ), "async GCP cluster must not use a static password (expires after 1h)"
+    assert isinstance(cluster_call_kwargs["credential_provider"], GCPIAMCredentialProvider)
+    assert "password" not in cluster_call_kwargs, "async GCP cluster must not use a static password (expires after 1h)"
 
 
 @patch("litellm._redis.init_redis_cluster")
@@ -399,9 +552,7 @@ def test_sync_client_prefers_cluster_over_url(mock_init_cluster, monkeypatch):
 
     mock_init_cluster.assert_called_once()
     call_kwargs = mock_init_cluster.call_args[0][0]
-    assert (
-        "startup_nodes" in call_kwargs
-    ), "startup_nodes must be forwarded to init_redis_cluster"
+    assert "startup_nodes" in call_kwargs, "startup_nodes must be forwarded to init_redis_cluster"
 
 
 @patch("litellm._redis.async_redis.RedisCluster")
@@ -417,18 +568,12 @@ def test_async_client_prefers_cluster_over_url(mock_cluster_cls, monkeypatch):
 
     mock_cluster_cls.assert_called_once()
     call_kwargs = mock_cluster_cls.call_args[1]
-    assert (
-        "startup_nodes" in call_kwargs
-    ), "startup_nodes must be forwarded to async RedisCluster"
-    assert (
-        len(call_kwargs["startup_nodes"]) == 1
-    ), "should forward exactly 1 cluster node"
+    assert "startup_nodes" in call_kwargs, "startup_nodes must be forwarded to async RedisCluster"
+    assert len(call_kwargs["startup_nodes"]) == 1, "should forward exactly 1 cluster node"
 
 
 @patch("litellm._redis.async_redis.RedisCluster")
-def test_async_client_prefers_cluster_over_url_via_env_var(
-    mock_cluster_cls, monkeypatch
-):
+def test_async_client_prefers_cluster_over_url_via_env_var(mock_cluster_cls, monkeypatch):
     """
     Test get_redis_async_client returns async RedisCluster when REDIS_CLUSTER_NODES is set
     even if REDIS_URL is also set.
@@ -443,15 +588,11 @@ def test_async_client_prefers_cluster_over_url_via_env_var(
 
     mock_cluster_cls.assert_called_once()
     call_kwargs = mock_cluster_cls.call_args[1]
-    assert (
-        "startup_nodes" in call_kwargs
-    ), "startup_nodes must be forwarded to async RedisCluster"
+    assert "startup_nodes" in call_kwargs, "startup_nodes must be forwarded to async RedisCluster"
 
 
 @patch("litellm._redis.init_redis_cluster")
-def test_sync_client_prefers_cluster_over_url_via_env_var(
-    mock_init_cluster, monkeypatch
-):
+def test_sync_client_prefers_cluster_over_url_via_env_var(mock_init_cluster, monkeypatch):
     """
     Test get_redis_client returns RedisCluster when REDIS_CLUSTER_NODES is set even if
     REDIS_URL is also set.
@@ -467,9 +608,7 @@ def test_sync_client_prefers_cluster_over_url_via_env_var(
 
     mock_init_cluster.assert_called_once()
     call_kwargs = mock_init_cluster.call_args[0][0]
-    assert (
-        "startup_nodes" in call_kwargs
-    ), "startup_nodes must be forwarded to init_redis_cluster"
+    assert "startup_nodes" in call_kwargs, "startup_nodes must be forwarded to init_redis_cluster"
     assert len(call_kwargs["startup_nodes"]) == 1
 
 
@@ -588,9 +727,7 @@ def test_async_sentinel_uses_sentinel_password_and_master_password(
 
 
 @patch("litellm._redis.init_redis_cluster")
-def test_sync_client_preserves_password_for_cluster_when_url_also_set(
-    mock_init_cluster, monkeypatch
-):
+def test_sync_client_preserves_password_for_cluster_when_url_also_set(mock_init_cluster, monkeypatch):
     """
     Test _get_redis_client_logic does not strip password from redis_kwargs when
     startup_nodes is present even if REDIS_URL is also set.
@@ -604,9 +741,7 @@ def test_sync_client_preserves_password_for_cluster_when_url_also_set(
 
     mock_init_cluster.assert_called_once()
     call_kwargs = mock_init_cluster.call_args[0][0]
-    assert (
-        "password" in call_kwargs
-    ), "password must not be stripped when routing to cluster"
+    assert "password" in call_kwargs, "password must not be stripped when routing to cluster"
     assert call_kwargs["password"] == "secret"
 
 

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -170,6 +170,29 @@ def test_get_signature_arg_names_strips_var_args_and_kwargs():
     assert "kwargs" not in names
 
 
+def test_get_redis_url_kwargs_introspects_provided_client():
+    """The async caller passes client=async_redis.Redis.from_url, so the allow-list must be
+    read from that client and not the sync redis.Redis.from_url. Otherwise async-only args like
+    single_connection_client / auto_close_connection_pool are silently dropped before connecting."""
+    sync_args = _get_redis_url_kwargs()
+    async_args = _get_redis_url_kwargs(client=async_redis.Redis.from_url)
+
+    assert "single_connection_client" in async_args
+    assert "auto_close_connection_pool" in async_args
+    assert "single_connection_client" not in sync_args
+    assert "auto_close_connection_pool" not in sync_args
+
+
+def test_get_redis_cluster_kwargs_introspects_provided_client():
+    """Async cluster allow-list must be read from async_redis.RedisCluster, not the sync class,
+    so async-only constructor args survive the allow-list filter."""
+    sync_args = _get_redis_cluster_kwargs()
+    async_args = _get_redis_cluster_kwargs(client=async_redis.RedisCluster)
+
+    assert "decode_responses" in async_args
+    assert "decode_responses" not in sync_args
+
+
 def test_max_connections_in_cluster_kwargs():
     """Test that max_connections is included in Redis cluster kwargs"""
     kwargs = _get_redis_cluster_kwargs()


### PR DESCRIPTION
## TLDR

Problem this solves:

- redis-py 7.1 wraps `Redis.__init__`, breaking arg introspection
- `inspect.getfullargspec` then returns no args for the constructor
- `REDIS_USERNAME` / `REDIS_PASSWORD` are then dropped, so auth fails against a secured redis
- same failure hits Router and proxy-hook introspection

How it solves it:

- switch introspection to `inspect.signature`, which unwraps decorators
- drop `*args`/`**kwargs` so no phantom `kwargs` arg leaks in
- add a CI matrix running the redis tests on redis-py 5.3.1 through 8.0.1

## Relevant issues

Supersedes #18875; that branch had to be force-pushed during a rebase onto latest, which permanently blocks GitHub from reopening it, so this is the same work on a fresh branch off `litellm_internal_staging`

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Captured against a real redis-server 8.8.1 and real redis-py 8.0.1, driving litellm's own `get_redis_async_client()`, which is what `RedisCache.init_async_client` calls. Before = `998a3724` (the branch point), after = `b011bd920` (this branch's tip)

The customer-visible symptom is a password-protected redis rejecting every cache operation. With redis-py 7.1+ wrapping `Redis.__init__`, `_get_redis_kwargs()` comes back empty, so `REDIS_USERNAME` and `REDIS_PASSWORD` never map into the client kwargs. A deployment that sets host and port through `cache_params` and credentials through the environment still connects to the primary, just with no credentials attached, and every cache read and write fails authentication

Captured against a live proxy on port 4000 and a real password-protected redis-server 8.8.1 on redis-py 8.0.1. The upstream is this repo's own mock LLM server (`tests/e2e/ui/fixtures/mock_llm_server/server.py`), the same fixture the Admin UI e2e suite runs its proxy against, so no provider spend is involved; the redis being exercised is real. Before = `998a3724` (the branch point), after = `b011bd920`

1. Start a password-protected redis with an ACL user, plus the mock upstream

```bash
cat > auth.conf <<'CONF'
port 7914
requirepass adminpass
user default on >adminpass ~* +@all
user litellmuser on >testpass123 ~* +@all
CONF
redis-server auth.conf --daemonize yes
python tests/e2e/ui/fixtures/mock_llm_server/server.py &
```

2. `proof_config.yaml`, with host and port as cache args and credentials left to the environment

```yaml
model_list:
  - model_name: fake-gpt-4
    litellm_params:
      model: openai/fake-gpt-4
      api_base: os.environ/MOCK_LLM_URL
      api_key: fake-key

litellm_settings:
  cache: true
  cache_params:
    type: redis
    host: 127.0.0.1
    port: 7914
```

3. Run the proxy and send the same request twice

```bash
export MOCK_LLM_URL=http://127.0.0.1:8090/v1 LITELLM_MASTER_KEY=sk-1234
export REDIS_USERNAME=litellmuser REDIS_PASSWORD=testpass123
python litellm/proxy/proxy_cli.py --config proof_config.yaml --port 4000 > litellm.log 2>&1 &

for i in 1 2; do curl -s http://localhost:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"fake-gpt-4","messages":[{"role":"user","content":"say hi"}]}' \
  | jq -r '"call '"$i"' id = " + .id'; done

redis-cli -p 7914 --user litellmuser --pass testpass123 DBSIZE
grep -ciE 'NOAUTH|AuthenticationError|HELLO must be called' litellm.log
```

Before, at `998a3724`, redis stays empty and the log fills with authentication failures:

```text
call 1 id = chatcmpl-13c1f9d1d61e
call 2 id = chatcmpl-13c1f9d1d61e
(integer) 0
10
```

After, at `b011bd920`, the cache is actually populated and no authentication error appears:

```text
call 1 id = chatcmpl-b6eed1324045
call 2 id = chatcmpl-b6eed1324045
(integer) 4
0
```

The response id is identical in both runs, so it is not the signal to read here: litellm falls back to its in-memory cache when redis is unreachable, which masks the failure inside a single process. The signals that matter are `DBSIZE`, which shows redis holding nothing at all before the fix, and the authentication errors, which stop entirely after it. On a multi-replica deployment the in-memory fallback is not shared, so before the fix every replica misses and the intended cross-replica cache never works

When host also comes from `REDIS_HOST` rather than `cache_params`, the same empty allow-list drops the host too, and the failure arrives earlier as `ValueError: Either 'host' or 'url' must be specified for redis.` instead of an auth error

The second commit on this branch fixes a separate defect on the async cluster path, which is reachable because `get_redis_connection_pool` returns `None` for cluster configs, so `RedisCache` hands `get_redis_async_client` no pool and the cluster branch runs. `_get_redis_cluster_kwargs` took a `client` and ignored it, introspecting the sync class, so async-only constructor args were filtered out before the client was built

3. Start a single-node cluster owning every slot

```bash
redis-server --port 7911 --cluster-enabled yes --cluster-config-file nodes.conf --dir . --save '' --daemonize yes
redis-cli -p 7911 CLUSTER ADDSLOTSRANGE 0 16383
redis-cli -p 7911 cluster info | grep -E 'cluster_state|cluster_slots_ok'
```

```text
cluster_state:ok
cluster_slots_ok:16384
```

4. Ask for an async cluster client with `REDIS_DECODE_RESPONSES=True` and read a key back

```bash
export REDIS_CLUSTER_NODES='[{"host": "127.0.0.1", "port": 7911}]'
export REDIS_DECODE_RESPONSES=True
python -c "
import asyncio, redis
from litellm._redis import get_redis_async_client
c = get_redis_async_client()
async def m():
    await c.set('k','hello'); print('redis-py', redis.__version__, '| GET ->', repr(await c.get('k'))); await c.aclose()
asyncio.run(m())
"
```

Before, at `8f9e5aeb5`, `decode_responses` is filtered out and the value comes back as bytes:

```text
redis-py 8.0.1 | GET -> b'hello'
```

After, at `b011bd920`, the setting survives and the value is decoded:

```text
redis-py 8.0.1 | GET -> 'hello'
```

No LLM provider call is included because this change never touches provider traffic; it decides which kwargs reach the redis client, and the runs above exercise that against real redis servers rather than mocks

## Type

🐛 Bug Fix
✅ Test

## Changes

`litellm/_redis.py` now derives the Redis, `Redis.from_url` and `RedisCluster` kwarg allow-lists from `inspect.signature` through a small `_get_signature_arg_names` helper. The helper drops `VAR_POSITIONAL` and `VAR_KEYWORD` parameters, which matters because `from_url` and `RedisCluster` expose a `**kwargs` on redis-py 7.x+; the raw `signature().parameters.keys()` the earlier revision used would otherwise inject a bogus `kwargs` arg (and a `REDIS_KWARGS` env mapping). The same `getfullargspec` to `signature` move is applied to `Router.get_valid_args` and the proxy-hook arg check in `litellm/proxy/utils.py`, since they share the identical failure mode against any decorated callable.

The follow-up commit makes both `_get_redis_url_kwargs` and `_get_redis_cluster_kwargs` introspect the `client` they are handed instead of the hardcoded sync class, and fixes the cluster helper's default, which pointed at `redis.Redis.from_url` while the body introspected `redis.RedisCluster`. Of the two, only the cluster half changes behavior under `RedisCache`: `get_redis_connection_pool` returns `None` for cluster configs, so the cluster branch runs, while url configs always receive a pool and return early before the url allow-list is consulted. `_get_redis_url_kwargs` is still exercised by the sync `get_redis_client`, which calls it with no client so the default stays `redis.Redis.from_url` and that path behaves exactly as before

`.github/workflows/test-redis-compat.yml` reinstalls redis-py per matrix leg and runs `tests/test_litellm/test_redis.py` on 5.3.1, 6.4.0, 7.4.1 and 8.0.1. 6.0.0 is the one release skipped, because `rq` (pulled in by the proxy extra) specifies `redis != 6`, which under PEP 440 excludes 6.0.0 alone, so 6.4.0 stands in for the 6.x line.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR




