### PR TITLE
fix(proxy): use top-level metadata for hanging-request alias

### DIFF
--- a/litellm/integrations/SlackAlerting/hanging_request_check.py
+++ b/litellm/integrations/SlackAlerting/hanging_request_check.py
@@ -57,7 +57,11 @@ class AlertingHangingRequestCheck:
         if request_data is None:
             return
 
-        request_metadata: Final = get_litellm_metadata_from_kwargs(kwargs=request_data)
+        request_metadata: Final = (
+            get_litellm_metadata_from_kwargs(kwargs=request_data)
+            or request_data.get("metadata", {})
+            or {}
+        )
         model: Final = request_data.get("model", "")
         api_base: str | None = None
 

--- a/litellm/integrations/SlackAlerting/hanging_request_check.py
+++ b/litellm/integrations/SlackAlerting/hanging_request_check.py
@@ -9,6 +9,8 @@ Notes:
 
 import asyncio
 import time
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final
 
 import litellm
@@ -25,6 +27,8 @@ if TYPE_CHECKING:
     from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
 else:
     SlackAlerting = Any
+
+_NO_METADATA: Mapping[str, Any] = MappingProxyType({})
 
 
 class AlertingHangingRequestCheck:
@@ -58,9 +62,7 @@ class AlertingHangingRequestCheck:
             return
 
         request_metadata: Final = (
-            get_litellm_metadata_from_kwargs(kwargs=request_data)
-            or request_data.get("metadata", {})
-            or {}
+            get_litellm_metadata_from_kwargs(kwargs=request_data) or request_data.get("metadata") or _NO_METADATA
         )
         model: Final = request_data.get("model", "")
         api_base: str | None = None

--- a/litellm/integrations/SlackAlerting/hanging_request_check.py
+++ b/litellm/integrations/SlackAlerting/hanging_request_check.py
@@ -9,6 +9,8 @@ Notes:
 
 import asyncio
 import time
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any
 
 import litellm
@@ -25,6 +27,8 @@ if TYPE_CHECKING:
     from litellm.integrations.SlackAlerting.slack_alerting import SlackAlerting
 else:
     SlackAlerting = Any
+
+_NO_METADATA: Mapping[str, Any] = MappingProxyType({})
 
 
 class AlertingHangingRequestCheck:
@@ -57,9 +61,9 @@ class AlertingHangingRequestCheck:
         if request_data is None:
             return
 
-        request_metadata = get_litellm_metadata_from_kwargs(kwargs=request_data)
-        if not request_metadata:
-            request_metadata = request_data.get("metadata", {}) or {}
+        request_metadata = (
+            get_litellm_metadata_from_kwargs(kwargs=request_data) or request_data.get("metadata") or _NO_METADATA
+        )
         model = request_data.get("model", "")
         api_base: str | None = None
 

--- a/litellm/integrations/SlackAlerting/hanging_request_check.py
+++ b/litellm/integrations/SlackAlerting/hanging_request_check.py
@@ -58,6 +58,8 @@ class AlertingHangingRequestCheck:
             return
 
         request_metadata = get_litellm_metadata_from_kwargs(kwargs=request_data)
+        if not request_metadata:
+            request_metadata = request_data.get("metadata", {}) or {}
         model = request_data.get("model", "")
         api_base: str | None = None
 

