### PR TITLE
fix(proxy): preserve team metadata and budget pointer during team updates

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -279,9 +279,11 @@ class TeamMemberBudgetHandler:
             user_api_key_dict=user_api_key_dict,
         )
 
-        # Add team_member_budget_id as metadata field to team table
+        # Add team_member_budget_id as metadata field to team table. Seed from
+        # the team's real existing metadata (not {}) so unrelated keys already
+        # on the team aren't wiped by this write (see issue #31447).
         if new_team_data_json.get("metadata") is None:
-            new_team_data_json["metadata"] = {}
+            new_team_data_json["metadata"] = dict(data.metadata) if data.metadata else {}
         new_team_data_json["metadata"]["team_member_budget_id"] = team_member_budget_table.budget_id
 
         # Remove team member fields from new_team_data_json
@@ -330,7 +332,7 @@ class TeamMemberBudgetHandler:
                 f"Updated team member budget table: {budget_row.budget_id}, with team_member_budget={team_member_budget}, team_member_rpm_limit={team_member_rpm_limit}, team_member_tpm_limit={team_member_tpm_limit}"
             )
             if updated_kv.get("metadata") is None:
-                updated_kv["metadata"] = {}
+                updated_kv["metadata"] = dict(team_table.metadata) if team_table.metadata else {}
             updated_kv["metadata"]["team_member_budget_id"] = budget_row.budget_id
 
         else:  # budget does not exist
@@ -1871,6 +1873,14 @@ async def update_team(
             )
         else:
             TeamMemberBudgetHandler._clean_team_member_fields(updated_kv)
+            # A metadata-only update replaces the Json metadata column
+            # wholesale (Prisma doesn't merge Json fields), so without this
+            # the server-owned team_member_budget_id stripped above would be
+            # silently dropped instead of carried forward (see issue #31447).
+            if isinstance(updated_kv.get("metadata"), dict):
+                _existing_budget_id = (existing_team_row.metadata or {}).get("team_member_budget_id")
+                if isinstance(_existing_budget_id, str) and "team_member_budget_id" not in updated_kv["metadata"]:
+                    updated_kv["metadata"]["team_member_budget_id"] = _existing_budget_id
 
         # Check object permission
         if data.object_permission is not None:

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -2355,6 +2355,134 @@ async def test_upsert_team_member_budget_table_no_existing_budget():
 
 
 @pytest.mark.asyncio
