### PR TITLE
fix(proxy): preserve adapter registry across pass-through route registration

### DIFF
--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1666,11 +1666,14 @@ def create_pass_through_route(
             adapter = target
         else:
             adapter = get_instance_fn(value=target, config_file_path=config_file_path)
-        adapter_id = str(uuid.uuid4())
-        litellm.adapters = [
-            *(entry for entry in litellm.adapters if entry["adapter"] is not adapter),
-            {"id": adapter_id, "adapter": adapter},
-        ]
+        existing_entry = next(
+            (entry for entry in litellm.adapters if entry["adapter"] is adapter), None
+        )
+        if existing_entry is not None:
+            adapter_id = existing_entry["id"]
+        else:
+            adapter_id = str(uuid.uuid4())
+            litellm.adapters = [*litellm.adapters, {"id": adapter_id, "adapter": adapter}]
 
         async def endpoint_func(  # type: ignore
             request: Request,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1667,7 +1667,10 @@ def create_pass_through_route(
         else:
             adapter = get_instance_fn(value=target, config_file_path=config_file_path)
         adapter_id = str(uuid.uuid4())
-        litellm.adapters = [{"id": adapter_id, "adapter": adapter}]
+        litellm.adapters = [
+            *(entry for entry in litellm.adapters if entry["adapter"] is not adapter),
+            {"id": adapter_id, "adapter": adapter},
+        ]
 
         async def endpoint_func(  # type: ignore
             request: Request,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1679,6 +1679,20 @@ def create_pass_through_route(
             user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
             subpath: str = "",  # captures sub-paths when include_subpath=True
         ):
+            from litellm.proxy.auth.auth_utils import (  # noqa: PLC0415
+                get_request_route,
+            )
+            from litellm.proxy.pass_through_endpoints.pass_through_endpoints import (  # noqa: PLC0415
+                InitPassThroughEndpointHelpers,
+            )
+
+            path = get_request_route(request)
+            if not InitPassThroughEndpointHelpers.is_registered_pass_through_route(route=path):
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Pass-through endpoint {endpoint} not found. This could have been deleted or not yet added to the proxy.",
+                )
+
             return await chat_completion_pass_through_endpoint(
                 fastapi_response=fastapi_response,
                 request=request,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -1666,9 +1666,7 @@ def create_pass_through_route(
             adapter = target
         else:
             adapter = get_instance_fn(value=target, config_file_path=config_file_path)
-        existing_entry = next(
-            (entry for entry in litellm.adapters if entry["adapter"] is adapter), None
-        )
+        existing_entry = next((entry for entry in litellm.adapters if entry["adapter"] is adapter), None)
         if existing_entry is not None:
             adapter_id = existing_entry["id"]
         else:

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -1092,13 +1092,19 @@ def test_create_pass_through_route_registers_multiple_adapters():
         litellm.adapters = original_adapters
 
 
-def test_create_pass_through_route_reregistering_same_adapter_replaces_entry():
+def test_create_pass_through_route_reregistering_same_adapter_reuses_id():
     """
     Regression test: re-registering the same adapter object (e.g. on the
     periodic pass-through reload cycle, which re-runs create_pass_through_route
-    for already-registered routes) must replace its existing litellm.adapters
-    entry rather than appending a duplicate. Otherwise the list grows
-    unboundedly with orphaned entries every reload.
+    for already-registered routes) must reuse its existing litellm.adapters
+    entry rather than appending a duplicate or minting a new id.
+
+    A route whose FastAPI registration is skipped as a duplicate (see
+    SafeRouteAdder.add_api_route_if_not_exists) keeps serving requests with
+    the adapter_id captured on its first registration. Minting a fresh id on
+    every reload and swapping out the old entry would silently break that
+    still-live route: its captured id would no longer resolve in
+    litellm.adapters.
     """
     original_adapters = litellm.adapters
 
@@ -1123,7 +1129,7 @@ def test_create_pass_through_route_reregistering_same_adapter_replaces_entry():
 
         assert len(litellm.adapters) == 1
         assert litellm.adapters[0]["adapter"] is adapter
-        assert litellm.adapters[0]["id"] != first_id
+        assert litellm.adapters[0]["id"] == first_id
     finally:
         litellm.adapters = original_adapters
 

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -10,6 +10,7 @@ from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
+import litellm
 import pytest
 from fastapi import Request, UploadFile
 from starlette.datastructures import FormData, Headers, QueryParams
@@ -1049,6 +1050,82 @@ async def test_create_pass_through_route_with_cost_per_request():
         mock_pass_through.assert_called_once()
         call_kwargs = mock_pass_through.call_args[1]
         assert call_kwargs["cost_per_request"] == 3.75
+
+
+def test_create_pass_through_route_registers_multiple_adapters():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/22645
+
+    Each adapter-backed pass_through_endpoints route must keep its own entry
+    in litellm.adapters. A prior bug overwrote the entire list on every
+    registration, so every route except the last one registered failed
+    lookup at request time with "No matching adapter given".
+    """
+    original_adapters = litellm.adapters
+
+    class _FirstAdapter(CustomLogger):
+        pass
+
+    class _SecondAdapter(CustomLogger):
+        pass
+
+    first_adapter = _FirstAdapter()
+    second_adapter = _SecondAdapter()
+
+    try:
+        litellm.adapters = []
+
+        create_pass_through_route(
+            endpoint="/test/path/unique/adapter_one",
+            target=first_adapter,
+        )
+        create_pass_through_route(
+            endpoint="/test/path/unique/adapter_two",
+            target=second_adapter,
+        )
+
+        assert len(litellm.adapters) == 2
+        assert litellm.adapters[0]["adapter"] is first_adapter
+        assert litellm.adapters[1]["adapter"] is second_adapter
+        assert litellm.adapters[0]["id"] != litellm.adapters[1]["id"]
+    finally:
+        litellm.adapters = original_adapters
+
+
+def test_create_pass_through_route_reregistering_same_adapter_replaces_entry():
+    """
+    Regression test: re-registering the same adapter object (e.g. on the
+    periodic pass-through reload cycle, which re-runs create_pass_through_route
+    for already-registered routes) must replace its existing litellm.adapters
+    entry rather than appending a duplicate. Otherwise the list grows
+    unboundedly with orphaned entries every reload.
+    """
+    original_adapters = litellm.adapters
+
+    class _ReloadedAdapter(CustomLogger):
+        pass
+
+    adapter = _ReloadedAdapter()
+
+    try:
+        litellm.adapters = []
+
+        create_pass_through_route(
+            endpoint="/test/path/unique/reload_adapter",
+            target=adapter,
+        )
+        first_id = litellm.adapters[0]["id"]
+
+        create_pass_through_route(
+            endpoint="/test/path/unique/reload_adapter",
+            target=adapter,
+        )
+
+        assert len(litellm.adapters) == 1
+        assert litellm.adapters[0]["adapter"] is adapter
+        assert litellm.adapters[0]["id"] != first_id
+    finally:
+        litellm.adapters = original_adapters
 
 
 def test_resolve_pass_through_request_timeout_precedence():

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py
@@ -1134,6 +1134,65 @@ def test_create_pass_through_route_reregistering_same_adapter_reuses_id():
         litellm.adapters = original_adapters
 
 
+@pytest.mark.asyncio
+async def test_create_pass_through_route_adapter_dispatch_rejects_deregistered_route():
+    """
+    Regression test: an adapter-backed pass-through route must stop
+    dispatching once it's no longer registered (e.g. after
+    delete_pass_through_endpoints removes it from the registry), the same
+    way the URL-backed pass-through route already does. Without this check,
+    a deleted adapter route stays reachable indefinitely because FastAPI has
+    no built-in route removal and the adapter closure otherwise dispatches
+    unconditionally on its captured adapter_id.
+    """
+    original_adapters = litellm.adapters
+
+    class _DeregisteredAdapter(CustomLogger):
+        pass
+
+    from fastapi import HTTPException
+
+    adapter = _DeregisteredAdapter()
+    unique_path = "/test/path/unique/adapter_deregistered"
+
+    try:
+        litellm.adapters = []
+
+        endpoint_func = create_pass_through_route(
+            endpoint=unique_path,
+            target=adapter,
+        )
+
+        with (
+            patch(
+                "litellm.proxy.pass_through_endpoints.pass_through_endpoints.InitPassThroughEndpointHelpers.is_registered_pass_through_route"
+            ) as mock_is_registered,
+            patch(
+                "litellm.proxy.pass_through_endpoints.pass_through_endpoints.chat_completion_pass_through_endpoint"
+            ) as mock_chat_completion,
+        ):
+            mock_is_registered.return_value = False
+
+            mock_request = MagicMock(spec=Request)
+            mock_request.scope = {"path": unique_path}
+            mock_request.url = MagicMock()
+            mock_request.url.path = unique_path
+            mock_user_api_key_dict = MagicMock()
+            mock_user_api_key_dict.api_key = "test-key"
+
+            with pytest.raises(HTTPException) as exc_info:
+                await endpoint_func(
+                    request=mock_request,
+                    user_api_key_dict=mock_user_api_key_dict,
+                    fastapi_response=MagicMock(),
+                )
+
+            assert exc_info.value.status_code == 404
+            mock_chat_completion.assert_not_called()
+    finally:
+        litellm.adapters = original_adapters
+
+
 def test_resolve_pass_through_request_timeout_precedence():
     assert resolve_pass_through_request_timeout(endpoint_timeout=900) == 900.0
 


### PR DESCRIPTION
## TLDR

Problem this solves:

create_pass_through_route() replaced the entire litellm.adapters list on every registration instead of appending to it. Configuring more than one adapter-backed pass_through_endpoints route meant only the most recently registered adapter stayed resolvable; earlier routes failed at request time with "No matching adapter given". The same overwrite also meant that re-registering an already-live route (for example on a config reload cycle, which re-runs create_pass_through_route for every configured route regardless of whether it's already mounted) generated a brand new adapter_id every time, so a naive append-only fix would instead leak a new orphaned entry into litellm.adapters on every cycle.

How it solves it:

create_pass_through_route() now checks whether the same adapter object (by identity) is already registered. If so, it reuses that entry's existing adapter_id instead of minting a new one. This matters because SafeRouteAdder skips re-mounting a route that's already on the FastAPI app, so an already-live route keeps serving requests through the closure from its first registration, which captured that original adapter_id; minting and swapping in a new id on every reload would silently break that route once its captured id no longer resolves in litellm.adapters. If the adapter object is new, it's appended with a fresh id as before. Distinct adapters registered on different routes coexist in the list, and re-registering the same adapter object neither breaks the live route nor accumulates duplicate entries.

Review on this PR also surfaced a related gap directly in the code this fix touches: the adapter-backed closure dispatched unconditionally on its captured adapter_id, with no check for whether the route was still registered. The URL-backed pass-through closure already guards against this with an is_registered_pass_through_route() check, since FastAPI has no route-removal API and a deleted endpoint's closure otherwise stays mounted forever. The adapter branch was missing that same guard, so a deleted adapter-backed endpoint (and its upstream credentials) stayed reachable indefinitely. Added the same check to the adapter closure.

## Relevant issues

Fixes #22645

A prior attempt at this fix, #30392, was discarded, closed as "withdrawn for cleanup" after being retargeted from main to litellm_oss_branch, not rejected on technical merit. This PR proposes a small, singular fix for the same problem, scoped to just the overwrite bug and the reload-growth issue it exposes once fixed.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

I was not able to run the local proxy with curl against real provider APIs for this PR: the maturin/Rust bridge build (litellm-rust) does not compile in my local Windows environment, which blocks the normal editable install this repo's proxy needs to boot. Rather than skip verification, I confirmed the fix at the unit level, including confirming both new tests fail against the old (pre-fix) code and pass against the new code:

```
uv run pytest tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py -k "adapter" -v
```

test_create_pass_through_route_registers_multiple_adapters, test_create_pass_through_route_reregistering_same_adapter_reuses_id, and test_create_pass_through_route_adapter_dispatch_rejects_deregistered_route all pass on this branch. I reverted each fix individually and reran to confirm the corresponding test fails without it: with the list overwrite reintroduced, the multi-adapter test drops to 1 entry; with id-reuse replaced by always minting a new id and swapping the entry, the reload test's captured id changes instead of staying the same; with the liveness check removed, the deregistered-route test's 404 never fires and the adapter dispatches anyway. The full test_pass_through_endpoints.py file, ruff (scoped and diff-scoped format check), the ruff strict-rule budget gate, the type-discipline budget gate, and the basedpyright budget gate all pass clean against this branch, matching the exact commands CI runs.

If a maintainer can run this locally, the QA runbook below reproduces the original bug on main and shows it resolved on this branch.

## Type

Bug Fix

## Changes

- litellm/proxy/pass_through_endpoints/pass_through_endpoints.py: replace the litellm.adapters list-overwrite in create_pass_through_route() with an identity-based lookup that reuses an existing adapter's id, or appends a fresh entry for a new adapter object. Add an is_registered_pass_through_route() liveness check to the adapter-backed closure, mirroring the URL-backed closure's existing check.
- tests/test_litellm/proxy/pass_through_endpoints/test_pass_through_endpoints.py: add test_create_pass_through_route_registers_multiple_adapters, test_create_pass_through_route_reregistering_same_adapter_reuses_id, and test_create_pass_through_route_adapter_dispatch_rejects_deregistered_route.

## QA runbook

Configure two adapter-backed pass_through_endpoints in a proxy config, each targeting a distinct CustomLogger adapter object, for example:

```yaml
general_settings:
  pass_through_endpoints:
    - path: /api/v1/predict/one
      target: example_adapters.adapter_one
    - path: /api/v1/predict/two
      target: example_adapters.adapter_two
```

Start the proxy, then hit both routes:

```bash
curl -s http://localhost:4000/api/v1/predict/one -X POST -H "Content-Type: application/json" -d '{}'
curl -s http://localhost:4000/api/v1/predict/two -X POST -H "Content-Type: application/json" -d '{}'
```

On main, the first route fails with "No matching adapter given" because registering the second route overwrote litellm.adapters. On this branch, both routes resolve their own adapter.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
