### PR TITLE
fix(anthropic): split mixed reasoning stream chunks

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -97,6 +97,38 @@ class _CombinedChunkSplitter:
         )
 
     @staticmethod
+    def _has_mixed_reasoning_and_text(chunk: Any) -> bool:
+        choices = getattr(chunk, "choices", None)
+        if not choices:
+            return False
+        delta = getattr(choices[0], "delta", None)
+        if delta is None:
+            return False
+        return bool(getattr(delta, "content", None) and getattr(delta, "reasoning_content", None))
+
+    @staticmethod
+    def _clear_usage(chunk: Any) -> None:
+        if hasattr(chunk, "usage"):
+            chunk.usage = None
+        hidden_params = getattr(chunk, "_hidden_params", None)
+        if isinstance(hidden_params, dict) and "usage" in hidden_params:
+            chunk._hidden_params = {key: value for key, value in hidden_params.items() if key != "usage"}
+
+    @staticmethod
+    def _split_mixed_reasoning_and_text(chunk: Any) -> List[Any]:
+        if not _CombinedChunkSplitter._has_mixed_reasoning_and_text(chunk):
+            return [chunk]
+
+        reasoning_chunk = copy.deepcopy(chunk)
+        reasoning_chunk.choices[0].finish_reason = None
+        reasoning_chunk.choices[0].delta.content = None
+        _CombinedChunkSplitter._clear_usage(reasoning_chunk)
+
+        text_chunk = copy.deepcopy(chunk)
+        text_chunk.choices[0].delta.reasoning_content = None
+        return [reasoning_chunk, text_chunk]
+
+    @staticmethod
     def _split(chunk: Any) -> List[Any]:
         """Return ``[chunk]``, or ``[content_chunk, finish_chunk]`` if combined."""
         if not _CombinedChunkSplitter._is_combined(chunk):
@@ -105,6 +137,7 @@ class _CombinedChunkSplitter:
         # Content chunk: keep the delta payload, clear the finish_reason.
         content_chunk = copy.deepcopy(chunk)
         content_chunk.choices[0].finish_reason = None
+        _CombinedChunkSplitter._clear_usage(content_chunk)
 
         # Finish chunk: keep finish_reason (and usage), clear the delta payload.
         finish_chunk = copy.deepcopy(chunk)
@@ -127,7 +160,11 @@ class _CombinedChunkSplitter:
         if self._sync_iter is None:
             self._sync_iter = iter(self._stream)
         chunk = next(self._sync_iter)  # propagates StopIteration when exhausted
-        self._buffer.extend(self._split(chunk))
+        self._buffer.extend(
+            split_chunk
+            for combined_chunk in self._split(chunk)
+            for split_chunk in self._split_mixed_reasoning_and_text(combined_chunk)
+        )
         return self._buffer.popleft()
 
     def __aiter__(self) -> "AsyncIterator[Any]":
@@ -139,7 +176,11 @@ class _CombinedChunkSplitter:
         if self._async_iter is None:
             self._async_iter = self._stream.__aiter__()
         chunk = await self._async_iter.__anext__()  # propagates StopAsyncIteration
-        self._buffer.extend(self._split(chunk))
+        self._buffer.extend(
+            split_chunk
+            for combined_chunk in self._split(chunk)
+            for split_chunk in self._split_mixed_reasoning_and_text(combined_chunk)
+        )
         return self._buffer.popleft()
 
 

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -115,7 +115,7 @@ class _CombinedChunkSplitter:
             chunk._hidden_params = {key: value for key, value in hidden_params.items() if key != "usage"}
 
     @staticmethod
-    def _split_mixed_reasoning_and_text(chunk: Any) -> List[Any]:
+    def _split_mixed_reasoning_and_text(chunk: Any) -> list[Any]:
         if not _CombinedChunkSplitter._has_mixed_reasoning_and_text(chunk):
             return [chunk]
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_first_delta.py
@@ -65,9 +65,7 @@ def _thinking_chunk(thinking: str, signature: str = "") -> MagicMock:
     return _make_chunk(Delta(content=None, thinking_blocks=[block]))
 
 
