### PR TITLE
fix(guardrails): preserve cache_control breakpoints in compresr write-back

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/compresr/compresr.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/compresr/compresr.py
@@ -47,6 +47,11 @@ from litellm.llms.custom_httpx.http_handler import (
     httpxSpecialProvider,
 )
 from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.guardrails.guardrail_hooks.content_text import (
+    content_to_text,
+    is_all_text_parts,
+    merge_rewritten_text_parts,
+)
 from litellm.secret_managers.main import get_secret_str
 from litellm.types.guardrails import GuardrailEventHooks, Mode
 from litellm.types.integrations.custom_logger import (
@@ -144,48 +149,20 @@ def _is_object_list(value: object) -> TypeGuard[list[object]]:  # guard-ok: isin
     return isinstance(value, list)
 
 
-def _content_to_text(content: object) -> str:
-    """Collapse a message ``content`` (str or list-of-parts) to plain text.
-
-    For the multimodal list shape, joins ``{type: "text", text: ...}`` parts
-    with blank-line separators; non-text parts are ignored.
-    """
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts: list[str] = []
-        for part in content:
-            if isinstance(part, dict) and part.get("type") == "text":
-                text = part.get("text")
-                if isinstance(text, str):
-                    parts.append(text)
-        return "\n\n".join(parts)
-    return ""
-
-
 def _replace_text_in_content(content: object, new_text: str) -> object:
     """Write ``new_text`` back into a ``content`` value, preserving shape.
 
-    ``str`` content is replaced directly. For list-of-parts content the first
-    text part carries ``new_text``, later text parts are dropped, and
-    non-text parts (images, audio, files) pass through untouched.
+    ``str`` content is replaced directly. An all-text part list collapses to a
+    single part carrying the last declared cache_control breakpoint. Anything
+    else is returned unchanged: breakpoints are positional, so one compressed
+    string cannot be written back across a non-text part without moving text
+    to the other side of it.
     """
     if isinstance(content, str):
         return new_text
-    if isinstance(content, list):
-        out: list[object] = []
-        replaced = False
-        for part in content:
-            if isinstance(part, dict) and part.get("type") == "text":
-                if not replaced:
-                    out.append({**part, "text": new_text})
-                    replaced = True
-                continue
-            out.append(part)
-        if not replaced:
-            out.insert(0, {"type": "text", "text": new_text})
-        return out
-    return new_text
+    if _is_object_list(content) and is_all_text_parts(content):
+        return merge_rewritten_text_parts(content, new_text)
+    return content
 
 
 def _render_tool_intent(fn: dict[str, object]) -> str:
@@ -422,7 +399,7 @@ def _assistant_text_from_response(response: object) -> str | None:
     if isinstance(choices, list) and choices:
         message = get_attribute_or_key(choices[0], "message", None)
         if message is not None:
-            text = _content_to_text(get_attribute_or_key(message, "content", None))
+            text = content_to_text(get_attribute_or_key(message, "content", None))
             if text:
                 return text
     content = get_attribute_or_key(response, "content", None)
@@ -905,7 +882,10 @@ class CompresrGuardrail(CustomGuardrail):
                     continue
             else:
                 continue
-            if len(_content_to_text(msg.get("content"))) < self.min_chars_to_compress:
+            content = msg.get("content")
+            if _is_object_list(content) and not is_all_text_parts(content):
+                continue
+            if len(content_to_text(content)) < self.min_chars_to_compress:
                 continue
             targets.append(idx)
         return targets
@@ -916,7 +896,7 @@ class CompresrGuardrail(CustomGuardrail):
     ) -> tuple[str, int | None]:
         for idx in range(len(messages) - 1, -1, -1):
             if messages[idx].get("role") == "user":
