### PR TITLE
fix(proxy): stop litellm/proxy from shadowing installed packages on sys.path

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -23,6 +23,22 @@ if TYPE_CHECKING:
 else:
     FastAPI = Any
 
+
+def _deprioritize_script_dir_in_sys_path() -> None:
+    """Stop ``litellm/proxy`` modules from shadowing installed packages.
+
+    Running this file as a script puts its own directory at ``sys.path[0]``, so
+    ``import a2a`` resolves to ``litellm/proxy/a2a`` instead of the ``a2a`` SDK
+    and A2A agent calls fail. The entry is moved to the end rather than dropped,
+    because the sibling-import fallbacks in this module (``from proxy_server
+    import ...``) still need it. No-op under the ``litellm`` console script.
+    """
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    if sys.path and os.path.abspath(sys.path[0]) == script_dir:
+        sys.path.append(sys.path.pop(0))
+
+
+_deprioritize_script_dir_in_sys_path()
 sys.path.append(os.getcwd())
 
 config_filename = "litellm.secrets"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every proxied A2A agent call fails with JSON-RPC -32603
- Only when the proxy runs as a script, which is our dev workflow

How it solves it:

- `litellm/proxy/a2a` was shadowing the installed `a2a` SDK
- Script dir moved to the end of `sys.path` instead of the front

## Relevant issues

## Linear ticket

Resolves LIT-4814

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Tests are deliberately not in this commit; this is the minimum change that unblocks A2A locally, and a regression test is listed as a follow-up below.

## Screenshots / Proof of Fix

Two real A2A agents (each serving `/.well-known/agent-card.json` and answering JSON-RPC `message/send`) registered on a live proxy with Postgres, then invoked through the gateway. Real OpenAI calls, no mocks.

**Before the fix** (at base `998a372417`, proxy started with `python litellm/proxy/proxy_cli.py --config ... --port 4078`):

```bash
curl -s -X POST "http://127.0.0.1:4078/a2a/$AGENT_ID/message/send" \
  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":"g1","method":"message/send","params":{"message":{"kind":"message","messageId":"m1","role":"user","parts":[{"kind":"text","text":"Gamma ray reads 120 API units across a 10 m interval. Sand or shale?"}]}}}'
```

```json
{"jsonrpc":"2.0","id":"g1","error":{"code":-32603,"message":"Internal error: NoneType takes no arguments"}}
```

Server-side traceback for that response:

```
litellm/proxy/agent_endpoints/a2a_endpoints.py:781  in invoke_agent_a2a
litellm/a2a_protocol/__init__.py:48                 in <module>
litellm/a2a_protocol/main.py:75                     in <module>
litellm/a2a_protocol/card_resolver.py:105           in <module>
TypeError: NoneType takes no arguments
```

**After the fix** (at `6e09b49710`, same command, same agent):

```json
{"id":"g1","jsonrpc":"2.0","result":{"contextId":"0d254ff8-0472-4288-9455-c5999cb8275c","kind":"message","messageId":"b6888b23-4745-4b22-b3f8-4027960ce85a","parts":[{"kind":"text","text":"Likely shale, since a gamma ray of 120 API is generally high and indicates a clay-rich interval rather than clean sand. The 10 m thickness doesn't change the lithology interpretation by itself."}],"role":"agent"}}
```

Second agent, pointed at a self-hosted OpenAI-compatible engine rather than a cloud model, same run:

```json
{"id":"g2","jsonrpc":"2.0","result":{"kind":"message","parts":[{"kind":"text","text":" Pump 2 tripped twice."}],"role":"agent"}}
```

Minimal proof of the shadowing itself, no proxy needed, at base `998a372417`:

```bash
python -c 'import sys; sys.path.insert(0, "litellm/proxy"); import a2a; print(a2a.__file__); from a2a.client import A2ACardResolver'
```

```
.../litellm/proxy/a2a/__init__.py
ModuleNotFoundError: No module named 'a2a.client'
```

The Admin UI at `http://localhost:4000/ui/logs/` now shows an `Agent` row per A2A call paired with the `LLM` row it caused; before the fix those calls never reached the agent.

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/proxy_cli.py`: when this file is executed as a script, Python puts `litellm/proxy` at `sys.path[0]`, so `import a2a` resolves to the internal `litellm/proxy/a2a` package instead of the `a2a` SDK. `litellm/a2a_protocol/card_resolver.py` guards that import with `except ImportError: pass` and keeps its `_A2ACardResolver = None` fallback, so the module-level `class LiteLLMA2ACardResolver(_A2ACardResolver)` evaluates `class X(None)` and raises `TypeError` on first use.

The entry is moved to the end of `sys.path` rather than removed, because the sibling-import fallbacks further down this module (`from proxy_server import ...` at line 947, reached when the relative import fails under script execution) still need the directory to resolve. Removing it outright makes the proxy fail to boot with `ModuleNotFoundError: No module named 'proxy_server'`. The move is guarded by an equality check against the script's own directory, so it is a no-op under the `litellm` console entrypoint and under `python -m`.

`litellm/proxy/a2a` is the only name under `litellm/proxy/` that collides with an installed or stdlib module, so nothing else changes resolution.

Follow-ups, intentionally not in this PR:

- regression test importing the A2A chain with `litellm/proxy` on `sys.path[0]`
- make the `card_resolver.py` guard fail loudly instead of producing `class X(None)`
- consider renaming `litellm/proxy/a2a` so the collision cannot return via another entrypoint

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
