### PR TITLE
feat(proxy): make user_api_key_cache in-memory size configurable

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2226,6 +2226,15 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
     use_google_kms: Optional[bool] = Field(None, description="decrypt keys with google kms")
     use_azure_key_vault: Optional[bool] = Field(None, description="load keys from azure key vault")
     master_key: Optional[str] = Field(None, description="require a key for all calls to proxy")
+    user_api_key_cache_max_size: int | None = Field(
+        None,
+        description=(
+            "max entries in the in-memory tier of user_api_key_cache. Shared across key, "
+            "team, user and org objects; defaults to InMemoryCache's 200, so proxies with "
+            "more active virtual keys than that evict on every insert and fall through to "
+            "Redis (or the DB) on each request"
+        ),
+    )
     coordination_redis: Optional[CoordinationRedisParams] = Field(
         None,
         description=(

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2324,6 +2324,15 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
     use_google_kms: bool | None = Field(None, description="decrypt keys with google kms")
     use_azure_key_vault: bool | None = Field(None, description="load keys from azure key vault")
     master_key: str | None = Field(None, description="require a key for all calls to proxy")
+    user_api_key_cache_max_size: int | None = Field(
+        None,
+        description=(
+            "max entries in the in-memory tier of user_api_key_cache. Shared across key, "
+            "team, user and org objects; defaults to InMemoryCache's 200, so proxies with "
+            "more active virtual keys than that evict on every insert and fall through to "
+            "Redis (or the DB) on each request"
+        ),
+    )
     coordination_redis: CoordinationRedisParams | None = Field(
         None,
         description=(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -4751,6 +4751,20 @@ class ProxyConfig:
                     default_redis_ttl=ttl,
                 )
 
+            ### USER API KEY CACHE MAX SIZE (in-memory tier) ###
+            user_api_key_cache_max_size = general_settings.get("user_api_key_cache_max_size", None)
+            if user_api_key_cache_max_size is not None:
+                # The default 200 is shared across key, team, user and org entries, so
+                # deployments with many active virtual keys evict on every insert and
+                # fall through to Redis (or the DB) on each request.
+                max_size = int(user_api_key_cache_max_size)
+                if max_size < 1:
+                    # A negative bound makes evict_cache() pop from an empty heap on the
+                    # next write; 0 silently disables the in-memory tier. Neither is a
+                    # useful way to express "smaller cache", so fail at startup instead.
+                    raise ValueError(f"general_settings.user_api_key_cache_max_size must be >= 1, got {max_size}")
+                user_api_key_cache.in_memory_cache.max_size_in_memory = max_size
+
             ### PKCE MULTI-INSTANCE PREREQUISITE CHECK ###
             # PKCE verifiers are stored in redis_usage_cache when available so they can
             # be read back by any instance (not just the one that started the auth flow).

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -5077,6 +5077,20 @@ class ProxyConfig:
                     default_redis_ttl=ttl,
                 )
 
+            ### USER API KEY CACHE MAX SIZE (in-memory tier) ###
+            user_api_key_cache_max_size = general_settings.get("user_api_key_cache_max_size", None)
+            if user_api_key_cache_max_size is not None:
+                # The default 200 is shared across key, team, user and org entries, so
+                # deployments with many active virtual keys evict on every insert and
+                # fall through to Redis (or the DB) on each request.
+                max_size = int(user_api_key_cache_max_size)
+                if max_size < 1:
+                    # A negative bound makes evict_cache() pop from an empty heap on the
+                    # next write; 0 silently disables the in-memory tier. Neither is a
+                    # useful way to express "smaller cache", so fail at startup instead.
+                    raise ValueError(f"general_settings.user_api_key_cache_max_size must be >= 1, got {max_size}")
+                user_api_key_cache.in_memory_cache.max_size_in_memory = max_size
+
             ### PKCE MULTI-INSTANCE PREREQUISITE CHECK ###
             # PKCE verifiers are stored in redis_usage_cache when available so they can
             # be read back by any instance (not just the one that started the auth flow).

--- a/tests/test_litellm/proxy/common_utils/test_user_api_key_cache.py
+++ b/tests/test_litellm/proxy/common_utils/test_user_api_key_cache.py
@@ -272,3 +272,22 @@ class TestManagementObjectTTL:
         )
 
         assert mem.last_ttl == 300
+
+
+class TestUserApiKeyCacheMaxSize:
+    """``general_settings.user_api_key_cache_max_size`` sizes the in-memory tier.
+
+    Without it the cache inherits ``InMemoryCache``'s default of 200 entries, shared
+    across key, team, user and org objects, so a deployment with more than ~200 active
+    virtual keys evicts on every insert.
+    """
+
+    def test_default_in_memory_size_is_inherited(self):
+        """The premise of the setting: nothing sizes this cache today, so it takes
+        ``InMemoryCache``'s general-purpose default rather than a value chosen for it."""
+        cache = UserApiKeyCache()
+        assert cache.in_memory_cache.max_size_in_memory == InMemoryCache().max_size_in_memory
+
+    def test_honors_an_explicitly_sized_in_memory_cache(self):
+        cache = UserApiKeyCache(in_memory_cache=InMemoryCache(max_size_in_memory=5000))
+        assert cache.in_memory_cache.max_size_in_memory == 5000

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -10604,3 +10604,124 @@ async def test_startup_survives_database_read_failure_for_coordination_redis():
         )
 
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_load_config_user_api_key_cache_max_size_applied(tmp_path):
+    """
+    general_settings.user_api_key_cache_max_size sizes the in-memory tier of
+    user_api_key_cache. Without it the cache inherits InMemoryCache's default of
+    200 entries, shared across key, team, user and org objects, so a deployment
+    with more than ~200 active virtual keys evicts on every insert.
+    """
+    from litellm.proxy.proxy_server import ProxyConfig, user_api_key_cache
+
+    test_config = {
+        "model_list": [],
+        "general_settings": {"user_api_key_cache_max_size": 5000},
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(test_config))
+
+    original = user_api_key_cache.in_memory_cache.max_size_in_memory
+    try:
+        proxy_config = ProxyConfig()
+        await proxy_config.load_config(
+            router=MagicMock(), config_file_path=str(config_file)
+        )
+        assert user_api_key_cache.in_memory_cache.max_size_in_memory == 5000
+    finally:
+        user_api_key_cache.in_memory_cache.max_size_in_memory = original
+
+
+@pytest.mark.asyncio
+async def test_load_config_user_api_key_cache_max_size_absent_leaves_default(tmp_path):
+    """Omitting the setting must not change the inherited default."""
+    from litellm.proxy.proxy_server import ProxyConfig, user_api_key_cache
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({"model_list": [], "general_settings": {}}))
+
+    original = user_api_key_cache.in_memory_cache.max_size_in_memory
+    try:
+        proxy_config = ProxyConfig()
+        await proxy_config.load_config(
+            router=MagicMock(), config_file_path=str(config_file)
+        )
+        assert user_api_key_cache.in_memory_cache.max_size_in_memory == original
+    finally:
+        user_api_key_cache.in_memory_cache.max_size_in_memory = original
+
+
+@pytest.mark.asyncio
+async def test_load_config_user_api_key_cache_max_size_coerced_from_env(
+    tmp_path, monkeypatch
+):
+    """
+    Configured via os.environ the value resolves to a string; load_config must
+    coerce it to int so the cache bound stays comparable to len(cache_dict).
+    """
+    from litellm.proxy.proxy_server import ProxyConfig, user_api_key_cache
+
+    monkeypatch.setenv("KEY_CACHE_MAX_SIZE", "1500")
+    test_config = {
+        "model_list": [],
+        "general_settings": {
+            "user_api_key_cache_max_size": "os.environ/KEY_CACHE_MAX_SIZE"
+        },
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(test_config))
+
+    original = user_api_key_cache.in_memory_cache.max_size_in_memory
+    try:
+        proxy_config = ProxyConfig()
+        await proxy_config.load_config(
+            router=MagicMock(), config_file_path=str(config_file)
+        )
+        assert user_api_key_cache.in_memory_cache.max_size_in_memory == 1500
+    finally:
+        user_api_key_cache.in_memory_cache.max_size_in_memory = original
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_value", [0, -1])
+async def test_load_config_user_api_key_cache_max_size_rejects_non_positive(
+    tmp_path, bad_value
+):
+    """
+    A negative bound makes InMemoryCache.evict_cache() pop from an empty heap on the
+    next write, and 0 silently disables the in-memory tier. load_config must reject
+    both at startup rather than leave the cache in that state.
+    """
+    from litellm.proxy.proxy_server import ProxyConfig, user_api_key_cache
+
+    test_config = {
+        "model_list": [],
+        "general_settings": {"user_api_key_cache_max_size": bad_value},
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(test_config))
+
+    original = user_api_key_cache.in_memory_cache.max_size_in_memory
+    try:
+        proxy_config = ProxyConfig()
+        with pytest.raises(ValueError, match="user_api_key_cache_max_size must be >= 1"):
+            await proxy_config.load_config(
+                router=MagicMock(), config_file_path=str(config_file)
+            )
+        assert user_api_key_cache.in_memory_cache.max_size_in_memory == original
+    finally:
+        user_api_key_cache.in_memory_cache.max_size_in_memory = original
+
+
+def test_user_api_key_cache_max_size_is_a_known_general_setting():
+    """
+    The DB-backed config endpoints reject any field not declared on
+    ConfigGeneralSettings, so the setting must be listed there to be settable
+    through /config/field/update as well as via config.yaml.
+    """
+    from litellm.proxy._types import ConfigGeneralSettings
+
+    assert "user_api_key_cache_max_size" in ConfigGeneralSettings.model_fields
+    ConfigGeneralSettings(user_api_key_cache_max_size=5000)

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -11064,3 +11064,123 @@ async def test_ptu_rollup_job_not_registered_without_opt_in(monkeypatch):
 
     assert scheduler.get_job(PTU_ROLLUP_JOB_ID) is None
     assert len(scheduler.get_jobs()) > 0
