### PR TITLE
feat(prometheus): add call_type label to request lifecycle metrics

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -8,6 +8,7 @@ import math
 import os
 import sys
 from datetime import datetime, timedelta
+from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -16,6 +17,7 @@ from typing import (
     Dict,
     List,
     Literal,
+    Mapping,
     Optional,
     Sequence,
     Tuple,
@@ -57,6 +59,7 @@ from litellm.types.integrations.prometheus import (
     _sanitize_prometheus_label_value,
 )
 from litellm.types.utils import (
+    CallTypes,
     StandardLoggingGuardrailInformation,
     StandardLoggingPayload,
 )
@@ -67,6 +70,34 @@ else:
     AsyncIOScheduler = Any
 
 _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT = 5.0
+
+
+def _build_async_call_type_aliases() -> Mapping[str, str]:
+    """
+    Map each async call type onto its sync twin, derived from ``CallTypes`` at
+    import time so new call types are covered without touching this file.
+
+    ``CallTypes`` names every async variant after its sync one (``acompletion``
+    for ``completion``, ``a_add_message`` for ``add_message``). Matching is done
+    on member names rather than values, because stripping a leading ``a`` from
+    the value would corrupt sync call types that legitimately start with one:
+    ``add_message`` would become ``dd_message`` and ``anthropic_messages`` would
+    become ``nthropic_messages``.
+    """
+    names = {member.name: member.value for member in CallTypes}
+    aliases: dict[str, str] = {}
+    for name, value in names.items():
+        for prefix in ("a_", "a"):
+            if not name.startswith(prefix):
+                continue
+            twin = name[len(prefix) :]
+            if twin in names and twin != name:
+                aliases[value] = names[twin]
+                break
+    return MappingProxyType(aliases)
+
+
+_ASYNC_CALL_TYPE_ALIASES = _build_async_call_type_aliases()
 
 
 def _get_budget_metrics_per_request_timeout() -> float:
@@ -1237,6 +1268,7 @@ class PrometheusLogger(CustomLogger):
             model_id=standard_logging_payload["model_id"],
             api_base=standard_logging_payload["api_base"],
             api_provider=standard_logging_payload["custom_llm_provider"],
+            call_type=self._normalize_call_type(standard_logging_payload.get("call_type")),
             exception_status=None,
             exception_class=None,
             custom_metadata_labels=get_custom_labels_from_metadata(metadata=combined_metadata),
@@ -2165,6 +2197,21 @@ class PrometheusLogger(CustomLogger):
         return False
 
     @staticmethod
+    def _normalize_call_type(call_type: str | None) -> str | None:
+        """
+        Collapse a call type onto its sync spelling so async and sync traffic for
+        the same operation share one series.
+
+        ``standard_logging_payload`` reports whichever entry point was used, so an
+        async chat completion arrives as ``acompletion`` and a sync one as
+        ``completion``. Labelling them separately would split every proxy's chat
+        traffic in two, since the proxy is async and the SDK is usually not.
+        """
+        if not call_type:
+            return None
+        return _ASYNC_CALL_TYPE_ALIASES.get(call_type, call_type)
+
+    @staticmethod
     def _extract_api_provider_from_request_data(request_data: dict) -> Optional[str]:
         """
         Best-effort provider for the client-side failure path.
@@ -2259,6 +2306,9 @@ class PrometheusLogger(CustomLogger):
                 user_agent=_metadata.get("user_agent"),
                 model_id=model_id,
                 api_provider=api_provider,
+                call_type=self._normalize_call_type(
+                    (request_data.get("standard_logging_object") or {}).get("call_type")
+                ),
                 stream=(str(request_data.get("stream")) if litellm.prometheus_emit_stream_label else None),
             )
             _label_ctx = PrometheusLabelFactoryContext(enum_values)
@@ -2472,6 +2522,7 @@ class PrometheusLogger(CustomLogger):
                 tags=standard_logging_payload.get("request_tags", []),
                 client_ip=client_ip,
                 user_agent=user_agent,
+                call_type=self._normalize_call_type(standard_logging_payload.get("call_type")),
             )
 
             """

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -10,6 +10,7 @@ import sys
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import replace
 from datetime import datetime, timedelta
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal, Protocol, TypeAlias, TypeVar, cast
 
 from pydantic import BaseModel
@@ -59,6 +60,7 @@ from litellm.types.proxy.carried_budget_state import (
     UserBudgetSnapshot,
 )
 from litellm.types.utils import (
+    CallTypes,
     StandardLoggingGuardrailInformation,
     StandardLoggingPayload,
 )
@@ -149,6 +151,35 @@ class _ExcludedLabelMetric:
 
 
 _MetricLike: TypeAlias = "NoOpMetric | _ExcludedLabelMetric | MetricWrapperBase"
+
+
+_ASYNC_CALL_TYPE_PREFIXES: Final = ("a_", "a")
+
+
+def _sync_twin(name: str, values_by_name: Mapping[str, str]) -> str | None:
+    return next(
+        (
+            values_by_name[name.removeprefix(prefix)]
+            for prefix in _ASYNC_CALL_TYPE_PREFIXES
+            if name.startswith(prefix) and name.removeprefix(prefix) in values_by_name
+        ),
+        None,
+    )
+
+
+def _build_async_call_type_aliases() -> Mapping[str, str]:
+    """Matches on ``CallTypes`` member names, not values: stripping "a" from values breaks ``add_message``."""
+    values_by_name: Final = MappingProxyType({member.name: str(member.value) for member in CallTypes})
+    return MappingProxyType(
+        {
+            value: twin
+            for name, value in values_by_name.items()
+            if (twin := _sync_twin(name, values_by_name)) is not None
+        }
+    )
+
+
+_ASYNC_CALL_TYPE_ALIASES: Final = _build_async_call_type_aliases()
 
 
 def _get_budget_metrics_per_request_timeout() -> float:
@@ -1442,6 +1473,7 @@ class PrometheusLogger(CustomLogger):
             model_id=standard_logging_payload["model_id"],
             api_base=standard_logging_payload["api_base"],
             api_provider=standard_logging_payload["custom_llm_provider"],
+            call_type=self._normalize_call_type(standard_logging_payload.get("call_type")),
             exception_status=None,
             exception_class=None,
             custom_metadata_labels=get_custom_labels_from_metadata(metadata=combined_metadata),
@@ -2545,6 +2577,13 @@ class PrometheusLogger(CustomLogger):
         return False
 
     @staticmethod
+    def _normalize_call_type(call_type: str | None) -> str | None:
+        """Collapse async call types onto their sync twin so the proxy (async) and SDK (sync) share one series."""
+        if not call_type:
+            return None
+        return _ASYNC_CALL_TYPE_ALIASES.get(call_type, call_type)
+
+    @staticmethod
     def _extract_api_provider_from_request_data(request_data: dict) -> str | None:
         """
         Best-effort provider for the client-side failure path.
@@ -2639,6 +2678,9 @@ class PrometheusLogger(CustomLogger):
                 user_agent=_metadata.get("user_agent"),
                 model_id=model_id,
                 api_provider=api_provider,
+                call_type=self._normalize_call_type(
+                    (request_data.get("standard_logging_object") or {}).get("call_type")
+                ),
                 stream=(str(request_data.get("stream")) if litellm.prometheus_emit_stream_label else None),
             )
             _label_ctx: Final = PrometheusLabelFactoryContext(enum_values)
@@ -2867,6 +2909,7 @@ class PrometheusLogger(CustomLogger):
                 tags=standard_logging_payload.get("request_tags", []),
                 client_ip=client_ip,
                 user_agent=user_agent,
+                call_type=self._normalize_call_type(standard_logging_payload.get("call_type")),
             )
 
             """

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -190,6 +190,7 @@ class UserAPIKeyLabelNames(Enum):
     ORG_ALIAS = "org_alias"
     MCP_TOOL_NAME = "mcp_tool_name"
     MCP_SERVER_NAME = "mcp_server_name"
+    CALL_TYPE = "call_type"
 
 
 DEFINED_PROMETHEUS_METRICS = Literal[
@@ -286,6 +287,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_llm_api_time_to_first_token_metric = [
@@ -299,6 +301,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_request_total_latency_metric = [
@@ -312,6 +315,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.v1_LITELLM_MODEL_NAME.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_request_queue_time_seconds = [
@@ -325,6 +329,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.v1_LITELLM_MODEL_NAME.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     # Guardrail metrics - these use custom labels (guardrail_name, status, error_type, hook_type)
@@ -348,6 +353,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER_AGENT.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_proxy_failed_requests_metric = [
@@ -370,6 +376,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER_AGENT.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_deployment_latency_per_output_token = [
@@ -381,6 +388,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.API_KEY_ALIAS.value,
         UserAPIKeyLabelNames.TEAM.value,
         UserAPIKeyLabelNames.TEAM_ALIAS.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_overhead_latency_metric = [
@@ -391,6 +399,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.API_KEY_HASH.value,
         UserAPIKeyLabelNames.API_KEY_ALIAS.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_overhead_with_guardrails_latency_metric = [
@@ -401,6 +410,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.API_KEY_HASH.value,
         UserAPIKeyLabelNames.API_KEY_ALIAS.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_remaining_requests_metric = [
@@ -437,6 +447,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_spend_metric = [
@@ -453,6 +464,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_input_tokens_metric = [
@@ -467,6 +479,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_total_tokens_metric = [
@@ -481,6 +494,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_output_tokens_metric = [
@@ -495,6 +509,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     # Token-type detail metrics — reuse the same label set as
@@ -632,6 +647,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.TEAM_ALIAS.value,
         UserAPIKeyLabelNames.CLIENT_IP.value,
         UserAPIKeyLabelNames.USER_AGENT.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_deployment_total_requests = [
@@ -646,6 +662,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.TEAM_ALIAS.value,
         UserAPIKeyLabelNames.CLIENT_IP.value,
         UserAPIKeyLabelNames.USER_AGENT.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_deployment_success_responses = litellm_deployment_total_requests
@@ -864,6 +881,7 @@ class UserAPIKeyLabelValues:
     model_id: Optional[str] = None
     api_base: Optional[str] = None
     api_provider: Optional[str] = None
+    call_type: Optional[str] = None
     exception_status: Optional[str] = None
     exception_class: Optional[str] = None
     rate_limit_category: Optional[str] = None

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -222,6 +222,7 @@ class UserAPIKeyLabelNames(Enum):
     MCP_SERVER_NAME = "mcp_server_name"
     SERVICE_TIER = "service_tier"
     INPUT_SEQUENCE_LENGTH = "input_sequence_length"
+    CALL_TYPE = "call_type"
 
 
 DEFINED_PROMETHEUS_METRICS = Literal[
@@ -415,6 +416,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
         UserAPIKeyLabelNames.SERVICE_TIER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_llm_api_time_to_first_token_metric = [
@@ -429,6 +431,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
         UserAPIKeyLabelNames.SERVICE_TIER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_request_total_latency_metric = [
@@ -443,6 +446,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
         UserAPIKeyLabelNames.SERVICE_TIER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_request_queue_time_seconds = [
@@ -456,6 +460,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.v1_LITELLM_MODEL_NAME.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     # Guardrail metrics - these use custom labels (guardrail_name, status, error_type, hook_type)
@@ -479,6 +484,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER_AGENT.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_proxy_failed_requests_metric = [
@@ -501,6 +507,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER_AGENT.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_deployment_latency_per_output_token = [
@@ -512,6 +519,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.API_KEY_ALIAS.value,
         UserAPIKeyLabelNames.TEAM.value,
         UserAPIKeyLabelNames.TEAM_ALIAS.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_overhead_latency_metric = [
@@ -522,6 +530,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.API_KEY_HASH.value,
         UserAPIKeyLabelNames.API_KEY_ALIAS.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_overhead_with_guardrails_latency_metric = [
@@ -532,6 +541,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.API_KEY_HASH.value,
         UserAPIKeyLabelNames.API_KEY_ALIAS.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_remaining_requests_metric = [
@@ -568,6 +578,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_spend_metric = [
@@ -585,6 +596,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
         UserAPIKeyLabelNames.SERVICE_TIER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_input_tokens_metric = [
@@ -599,6 +611,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_total_tokens_metric = [
@@ -613,6 +626,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_output_tokens_metric = [
@@ -627,6 +641,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     # Token-type detail metrics — reuse the same label set as
@@ -764,6 +779,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.TEAM_ALIAS.value,
         UserAPIKeyLabelNames.CLIENT_IP.value,
         UserAPIKeyLabelNames.USER_AGENT.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_deployment_total_requests = [
@@ -778,6 +794,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.TEAM_ALIAS.value,
         UserAPIKeyLabelNames.CLIENT_IP.value,
         UserAPIKeyLabelNames.USER_AGENT.value,
+        UserAPIKeyLabelNames.CALL_TYPE.value,
     ]
 
     litellm_deployment_success_responses = litellm_deployment_total_requests
@@ -1033,6 +1050,7 @@ class UserAPIKeyLabelValues:
     model_id: str | None = None
     api_base: str | None = None
     api_provider: str | None = None
+    call_type: str | None = None
     exception_status: str | None = None
     exception_class: str | None = None
     rate_limit_category: str | None = None

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
@@ -244,6 +244,7 @@ def test_increment_token_metrics(prometheus_logger):
         model="gpt-5-mini",
         model_id="model-123",
         api_provider="openai",
+        call_type="completion",
     )
     prometheus_logger.litellm_tokens_metric.labels().inc.assert_called_once_with(100)
 
@@ -261,6 +262,7 @@ def test_increment_token_metrics(prometheus_logger):
         model="gpt-5-mini",
         model_id="model-123",
         api_provider="openai",
+        call_type="completion",
     )
     prometheus_logger.litellm_input_tokens_metric.labels().inc.assert_called_once_with(
         50
@@ -280,6 +282,7 @@ def test_increment_token_metrics(prometheus_logger):
         model="gpt-5-mini",
         model_id="model-123",
         api_provider="openai",
+        call_type="completion",
     )
     prometheus_logger.litellm_output_tokens_metric.labels().inc.assert_called_once_with(
         50
@@ -443,6 +446,7 @@ def test_set_latency_metrics(prometheus_logger):
         model="gpt-5-mini",
         model_id="model-123",
         api_provider="openai",
+        call_type="completion",
         service_tier=None,
     )
     prometheus_logger.litellm_llm_api_time_to_first_token_metric.labels().observe.assert_called_once_with(
@@ -463,6 +467,7 @@ def test_set_latency_metrics(prometheus_logger):
         model="gpt-5-mini",
         model_id="model-123",
         api_provider="openai",
+        call_type="completion",
         service_tier=None,
     )
     prometheus_logger.litellm_llm_api_latency_metric.labels().observe.assert_called_once_with(
@@ -483,6 +488,7 @@ def test_set_latency_metrics(prometheus_logger):
         model="gpt-5-mini",
         model_id="model-123",
         api_provider="openai",
+        call_type="completion",
         service_tier=None,
     )
     prometheus_logger.litellm_request_total_latency_metric.labels().observe.assert_called_once_with(
@@ -629,6 +635,7 @@ def test_increment_top_level_request_and_spend_metrics(prometheus_logger):
         model="gpt-5-mini",
         model_id="model-123",
         api_provider="openai",
+        call_type="completion",
         client_ip=None,
         user_agent=None,
         requested_model=None,
@@ -649,6 +656,7 @@ def test_increment_top_level_request_and_spend_metrics(prometheus_logger):
         model="gpt-5-mini",
         model_id="model-123",
         api_provider="openai",
+        call_type="completion",
         client_ip=None,
         user_agent=None,
         requested_model=None,
@@ -870,6 +878,7 @@ async def test_async_post_call_failure_hook(prometheus_logger, known_model_route
             client_ip=None,
             user_agent=None,
             api_provider="openai",
+            call_type=None,
         )
     finally:
         litellm.prometheus_emit_rate_limit_labels = original_emit
@@ -894,6 +903,7 @@ async def test_async_post_call_failure_hook(prometheus_logger, known_model_route
         client_ip=None,
         user_agent=None,
         api_provider="openai",
+        call_type=None,
     )
     prometheus_logger.litellm_proxy_total_requests_metric.labels().inc.assert_called_once()
 
@@ -1030,6 +1040,7 @@ def test_set_llm_deployment_success_metrics(prometheus_logger):
         model_id="model-123",
         api_base="https://api.openai.com",
         api_provider="openai",
+        call_type="completion",
         requested_model="my_custom_model_group",
         hashed_api_key=standard_logging_payload["metadata"]["user_api_key_hash"],
         api_key_alias=standard_logging_payload["metadata"]["user_api_key_alias"],
@@ -1046,6 +1057,7 @@ def test_set_llm_deployment_success_metrics(prometheus_logger):
         model_id="model-123",
         api_base="https://api.openai.com",
         api_provider="openai",
+        call_type="completion",
         requested_model="my_custom_model_group",
         hashed_api_key=standard_logging_payload["metadata"]["user_api_key_hash"],
         api_key_alias=standard_logging_payload["metadata"]["user_api_key_alias"],
@@ -1062,6 +1074,7 @@ def test_set_llm_deployment_success_metrics(prometheus_logger):
         model_id="model-123",
         api_base="https://api.openai.com",
         api_provider="openai",
+        call_type="completion",
         hashed_api_key=standard_logging_payload["metadata"]["user_api_key_hash"],
         api_key_alias=standard_logging_payload["metadata"]["user_api_key_alias"],
         team=standard_logging_payload["metadata"]["user_api_key_team_id"],
@@ -1073,6 +1086,7 @@ def test_set_llm_deployment_success_metrics(prometheus_logger):
         api_base="https://api.openai.com",
         api_key_alias=standard_logging_payload["metadata"]["user_api_key_alias"],
         api_provider="openai",
+        call_type="completion",
         hashed_api_key=standard_logging_payload["metadata"]["user_api_key_hash"],
         litellm_model_name="gpt-5-mini",
         model_group="my_custom_model_group",

--- a/tests/test_litellm/integrations/test_prometheus_labels.py
+++ b/tests/test_litellm/integrations/test_prometheus_labels.py
@@ -730,3 +730,141 @@ if __name__ == "__main__":
     test_prometheus_label_value_sanitization_none()
     test_prometheus_label_value_sanitization_non_string_types()
     print("\n✅ All prometheus label tests passed!")
+
+
+def test_call_type_in_request_lifecycle_metrics():
+    """
+    Chat, embedding, image and audio traffic all land in the same series without
+    this label. Embeddings are typically much higher volume and much lower cost
+    than chat, so mixing them makes both the request rate and the spend series
+    hard to read.
+    """
+    call_type_label = UserAPIKeyLabelNames.CALL_TYPE.value
+
+    metrics_with_call_type = [
+        "litellm_spend_metric",
+        "litellm_requests_metric",
+        "litellm_input_tokens_metric",
+        "litellm_output_tokens_metric",
+        "litellm_total_tokens_metric",
+        "litellm_llm_api_latency_metric",
+        "litellm_llm_api_time_to_first_token_metric",
+        "litellm_request_total_latency_metric",
+        "litellm_request_queue_time_seconds",
+        "litellm_overhead_latency_metric",
+        "litellm_overhead_with_guardrails_latency_metric",
+        "litellm_proxy_total_requests_metric",
+        "litellm_proxy_failed_requests_metric",
+        "litellm_deployment_latency_per_output_token",
+        "litellm_deployment_failure_responses",
+        "litellm_deployment_total_requests",
+        # Alias of the list above; assert it so the shared list cannot silently
+        # drop the label from it.
+        "litellm_deployment_success_responses",
+    ]
+
+    for metric_name in metrics_with_call_type:
+        labels = PrometheusMetricLabels.get_labels(metric_name)
+        assert call_type_label in labels, f"Metric {metric_name} should contain call_type"
+
+
+def test_call_type_absent_from_quota_and_deployment_gauges():
+    """
+    Remaining quota and configured limits belong to a deployment, not to a call
+    type. Splitting them by call type would emit several series that each claim
+    to describe the same headroom.
+    """
+    call_type_label = UserAPIKeyLabelNames.CALL_TYPE.value
+
+    for metric_name in [
+        "litellm_remaining_requests_metric",
+        "litellm_remaining_tokens_metric",
+        "litellm_deployment_tpm_limit",
+        "litellm_deployment_rpm_limit",
+        "litellm_deployment_state",
+        "litellm_deployment_cooled_down",
+    ]:
+        labels = PrometheusMetricLabels.get_labels(metric_name)
+        assert call_type_label not in labels, f"Metric {metric_name} should not carry call_type"
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("acompletion", "completion"),
+        ("completion", "completion"),
+        ("aembedding", "embedding"),
+        ("aimage_generation", "image_generation"),
+        ("a_add_message", "add_message"),
+        ("aanthropic_messages", "anthropic_messages"),
+        # Sync call types that happen to start with "a" must survive untouched;
+        # naive prefix stripping would turn these into nonsense.
+        ("add_message", "add_message"),
+        ("anthropic_messages", "anthropic_messages"),
+        # Unknown values pass through rather than being dropped.
+        ("something_new", "something_new"),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_normalize_call_type(raw, expected):
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    assert PrometheusLogger._normalize_call_type(raw) == expected
+
+
+def test_async_call_type_aliases_cover_every_async_member():
+    """
+    The alias table is derived from CallTypes at import time. If a future async
+    call type is added with a sync twin, it should be covered without editing
+    the integration.
+    """
+    from litellm.integrations.prometheus import _ASYNC_CALL_TYPE_ALIASES
+    from litellm.types.utils import CallTypes
+
+    names = {member.name: member.value for member in CallTypes}
+    for name, value in names.items():
+        for prefix in ("a_", "a"):
+            twin = name[len(prefix) :] if name.startswith(prefix) else None
+            if twin and twin in names and twin != name:
+                assert _ASYNC_CALL_TYPE_ALIASES.get(value) == names[twin]
+                break
+
+
+def test_call_type_reaches_rendered_metrics_output():
+    """
+    End to end through a real population site: a label can be declared and never
+    populated, and the allow-list assertions above would not notice.
+    """
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    _clear_prometheus_registry()
+    logger = PrometheusLogger()
+
+    standard_logging_payload = {
+        "model_group": "gpt-4o-group",
+        "call_type": "acompletion",
+        "api_base": "https://example.invalid",
+        "model_id": "deployment-1",
+        "request_tags": [],
+        "metadata": {
+            "user_api_key_hash": "test-key",
+            "user_api_key_alias": None,
+            "user_api_key_team_id": None,
+            "user_api_key_team_alias": None,
+        },
+    }
+
+    logger.set_llm_deployment_failure_metrics(
+        {
+            "model": "gpt-4o",
+            "litellm_params": {"custom_llm_provider": "openai"},
+            "standard_logging_object": standard_logging_payload,
+            "exception": Exception("boom"),
+        }
+    )
+
+    samples = _collected_samples("litellm_deployment_failure_responses_total")
+    assert samples, "expected litellm_deployment_failure_responses to be emitted"
+    # Emitted as the sync spelling even though the call arrived as acompletion.
+    assert samples[0].labels.get("call_type") == "completion"

--- a/tests/test_litellm/integrations/test_prometheus_labels.py
+++ b/tests/test_litellm/integrations/test_prometheus_labels.py
@@ -730,3 +730,116 @@ if __name__ == "__main__":
     test_prometheus_label_value_sanitization_none()
     test_prometheus_label_value_sanitization_non_string_types()
     print("\n✅ All prometheus label tests passed!")
+
+
+def test_call_type_in_request_lifecycle_metrics():
+    call_type_label = UserAPIKeyLabelNames.CALL_TYPE.value
+
+    metrics_with_call_type = [
+        "litellm_spend_metric",
+        "litellm_requests_metric",
+        "litellm_input_tokens_metric",
+        "litellm_output_tokens_metric",
+        "litellm_total_tokens_metric",
+        "litellm_llm_api_latency_metric",
+        "litellm_llm_api_time_to_first_token_metric",
+        "litellm_request_total_latency_metric",
+        "litellm_request_queue_time_seconds",
+        "litellm_overhead_latency_metric",
+        "litellm_overhead_with_guardrails_latency_metric",
+        "litellm_proxy_total_requests_metric",
+        "litellm_proxy_failed_requests_metric",
+        "litellm_deployment_latency_per_output_token",
+        "litellm_deployment_failure_responses",
+        "litellm_deployment_total_requests",
+        "litellm_deployment_success_responses",
+    ]
+
+    for metric_name in metrics_with_call_type:
+        labels = PrometheusMetricLabels.get_labels(metric_name)
+        assert call_type_label in labels, f"Metric {metric_name} should contain call_type"
+
+
+def test_call_type_absent_from_quota_and_deployment_gauges():
+    """Headroom belongs to a deployment; splitting it by call type would emit duplicate series for one limit."""
+    call_type_label = UserAPIKeyLabelNames.CALL_TYPE.value
+
+    for metric_name in [
+        "litellm_remaining_requests_metric",
+        "litellm_remaining_tokens_metric",
+        "litellm_deployment_tpm_limit",
+        "litellm_deployment_rpm_limit",
+        "litellm_deployment_state",
+        "litellm_deployment_cooled_down",
+    ]:
+        labels = PrometheusMetricLabels.get_labels(metric_name)
+        assert call_type_label not in labels, f"Metric {metric_name} should not carry call_type"
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("acompletion", "completion"),
+        ("completion", "completion"),
+        ("aembedding", "embedding"),
+        ("aimage_generation", "image_generation"),
+        ("a_add_message", "add_message"),
+        ("aanthropic_messages", "anthropic_messages"),
+        ("add_message", "add_message"),
+        ("anthropic_messages", "anthropic_messages"),
+        ("something_new", "something_new"),
+        (None, None),
+        ("", None),
+    ],
+)
+def test_normalize_call_type(raw, expected):
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    assert PrometheusLogger._normalize_call_type(raw) == expected
+
+
+def test_async_call_type_aliases_cover_every_async_member():
+    from litellm.integrations.prometheus import _ASYNC_CALL_TYPE_ALIASES
+    from litellm.types.utils import CallTypes
+
+    names = {member.name: member.value for member in CallTypes}
+    for name, value in names.items():
+        for prefix in ("a_", "a"):
+            twin = name[len(prefix) :] if name.startswith(prefix) else None
+            if twin and twin in names and twin != name:
+                assert _ASYNC_CALL_TYPE_ALIASES.get(value) == names[twin]
+                break
+
+
+def test_call_type_reaches_rendered_metrics_output():
+    from litellm.integrations.prometheus import PrometheusLogger
+
+    _clear_prometheus_registry()
+    logger = PrometheusLogger()
+
+    standard_logging_payload = {
+        "model_group": "gpt-4o-group",
+        "call_type": "acompletion",
+        "api_base": "https://example.invalid",
+        "model_id": "deployment-1",
+        "request_tags": [],
+        "metadata": {
+            "user_api_key_hash": "test-key",
+            "user_api_key_alias": None,
+            "user_api_key_team_id": None,
+            "user_api_key_team_alias": None,
+        },
+    }
+
+    logger.set_llm_deployment_failure_metrics(
+        {
+            "model": "gpt-4o",
+            "litellm_params": {"custom_llm_provider": "openai"},
+            "standard_logging_object": standard_logging_payload,
+            "exception": Exception("boom"),
+        }
+    )
+
+    samples = _collected_samples("litellm_deployment_failure_responses_total")
+    assert samples, "expected litellm_deployment_failure_responses to be emitted"
+    assert samples[0].labels.get("call_type") == "completion"


### PR DESCRIPTION
## TLDR

Problem this solves:

- chat, embedding, image and audio traffic all share one `litellm_requests_metric` and one `litellm_spend_metric` series
- embeddings are usually far higher volume and far lower cost than chat, so both the request rate and the spend numbers are hard to read once they are mixed

How it solves it:

- adds a `call_type` label to the 16 request lifecycle metrics
- collapses async call types onto their sync twin so `acompletion` and `completion` do not become two series

The value is already on `standard_logging_payload` as `call_type`, so this is label plumbing rather than new collection

Same shape as #32126, which added `api_provider` to the metrics that were emitted from call sites already holding the value. Part of #34704

## The async spelling

`CallTypes` names every async variant after its sync one, and the proxy is async while the SDK usually is not. Left alone, one proxy's chat traffic would be labelled `acompletion` and an SDK user's would be `completion`, which splits the same operation across two series

The alias table is derived from `CallTypes` on first use and cached, so a new call type is covered without editing the integration. It matches on member names rather than values on purpose: stripping a leading `a` from the value turns `add_message` into `dd_message` and `anthropic_messages` into `nthropic_messages`, and both of those are sync call types that legitimately start with one. There is a test for each

## Relevant issues

Part of #34704

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Current validation and review status

At `860713be14`, both `CallTypes` and `MappingProxyType` are imported inside the cached alias builder. The table is first created when a non-empty call type is normalized, removing the new module-load dependencies reported by CodeQL

The focused Prometheus selection passed 86 tests before the final import relocation; all 37 label tests passed again at the final source state. Six fresh Python processes, starting from each module named in the CodeQL findings, successfully imported the logger and normalized `acompletion` to `completion`. Success and proxy-failure tests now assert the rendered `call_type` label as well as the existing provider label. Ruff, strict-rule, type-discipline and test-quality gates passed locally

Current-tip CI and automated reviews must still finish. The previous Greptile 5/5 references an older commit, so it is not counted as approval of this tip. Local full e2e typing encountered missing Playwright/Locust dependencies; that result is not claimed as a pass

The earlier `proxy-behavior` failure is also present on main `30f33a949b`: [main run](https://github.com/BerriAI/litellm/actions/runs/34737619378) fails `test_join_binds_the_membership_to_the_requested_team` with `TypeError: object MagicMock can't be used in 'await' expression` (847 passed, 1 failed). The earlier schema check reports only two stale `soft_budget` documentation lines in `schema.d.ts`

## Screenshots / Proof of Fix

The following is the earlier mock-provider demonstration, retained as reproduction instructions. It has not been rerun against a real provider at the current tip; no provider credentials were available in this checkout

Two deployments on a local proxy, one chat and one embedding. The deployments use `mock_response` so the run costs nothing; the label is read off `standard_logging_payload`, so the provider's answer has no bearing on it

```yaml
model_list:
  - model_name: chat-demo
    litellm_params:
      model: openai/gpt-4o
      api_key: os.environ/OPENAI_API_KEY
      mock_response: "hi"
  - model_name: embed-demo
    litellm_params:
      model: openai/text-embedding-3-small
      api_key: os.environ/OPENAI_API_KEY
      mock_response: "[0.1, 0.2]"

litellm_settings:
  callbacks: ["prometheus"]

general_settings:
  master_key: sk-1234
```

Three chat calls and two embedding calls, then scrape:

```bash
for i in 1 2 3; do
  curl -s -o /dev/null http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"chat-demo","messages":[{"role":"user","content":"hi"}]}'
done
for i in 1 2; do
  curl -s -o /dev/null http://localhost:4000/v1/embeddings \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"embed-demo","input":"hello"}'
done

curl -sL -H "Authorization: Bearer sk-1234" http://localhost:4000/metrics \
  | grep "^litellm_requests_metric_total{"
```

After, with the labels trimmed to the interesting ones:

```
call_type=completion   model=gpt-4o                   requested_model=chat-demo  -> 3.0
call_type=embedding    model=text-embedding-3-small   requested_model=embed-demo -> 2.0
```

Before, both rows collapse into series that differ only by model name, with nothing to group or filter on. Note the proxy served these asynchronously and the label still reads `completion`, which is the normalisation doing its job

## Type

🆕 New Feature

## Changes

`litellm/types/integrations/prometheus.py`: `UserAPIKeyLabelNames.CALL_TYPE`, a `call_type` field on `UserAPIKeyLabelValues`, and the label added to 16 metric label lists

`litellm/integrations/prometheus.py`: `_build_async_call_type_aliases()` lazily builds and caches the async to sync table from `CallTypes`, `_normalize_call_type()` applies it, and the value is populated at the three sites that already resolve the payload: `async_log_success_event`, `set_llm_deployment_failure_metrics` and `async_post_call_failure_hook`

`tests/test_litellm/integrations/test_prometheus_labels.py`: extended with allow-list assertions, the normalisation table, a check that every async member of `CallTypes` is covered, and an end to end assertion that reads the label back off a rendered sample

Remaining quota gauges and the configured tpm/rpm limits deliberately do not get the label, since headroom belongs to a deployment rather than to a call type; splitting it would emit several series each claiming to describe the same number. There is a test pinning that

## QA runbook

1. start a proxy with the config above
2. send a few chat completions to `chat-demo` and a few embeddings to `embed-demo`
3. `curl -sL -H "Authorization: Bearer sk-1234" http://localhost:4000/metrics | grep "^litellm_requests_metric_total{"` should show two series, one `call_type="completion"` and one `call_type="embedding"`
4. on unpatched code neither series carries the label

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

