### PR TITLE
fix(ui): clear existing credentials when editing models

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -143,6 +143,10 @@ def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> Pr
                 merged_deployment_dict["model_info"].pop(field, None)  # type: ignore
                 merged_deployment_dict.get("litellm_params", {}).pop(field, None)  # type: ignore
 
+    if updated_patch.litellm_params and "litellm_credential_name" in updated_patch.litellm_params.model_fields_set:
+        if updated_patch.litellm_params.litellm_credential_name is None:
+            merged_deployment_dict["litellm_params"].pop("litellm_credential_name", None)  # type: ignore
+
     # convert to prisma compatible format
 
     prisma_compatible_model_dict = PrismaCompatibleUpdateDBModel()
@@ -1773,3 +1777,5 @@ async def clear_cache():
         )
     except Exception as e:
         verbose_proxy_logger.exception(f"Failed to clear cache and reload models. Due to error - {str(e)}")
+
+

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -2643,6 +2643,33 @@ def _build_db_model_with_pricing():
     )
 
 
+class TestUpdateDBModelClearCredential:
+    def test_clear_credential_name_removes_existing_value(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            update_db_model,
+        )
+        from litellm.types.router import ModelInfo, updateLiteLLMParams
+
+        db_model = Deployment(
+            model_name="gpt-4o",
+            litellm_params=LiteLLM_Params(
+                model="openai/gpt-4o",
+                litellm_credential_name="existing-credential",
+            ),
+            model_info=ModelInfo(id="dep-credential-0"),
+        )
+
+        result = update_db_model(
+            db_model=db_model,
+            updated_patch=updateDeployment(
+                litellm_params=updateLiteLLMParams(litellm_credential_name=None)
+            ),
+        )
+
+        params = json.loads(result["litellm_params"])
+        assert "litellm_credential_name" not in params
+
+
 class TestUpdateDBModelClearPricing:
     """Sending an explicit `null` for a pricing field must remove it from both
     `litellm_params` and `model_info` (SPECIAL_MODEL_INFO_PARAMS are mirrored

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -383,7 +383,7 @@ export default function ModelInfoView({
       if (values.litellm_credential_name) {
         updatedLitellmParams.litellm_credential_name = values.litellm_credential_name;
       } else {
-        delete updatedLitellmParams.litellm_credential_name;
+        updatedLitellmParams.litellm_credential_name = null;
       }
       if (values.guardrails) {
         updatedLitellmParams.guardrails = values.guardrails;
@@ -1499,3 +1499,4 @@ export default function ModelInfoView({
     </div>
   );
 }
+

--- a/ui/litellm-dashboard/src/components/model_info_view.tsx
+++ b/ui/litellm-dashboard/src/components/model_info_view.tsx
@@ -1499,4 +1499,3 @@ export default function ModelInfoView({
     </div>
   );
 }
-


### PR DESCRIPTION
## TLDR

Problem this solves:

- Clearing Existing Credentials leaves the previous credential name stored
- Refreshing the model page incorrectly shows the old credential

How it solves it:

- The UI sends an explicit null when None is selected
- The backend removes the credential during model update merging

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Manual verification:

1. Create a model with an Existing Credential assigned
2. Edit the model and change Existing Credentials to None
3. Save the model and refresh the page
4. Confirm that Existing Credentials no longer shows the previous credential name

Before fix: the previous credential remained visible after saving and refreshing

After fix, commit `2c6c8d8b30`: the credential is removed and the model shows Manual credentials

## Type

🐛 Bug Fix

## Changes

- Send `null` when the Existing Credentials field is cleared
- Remove explicitly cleared credentials during backend model updates
- Leave unrelated model update behavior unchanged

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR