### PR TITLE
fix(vertex): decide rawPredict passthrough streaming from the request body

### DIFF
--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -86,11 +86,16 @@ def is_passthrough_request_using_router_model(request_body: dict, llm_router: Op
         return False
 
 
-def is_passthrough_request_streaming(request_body: dict) -> bool:
+def is_passthrough_request_streaming(request_body: object) -> bool:
     """
-    Returns True if the request is streaming
+    Returns True if the request is streaming.
+
+    A JSON body need not be an object, so a list or scalar can reach here; it
+    carries no streaming flag.
     """
-    return request_body.get("stream", False)
+    if not isinstance(request_body, dict):
+        return False
+    return bool(request_body.get("stream", False))
 
 
 async def llm_passthrough_factory_proxy_route(
@@ -551,8 +556,7 @@ async def is_streaming_request_fn(request: Request) -> bool:
             _request_body = await get_form_data(request)
         else:
             _request_body = await _read_request_body(request)
-        if _request_body.get("stream"):
-            return True
+        return is_passthrough_request_streaming(_request_body)
     return False
 
 
@@ -1755,9 +1759,11 @@ async def _base_vertex_proxy_route(
 
     ## check for streaming
     target = str(updated_url)
-    is_streaming_request = False
-    if "stream" in str(updated_url):
-        is_streaming_request = True
+    if ":rawPredict" in target or ":streamRawPredict" in target:
+        is_streaming_request = await is_streaming_request_fn(request)
+    else:
+        is_streaming_request = "stream" in target
+    if is_streaming_request:
         target += "?alt=sse"
 
     ## CREATE PASS-THROUGH

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_llm_pass_through_endpoints.py
@@ -3022,3 +3022,172 @@ class TestCursorProxyRoute:
             assert call_args["target"] == "https://api.cursor.com/v0/agents"
             assert result["id"] == "bc_abc123"
             assert result["status"] == "CREATING"
+
+
+class TestVertexRawPredictStreamingClassification:
+    """
+    Regression coverage for LIT-4761.
+
+    `_base_vertex_proxy_route` classified any target URL containing "stream" as a
+    streaming request. `:streamRawPredict` carries that substring, so a unary
+    Anthropic-on-Vertex call (no `stream` field in the body) was sent with
+    `?alt=sse` and logged through the streaming chunk collector, which parses
+    Anthropic SSE deltas and finds no usage in a complete `"type": "message"`
+    body; the spend log recorded 0 tokens and $0 cost.
+
+    Streaming for the rawPredict family is decided by the request body, per the
+    Anthropic Messages contract. The Gemini generateContent family stays
+    URL-signalled because the Gemini REST body has no `stream` field.
+    """
+
+    RAW_PREDICT_ENDPOINT = (
+        "v1/projects/test-project/locations/us-east5/publishers/anthropic/models/"
+        "claude-sonnet-4-6:streamRawPredict"
+    )
+    GENERATE_CONTENT_ENDPOINT = (
+        "v1/projects/test-project/locations/us-east5/publishers/google/models/"
+        "gemini-2.5-flash:streamGenerateContent"
+    )
+
+    async def _capture_passthrough_kwargs(self, endpoint: str, body: object) -> dict:
+        raw_body = json.dumps(body).encode("utf-8")
+
+        async def receive():
+            return {"type": "http.request", "body": raw_body, "more_body": False}
+
+        request = Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": f"/vertex_ai/{endpoint}",
+                "headers": [(b"content-type", b"application/json")],
+                "query_string": b"",
+            },
+            receive=receive,
+        )
+
+        captured: dict = {}
+
+        def fake_create_pass_through_route(**kwargs):
+            captured.update(kwargs)
+            return AsyncMock(return_value={"status": "success"})
+
+        mock_credentials = Mock()
+        mock_credentials.token = "test-token"
+
+        base_url = "https://us-east5-aiplatform.googleapis.com/"
+        mock_handler = Mock()
+        mock_handler.get_default_base_target_url.return_value = base_url
+        mock_handler.update_base_target_url_with_credential_location = Mock(return_value=base_url)
+
+        module = "litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints"
+        with (
+            mock.patch(
+                "litellm.llms.vertex_ai.vertex_llm_base.VertexBase.load_auth",
+                return_value=(mock_credentials, "test-project"),
+            ),
+            mock.patch(f"{module}.create_pass_through_route", side_effect=fake_create_pass_through_route),
+            mock.patch(f"{module}.get_litellm_virtual_key", return_value="Bearer test-key"),
+            mock.patch(f"{module}.user_api_key_auth", new=AsyncMock(return_value={"api_key": "test-key"})),
+            mock.patch(f"{module}.get_vertex_pass_through_handler", return_value=mock_handler),
+        ):
+            await vertex_proxy_route(
+                endpoint=endpoint,
+                request=request,
+                fastapi_response=Response(),
+                user_api_key_dict=UserAPIKeyAuth(token="test-key"),
+            )
+
+        assert captured, "create_pass_through_route was never called"
+        return captured
+
+    @pytest.mark.asyncio
+    async def test_raw_predict_without_stream_field_is_not_streaming(self):
+        captured = await self._capture_passthrough_kwargs(
+            endpoint=self.RAW_PREDICT_ENDPOINT,
+            body={
+                "anthropic_version": "vertex-2023-10-16",
+                "messages": [{"role": "user", "content": "Explain MLOps"}],
+                "max_tokens": 5000,
+            },
+        )
+
+        assert captured["is_streaming_request"] is False
+        assert "alt=sse" not in captured["target"]
+
+    @pytest.mark.asyncio
+    async def test_raw_predict_with_stream_false_is_not_streaming(self):
+        captured = await self._capture_passthrough_kwargs(
+            endpoint=self.RAW_PREDICT_ENDPOINT,
+            body={
+                "anthropic_version": "vertex-2023-10-16",
+                "stream": False,
+                "messages": [{"role": "user", "content": "Explain MLOps"}],
+                "max_tokens": 5000,
+            },
+        )
+
+        assert captured["is_streaming_request"] is False
+        assert "alt=sse" not in captured["target"]
+
+    @pytest.mark.asyncio
+    async def test_raw_predict_with_stream_true_still_streams(self):
+        captured = await self._capture_passthrough_kwargs(
+            endpoint=self.RAW_PREDICT_ENDPOINT,
+            body={
+                "anthropic_version": "vertex-2023-10-16",
+                "stream": True,
+                "messages": [{"role": "user", "content": "Explain MLOps"}],
+                "max_tokens": 5000,
+            },
+        )
+
+        assert captured["is_streaming_request"] is True
+        assert captured["target"].endswith("?alt=sse")
+
+    @pytest.mark.asyncio
+    async def test_gemini_stream_generate_content_stays_url_signalled(self):
+        captured = await self._capture_passthrough_kwargs(
+            endpoint=self.GENERATE_CONTENT_ENDPOINT,
+            body={"contents": [{"role": "user", "parts": [{"text": "Explain MLOps"}]}]},
+        )
+
+        assert captured["is_streaming_request"] is True
+        assert captured["target"].endswith("?alt=sse")
+
+    @pytest.mark.asyncio
+    async def test_raw_predict_with_non_object_body_is_not_streaming(self):
+        captured = await self._capture_passthrough_kwargs(
+            endpoint=self.RAW_PREDICT_ENDPOINT,
+            body=[{"role": "user", "content": "Explain MLOps"}],
+        )
+
+        assert captured["is_streaming_request"] is False
+        assert "alt=sse" not in captured["target"]
+
+
+@pytest.mark.parametrize(
+    "request_body, expected",
+    [
+        ({"stream": True}, True),
+        ({"stream": "true"}, True),
+        ({"stream": False}, False),
+        ({}, False),
+        ([{"role": "user"}], False),
+        ([], False),
+        ("stream", False),
+        (7, False),
+        (None, False),
+    ],
+)
+def test_is_passthrough_request_streaming_tolerates_non_object_bodies(request_body, expected):
+    """
+    A JSON request body is not required to be an object. Every passthrough
+    streaming decision funnels through this predicate, so a list or scalar body
+    must answer False instead of raising AttributeError.
+    """
+    from litellm.proxy.pass_through_endpoints.llm_passthrough_endpoints import (
+        is_passthrough_request_streaming,
+    )
+
+    assert is_passthrough_request_streaming(request_body) is expected


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex passthrough spend logs record 0 prompt tokens, 0 completion tokens and zero cost for non-streaming Claude-on-Vertex calls to `:streamRawPredict`
- The same request with `"stream": true` logs the correct tokens, so passthrough traffic that happens to be non-streaming is invisible to spend tracking

How it solves it:

- Requests on the rawPredict family take their streaming flag from the request body, which is what the Anthropic Messages contract uses for those endpoints
- The generateContent family keeps its URL signal, so Gemini framing and its usage parsing are untouched

## Relevant issues

- Vertex passthrough classified any target URL containing `stream` as a streaming request; `:streamRawPredict` carries that substring, so a unary Anthropic body was logged through the SSE chunk parser and produced a zero-token spend row
- Streaming for the rawPredict family is now read from the request body; every other Vertex method keeps the behavior it has today
- Adds regression coverage for the unary, `stream: false` and `stream: true` rawPredict cases plus a `:streamGenerateContent` control that pins the Gemini path
- Folds the two passthrough streaming predicates into one owner that tolerates a non-object JSON body, which also fixes a pre-existing `AttributeError` on the mistral, anthropic, vllm and azure passthrough routes

## Linear ticket

Resolves LIT-4761

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Run against a proxy on `localhost:4761` backed by real Postgres, with the upstream `us-east5-aiplatform.googleapis.com` served by a stub that returns the Anthropic Messages shapes Vertex produces; SSE deltas when the body sets `stream: true`, a complete JSON message when it does not. The proxy image is stock `ghcr.io/berriai/litellm-database:main-latest` (1.95.0), patched in place with this diff for the "after" run. Token counts are fixed at 4242 in / 1337 out so the spend row is unambiguous.

Because the local environment has no Google credentials, the same two curls against a real Vertex project are owed before this closes; the commands are identical apart from the host and the bearer token.

1. Non-streaming request, the reported bug

```bash
curl -sS -X POST 'http://localhost:4761/vertex_ai/v1/projects/my-project/locations/us-east5/publishers/anthropic/models/claude-sonnet-4-6:streamRawPredict' \
 -H 'x-litellm-api-key: sk-lit4761' \
 -H 'Authorization: Bearer <gcp-access-token>' \
 -H 'Content-Type: application/json' \
 -d '{"anthropic_version":"vertex-2023-10-16","messages":[{"role":"user","content":"Explain the three main concepts in MLOps"}],"max_tokens":5000}'
```

2. Same request with streaming, which already worked

```bash
curl -sS -N -X POST 'http://localhost:4761/vertex_ai/v1/projects/my-project/locations/us-east5/publishers/anthropic/models/claude-sonnet-4-6:streamRawPredict' \
 -H 'x-litellm-api-key: sk-lit4761' \
 -H 'Authorization: Bearer <gcp-access-token>' \
 -H 'Content-Type: application/json' \
 -d '{"anthropic_version":"vertex-2023-10-16","stream":true,"messages":[{"role":"user","content":"Explain the three main concepts in MLOps"}],"max_tokens":5000}'
```

3. Read the spend rows

```bash
psql -c 'select prompt_tokens, completion_tokens, total_tokens, spend from "LiteLLM_SpendLogs" order by "startTime";'
```

Before, on stock 1.95.0. The non-streaming call returns a normal 200 with the full message body, and still books nothing:

```
 prompt_tokens | completion_tokens | total_tokens |  spend
---------------+-------------------+--------------+----------
             0 |                 0 |            0 |        0     <- non-streaming
          4242 |              1337 |         5579 | 0.032781     <- stream: true
```

After, with this diff:

```
 prompt_tokens | completion_tokens | total_tokens |  spend
---------------+-------------------+--------------+----------
          4242 |              1337 |         5579 | 0.032781     <- non-streaming
          4242 |              1337 |         5579 | 0.032781     <- stream: true
```

The client-facing responses are byte-identical across both runs; only the spend row changes.

## Type

🐛 Bug Fix

## Changes

- `_base_vertex_proxy_route` resolves `is_streaming_request` from the request body for `:rawPredict` and `:streamRawPredict`, reusing the existing `is_streaming_request_fn` helper that the mistral and anthropic passthrough routes already use
- Every other Vertex method keeps the URL substring check it has today, so `:streamGenerateContent`, `:streamQuery` and the discovery routes are unaffected
- `?alt=sse` is still appended for anything classified as streaming, so no currently-streaming request changes shape
- `is_streaming_request_fn` now delegates to `is_passthrough_request_streaming` instead of repeating `.get("stream")`, and that single predicate returns False for a body that is not a JSON object; `_read_request_body` is annotated `-> Dict` but returns whatever the parser produced, so an array body previously raised `AttributeError` on five call sites
- Six regression tests in the mapped test file, including a `:streamGenerateContent` control that fails if the URL signal is ever made body-driven, and a parametrized pin on the predicate for list, scalar and empty bodies

Three things a reviewer may want to know. This overlaps PR #29049, which edits the same block for a different reason and leaves the classification untouched; whichever lands second will need a small rebase. The `?alt=sse` append appears to be dropped before egress, since the stub upstream observes no `alt` parameter on a request that litellm classified as streaming, which is worth its own look and is not addressed here. Separately, and distinct from the request-body shape handled above, if a Vertex endpoint ever returns a JSON array as the unary rawPredict *response*, the buffered logging path raises `TypeError: list indices must be integers or slices, not str` and writes no spend row at all; that shape is not what this route returns today, because response array framing produces no row on unfixed code while the reported symptom is a row containing zeros.

## QA runbook

1. Point a proxy at a Vertex project with a Claude publisher model available in `us-east5`
2. Send the non-streaming curl above and confirm a 200 with the full Anthropic message body
3. Query `LiteLLM_SpendLogs` and confirm the row carries the same `input_tokens` and `output_tokens` the upstream reported, with a non-zero spend
4. Send the streaming curl and confirm the SSE stream is unchanged and its spend row still matches
5. Send a `:streamGenerateContent` request to a Gemini model and confirm it still streams and still books tokens

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes passthrough streaming classification and spend logging for Vertex rawPredict and several routes that share the helper; behavior is well covered by tests but affects billing visibility.
> 
> **Overview**
> Fixes **Vertex passthrough spend logging** for unary Claude calls to `:streamRawPredict` (LIT-4761). Those URLs contain `"stream"`, so they were always treated as streaming, got `?alt=sse`, and token/cost logging showed zeros for non-streaming bodies.
> 
> For **`:rawPredict` / `:streamRawPredict`**, streaming now follows the JSON body's `stream` flag (Anthropic Messages style). **Gemini `:streamGenerateContent`** and other Vertex routes still use the URL `"stream"` heuristic.
> 
> **`is_streaming_request_fn`** now routes through **`is_passthrough_request_streaming`**, which returns false for non-object JSON bodies instead of raising **`AttributeError`** on list/scalar payloads. Regression tests cover rawPredict unary/streaming cases, Gemini URL-signalled streaming, and the shared predicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 970ea2949eec6c40091b64098a186560747d301d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->