### PR TITLE
fix(anthropic): emit stop_reason tool_use for streamed /v1/messages t…

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -209,6 +209,17 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
             type="text",
             text="",
         )
+        self._emitted_tool_use = False
+
+    def _override_stop_reason_for_tool_use(self, processed_chunk: Any) -> Any:
+        if (
+            self._emitted_tool_use
+            and isinstance(processed_chunk, dict)
+            and processed_chunk.get("type") == "message_delta"
+            and processed_chunk.get("delta", {}).get("stop_reason") == "end_turn"
+        ):
+            processed_chunk["delta"]["stop_reason"] = "tool_use"
+        return processed_chunk
 
     def _merge_usage_into_held_stop_reason_chunk(self, chunk: Any) -> Dict[str, Any]:
         """Merge usage data from ``chunk`` into the held ``message_delta`` chunk.
@@ -424,10 +435,12 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                     self.holding_stop_reason_chunk is not None and getattr(chunk, "usage", None) is not None
                 )
                 is_final_chunk = chunk.choices[0].finish_reason is not None
-                processed_chunk = LiteLLMAnthropicMessagesAdapter().translate_streaming_openai_response_to_anthropic(
-                    response=chunk,
-                    current_content_block_index=self.current_content_block_index,
-                    applied_edits=(self.applied_edits if is_final_chunk and not will_merge_into_held else None),
+                processed_chunk = self._override_stop_reason_for_tool_use(
+                    LiteLLMAnthropicMessagesAdapter().translate_streaming_openai_response_to_anthropic(
+                        response=chunk,
+                        current_content_block_index=self.current_content_block_index,
+                        applied_edits=(self.applied_edits if is_final_chunk and not will_merge_into_held else None),
+                    )
                 )
 
                 # Check if this is a usage chunk and we have a held stop_reason chunk
@@ -647,10 +660,12 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                     self.holding_stop_reason_chunk is not None and getattr(chunk, "usage", None) is not None
                 )
                 is_final_chunk = chunk.choices[0].finish_reason is not None
-                processed_chunk = LiteLLMAnthropicMessagesAdapter().translate_streaming_openai_response_to_anthropic(
-                    response=chunk,
-                    current_content_block_index=self.current_content_block_index,
-                    applied_edits=(self.applied_edits if is_final_chunk and not will_merge_into_held else None),
+                processed_chunk = self._override_stop_reason_for_tool_use(
+                    LiteLLMAnthropicMessagesAdapter().translate_streaming_openai_response_to_anthropic(
+                        response=chunk,
+                        current_content_block_index=self.current_content_block_index,
+                        applied_edits=(self.applied_edits if is_final_chunk and not will_merge_into_held else None),
+                    )
                 )
 
                 # Check if this is a usage chunk and we have a held stop_reason chunk
@@ -901,6 +916,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
 
         # Restore original tool name if it was truncated for OpenAI's 64-char limit
         if block_type == "tool_use":
+            self._emitted_tool_use = True
             # Type narrowing: content_block_start is ToolUseBlock when block_type is "tool_use"
             from typing import cast
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_tool_args.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_streaming_iterator_tool_args.py
@@ -381,3 +381,89 @@ def test_sync_stream_no_extra_delta_when_tool_args_empty():
         f"got {len(input_json_deltas)}"
     )
     assert input_json_deltas[0]["delta"]["partial_json"] == '{"location": "NYC"}'
+
+
+def _last_message_delta(events):
+    deltas = [
+        e
+        for e in events
+        if isinstance(e, dict) and e.get("type") == "message_delta"
+    ]
+    assert deltas, f"expected a message_delta event; got {[e.get('type') for e in events if isinstance(e, dict)]}"
+    return deltas[-1]
+
+
+def _tool_call_chunk():
+    return _make_chunk(
+        Delta(
+            content=None,
+            role="assistant",
+            tool_calls=[
+                ChatCompletionDeltaToolCall(
+                    id="call_abc123",
+                    function=Function(name="get_weather", arguments='{"city": "San Francisco"}'),
+                    type="function",
+                    index=0,
+                )
+            ],
+        )
+    )
+
+
+def test_sync_stream_stop_reason_is_tool_use_when_finish_reason_stop():
+    """
+    Regression for #34692: ollama_chat streaming reports finish_reason="stop"
+    on the final chunk even when the turn contains a tool call. The emitted
+    message_delta must still carry stop_reason="tool_use" (matching the
+    non-streaming response and the Anthropic Messages spec), or clients drop
+    the tool call.
+    """
+    finish_chunk = _make_chunk(
+        Delta(content=None, role="assistant", tool_calls=None),
+        finish_reason="stop",
+    )
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=iter([_tool_call_chunk(), finish_chunk]),
+        model="test-model",
+    )
+    events = _collect_events_sync(wrapper)
+    assert _last_message_delta(events)["delta"]["stop_reason"] == "tool_use"
+
+
+@pytest.mark.asyncio
+async def test_async_stream_stop_reason_is_tool_use_when_finish_reason_stop():
+    """Async counterpart of the #34692 stop_reason regression."""
+    finish_chunk = _make_chunk(
+        Delta(content=None, role="assistant", tool_calls=None),
+        finish_reason="stop",
+    )
+
+    async def mock_stream():
+        for c in [_tool_call_chunk(), finish_chunk]:
+            yield c
+
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=mock_stream(),
+        model="test-model",
+    )
+    events = await _collect_events_async(wrapper)
+    assert _last_message_delta(events)["delta"]["stop_reason"] == "tool_use"
+
+
+def test_sync_stream_stop_reason_stays_end_turn_without_tool_use():
+    """
+    Guard: a plain text turn ending in finish_reason="stop" must keep
+    stop_reason="end_turn". The tool_use override must not fire when no
+    tool_use block was streamed.
+    """
+    text_chunk = _make_chunk(Delta(content="Hello there", role="assistant", tool_calls=None))
+    finish_chunk = _make_chunk(
+        Delta(content=None, role="assistant", tool_calls=None),
+        finish_reason="stop",
+    )
+    wrapper = AnthropicStreamWrapper(
+        completion_stream=iter([text_chunk, finish_chunk]),
+        model="test-model",
+    )
+    events = _collect_events_sync(wrapper)
+    assert _last_message_delta(events)["delta"]["stop_reason"] == "end_turn"