--- a/tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py
+++ b/tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py
@@ -338,3 +338,91 @@ class TestAlertingHangingRequestCheck:
 
         # Should not crash and should not send any alerts
         hanging_request_checker.slack_alerting_object.send_alert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_add_request_uses_top_level_metadata_when_litellm_params_absent(
+        self, hanging_request_checker
+    ):
+        """Fall back to top-level metadata when litellm_params is absent."""
+        request_data = {
+            "litellm_call_id": "precall_request_001",
+            "model": "gpt-4",
+            "metadata": {
+                "user_api_key_alias": "my-key-alias",
+                "user_api_key_team_alias": "my-team-alias",
+            },
+        }
+
+        await hanging_request_checker.add_request_to_hanging_request_check(request_data)
+
+        cached_data = (
+            await hanging_request_checker.hanging_request_cache.async_get_cache(
+                key="precall_request_001"
+            )
+        )
+
+        assert cached_data is not None
+        assert cached_data.key_alias == "my-key-alias"
+        assert cached_data.team_alias == "my-team-alias"
+
+    @pytest.mark.asyncio
+    async def test_add_request_prefers_litellm_params_metadata_when_present(
+        self, hanging_request_checker
+    ):
+        """Prefer litellm_params.metadata over top-level metadata when present."""
+        request_data = {
+            "litellm_call_id": "postcall_request_002",
+            "model": "gpt-4",
+            "litellm_params": {
+                "metadata": {
+                    "user_api_key_alias": "lp-key-alias",
+                    "user_api_key_team_alias": "lp-team-alias",
+                },
+            },
+            "metadata": {
+                "user_api_key_alias": "should-not-use-this",
+                "user_api_key_team_alias": "should-not-use-this-either",
+            },
+        }
+
+        await hanging_request_checker.add_request_to_hanging_request_check(request_data)
+
+        cached_data = (
+            await hanging_request_checker.hanging_request_cache.async_get_cache(
+                key="postcall_request_002"
+            )
+        )
+
+        assert cached_data is not None
+        assert cached_data.key_alias == "lp-key-alias"
+        assert cached_data.team_alias == "lp-team-alias"
+
+    @pytest.mark.asyncio
+    async def test_add_request_preserves_team_alias_without_key_alias(
+        self, hanging_request_checker
+    ):
+        """Keep litellm_params team alias when key alias is absent (no overwrite)."""
+        request_data = {
+            "litellm_call_id": "team_only_request_003",
+            "model": "gpt-4",
+            "litellm_params": {
+                "metadata": {
+                    "user_api_key_team_alias": "lp-team-alias",
+                },
+            },
+            "metadata": {
+                "user_api_key_team_alias": "should-not-use-this",
+            },
+        }
+
+        await hanging_request_checker.add_request_to_hanging_request_check(request_data)
+
+        cached_data = (
+            await hanging_request_checker.hanging_request_cache.async_get_cache(
+                key="team_only_request_003"
+            )
+        )
+
+        assert cached_data is not None
+        assert cached_data.key_alias == ""
+        assert cached_data.team_alias == "lp-team-alias"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Hanging-request Slack alert always shows empty Key Alias / Team Alias
- Metadata is read from the wrong location at proxy pre-call time

How it solves it:

- Fall back to the top-level request metadata when the resolved metadata is empty
- A populated `litellm_params.metadata` is always preferred (guard on emptiness)

## Relevant issues

Fixes #34708

## Linear ticket

<!-- external contributor: no Linear ticket -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

**Unit-level before/after** at commit `faf3b132b86aec1c43d876934f788cf63b248298`. The new pre-call test **fails without** the source change and **passes with** it (the test drives the real `add_request_to_hanging_request_check` code path, no mock of the code under test):

Without the source change (test reverted, tests kept):

```
FAILED tests/test_litellm/integrations/SlackAlerting/test_hanging_request_check.py::TestAlertingHangingRequestCheck::test_add_request_uses_top_level_metadata_when_litellm_params_absent
  AssertionError: assert '' == 'my-key-alias'
1 failed, 2 passed
```

With the source change:

```
14 passed in 3.22s
```

> Full end-to-end proof against a live proxy (hang a request past `alerting_threshold` and confirm the Slack alert now carries the key/team alias) will be added as a follow-up comment on this PR once deployed.

## Type

🐛 Bug Fix

## Changes

`AlertingHangingRequestCheck.add_request_to_hanging_request_check` reads request metadata via `get_litellm_metadata_from_kwargs()`, which only reads `kwargs["litellm_params"]["metadata"]`. The hanging-request check is scheduled from the proxy **pre-call** path, where `litellm_params` has not been constructed yet — the key/team alias lives at top-level `request_data["metadata"]`. So the helper returns `{}` and both aliases resolve to `""` for every proxy request.

This adds a fallback to the top-level `metadata` when the helper returns nothing:

```python
_NO_METADATA: Mapping[str, Any] = MappingProxyType({})

request_metadata = (
    get_litellm_metadata_from_kwargs(kwargs=request_data) or request_data.get("metadata") or _NO_METADATA
)
```

Guarding on emptiness (rather than a specific field) means a populated `litellm_params.metadata` is always preferred, so the sibling post-call path (`response_taking_too_long_callback`) is unaffected.

The fallback chains through a module-level frozen empty mapping rather than seeding `{}` literals, so the file carries the same `LIT002` count as its base and the `type-discipline-budget.json` ceiling holds. Same pattern as `litellm/responses/streaming_iterator.py` and `litellm/types/files.py`.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