-def _tool_chunk(
-    call_id: str, name: Optional[str], arguments: Optional[str]
-) -> MagicMock:
+def _tool_chunk(call_id: str, name: Optional[str], arguments: Optional[str]) -> MagicMock:
     return _make_chunk(
         Delta(
             content=None,
@@ -109,8 +107,7 @@ def _text_deltas(events: List[dict]) -> List[str]:
     return [
         e["delta"]["text"]
         for e in events
-        if e.get("type") == "content_block_delta"
-        and e["delta"].get("type") == "text_delta"
+        if e.get("type") == "content_block_delta" and e["delta"].get("type") == "text_delta"
     ]
 
 
@@ -118,8 +115,7 @@ def _input_json_deltas(events: List[dict]) -> List[str]:
     return [
         e["delta"]["partial_json"]
         for e in events
-        if e.get("type") == "content_block_delta"
-        and e["delta"].get("type") == "input_json_delta"
+        if e.get("type") == "content_block_delta" and e["delta"].get("type") == "input_json_delta"
     ]
 
 
@@ -127,8 +123,7 @@ def _thinking_deltas(events: List[dict]) -> List[str]:
     return [
         e["delta"]["thinking"]
         for e in events
-        if e.get("type") == "content_block_delta"
-        and e["delta"].get("type") == "thinking_delta"
+        if e.get("type") == "content_block_delta" and e["delta"].get("type") == "thinking_delta"
     ]
 
 
@@ -136,8 +131,7 @@ def _signature_deltas(events: List[dict]) -> List[str]:
     return [
         e["delta"]["signature"]
         for e in events
-        if e.get("type") == "content_block_delta"
-        and e["delta"].get("type") == "signature_delta"
+        if e.get("type") == "content_block_delta" and e["delta"].get("type") == "signature_delta"
     ]
 
 
@@ -228,9 +222,7 @@ async def test_first_text_delta_after_tool_use_is_not_dropped_async():
         _make_chunk(Delta(content=" Bye.")),
         _make_chunk(Delta(content=None), finish_reason="stop"),
     ]
-    wrapper = AnthropicStreamWrapper(
-        completion_stream=_AsyncStream(chunks), model="claude-x"
-    )
+    wrapper = AnthropicStreamWrapper(completion_stream=_AsyncStream(chunks), model="claude-x")
     events = await _drain_async(wrapper)
 
     assert _input_json_deltas(events) == ['{"city": "NY"}']
@@ -506,3 +498,39 @@ def test_empty_content_chunk_mid_text_block_is_suppressed_sync():
 
     assert _text_deltas(events) == ["Hi", " there"]
     _assert_deltas_match_their_block_type(events)
+
+
+def _mixed_reasoning_and_text_chunks() -> List[MagicMock]:
+    return [
+        _make_chunk(Delta(content=None, reasoning_content="First thought.")),
+        _make_chunk(
+            Delta(content="Answer.", reasoning_content=" Last thought."),
+            finish_reason="stop",
+        ),
+    ]
+
+
+def _assert_mixed_reasoning_and_text_chunk_is_split(events: List[dict]) -> None:
+    _assert_deltas_match_their_block_type(events)
+    assert _thinking_deltas(events) == ["First thought.", " Last thought."]
+    assert _text_deltas(events) == ["Answer."]
+    assert [event["type"] for event in events].count("message_delta") == 1
+
+
+def test_mixed_reasoning_and_text_chunk_is_split_sync():
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=iter(_mixed_reasoning_and_text_chunks()),
+        model="claude-x",
+    )
+
+    _assert_mixed_reasoning_and_text_chunk_is_split(_drain_sync(wrapper))
+
+
+@pytest.mark.asyncio
+async def test_mixed_reasoning_and_text_chunk_is_split_async():
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=_AsyncStream(_mixed_reasoning_and_text_chunks()),
+        model="claude-x",
+    )
+
+    _assert_mixed_reasoning_and_text_chunk_is_split(await _drain_async(wrapper))


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mixed chunks emitted thinking deltas inside text blocks
- Strict Anthropic clients like Claude Code rejected this as an invalid SSE stream

