### PR TITLE
fix(mcp): recover the tool-name prefix boundary from registered prefixes

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -1964,6 +1964,18 @@ class MCPRequestHandler:
         return allowed_tools
 
     @staticmethod
+    def tool_is_granted(bare_tool_name: str, allowed_tool_names: list[str] | None) -> bool:
+        """Whether key/team tool permissions reach ``bare_tool_name`` on one server.
+
+        ``None`` means no tool-level restriction; an empty list grants nothing. Entries
+        name a tool on a single server and every writer stores them bare, so the
+        comparison is exact against the bare name rather than against the spellings
+        routing accepts. Both the listing path and the call path answer through here, so
+        discovery cannot advertise a tool that ``tools/call`` then refuses.
+        """
+        return allowed_tool_names is None or bare_tool_name in allowed_tool_names
+
+    @staticmethod
     async def is_tool_allowed_for_server(
         tool_name: str,
         server_id: str,
@@ -1973,7 +1985,7 @@ class MCPRequestHandler:
         Check if a specific tool is allowed for a server based on key/team permissions.
 
         Args:
-            tool_name: Name of the tool to check
+            tool_name: Bare tool name, already resolved against the server's prefixes
             server_id: Server ID
             user_api_key_auth: User auth
 
@@ -1984,17 +1996,7 @@ class MCPRequestHandler:
             server_id=server_id,
             user_api_key_auth=user_api_key_auth,
         )
