### PR TITLE
fix(vertex_ai): preserve usage on filtered Gemini responses

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1681,12 +1681,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         model_response.choices = [choice]
 
-        ## GET USAGE ##
-        usage = Usage(
-            prompt_tokens=completion_response["usageMetadata"].get("promptTokenCount", 0),
-            completion_tokens=completion_response["usageMetadata"].get("candidatesTokenCount", 0),
-            total_tokens=completion_response["usageMetadata"].get("totalTokenCount", 0),
-        )
+        usage = self._calculate_usage(completion_response)
 
         setattr(model_response, "usage", usage)
 
@@ -1715,12 +1710,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         model_response.choices = [choice]
 
-        ## GET USAGE ##
-        usage = Usage(
-            prompt_tokens=completion_response["usageMetadata"].get("promptTokenCount", 0),
-            completion_tokens=completion_response["usageMetadata"].get("candidatesTokenCount", 0),
-            total_tokens=completion_response["usageMetadata"].get("totalTokenCount", 0),
-        )
+        usage = self._calculate_usage(completion_response)
 
         setattr(model_response, "usage", usage)
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -15,7 +15,7 @@ from litellm.llms.vertex_ai.common_utils import VertexAIError
 from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
     VertexGeminiConfig,
 )
-from litellm.types.llms.vertex_ai import UsageMetadata
+from litellm.types.llms.vertex_ai import GenerateContentResponseBody, UsageMetadata
 from litellm.types.utils import ChoiceLogprobs, Usage
 from litellm.utils import CustomStreamWrapper
 
@@ -1522,6 +1522,36 @@ def test_vertex_ai_usage_metadata_missing_token_count():
     assert (
         result.completion_tokens_details.audio_tokens == 0
     )  # Default value for missing tokenCount
+
+
+@pytest.mark.parametrize(
+    "handler_name",
+    ["_handle_blocked_response", "_handle_content_policy_violation"],
+)
+def test_vertex_ai_content_filter_usage_includes_hidden_token_components(
+    handler_name: str,
+):
+    config = VertexGeminiConfig()
+    completion_response = GenerateContentResponseBody(
+        usageMetadata=UsageMetadata(
+            promptTokenCount=2457,
+            toolUsePromptTokenCount=11,
+            candidatesTokenCount=337,
+            thoughtsTokenCount=806,
+            totalTokenCount=3611,
+        )
+    )
+
+    result = getattr(config, handler_name)(
+        model_response=ModelResponse(),
+        completion_response=completion_response,
+    )
+
+    assert result.choices[0].finish_reason == "content_filter"
+    assert result.usage.prompt_tokens == 2468
+    assert result.usage.completion_tokens == 1143
+    assert result.usage.total_tokens == 3611
+    assert result.usage.prompt_tokens + result.usage.completion_tokens == 3611
 
 
 def test_vertex_ai_process_candidates_with_grounding_metadata():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Filtered Gemini responses undercount hidden token usage
- Reported components can disagree with total tokens

How it solves it:

- Reuse the shared Vertex Gemini usage normalizer
- Cover both filtered response handlers with regression tests

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

A live content-filter response is provider-controlled and was not reproducibly forced for this PR. The regression uses the observed `usageMetadata` shape and covers both filtered-response handlers. Before this change, the handlers return prompt/completion/total usage of `2457/337/3611`. At commit `27f1a9c2cd429c00b8e44b2be49ae57c2a1ce3ea`, they return `2468/1143/3611`, preserving `toolUsePromptTokenCount` and `thoughtsTokenCount`

## Type

Bug Fix

## Changes

Both filtered Vertex Gemini response paths now use `_calculate_usage`, matching normal response handling. This keeps tool-use prompt tokens in input usage and thoughts tokens in output usage, including candidate-token inclusive and exclusive variants

The regression test passes the same metadata through `_handle_blocked_response` and `_handle_content_policy_violation`, then verifies that prompt plus completion tokens equals total tokens

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR