### PR TITLE
fix(logging): snapshot model_call_details items before iterating in success/failure handlers

### DIFF
--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -2137,7 +2137,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     if callback == "logfire" and logfireLogger is not None:
                         verbose_logger.debug("reaches logfire for success logging!")
                         kwargs = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             if k != "original_response":  # copy.deepcopy raises errors as this could be a coroutine
                                 kwargs[k] = v
 
@@ -2216,7 +2216,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         global langFuseLogger
                         print_verbose("reaches langfuse for success logging!")
                         kwargs = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             if k != "original_response":  # copy.deepcopy raises errors as this could be a coroutine
                                 kwargs[k] = v
                         # this only logs streaming once, complete_streaming_response exists i.e when stream ends
@@ -2253,7 +2253,7 @@ class Logging(LiteLLMLoggingBaseClass):
                                     )
                     if callback == "greenscale" and greenscaleLogger is not None:
                         kwargs = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             if k != "original_response":  # copy.deepcopy raises errors as this could be a coroutine
                                 kwargs[k] = v
                         # this only logs streaming once, complete_streaming_response exists i.e when stream ends
@@ -2276,7 +2276,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         )
                     if callback == "athina" and athinaLogger is not None:
                         deep_copy = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             deep_copy[k] = v
                         athinaLogger.log_event(
                             kwargs=deep_copy,
@@ -2287,7 +2287,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         )
                     if callback == "traceloop":
                         deep_copy = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             if k != "original_response":
                                 deep_copy[k] = v
                         traceloopLogger.log_event(
@@ -2899,7 +2899,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         global langFuseLogger
                         verbose_logger.debug("reaches langfuse for logging failure")
                         kwargs = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             if k != "original_response":  # copy.deepcopy raises errors as this could be a coroutine
                                 kwargs[k] = v
                         # this only logs streaming once, complete_streaming_response exists i.e when stream ends
@@ -2939,7 +2939,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     if callback == "logfire" and logfireLogger is not None:
                         verbose_logger.debug("reaches logfire for failure logging!")
                         kwargs = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             if k != "original_response":  # copy.deepcopy raises errors as this could be a coroutine
                                 kwargs[k] = v
                         kwargs["exception"] = exception

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -2251,7 +2251,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     if callback == "logfire" and logfireLogger is not None:
                         verbose_logger.debug("reaches logfire for success logging!")
                         kwargs = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             if k != "original_response":  # copy.deepcopy raises errors as this could be a coroutine
                                 kwargs[k] = v
 
@@ -2330,7 +2330,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         global langFuseLogger
                         print_verbose("reaches langfuse for success logging!")
                         kwargs = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             if k != "original_response":  # copy.deepcopy raises errors as this could be a coroutine
                                 kwargs[k] = v
                         # this only logs streaming once, complete_streaming_response exists i.e when stream ends
@@ -2368,7 +2368,7 @@ class Logging(LiteLLMLoggingBaseClass):
                                     )
                     if callback == "greenscale" and greenscaleLogger is not None:
                         kwargs = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             if k != "original_response":  # copy.deepcopy raises errors as this could be a coroutine
                                 kwargs[k] = v
                         # this only logs streaming once, complete_streaming_response exists i.e when stream ends