-
-        # None means no restrictions (allow all)
-        if allowed_tools is None:
-            return True
-
-        # Empty list means no tools allowed
-        if not allowed_tools:
-            return False
-
-        # Check if tool is in allowed list
-        return tool_name in allowed_tools
+        return MCPRequestHandler.tool_is_granted(tool_name, allowed_tools)
 
     @staticmethod
     def is_tool_allowed(

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -118,10 +118,11 @@ from litellm.proxy._experimental.mcp_server.utils import (
     is_short_mcp_tool_prefix_enabled,
     iter_known_server_prefixes,
     iter_known_tool_name_spellings,
-    match_known_tool_name,
     match_known_server_prefix,
+    match_known_tool_name,
     merge_mcp_headers,
     normalize_server_name,
+    openapi_tool_name,
     parse_admin_env_vars,
     strip_known_server_prefix,
     validate_mcp_server_name,
@@ -1785,7 +1786,7 @@ class MCPServerManager:
 
                     # Generate tool name (without prefix initially)
                     operation_id = operation.get("operationId", f"{method}_{path.replace('/', '_')}")
-                    base_tool_name = operation_id.replace(" ", "_").lower()
+                    base_tool_name = openapi_tool_name(operation_id)
 
                     # Add server prefix to tool name
                     prefixed_tool_name = add_server_prefix_to_name(base_tool_name, server_prefix)

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -118,6 +118,7 @@ from litellm.proxy._experimental.mcp_server.utils import (
     is_short_mcp_tool_prefix_enabled,
     iter_known_server_prefixes,
     iter_known_tool_name_spellings,
+    match_known_tool_name,
     match_known_server_prefix,
     merge_mcp_headers,
     normalize_server_name,
@@ -4262,26 +4263,19 @@ class MCPServerManager:
         """
         Check if the tool is allowed or banned for the given server.
 
-        ``tool_name`` is bare: every caller resolves the boundary against the
-        server's registered prefixes before dispatch (``server.py``'s
-        ``original_tool_name``, the Responses handler's ``sanitized_tool_name``).
-        Stored entries are matched by deriving the spellings routing accepts
-        rather than by stripping the entries, which would cut a second boundary
-        out of a native name that itself opens with the server prefix.
+        ``tool_name`` is bare: every caller resolves the boundary against the server's
+        registered prefixes before dispatch (``server.py``'s ``original_tool_name``, the
+        Responses handler's ``sanitized_tool_name``). Configured entries are matched by
+        deriving the spellings routing accepts, never by stripping the entry, which would
+        cut a second boundary out of a native name that opens with the server prefix.
         """
         from litellm.proxy._experimental.mcp_server.utils import (
             server_applies_tool_allowlist,
         )
 
-        spellings = tuple(iter_known_tool_name_spellings(tool_name, server))
-
         if server_applies_tool_allowlist(server):
-            if not server.allowed_tools:
-                return False
-            return any(spelling in server.allowed_tools for spelling in spellings)
-        if server.disallowed_tools:
-            return all(spelling not in server.disallowed_tools for spelling in spellings)
-        return True
+            return match_known_tool_name(tool_name, server, server.allowed_tools or ()) is not None
+        return match_known_tool_name(tool_name, server, server.disallowed_tools or ()) is None
 
     def validate_allowed_params(self, tool_name: str, arguments: dict[str, Any], server: MCPServer) -> None:
         """
@@ -4299,18 +4293,12 @@ class MCPServerManager:
         Raises:
             HTTPException: If allowed_params is configured for this tool but arguments contain disallowed params
         """
-        # If no allowed_params configured, return all arguments
-        if not server.allowed_params:
+        allowed_params = server.allowed_params or {}
+        matched = match_known_tool_name(tool_name, server, allowed_params)
+        if matched is None:
             return
 
-        spellings = iter_known_tool_name_spellings(tool_name, server)
-        allowed_params_list = next(
-            (server.allowed_params[name] for name in spellings if name in server.allowed_params), None
-        )
-
-        # If this tool doesn't have allowed_params specified, allow all params
-        if allowed_params_list is None:
-            return None
+        allowed_params_list = allowed_params[matched]
 
         # Filter arguments to only include allowed parameters
         disallowed_params = [param for param in arguments.keys() if param not in allowed_params_list]

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -116,12 +116,13 @@ from litellm.proxy._experimental.mcp_server.utils import (
     get_server_prefix,
     interpolate_headers,
     is_short_mcp_tool_prefix_enabled,
-    is_tool_name_prefixed,
     iter_known_server_prefixes,
+    iter_known_tool_name_spellings,
+    match_known_server_prefix,
     merge_mcp_headers,
     normalize_server_name,
     parse_admin_env_vars,
-    split_server_prefix_from_name,
+    strip_known_server_prefix,
     validate_mcp_server_name,
 )
 from litellm.proxy._types import (
@@ -4185,10 +4186,8 @@ class MCPServerManager:
             # Register every known prefix form (alias, server_name, server_id,
             # short ID) so call_tool can resolve regardless of which form a
             # caller / cached client is using.
-            self.tool_name_to_mcp_server_name_mapping[original_name] = prefix
-            for known_prefix in iter_known_server_prefixes(server):
-                qualified = add_server_prefix_to_name(original_name, known_prefix)
-                self.tool_name_to_mcp_server_name_mapping[qualified] = prefix
+            for spelling in iter_known_tool_name_spellings(original_name, server):
+                self.tool_name_to_mcp_server_name_mapping[spelling] = prefix
 
         verbose_logger.info(f"Successfully fetched {len(prefixed_tools)} tools from server {server.name}")
         return prefixed_tools
@@ -4261,20 +4260,27 @@ class MCPServerManager:
 
     def check_allowed_or_banned_tools(self, tool_name: str, server: MCPServer) -> bool:
         """
-        Check if the tool is allowed or banned for the given server
+        Check if the tool is allowed or banned for the given server.
+
+        ``tool_name`` is bare: every caller resolves the boundary against the
+        server's registered prefixes before dispatch (``server.py``'s
+        ``original_tool_name``, the Responses handler's ``sanitized_tool_name``).
+        Stored entries are matched by deriving the spellings routing accepts
+        rather than by stripping the entries, which would cut a second boundary
+        out of a native name that itself opens with the server prefix.
         """
         from litellm.proxy._experimental.mcp_server.utils import (
             server_applies_tool_allowlist,
         )
 
+        spellings = tuple(iter_known_tool_name_spellings(tool_name, server))
+
         if server_applies_tool_allowlist(server):
             if not server.allowed_tools:
                 return False
-            return tool_name in server.allowed_tools or f"{server.name}-{tool_name}" in server.allowed_tools
+            return any(spelling in server.allowed_tools for spelling in spellings)
         if server.disallowed_tools:
-            return (
-                tool_name not in server.disallowed_tools and f"{server.name}-{tool_name}" not in server.disallowed_tools
-            )
+            return all(spelling not in server.disallowed_tools for spelling in spellings)
         return True
 
     def validate_allowed_params(self, tool_name: str, arguments: dict[str, Any], server: MCPServer) -> None:
@@ -4282,7 +4288,8 @@ class MCPServerManager:
         Filter arguments to only include allowed parameters for the given tool.
 
         Args:
-            tool_name: Name of the tool (with or without prefix)
+            tool_name: Bare tool name, already resolved against the server's
+                registered prefixes by the caller
             arguments: Dictionary of arguments to filter
             server: MCPServer configuration
 
@@ -4292,19 +4299,14 @@ class MCPServerManager:
         Raises:
             HTTPException: If allowed_params is configured for this tool but arguments contain disallowed params
         """
-        from litellm.proxy._experimental.mcp_server.utils import (
-            split_server_prefix_from_name,
-        )
-
         # If no allowed_params configured, return all arguments
         if not server.allowed_params:
             return
 
-        # Get the unprefixed tool name to match against config
-        unprefixed_tool_name, _ = split_server_prefix_from_name(tool_name)
-
-        # Check both prefixed and unprefixed tool names
-        allowed_params_list = server.allowed_params.get(tool_name) or server.allowed_params.get(unprefixed_tool_name)
+        spellings = iter_known_tool_name_spellings(tool_name, server)
+        allowed_params_list = next(
+            (server.allowed_params[name] for name in spellings if name in server.allowed_params), None
+        )
 
         # If this tool doesn't have allowed_params specified, allow all params
         if allowed_params_list is None:
@@ -4390,8 +4392,11 @@ class MCPServerManager:
             global_mcp_tool_registry,
         )
 
-        # Get the tool from the registry
-        tool = global_mcp_tool_registry.get_tool(f"{server.name}-{tool_name}")
+        # Registration used add_server_prefix_to_name(base, get_server_prefix(server)),
+        # and tool_name is the bare base name by the time call_tool reaches here, so
+        # rebuilding the key the same way reproduces it exactly
+        registry_key = add_server_prefix_to_name(tool_name, get_server_prefix(server))
+        tool = global_mcp_tool_registry.get_tool(registry_key)
         if tool is None:
             # Tool not found in registry
             error_msg = f"OpenAPI tool {tool_name} not found in registry"
@@ -5251,7 +5256,7 @@ class MCPServerManager:
             for tool in tools:
                 # The tool.name here is already prefixed from _get_tools_from_server
                 # Extract original name for mapping
-                original_name, _ = split_server_prefix_from_name(tool.name)
+                original_name = strip_known_server_prefix(tool.name, server)
                 self.tool_name_to_mcp_server_name_mapping[original_name] = server.name
                 self.tool_name_to_mcp_server_name_mapping[tool.name] = server.name
 
@@ -5288,13 +5293,10 @@ class MCPServerManager:
 
         # If not found and tool name is prefixed, extract the prefix and
         # match against any known form.
-        if is_tool_name_prefixed(tool_name, known_server_prefixes=set(prefix_to_server.keys())):
-            (
-                original_tool_name,
-                server_name_from_prefix,
-            ) = split_server_prefix_from_name(tool_name)
-            normalised_prefix = normalize_server_name(server_name_from_prefix)
-            matched_server = prefix_to_server.get(normalised_prefix)
+        matched = match_known_server_prefix(tool_name, prefix_to_server.keys())
+        if matched is not None:
+            matched_prefix, original_tool_name = matched
+            matched_server = prefix_to_server.get(matched_prefix)
             if matched_server is not None and (
                 original_tool_name in self.tool_name_to_mcp_server_name_mapping
                 or tool_name in self.tool_name_to_mcp_server_name_mapping

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -99,9 +99,9 @@ if MCP_AVAILABLE:
         MCPServer,
         _apply_toolset_scope,
         _fire_mcp_tool_call_logging,
-        _tool_name_matches,
         execute_mcp_tool,
         filter_tools_by_allowed_tools,
+        filter_tools_by_key_team_permissions,
     )
 
     ########################################################
@@ -530,19 +530,17 @@ if MCP_AVAILABLE:
         tools = filter_tools_by_allowed_tools(tools, server)
 
         # Filter by the key's effective tool permissions through the same
-        # primitive the MCP protocol path uses (direct grants, toolset grants,
-        # and team/agent/org ceilings), so REST listing cannot drift from it
+        # function the MCP protocol path uses (direct grants, toolset grants,
+        # and team/agent/org ceilings), so REST listing cannot drift from it.
+        # Entries here are tool names on one server, written bare by every
+        # writer, and dispatch compares them bare; matching a wider set of
+        # spellings would advertise a tool that tools/call then refuses
         if user_api_key_auth:
-            from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
-                MCPRequestHandler,
-            )
-
-            allowed_tools_for_server = await MCPRequestHandler.get_allowed_tools_for_server(
+            tools = await filter_tools_by_key_team_permissions(
+                tools=tools,
                 server_id=server.server_id,
                 user_api_key_auth=user_api_key_auth,
             )
-            if allowed_tools_for_server is not None:
-                tools = [tool for tool in tools if _tool_name_matches(tool.name, allowed_tools_for_server, server)]
 
         return _create_tool_response_objects(tools, server)
 

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -542,7 +542,7 @@ if MCP_AVAILABLE:
                 user_api_key_auth=user_api_key_auth,
             )
             if allowed_tools_for_server is not None:
-                tools = [tool for tool in tools if _tool_name_matches(tool.name, allowed_tools_for_server)]
+                tools = [tool for tool in tools if _tool_name_matches(tool.name, allowed_tools_for_server, server)]
 
         return _create_tool_response_objects(tools, server)
 

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -65,7 +65,7 @@ from litellm.proxy._experimental.mcp_server.utils import (
     extract_mcp_tool_result_error_message,
     get_server_prefix,
     iter_known_server_prefixes,
-    iter_known_tool_name_spellings,
+    match_known_tool_name,
 )
 from litellm.proxy._types import (
     ProxyException,
@@ -1421,28 +1421,13 @@ if MCP_AVAILABLE:
         """
         Check if a tool name matches any name in the filter list.
 
-        Matches via the same ``iter_known_tool_name_spellings`` the server-level
-        permission checks use, so discovery hides exactly what dispatch refuses;
-        covering fewer spellings here leaves a blocked tool advertised in
-        ``tools/list``. Comparison is case-insensitive to handle OpenAPI
-        operationIds that may be in camelCase.
-
-        Args:
-            tool_name: The tool name to check (may be prefixed like "server-tool_name")
-            filter_list: List of tool names to match against
-            mcp_server: The server the tool belongs to, whose registered prefixes
-                locate the boundary exactly. Required: guessing the boundary at
-                the first separator silently mismatches every tool on a server
-                whose prefix contains the separator.
-
-        Returns:
-            True if any spelling of the tool name is in the filter list
+        Reads the same owner the server-level permission checks use, so discovery hides
+        exactly what dispatch refuses. ``mcp_server`` is required: guessing the boundary
+        at the first separator mismatches every tool on a server whose prefix contains
+        the separator.
         """
-        filter_list_lower = {f.lower() for f in filter_list}
         bare_name = strip_known_server_prefix(tool_name, mcp_server)
-        spellings = (tool_name, *iter_known_tool_name_spellings(bare_name, mcp_server))
-
-        return any(spelling.lower() in filter_list_lower for spelling in spellings)
+        return match_known_tool_name(bare_name, mcp_server, filter_list) is not None
 
     def filter_tools_by_allowed_tools(
         tools: list[MCPTool],

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2305,14 +2305,16 @@ if MCP_AVAILABLE:
             server_id=server_id,
             user_api_key_auth=user_api_key_auth,
         )
-        if allowed_tool_names is None:
-            return tools
 
         # Tools arrive prefixed with the server's own prefix; strip exactly that
         # prefix (resolved from the server) rather than the first separator, so a
         # prefix containing the separator still reduces to the stored bare name.
         server = global_mcp_server_manager.get_mcp_server_by_id(server_id)
-        return [t for t in tools if strip_known_server_prefix(t.name, server) in allowed_tool_names]
+        return [
+            t
+            for t in tools
+            if MCPRequestHandler.tool_is_granted(strip_known_server_prefix(t.name, server), allowed_tool_names)
+        ]
 
     async def _list_mcp_tools(
         user_api_key_auth: UserAPIKeyAuth | None = None,

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -65,6 +65,7 @@ from litellm.proxy._experimental.mcp_server.utils import (
     extract_mcp_tool_result_error_message,
     get_server_prefix,
     iter_known_server_prefixes,
+    iter_known_tool_name_spellings,
 )
 from litellm.proxy._types import (
     ProxyException,
@@ -1416,34 +1417,32 @@ if MCP_AVAILABLE:
 
         return allowed_mcp_servers
 
-    def _tool_name_matches(tool_name: str, filter_list: list[str]) -> bool:
+    def _tool_name_matches(tool_name: str, filter_list: list[str], mcp_server: MCPServer) -> bool:
         """
         Check if a tool name matches any name in the filter list.
 
-        Checks both the full tool name and unprefixed version (without server prefix).
-        This allows users to configure simple tool names regardless of prefixing.
-        Comparison is case-insensitive to handle OpenAPI operationIds that may be in camelCase.
+        Matches via the same ``iter_known_tool_name_spellings`` the server-level
+        permission checks use, so discovery hides exactly what dispatch refuses;
+        covering fewer spellings here leaves a blocked tool advertised in
+        ``tools/list``. Comparison is case-insensitive to handle OpenAPI
+        operationIds that may be in camelCase.
 
         Args:
             tool_name: The tool name to check (may be prefixed like "server-tool_name")
             filter_list: List of tool names to match against
+            mcp_server: The server the tool belongs to, whose registered prefixes
+                locate the boundary exactly. Required: guessing the boundary at
+                the first separator silently mismatches every tool on a server
+                whose prefix contains the separator.
 
         Returns:
-            True if the tool name (prefixed or unprefixed) is in the filter list
+            True if any spelling of the tool name is in the filter list
         """
-        from litellm.proxy._experimental.mcp_server.utils import (
-            split_server_prefix_from_name,
-        )
+        filter_list_lower = {f.lower() for f in filter_list}
+        bare_name = strip_known_server_prefix(tool_name, mcp_server)
+        spellings = (tool_name, *iter_known_tool_name_spellings(bare_name, mcp_server))
 
-        # Normalize filter list to lowercase for case-insensitive comparison
-        filter_list_lower = [f.lower() for f in filter_list]
-
-        if tool_name.lower() in filter_list_lower:
-            return True
-
-        # Check if the unprefixed name is in the list (case-insensitive)
-        unprefixed_name, _ = split_server_prefix_from_name(tool_name)
-        return unprefixed_name.lower() in filter_list_lower
+        return any(spelling.lower() in filter_list_lower for spelling in spellings)
 
     def filter_tools_by_allowed_tools(
         tools: list[MCPTool],
@@ -1473,12 +1472,16 @@ if MCP_AVAILABLE:
         if server_applies_tool_allowlist(mcp_server):
             if not mcp_server.allowed_tools:
                 return []
-            tools_to_return = [tool for tool in tools if _tool_name_matches(tool.name, mcp_server.allowed_tools)]
+            tools_to_return = [
+                tool for tool in tools if _tool_name_matches(tool.name, mcp_server.allowed_tools, mcp_server)
+            ]
 
         # Filter by disallowed_tools (blacklist)
         if mcp_server.disallowed_tools:
             tools_to_return = [
-                tool for tool in tools_to_return if not _tool_name_matches(tool.name, mcp_server.disallowed_tools)
+                tool
+                for tool in tools_to_return
+                if not _tool_name_matches(tool.name, mcp_server.disallowed_tools, mcp_server)
             ]
 
         return tools_to_return
@@ -1498,7 +1501,7 @@ if MCP_AVAILABLE:
             return tools
 
         for tool in tools:
-            unprefixed, _ = split_server_prefix_from_name(tool.name)
+            unprefixed = strip_known_server_prefix(tool.name, mcp_server)
             lookup_key = unprefixed or tool.name
             if lookup_key in display_name_map:
                 tool.name = display_name_map[lookup_key]
@@ -2699,6 +2702,7 @@ if MCP_AVAILABLE:
                         break
             if mcp_server is not None:
                 server_name = mcp_server.name
+                original_tool_name = strip_known_server_prefix(name, mcp_server)
 
             if requested_server is not None:
                 if mcp_server is not None and mcp_server.server_id != requested_server.server_id:
@@ -2716,6 +2720,7 @@ if MCP_AVAILABLE:
                 if mcp_server is None:
                     mcp_server = requested_server
                     server_name = requested_server.name
+                    original_tool_name = strip_known_server_prefix(name, requested_server)
 
         # Only enforce server-level permissions when we can resolve a server
         if server_name:
@@ -2887,13 +2892,14 @@ if MCP_AVAILABLE:
                 _request_resolved_auth_headers.reset(_resolved_token)
             response = CallToolResult(content=cast(Any, local_content), isError=False)
 
-        # Try managed MCP server tool (pass the full prefixed name)
+        # Try managed MCP server tool (the name is bare; the prefix boundary was
+        # already resolved above against this server's registered prefixes)
         # Primary and recommended way to use external MCP servers
         #########################################################
         elif mcp_server:
             response = await _handle_managed_mcp_tool(
                 server_name=server_name,
-                name=original_tool_name,  # Pass the full name (potentially prefixed)
+                name=original_tool_name,
                 arguments=arguments,
                 user_api_key_auth=user_api_key_auth,
                 mcp_auth_header=mcp_auth_header,

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -326,13 +326,60 @@ def iter_known_server_prefixes(server: Any) -> Iterator[str]:
     yield from _emit(server_id)
 
 
+def iter_known_tool_name_spellings(tool_name: str, server: Any) -> Iterator[str]:
+    """Yield every name that denotes the bare ``tool_name`` on ``server``.
+
+    The bare name, then its wire spelling under each prefix from
+    ``iter_known_server_prefixes``. Routing resolves an inbound name against that
+    whole set, so anything keyed by tool name (the routing map, the allow/deny
+    lists, ``allowed_params``) must cover it too or it answers for fewer names
+    than are reachable, which fails open on ``disallowed_tools``.
+    ``get_server_prefix`` alone covers only the published spelling, and that moves
+    with the alias and with ``LITELLM_USE_SHORT_MCP_TOOL_PREFIX``. These are
+    spellings of one tool on one server, so honoring all of them normalizes the
+    entry rather than widening a grant.
+    """
+    yield tool_name
+    for prefix in iter_known_server_prefixes(server):
+        yield add_server_prefix_to_name(tool_name, prefix)
+
+
 def split_server_prefix_from_name(prefixed_name: str) -> Tuple[str, str]:
-    """Return the unprefixed name plus the server name used as prefix."""
+    """Return the unprefixed name plus the server name used as prefix.
+
+    Cuts at the FIRST separator, so the two halves are only trustworthy as a
+    pair: they reassemble into ``prefixed_name`` exactly, which is what makes
+    this safe for routing. Reading one half on its own is a guess about where the
+    boundary fell, and that guess is wrong whenever the prefix itself contains
+    the separator. Callers that compare a half against configuration must use
+    :func:`match_known_server_prefix` or :func:`strip_known_server_prefix`.
+    """
     if MCP_TOOL_PREFIX_SEPARATOR in prefixed_name:
         parts = prefixed_name.split(MCP_TOOL_PREFIX_SEPARATOR, 1)
         if len(parts) == 2:
             return parts[1], parts[0]
     return prefixed_name, ""
+
+
+def match_known_server_prefix(name: str, known_prefixes: Iterable[str]) -> tuple[str, str] | None:
+    """Return ``(matched_prefix, bare_name)`` when ``name`` carries a known prefix.
+
+    Candidates are normalized and tried LONGEST first, so a prefix that itself
+    contains :data:`MCP_TOOL_PREFIX_SEPARATOR` (the UUID ``server_id`` used when
+    a server has no alias, or a legacy hyphenated alias) wins over a shorter
+    prefix that is merely its leading segment. Returns ``None`` when no candidate
+    matches, i.e. ``name`` carries none of these prefixes.
+    """
+    candidates = sorted(
+        {normalize_server_name(prefix) for prefix in known_prefixes if prefix},
+        key=len,
+        reverse=True,
+    )
+    for prefix in candidates:
+        separator_suffixed = prefix + MCP_TOOL_PREFIX_SEPARATOR
+        if name.startswith(separator_suffixed):
+            return prefix, name[len(separator_suffixed) :]
+    return None
 
 
 def strip_known_server_prefix(name: str, server: Optional[Any]) -> str:
@@ -352,11 +399,8 @@ def strip_known_server_prefix(name: str, server: Optional[Any]) -> str:
     """
     if server is None:
         return split_server_prefix_from_name(name)[0]
-    for prefix in iter_known_server_prefixes(server):
-        candidate = normalize_server_name(prefix) + MCP_TOOL_PREFIX_SEPARATOR
-        if name.startswith(candidate):
-            return name[len(candidate) :]
-    return name
+    matched = match_known_server_prefix(name, iter_known_server_prefixes(server))
+    return name if matched is None else matched[1]
 
 
 def is_tool_name_prefixed(
@@ -367,15 +411,16 @@ def is_tool_name_prefixed(
     Check if tool name has a known MCP server prefix.
 
     When ``known_server_prefixes`` is provided the function verifies that the
-    substring before the first separator is an actual registered server
-    prefix.  Without it the check falls back to the legacy heuristic
+    name actually starts with one of those prefixes followed by the separator,
+    matching the longest candidate first so a prefix containing the separator
+    still resolves.  Without it the check falls back to the legacy heuristic
     (separator present anywhere in the name), which can produce false
     positives for non-MCP tools whose names contain hyphens
     (e.g. ``text-to-speech``, ``code-review``).
 
     Args:
         tool_name: Tool name to check.
-        known_server_prefixes: Optional set of normalised server prefixes
+        known_server_prefixes: Optional set of normalized server prefixes
             currently registered in the MCP manager.  Pass this whenever
             the caller has access to the server registry so that the check
             is accurate.
@@ -387,8 +432,7 @@ def is_tool_name_prefixed(
         return False
 
     if known_server_prefixes is not None:
-        candidate_prefix = tool_name.split(MCP_TOOL_PREFIX_SEPARATOR, 1)[0]
-        return normalize_server_name(candidate_prefix) in known_server_prefixes
+        return match_known_server_prefix(tool_name, known_server_prefixes) is not None
 
     # Legacy fallback – separator present somewhere in the name.
     return True

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -343,14 +343,30 @@ def match_known_tool_name(tool_name: str, server: MCPServer, names: Iterable[str
     """Return the entry of ``names`` that denotes ``tool_name`` on ``server``, else ``None``.
 
     The single question every tool-name-keyed site asks: the allow list, the deny list,
-    ``allowed_params`` and the discovery filter. Matching spans every spelling routing
-    accepts and ignores case, so discovery hides exactly what dispatch refuses. Callers
-    read the returned entry rather than testing a container's values, which is what stops
-    an explicitly empty ``allowed_params`` list from reading as "nothing configured".
+    ``allowed_params`` and the discovery filter, so discovery hides exactly what dispatch
+    refuses. It spans every spelling routing accepts and no more. A tool's identity is its
+    exact name, because routing dispatches two names differing only in case as two tools,
+    and folding case here would let one policy decide both.
+
+    OpenAPI servers are the exception, and not a fuzzy one. ``_register_openapi_tools``
+    rewrites every operationId through ``sanitize_openapi_tool_name``, so configuration
+    holding the spec's own spelling never equals the registered name; replaying that exact
+    rewrite on the entry recovers the link. It cannot merge identities, because every name
+    it produces is lowercased, so no two tools on such a server differ only in case.
+
+    Callers read the returned entry rather than testing a container's values, which is what
+    stops an explicitly empty ``allowed_params`` list from reading as "nothing configured".
     """
-    entries = {name.casefold(): name for name in names}
-    spellings = map(str.casefold, iter_known_tool_name_spellings(tool_name, server))
-    return next((entries[spelling] for spelling in spellings if spelling in entries), None)
+    from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
+        sanitize_openapi_tool_name,
+    )
+
+    spellings = set(iter_known_tool_name_spellings(tool_name, server))
+    exact = next((name for name in names if name in spellings), None)
+    if exact is not None or not getattr(server, "spec_path", None):
+        return exact
+    sanitized = {sanitize_openapi_tool_name(spelling) for spelling in spellings}
+    return next((name for name in names if sanitize_openapi_tool_name(name) in sanitized), None)
 
 
 def split_server_prefix_from_name(prefixed_name: str) -> Tuple[str, str]:

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -2,7 +2,10 @@
 MCP Server Utilities
 """
 
+import hashlib
+import importlib
 import json
+import os
 import re
 from collections.abc import MutableMapping, MutableSequence
 from typing import (
@@ -17,10 +20,6 @@ from typing import (
     Tuple,
     Union,
 )
-
-import hashlib
-import importlib
-import os
 from urllib.parse import quote
 
 from litellm.types.mcp_server.mcp_server_manager import MCPServer
@@ -339,34 +338,36 @@ def iter_known_tool_name_spellings(tool_name: str, server: MCPServer) -> Iterato
         yield add_server_prefix_to_name(tool_name, prefix)
 
 
+def openapi_tool_name(operation_id: str) -> str:
+    """Return the tool name ``_register_openapi_tools`` registers ``operation_id`` under.
+
+    The single transform between a spec's operationId and the name the gateway serves.
+    Policy recovers the link by replaying this exact function, which is what keeps it from
+    deciding for a tool it does not name: two operationIds that register as two tools
+    necessarily normalize to two names here, because this is the map that registered them.
+    """
+    return operation_id.replace(" ", "_").lower()
+
+
 def match_known_tool_name(tool_name: str, server: MCPServer, names: Iterable[str]) -> str | None:
     """Return the entry of ``names`` that denotes ``tool_name`` on ``server``, else ``None``.
 
     The single question every tool-name-keyed site asks: the allow list, the deny list,
     ``allowed_params`` and the discovery filter, so discovery hides exactly what dispatch
-    refuses. It spans every spelling routing accepts and no more. A tool's identity is its
-    exact name, because routing dispatches two names differing only in case as two tools,
-    and folding case here would let one policy decide both.
+    refuses. It spans every spelling routing accepts and no more, because a tool's identity
+    is the exact name routing dispatches; anything looser lets one policy decide two tools.
 
-    OpenAPI servers are the exception, and not a fuzzy one. ``_register_openapi_tools``
-    rewrites every operationId through ``sanitize_openapi_tool_name``, so configuration
-    holding the spec's own spelling never equals the registered name; replaying that exact
-    rewrite on the entry recovers the link. It cannot merge identities, because every name
-    it produces is lowercased, so no two tools on such a server differ only in case.
+    On an OpenAPI server the configured entry holds the spec's operationId while routing
+    holds :func:`openapi_tool_name` of it, so both sides go through that map first. Doing it
+    with the registering function rather than a lookalike is the whole safety argument: a
+    coarser one collapses operationIds that registration keeps apart.
 
     Callers read the returned entry rather than testing a container's values, which is what
     stops an explicitly empty ``allowed_params`` list from reading as "nothing configured".
     """
-    from litellm.proxy._experimental.mcp_server.openapi_to_mcp_generator import (
-        sanitize_openapi_tool_name,
-    )
-
-    spellings = set(iter_known_tool_name_spellings(tool_name, server))
-    exact = next((name for name in names if name in spellings), None)
-    if exact is not None or not getattr(server, "spec_path", None):
-        return exact
-    sanitized = {sanitize_openapi_tool_name(spelling) for spelling in spellings}
-    return next((name for name in names if sanitize_openapi_tool_name(name) in sanitized), None)
+    normalize = openapi_tool_name if getattr(server, "spec_path", None) else str
+    spellings = {normalize(spelling) for spelling in iter_known_tool_name_spellings(tool_name, server)}
+    return next((name for name in names if normalize(name) in spellings), None)
 
 
 def split_server_prefix_from_name(prefixed_name: str) -> Tuple[str, str]:

--- a/litellm/proxy/_experimental/mcp_server/utils.py
+++ b/litellm/proxy/_experimental/mcp_server/utils.py
@@ -23,6 +23,8 @@ import importlib
 import os
 from urllib.parse import quote
 
+from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
 # Constants
 #
 # NOTE: The environment-backed values below are read once, when this module is
@@ -326,22 +328,29 @@ def iter_known_server_prefixes(server: Any) -> Iterator[str]:
     yield from _emit(server_id)
 
 
-def iter_known_tool_name_spellings(tool_name: str, server: Any) -> Iterator[str]:
-    """Yield every name that denotes the bare ``tool_name`` on ``server``.
-
-    The bare name, then its wire spelling under each prefix from
-    ``iter_known_server_prefixes``. Routing resolves an inbound name against that
-    whole set, so anything keyed by tool name (the routing map, the allow/deny
-    lists, ``allowed_params``) must cover it too or it answers for fewer names
-    than are reachable, which fails open on ``disallowed_tools``.
-    ``get_server_prefix`` alone covers only the published spelling, and that moves
-    with the alias and with ``LITELLM_USE_SHORT_MCP_TOOL_PREFIX``. These are
-    spellings of one tool on one server, so honoring all of them normalizes the
-    entry rather than widening a grant.
+def iter_known_tool_name_spellings(tool_name: str, server: MCPServer) -> Iterator[str]:
+    """Yield every name that denotes the bare ``tool_name`` on ``server``: the bare name,
+    then its wire spelling under each prefix ``iter_known_server_prefixes`` accepts.
+    ``get_server_prefix`` covers only the currently published one, and that moves with the
+    alias and with ``LITELLM_USE_SHORT_MCP_TOOL_PREFIX``.
     """
     yield tool_name
     for prefix in iter_known_server_prefixes(server):
         yield add_server_prefix_to_name(tool_name, prefix)
+
+
+def match_known_tool_name(tool_name: str, server: MCPServer, names: Iterable[str]) -> str | None:
+    """Return the entry of ``names`` that denotes ``tool_name`` on ``server``, else ``None``.
+
+    The single question every tool-name-keyed site asks: the allow list, the deny list,
+    ``allowed_params`` and the discovery filter. Matching spans every spelling routing
+    accepts and ignores case, so discovery hides exactly what dispatch refuses. Callers
+    read the returned entry rather than testing a container's values, which is what stops
+    an explicitly empty ``allowed_params`` list from reading as "nothing configured".
+    """
+    entries = {name.casefold(): name for name in names}
+    spellings = map(str.casefold, iter_known_tool_name_spellings(tool_name, server))
+    return next((entries[spelling] for spelling in spellings if spelling in entries), None)
 
 
 def split_server_prefix_from_name(prefixed_name: str) -> Tuple[str, str]:

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -2010,6 +2010,9 @@ async def test_get_tools_for_single_server_applies_disallowed_tools_without_allo
     mock_server.mcp_info = {"server_name": "zapier"}
     mock_server.name = "zapier"
     mock_server.server_id = "zapier"
+    mock_server.server_name = "zapier"
+    mock_server.alias = None
+    mock_server.short_prefix = None
     mock_server.allowed_tools = None
     mock_server.disallowed_tools = ["send_email"]
 

--- a/tests/mcp_tests/test_mcp_server.py
+++ b/tests/mcp_tests/test_mcp_server.py
@@ -2040,6 +2040,65 @@ async def test_get_tools_for_single_server_applies_disallowed_tools_without_allo
 
 
 @pytest.mark.asyncio
+async def test_rest_listing_hides_key_grants_dispatch_would_refuse():
+    """REST listing must answer for exactly the key/team grants dispatch honors.
+
+    ``mcp_tool_permissions`` and toolset rows name a tool on one server, so both
+    the MCP list path and ``tools/call`` compare them bare. A wire-form entry
+    therefore grants nothing, and REST listing that matched the prefixed
+    spelling would advertise a tool the very next call refuses.
+    """
+    from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+        MCPRequestHandler,
+    )
+    from litellm.proxy._experimental.mcp_server.rest_endpoints import (
+        _get_tools_for_single_server,
+    )
+    from litellm.proxy._types import UserAPIKeyAuth
+    from mcp.types import Tool as MCPTool
+
+    server_id = "3c6f6617-d23c-4f48-bfb0-f205e3b27bab"
+    mock_server = MagicMock()
+    mock_server.mcp_info = {"server_name": server_id}
+    mock_server.name = server_id
+    mock_server.server_id = server_id
+    mock_server.server_name = None
+    mock_server.alias = None
+    mock_server.short_prefix = None
+    mock_server.allowed_tools = None
+    mock_server.disallowed_tools = None
+    mock_server.tool_name_to_display_name = None
+
+    mock_tools = [
+        MCPTool(
+            name="read_wiki_contents",
+            description="Read a wiki",
+            inputSchema={"type": "object"},
+        ),
+    ]
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.rest_endpoints.global_mcp_server_manager"
+    ) as mock_manager, patch(
+        "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager"
+    ) as mock_server_manager, patch.object(
+        MCPRequestHandler,
+        "get_allowed_tools_for_server",
+        AsyncMock(return_value=[f"{server_id}-read_wiki_contents"]),
+    ):
+        mock_manager._get_tools_from_server = AsyncMock(return_value=mock_tools)
+        mock_server_manager.get_mcp_server_by_id.return_value = mock_server
+
+        result = await _get_tools_for_single_server(
+            mock_server,
+            "Bearer test_token",
+            user_api_key_auth=UserAPIKeyAuth(api_key="sk-test"),
+        )
+
+    assert result == []
+
+
+@pytest.mark.asyncio
 async def test_list_tool_rest_api_with_server_specific_auth():
     """Test list_tool_rest_api with server-specific auth headers."""
     from litellm.proxy._experimental.mcp_server.rest_endpoints import list_tool_rest_api

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -1029,6 +1029,9 @@ async def test_get_tools_from_mcp_servers_continues_when_one_server_fails():
     working_server.server_name = "working_server"
     working_server.auth_type = None
     working_server.extra_headers = None
+    working_server.short_prefix = None
+    working_server.tool_name_to_display_name = None
+    working_server.tool_name_to_description = None
 
     failing_server = MagicMock()
     failing_server.name = "failing_server"
@@ -1039,6 +1042,9 @@ async def test_get_tools_from_mcp_servers_continues_when_one_server_fails():
     failing_server.server_name = "failing_server"
     failing_server.auth_type = None
     failing_server.extra_headers = None
+    failing_server.short_prefix = None
+    failing_server.tool_name_to_display_name = None
+    failing_server.tool_name_to_description = None
 
     # Mock global_mcp_server_manager
     mock_manager = MagicMock()
@@ -4507,28 +4513,36 @@ def test_tool_name_matches_case_insensitive():
     except ImportError:
         pytest.skip("MCP server not available")
 
+    server = MCPServer(
+        server_id="srv-per-store",
+        name="per_store",
+        server_name="per_store",
+        url="http://127.0.0.1:5115/mcp",
+        transport=MCPTransport.http,
+    )
+
     # Test case 1: Unprefixed tool name with camelCase in filter list
-    assert _tool_name_matches("addpet", ["addPet", "updatePet"]) is True
-    assert _tool_name_matches("updatepet", ["addPet", "updatePet"]) is True
-    assert _tool_name_matches("deletepet", ["addPet", "updatePet"]) is False
+    assert _tool_name_matches("addpet", ["addPet", "updatePet"], server) is True
+    assert _tool_name_matches("updatepet", ["addPet", "updatePet"], server) is True
+    assert _tool_name_matches("deletepet", ["addPet", "updatePet"], server) is False
 
     # Test case 2: Prefixed tool name with camelCase in filter list
-    assert _tool_name_matches("per_store-addpet", ["addPet", "updatePet"]) is True
-    assert _tool_name_matches("per_store-updatepet", ["addPet", "updatePet"]) is True
-    assert _tool_name_matches("per_store-deletepet", ["addPet", "updatePet"]) is False
+    assert _tool_name_matches("per_store-addpet", ["addPet", "updatePet"], server) is True
+    assert _tool_name_matches("per_store-updatepet", ["addPet", "updatePet"], server) is True
+    assert _tool_name_matches("per_store-deletepet", ["addPet", "updatePet"], server) is False
 
     # Test case 3: Mixed case variations
-    assert _tool_name_matches("findPetsByStatus", ["findpetsbystatus"]) is True
-    assert _tool_name_matches("findpetsbystatus", ["findPetsByStatus"]) is True
-    assert _tool_name_matches("FINDPETSBYSTATUS", ["findPetsByStatus"]) is True
+    assert _tool_name_matches("findPetsByStatus", ["findpetsbystatus"], server) is True
+    assert _tool_name_matches("findpetsbystatus", ["findPetsByStatus"], server) is True
+    assert _tool_name_matches("FINDPETSBYSTATUS", ["findPetsByStatus"], server) is True
 
     # Test case 4: Full prefixed name in filter list (case-insensitive)
-    assert _tool_name_matches("server-addPet", ["server-addpet"]) is True
-    assert _tool_name_matches("server-addpet", ["server-addPet"]) is True
+    assert _tool_name_matches("server-addPet", ["server-addpet"], server) is True
+    assert _tool_name_matches("server-addpet", ["server-addPet"], server) is True
 
     # Test case 5: Ensure non-matching names still don't match
-    assert _tool_name_matches("addpet", ["deletePet", "updatePet"]) is False
-    assert _tool_name_matches("server-addpet", ["deletePet", "updatePet"]) is False
+    assert _tool_name_matches("addpet", ["deletePet", "updatePet"], server) is False
+    assert _tool_name_matches("server-addpet", ["deletePet", "updatePet"], server) is False
 
 
 def test_filter_tools_by_allowed_tools_case_insensitive():
@@ -4581,6 +4595,7 @@ def test_filter_tools_by_allowed_tools_case_insensitive():
     server = MCPServer(
         server_id="test-server",
         name="per_store",
+        server_name="per_store",
         transport=MCPTransport.http,
         allowed_tools=["addPet", "updatePet", "findPetsByStatus"],
     )
@@ -6122,6 +6137,70 @@ async def test_execute_mcp_tool_rest_server_id_authoritative_for_unprefixed_tool
 
 
 @pytest.mark.asyncio
+async def test_execute_mcp_tool_strips_a_prefix_that_contains_the_separator():
+    """A server with no alias publishes its UUID server_id as the tool prefix.
+
+    Splitting that wire name at the first separator leaves a truncated UUID tail
+    glued to the tool name, which then travels to the upstream server as the tool
+    to call, into the spend log, and into the server-level allowed_tools check.
+    """
+    from mcp.types import TextContent
+
+    from litellm.proxy._experimental.mcp_server import server as mcp_module
+
+    server_id = "117c814c-1a2b-4c4d-8e8f-0a1b2c3d4e5f"
+    alias_less_server = MCPServer(
+        server_id=server_id,
+        name=server_id,
+        url="http://127.0.0.1:5115/mcp",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.api_key,
+        authentication_token="abc123",
+    )
+
+    captured: dict = {}
+
+    async def fake_handle_managed_mcp_tool(**kwargs):
+        captured.update(kwargs)
+        return mcp_module.CallToolResult(
+            content=[TextContent(type="text", text="ok")],
+            isError=False,
+        )
+
+    with (
+        patch.object(
+            mcp_module.global_mcp_server_manager,
+            "_get_mcp_server_from_tool_name",
+            return_value=alias_less_server,
+        ),
+        patch.object(
+            mcp_module,
+            "_handle_managed_mcp_tool",
+            new=fake_handle_managed_mcp_tool,
+        ),
+        patch.object(
+            mcp_module.MCPRequestHandler,
+            "is_tool_allowed",
+            return_value=True,
+        ),
+        patch.object(
+            mcp_module.global_mcp_tool_registry,
+            "get_tool",
+            return_value=None,
+        ),
+    ):
+        await mcp_module.execute_mcp_tool(
+            name=f"{server_id}-read_wiki_contents",
+            arguments={"repoName": "acme/wiki"},
+            allowed_mcp_servers=[alias_less_server],
+            start_time=datetime.now(),
+        )
+
+    assert captured["server_name"] == server_id
+    assert captured["name"] == "read_wiki_contents"
+
+
+@pytest.mark.asyncio
 async def test_execute_mcp_tool_rest_server_id_injects_requested_server_credentials():
     """REST server_id must inject the requested server's auth, not a URL-collision peer's."""
     from mcp.types import TextContent
@@ -6426,6 +6505,8 @@ async def test_execute_mcp_tool_sets_model_in_model_call_details():
     fake_server.mcp_info = None
     fake_server.server_id = "srv-1"
     fake_server.server_name = "openapi-petstore"
+    fake_server.alias = None
+    fake_server.short_prefix = None
 
     fake_tool = MagicMock()
     fake_tool.name = "list_pets"
@@ -6481,7 +6562,13 @@ async def test_execute_mcp_tool_sets_model_in_model_call_details():
 
 @pytest.mark.asyncio
 async def test_execute_mcp_tool_rest_unresolved_prefixed_name_routes_to_requested_server():
-    """A prefixed REST name that resolves to no tool must still dispatch to the server_id."""
+    """A prefixed REST name that resolves to no tool must still dispatch to the server_id.
+
+    The prefix here belongs to a different server, so it is not a prefix boundary on the
+    routed server and the name travels upstream whole. Stripping it would invoke the routed
+    server's similarly named tool instead, which is what the tool_server_mismatch 403 exists
+    to prevent when the prefix does resolve.
+    """
     from mcp.types import TextContent
 
     from litellm.proxy._experimental.mcp_server import server as mcp_module
@@ -6553,7 +6640,7 @@ async def test_execute_mcp_tool_rest_unresolved_prefixed_name_routes_to_requeste
         )
 
     assert captured["server_name"] == "rest_target"
-    assert captured["name"] == "list_things"
+    assert captured["name"] == "known_prefix-list_things"
 
     routed_server = {
         requested_server.name: requested_server,
@@ -7587,22 +7674,28 @@ async def test_aggregate_listing_reports_per_server_outcomes():
     working_server = MagicMock()
     working_server.name = "working_server"
     working_server.alias = "working"
+    working_server.short_prefix = None
     working_server.allowed_tools = None
     working_server.disallowed_tools = None
     working_server.server_id = "working_server"
     working_server.server_name = "working_server"
     working_server.auth_type = None
     working_server.extra_headers = None
+    working_server.tool_name_to_display_name = None
+    working_server.tool_name_to_description = None
 
     broken_server = MagicMock()
     broken_server.name = "broken_server"
     broken_server.alias = "broken"
+    broken_server.short_prefix = None
     broken_server.allowed_tools = None
     broken_server.disallowed_tools = None
     broken_server.server_id = "broken_server"
     broken_server.server_name = "broken_server"
     broken_server.auth_type = None
     broken_server.extra_headers = None
+    broken_server.tool_name_to_display_name = None
+    broken_server.tool_name_to_description = None
 
     mock_manager = MagicMock()
     mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["working_server", "broken_server"])
@@ -7924,3 +8017,139 @@ async def test_post_mcp_call_guardrails_propagate_a_block():
                 user_api_key_auth=None,
                 request_data={},
             )
+
+
+class TestListFiltersHonorThePrefixBoundary:
+    """The listing filters compare a published (prefixed) tool name against
+    configured entries, so they have to locate the boundary with the server's
+    registered prefixes. An alias-less server publishes its UUID server_id as
+    the prefix, and that prefix contains the separator, so cutting at the first
+    separator drops every tool on the server from the listing.
+    """
+
+    SERVER_ID = "117c814c-1a2b-4c4d-8e8f-0a1b2c3d4e5f"
+
+    @staticmethod
+    def _alias_less_server(**overrides):
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServer
+
+        return MCPServer(
+            server_id=TestListFiltersHonorThePrefixBoundary.SERVER_ID,
+            name=TestListFiltersHonorThePrefixBoundary.SERVER_ID,
+            url="http://127.0.0.1:5115/mcp",
+            transport=MCPTransport.http,
+            **overrides,
+        )
+
+    def _published_tools(self, *bare_names: str):
+        from mcp.types import Tool as MCPTool
+
+        return [
+            MCPTool(name=f"{self.SERVER_ID}-{bare}", description=bare, inputSchema={"type": "object"})
+            for bare in bare_names
+        ]
+
+    def test_bare_allowlist_entry_keeps_the_published_tool(self):
+        from litellm.proxy._experimental.mcp_server.server import (
+            filter_tools_by_allowed_tools,
+        )
+
+        server = self._alias_less_server(allowed_tools=["read_wiki_contents"])
+        tools = self._published_tools("read_wiki_contents", "read_wiki_structure")
+
+        kept = filter_tools_by_allowed_tools(tools, server)
+
+        assert [tool.name for tool in kept] == [f"{self.SERVER_ID}-read_wiki_contents"]
+
+    def test_bare_blocklist_entry_excludes_the_published_tool(self):
+        from litellm.proxy._experimental.mcp_server.server import (
+            filter_tools_by_allowed_tools,
+        )
+
+        server = self._alias_less_server(disallowed_tools=["read_wiki_structure"])
+        tools = self._published_tools("read_wiki_contents", "read_wiki_structure")
+
+        kept = filter_tools_by_allowed_tools(tools, server)
+
+        assert [tool.name for tool in kept] == [f"{self.SERVER_ID}-read_wiki_contents"]
+
+    def test_unrelated_entry_does_not_match(self):
+        from litellm.proxy._experimental.mcp_server.server import _tool_name_matches
+
+        server = self._alias_less_server()
+
+        assert not _tool_name_matches(f"{self.SERVER_ID}-read_wiki_contents", ["read_wiki_structure"], server)
+
+    def test_match_is_still_case_insensitive(self):
+        from litellm.proxy._experimental.mcp_server.server import _tool_name_matches
+
+        server = self._alias_less_server()
+
+        assert _tool_name_matches(f"{self.SERVER_ID}-findPetsByStatus", ["findpetsbystatus"], server)
+
+    def test_alias_form_entry_matches_a_tool_published_under_the_short_prefix(self, monkeypatch):
+        # Routing accepts the alias form, so an entry stored before short
+        # prefixes were turned on still governs the tool. Matching only the
+        # published spelling left it advertised while dispatch refused it.
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import MCPServer
+        from litellm.proxy._experimental.mcp_server.server import _tool_name_matches
+
+        monkeypatch.setenv("LITELLM_USE_SHORT_MCP_TOOL_PREFIX", "true")
+        server = MCPServer(
+            server_id=self.SERVER_ID,
+            name="deepwiki_cfg",
+            alias="deepwiki_cfg",
+            short_prefix="eiG",
+            url="http://127.0.0.1:5115/mcp",
+            transport=MCPTransport.http,
+        )
+
+        assert _tool_name_matches("eiG-read_wiki_contents", ["deepwiki_cfg-read_wiki_contents"], server)
+
+    def test_discovery_hides_exactly_what_dispatch_refuses(self, monkeypatch):
+        """Both halves of one decision, driven through both production paths.
+
+        A spelling the blocklist enforces but the filter misses leaves a blocked
+        tool advertised; the reverse hides a tool that would have been callable.
+        """
+        from mcp.types import Tool as MCPTool
+
+        from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+            MCPServer,
+            MCPServerManager,
+        )
+        from litellm.proxy._experimental.mcp_server.server import (
+            filter_tools_by_allowed_tools,
+        )
+
+        monkeypatch.setenv("LITELLM_USE_SHORT_MCP_TOOL_PREFIX", "true")
+
+        def _server(**overrides):
+            return MCPServer(
+                server_id=self.SERVER_ID,
+                name="deepwiki_prod",
+                alias="deepwiki",
+                server_name="deepwiki_prod",
+                short_prefix="eiG",
+                url="http://127.0.0.1:5115/mcp",
+                transport=MCPTransport.http,
+                **overrides,
+            )
+
+        manager = MCPServerManager()
+        manager._create_prefixed_tools(
+            [MCPTool(name="read_wiki_contents", description="", inputSchema={"type": "object"})],
+            _server(),
+        )
+        registered = sorted(manager.tool_name_to_mcp_server_name_mapping)
+        assert len(registered) > 1
+
+        published = MCPTool(name="eiG-read_wiki_contents", description="", inputSchema={"type": "object"})
+        for spelling in registered:
+            server = _server(disallowed_tools=[spelling])
+
+            refused = not manager.check_allowed_or_banned_tools("read_wiki_contents", server)
+            hidden = filter_tools_by_allowed_tools([published], server) == []
+
+            assert refused, spelling
+            assert hidden, spelling

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -8146,10 +8146,11 @@ class TestListFiltersHonorThePrefixBoundary:
 
         published = MCPTool(name="eiG-read_wiki_contents", description="", inputSchema={"type": "object"})
         for spelling in registered:
-            server = _server(disallowed_tools=[spelling])
+            for entry in (spelling, spelling.upper()):
+                server = _server(disallowed_tools=[entry])
 
-            refused = not manager.check_allowed_or_banned_tools("read_wiki_contents", server)
-            hidden = filter_tools_by_allowed_tools([published], server) == []
+                refused = not manager.check_allowed_or_banned_tools("read_wiki_contents", server)
+                hidden = filter_tools_by_allowed_tools([published], server) == []
 
-            assert refused, spelling
-            assert hidden, spelling
+                assert refused, entry
+                assert hidden, entry

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -8154,3 +8154,61 @@ class TestListFiltersHonorThePrefixBoundary:
 
                 assert refused, entry
                 assert hidden, entry
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "grants,expected",
+        [
+            (None, True),
+            ([], False),
+            (["read_wiki_contents"], True),
+            (["read_wiki_structure"], False),
+            ([f"{SERVER_ID}-read_wiki_contents"], False),
+            (["READ_WIKI_CONTENTS"], False),
+        ],
+    )
+    async def test_key_team_listing_and_dispatch_agree(self, grants, expected):
+        """The key/team grant question, driven through both production paths.
+
+        Listing and dispatch read one predicate, so a row where the tool is advertised
+        and then refused (or hidden while callable) cannot exist. Asserting the expected
+        verdict as well as the agreement matters: both paths reading one predicate makes
+        equality alone tautological, so a wrong predicate would keep them consistent.
+        Grants are stored bare, so the wire-form and case-variant rows deny; that is
+        deliberately unlike the server-level lists, which honor every spelling.
+        """
+        from mcp.types import Tool as MCPTool
+
+        from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+            MCPRequestHandler,
+        )
+        from litellm.proxy._experimental.mcp_server.server import (
+            filter_tools_by_key_team_permissions,
+        )
+        from litellm.proxy._types import UserAPIKeyAuth
+
+        server = MCPServer(
+            server_id=self.SERVER_ID,
+            name=self.SERVER_ID,
+            url="http://127.0.0.1:5115/mcp",
+            transport=MCPTransport.http,
+        )
+        published = MCPTool(
+            name=f"{self.SERVER_ID}-read_wiki_contents", description="", inputSchema={"type": "object"}
+        )
+        auth = UserAPIKeyAuth(api_key="sk-test")
+
+        with patch.object(
+            MCPRequestHandler, "get_allowed_tools_for_server", AsyncMock(return_value=grants)
+        ), patch(
+            "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager"
+        ) as mock_manager:
+            mock_manager.get_mcp_server_by_id.return_value = server
+
+            listed = await filter_tools_by_key_team_permissions([published], self.SERVER_ID, auth) != []
+            callable_ = await MCPRequestHandler.is_tool_allowed_for_server(
+                tool_name="read_wiki_contents", server_id=self.SERVER_ID, user_api_key_auth=auth
+            )
+
+        assert listed == callable_, f"grants={grants!r} listed={listed} callable={callable_}"
+        assert listed is expected, f"grants={grants!r} expected={expected} got={listed}"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -4519,6 +4519,7 @@ def test_tool_name_matches_case_insensitive():
         server_name="per_store",
         url="http://127.0.0.1:5115/mcp",
         transport=MCPTransport.http,
+        spec_path="/specs/petstore.yaml",
     )
 
     # Test case 1: Unprefixed tool name with camelCase in filter list