How it solves it:

- Splits reasoning and text into separate upstream chunks
- Keeps finish reason and usage on the final chunk
- Covers sync and async streams with a finishing mixed chunk

## Relevant issues

Fixes #33224

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review


## Screenshots / Proof of Fix

This is a deterministic reproduction using an OpenAI-compatible SSE backend that emits:

1. `reasoning_content: "The"`
2. `reasoning_content: " assistant."` and `content: " Hello"` in one chunk
3. `content: " world"`
4. `finish_reason: "stop"`

It exercises the real LiteLLM proxy and `/v1/messages` adapter without loading a model

Before, commit `24123269cc`:

```bash
curl --no-buffer http://127.0.0.1:4100/v1/messages \
  -H 'x-api-key: sk-mixed-reasoning-demo' \
  -H 'anthropic-version: 2023-06-01' \
  -H 'content-type: application/json' \
  -d '{"model":"mixed-reasoning-demo","max_tokens":128,"stream":true,"thinking":{"type":"enabled","budget_tokens":64},"messages":[{"role":"user","content":"Say hello"}]}'
```

```text
event: content_block_start
data: {"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}

event: content_block_delta
data: {"type":"content_block_delta","index":2,"delta":{"type":"thinking_delta","thinking":" assistant."}}

event: content_block_delta
data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":" world"}}
```

The stream is invalid because a `thinking_delta` is emitted in a `text` block. The mixed chunk's `" Hello"` text is also lost

After, commit `2a8e29cc0b`:

```bash
curl --no-buffer http://127.0.0.1:4101/v1/messages \
  -H 'x-api-key: sk-mixed-reasoning-demo' \
  -H 'anthropic-version: 2023-06-01' \
  -H 'content-type: application/json' \
  -d '{"model":"mixed-reasoning-demo","max_tokens":128,"stream":true,"thinking":{"type":"enabled","budget_tokens":64},"messages":[{"role":"user","content":"Say hello"}]}'
```

```text
event: content_block_delta
data: {"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":" assistant."}}

event: content_block_stop
data: {"type":"content_block_stop","index":1}

event: content_block_start
data: {"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}

event: content_block_delta
data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":" Hello"}}

event: content_block_delta
data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":" world"}}
```

The mixed chunk is split into a valid `thinking` delta followed by a valid `text` delta, preserving both `" Hello"` and `" world"`

## Type

Bug Fix

## Changes

- Split OpenAI-compatible chunks containing both `reasoning_content` and `content`
- Preserve chunk ordering as reasoning, text, then finish
- Add regression coverage for sync and async iterator paths
- Cover the mixed chunk plus `finish_reason` case

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core streaming chunk normalization for the Anthropic pass-through adapter; behavior change is scoped to mixed reasoning/text (and usage on split chunks) with new regression tests.
> 
> **Overview**
> Fixes invalid `/v1/messages` SSE when upstream OpenAI-style streams put **`reasoning_content` and `content` in the same chunk**, which made strict clients (e.g. Claude Code) see **`thinking_delta` inside a text block** and could drop part of the answer.
> 
> **`_CombinedChunkSplitter`** now detects those mixed deltas and emits two chunks in order: reasoning-only (no text, no finish/usage on that half), then text-only. That runs after the existing content+`finish_reason` split on both sync and async paths. Usage is stripped from intermediate split chunks so it stays on the final finish chunk.
> 
> Regression tests cover sync and async streams, including a mixed chunk that also carries **`finish_reason: stop`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b94847364aa284c54ea52ca76721eb330a2c227. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->