### PR TITLE
fix(proxy): redact secrets and sanitize control chars in print_verbose stdout

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -424,12 +424,14 @@ def _sanitize_log_message(message: str) -> str:
     return re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]", "?", message)
 
 
+def _redact_and_sanitize(value) -> str:
+    return _sanitize_log_message(redact_secrets(str(value)))
+
+
 def print_verbose(print_statement):
     try:
         if set_verbose:
-            print(  # noqa: T201
-                _sanitize_log_message(redact_secrets(str(print_statement)))
-            )
+            print(_redact_and_sanitize(print_statement))  # noqa: T201
     except Exception:
         pass
 

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -421,7 +421,7 @@ def _sanitize_log_message(message: str) -> str:
     }
     for char, escaped in line_breaks.items():
         message = message.replace(char, escaped)
-    return re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "?", message)
+    return re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]", "?", message)
 
 
 def print_verbose(print_statement):

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -1,6 +1,7 @@
 import ast
 import logging
 import os
+import re
 import sys
 from datetime import datetime
 from logging import Formatter
@@ -410,10 +411,18 @@ def _enable_debugging():
     verbose_proxy_logger.disabled = False
 
 
+def _sanitize_log_message(message: str) -> str:
+    sanitized_message = message.replace("\r", "\\r").replace("\n", "\\n")
+    sanitized_message = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "?", sanitized_message)
+    return sanitized_message
+
+
 def print_verbose(print_statement):
     try:
         if set_verbose:
-            print(redact_secrets(str(print_statement)))  # noqa: T201
+            print(  # noqa: T201
+                _sanitize_log_message(redact_secrets(str(print_statement)))
+            )
     except Exception:
         pass
 

--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -412,9 +412,16 @@ def _enable_debugging():
 
 
 def _sanitize_log_message(message: str) -> str:
-    sanitized_message = message.replace("\r", "\\r").replace("\n", "\\n")
-    sanitized_message = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "?", sanitized_message)
-    return sanitized_message
+    line_breaks = {
+        "\r": "\\r",
+        "\n": "\\n",
+        "\x85": "\\x85",
+        "\u2028": "\\u2028",
+        "\u2029": "\\u2029",
+    }
+    for char, escaped in line_breaks.items():
+        message = message.replace(char, escaped)
+    return re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "?", message)
 
 
 def print_verbose(print_statement):

--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from pydantic import BaseModel
 
 import litellm
-from litellm._logging import verbose_logger
+from litellm._logging import _sanitize_log_message, redact_secrets, verbose_logger
 from litellm.constants import CACHED_STREAMING_CHUNK_DELAY
 from litellm.litellm_core_utils.model_param_helper import ModelParamHelper
 from litellm.types.caching import *
@@ -41,7 +41,9 @@ def print_verbose(print_statement):
     try:
         verbose_logger.debug(print_statement)
         if litellm.set_verbose:
-            print(print_statement)  # noqa: T201
+            print(  # noqa: T201
+                _sanitize_log_message(redact_secrets(str(print_statement)))
+            )
     except Exception:
         pass
 

--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from pydantic import BaseModel
 
 import litellm
-from litellm._logging import _sanitize_log_message, redact_secrets, verbose_logger
+from litellm._logging import _redact_and_sanitize, verbose_logger
 from litellm.constants import CACHED_STREAMING_CHUNK_DELAY
 from litellm.litellm_core_utils.model_param_helper import ModelParamHelper
 from litellm.types.caching import *
@@ -41,9 +41,7 @@ def print_verbose(print_statement):
     try:
         verbose_logger.debug(print_statement)
         if litellm.set_verbose:
-            print(  # noqa: T201
-                _sanitize_log_message(redact_secrets(str(print_statement)))
-            )
+            print(_redact_and_sanitize(print_statement))  # noqa: T201
     except Exception:
         pass
 

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel
 
 import litellm
 from litellm import verbose_logger
