### PR TITLE
chore(terraform): bump grpc to 1.79.3

### DIFF
--- a/terraform/provider/go.mod
+++ b/terraform/provider/go.mod
@@ -56,6 +56,6 @@ require (
 	golang.org/x/tools v0.41.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
-	google.golang.org/grpc v1.79.2 // indirect
+	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/terraform/provider/go.sum
+++ b/terraform/provider/go.sum
@@ -223,8 +223,8 @@ google.golang.org/appengine v1.6.8 h1:IhEN5q69dyKagZPYMSdIjS2HqprW324FRQZJcGqPAs
 google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJffLiz/Ds=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 h1:gRkg/vSppuSQoDjxyiGfN4Upv/h/DQmIR10ZU8dh4Ww=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217/go.mod h1:7i2o+ce6H/6BluujYR+kqX3GKH+dChPTQU19wjRPiGk=
-google.golang.org/grpc v1.79.2 h1:fRMD94s2tITpyJGtBBn7MkMseNpOZU8ZxgC3MMBaXRU=
-google.golang.org/grpc v1.79.2/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
+google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
+google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=


### PR DESCRIPTION
## TLDR

Problem this solves:

- terraform/provider (the Go Terraform provider, not the core Python proxy) pins google.golang.org/grpc v1.79.2
- trivy flags v1.79.2 for CVE-2026-33186, an authorization bypass in gRPC-Go's HTTP/2 path validation

How it solves it:

- Bumps the indirect google.golang.org/grpc dependency to v1.79.3, the release containing the upstream fix, in terraform/provider/go.mod and go.sum

This is scoped as a dependency-security update rather than a confirmed exploit against this repo. There's no evidence that terraform/provider, or anything else in LiteLLM, exercises the specific gRPC authorization/HTTP2 path-validation interceptor the CVE targets; the provider only consumes grpc transitively through the Terraform plugin SDK and doesn't configure gRPC authorization itself

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before this change, on litellm_internal_staging:

```
$ git show litellm_internal_staging:terraform/provider/go.mod | grep grpc
	google.golang.org/grpc v1.79.2 // indirect
```

After this change, from terraform/provider:

```
$ go list -m google.golang.org/grpc
google.golang.org/grpc v1.79.3

$ go build ./...
(exits 0, no output)

$ go vet ./...
(exits 0, no output)

$ go test ./...
?   	github.com/BerriAI/terraform-provider-litellm	[no test files]
ok  	github.com/BerriAI/terraform-provider-litellm/litellm	6.005s
ok  	github.com/BerriAI/terraform-provider-litellm/tools/endpointaudit	1.536s
```

## Type

🚄 Infrastructure

## Changes

- terraform/provider/go.mod: bump google.golang.org/grpc from v1.79.2 to v1.79.3
- terraform/provider/go.sum: update checksums for the bumped grpc module

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