@@ -4597,6 +4598,7 @@ def test_filter_tools_by_allowed_tools_case_insensitive():
         name="per_store",
         server_name="per_store",
         transport=MCPTransport.http,
+        spec_path="/specs/petstore.yaml",
         allowed_tools=["addPet", "updatePet", "findPetsByStatus"],
     )
 
@@ -8080,12 +8082,19 @@ class TestListFiltersHonorThePrefixBoundary:
 
         assert not _tool_name_matches(f"{self.SERVER_ID}-read_wiki_contents", ["read_wiki_structure"], server)
 
-    def test_match_is_still_case_insensitive(self):
+    def test_case_folding_applies_to_openapi_servers_and_not_to_native_ones(self):
+        # Registration rewrites operationIds through sanitize_openapi_tool_name, so
+        # folding recovers a spec-spelled entry on an OpenAPI server. A native server
+        # gets none of it: routing dispatches two names differing only in case as two
+        # tools, so one policy must not decide both.
         from litellm.proxy._experimental.mcp_server.server import _tool_name_matches
 
-        server = self._alias_less_server()
+        native = self._alias_less_server()
+        openapi = self._alias_less_server(spec_path="/specs/petstore.yaml")
 
-        assert _tool_name_matches(f"{self.SERVER_ID}-findPetsByStatus", ["findpetsbystatus"], server)
+        assert _tool_name_matches(f"{self.SERVER_ID}-findPetsByStatus", ["findpetsbystatus"], openapi)
+        assert not _tool_name_matches(f"{self.SERVER_ID}-findPetsByStatus", ["findpetsbystatus"], native)
+        assert _tool_name_matches(f"{self.SERVER_ID}-findpetsbystatus", ["findpetsbystatus"], native)
 
     def test_alias_form_entry_matches_a_tool_published_under_the_short_prefix(self, monkeypatch):
         # Routing accepts the alias form, so an entry stored before short
