### PR TITLE
feat(cli): add `litellm-cost-estimate` subcommand for pre-deployment cost estimation (Fixes #34686)

### DIFF
--- a/litellm/cli/cost_estimate.py
+++ b/litellm/cli/cost_estimate.py
@@ -1,0 +1,240 @@
+"""``litellm cost-estimate`` — pre-deployment cost estimation for a single prompt.
+
+Computes the dollar cost of a given model + token count (or model + text)
+using the local ``model_prices_and_context_window.json``. Reuses the
+public ``litellm.cost_per_token`` and ``litellm.token_counter`` helpers,
+so the calculation matches what a real ``litellm.completion`` call
+would produce. No network calls are made.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict, dataclass
+from typing import Any, Optional
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+
+@dataclass(frozen=True)
+class CostEstimate:
+    """Result of a cost-estimate run, suitable for both table and JSON output."""
+
+    model: str
+    input_tokens: int
+    output_tokens: int
+    input_cost: float
+    output_cost: float
+    total_cost: float
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _load_local_cost_map() -> dict[str, Any]:
+    """Read the local cost map. Raises if the file is missing or malformed."""
+    from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+
+    return GetModelCostMap.load_local_model_cost_map()
+
+
+def _resolve_input_tokens(
+    model: str,
+    *,
+    input_tokens: Optional[int],
+    input_text: Optional[str],
+    messages_json: Optional[str],
+) -> int:
+    """Pick the right input-source option and return the input token count.
+
+    Exactly one of ``input_tokens``, ``input_text``, or ``messages_json``
+    must be provided. Returns the input token count. Raises ``click.UsageError``
+    on invalid combinations.
+    """
+    provided = [
+        name
+        for name, val in (("input-tokens", input_tokens), ("input-text", input_text), ("messages", messages_json))
+        if val is not None
+    ]
+    if len(provided) == 0:
+        raise click.UsageError("Provide one of --input-tokens, --input-text, or --messages (as a JSON list).")
+    if len(provided) > 1:
+        raise click.UsageError(f"--{provided[0]} and --{provided[1]} are mutually exclusive; pass only one.")
+    if input_tokens is not None:
+        if input_tokens < 0:
+            raise click.UsageError("--input-tokens must be >= 0")
+        return int(input_tokens)
+    if input_text is not None:
+        from litellm import token_counter
+
+        return int(
+            token_counter(
+                model=model,
+                text=input_text,
+            )
+        )
+    try:
+        messages = json.loads(messages_json)  # type: ignore[arg-type]
+    except json.JSONDecodeError as exc:
+        raise click.UsageError(f"--messages must be valid JSON: {exc}") from exc
+    if not isinstance(messages, list):
+        raise click.UsageError("--messages must be a JSON list of message objects.")
+    from litellm import token_counter
+
+    return int(token_counter(model=model, messages=messages))
+
+
+def _compute_costs(model: str, input_tokens: int, output_tokens: int) -> tuple[float, float]:
+    """Return (input_cost, output_cost) in USD for the given token counts.
+
+    Raises ``click.ClickException`` if the model is not in the local
+    cost map.
+    """
+    cost_map = _load_local_cost_map()
+    if model not in cost_map:
+        raise click.ClickException(
+            f"model {model!r} is not in the local cost map; register it with custom pricing or update the cost map."
+        )
+    try:
+        from litellm import cost_per_token
+
+        input_cost, output_cost = cost_per_token(
+            model=model,
+            prompt_tokens=input_tokens,
+            completion_tokens=output_tokens,
+        )
+    except Exception as exc:
+        raise click.ClickException(f"cost_per_token raised {type(exc).__name__}: {exc}") from exc
+    return float(input_cost), float(output_cost)
+
+
+def estimate_cost(
+    model: str,
+    *,
+    input_tokens: Optional[int] = None,
+    input_text: Optional[str] = None,
+    messages_json: Optional[str] = None,
+    output_tokens: int = 0,
+) -> CostEstimate:
+    """Public helper for programmatic use. Returns a ``CostEstimate``.
+
+    Raises :class:`ValueError` for invalid input (no input source, two
+    input sources, negative token counts, malformed messages JSON).
+    Raises :class:`click.ClickException` only when the model is not
+    in the local cost map, so callers can catch the missing-model
+    case separately from input-validation errors.
+    """
+    if output_tokens < 0:
+        raise ValueError("output_tokens must be >= 0")
+    try:
+        resolved_input = _resolve_input_tokens(
+            model,
+            input_tokens=input_tokens,
+            input_text=input_text,
+            messages_json=messages_json,
+        )
+    except click.UsageError as exc:
+        raise ValueError(str(exc)) from exc
+    input_cost, output_cost = _compute_costs(model, resolved_input, output_tokens)
+    return CostEstimate(
+        model=model,
+        input_tokens=resolved_input,
+        output_tokens=output_tokens,
+        input_cost=input_cost,
+        output_cost=output_cost,
+        total_cost=input_cost + output_cost,
+    )
+
+
+def _render_table(estimate: CostEstimate, console: Console) -> None:
+    table = Table(title=f"cost-estimate: {estimate.model}", show_lines=False)
+    table.add_column("field", style="cyan", no_wrap=True)
+    table.add_column("value")
+    table.add_row("model", estimate.model)
+    table.add_row("input_tokens", f"{estimate.input_tokens}")
+    table.add_row("output_tokens", f"{estimate.output_tokens}")
+    table.add_row("input_cost", f"${estimate.input_cost:.6f}")
+    table.add_row("output_cost", f"${estimate.output_cost:.6f}")
+    table.add_row("total_cost", f"[bold]${estimate.total_cost:.6f}[/bold]")
+    console.print(table)
+
+
+@click.command()
+@click.option(
+    "--model",
+    "model",
+    required=True,
+    help="Model name as it appears in the local cost map (e.g. gpt-4o, claude-sonnet-4-6).",
+)
+@click.option(
+    "--input-tokens",
+    "input_tokens",
+    type=int,
+    default=None,
+    help="Pre-counted input token count. Mutually exclusive with --input-text and --messages.",
+)
+@click.option(
+    "--input-text",
+    "input_text",
+    default=None,
+    help="Input text to count tokens for. Mutually exclusive with --input-tokens and --messages.",
+)
+@click.option(
+    "--messages",
+    "messages_json",
+    default=None,
+    help="JSON list of OpenAI-style message objects to count input tokens for. Mutually exclusive with --input-tokens and --input-text.",
+)
+@click.option(
+    "--output-tokens",
+    "output_tokens",
+    type=int,
+    default=0,
+    show_default=True,
+    help="Expected output token count (default 0).",
+)
+@click.option(
+    "--json",
+    "output_json",
+    is_flag=True,
+    help="Emit a JSON object instead of a table.",
+)
+def cli(
+    model: str,
+    input_tokens: Optional[int],
+    input_text: Optional[str],
+    messages_json: Optional[str],
+    output_tokens: int,
+    output_json: bool,
+) -> None:
+    """Estimate the cost of a single litellm completion call."""
+    try:
+        estimate = estimate_cost(
+            model,
+            input_tokens=input_tokens,
+            input_text=input_text,
+            messages_json=messages_json,
+            output_tokens=output_tokens,
+        )
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+    except click.UsageError:
+        raise
+    except click.ClickException:
+        raise
+    except Exception as exc:
+        click.echo(f"cost-estimate failed: {type(exc).__name__}: {exc}", err=True)
+        sys.exit(1)
+
+    if output_json:
+        click.echo(json.dumps(estimate.to_jsonable()))
+    else:
+        _render_table(estimate, Console())
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ proxy-runtime = [
 litellm = "litellm:run_server"
 lite = "litellm.proxy.client.cli:cli"
 litellm-proxy = "litellm.proxy.client.cli:cli"
+litellm-cost-estimate = "litellm.cli.cost_estimate:cli"
 
 [dependency-groups]
 dev = [

--- a/tests/test_litellm/cli/test_cost_estimate.py
+++ b/tests/test_litellm/cli/test_cost_estimate.py
@@ -1,0 +1,318 @@
+"""Tests for the ``litellm cost-estimate`` CLI subcommand."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from litellm.cli.cost_estimate import (
+    CostEstimate,
+    cli,
+    estimate_cost,
+    _compute_costs,
+    _resolve_input_tokens,
+)
+
+
+def test_estimate_cost_uses_local_cost_map(monkeypatch):
+    """End-to-end: pass --input-tokens and get a non-negative USD total."""
+    monkeypatch.setattr(
+        "litellm.cost_per_token",
+        lambda **kw: (0.0025, 0.0050),
+    )
+    estimate = estimate_cost(model="gpt-4o", input_tokens=1000, output_tokens=500)
+    assert isinstance(estimate, CostEstimate)
+    assert estimate.model == "gpt-4o"
+    assert estimate.input_tokens == 1000
+    assert estimate.output_tokens == 500
+    assert estimate.input_cost == pytest.approx(0.0025)
+    assert estimate.output_cost == pytest.approx(0.0050)
+    assert estimate.total_cost == pytest.approx(0.0075)
+
+
+def test_estimate_cost_counts_tokens_from_text(monkeypatch):
+    """When --input-text is used, token_counter is invoked for the given model."""
+    monkeypatch.setattr(
+        "litellm.token_counter",
+        lambda **kw: 42,
+    )
+    monkeypatch.setattr(
+        "litellm.cost_per_token",
+        lambda **kw: (0.0001, 0.0),
+    )
+    estimate = estimate_cost(
+        model="gpt-4o",
+        input_text="hello world",
+        output_tokens=0,
+    )
+    assert estimate.input_tokens == 42
+    assert estimate.output_tokens == 0
+    assert estimate.total_cost == pytest.approx(0.0001)
+
+
+def test_estimate_cost_counts_tokens_from_messages(monkeypatch):
+    """When --messages is used, token_counter receives the parsed JSON list."""
+    captured: dict = {}
+
+    def fake_token_counter(**kw):
+        captured.update(kw)
+        return 17
+
+    monkeypatch.setattr("litellm.token_counter", fake_token_counter)
+    monkeypatch.setattr("litellm.cost_per_token", lambda **kw: (0.001, 0.0))
+    messages = '[{"role": "user", "content": "hi"}]'
+    estimate = estimate_cost(
+        model="claude-sonnet-4-6",
+        messages_json=messages,
+        output_tokens=10,
+    )
+    assert captured["model"] == "claude-sonnet-4-6"
+    assert captured["messages"] == [{"role": "user", "content": "hi"}]
+    assert estimate.input_tokens == 17
+    assert estimate.output_tokens == 10
+
+
+def test_estimate_cost_rejects_mutually_exclusive_input_options(monkeypatch):
+    """Passing two input sources at once is a usage error."""
+    monkeypatch.setattr("litellm.cost_per_token", lambda **kw: (0.0, 0.0))
+    monkeypatch.setattr("litellm.token_counter", lambda **kw: 0)
+    with pytest.raises(ValueError) as exc:
+        estimate_cost(
+            model="gpt-4o",
+            input_tokens=10,
+            input_text="also this",
+        )
+    assert "mutually exclusive" in str(exc.value).lower()
+
+
+def test_estimate_cost_requires_some_input():
+    """No input source at all is a usage error."""
+    with pytest.raises(ValueError) as exc:
+        estimate_cost(model="gpt-4o")
+    assert "input-tokens" in str(exc.value)
+
+
+def test_estimate_cost_rejects_negative_tokens():
+    with pytest.raises(ValueError):
+        estimate_cost(model="gpt-4o", input_tokens=-1)
+    with pytest.raises(ValueError):
+        estimate_cost(model="gpt-4o", input_tokens=0, output_tokens=-1)
+
+
+def test_estimate_cost_raises_on_unknown_model(monkeypatch):
+    monkeypatch.setattr(
+        "litellm.cli.cost_estimate._load_local_cost_map",
+        lambda: {"gpt-4o": {}},
+    )
+    monkeypatch.setattr("litellm.cost_per_token", lambda **kw: (0.0, 0.0))
+    from click import ClickException
+
+    with pytest.raises(ClickException) as exc:
+        estimate_cost(model="totally-unknown-model-9000", input_tokens=10)
+    assert "not in the local cost map" in str(exc.value)
+
+
+def test_estimate_cost_propagates_cost_per_token_failure(monkeypatch):
+    monkeypatch.setattr(
+        "litellm.cli.cost_estimate._load_local_cost_map",
+        lambda: {"gpt-4o": {}},
+    )
+
+    def _raise(**kw):
+        raise RuntimeError("simulated cost_per_token failure")
+
+    monkeypatch.setattr("litellm.cost_per_token", _raise)
+    from click import ClickException
+
+    with pytest.raises(ClickException) as exc:
+        estimate_cost(model="gpt-4o", input_tokens=10)
+    assert "simulated cost_per_token failure" in str(exc.value)
+
+
+def test_to_jsonable_round_trip():
+    estimate = CostEstimate(
+        model="gpt-4o",
+        input_tokens=10,
+        output_tokens=5,
+        input_cost=0.001,
+        output_cost=0.002,
+        total_cost=0.003,
+    )
+    assert json.loads(json.dumps(estimate.to_jsonable())) == {
+        "model": "gpt-4o",
+        "input_tokens": 10,
+        "output_tokens": 5,
+        "input_cost": 0.001,
+        "output_cost": 0.002,
+        "total_cost": 0.003,
+    }
+
+
+def test_cli_table_output_for_input_tokens():
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--model", "gpt-4o", "--input-tokens", "1000", "--output-tokens", "500"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "cost-estimate: gpt-4o" in result.output
+    assert "input_tokens" in result.output
+    assert "output_tokens" in result.output
+    assert "total_cost" in result.output
+
+
+def test_cli_json_output_is_valid_json():
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--model",
+            "gpt-4o",
+            "--input-tokens",
+            "1000",
+            "--output-tokens",
+            "500",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["model"] == "gpt-4o"
+    assert payload["input_tokens"] == 1000
+    assert payload["output_tokens"] == 500
+    assert payload["total_cost"] > 0
+
+
+def test_cli_input_text_counts_tokens_and_estimates(monkeypatch):
+    monkeypatch.setattr("litellm.token_counter", lambda **kw: 9)
+    monkeypatch.setattr("litellm.cost_per_token", lambda **kw: (0.00009, 0.0))
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--model",
+            "gpt-4o",
+            "--input-text",
+            "hi",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["input_tokens"] == 9
+    assert payload["output_tokens"] == 0
+    assert payload["total_cost"] == pytest.approx(0.00009)
+
+
+def test_cli_messages_json_input(monkeypatch):
+    monkeypatch.setattr("litellm.token_counter", lambda **kw: 25)
+    monkeypatch.setattr("litellm.cost_per_token", lambda **kw: (0.00025, 0.0))
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--model",
+            "claude-sonnet-4-6",
+            "--messages",
+            '[{"role": "user", "content": "hello there"}]',
+            "--output-tokens",
+            "100",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["input_tokens"] == 25
+    assert payload["output_tokens"] == 100
+
+
+def test_cli_rejects_mutually_exclusive_input_flags():
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--model",
+            "gpt-4o",
+            "--input-tokens",
+            "10",
+            "--input-text",
+            "also this",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "mutually exclusive" in result.output.lower()
+
+
+def test_cli_rejects_missing_input():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--model", "gpt-4o"])
+    assert result.exit_code == 2
+
+
+def test_cli_rejects_invalid_messages_json():
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--model", "gpt-4o", "--messages", "not-json"],
+    )
+    assert result.exit_code == 2
+    assert "valid json" in result.output.lower()
+
+
+def test_cli_rejects_non_list_messages():
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--model", "gpt-4o", "--messages", '{"role": "user", "content": "hi"}'],
+    )
+    assert result.exit_code == 2
+    assert "list" in result.output.lower()
+
+
+def test_cli_exits_1_on_unknown_model(monkeypatch):
+    """The ClickException path surfaces as exit code 1 in the CLI runner."""
+    monkeypatch.setattr(
+        "litellm.cli.cost_estimate._load_local_cost_map",
+        lambda: {"gpt-4o": {}},
+    )
+    monkeypatch.setattr("litellm.cost_per_token", lambda **kw: (0.0, 0.0))
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["--model", "totally-unknown-xyz", "--input-tokens", "10"],
+    )
+    assert result.exit_code == 1
+    assert "not in the local cost map" in result.output
+
+
+def test_resolve_input_tokens_uses_token_counter_for_text(monkeypatch):
+    monkeypatch.setattr("litellm.token_counter", lambda **kw: 7)
+    assert _resolve_input_tokens("gpt-4o", input_tokens=None, input_text="hi", messages_json=None) == 7
+
+
+def test_resolve_input_tokens_uses_token_counter_for_messages(monkeypatch):
+    monkeypatch.setattr("litellm.token_counter", lambda **kw: 11)
+    assert (
+        _resolve_input_tokens(
+            "gpt-4o",
+            input_tokens=None,
+            input_text=None,
+            messages_json='[{"role":"user","content":"hi"}]',
+        )
+        == 11
+    )
+
+
+def test_resolve_input_tokens_returns_raw_int_when_provided():
+    assert _resolve_input_tokens("gpt-4o", input_tokens=42, input_text=None, messages_json=None) == 42
+
+
+def test_compute_costs_returns_tuple_from_cost_per_token(monkeypatch):
+    monkeypatch.setattr(
+        "litellm.cli.cost_estimate._load_local_cost_map",
+        lambda: {"gpt-4o": {}},
+    )
+    monkeypatch.setattr("litellm.cost_per_token", lambda **kw: (0.01, 0.02))
+    assert _compute_costs("gpt-4o", 100, 50) == (0.01, 0.02)