+async def test_upsert_team_member_budget_table_preserves_unrelated_metadata():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/31447 (symptom 1).
+
+    upsert_team_member_budget_table must merge team_member_budget_id into the
+    team's existing metadata rather than replacing it - unrelated keys set by
+    other callers (e.g. managed_by) must survive a budget write.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm.proxy._types import LitellmUserRoles, LiteLLM_TeamTable, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        TeamMemberBudgetHandler,
+    )
+
+    mock_user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="test_user_id"
+    )
+
+    team_table = MagicMock(spec=LiteLLM_TeamTable)
+    team_table.metadata = {
+        "team_member_budget_id": "existing_budget_123",
+        "managed_by": "my-controller",
+    }
+
+    updated_kv = {
+        "team_id": "test_team_id",
+        "team_member_budget": 200.0,
+    }
+
+    mock_budget_response = MagicMock()
+    mock_budget_response.budget_id = "existing_budget_123"
+
+    with patch(
+        "litellm.proxy.management_endpoints.budget_management_endpoints.update_budget",
+        new_callable=AsyncMock,
+    ) as mock_update_budget:
+        mock_update_budget.return_value = mock_budget_response
+
+        result = await TeamMemberBudgetHandler.upsert_team_member_budget_table(
+            team_table=team_table,
+            user_api_key_dict=mock_user_api_key_dict,
+            updated_kv=updated_kv,
+            team_member_budget=200.0,
+        )
+
+    assert result["metadata"]["team_member_budget_id"] == "existing_budget_123"
+    assert (
+        result["metadata"]["managed_by"] == "my-controller"
+    ), f"expected unrelated metadata key to survive a budget write, got: {result.get('metadata')}"
+
+
+@pytest.mark.asyncio
+async def test_update_team_metadata_only_preserves_team_member_budget_pointer():
+    """
+    Regression test for https://github.com/BerriAI/litellm/issues/31447 (symptom 2).
+
+    A metadata-only /team/update request (no team_member_* fields) must not
+    null out the team's existing team_member_budget_id - Prisma replaces the
+    Json metadata column wholesale, so the existing pointer has to be carried
+    forward explicitly rather than left to be dropped by
+    strip_system_managed_metadata_keys with nothing re-adding it.
+    """
+    from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+    from fastapi import Request
+
+    from litellm.proxy._types import LitellmUserRoles, UpdateTeamRequest, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.team_endpoints import update_team
+
+    mock_request = Mock(spec=Request)
+    mock_user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="test_user_id"
+    )
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client,
+        patch("litellm.proxy.proxy_server.llm_router"),
+        patch("litellm.proxy.proxy_server.user_api_key_cache"),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj"),
+        patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"),
+        patch("litellm.proxy.management_endpoints.team_endpoints._cache_team_object"),
+    ):
+        mock_existing_team = MagicMock()
+        mock_existing_team.model_dump.return_value = {
+            "team_id": "test_team_id",
+            "team_alias": "test_team",
+            "metadata": {"team_member_budget_id": "existing_budget_123"},
+        }
+        mock_existing_team.metadata = {"team_member_budget_id": "existing_budget_123"}
+        mock_existing_team.members_with_roles = []
+        mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(
+            return_value=mock_existing_team
+        )
+
+        mock_updated_team = MagicMock()
+        mock_updated_team.team_id = "test_team_id"
+        mock_updated_team.model_dump.return_value = {"team_id": "test_team_id"}
+        mock_prisma_client.db.litellm_teamtable.update = AsyncMock(
+            return_value=mock_updated_team
+        )
+        mock_prisma_client.jsonify_team_object = MagicMock(
+            side_effect=lambda db_data: db_data
+        )
+
+        update_request = UpdateTeamRequest(
+            team_id="test_team_id",
+            metadata={"managed_by": "my-controller"},
+        )
+
+        await update_team(
+            data=update_request,
+            http_request=mock_request,
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+        assert mock_prisma_client.db.litellm_teamtable.update.called
+        call_args = mock_prisma_client.db.litellm_teamtable.update.call_args
+        update_data = call_args[1]["data"]
+
+        assert update_data["metadata"]["managed_by"] == "my-controller"
+        assert update_data["metadata"].get("team_member_budget_id") == "existing_budget_123", (
+            f"expected existing team_member_budget_id to survive a metadata-only "
+            f"update, got: {update_data.get('metadata')}"
+        )
+
+
+@pytest.mark.asyncio
 async def test_update_team_with_team_member_budget_duration():
     """
     Test that team/update endpoint properly handles team_member_budget_duration.
@@ -10011,17 +10139,25 @@ async def test_top_level_fields_identical_post_and_patch(body, field, expected):
 @pytest.mark.asyncio
 async def test_patch_strips_system_managed_metadata_key_like_post():
     """A caller cannot inject/overwrite server-owned keys via PATCH any more than
-    via POST: team_member_budget_id is stripped from the write in both."""
+    via POST: a caller-supplied team_member_budget_id is discarded by both.
+
+    Both also re-inject the team's real, existing team_member_budget_id after
+    stripping the caller's value, so a metadata-only write doesn't orphan the
+    team's budget row (see issue #31447). PATCH gets this for free because it
+    delegates to update_team() for the actual write (see patch_team).
+    """
     existing = {"team_member_budget_id": "budget-123", "cost_center": "1234"}
     body = {"metadata": {"team_member_budget_id": "HACKED", "cost_center": "9999"}}
 
     post_meta = await _written_metadata("post", existing, body)
     patch_meta = await _written_metadata("patch", existing, body)
 
-    assert "team_member_budget_id" not in post_meta
-    assert "team_member_budget_id" not in patch_meta
-    assert post_meta == {"cost_center": "9999"}
-    assert patch_meta == {"cost_center": "9999"}
+    # The caller's injected value must never survive, in either endpoint.
+    assert post_meta.get("team_member_budget_id") != "HACKED"
+    assert patch_meta.get("team_member_budget_id") != "HACKED"
+
+    assert post_meta == {"cost_center": "9999", "team_member_budget_id": "budget-123"}
+    assert patch_meta == {"cost_center": "9999", "team_member_budget_id": "budget-123"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Fixes #31447.

Updating a team's `team_member_budget` replaced the entire `metadata` object, causing unrelated metadata keys to be lost.

Additionally, metadata-only updates could unintentionally remove the persisted `team_member_budget_id`, orphaning the team's budget association.

## Root Cause

Budget update paths initialized metadata from an empty dictionary instead of the existing metadata. Since Prisma replaces the JSON column rather than merging it, unrelated metadata was overwritten.

Metadata-only updates correctly stripped caller-supplied system-managed keys, but never restored the persisted `team_member_budget_id`.

## Implementation

- Seed metadata from the existing metadata during budget create/update operations.
- Restore the persisted `team_member_budget_id` during metadata-only updates after removing any caller-supplied value.
- PATCH automatically inherits the fix because it delegates to `update_team()`.

## Validation

- Reproduced both reported issues on unmodified `main`.
- Added regression tests covering both failure modes.
- Verified both tests fail before the fix and pass afterward.
- Revalidated against a live proxy with PostgreSQL.
- Existing endpoint tests continue to pass.

## Risk

Low.

The change only affects construction of the metadata dictionary before existing persistence logic executes. No database schema, repository logic, or API behavior outside the reported bug was modified.