-                return _content_to_text(messages[idx].get("content")), idx
+                return content_to_text(messages[idx].get("content")), idx
         return "", None
 
     def _apply_compression_results(
@@ -1034,7 +1014,7 @@ class CompresrGuardrail(CustomGuardrail):
             verbose_proxy_logger.debug("Compresr: no messages eligible for compression")
             return inputs
 
-        contexts = [_content_to_text(messages[idx].get("content")) for idx in targets]
+        contexts = [content_to_text(messages[idx].get("content")) for idx in targets]
 
         start_time = time.monotonic()
         results = await self._call_compress(contexts=contexts, queries=queries)

--- a/litellm/proxy/guardrails/guardrail_hooks/content_text.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/content_text.py
@@ -1,0 +1,55 @@
+"""Shared content-part helpers for compression guardrails (headroom, compresr).
+
+Compression services only transform plain-string message content: every
+transform in the service pipeline gates on ``isinstance(content, str)`` and
+silently skips the OpenAI list-of-parts shape. Guardrails that send messages
+to such a service collapse text-bearing part lists to strings here, and write
+the rewritten text back through ``merge_rewritten_text_parts``.
+
+Anthropic ``cache_control`` breakpoints are positional: each one caches the
+prefix ending at the part that carries it. A single compressed string can
+therefore only be written back over a run of text parts, never across a
+non-text part, which is what ``is_all_text_parts`` gates.
+"""
+
+from collections.abc import Sequence
+
+
+def content_to_text(content: object) -> str:
+    """Collapse a message ``content`` (str or list-of-parts) to plain text.
+
+    For the multimodal list shape, joins ``{type: "text", text: ...}`` parts
+    with blank-line separators; non-text parts are ignored.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                text = part.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n\n".join(parts)
+    return ""
+
+
+def is_all_text_parts(content: object) -> bool:
+    """True when ``content`` is a non-empty part list holding only text parts."""
+    if not isinstance(content, list) or not content:
+        return False
+    return all(isinstance(part, dict) and part.get("type") == "text" for part in content)
+
+
+def merge_rewritten_text_parts(parts: Sequence[object], new_text: str) -> list[object]:
+    """Collapse a rewritten all-text part list into one part carrying ``new_text``.
+
+    Only all-text rows are ever flattened, so the merged part IS the whole row:
+    it keeps the first part's fields and the LAST declared cache_control
+    breakpoint. A breakpoint caches the prefix ending at its part, so after the
+    merge the last one (and its TTL) is the one that still describes the row.
+    """
+    dict_parts = tuple(part for part in parts if isinstance(part, dict))
+    breakpoints = tuple(part["cache_control"] for part in dict_parts if part.get("cache_control") is not None)
+    base = {**dict_parts[0], "text": new_text} if dict_parts else {"type": "text", "text": new_text}
+    return [{**base, "cache_control": breakpoints[-1]} if breakpoints else base]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_compresr.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_compresr.py
@@ -6,7 +6,8 @@ Tests cover:
   resolved via tool_call_id, falling back to the last user message)
 - target selection: tool outputs by default, system/history opt-in, min-chars
   threshold, targets without a derivable query are left uncompressed
-- multimodal content: text parts replaced, non-text parts preserved
+- multimodal content: all-text rows merge into one part carrying the last
+  cache_control breakpoint, rows holding a non-text part are left uncompressed
 - recovery: hash marker appended, compresr_retrieve tool injected, originals
   stored per litellm_call_id, agentic loop returns the original content and
   rejects hashes not issued for the current request
@@ -560,7 +561,7 @@ async def test_short_messages_skipped(guardrail: CompresrGuardrail):
 
 
 @pytest.mark.asyncio
-async def test_multimodal_text_replaced_non_text_preserved(
+async def test_multimodal_row_with_non_text_part_is_not_compressed(
     guardrail: CompresrGuardrail,
 ):
     image_part = {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}}
@@ -570,6 +571,35 @@ async def test_multimodal_text_replaced_non_text_preserved(
             "role": "tool",
             "tool_call_id": "c1",
             "content": [{"type": "text", "text": TOOL_OUTPUT}, image_part],
+        },
+    ]
+    expected = json.loads(json.dumps(messages[1]["content"]))
+    mock_post = AsyncMock(return_value=_make_single_compress_response())
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(
+            inputs=_apply_inputs(messages),
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    mock_post.assert_not_called()
+    assert result["structured_messages"][1]["content"] == expected
+
+
+@pytest.mark.asyncio
+async def test_all_text_row_merges_and_keeps_last_cache_control(
+    guardrail: CompresrGuardrail,
+):
+    messages = [
+        {"role": "user", "content": USER_QUESTION},
+        {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": [
+                {"type": "text", "text": TOOL_OUTPUT, "cache_control": {"type": "ephemeral"}},
+                {"type": "text", "text": TOOL_OUTPUT, "cache_control": {"type": "ephemeral", "ttl": "1h"}},
+            ],
         },
     ]
     mock_post = AsyncMock(return_value=_make_single_compress_response())
@@ -583,9 +613,41 @@ async def test_multimodal_text_replaced_non_text_preserved(
 
     content = result["structured_messages"][1]["content"]
     assert isinstance(content, list)
+    assert len(content) == 1
     assert content[0]["type"] == "text"
     assert content[0]["text"].startswith("compressed summary")
-    assert content[1] == image_part
+    assert content[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+@pytest.mark.asyncio
+async def test_text_around_non_text_part_is_never_relocated(
+    guardrail: CompresrGuardrail,
+):
+    image_part = {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}}
+    messages = [
+        {"role": "user", "content": USER_QUESTION},
+        {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": [
+                {"type": "text", "text": TOOL_OUTPUT},
+                image_part,
+                {"type": "text", "text": TOOL_OUTPUT, "cache_control": {"type": "ephemeral"}},
+            ],
+        },
+    ]
+    expected = json.loads(json.dumps(messages[1]["content"]))
+    mock_post = AsyncMock(return_value=_make_single_compress_response())
+
+    with patch.object(guardrail.async_handler, "post", mock_post):
+        result = await guardrail.apply_guardrail(
+            inputs=_apply_inputs(messages),
+            request_data={"model": "gpt-4o"},
+            input_type="request",
+        )
+
+    mock_post.assert_not_called()
+    assert result["structured_messages"][1]["content"] == expected
 
 
 # ── passthrough / bypass ─────────────────────────────────────────────


### PR DESCRIPTION
## TLDR

Problem this solves:

- Compresr silently dropped Anthropic `cache_control` breakpoints declared on any text block after the first, so a caller's configured prompt cache never formed
- For a row holding an image between two text blocks, compresr moved the post-image text to the slot before the image, so the model saw a different content order than the caller sent

How it solves it:

- Breakpoints are positional, so a compressed string is only written back over a contiguous run of text parts; the merged part carries the last declared breakpoint and its TTL
- Rows holding a non-text part are no longer selected for compression

## Relevant issues

- Compresr keeps only the first text part's `cache_control` when it rewrites a multi-part row, dropping every later breakpoint
- Compresr flattens text from both sides of an image into one context and writes it back before the image, relocating content and dropping its breakpoint
- Both hazards ship today; this is a follow-up to the same positional-breakpoint invariant fixed for the headroom guardrail in #34586

## Linear ticket

Resolves LIT-4804

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy on `localhost:4804` against real `claude-sonnet-5` through `/v1/messages`, so the cache counters below are Anthropic's own accounting. The compresr compression service is a local stub that records every context it is handed and returns a deterministic ~4000 token summary; that is the component under test's collaborator, and stubbing it is what makes "which rows did the gateway select, and what text did it flatten" observable.

Two request shapes, byte-identical across the before and after runs:

```bash
# A: all-text row, cache_control {"type":"ephemeral","ttl":"1h"} on the LAST of two text blocks
# B: mixed row [text, image, text(cache_control ephemeral)]
curl -s -X POST http://127.0.0.1:4804/v1/messages \
  -H 'x-api-key: sk-1234' -H 'anthropic-version: 2023-06-01' -H 'content-type: application/json' \
  --data-binary @req_alltext.json | jq .usage

curl -s http://127.0.0.1:8934/stats   # what the gateway asked the compression service to compress
```

Before, on unfixed code:

```
A all-text : stub called once with 27322 chars (both blocks flattened)
             input=4977 cache_creation=0 cache_read=0 ephemeral_1h=0
B mixed    : stub called once with 27322 chars (text from BOTH sides of the image)
             input=4981 cache_creation=0 cache_read=0 ephemeral_5m=0
```

The 27322 chars on B is the hazard in one number; it is block A plus block B concatenated, with the image dropped from the middle, and that single string is written back ahead of the image.

After, same requests:

```
A all-text : stub called once with 27322 chars (still compressed)
             input=2 cache_creation=4975 cache_read=0 ephemeral_1h=4975
A repeated : input=2 cache_creation=0 cache_read=4975
B mixed    : stub called 0 times (row no longer selected)
             input=2 cache_creation=8130 cache_read=0 ephemeral_5m=8130
```

A still compresses and now writes a 1h cache entry, and the repeat run reads 4975 tokens back out of it, which is the caching the caller configured and previously never got. B is left alone, so its blocks reach the model in the order they were sent and its breakpoint is honored.

## Type

🐛 Bug Fix

## Changes

- Add `guardrail_hooks/content_text.py` holding `content_to_text` (moved out of compresr) plus `is_all_text_parts` and `merge_rewritten_text_parts`, so the positional-breakpoint rule has one owner
- `_replace_text_in_content` collapses an all-text row into a single part carrying the last declared `cache_control` and its TTL, and returns any other list unchanged
- `_select_targets` stops selecting rows that hold a non-text part
- Update `test_compresr.py` for the new contract and pin both hazards; string content is unaffected throughout

## QA runbook

Configure the compresr guardrail against a compression service, send an Anthropic request whose user content is two text blocks with `cache_control` on the second, and confirm the response reports non-zero `cache_creation_input_tokens`; repeat the request and confirm `cache_read_input_tokens` matches. Then send a row shaped `[text, image, text]` and confirm the content reaches the model unmodified.

### Things a reviewer will ask about

Mixed rows stop being compressed, and that is the deliberate trade. A breakpoint caches the prefix ending at its own part, so no single-string write-back can preserve one across an image; compressing each text run separately would mean one service call per run and a per-part rather than per-message batch contract, which is a larger change than the defect warrants. This matches the contract #34586 landed for headroom.

The merged part carries the last declared breakpoint rather than the first. After the merge the row is a single part, so the last one is the only one that still describes it; keeping the first would cache a prefix shorter than any the caller asked for.

`content_text.py` is also created by #34586, which is open. Whichever lands first, the other resolves to the union; this PR's copy is a superset and `content_to_text` is byte-identical in both.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Compresr guardrail message mutation and eligibility rules for multimodal content; behavior is narrower (fewer rows compressed) but affects prompt caching and tool-message shapes on the proxy hot path.
> 
> **Overview**
> Fixes Compresr multimodal write-back so Anthropic **`cache_control`** breakpoints and part order stay correct.
> 
> **Shared helpers** in `content_text.py` (`content_to_text`, `is_all_text_parts`, `merge_rewritten_text_parts`) replace inline Compresr logic and document the positional-breakpoint rule (aligned with headroom).
> 
> **Write-back:** all-text part lists collapse to **one** text part with the **last** declared `cache_control` (and TTL). Lists that include images or other non-text parts are **returned unchanged**—no more flattening text across an image.
> 
> **Target selection:** messages whose content is not an all-text part list are **skipped** for compression, so mixed rows are never sent to the service or rewritten.
> 
> Unit tests cover last-breakpoint preservation, skipping mixed rows, and refusing to relocate text around non-text parts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c63e24bacf1229581c6281d717809b3af034741a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->