### PR DESCRIPTION
## Relevant issues

Fixes #34686

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests) — locally verified; CI pending
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review (pending; PR is in draft)

## Screenshots / Proof of Fix

This is a new offline CLI command. The proof is the command running end-to-end against real model data. No live proxy is required.

After `pip install -e .` (or `uv pip install -e .`):

```
$ litellm-cost-estimate --model gpt-4o --input-tokens 1000 --output-tokens 500
    cost-estimate: gpt-4o
┏━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ field         ┃ value     ┃
┡━━━━━━━━━━━━━━━╇━━━━━━━━━━━┡
│ model         │ gpt-4o    │
│ input_tokens  │ 1000      │
│ output_tokens │ 500       │
│ input_cost    │ $0.002500 │
│ output_cost   │ $0.005000 │
│ total_cost    │ $0.007500 │
└───────────────┴───────────┘
```

JSON output for scripts:

```
$ litellm-cost-estimate --model claude-sonnet-4-6 \
    --input-text "Hello, world!" --output-tokens 100 --json
{"model": "claude-sonnet-4-6", "input_tokens": 4, "output_tokens": 100, "input_cost": 1.2e-05, "output_cost": 0.0015, "total_cost": 0.001512}
```

Unknown model surfaces a clear error and exit 1:

