### PR TITLE
fix(anthropic): shallow-copy input_schema to prevent caller mutation

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -762,9 +762,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 name=truncated_name,
             )
             if "input_schema" in tool:
-                # Shallow-copy to avoid mutating the caller's original dict when
-                # extra kwargs are merged below (see #34510).
-                function_chunk["parameters"] = dict(tool["input_schema"])
+                # Deep-copy so extra kwargs merged below (see #34510) never mutate
+                # the caller's original `input_schema` dict.
+                function_chunk["parameters"] = copy.deepcopy(tool["input_schema"])
             if "description" in tool:
                 function_chunk["description"] = tool["description"]
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -762,7 +762,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 name=truncated_name,
             )
             if "input_schema" in tool:
-                function_chunk["parameters"] = tool["input_schema"]
+                # Shallow-copy to avoid mutating the caller's original dict when
+                # extra kwargs are merged below (see #34510).
+                function_chunk["parameters"] = dict(tool["input_schema"])
             if "description" in tool:
                 function_chunk["description"] = tool["description"]
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -768,9 +768,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 name=truncated_name,
             )
             if "input_schema" in tool:
-                # Shallow-copy to avoid mutating the caller's original dict when
-                # extra kwargs are merged below (see #34510).
-                function_chunk["parameters"] = dict(tool["input_schema"])
+                # Deep-copy so extra kwargs merged below (see #34510) never mutate
+                # the caller's original `input_schema` dict.
+                function_chunk["parameters"] = copy.deepcopy(tool["input_schema"])
             if "description" in tool:
                 function_chunk["description"] = tool["description"]
             if "strict" in tool:

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -768,7 +768,9 @@ class LiteLLMAnthropicMessagesAdapter:
                 name=truncated_name,
             )
             if "input_schema" in tool:
-                function_chunk["parameters"] = tool["input_schema"]
+                # Shallow-copy to avoid mutating the caller's original dict when
+                # extra kwargs are merged below (see #34510).
+                function_chunk["parameters"] = dict(tool["input_schema"])
             if "description" in tool:
                 function_chunk["description"] = tool["description"]
             if "strict" in tool:


### PR DESCRIPTION
## Description

The Anthropic→OpenAI tool translation adapter was directly assigning the caller's `input_schema` dict to the `function_chunk["parameters"]` field. A subsequent loop that merges extra kwargs mutated it in place:

```python
for k, v in tool.items():
    if k not in mapped_tool_params:
        function_chunk.setdefault("parameters", {}).update({k: v})
```

This means the caller's original tool definition dict gets mutated every time the adapter runs, breaking reusability of the tool schema across multiple calls.

## Fix

Wrap with `dict()` to create a shallow copy before assigning — the extra kwargs loop now mutates the copy, not the original:

```python
function_chunk["parameters"] = dict(tool["input_schema"])
```

## Related Issue

Closes #34510