@@ -2392,7 +2392,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         )
                     if callback == "athina" and athinaLogger is not None:
                         deep_copy = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             deep_copy[k] = v
                         athinaLogger.log_event(
                             kwargs=deep_copy,
@@ -2403,7 +2403,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         )
                     if callback == "traceloop":
                         deep_copy = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             if k != "original_response":
                                 deep_copy[k] = v
                         traceloopLogger.log_event(
@@ -3065,7 +3065,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         global langFuseLogger
                         verbose_logger.debug("reaches langfuse for logging failure")
                         kwargs = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             if k != "original_response":  # copy.deepcopy raises errors as this could be a coroutine
                                 kwargs[k] = v
                         # this only logs streaming once, complete_streaming_response exists i.e when stream ends
@@ -3105,7 +3105,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     if callback == "logfire" and logfireLogger is not None:
                         verbose_logger.debug("reaches logfire for failure logging!")
                         kwargs = {}
-                        for k, v in self.model_call_details.items():
+                        for k, v in list(self.model_call_details.items()):
                             if k != "original_response":  # copy.deepcopy raises errors as this could be a coroutine
                                 kwargs[k] = v
                         kwargs["exception"] = exception

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -4161,3 +4161,69 @@ def test_success_handler_survives_concurrent_model_call_details_mutation(logging
         mock_langfuse_logger.log_event_on_langfuse.assert_called_once()
     finally:
         litellm.success_callback = original_success_callbacks
+
+
+def _build_model_response():
+    return ModelResponse(
+        id="resp-snapshot",
+        model="gpt-4o-mini",
+        choices=[
+            {
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+
+@pytest.mark.parametrize("callback_name", ["logfire", "greenscale", "athina", "traceloop"])
+def test_success_handler_snapshots_model_call_details_per_callback(logging_obj, callback_name):
+    """Every sync success callback that copies model_call_details must iterate a snapshot."""
+    logger_attr = {
+        "logfire": "logfireLogger",
+        "greenscale": "greenscaleLogger",
+        "athina": "athinaLogger",
+        "traceloop": "traceloopLogger",
+    }[callback_name]
+
+    original_success_callbacks = list(litellm.success_callback or [])
+    litellm.success_callback = [callback_name]
+    try:
+        logging_obj.stream = False
+        logging_obj.call_type = "completion"
+        with patch(
+            f"litellm.litellm_core_utils.litellm_logging.{logger_attr}",
+            MagicMock(),
+            create=True,
+        ):
+            logging_obj.success_handler(result=_build_model_response())
+    finally:
+        litellm.success_callback = original_success_callbacks
+
+
+@pytest.mark.parametrize("callback_name", ["langfuse", "logfire"])
+def test_failure_handler_snapshots_model_call_details_per_callback(logging_obj, callback_name):
+    """Every sync failure callback that copies model_call_details must iterate a snapshot."""
+    original_failure_callbacks = list(litellm.failure_callback or [])
+    litellm.failure_callback = [callback_name]
+    try:
+        logging_obj.stream = False
+        logging_obj.call_type = "completion"
+        with (
+            patch(
+                "litellm.litellm_core_utils.litellm_logging.logfireLogger",
+                MagicMock(),
+            ),
+            patch(
+                "litellm.litellm_core_utils.litellm_logging.LangFuseHandler.get_langfuse_logger_for_request",
+                return_value=MagicMock(),
+            ),
+        ):
+            logging_obj.failure_handler(
+                Exception("boom"),
+                "traceback",
+            )
+    finally:
+        litellm.failure_callback = original_failure_callbacks

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -4101,3 +4101,63 @@ def test_pre_call_does_not_pin_request_in_module_state(logging_obj):
     logging_obj.post_call(original_response='{"ok": true}', input=big_input, api_key="sk-test")
 
     assert litellm.error_logs == {}
+
+
+def test_success_handler_survives_concurrent_model_call_details_mutation(logging_obj):
+    """
+    success_handler runs on a worker thread while async_success_handler writes new
+    keys into the shared model_call_details on the event loop. Iterating a live
+    .items() view raised 'dictionary changed size during iteration', aborting the
+    callback mid-loop. Snapshotting with list(...) must let the callback complete
+    even when a key is inserted during iteration.
+    """
+    original_success_callbacks = list(litellm.success_callback or [])
+    litellm.success_callback = ["langfuse"]
+
+    class _InsertsKeyOnCompare(str):
+        def __new__(cls, value, sink):
+            obj = super().__new__(cls, value)
+            obj._sink = sink
+            return obj
+
+        def __ne__(self, other):
+            if "concurrent_insert" not in self._sink:
+                self._sink["concurrent_insert"] = "added-mid-iteration"
+            return str.__ne__(self, other)
+
+        def __hash__(self):
+            return str.__hash__(self)
+
+    result = ModelResponse(
+        id="resp-concurrent",
+        model="gpt-4o-mini",
+        choices=[
+            {
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    mock_langfuse_logger = MagicMock()
+
+    try:
+        logging_obj.stream = False
+        logging_obj.call_type = "completion"
+        model_call_details = logging_obj.model_call_details
+        existing_key = next(iter(model_call_details.keys()))
+        existing_value = model_call_details.pop(existing_key)
+        model_call_details[_InsertsKeyOnCompare(existing_key, model_call_details)] = existing_value
+
+        with patch(
+            "litellm.litellm_core_utils.litellm_logging.LangFuseHandler.get_langfuse_logger_for_request",
+            return_value=mock_langfuse_logger,
+        ):
+            logging_obj.success_handler(result=result)
+
+        assert "concurrent_insert" in logging_obj.model_call_details
+        mock_langfuse_logger.log_event_on_langfuse.assert_called_once()
+    finally:
+        litellm.success_callback = original_success_callbacks

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -4539,3 +4539,61 @@ async def test_restore_correlation_context_works_across_asyncio_task_boundary():
     finally:
         trace_id_var.set("")
         session_id_var.set("")
+def test_success_handler_survives_concurrent_model_call_details_mutation(logging_obj):
+    """
+    success_handler runs on a worker thread while async_success_handler writes new
+    keys into the shared model_call_details on the event loop. Iterating a live
+    .items() view raised 'dictionary changed size during iteration', aborting the
+    callback mid-loop. Snapshotting with list(...) must let the callback complete
+    even when a key is inserted during iteration.
+    """
+    original_success_callbacks = list(litellm.success_callback or [])
+    litellm.success_callback = ["langfuse"]
+
+    class _InsertsKeyOnCompare(str):
+        def __new__(cls, value, sink):
+            obj = super().__new__(cls, value)
+            obj._sink = sink
+            return obj
+
+        def __ne__(self, other):
+            if "concurrent_insert" not in self._sink:
+                self._sink["concurrent_insert"] = "added-mid-iteration"
+            return str.__ne__(self, other)
+
+        def __hash__(self):
+            return str.__hash__(self)
+
+    result = ModelResponse(
+        id="resp-concurrent",
+        model="gpt-4o-mini",
+        choices=[
+            {
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+    mock_langfuse_logger = MagicMock()
+
+    try:
+        logging_obj.stream = False
+        logging_obj.call_type = "completion"
+        model_call_details = logging_obj.model_call_details
+        existing_key = next(iter(model_call_details.keys()))
+        existing_value = model_call_details.pop(existing_key)
+        model_call_details[_InsertsKeyOnCompare(existing_key, model_call_details)] = existing_value
+
+        with patch(
+            "litellm.litellm_core_utils.litellm_logging.LangFuseHandler.get_langfuse_logger_for_request",
+            return_value=mock_langfuse_logger,
+        ):
+            logging_obj.success_handler(result=result)
+
+        assert "concurrent_insert" in logging_obj.model_call_details
+        mock_langfuse_logger.log_event_on_langfuse.assert_called_once()
+    finally:
+        litellm.success_callback = original_success_callbacks

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -4597,3 +4597,69 @@ def test_success_handler_survives_concurrent_model_call_details_mutation(logging
         mock_langfuse_logger.log_event_on_langfuse.assert_called_once()
     finally:
         litellm.success_callback = original_success_callbacks
+
+
+def _build_model_response():
+    return ModelResponse(
+        id="resp-snapshot",
+        model="gpt-4o-mini",
+        choices=[
+            {
+                "message": {"role": "assistant", "content": "hi"},
+                "finish_reason": "stop",
+                "index": 0,
+            }
+        ],
+        usage={"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    )
+
+
+@pytest.mark.parametrize("callback_name", ["logfire", "greenscale", "athina", "traceloop"])
+def test_success_handler_snapshots_model_call_details_per_callback(logging_obj, callback_name):
+    """Every sync success callback that copies model_call_details must iterate a snapshot."""
+    logger_attr = {
+        "logfire": "logfireLogger",
+        "greenscale": "greenscaleLogger",
+        "athina": "athinaLogger",
+        "traceloop": "traceloopLogger",
+    }[callback_name]
+
+    original_success_callbacks = list(litellm.success_callback or [])
+    litellm.success_callback = [callback_name]
+    try:
+        logging_obj.stream = False
+        logging_obj.call_type = "completion"
+        with patch(
+            f"litellm.litellm_core_utils.litellm_logging.{logger_attr}",
+            MagicMock(),
+            create=True,
+        ):
+            logging_obj.success_handler(result=_build_model_response())
+    finally:
+        litellm.success_callback = original_success_callbacks
+
+
+@pytest.mark.parametrize("callback_name", ["langfuse", "logfire"])
+def test_failure_handler_snapshots_model_call_details_per_callback(logging_obj, callback_name):
+    """Every sync failure callback that copies model_call_details must iterate a snapshot."""
+    original_failure_callbacks = list(litellm.failure_callback or [])
+    litellm.failure_callback = [callback_name]
+    try:
+        logging_obj.stream = False
+        logging_obj.call_type = "completion"
+        with (
+            patch(
+                "litellm.litellm_core_utils.litellm_logging.logfireLogger",
+                MagicMock(),
+            ),
+            patch(
+                "litellm.litellm_core_utils.litellm_logging.LangFuseHandler.get_langfuse_logger_for_request",
+                return_value=MagicMock(),
+            ),
+        ):
+            logging_obj.failure_handler(
+                Exception("boom"),
+                "traceback",
+            )
+    finally:
+        litellm.failure_callback = original_failure_callbacks


### PR DESCRIPTION
## TLDR

Problem this solves:

- Concurrent logging crashes sync success/failure handlers
- `RuntimeError: dictionary changed size during iteration` silently drops logs

How it solves it:

- Snapshot `model_call_details.items()` with `list()` before iterating

## Relevant issues

Fixes #34719

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Reproduced via the actual `success_handler` code path (langfuse copy-loop at `litellm_logging.py:2219`), with a key that inserts into `model_call_details` mid-iteration to simulate the concurrent `async_success_handler` write:

**Before the fix** (commit `24123269cc`, raw `.items()`) — the `RuntimeError` aborts the loop, so the callback never fires:

```
$ pytest ...::test_success_handler_survives_concurrent_model_call_details_mutation
AssertionError: Expected 'log_event_on_langfuse' to have been called once. Called 0 times.
1 failed
```

**After the fix** (commit `755fb0822c`, `list(...)` snapshot) — the loop completes, callback fires:

```
$ pytest ...::test_success_handler_survives_concurrent_model_call_details_mutation
1 passed
```

Full mapped test file: `125 passed` (1 pre-existing unrelated failure — `test_logfire_logger_accepts_env_vars_for_base_url`, missing optional `opentelemetry` locally).

> Note: I'll add a real e2e before/after against live traffic (real LLM $) once the review settles, per the maintainer proof-of-fix requirement.

## Type

🐛 Bug Fix

## Changes

The synchronous `success_handler` and `failure_handler` (`litellm/litellm_core_utils/litellm_logging.py`) iterate the live `self.model_call_details` dict while copying it for sync callbacks (langfuse, logfire, greenscale, athina, traceloop). They run on a worker thread (`executor.submit` / `threading.Thread`), while `async_success_handler` / `async_failure_handler` insert new keys into the same object on the event loop:

- **Success** is dispatched concurrently: the async wrapper enqueues `async_success_handler`, then `executor.submit(success_handler)` via `handle_sync_success_callbacks_for_async_calls`, with no `await` between them.
- **Failure** is dispatched concurrently in `router.py` (5 sites, e.g. lines 7312/7335/7383/10771/10897) pairing `asyncio.create_task(async_failure_handler)` with `threading.Thread(target=failure_handler)` on the same logging object.

When the async path inserts a key mid-iteration, Python raises `RuntimeError: dictionary changed size during iteration`, which the handler's non-blocking `try/except` swallows — silently dropping that request's callback log.

Wraps the 7 raw iterations (5 in `success_handler`, 2 in `failure_handler`) with `list(...)` so a concurrent insert can't invalidate the iterator. Each loop only reads `k`/`v` and writes into a separate dict, so snapshotting changes no behavior other than removing the race. Adds a deterministic mocked test to the existing mapped `tests/test_litellm/litellm_core_utils/test_litellm_logging.py`.