```
$ litellm-cost-estimate --model totally-unknown-xyz --input-tokens 10
Error: model 'totally-unknown-xyz' is not in the local cost map; register it with custom pricing or update the cost map.
$ echo $?
1
```

## Type

🆕 New Feature

## Changes

New package `litellm/cli/` (alongside the existing `litellm/cli/doctor.py` from #34514):
- `litellm/cli/cost_estimate.py`: the `cli` command, the public `estimate_cost()` helper, the `CostEstimate` dataclass, and the input-resolution helpers. Reuses `litellm.cost_per_token()` and `litellm.token_counter()` for the actual math, so the result is byte-identical to what a real `litellm.completion` call would produce.

New test package `tests/test_litellm/cli/`:
- `tests/test_litellm/cli/test_cost_estimate.py`: 22 tests covering pass / fail / invalid-input paths at both the programmatic (`estimate_cost`) and CLI (`cli`) layers.

Modified:
- `pyproject.toml`: added one `[project.scripts]` entry `litellm-cost-estimate = "litellm.cli.cost_estimate:cli"`.

Two logical commits:
- `feat(cli): add litellm-cost-estimate subcommand for pre-deployment cost estimation`
- `test(cli): cover litellm-cost-estimate pass / fail / invalid-input paths`

Total diff: 3 files changed, 559 insertions, 0 deletions.

No change to `litellm.completion`, `litellm.acompletion`, `litellm.cost_per_token`, `litellm.token_counter`, or any public API. No change to the proxy. The new command is strictly read-only and offline.

## QA runbook

This PR does not edit `tests/e2e/`. No runbook needed.
