### PR TITLE
chore: sync Friendli serverless models (2026-07-26)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -46194,5 +46194,95 @@
                 }
             }
         ]
+    },
+    "friendliai/Qwen/Qwen3-235B-A22B-Instruct-2507": {
+        "litellm_provider": "friendliai",
+        "mode": "chat",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 8e-07,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "deprecation_date": "2026-08-05"
+    },
+    "friendliai/LGAI-EXAONE/K-EXAONE-236B-A23B": {
+        "litellm_provider": "friendliai",
+        "mode": "chat",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "input_cost_per_token": 2e-07,
+        "output_cost_per_token": 8e-07,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "cache_read_input_token_cost": 1e-07
+    },
+    "friendliai/MiniMaxAI/MiniMax-M2.5": {
+        "litellm_provider": "friendliai",
+        "mode": "chat",
+        "max_input_tokens": 196608,
+        "max_output_tokens": 196608,
+        "max_tokens": 196608,
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "cache_read_input_token_cost": 6e-08
+    },
+    "friendliai/deepseek-ai/DeepSeek-V3.2": {
+        "litellm_provider": "friendliai",
+        "mode": "chat",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 163840,
+        "max_tokens": 163840,
+        "input_cost_per_token": 5e-07,
+        "output_cost_per_token": 1.5e-06,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "cache_read_input_token_cost": 2.5e-07
+    },
+    "friendliai/zai-org/GLM-5.1": {
+        "litellm_provider": "friendliai",
+        "mode": "chat",
+        "max_input_tokens": 202752,
+        "max_output_tokens": 202752,
+        "max_tokens": 202752,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "cache_read_input_token_cost": 2.6e-07
+    },
+    "friendliai/google/gemma-4-31B-it": {
+        "litellm_provider": "friendliai",
+        "mode": "chat",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "input_cost_per_token": 1.4e-07,
+        "output_cost_per_token": 4e-07,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true
+    },
+    "friendliai/zai-org/GLM-5.2": {
+        "litellm_provider": "friendliai",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "input_cost_per_token": 1.4e-06,
+        "output_cost_per_token": 4.4e-06,
+        "supports_function_calling": true,
+        "supports_parallel_function_calling": true,
+        "supports_response_schema": true,
+        "cache_read_input_token_cost": 2.6e-07
     }
 }


### PR DESCRIPTION
Auto-sync of Friendli serverless `/v1/models` entries.

Source: https://api.friendli.ai/serverless/v1/models

### New models
- `friendliai/Qwen/Qwen3-235B-A22B-Instruct-2507`
- `friendliai/LGAI-EXAONE/K-EXAONE-236B-A23B`
- `friendliai/MiniMaxAI/MiniMax-M2.5`
- `friendliai/deepseek-ai/DeepSeek-V3.2`
- `friendliai/zai-org/GLM-5.1`
- `friendliai/google/gemma-4-31B-it`
- `friendliai/zai-org/GLM-5.2`