-from litellm._logging import _sanitize_log_message, redact_secrets
+from litellm._logging import _redact_and_sanitize
 from litellm._uuid import uuid
 from litellm.litellm_core_utils.model_response_utils import (
     is_model_response_stream_empty,
@@ -94,9 +94,7 @@ def is_async_iterable(obj: Any) -> bool:
 def print_verbose(print_statement):
     try:
         if litellm.set_verbose:
-            print(  # noqa: T201
-                _sanitize_log_message(redact_secrets(str(print_statement)))
-            )
+            print(_redact_and_sanitize(print_statement))  # noqa: T201
     except Exception:
         pass
 

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel
 
 import litellm
 from litellm import verbose_logger
+from litellm._logging import _sanitize_log_message, redact_secrets
 from litellm._uuid import uuid
 from litellm.litellm_core_utils.model_response_utils import (
     is_model_response_stream_empty,
@@ -93,7 +94,9 @@ def is_async_iterable(obj: Any) -> bool:
 def print_verbose(print_statement):
     try:
         if litellm.set_verbose:
-            print(print_statement)  # noqa: T201
+            print(  # noqa: T201
+                _sanitize_log_message(redact_secrets(str(print_statement)))
+            )
     except Exception:
         pass
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -179,7 +179,7 @@ from litellm.utils import (
     validate_openai_optional_params,
 )
 
-from ._logging import verbose_logger
+from ._logging import _sanitize_log_message, redact_secrets, verbose_logger
 from .caching.caching import disable_cache, enable_cache, update_cache
 from .litellm_core_utils.core_helpers import safe_deep_copy
 from .litellm_core_utils.fallback_utils import (
@@ -8381,7 +8381,9 @@ def print_verbose(print_statement):
     try:
         verbose_logger.debug(print_statement)
         if litellm.set_verbose:
-            print(print_statement)  # noqa: T201
+            print(  # noqa: T201
+                _sanitize_log_message(redact_secrets(str(print_statement)))
+            )
     except Exception:
         pass
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -179,7 +179,7 @@ from litellm.utils import (
     validate_openai_optional_params,
 )
 
-from ._logging import _sanitize_log_message, redact_secrets, verbose_logger
+from ._logging import _redact_and_sanitize, verbose_logger
 from .caching.caching import disable_cache, enable_cache, update_cache
 from .litellm_core_utils.core_helpers import safe_deep_copy
 from .litellm_core_utils.fallback_utils import (
@@ -8381,9 +8381,7 @@ def print_verbose(print_statement):
     try:
         verbose_logger.debug(print_statement)
         if litellm.set_verbose:
-            print(  # noqa: T201
-                _sanitize_log_message(redact_secrets(str(print_statement)))
-            )
+            print(_redact_and_sanitize(print_statement))  # noqa: T201
     except Exception:
         pass
 

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -30,7 +30,11 @@ import aiohttp
 
 import litellm
 from litellm import get_secret
-from litellm._logging import verbose_proxy_logger
+from litellm._logging import (
+    _sanitize_log_message,
+    redact_secrets,
+    verbose_proxy_logger,
+)
 from litellm.types.utils import GenericGuardrailAPIInputs
 
 if TYPE_CHECKING:
@@ -1320,7 +1324,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         try:
             verbose_proxy_logger.debug(print_statement)
             if litellm.set_verbose:
-                print(print_statement)  # noqa: T201
+                print(  # noqa: T201
+                    _sanitize_log_message(redact_secrets(str(print_statement)))
+                )
         except Exception:
             pass
 

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -31,8 +31,7 @@ import aiohttp
 import litellm
 from litellm import get_secret
 from litellm._logging import (
-    _sanitize_log_message,
-    redact_secrets,
+    _redact_and_sanitize,
     verbose_proxy_logger,
 )
 from litellm.types.utils import GenericGuardrailAPIInputs
@@ -1324,9 +1323,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
         try:
             verbose_proxy_logger.debug(print_statement)
             if litellm.set_verbose:
-                print(  # noqa: T201
-                    _sanitize_log_message(redact_secrets(str(print_statement)))
-                )
+                print(_redact_and_sanitize(print_statement))  # noqa: T201
         except Exception:
             pass
 

--- a/litellm/proxy/hooks/batch_redis_get.py
+++ b/litellm/proxy/hooks/batch_redis_get.py
@@ -9,7 +9,11 @@ from typing import Literal, Optional
 from fastapi import HTTPException
 
 import litellm
-from litellm._logging import verbose_proxy_logger
+from litellm._logging import (
+    _sanitize_log_message,
+    redact_secrets,
+    verbose_proxy_logger,
+)
 from litellm.caching.caching import DualCache, InMemoryCache, RedisCache
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.proxy._types import UserAPIKeyAuth
@@ -31,7 +35,9 @@ class _PROXY_BatchRedisRequests(CustomLogger):
         elif debug_level == "INFO":
             verbose_proxy_logger.debug(print_statement)
         if litellm.set_verbose is True:
-            print(print_statement)  # noqa: T201
+            print(  # noqa: T201
+                _sanitize_log_message(redact_secrets(str(print_statement)))
+            )
 
     async def async_pre_call_hook(
         self,

--- a/litellm/proxy/hooks/batch_redis_get.py
+++ b/litellm/proxy/hooks/batch_redis_get.py
@@ -10,8 +10,7 @@ from fastapi import HTTPException
 
 import litellm
 from litellm._logging import (
-    _sanitize_log_message,
-    redact_secrets,
+    _redact_and_sanitize,
     verbose_proxy_logger,
 )
 from litellm.caching.caching import DualCache, InMemoryCache, RedisCache
@@ -35,9 +34,7 @@ class _PROXY_BatchRedisRequests(CustomLogger):
         elif debug_level == "INFO":
             verbose_proxy_logger.debug(print_statement)
         if litellm.set_verbose is True:
-            print(  # noqa: T201
-                _sanitize_log_message(redact_secrets(str(print_statement)))
-            )
+            print(_redact_and_sanitize(print_statement))  # noqa: T201
 
     async def async_pre_call_hook(
         self,

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -8,7 +8,11 @@ from typing_extensions import TypedDict
 
 import litellm
 from litellm import DualCache, EmbeddingResponse, ModelResponse, TextCompletionResponse
-from litellm._logging import verbose_proxy_logger
+from litellm._logging import (
+    _sanitize_log_message,
+    redact_secrets,
+    verbose_proxy_logger,
+)
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.litellm_core_utils.core_helpers import _get_parent_otel_span_from_kwargs
 from litellm.proxy._types import CommonProxyErrors, CurrentItemRateLimit, UserAPIKeyAuth
@@ -51,7 +55,9 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
         try:
             verbose_proxy_logger.debug(print_statement)
             if litellm.set_verbose:
-                print(print_statement)  # noqa: T201
+                print(  # noqa: T201
+                    _sanitize_log_message(redact_secrets(str(print_statement)))
+                )
         except Exception:
             pass
 

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -9,8 +9,7 @@ from typing_extensions import TypedDict
 import litellm
 from litellm import DualCache, EmbeddingResponse, ModelResponse, TextCompletionResponse
 from litellm._logging import (
-    _sanitize_log_message,
-    redact_secrets,
+    _redact_and_sanitize,
     verbose_proxy_logger,
 )
 from litellm.integrations.custom_logger import CustomLogger
@@ -55,9 +54,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
         try:
             verbose_proxy_logger.debug(print_statement)
             if litellm.set_verbose:
-                print(  # noqa: T201
-                    _sanitize_log_message(redact_secrets(str(print_statement)))
-                )
+                print(_redact_and_sanitize(print_statement))  # noqa: T201
         except Exception:
             pass
 

--- a/litellm/proxy/hooks/prompt_injection_detection.py
+++ b/litellm/proxy/hooks/prompt_injection_detection.py
@@ -14,8 +14,7 @@ from fastapi import HTTPException
 
 import litellm
 from litellm._logging import (
-    _sanitize_log_message,
-    redact_secrets,
+    _redact_and_sanitize,
     verbose_proxy_logger,
 )
 from litellm.caching.caching import DualCache
@@ -76,9 +75,7 @@ class _OPTIONAL_PromptInjectionDetection(CustomLogger):
             verbose_proxy_logger.debug(print_statement)
 
         if litellm.set_verbose is True:
-            print(  # noqa: T201
-                _sanitize_log_message(redact_secrets(str(print_statement)))
-            )
+            print(_redact_and_sanitize(print_statement))  # noqa: T201
 
     def update_environment(self, router: Optional[Router] = None):
         self.llm_router = router

--- a/litellm/proxy/hooks/prompt_injection_detection.py
+++ b/litellm/proxy/hooks/prompt_injection_detection.py
@@ -13,7 +13,11 @@ from typing import List, Literal, Optional
 from fastapi import HTTPException
 
 import litellm
-from litellm._logging import verbose_proxy_logger
+from litellm._logging import (
+    _sanitize_log_message,
+    redact_secrets,
+    verbose_proxy_logger,
+)
 from litellm.caching.caching import DualCache
 from litellm.constants import DEFAULT_PROMPT_INJECTION_SIMILARITY_THRESHOLD
 from litellm.integrations.custom_logger import CustomLogger
@@ -72,7 +76,9 @@ class _OPTIONAL_PromptInjectionDetection(CustomLogger):
             verbose_proxy_logger.debug(print_statement)
 
         if litellm.set_verbose is True:
-            print(print_statement)  # noqa: T201
+            print(  # noqa: T201
+                _sanitize_log_message(redact_secrets(str(print_statement)))
+            )
 
     def update_environment(self, router: Optional[Router] = None):
         self.llm_router = router

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -89,8 +89,8 @@ from litellm import (
     Router,
 )
 from litellm._logging import (
+    _redact_and_sanitize,
     _redact_string,
-    _sanitize_log_message,
     verbose_proxy_logger,
 )
 from litellm._service_logger import ServiceLogging, ServiceTypes
@@ -201,7 +201,7 @@ def print_verbose(print_statement):
     verbose_proxy_logger.debug("{}\n{}".format(print_statement, traceback.format_exc()))
     if litellm.set_verbose:
         print(  # noqa: T201
-            f"LiteLLM Proxy: {_sanitize_log_message(_redact_string(str(print_statement)))}"
+            f"LiteLLM Proxy: {_redact_and_sanitize(print_statement)}"
         )
 
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -88,7 +88,11 @@ from litellm import (
     ModelResponseStream,
     Router,
 )
-from litellm._logging import _redact_string, verbose_proxy_logger
+from litellm._logging import (
+    _redact_string,
+    _sanitize_log_message,
+    verbose_proxy_logger,
+)
 from litellm._service_logger import ServiceLogging, ServiceTypes
 from litellm.caching.caching import DualCache, RedisCache
 from litellm.caching.dual_cache import LimitedSizeOrderedDict
@@ -196,7 +200,9 @@ def print_verbose(print_statement):
 
     verbose_proxy_logger.debug("{}\n{}".format(print_statement, traceback.format_exc()))
     if litellm.set_verbose:
-        print(f"LiteLLM Proxy: {_redact_string(str(print_statement))}")  # noqa: T201
+        print(  # noqa: T201
+            f"LiteLLM Proxy: {_sanitize_log_message(_redact_string(str(print_statement)))}"
+        )
 
 
 def _get_email_logger_class():

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -395,7 +395,12 @@ from litellm.llms.base_llm.evals.transformation import BaseEvalsAPIConfig
 from litellm.llms.base_llm.responses.transformation import BaseResponsesAPIConfig
 from litellm.llms.base_llm.skills.transformation import BaseSkillsAPIConfig
 
-from ._logging import _is_debugging_on, verbose_logger
+from ._logging import (
+    _is_debugging_on,
+    _sanitize_log_message,
+    redact_secrets,
+    verbose_logger,
+)
 from .caching.caching import (
     AzureBlobCache,
     Cache,
@@ -492,7 +497,9 @@ def print_verbose(
         elif log_level == "ERROR":
             verbose_logger.error(print_statement)
         if litellm.set_verbose is True and logger_only is False:
-            print(print_statement)  # noqa: T201
+            print(  # noqa: T201
+                _sanitize_log_message(redact_secrets(str(print_statement)))
+            )
     except Exception:
         pass
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -397,8 +397,7 @@ from litellm.llms.base_llm.skills.transformation import BaseSkillsAPIConfig
 
 from ._logging import (
     _is_debugging_on,
-    _sanitize_log_message,
-    redact_secrets,
+    _redact_and_sanitize,
     verbose_logger,
 )
 from .caching.caching import (
@@ -497,9 +496,7 @@ def print_verbose(
         elif log_level == "ERROR":
             verbose_logger.error(print_statement)
         if litellm.set_verbose is True and logger_only is False:
-            print(  # noqa: T201
-                _sanitize_log_message(redact_secrets(str(print_statement)))
-            )
+            print(_redact_and_sanitize(print_statement))  # noqa: T201
     except Exception:
         pass
 

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -404,6 +404,16 @@ def test_print_verbose_sanitizes_unicode_line_separators(capsys, monkeypatch):
     assert "\x85" not in out and "\u2028" not in out and "\u2029" not in out
 
 
+def test_print_verbose_sanitizes_c1_control_chars(capsys, monkeypatch):
+    import litellm._logging as _logging_mod
+
+    monkeypatch.setattr(_logging_mod, "set_verbose", True)
+    _logging_mod.print_verbose("a\x80b\x9bc\x9fd")
+    out = capsys.readouterr().out
+    assert "\x80" not in out and "\x9b" not in out and "\x9f" not in out
+    assert "?" in out
+
+
 def test_utils_print_verbose_skips_stdout_when_not_verbose(capsys, monkeypatch):
     from litellm.utils import print_verbose as utils_print_verbose
 

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -480,6 +480,14 @@ def test_proxy_hook_print_verbose_methods_redact_and_sanitize(capsys, monkeypatc
         assert "\\r\\n" in out and "\x9b" not in out, cls.__name__
 
 
+def test_redact_and_sanitize_helper_combines_both_stages():
+    from litellm._logging import _redact_and_sanitize
+
+    out = _redact_and_sanitize({"api_key": SECRET_VALUE, "note": "a\r\nb\x9b"})
+    assert SECRET_VALUE not in out and "REDACTED" in out
+    assert "\\r\\n" in out and "\x9b" not in out
+
+
 def test_utils_print_verbose_skips_stdout_when_not_verbose(capsys, monkeypatch):
     from litellm.utils import print_verbose as utils_print_verbose
 

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -328,3 +328,75 @@ async def test_cache_hit_includes_custom_llm_provider():
         # Clean up
         litellm.callbacks = original_callbacks
         litellm.cache = None
+
+
+SECRET_VALUE = "sk-ant-test-DO-NOT-LEAK-12345"
+
+
+def _secret_payload():
+    return {
+        "model": "claude-3-5-sonnet-20241022",
+        "api_key": SECRET_VALUE,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+
+def test_utils_print_verbose_redacts_stdout_when_set_verbose(capsys, monkeypatch):
+    from litellm.utils import print_verbose as utils_print_verbose
+
+    monkeypatch.setattr(litellm, "set_verbose", True)
+    utils_print_verbose(_secret_payload())
+    out = capsys.readouterr().out
+    assert SECRET_VALUE not in out
+    assert "REDACTED" in out
+
+
+def test_logging_print_verbose_redacts_stdout_when_set_verbose(capsys, monkeypatch):
+    import litellm._logging as _logging_mod
+
+    monkeypatch.setattr(_logging_mod, "set_verbose", True)
+    _logging_mod.print_verbose(_secret_payload())
+    out = capsys.readouterr().out
+    assert SECRET_VALUE not in out
+    assert "REDACTED" in out
+
+
+def test_utils_print_verbose_sanitizes_control_chars(capsys, monkeypatch):
+    from litellm.utils import print_verbose as utils_print_verbose
+
+    monkeypatch.setattr(litellm, "set_verbose", True)
+    utils_print_verbose("line1\r\nINJECTED\x00\x1fend")
+    out = capsys.readouterr().out
+    assert "\\r\\n" in out
+    assert "\r\n" not in out.replace("\\r\\n", "")
+    assert "\x00" not in out and "\x1f" not in out
+
+
+def test_logging_print_verbose_sanitizes_control_chars(capsys, monkeypatch):
+    import litellm._logging as _logging_mod
+
+    monkeypatch.setattr(_logging_mod, "set_verbose", True)
+    _logging_mod.print_verbose("line1\r\nINJECTED\x00\x1fend")
+    out = capsys.readouterr().out
+    assert "\\r\\n" in out
+    assert "\r\n" not in out.replace("\\r\\n", "")
+    assert "\x00" not in out and "\x1f" not in out
+
+
+def test_print_verbose_redaction_opt_out_still_sanitizes(capsys, monkeypatch):
+    import litellm._logging as _logging_mod
+
+    monkeypatch.setattr(_logging_mod, "set_verbose", True)
+    monkeypatch.setattr(_logging_mod, "_ENABLE_SECRET_REDACTION", False)
+    _logging_mod.print_verbose(f"{SECRET_VALUE}\r\ntail")
+    out = capsys.readouterr().out
+    assert SECRET_VALUE in out
+    assert "\\r\\n" in out
+
+
+def test_utils_print_verbose_skips_stdout_when_not_verbose(capsys, monkeypatch):
+    from litellm.utils import print_verbose as utils_print_verbose
+
+    monkeypatch.setattr(litellm, "set_verbose", False)
+    utils_print_verbose(_secret_payload())
+    assert capsys.readouterr().out == ""

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -424,6 +424,62 @@ def test_main_print_verbose_redacts_and_sanitizes_stdout(capsys, monkeypatch):
     assert "\\r\\n" in out and "\x9b" not in out
 
 
+def test_streaming_handler_print_verbose_redacts_and_sanitizes(capsys, monkeypatch):
+    from litellm.litellm_core_utils.streaming_handler import print_verbose as sh_pv
+
+    monkeypatch.setattr(litellm, "set_verbose", True)
+    sh_pv(f"chunk {_secret_payload()}\r\n\x9b")
+    out = capsys.readouterr().out
+    assert SECRET_VALUE not in out and "REDACTED" in out
+    assert "\\r\\n" in out and "\x9b" not in out
+
+
+def test_caching_print_verbose_redacts_and_sanitizes(capsys, monkeypatch):
+    from litellm.caching.caching import print_verbose as cache_pv
+
+    monkeypatch.setattr(litellm, "set_verbose", True)
+    cache_pv(f"cache {_secret_payload()}\r\n\x9b")
+    out = capsys.readouterr().out
+    assert SECRET_VALUE not in out and "REDACTED" in out
+    assert "\\r\\n" in out and "\x9b" not in out
+
+
+def test_proxy_print_verbose_sanitizes_stdout(capsys, monkeypatch):
+    from litellm.proxy.utils import print_verbose as proxy_pv
+
+    monkeypatch.setattr(litellm, "set_verbose", True)
+    proxy_pv("proxy line\r\nINJ\x9b")
+    out = capsys.readouterr().out
+    assert "\\r\\n" in out and "\x9b" not in out
+
+
+def test_proxy_hook_print_verbose_methods_redact_and_sanitize(capsys, monkeypatch):
+    from litellm.proxy.guardrails.guardrail_hooks.presidio import (
+        _OPTIONAL_PresidioPIIMasking,
+    )
+    from litellm.proxy.hooks.batch_redis_get import _PROXY_BatchRedisRequests
+    from litellm.proxy.hooks.parallel_request_limiter import (
+        _PROXY_MaxParallelRequestsHandler,
+    )
+    from litellm.proxy.hooks.prompt_injection_detection import (
+        _OPTIONAL_PromptInjectionDetection,
+    )
+
+    monkeypatch.setattr(litellm, "set_verbose", True)
+    payload = f"hook {_secret_payload()}\r\nINJ\x9b"
+    for cls in (
+        _OPTIONAL_PresidioPIIMasking,
+        _PROXY_BatchRedisRequests,
+        _OPTIONAL_PromptInjectionDetection,
+        _PROXY_MaxParallelRequestsHandler,
+    ):
+        cls.print_verbose(object.__new__(cls), payload)
+        out = capsys.readouterr().out
+        assert SECRET_VALUE not in out, cls.__name__
+        assert "REDACTED" in out, cls.__name__
+        assert "\\r\\n" in out and "\x9b" not in out, cls.__name__
+
+
 def test_utils_print_verbose_skips_stdout_when_not_verbose(capsys, monkeypatch):
     from litellm.utils import print_verbose as utils_print_verbose
 

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -414,6 +414,16 @@ def test_print_verbose_sanitizes_c1_control_chars(capsys, monkeypatch):
     assert "?" in out
 
 
+def test_main_print_verbose_redacts_and_sanitizes_stdout(capsys, monkeypatch):
+    from litellm.main import print_verbose as main_print_verbose
+
+    monkeypatch.setattr(litellm, "set_verbose", True)
+    main_print_verbose(f"line in async streaming: {_secret_payload()}\r\nINJ\x9b")
+    out = capsys.readouterr().out
+    assert SECRET_VALUE not in out and "REDACTED" in out
+    assert "\\r\\n" in out and "\x9b" not in out
+
+
 def test_utils_print_verbose_skips_stdout_when_not_verbose(capsys, monkeypatch):
     from litellm.utils import print_verbose as utils_print_verbose
 

--- a/tests/test_litellm/test_logging.py
+++ b/tests/test_litellm/test_logging.py
@@ -394,6 +394,16 @@ def test_print_verbose_redaction_opt_out_still_sanitizes(capsys, monkeypatch):
     assert "\\r\\n" in out
 
 
+def test_print_verbose_sanitizes_unicode_line_separators(capsys, monkeypatch):
+    import litellm._logging as _logging_mod
+
+    monkeypatch.setattr(_logging_mod, "set_verbose", True)
+    _logging_mod.print_verbose("a\x85b\u2028c\u2029d")
+    out = capsys.readouterr().out
+    assert "\\x85" in out and "\\u2028" in out and "\\u2029" in out
+    assert "\x85" not in out and "\u2028" not in out and "\u2029" not in out
+
+
 def test_utils_print_verbose_skips_stdout_when_not_verbose(capsys, monkeypatch):
     from litellm.utils import print_verbose as utils_print_verbose
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- print_verbose printed api_key to stdout when set_verbose=True
- unescaped CR/LF in the same output allowed log forging (CWE-117)

How it solves it:

- redact secrets, then sanitize control chars, before the stdout print
- applied to both print_verbose stdout paths (utils.py and _logging.py)

## Relevant issues

Fixes #34705

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

`litellm/utils.py::print_verbose` prints its argument raw to stdout when `litellm.set_verbose is True`. Real completion code paths pass `model_call_details` (which carries `api_key`) through it, so the credential lands on stdout and any log collector that captures it; unescaped CR/LF in the same string additionally allows forged log lines.

Reproduced with only the `litellm` package (no proxy/provider needed).

**BEFORE** (base `litellm_internal_staging` @ `24123269cc`):

```python
import litellm
from litellm.utils import print_verbose
litellm.set_verbose = True
print_verbose({"model": "gpt-4o", "api_key": "sk-secret-DO-NOT-LEAK-1234567890", "messages": [{"role": "user", "content": "hi"}]})
print_verbose("attacker\r\nFORGED-LOG-LINE injected")
```

stdout:

```
{'model': 'gpt-4o', 'api_key': 'sk-secret-DO-NOT-LEAK-1234567890', 'messages': [{'role': 'user', 'content': 'hi'}]}
attacker
FORGED-LOG-LINE injected
```

The api_key is emitted verbatim and the CR/LF splits the record into a forged second line.

**AFTER** (this branch @ `75beca6b87`):

stdout:

```
{'model': 'gpt-4o', 'REDACTED', 'messages': [{'role': 'user', 'content': 'hi'}]}
attacker\r\nFORGED-LOG-LINE injected
```

The secret is masked and the CR/LF is escaped, so the injected content stays on a single line.

Redaction still honors the existing `LITELLM_DISABLE_REDACT_SECRETS=true` opt-out; the control-char sanitization is independent and applies regardless.

## Type

🐛 Bug Fix

## Changes

- `litellm/_logging.py`: add `_sanitize_log_message()` (escape CR/LF, replace other control chars with `?`; tab preserved) and wrap the `print_verbose` stdout path in `_sanitize_log_message(redact_secrets(str(...)))`.
- `litellm/utils.py`: import `redact_secrets` / `_sanitize_log_message` from `._logging` and wrap the `set_verbose` stdout fallback the same way.
- `tests/test_litellm/test_logging.py`: add tests for stdout redaction, CR/LF + control-char sanitization (both paths), the redaction opt-out still sanitizing, and the not-verbose short-circuit.

Scope note: the `verbose_logger.debug/info/error` sinks and the `set_verbose` guard are intentionally unchanged — this PR is limited to the stdout secret leak. The separate "emit through verbose_logger even when set_verbose is False" behavior (#32318) is deliberately out of scope.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