### PR DESCRIPTION
## TLDR

Problem this solves:

When an `ollama_chat` model is served through the Anthropic `/v1/messages` adapter with `stream: true` and the turn contains a tool call, the streamed final `message_delta` carries `stop_reason: "end_turn"` instead of `stop_reason: "tool_use"`. Anthropic Messages clients such as Claude Code and the Anthropic SDK key off `stop_reason == "tool_use"` to decide whether to run the emitted `tool_use` block, so with `end_turn` they treat the turn as final assistant text and silently drop the tool call. The identical request with `stream: false` already returns `tool_use`, so this is specific to the streaming translation path

How it solves it:

The bridge maps the provider `finish_reason` straight to a `stop_reason`, and `ollama_chat` streaming reports `finish_reason: "stop"` on its final chunk even when a tool call was emitted, which maps to `end_turn`. This tracks whether a `tool_use` content block was streamed and, on the terminal `message_delta`, rewrites `end_turn` to `tool_use` when one was; `max_tokens` and genuine `end_turn` turns are left untouched. The override runs through a single helper at the one point where the translated chunk is produced, so the sync and async iterators stay in lock-step

## Relevant issues

Fixes #34692

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Verified against a live tool-capable model (`ollama_chat/qwen3:8b`) through the proxy. The same streamed `/v1/messages` request whose turn makes a tool call, run against the code before and after this change:

```
$ curl -sN http://localhost:4000/v1/messages \
    -H 'content-type: application/json' -H 'x-api-key: sk-1234' -H 'anthropic-version: 2023-06-01' \
    -d '{"model":"qwen3","max_tokens":512,"stream":true,"messages":[{"role":"user","content":"What is the weather in San Francisco? Use the get_weather tool."}],"tools":[{"name":"get_weather","description":"Get the current weather for a city","input_schema":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}]}'

BEFORE this change:  "stop_reason": "end_turn"
AFTER  this change:  "stop_reason": "tool_use"
```

The non-streaming path already returned `tool_use`, so this brings streaming in line with it and the Anthropic Messages spec; before the change, clients keying off `stop_reason == "tool_use"` treated the turn as final assistant text and dropped the tool call

## Type

Bug Fix

## Changes

`AnthropicStreamWrapper` now records when a `tool_use` content block is emitted during a stream and corrects the terminal `message_delta` accordingly. A new `_override_stop_reason_for_tool_use` helper rewrites `end_turn` to `tool_use` only when a tool block was streamed, wrapping the translated chunk at the single shared call site used by both `__next__` and `__anext__` so the two paths cannot drift. Regression tests were added to `test_streaming_iterator_tool_args.py` covering the sync and async paths, plus a guard that a plain text turn ending in `finish_reason: "stop"` keeps `end_turn`

## QA runbook

1. Save a config with any tool-capable Ollama model:

```yaml
model_list:
  - model_name: qwen3
    litellm_params:
      model: ollama_chat/qwen3:8b
      api_base: http://localhost:11434
```

2. Start the proxy:

```bash
litellm --config config.yaml
```

3. Send a streaming `/v1/messages` request with one tool and confirm the final `message_delta` carries `stop_reason: "tool_use"`:

```bash
curl -sN http://localhost:4000/v1/messages \
  -H 'content-type: application/json' \
  -H 'x-api-key: sk-1234' \
  -H 'anthropic-version: 2023-06-01' \
  -d '{
    "model": "qwen3",
    "max_tokens": 512,
    "stream": true,
    "messages": [{"role": "user", "content": "What is the weather in San Francisco? Use the get_weather tool."}],
    "tools": [{"name": "get_weather", "description": "Get the current weather for a city", "input_schema": {"type": "object", "properties": {"city": {"type": "string"}}, "required": ["city"]}}]
  }'
```

4. Send the same request with `"stream": false` and confirm it still returns `stop_reason: "tool_use"`, unchanged

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