@@ -8111,6 +8120,10 @@ class TestListFiltersHonorThePrefixBoundary:
 
         A spelling the blocklist enforces but the filter misses leaves a blocked
         tool advertised; the reverse hides a tool that would have been callable.
+        Every spelling routing registers bans, and its upper-cased form bans nothing,
+        because a tool's identity is its exact name; asserting the verdict and not only
+        the agreement is what keeps this from passing on a matcher that answers wrongly
+        but consistently.
         """
         from mcp.types import Tool as MCPTool
 
@@ -8146,14 +8159,14 @@ class TestListFiltersHonorThePrefixBoundary:
 
         published = MCPTool(name="eiG-read_wiki_contents", description="", inputSchema={"type": "object"})
         for spelling in registered:
-            for entry in (spelling, spelling.upper()):
+            for entry, expected in ((spelling, True), (spelling.upper(), False)):
                 server = _server(disallowed_tools=[entry])
 
                 refused = not manager.check_allowed_or_banned_tools("read_wiki_contents", server)
                 hidden = filter_tools_by_allowed_tools([published], server) == []
 
-                assert refused, entry
-                assert hidden, entry
+                assert refused == hidden, entry
+                assert refused is expected, entry
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -9512,6 +9512,21 @@ class TestServerToolListsHonorThePrefixBoundary:
         assert "include_internal" in exc_info.value.detail["error"]
 
     @pytest.mark.asyncio
+    async def test_a_case_variant_blocklist_entry_still_blocks(self):
+        server = self._aliased_server(disallowed_tools=["PetStore-DeletePet"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(server, "deletepet")
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_a_case_variant_allowlist_entry_grants_the_tool(self):
+        server = self._aliased_server(allowed_tools=["PetStore-GetPetById"])
+
+        await self._run_check(server, "getpetbyid")
+
+    @pytest.mark.asyncio
     async def test_an_explicitly_empty_allowed_params_list_refuses_every_parameter(self):
         server = self._alias_less_server(allowed_params={"read_wiki_contents": []})
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -9512,19 +9512,25 @@ class TestServerToolListsHonorThePrefixBoundary:
         assert "include_internal" in exc_info.value.detail["error"]
 
     @pytest.mark.asyncio
-    async def test_a_case_variant_blocklist_entry_still_blocks(self):
-        server = self._aliased_server(disallowed_tools=["PetStore-DeletePet"])
+    async def test_a_blocklist_entry_does_not_reach_a_case_variant_sibling_tool(self):
+        server = self._aliased_server(disallowed_tools=["petstore-getPet"])
 
         with pytest.raises(HTTPException) as exc_info:
-            await self._run_check(server, "deletepet")
+            await self._run_check(server, "getPet")
 
         assert exc_info.value.status_code == 403
+        await self._run_check(server, "getpet")
 
     @pytest.mark.asyncio
-    async def test_a_case_variant_allowlist_entry_grants_the_tool(self):
-        server = self._aliased_server(allowed_tools=["PetStore-GetPetById"])
+    async def test_an_allowlist_entry_does_not_grant_a_case_variant_sibling_tool(self):
+        server = self._aliased_server(allowed_tools=["petstore-getPet"])
 
-        await self._run_check(server, "getpetbyid")
+        await self._run_check(server, "getPet")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(server, "getpet")
+
+        assert exc_info.value.status_code == 403
 
     @pytest.mark.asyncio
     async def test_an_explicitly_empty_allowed_params_list_refuses_every_parameter(self):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -9512,6 +9512,16 @@ class TestServerToolListsHonorThePrefixBoundary:
         assert "include_internal" in exc_info.value.detail["error"]
 
     @pytest.mark.asyncio
+    async def test_an_entry_does_not_decide_an_operation_id_registration_keeps_separate(self):
+        server = self._aliased_server(disallowed_tools=["foo/bar"], spec_path="/specs/petstore.yaml")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(server, "foo/bar")
+
+        assert exc_info.value.status_code == 403
+        await self._run_check(server, "foo.bar")
+
+    @pytest.mark.asyncio
     async def test_a_blocklist_entry_does_not_reach_a_case_variant_sibling_tool(self):
         server = self._aliased_server(disallowed_tools=["petstore-getPet"])
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -9189,3 +9189,471 @@ class TestDiscoveryFailureLogging:
         assert "typo_row" in caplog.text
         assert "authorization_url, token_url" in caplog.text
         assert "unresolved" in caplog.text
+
+
+def _unrestricted_auth() -> MagicMock:
+    """A caller with no object_permission, so only server-level checks apply."""
+    user_api_key_auth = MagicMock()
+    user_api_key_auth.object_permission = None
+    user_api_key_auth.object_permission_id = None
+    return user_api_key_auth
+
+
+def _permissive_proxy_logging() -> MagicMock:
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj._create_mcp_request_object_from_kwargs = MagicMock(return_value={})
+    proxy_logging_obj._convert_mcp_to_llm_format = MagicMock(return_value={})
+    proxy_logging_obj.pre_call_hook = AsyncMock(return_value={})
+    return proxy_logging_obj
+
+
+ALIAS_LESS_SERVER_ID = "117c814c-1a2b-4c4d-8e8f-0a1b2c3d4e5f"
+
+
+class TestServerToolListsHonorThePrefixBoundary:
+    """The server-level allowed_tools / disallowed_tools / allowed_params checks
+    receive a BARE tool name. Every caller resolves the prefix boundary before
+    dispatch (``server.py``'s ``original_tool_name``, the Responses handler's
+    ``sanitized_tool_name``), and ``call_tool`` hands that same value to the
+    upstream client verbatim, which only works because it carries no prefix.
+
+    Stored entries may also carry a prefix, and routing accepts *every* prefix
+    from ``iter_known_server_prefixes`` (short ID, alias, server_name,
+    server_id), so enforcement derives that whole set via
+    ``iter_known_tool_name_spellings``. Rebuilding a single comparand as
+    ``f"{server.name}-{tool_name}"`` used a field the prefix chain never reads
+    (``get_server_prefix`` is short_prefix, then alias, then server_name, then
+    server_id) and hardcoded the separator; deriving only ``get_server_prefix``
+    covers just the currently published spelling. Either way the check answers
+    for fewer spellings than are reachable, and on the blocklist arm that is a
+    fail-open.
+    """
+
+    async def _run_check(self, server: MCPServer, name: str, arguments: dict[str, Any] | None = None) -> None:
+        await MCPServerManager().pre_call_tool_check(
+            name=name,
+            arguments=arguments if arguments is not None else {},
+            server_name=server.name,
+            user_api_key_auth=_unrestricted_auth(),
+            proxy_logging_obj=_permissive_proxy_logging(),
+            server=server,
+        )
+
+    @staticmethod
+    def _aliased_server(**overrides: Any) -> MCPServer:
+        return MCPServer(
+            server_id="dd7f2b9e-2c4a-4f1b-9e0a-8d3c6b5a4f21",
+            name="petstore_prod",
+            alias="petstore",
+            server_name="petstore_prod",
+            url="https://petstore.example.com/mcp",
+            transport=MCPTransport.http,
+            **overrides,
+        )
+
+    @staticmethod
+    def _alias_less_server(**overrides: Any) -> MCPServer:
+        # No alias and no server_name, so the published prefix is the UUID
+        # server_id, which itself contains the prefix separator.
+        return MCPServer(
+            server_id=ALIAS_LESS_SERVER_ID,
+            name=ALIAS_LESS_SERVER_ID,
+            url="https://wiki.example.com/mcp",
+            transport=MCPTransport.http,
+            **overrides,
+        )
+
+    @pytest.mark.asyncio
+    async def test_allowlist_entry_prefixed_with_the_alias_matches_a_bare_call(self):
+        # The dashboard shows tools under the published prefix, so admins store
+        # "petstore-getpetbyid"; the display name "petstore_prod" is not it.
+        server = self._aliased_server(allowed_tools=["petstore-getpetbyid"])
+
+        await self._run_check(server, "getpetbyid")
+
+    @pytest.mark.asyncio
+    async def test_bare_allowlist_entry_matches_on_an_alias_less_server(self):
+        server = self._alias_less_server(allowed_tools=["read_wiki_contents"])
+
+        await self._run_check(server, "read_wiki_contents")
+
+    @pytest.mark.asyncio
+    async def test_wire_form_allowlist_entry_matches_on_an_alias_less_server(self):
+        # The published prefix is the UUID server_id, so it contains the
+        # separator; the derived wire form has to reproduce it whole.
+        server = self._alias_less_server(allowed_tools=[f"{ALIAS_LESS_SERVER_ID}-read_wiki_contents"])
+
+        await self._run_check(server, "read_wiki_contents")
+
+    @pytest.mark.asyncio
+    async def test_wire_form_entry_matches_a_native_name_that_opens_with_the_prefix(self):
+        # "petstore-getpetbyid" is a real upstream tool name here, so its wire
+        # form is "petstore-petstore-getpetbyid". Stripping the stored entry
+        # instead of deriving the wire form cut a boundary the caller had already
+        # consumed, leaving asymmetric operands that denied a permitted call.
+        server = self._aliased_server(allowed_tools=["petstore-petstore-getpetbyid"])
+
+        await self._run_check(server, "petstore-getpetbyid")
+
+    @pytest.mark.asyncio
+    async def test_wire_form_blocklist_entry_blocks_a_native_name_that_opens_with_the_prefix(self):
+        server = self._aliased_server(disallowed_tools=["petstore-petstore-getpetbyid"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(server, "petstore-getpetbyid")
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_wire_form_blocklist_entry_blocks_under_the_short_prefix_mode(self, monkeypatch):
+        # short_prefix wins in get_server_prefix but is never server.name, so the
+        # hand-built comparand could not match a stored wire-form entry and the
+        # blocklisted tool stayed callable.
+        monkeypatch.setenv("LITELLM_USE_SHORT_MCP_TOOL_PREFIX", "true")
+        server = self._aliased_server(short_prefix="F3X", disallowed_tools=["F3X-deletepet"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(server, "deletepet")
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_alias_form_blocklist_entry_still_blocks_under_the_short_prefix_mode(self, monkeypatch):
+        # Turning short prefixes on republishes every tool under the short ID,
+        # but routing still resolves the alias form, so an entry an admin stored
+        # before the flip stays reachable and has to stay enforced. Deriving only
+        # the published spelling silently stops honoring it: a fail-open on a
+        # config nobody edited.
+        monkeypatch.setenv("LITELLM_USE_SHORT_MCP_TOOL_PREFIX", "true")
+        server = self._aliased_server(short_prefix="F3X", disallowed_tools=["petstore-deletepet"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(server, "deletepet")
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_alias_form_allowlist_entry_still_matches_under_the_short_prefix_mode(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_USE_SHORT_MCP_TOOL_PREFIX", "true")
+        server = self._aliased_server(short_prefix="F3X", allowed_tools=["petstore-getpetbyid"])
+
+        await self._run_check(server, "getpetbyid")
+
+    @pytest.mark.asyncio
+    async def test_server_name_form_blocklist_entry_still_blocks_under_the_short_prefix_mode(self, monkeypatch):
+        # server_name sits third in the prefix chain, so it is published only
+        # when alias and short_prefix are both absent, yet routing accepts it
+        # regardless.
+        monkeypatch.setenv("LITELLM_USE_SHORT_MCP_TOOL_PREFIX", "true")
+        server = self._aliased_server(short_prefix="F3X", disallowed_tools=["petstore_prod-deletepet"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(server, "deletepet")
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_raw_server_id_form_blocklist_entry_still_blocks_under_the_short_prefix_mode(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_USE_SHORT_MCP_TOOL_PREFIX", "true")
+        server = self._alias_less_server(disallowed_tools=[f"{ALIAS_LESS_SERVER_ID}-read_wiki_contents"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(server, "read_wiki_contents")
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_allowed_params_keyed_by_the_alias_form_are_enforced_under_the_short_prefix_mode(self, monkeypatch):
+        monkeypatch.setenv("LITELLM_USE_SHORT_MCP_TOOL_PREFIX", "true")
+        server = self._aliased_server(short_prefix="F3X", allowed_params={"petstore-getpetbyid": ["petid"]})
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(
+                server,
+                "getpetbyid",
+                arguments={"petid": "7", "include_internal": "true"},
+            )
+
+        assert exc_info.value.status_code == 403
+        assert "include_internal" in exc_info.value.detail["error"]
+
+    @pytest.mark.asyncio
+    async def test_foreign_prefix_entry_does_not_match_under_the_short_prefix_mode(self, monkeypatch):
+        # Honoring every known prefix must not become "honor any prefix": the
+        # widened set is this server's spellings only.
+        monkeypatch.setenv("LITELLM_USE_SHORT_MCP_TOOL_PREFIX", "true")
+        server = self._aliased_server(short_prefix="F3X", allowed_tools=["other_server-getpetbyid"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(server, "getpetbyid")
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.parametrize("short_prefix_mode", [False, True])
+    @pytest.mark.asyncio
+    async def test_every_spelling_routing_registers_is_also_enforced(self, monkeypatch, short_prefix_mode):
+        """The invariant, driven through production code on both sides.
+
+        ``_create_prefixed_tools`` decides which spellings reach dispatch, so
+        every key it registers has to be a spelling the blocklist can refuse.
+        Any key routing accepts but enforcement misses is a callable blocked
+        tool.
+        """
+        monkeypatch.setenv("LITELLM_USE_SHORT_MCP_TOOL_PREFIX", "true" if short_prefix_mode else "false")
+        shape = self._aliased_server(short_prefix="F3X")
+
+        manager = MCPServerManager()
+        manager._create_prefixed_tools([MCPTool(name="deletepet", description="", inputSchema={})], shape)
+        registered = sorted(manager.tool_name_to_mcp_server_name_mapping)
+        assert len(registered) > 1
+
+        for spelling in registered:
+            server = self._aliased_server(short_prefix="F3X", disallowed_tools=[spelling])
+            with pytest.raises(HTTPException) as exc_info:
+                await self._run_check(server, "deletepet")
+            assert exc_info.value.status_code == 403, spelling
+
+    @pytest.mark.asyncio
+    async def test_wire_form_allowlist_entry_follows_a_non_default_separator(self):
+        from litellm.proxy._experimental.mcp_server import utils as mcp_utils
+
+        server = self._aliased_server(allowed_tools=["petstore__getpetbyid"])
+
+        with patch.object(mcp_utils, "MCP_TOOL_PREFIX_SEPARATOR", "__"):
+            await self._run_check(server, "getpetbyid")
+
+    @pytest.mark.asyncio
+    async def test_tool_outside_the_allowlist_is_still_denied(self):
+        server = self._aliased_server(allowed_tools=["petstore-getpetbyid"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(server, "deletepet")
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_allowlist_entry_prefixed_for_another_server_does_not_match(self):
+        # Reducing both sides must not widen the allowlist across servers: a
+        # foreign prefix is not one of this server's known prefixes, so the
+        # entry keeps it and never collapses onto a bare name.
+        server = self._aliased_server(allowed_tools=["other_server-getpetbyid"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(server, "getpetbyid")
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_prefixed_disallowed_entry_blocks_a_bare_call(self):
+        # Fail-open regression: the blocklist arm answered "not banned" whenever
+        # the stored entry carried a prefix it failed to reconstruct.
+        server = self._aliased_server(disallowed_tools=["petstore-deletepet"])
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(server, "deletepet")
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_tool_outside_the_blocklist_is_still_allowed(self):
+        server = self._aliased_server(disallowed_tools=["petstore-deletepet"])
+
+        await self._run_check(server, "getpetbyid")
+
+    @pytest.mark.asyncio
+    async def test_allowed_params_are_enforced_for_a_bare_key(self):
+        server = self._alias_less_server(allowed_params={"read_wiki_contents": ["repo"]})
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(
+                server,
+                "read_wiki_contents",
+                arguments={"repo": "acme/wiki", "internal_only": "true"},
+            )
+
+        assert exc_info.value.status_code == 403
+        assert "internal_only" in exc_info.value.detail["error"]
+
+    @pytest.mark.asyncio
+    async def test_allowed_params_are_enforced_for_a_wire_form_key(self):
+        # A key stored under the published prefix matched nothing, so the lookup
+        # returned None and the check silently allowed every parameter instead of
+        # enforcing the configured list.
+        server = self._alias_less_server(allowed_params={f"{ALIAS_LESS_SERVER_ID}-read_wiki_contents": ["repo"]})
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(
+                server,
+                "read_wiki_contents",
+                arguments={"repo": "acme/wiki", "internal_only": "true"},
+            )
+
+        assert exc_info.value.status_code == 403
+        assert "internal_only" in exc_info.value.detail["error"]
+
+    @pytest.mark.asyncio
+    async def test_allowed_params_still_accept_the_configured_parameters(self):
+        server = self._alias_less_server(allowed_params={f"{ALIAS_LESS_SERVER_ID}-read_wiki_contents": ["repo"]})
+
+        await self._run_check(server, "read_wiki_contents", arguments={"repo": "acme/wiki"})
+
+    @pytest.mark.asyncio
+    async def test_allowed_params_are_enforced_for_a_native_name_that_opens_with_the_prefix(self):
+        server = self._aliased_server(allowed_params={"petstore-petstore-getpetbyid": ["petid"]})
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(
+                server,
+                "petstore-getpetbyid",
+                arguments={"petid": "7", "include_internal": "true"},
+            )
+
+        assert exc_info.value.status_code == 403
+        assert "include_internal" in exc_info.value.detail["error"]
+
+    @pytest.mark.asyncio
+    async def test_an_explicitly_empty_allowed_params_list_refuses_every_parameter(self):
+        server = self._alias_less_server(allowed_params={"read_wiki_contents": []})
+
+        with pytest.raises(HTTPException) as exc_info:
+            await self._run_check(server, "read_wiki_contents", arguments={"repo": "acme/wiki"})
+
+        assert exc_info.value.status_code == 403
+        assert "repo" in exc_info.value.detail["error"]
+
+    @pytest.mark.asyncio
+    async def test_an_explicitly_empty_allowed_params_list_still_permits_an_argument_free_call(self):
+        server = self._alias_less_server(allowed_params={"read_wiki_contents": []})
+
+        await self._run_check(server, "read_wiki_contents", arguments={})
+
+
+class TestOpenAPIRegistryKeyMatchesRegistration:
+    """OpenAPI tools are registered under ``add_server_prefix_to_name(base, get_server_prefix(server))``,
+    so the dispatch lookup has to build its key the same way from the bare name ``call_tool``
+    hands it. Rebuilding it as ``f"{server.name}-{bare_name}"`` used a field the prefix chain
+    never reads and hardcoded the separator, so every call on a server whose published prefix
+    differs from its display name failed with "not found in registry" instead of dispatching.
+    """
+
+    @staticmethod
+    def _register(server: MCPServer, base_tool_name: str) -> str:
+        from litellm.proxy._experimental.mcp_server.utils import (
+            add_server_prefix_to_name,
+            get_server_prefix,
+        )
+
+        return add_server_prefix_to_name(base_tool_name, get_server_prefix(server))
+
+    async def _call(self, server: MCPServer, registered_key: str, bare_tool_name: str) -> CallToolResult:
+        from litellm.proxy._experimental.mcp_server.tool_registry import (
+            global_mcp_tool_registry,
+        )
+
+        async def handler(**kwargs: Any) -> str:
+            return "dispatched"
+
+        tool = MagicMock()
+        tool.handler = handler
+
+        with patch.dict(global_mcp_tool_registry.tools, {registered_key: tool}, clear=True):
+            return await MCPServerManager()._call_openapi_tool_handler(server, bare_tool_name, {})
+
+    @pytest.mark.asyncio
+    async def test_aliased_server_dispatches_when_name_differs_from_published_prefix(self):
+        server = MCPServer(
+            server_id="dd7f2b9e-2c4a-4f1b-9e0a-8d3c6b5a4f21",
+            name="petstore_prod",
+            alias="petstore",
+            server_name="petstore_prod",
+            url=None,
+            transport=MCPTransport.http,
+            spec_path="https://example.com/petstore.yaml",
+        )
+        registered_key = self._register(server, "list_pets")
+        assert registered_key == "petstore-list_pets"
+
+        result = await self._call(server, registered_key, "list_pets")
+
+        assert result.isError is False
+        assert result.content[0].text == "dispatched"
+
+    @pytest.mark.asyncio
+    async def test_alias_less_server_dispatches_when_the_prefix_contains_the_separator(self):
+        server = MCPServer(
+            server_id=ALIAS_LESS_SERVER_ID,
+            name=ALIAS_LESS_SERVER_ID,
+            url=None,
+            transport=MCPTransport.http,
+            spec_path="https://example.com/wiki.yaml",
+        )
+        registered_key = self._register(server, "read_wiki_contents")
+        assert registered_key == f"{ALIAS_LESS_SERVER_ID}-read_wiki_contents"
+
+        result = await self._call(server, registered_key, "read_wiki_contents")
+
+        assert result.isError is False
+        assert result.content[0].text == "dispatched"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_keeps_a_native_name_that_opens_with_the_prefix(self):
+        # Registration prefixes the upstream name whatever it looks like, so
+        # "petstore-list_pets" is registered as "petstore-petstore-list_pets".
+        # Stripping the bare name again before rebuilding the key cut that
+        # leading segment back off and the lookup missed.
+        server = MCPServer(
+            server_id="dd7f2b9e-2c4a-4f1b-9e0a-8d3c6b5a4f21",
+            name="petstore_prod",
+            alias="petstore",
+            server_name="petstore_prod",
+            url=None,
+            transport=MCPTransport.http,
+            spec_path="https://example.com/petstore.yaml",
+        )
+        registered_key = self._register(server, "petstore-list_pets")
+        assert registered_key == "petstore-petstore-list_pets"
+
+        result = await self._call(server, registered_key, "petstore-list_pets")
+
+        assert result.isError is False
+        assert result.content[0].text == "dispatched"
+
+    @pytest.mark.asyncio
+    async def test_dispatch_follows_a_non_default_prefix_separator(self):
+        from litellm.proxy._experimental.mcp_server import utils as mcp_utils
+
+        server = MCPServer(
+            server_id="dd7f2b9e-2c4a-4f1b-9e0a-8d3c6b5a4f21",
+            name="petstore_prod",
+            alias="petstore",
+            server_name="petstore_prod",
+            url=None,
+            transport=MCPTransport.http,
+            spec_path="https://example.com/petstore.yaml",
+        )
+
+        with patch.object(mcp_utils, "MCP_TOOL_PREFIX_SEPARATOR", "__"):
+            registered_key = self._register(server, "list_pets")
+            assert registered_key == "petstore__list_pets"
+
+            result = await self._call(server, registered_key, "list_pets")
+
+        assert result.isError is False
+        assert result.content[0].text == "dispatched"
+
+    @pytest.mark.asyncio
+    async def test_unregistered_tool_is_still_reported_missing(self):
+        server = MCPServer(
+            server_id="dd7f2b9e-2c4a-4f1b-9e0a-8d3c6b5a4f21",
+            name="petstore_prod",
+            alias="petstore",
+            server_name="petstore_prod",
+            url=None,
+            transport=MCPTransport.http,
+            spec_path="https://example.com/petstore.yaml",
+        )
+
+        result = await self._call(server, "petstore-list_pets", "delete_pet")
+
+        assert result.isError is True
+        assert "not found in registry" in result.content[0].text

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_tool_auth.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_tool_auth.py
@@ -32,6 +32,8 @@ async def test_openapi_local_tool_runs_pre_call_tool_check():
     fake_server.mcp_info = None
     fake_server.server_id = "srv-1"
     fake_server.server_name = "openapi-petstore"
+    fake_server.alias = None
+    fake_server.short_prefix = None
 
     fake_tool = MagicMock()
     fake_tool.name = "list_pets"
@@ -111,6 +113,8 @@ async def test_openapi_local_tool_blocked_when_pre_call_check_raises():
     fake_server.mcp_info = None
     fake_server.server_id = "srv-1"
     fake_server.server_name = "openapi-petstore"
+    fake_server.alias = None
+    fake_server.short_prefix = None
 
     fake_tool = MagicMock()
     fake_tool.name = "delete_pet"

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_short_mcp_tool_prefix.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_short_mcp_tool_prefix.py
@@ -20,7 +20,9 @@ from litellm.proxy._experimental.mcp_server.utils import (
     compute_short_server_prefix,
     get_server_prefix,
     is_short_mcp_tool_prefix_enabled,
+    is_tool_name_prefixed,
     iter_known_server_prefixes,
+    match_known_server_prefix,
     strip_known_server_prefix,
 )
 from litellm.types.mcp_server.mcp_server_manager import MCPServer
@@ -193,6 +195,70 @@ class TestStripKnownServerPrefix:
 
     def test_none_server_falls_back_to_first_separator_split(self):
         assert strip_known_server_prefix("svc-tool", None) == "tool"
+
+
+# ---------------------------------------------------------------------------
+# match_known_server_prefix — the shared boundary primitive
+# ---------------------------------------------------------------------------
+
+
+class TestMatchKnownServerPrefix:
+    """Locates the boundary by matching registered prefixes instead of cutting
+    at the first separator, preferring the longest candidate so a prefix that
+    itself contains the separator still wins."""
+
+    def test_returns_matched_prefix_and_bare_name(self):
+        assert match_known_server_prefix("deepwiki-contents", ["deepwiki"]) == (
+            "deepwiki",
+            "contents",
+        )
+
+    def test_returns_none_when_no_candidate_matches(self):
+        assert match_known_server_prefix("contents", ["deepwiki"]) is None
+
+    def test_separator_must_follow_the_prefix(self):
+        assert match_known_server_prefix("deepwikicontents", ["deepwiki"]) is None
+
+    def test_uuid_prefix_survives_its_own_separators(self):
+        server_id = "117c814c-1a2b-3c4d-9e8f"
+        assert match_known_server_prefix(f"{server_id}-contents", [server_id]) == (
+            server_id,
+            "contents",
+        )
+
+    def test_longest_candidate_wins_over_leading_segment(self):
+        # "svc" is a registered prefix in its own right and also the leading
+        # segment of "svc-prod". A first-separator split hands the tool to
+        # "svc" with a bare name of "prod-run", attributing it to the wrong
+        # server; longest-match keeps it on "svc-prod".
+        assert match_known_server_prefix("svc-prod-run", ["svc", "svc-prod"]) == (
+            "svc-prod",
+            "run",
+        )
+
+    def test_candidates_are_normalised_before_matching(self):
+        assert match_known_server_prefix("my_server-run", ["my server"]) == (
+            "my_server",
+            "run",
+        )
+
+    def test_empty_candidate_never_matches_a_leading_separator(self):
+        assert match_known_server_prefix("-run", [""]) is None
+
+
+class TestIsToolNamePrefixedBoundary:
+    """The known-prefix gate decides which branch the call path takes, so it has
+    to agree with the prefix the list path actually emitted."""
+
+    def test_uuid_prefix_is_recognised(self):
+        server_id = "117c814c-1a2b-3c4d-9e8f"
+        assert is_tool_name_prefixed(f"{server_id}-contents", known_server_prefixes={server_id})
+
+    def test_unrelated_hyphenated_tool_is_still_not_prefixed(self):
+        # Negative control: an upstream tool whose own name contains the
+        # separator must not start reading as prefixed just because the gate
+        # got more permissive about where the boundary can fall.
+        assert not is_tool_name_prefixed("text-to-speech", known_server_prefixes={"deepwiki"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## TLDR

Problem this solves:

- A tool that `tools/list` advertises gets refused on `tools/call`
- Worse, on some servers a `disallowed_tools` entry hides the tool from discovery and still lets it execute
- The call path recovered the tool-name prefix boundary by cutting at the first separator; the list path matched against the prefixes the server actually registered
- A server with no alias is prefixed by its `server_id`, and a UUID contains that separator
- OpenAPI dispatch built its registry key from a field the prefix chain never reads

How it solves it:

- One owner recovers the boundary from the server's registered prefixes, longest candidate first
- A second owner enumerates every spelling routing accepts for one tool, and the permission lists, `allowed_params`, the routing map and the discovery filter all read it, so enforcement honors exactly the names that are reachable
- `_tool_name_matches` now requires the server, so the guess is structurally unavailable to a future caller, and discovery hides exactly what dispatch refuses

## Relevant issues

- Fixes a tool-permission defect on any MCP server whose published prefix contains the tool-name separator: a server-level `allowed_tools` entry matched nothing, so the tool neither listed nor called
- Fixes a fail-open on the same class of server, where a `disallowed_tools` entry written in the wire form removed the tool from `tools/list` but left it fully callable; that one is live-reproduced below against shipped code
- Follow-up to #34559, which fixed the toolset side of the same boundary problem and left the server-level lists and the call path untouched

## Linear ticket

LIT-3419, deliberately without a closing keyword. #34559 already shipped that ticket's toolset-side fix, and the reporter's effective `MCP_TOOL_PREFIX_SEPARATOR` is still unconfirmed, so a human should decide when the ticket closes

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

CI is green. `osv-scan` was red on earlier pushes of this branch, and was red on `litellm_internal_staging` itself at `59f2bd7881`, `2c6c8d8b30` and `d19787e816`; rebasing onto current staging picked up the upstream fix and it now passes, so the exception this section used to carry no longer applies

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on `127.0.0.1:4111` against a real Postgres and the real public DeepWiki MCP server at `https://mcp.deepwiki.com/mcp`, which exposes three tools (`ask_question`, `read_wiki_contents`, `read_wiki_structure`). Two independent runs follow: the first is the listed-then-refused defect, the second is the fail-open. Both compare this branch against its own base with nothing else changed

### Run 1: a tool that lists and then refuses

The server was created through the public API with `server_name` and `alias` both left null, which is what a config-driven or API-driven deployment produces and what makes the prefix fall back to the `server_id`. A virtual key scoped to that server does the probing

```bash
curl -sS http://127.0.0.1:4111/v1/mcp/server -H "Authorization: Bearer $MASTER_KEY"
```

```json
[
  {
    "server_id": "3c6f6617-d23c-4f48-bfb0-f205e3b27bab",
    "alias": null,
    "server_name": null,
    "url": "https://mcp.deepwiki.com/mcp",
    "allowed_tools": [
      "read_wiki_contents"
    ]
  }
]
```

The probe script, unchanged between the two runs:

```bash
#!/bin/bash
# usage: capture.sh <label>
KEY="$MCP_PROBE_KEY"; SID=3c6f6617-d23c-4f48-bfb0-f205e3b27bab
B="http://127.0.0.1:4111"
echo "=============== $1 ==============="
S=$(curl -sS -D /tmp/h.txt -o /dev/null -X POST $B/mcp/ -H "x-litellm-api-key: Bearer $KEY" \
  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"probe","version":"1"}}}' --max-time 60
  grep -i '^mcp-session-id' /tmp/h.txt | tr -d '\r' | awk '{print $2}')

echo "--- 1. MCP tools/list (what the client is told it may call)"
curl -sS -X POST $B/mcp/ -H "x-litellm-api-key: Bearer $KEY" -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' -H "mcp-session-id: $S" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' --max-time 90 \
  | tr -d '\r' | grep -o '"name":"[^"]*"'

echo "--- 2. MCP tools/call with that exact advertised name"
curl -sS -X POST $B/mcp/ -H "x-litellm-api-key: Bearer $KEY" -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' -H "mcp-session-id: $S" \
  -d "{\"jsonrpc\":\"2.0\",\"id\":3,\"method\":\"tools/call\",\"params\":{\"name\":\"$SID-read_wiki_contents\",\"arguments\":{\"repoName\":\"BerriAI/litellm\"}}}" \
  --max-time 180 | tr -d '\r' | cut -c1-260

echo "--- 3. REST tools/call with server_id + advertised name"
curl -sS -X POST "$B/mcp-rest/tools/call" -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -d "{\"name\":\"$SID-read_wiki_contents\",\"arguments\":{\"repoName\":\"BerriAI/litellm\"},\"server_id\":\"$SID\"}" \
  --max-time 180 | cut -c1-260

echo "--- 4. negative control: ask_question is upstream and is NOT in allowed_tools"
curl -sS -X POST $B/mcp/ -H "x-litellm-api-key: Bearer $KEY" -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' -H "mcp-session-id: $S" \
  -d "{\"jsonrpc\":\"2.0\",\"id\":4,\"method\":\"tools/call\",\"params\":{\"name\":\"$SID-ask_question\",\"arguments\":{\"repoName\":\"BerriAI/litellm\",\"question\":\"hi\"}}}" \
  --max-time 180 | tr -d '\r' | cut -c1-320
```

Before, with the four production files at `215f05588d`, this PR's base:

```
=============== BEFORE (unfixed, production files at 215f05588d) ===============
--- 1. MCP tools/list (what the client is told it may call)
--- 2. MCP tools/call with that exact advertised name
event: message
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"Error: Tool d23c-4f48-bfb0-f205e3b27bab-read_wiki_contents not found"}],"isError":true}}

--- 3. REST tools/call with server_id + advertised name
{"detail":{"error":"Tool 3c6f6617-d23c-4f48-bfb0-f205e3b27bab-read_wiki_contents is not allowed for server 3c6f6617-d23c-4f48-bfb0-f205e3b27bab. Contact proxy admin to allow this tool."}}
```

Step 1 prints nothing: the allowlist granted `read_wiki_contents`, the filter matched zero tools, and the client is offered none of the three. Step 2 shows why, in the leaked name `d23c-4f48-bfb0-f205e3b27bab-read_wiki_contents`; the first `-` of the UUID was taken for the prefix boundary, the first UUID segment was discarded as the server name, and the rest travelled upstream as if it were the tool. Step 3 is the same mistake surfacing as an authorization refusal on a name the caller supplied verbatim

After, at `b818e95400`:

```
=============== AFTER (fix applied, b818e95400) ===============
--- 1. MCP tools/list (what the client is told it may call)
"name":"3c6f6617-d23c-4f48-bfb0-f205e3b27bab-read_wiki_contents"
--- 2. MCP tools/call with that exact advertised name
event: message
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"# Page: Overview\n\n# Overview\n\n<details>\n<summary>Relevant source files</summary>\n\nThe following files were used as context for generating this wiki page:\n\n- [README.md](README.m

--- 3. REST tools/call with server_id + advertised name
{"_meta":null,"content":[{"type":"text","text":"# Page: Overview\n\n# Overview\n\n<details>\n<summary>Relevant source files</summary>\n\nThe following files were used as context for generating this wiki page:\n\n- [README.md](README.md)\n- [enterprise/pyprojec

--- 4. negative control: ask_question is upstream and is NOT in allowed_tools
event: message
data: {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"Error: {'error': 'Tool ask_question is not allowed for server 3c6f6617-d23c-4f48-bfb0-f205e3b27bab. Contact proxy admin to allow this tool.'}"}],"isError":true}}
```

Exactly one of the three upstream tools is offered, it is the one the allowlist grants, and the name the client is handed works on both the MCP and the REST call path. The negative control still refuses, and the refusal now names `ask_question` rather than a mangled fragment, which is the same boundary resolving correctly on the denial path

Because an admin reading their client sees the prefixed name, the same run was repeated with `allowed_tools` set to the wire spelling instead of the bare one, changing nothing else:

```bash
curl -sS -X PUT http://127.0.0.1:4111/v1/mcp/server -H "Authorization: Bearer $MASTER_KEY" \
  -H 'Content-Type: application/json' \
  -d '{"server_id":"3c6f6617-d23c-4f48-bfb0-f205e3b27bab","allowed_tools":["3c6f6617-d23c-4f48-bfb0-f205e3b27bab-read_wiki_contents"]}'
```

```
=============== AFTER, wire-form allowed_tools entry (b818e95400) ===============
--- 1. MCP tools/list (what the client is told it may call)
"name":"3c6f6617-d23c-4f48-bfb0-f205e3b27bab-read_wiki_contents"
--- 2. MCP tools/call with that exact advertised name
event: message
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"# Page: Overview\n\n# Overview\n\n<details>\n<summary>Relevant source files</summary>\n\nThe following files were used as context for generating this wiki page:\n\n- [README.md](README.m

--- 4. negative control: ask_question is upstream and is NOT in allowed_tools
event: message
data: {"jsonrpc":"2.0","id":4,"result":{"content":[{"type":"text","text":"Error: {'error': 'Tool ask_question is not allowed for server 3c6f6617-d23c-4f48-bfb0-f205e3b27bab. Contact proxy admin to allow this tool."}],"isError":true}}
```

Both spellings grant the same one tool, and the negative control still refuses under the wire-form entry, so accepting the second spelling did not widen the grant

### Run 2: the fail-open, reproduced on shipped code

`disallowed_tools` has no column in `schema.prisma` and no UI writer; its only sources are `server_config.get("disallowed_tools")` in the config loader and a carry-forward `getattr`. It is therefore hand-authored YAML, which is exactly where the wire spelling is most likely, since that is the spelling the admin sees in their client. This run uses a config-defined server under `LITELLM_USE_SHORT_MCP_TOOL_PREFIX=true`, where the published prefix is the computed short prefix and so can never equal `server.name`

```yaml
mcp_servers:
  deepwiki_cfg:
    url: https://mcp.deepwiki.com/mcp
    transport: http
    disallowed_tools:
      - "eiG-read_wiki_contents"
```

`eiG` is the prefix the proxy itself published for that server, read out of a prior `tools/list` rather than guessed. The probe lists the server's tools and then calls the banned one:

```bash
echo "--- tools/list for the config server (eiG): is the banned tool hidden?"
curl -sS -X POST $B/mcp/ -H "x-litellm-api-key: Bearer $MASTER_KEY" -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' -H "mcp-session-id: $S" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' --max-time 90 \
  | tr -d '\r' | grep -o '"name":"eiG-[^"]*"' | sort -u

echo "--- tools/call the BANNED tool eiG-read_wiki_contents"
curl -sS -X POST $B/mcp/ -H "x-litellm-api-key: Bearer $MASTER_KEY" -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' -H "mcp-session-id: $S" \
  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"eiG-read_wiki_contents","arguments":{"repoName":"BerriAI/litellm"}}}' \
  --max-time 180 | tr -d '\r' | cut -c1-300
```

```
=============== BASE 215f05588d (shipped), short-prefix mode, wire-form disallowed_tools ===============
--- tools/list for the config server (eiG): is the banned tool hidden?
"name":"eiG-ask_question"
"name":"eiG-read_wiki_structure"
--- tools/call the BANNED tool eiG-read_wiki_contents
event: message
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"# Page: Overview\n\n# Overview\n\n<details>\n<summary>Relevant source files</summary>\n\nThe following files were used as context for generating this wiki page:\n\n- [README.md](README.md)\n- [enterprise/pyproject.toml](enterp
```

The blocklist works on the list path and does nothing on the call path. `read_wiki_contents` is hidden from discovery and returns real upstream content to anyone who names it, which is a ban that only holds against clients that do not guess. Same config, same request, this branch:

```
=============== FIXED (b818e95400), short-prefix mode, wire-form disallowed_tools ===============
--- tools/list for the config server (eiG): is the banned tool hidden?
"name":"eiG-ask_question"
"name":"eiG-read_wiki_structure"
--- tools/call the BANNED tool eiG-read_wiki_contents
event: message
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"Error: {'error': 'Tool read_wiki_contents is not allowed for server deepwiki_cfg. Contact proxy admin to allow this tool.'}"}],"isError":true}}
```

### Run 3: discovery and dispatch agreeing on one entry

Same config server and same probe as run 2, with the blocklist entry written in the alias form the admin typed into their own YAML rather than the short prefix the proxy computed at boot. Both spellings name the same tool on the same server:

```yaml
mcp_servers:
  deepwiki_cfg:
    url: https://mcp.deepwiki.com/mcp
    transport: http
    disallowed_tools:
      - "deepwiki_cfg-read_wiki_contents"
```

```
=============== BASE 215f05588d (shipped), short-prefix mode, alias-form disallowed_tools ===============
config blocklist entry: deepwiki_cfg-read_wiki_contents   (alias form)
LITELLM_USE_SHORT_MCP_TOOL_PREFIX=1, so tools publish as eiG-*
--- tools/list: which eiG-* tools are advertised?
"name":"eiG-ask_question"
"name":"eiG-read_wiki_contents"
"name":"eiG-read_wiki_structure"
--- tools/call eiG-read_wiki_contents (the blocked tool, called by its published name)
event: message
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"Error: {'error': 'Tool read_wiki_contents is not allowed for server deepwiki_cfg. Contact proxy admin to allow this tool.'}"}],"isError":true}}
```

The ban holds on the call path here, through the `f"{server.name}-{tool_name}"` arm, and the list path advertises the banned tool anyway because it recovered the boundary the other way. A client discovers `eiG-read_wiki_contents`, calls the exact name it was handed, and is refused, which is run 1's defect landing on a denial instead of a grant. Same config, this branch:

```
=============== FIXED bb7eabde18 (this branch), short-prefix mode, alias-form disallowed_tools ===============
config blocklist entry: deepwiki_cfg-read_wiki_contents   (alias form)
LITELLM_USE_SHORT_MCP_TOOL_PREFIX=1, so tools publish as eiG-*
--- tools/list: which eiG-* tools are advertised?
"name":"eiG-ask_question"
"name":"eiG-read_wiki_structure"
--- tools/call eiG-read_wiki_contents (the blocked tool, called by its published name)
event: message
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"Error: {'error': 'Tool read_wiki_contents is not allowed for server deepwiki_cfg. Contact proxy admin to allow this tool.'}"}],"isError":true}}
```

The two runs together are why the fix is the whole spelling set rather than one derived spelling. Run 2's entry is the published form and run 3's is the alias form; shipped code gets each one half right and in opposite halves, and only enforcement that honors every spelling routing accepts gets both cells right on both paths

### Run 4: an explicitly empty parameter allowlist

This one is a regression an earlier commit on this branch introduced and review caught, rather than shipped behavior, and it is reported here because its fix is in the diff. `allowed_params` has exactly one writer, `server_config.get("allowed_params", None)` in the config loader, and one reader, so `{tool: []}` can only be an administrator saying that tool accepts no parameters

```yaml
mcp_servers:
  deepwiki_cfg:
    url: https://mcp.deepwiki.com/mcp
    transport: http
    allowed_params:
      read_wiki_structure: []
```

```bash
curl -sS -X POST http://127.0.0.1:4111/mcp/ -H "x-litellm-api-key: Bearer $MASTER_KEY" \
  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
  -H "mcp-session-id: $S" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"deepwiki_cfg-read_wiki_structure","arguments":{"repoName":"BerriAI/litellm"}}}'
```

Base refuses it, because `.get(a) or .get(b)` yields the second operand when the first is falsy and both lookups find the same empty list:

```
data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Error: {'error': \"Parameters ['repoName'] are not allowed for tool read_wiki_structure. Allowed parameters: []. Contact proxy admin to allow these parameters.\"}"}],"isError":true}}
```

The rewritten lookup tested the value instead of the key, so an empty list read as nothing configured and the call reached the real upstream:

```
data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Available pages for BerriAI/litellm:\n\n- 1 Overview\n  - 1.1 Getting Started and Repo Orientation\n  - 1.2 System Architecture at a Glance\n
```

This branch restores the refusal, and the negative control in the same session shows the gate is filtering parameters rather than blocking the tool, since an argument-free call passes it and reaches upstream's own validation:

```
--- tools/call deepwiki_cfg-read_wiki_structure WITH a parameter (must be refused)
data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Error: {'error': \"Parameters ['repoName'] are not allowed for tool read_wiki_structure. Allowed parameters: []. Contact proxy admin to allow these parameters.\"}"}],"isError":true}}

--- negative control: same tool, NO parameters (gate must let it through to upstream)
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"Input validation error: 'repoName' is a required property"}],"isError":true}}
```

### Run 5: a case-variant deny entry, hidden from discovery but still callable

Collapsing the four sites onto one matcher forced a single case rule, and getting it wrong first is what made the right answer legible. Discovery lowercases before comparing; enforcement compares exactly. So on shipped code an entry differing from the published name only in case is honored by `tools/list` and ignored by `tools/call`. Folding case everywhere makes the two agree, and review caught that it buys the agreement at too high a price: routing dispatches two names differing only in case as two tools, so a folded matcher lets one policy decide both

```yaml
mcp_servers:
  deepwiki_cfg:
    url: https://mcp.deepwiki.com/mcp
    transport: http
    disallowed_tools:
      - "DeepWiki_CFG-Read_Wiki_Contents"
```

```
=============== BEFORE 215f05588d (shipped) ===============
--- tools/list: is the blocked tool advertised?
"name":"deepwiki_cfg-ask_question"
"name":"deepwiki_cfg-read_wiki_structure"
--- tools/call deepwiki_cfg-read_wiki_contents (the tool the admin banned)
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"# Page: Overview\n\n# Overview\n\n<details>\n<summary>Relevant source files</summary>\n\nThe following files were used as context for generating this wiki page:\n\n- [README.md](README.md)\n
```

The banned tool is absent from the listing and returns the full wiki page when called by the exact name the proxy publishes. An administrator reading `tools/list` sees the ban working. Same config, this branch:

```
=============== AFTER (unified matcher) ===============
--- tools/list: is the blocked tool advertised?
"name":"deepwiki_cfg-ask_question"
"name":"deepwiki_cfg-read_wiki_structure"
--- tools/call deepwiki_cfg-read_wiki_contents (the tool the admin banned)
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"Error: {'error': 'Tool read_wiki_contents is not allowed for server deepwiki_cfg. Contact proxy admin to allow this tool.'}"}],"isError":true}}
```

The branch above folded case on every server, and that is the version this run was first written against. On a server exposing both `getPet` and `getpet` it granted `getpet` from an allowlist naming only `getPet`, and denied `getpet` from a blocklist naming only `getPet`; unauthorized execution on one arm, the wrong tool denied on the other. Driven through the real functions:

```
ROUTING keys registered:  getPet  getpet  petstore-getPet  petstore-getpet  ...   (8 distinct)
allowlist ["getPet"] ->  getPet allowed=True   getpet allowed=True    <- merged
blocklist ["getPet"] ->  getPet allowed=False  getpet allowed=False   <- merged
```

Matching is exact now, and the same probe reads `getpet allowed=False` under the allowlist and `getpet allowed=True` under the blocklist. Live, with a deny entry that names no tool that exists, the branch that folded case hid the real tool from `tools/list` and refused the call, while this one lists it and calls it:

```
=============== BEFORE (folded matcher), deny entry deepwiki_cfg-Read_Wiki_Contents ===============
--- tools/list
"name":"deepwiki_cfg-ask_question"
"name":"deepwiki_cfg-read_wiki_structure"
--- tools/call deepwiki_cfg-read_wiki_contents
data: ... "Error: {'error': 'Tool read_wiki_contents is not allowed for server deepwiki_cfg...'}" "isError":true

=============== AFTER (identity-exact matcher) ===============
--- tools/list
"name":"deepwiki_cfg-ask_question"
"name":"deepwiki_cfg-read_wiki_contents"
"name":"deepwiki_cfg-read_wiki_structure"
--- tools/call deepwiki_cfg-read_wiki_contents
data: ... "# Page: Overview\n\n# Overview\n\n<details>..."
```

What the fold was actually for survives, in the one place it is provably safe, and getting that place right took a second correction. `_register_openapi_tools` names an operationId inline with `operation_id.replace(" ", "_").lower()`, which preserves `/` and `.`; the similarly named `sanitize_openapi_tool_name` replaces every character outside `[a-zA-Z0-9_-]` and belongs to `register_tools_from_openapi`, which has no production caller. Replaying the second while gating on `spec_path`, which registers through the first, collapsed `foo/bar` and `foo.bar` onto one policy identity

So the map has one owner now. That inline expression is `openapi_tool_name` in `utils.py`, and registration and the matcher both call it, which turns the safety argument into a property rather than a claim: two operationIds that register as two tools normalize to two names here by construction, because this is the map that registered them

```
REGISTRATION maps:   foo/bar -> foo/bar     foo.bar -> foo.bar     addPet -> addpet
policy entry ["foo/bar"]:   tool foo/bar -> matched 'foo/bar'   tool foo.bar -> matched None
spec-spelled entry:         tool 'addpet' vs ['addPet'] -> 'addPet'
same on a native server:    None
```

`test_case_folding_applies_to_openapi_servers_and_not_to_native_ones` pins both halves, `test_an_entry_does_not_decide_an_operation_id_registration_keeps_separate` pins the collision, and two tests pin that a policy naming one tool leaves its case-variant sibling alone

So the shipped `tools/list` and `tools/call` disagreement in the transcript at the top of this run is still closed, just from the other side: the typo'd entry now names nothing on either path instead of half-banning a tool

## Type

🐛 Bug Fix

## Changes

The name a client sees on the wire is `{server_prefix}{MCP_TOOL_PREFIX_SEPARATOR}{tool_name}`, and `get_server_prefix` takes that prefix from `short_prefix`, else `alias`, else `server_name`, else `server_id`. Both `server_name` and `alias` are nullable in `schema.prisma`, so a server created with neither is prefixed by its `server_id`, and a UUID contains the default separator `-`. From there, any code that recovers the tool name by cutting at the first separator disagrees with any code that matches against the prefixes the server actually registered. That disagreement is the bug, and it is not limited to UUIDs: a hyphenated alias, an enabled `short_prefix`, or a deployment that overrides the separator each hit it a different way

Recovering the boundary is now owned by one function. `match_known_server_prefix(name, known_prefixes)` in `utils.py` returns `(matched_prefix, bare_name)`, or `None` when the name carries none of them. Candidates are normalized and tried longest first, so a prefix that itself contains the separator wins over a shorter prefix that is merely its leading segment. `strip_known_server_prefix` and the known-prefix branch of `is_tool_name_prefixed` delegate to it instead of each re-deriving the boundary, and `_resolve_mcp_server_for_tool_call` calls it directly in place of the split-then-normalize-then-look-up sequence it hand-rolled

`split_server_prefix_from_name` stays, and stays used for routing, because the two halves it returns reassemble into the input exactly; that property is what makes it safe there. Its docstring now says that reading one half on its own is a guess, and points at the owner

The list path and the call path stopped disagreeing:

- `execute_mcp_tool` took the routing pair from the blunt split and repaired only the server half, so `original_tool_name` stayed mangled for the whole rest of the request. It now recovers the tool name from the resolved server, on both the resolved-by-prefix and the routed-by-`server_id` branch
- `_tool_name_matches`, used by both the MCP list filter and the REST list filter, took no server at all and so could only guess. It now takes the server as a required parameter, which is the structural half of the fix: a future caller cannot reintroduce the guess by omitting it. With the server in hand it reads the same spelling owner the permission checks read, so the two paths cannot answer for different sets of names
- `apply_tool_overrides` and the `tool_name_to_mcp_server_name_mapping` build both keyed off the blunt split

The three comparison sites needed the opposite correction, and this is the part the first review round got wrong. By the time `check_allowed_or_banned_tools`, `validate_allowed_params`, and `_call_openapi_tool_handler` run, the tool name is already bare. Every caller resolves the boundary before dispatch: `server.py` passes `original_tool_name` on both entry points, the Responses handler passes a `sanitized_tool_name` it produced with `strip_known_server_prefix`, and `call_tool` hands that same value to the upstream client verbatim, which only works because it carries no prefix. Stripping inside these three functions is therefore a second strip. On an ordinary name it is a no-op, which is why it looked harmless; on a native name that itself opens with the server prefix it cuts a boundary the caller already consumed, while a stored wire-form entry gets only one strip, so the two operands are no longer comparable. These sites now derive their comparison operands instead of cutting them back out of anything

Which operands to derive is the part the second review round corrected, and it is the real invariant here. `get_server_prefix` publishes one prefix, but routing accepts several: `iter_known_server_prefixes` yields `short_prefix`, the computed short prefix, `alias`, `server_name` and `server_id`, and an inbound name carrying any of them resolves to the same tool on the same server. Deriving only the published spelling therefore answers for fewer names than are reachable, and on `disallowed_tools` that difference fails open. The new owner is `iter_known_tool_name_spellings(tool_name, server)` in `utils.py`, which yields the bare name and then its wire spelling under each accepted prefix. `check_allowed_or_banned_tools`, `validate_allowed_params`, the `tool_name_to_mcp_server_name_mapping` build and `_tool_name_matches` all read it, so the routing map, both permission lists and the discovery filter agree on one set by construction. These are spellings of one tool on one server rather than candidate identities, so honoring all of them normalizes the entry rather than widening a grant, and `test_every_spelling_routing_registers_is_also_enforced` drives `_create_prefixed_tools` and asserts every key routing registers is a key enforcement can refuse

That correction is also what closes the fail-open in run 2. `check_allowed_or_banned_tools` previously built its second operand as `f"{server.name}-{tool_name}"`, which hardcodes the separator and uses a field the prefix chain never reads. On a server with a `short_prefix`, or under an overridden separator, that string can never equal the wire name the proxy published, so a wire-form `disallowed_tools` entry matched nothing. `_call_openapi_tool_handler` had the same expression as its registry key while registration builds the key with `add_server_prefix_to_name(..., get_server_prefix(server))`, so lookup and registration disagreed under exactly those conditions

Every spelling routing accepts stays accepted, which is a deliberate call rather than the default. Rule of thumb would be to delete a tolerance for a form nothing writes, so I audited the writers. `allowed_tools` reaches the manager from config verbatim, from the create and update API bodies verbatim, and from the DB column verbatim; `disallowed_tools` has no DB column and no UI writer at all, so its only real source is hand-written YAML. In every case the writer is or can be a human who is reading prefixed names out of their client, shipped code honors the prefixed form today, and dropping it from `disallowed_tools` would make a currently-blocked tool callable, which is a fail-open introduced by a bug fix. Deleting the second spelling is a deprecation with its own migration note, not something to slip in here

Four sites elsewhere read one half of the blunt split and are deliberately left alone, because fixing them is a different change rather than a smaller one. `litellm_proxy_mcp_handler.py:327` and `:363` have no server object in scope, since the Responses API path carries a flat set of names from the request body; threading one in is a signature change up that chain. `mcp_end_user_permission.py:228` mixes server IDs and server names in a single list, which is its own normalization problem. `server.py:3110` is `prompts/get`, which matches on `.name` only. `user_api_key_auth_mcp.py:1155` splits a header name, not a tool name

One residual is worth stating plainly, and it is unchanged from shipped behavior rather than introduced here. Because more than one spelling is accepted, a single entry string can name two different tools on the same server: on a server prefixed `foo`, the entry `foo-bar` matches the native tool `foo-bar` by its bare name and the native tool `bar` by its wire name. No amount of prefix matching settles that from the string alone, and shipped code has the same property through its `f"{server.name}-{tool_name}"` arm. What changes here is that every site resolves it the same way, instead of the list path and the call path resolving it differently, which is what produced a tool that lists and then refuses

On size, the four permission sites now share one matcher, so the diff deletes more than it adds where the duplication was. Counting executable lines only, by parsing each file and dropping docstrings, comments and blanks, the production tree goes from 8772 lines at the merge-base to 8776, a net of four, and all four are `match_known_tool_name` itself. `mcp_server_manager.py` drops twelve lines, `server.py` gains one, `rest_endpoints.py` is unchanged, and `utils.py` absorbs fifteen. The discovery filter alone goes from twenty-four lines to seven

Tests are regression-shaped and mutation-checked. Eight mutants target the unified matcher and all eight are killed. On the matcher itself: narrowing it to the bare name fails twenty-two tests, making the blocklist arm always allow fails eleven, and reintroducing a truthiness test in the `allowed_params` lookup fails exactly one, `test_an_explicitly_empty_allowed_params_list_refuses_every_parameter`, which is the mutant run 4 reproduces live. On the case rule: dropping the `spec_path` guard so the fold applies everywhere fails four, dropping the OpenAPI fold entirely fails three, and forcing the fold path by never matching exactly fails thirty-two. On the key/team predicate: restoring every-spelling matching on the listing side fails two, dropping the rule that `None` means no restriction fails one, and always granting fails four. That last group is why `test_key_team_listing_and_dispatch_agree` asserts the expected verdict and not only that the two paths agree; with both paths reading one predicate, equality alone is tautological, and the first version of that test let two of those three mutants live. Nine further mutants target the prefix design underneath and all nine are killed: narrowing the owner to the published prefix alone fails five tests; dropping the bare name from the owner fails three; registering only the bare name in the routing map fails three; comparing only the bare name in the blocklist fails eight; the same narrowing in `allowed_params` fails three; narrowing the discovery filter to the published prefix fails two; dropping the bare name from the filter fails seven; and restoring the truthiness test in the `allowed_params` lookup fails `test_an_explicitly_empty_allowed_params_list_refuses_every_parameter`, which is the mutant run 4 reproduces live. Each mutation was undone with an edit rather than `git checkout --`, so the fix under test was never at risk. Two mutants from the earlier round still apply and still die: restoring the double strip in the registry key fails `test_dispatch_keeps_a_native_name_that_opens_with_the_prefix`, and restoring the original `f"{server.name}-{tool_name}"` fails the rows named for the blocklist bypass. `TestMatchKnownServerPrefix` pins the owner's contract, including that the longest candidate beats a leading segment, that the separator must follow the prefix, that candidates are normalized before matching, and that an empty candidate never matches a bare leading separator. `TestServerToolListsHonorThePrefixBoundary` drives both spellings of both list arms through `pre_call_tool_check`, under the default separator, under an overridden one, and under short-prefix mode. `TestOpenAPIRegistryKeyMatchesRegistration` exists because a mutant on the registry key survived the first round: every pre-existing test on that path patches `_call_openapi_tool_handler` out, so nothing pinned the agreement between lookup and registration

Alongside the live runs, two differential probes drive server shapes through the real permission function on both list arms and in both prefix modes. The first derives each entry spelling from `get_server_prefix`, so it only ever covers the currently published name; this branch is 16 of 16 there in both modes, against 16 of 16 default and 8 of 16 short-prefix on the base, where four of the eight wrong rows are denials that returned allow. That probe was too narrow, which is what the second review round caught: a probe built from the published prefix cannot see an entry written with an accepted-but-unpublished one. The second probe enumerates entry spellings over every prefix `iter_known_server_prefixes` accepts, 48 rows per mode, and that is the matrix that matches the invariant. This branch is 48 of 48 in default mode and 48 of 48 in short-prefix mode; the base is 24 of 48 in both, split evenly between grants that never matched and denials that returned allow

Two test-side notes for the reviewer. Several `MagicMock` server fixtures had drifted into shapes production never produces, where auto-created attributes stood in for `alias`, `short_prefix`, and the display-name maps, and a truthy auto-`MagicMock` for `tool_name_to_display_name` was defeating a production early return; those are now pinned to `None`. And `test_execute_mcp_tool_rest_unresolved_prefixed_name_routes_to_requested_server` changed on purpose: it asserted that a prefix belonging to a different server was stripped before dispatch to the routed server. It now asserts the name travels whole, because that prefix is not a boundary on the routed server, and stripping it is how the routed server's similarly named tool gets invoked instead, which is the confusion the `tool_server_mismatch` 403 exists to prevent. That reading follows the routing principle in #30184, whose own commits include allowing hyphenated upstream tool names when the REST `server_id` is authoritative

One red that is not mine, flagged rather than absorbed: two cases in `test_mcp_env_vars.py` fail when the MCP test directory runs in file order under `-p no:randomly`. They pass alone, they pass alongside the four files this PR touches, and they still fail with all four of those files ignored, so the order dependence predates the branch; none of the tests added here write `os.environ` directly

One change deserves a reviewer's eye rather than a claim that it is safe. `validate_allowed_params` used to fall back to `server.allowed_params.get(split_server_prefix_from_name(tool_name)[0])`, and now falls back to the derived wire form. The only key that matched before and does not now is a malformed one equal to the post-first-separator suffix of a real tool name, such as `wiki` configured for a native `read-wiki`, and a miss there means `allowed_params_list is None`, which allows all parameters. Nothing writes such a key and it is the blunt-split defect itself rather than a supported spelling, so removing it is the point; it is called out here because it can be misread as swapping which fallback is honored. The same lookup now tests key presence rather than value truthiness, so an explicitly empty allowlist denies every parameter instead of reading as nothing configured; an earlier commit on this branch got that wrong and run 4 is the differential

## QA runbook

1. Create an MCP server through `POST /v1/mcp/server` with `alias` and `server_name` both omitted, pointing at `https://mcp.deepwiki.com/mcp` with `transport: http`, and set `allowed_tools` to `["read_wiki_contents"]`
2. Mint a virtual key scoped to that server, then run `initialize` and `tools/list` over `POST /mcp/` with `x-litellm-api-key: Bearer <key>`. Expect exactly one tool, named `<server_id>-read_wiki_contents`
3. Call that exact advertised name with `tools/call` and `{"repoName": "BerriAI/litellm"}`. Expect wiki content, not `Tool ... not found`
4. Repeat step 3 through `POST /mcp-rest/tools/call` with `server_id` in the body. Expect the same content
5. Call `<server_id>-ask_question` the same way. Expect a refusal naming `ask_question`, which confirms the fix narrowed correctly instead of just stopping refusals
6. Update `allowed_tools` to the wire spelling `["<server_id>-read_wiki_contents"]` and repeat steps 2, 3 and 5. Expect identical results, since an admin copying the name out of their client writes this form
7. For the fail-open, define a server in config with `disallowed_tools` set to the wire name the proxy publishes for it, run the proxy with `LITELLM_USE_SHORT_MCP_TOOL_PREFIX=true`, and call the banned tool. Expect a refusal. On `litellm_internal_staging` the same call returns upstream content

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization and tool-routing behavior across MCP list/call and REST paths; mistakes could fail-open blocklists or break OpenAPI dispatch, though behavior is heavily regression-tested.
> 
> **Overview**
> Fixes MCP proxy bugs where **tool discovery and `tools/call` disagreed** because the code split prefixed names at the **first separator** instead of using each server’s **registered prefixes** (notably when the prefix is a UUID `server_id` containing `-`).
> 
> **Prefix handling:** Adds `match_known_server_prefix` (longest-prefix match) and routes `strip_known_server_prefix`, prefixed-tool detection, and `execute_mcp_tool` through it so the **bare tool name** sent upstream matches what routing registered.
> 
> **One matcher for policy:** Adds `iter_known_tool_name_spellings` and `match_known_tool_name` so `allowed_tools` / `disallowed_tools`, `allowed_params`, OpenAPI registry lookup, and list filters honor **every wire spelling** routing accepts (alias, short prefix, `server_id`, etc.), not only `f"{server.name}-…"`. OpenAPI servers normalize via shared `openapi_tool_name`; native tools stay **case-exact**.
> 
> **Permissions alignment:** Introduces `MCPRequestHandler.tool_is_granted` for **bare** key/team grants; REST listing uses `filter_tools_by_key_team_permissions` like the MCP path so prefixed grant strings cannot advertise tools that calls reject.
> 
> **Tests:** Large regression coverage for UUID prefixes, short-prefix mode, OpenAPI keys, empty `allowed_params`, and list vs dispatch parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4312fd7fe3a897acd00241baa613c6d8fe5a235. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