+
+@pytest.mark.asyncio
+async def test_load_config_user_api_key_cache_max_size_applied(tmp_path):
+    """
+    general_settings.user_api_key_cache_max_size sizes the in-memory tier of
+    user_api_key_cache. Without it the cache inherits InMemoryCache's default of
+    200 entries, shared across key, team, user and org objects, so a deployment
+    with more than ~200 active virtual keys evicts on every insert.
+    """
+    from litellm.proxy.proxy_server import ProxyConfig, user_api_key_cache
+
+    test_config = {
+        "model_list": [],
+        "general_settings": {"user_api_key_cache_max_size": 5000},
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(test_config))
+
+    original = user_api_key_cache.in_memory_cache.max_size_in_memory
+    try:
+        proxy_config = ProxyConfig()
+        await proxy_config.load_config(
+            router=MagicMock(), config_file_path=str(config_file)
+        )
+        assert user_api_key_cache.in_memory_cache.max_size_in_memory == 5000
+    finally:
+        user_api_key_cache.in_memory_cache.max_size_in_memory = original
+
+
+@pytest.mark.asyncio
+async def test_load_config_user_api_key_cache_max_size_absent_leaves_default(tmp_path):
+    """Omitting the setting must not change the inherited default."""
+    from litellm.proxy.proxy_server import ProxyConfig, user_api_key_cache
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({"model_list": [], "general_settings": {}}))
+
+    original = user_api_key_cache.in_memory_cache.max_size_in_memory
+    try:
+        proxy_config = ProxyConfig()
+        await proxy_config.load_config(
+            router=MagicMock(), config_file_path=str(config_file)
+        )
+        assert user_api_key_cache.in_memory_cache.max_size_in_memory == original
+    finally:
+        user_api_key_cache.in_memory_cache.max_size_in_memory = original
+
+
+@pytest.mark.asyncio
+async def test_load_config_user_api_key_cache_max_size_coerced_from_env(
+    tmp_path, monkeypatch
+):
+    """
+    Configured via os.environ the value resolves to a string; load_config must
+    coerce it to int so the cache bound stays comparable to len(cache_dict).
+    """
+    from litellm.proxy.proxy_server import ProxyConfig, user_api_key_cache
+
+    monkeypatch.setenv("KEY_CACHE_MAX_SIZE", "1500")
+    test_config = {
+        "model_list": [],
+        "general_settings": {
+            "user_api_key_cache_max_size": "os.environ/KEY_CACHE_MAX_SIZE"
+        },
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(test_config))
+
+    original = user_api_key_cache.in_memory_cache.max_size_in_memory
+    try:
+        proxy_config = ProxyConfig()
+        await proxy_config.load_config(
+            router=MagicMock(), config_file_path=str(config_file)
+        )
+        assert user_api_key_cache.in_memory_cache.max_size_in_memory == 1500
+    finally:
+        user_api_key_cache.in_memory_cache.max_size_in_memory = original
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_value", [0, -1])
+async def test_load_config_user_api_key_cache_max_size_rejects_non_positive(
+    tmp_path, bad_value
+):
+    """
+    A negative bound makes InMemoryCache.evict_cache() pop from an empty heap on the
+    next write, and 0 silently disables the in-memory tier. load_config must reject
+    both at startup rather than leave the cache in that state.
+    """
+    from litellm.proxy.proxy_server import ProxyConfig, user_api_key_cache
+
+    test_config = {
+        "model_list": [],
+        "general_settings": {"user_api_key_cache_max_size": bad_value},
+    }
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(test_config))
+
+    original = user_api_key_cache.in_memory_cache.max_size_in_memory
+    try:
+        proxy_config = ProxyConfig()
+        with pytest.raises(ValueError, match="user_api_key_cache_max_size must be >= 1"):
+            await proxy_config.load_config(
+                router=MagicMock(), config_file_path=str(config_file)
+            )
+        assert user_api_key_cache.in_memory_cache.max_size_in_memory == original
+    finally:
+        user_api_key_cache.in_memory_cache.max_size_in_memory = original
+
+
+def test_user_api_key_cache_max_size_is_a_known_general_setting():
+    """
+    The DB-backed config endpoints reject any field not declared on
+    ConfigGeneralSettings, so the setting must be listed there to be settable
+    through /config/field/update as well as via config.yaml.
+    """
+    from litellm.proxy._types import ConfigGeneralSettings
+
+    assert "user_api_key_cache_max_size" in ConfigGeneralSettings.model_fields
+    ConfigGeneralSettings(user_api_key_cache_max_size=5000)

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22839,6 +22839,11 @@ export interface components {
              * @description If True and LiteLLM_SpendLogs has been converted to a range-partitioned table (db_scripts/partition_spend_logs.sql), retention cleanup drops expired partitions instead of deleting rows, and pre-creates upcoming partitions. Default is False.
              */
             use_spend_logs_partitioning?: boolean | null;
+            /**
+             * User Api Key Cache Max Size
+             * @description max entries in the in-memory tier of user_api_key_cache. Shared across key, team, user and org objects; defaults to InMemoryCache's 200, so proxies with more active virtual keys than that evict on every insert and fall through to Redis (or the DB) on each request
+             */
+            user_api_key_cache_max_size?: number | null;
             /** User Header Mappings */
             user_header_mappings?: components["schemas"]["UserHeaderMapping"][] | null;
             /**

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23868,6 +23868,11 @@ export interface components {
              * @description If True and LiteLLM_SpendLogs has been converted to a range-partitioned table (db_scripts/partition_spend_logs.sql), retention cleanup drops expired partitions instead of deleting rows, and pre-creates upcoming partitions. Default is False.
              */
             use_spend_logs_partitioning?: boolean | null;
+            /**
+             * User Api Key Cache Max Size
+             * @description max entries in the in-memory tier of user_api_key_cache. Shared across key, team, user and org objects; defaults to InMemoryCache's 200, so proxies with more active virtual keys than that evict on every insert and fall through to Redis (or the DB) on each request
+             */
+            user_api_key_cache_max_size?: number | null;
             /** User Header Mappings */
             user_header_mappings?: components["schemas"]["UserHeaderMapping"][] | null;
             /**


### PR DESCRIPTION
## TLDR

Problem this solves:

- `user_api_key_cache`'s in-memory tier is hardcoded to 200 entries
- 200 is shared across key, team, user and org objects
- Proxies with >200 active virtual keys evict on every insert
- Every request then falls through to Redis or the DB

How it solves it:

- Adds `general_settings.user_api_key_cache_max_size`
- Sized right where `user_api_key_cache_ttl` is already handled
- Rejects values below 1 at startup, rather than breaking the cache
- Default behaviour unchanged when the setting is absent

## Relevant issues

<!-- none identified -->

## Linear ticket

<!-- external contribution -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

<!-- Verified locally against litellm_internal_staging @ 24123269cc, in a container
     provisioned with `uv sync --frozen --all-groups --all-extras`:

       make lint ................... exit 0, all 8 checks green
       make test-unit-proxy-core ... 2613 passed, 1 skipped
       make test-unit-proxy-misc ... the tests added here pass; the remaining failures are
                                     pre-existing and flaky. Two consecutive runs of this
                                     target on unpatched 24123269cc gave 8 failed / 0 errored
                                     and 11 failed / 2 errored respectively, so the failure
                                     count varies run-to-run on untouched upstream code
                                     (a2a_endpoints, mcp_env_vars, _FakeRedisCache).

     `make test-unit` is not runnable on a clean checkout, independently of this PR:
     tests/test_litellm/models/test_models.py and tests/test_litellm/proxy/client/test_models.py
     both sit in directories without __init__.py, so both import as the bare module
     `test_models` and collide under pytest's default prepend import mode. CI does not hit
     this because it runs the scoped test-unit-* matrix targets, which never collect both
     directories in one session. -->

## Screenshots / Proof of Fix

Real proxy, real postgres, 260 real virtual keys minted and exercised over HTTP, reading the
proxy's own `/memory-usage-in-mem-cache`. Both runs use the **same build**, so the only
variable is the setting — a before/after across two builds would also differ by the code
change itself.

Note that endpoint reports `len(cache_dict) + len(ttl_dict)`, i.e. it double-counts each
entry (`litellm/proxy/common_utils/debug_utils.py`).

Both runs: commit `0c9824abbc`, `litellm --config … --port 4499 --num_workers 1` against a
real postgres, 260 virtual keys minted via `POST /key/generate`, each then used against
`GET /v1/models`, followed by `GET /memory-usage-in-mem-cache`.

```
BEFORE — general_settings has no user_api_key_cache_max_size   (commit 0c9824abbc)
  minted+used 260 keys
  {"num_items_in_user_api_key_cache":400, ...}      ->  ~200 entries   # capped, 60 evicted

AFTER  — general_settings.user_api_key_cache_max_size: 5000    (commit 0c9824abbc)
  minted+used 260 keys
  num_items_in_user_api_key_cache=522                ->  ~261 entries   # all retained
```

## Type

🆕 New Feature

## Changes

`user_api_key_cache` is constructed without an `in_memory_cache` argument
(`litellm/proxy/proxy_server.py`), so it inherits `InMemoryCache`'s default
`max_size_in_memory` of **200** — a general anti-leak default rather than a value chosen for
this cache. Those 200 slots are shared across key, team, user, org and object-permission
entries, so a proxy with more than ~200 active virtual keys evicts on every insert and falls
through to Redis (or the DB) on essentially every request.

The TTL of the same cache is already configurable
(`general_settings.user_api_key_cache_ttl`); the size is not. Other caches in the codebase
size themselves explicitly — the container-ownership caches use `max_size_in_memory=10000`,
for example. This adds the missing knob directly beneath the TTL handling it mirrors.

```yaml
general_settings:
  user_api_key_cache_max_size: 5000
```

This is a tuning knob, not a correctness fix: it is **not** a limit on how many virtual keys
work. Keys beyond the bound authenticate fine; they just miss the in-memory tier.

Values below 1 are rejected at startup. A negative bound leaves
`InMemoryCache.evict_cache()`'s `len(cache_dict) >= max_size_in_memory` permanently true, so
the next write pops an already-empty `expiration_heap` and raises `IndexError`; `0` is
handled in `set_cache` but silently disables the in-memory tier. Neither is a useful way to
express "smaller cache".

The field is also declared on `ConfigGeneralSettings`, since the DB-backed config endpoints
reject any `general_settings` field not listed there. Note it is *not* added to the
`allowed_args` allowlist used to build the admin UI settings page, so this only affects
`/config/field/update` — no new UI surface. For transparency: the sibling
`user_api_key_cache_ttl` is likewise absent from `ConfigGeneralSettings` today, so it remains
settable only through `config.yaml`. Happy to declare it in a follow-up if you'd like the two
to match; it is left out here to keep this PR to one change.

Declaring the field changes the proxy OpenAPI spec, so
`ui/litellm-dashboard/src/lib/http/schema.d.ts` is regenerated to match (`npm run gen:api`).

Tests added:

- `tests/test_litellm/proxy/test_proxy_server.py` — `load_config` tests covering the new
  wiring: the setting is applied, its absence leaves the inherited default untouched, an
  `os.environ/…` value is coerced from `str` to `int`, and `0`/`-1` are rejected without
  mutating the cache. The applied/coerced tests fail if the `proxy_server.py` change is
  reverted. Plus a test that the field is a known `ConfigGeneralSettings` field.
- `tests/test_litellm/proxy/common_utils/test_user_api_key_cache.py` — records the premise
  (the cache inherits `InMemoryCache`'s default today) and that an explicitly sized
  `InMemoryCache` is honoured.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
