### PR TITLE
fix(evals): forward the caller's metadata on create_eval and create_run

### DIFF
--- a/.github/workflows/test-unit-misc.yml
+++ b/.github/workflows/test-unit-misc.yml
@@ -28,6 +28,7 @@ jobs:
         tests/test_litellm/anthropic_interface
         tests/test_litellm/completion_extras
         tests/test_litellm/containers
+        tests/test_litellm/evals
         tests/test_litellm/experimental_mcp_client
         tests/test_litellm/models
         tests/test_litellm/repositories

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -104,6 +104,7 @@ jobs:
               tests/test_litellm/compression
               tests/test_litellm/containers
               tests/test_litellm/endpoints
+              tests/test_litellm/evals
               tests/test_litellm/experimental_mcp_client
               tests/test_litellm/models
               tests/test_litellm/repositories

--- a/litellm/evals/main.py
+++ b/litellm/evals/main.py
@@ -39,45 +39,38 @@ DEFAULT_OPENAI_API_BASE = "https://api.openai.com"
 
 # Internal LiteLLM metadata keys that the proxy attaches to `metadata` and that
 # must never be forwarded to the provider.
+#
+# The `user_api_key_` family is matched by prefix rather than by name, matching what
+# the proxy already does to user-supplied metadata in
+# `litellm/proxy/litellm_pre_call_utils.py` ("Strip spoofable auth metadata"). An
+# exact-name list drifts: it currently misses 13 of the 33 `user_api_key_*` keys in
+# the codebase, including `user_api_key_token`.
+INTERNAL_METADATA_KEY_PREFIXES = ("user_api_key_", "litellm_")
+
 INTERNAL_METADATA_KEYS = {
     "headers",
     "requester_metadata",
-    "user_api_key_hash",
-    "user_api_key_alias",
-    "user_api_key_spend",
-    "user_api_key_max_budget",
-    "user_api_key_team_id",
-    "user_api_key_user_id",
-    "user_api_key_org_id",
-    "user_api_key_team_alias",
-    "user_api_key_end_user_id",
-    "user_api_key_user_email",
-    "user_api_key_request_route",
-    "user_api_key_budget_reset_at",
-    "user_api_key_auth_metadata",
     "user_api_key",
     "user_api_end_user_max_budget",
-    "user_api_key_auth",
-    "litellm_api_version",
     "global_max_parallel_requests",
-    "user_api_key_team_max_budget",
-    "user_api_key_team_spend",
-    "user_api_key_model_max_budget",
-    "user_api_key_user_spend",
-    "user_api_key_user_max_budget",
-    "user_api_key_metadata",
     "endpoint",
-    "litellm_parent_otel_span",
     "requester_ip_address",
     "user_agent",
+    "spend_logs_metadata",
+    "proxy_server_request",
+    "standard_logging_object",
 }
+
+
+def _is_internal_metadata_key(key: str) -> bool:
+    return key in INTERNAL_METADATA_KEYS or key.startswith(INTERNAL_METADATA_KEY_PREFIXES)
 
 
 def _user_metadata(metadata: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """Return only the caller's metadata keys, or None if nothing is left."""
     if metadata is None:
         return None
-    filtered = {k: v for k, v in metadata.items() if k not in INTERNAL_METADATA_KEYS}
+    filtered = {k: v for k, v in metadata.items() if not _is_internal_metadata_key(k)}
     return filtered or None
 
 

--- a/litellm/evals/main.py
+++ b/litellm/evals/main.py
@@ -66,7 +66,7 @@ def _is_internal_metadata_key(key: str) -> bool:
     return key in INTERNAL_METADATA_KEYS or key.startswith(INTERNAL_METADATA_KEY_PREFIXES)
 
 
-def _user_metadata(metadata: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+def _user_metadata(metadata: dict[str, Any] | None) -> dict[str, Any] | None:
     """Return only the caller's metadata keys, or None if nothing is left."""
     if metadata is None:
         return None

--- a/litellm/evals/main.py
+++ b/litellm/evals/main.py
@@ -37,6 +37,49 @@ from litellm.utils import ProviderConfigManager, client
 base_llm_http_handler = BaseLLMHTTPHandler()
 DEFAULT_OPENAI_API_BASE = "https://api.openai.com"
 
+# Internal LiteLLM metadata keys that the proxy attaches to `metadata` and that
+# must never be forwarded to the provider.
+INTERNAL_METADATA_KEYS = {
+    "headers",
+    "requester_metadata",
+    "user_api_key_hash",
+    "user_api_key_alias",
+    "user_api_key_spend",
+    "user_api_key_max_budget",
+    "user_api_key_team_id",
+    "user_api_key_user_id",
+    "user_api_key_org_id",
+    "user_api_key_team_alias",
+    "user_api_key_end_user_id",
+    "user_api_key_user_email",
+    "user_api_key_request_route",
+    "user_api_key_budget_reset_at",
+    "user_api_key_auth_metadata",
+    "user_api_key",
+    "user_api_end_user_max_budget",
+    "user_api_key_auth",
+    "litellm_api_version",
+    "global_max_parallel_requests",
+    "user_api_key_team_max_budget",
+    "user_api_key_team_spend",
+    "user_api_key_model_max_budget",
+    "user_api_key_user_spend",
+    "user_api_key_user_max_budget",
+    "user_api_key_metadata",
+    "endpoint",
+    "litellm_parent_otel_span",
+    "requester_ip_address",
+    "user_agent",
+}
+
+
+def _user_metadata(metadata: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Return only the caller's metadata keys, or None if nothing is left."""
+    if metadata is None:
+        return None
+    filtered = {k: v for k, v in metadata.items() if k not in INTERNAL_METADATA_KEYS}
+    return filtered or None
+
 
 @client
 async def acreate_eval(
@@ -166,6 +209,11 @@ def create_eval(
         }
         if name is not None:
             create_request["name"] = name
+
+        # Filter metadata to exclude internal LiteLLM fields
+        filtered_metadata = _user_metadata(metadata)
+        if filtered_metadata is not None:
+            create_request["metadata"] = filtered_metadata
 
         # Merge extra_body if provided
         if extra_body:
@@ -681,44 +729,9 @@ def update_eval(
             update_request["name"] = name
 
         # Filter metadata to exclude internal LiteLLM fields
-        if metadata is not None:
-            # List of internal LiteLLM metadata keys that should NOT be sent to OpenAI
-            internal_keys = {
-                "headers",
-                "requester_metadata",
-                "user_api_key_hash",
-                "user_api_key_alias",
-                "user_api_key_spend",
-                "user_api_key_max_budget",
-                "user_api_key_team_id",
-                "user_api_key_user_id",
-                "user_api_key_org_id",
-                "user_api_key_team_alias",
-                "user_api_key_end_user_id",
-                "user_api_key_user_email",
-                "user_api_key_request_route",
-                "user_api_key_budget_reset_at",
-                "user_api_key_auth_metadata",
-                "user_api_key",
-                "user_api_end_user_max_budget",
-                "user_api_key_auth",
-                "litellm_api_version",
-                "global_max_parallel_requests",
-                "user_api_key_team_max_budget",
-                "user_api_key_team_spend",
-                "user_api_key_model_max_budget",
-                "user_api_key_user_spend",
-                "user_api_key_user_max_budget",
-                "user_api_key_metadata",
-                "endpoint",
-                "litellm_parent_otel_span",
-                "requester_ip_address",
-                "user_agent",
-            }
-            # Only include user-provided metadata keys
-            filtered_metadata = {k: v for k, v in metadata.items() if k not in internal_keys}
-            if filtered_metadata:  # Only add if there's user metadata
-                update_request["metadata"] = filtered_metadata
+        filtered_metadata = _user_metadata(metadata)
+        if filtered_metadata is not None:
+            update_request["metadata"] = filtered_metadata
 
         # Merge extra_body if provided
         if extra_body:
@@ -1215,8 +1228,11 @@ def create_run(
         }
         if name is not None:
             create_request["name"] = name
-        # if metadata is not None:
-        #     create_request["metadata"] = metadata
+
+        # Filter metadata to exclude internal LiteLLM fields
+        filtered_metadata = _user_metadata(metadata)
+        if filtered_metadata is not None:
+            create_request["metadata"] = filtered_metadata
 
         # Merge extra_body if provided
         if extra_body:

--- a/litellm/evals/main.py
+++ b/litellm/evals/main.py
@@ -5,7 +5,7 @@ Provides create, list, get, update, delete, and cancel operations for evals
 
 import asyncio
 import contextvars
-from collections.abc import Coroutine
+from collections.abc import Coroutine, Mapping
 from functools import partial
 from typing import Final
 
@@ -39,6 +39,47 @@ from litellm.utils import ProviderConfigManager, client
 # Initialize HTTP handler
 base_llm_http_handler = BaseLLMHTTPHandler()
 DEFAULT_OPENAI_API_BASE: Final = "https://api.openai.com"
+
+# Internal LiteLLM metadata keys that the proxy attaches to `metadata` and that
+# must never be forwarded to the provider.
+#
+# The `user_api_key_` family is matched by prefix rather than by name, matching what
+# the proxy already does to user-supplied metadata in
+# `litellm/proxy/litellm_pre_call_utils.py` ("Strip spoofable auth metadata"). An
+# exact-name list drifts: it currently misses 13 of the 33 `user_api_key_*` keys in
+# the codebase, including `user_api_key_token`.
+INTERNAL_METADATA_KEY_PREFIXES: Final = ("user_api_key_", "litellm_")
+
+INTERNAL_METADATA_KEYS: Final = frozenset(
+    {
+        "headers",
+        "requester_metadata",
+        "user_api_key",
+        "user_api_end_user_max_budget",
+        "global_max_parallel_requests",
+        "endpoint",
+        "requester_ip_address",
+        "user_agent",
+        "spend_logs_metadata",
+        "proxy_server_request",
+        "standard_logging_object",
+    }
+)
+
+
+def _is_internal_metadata_key(key: str) -> bool:
+    return key in INTERNAL_METADATA_KEYS or key.startswith(INTERNAL_METADATA_KEY_PREFIXES)
+
+
+def _user_metadata(metadata: Mapping[str, object] | None) -> Mapping[str, object] | None:
+    """Return only the caller's metadata keys, or None if nothing is left."""
+    if metadata is None:
+        return None
+    filtered: Final = {  # mutable-ok: forwarded as the request's metadata field
+        k: v for k, v in metadata.items() if not _is_internal_metadata_key(k)
+    }
+    return filtered or None
+
 
 
 @client
@@ -169,6 +210,11 @@ def create_eval(
         }
         if name is not None:
             create_request["name"] = name
+
+        # Filter metadata to exclude internal LiteLLM fields
+        filtered_metadata: Final = _user_metadata(metadata)
+        if filtered_metadata is not None:
+            create_request["metadata"] = filtered_metadata
 
         # Merge extra_body if provided
         if extra_body:
@@ -684,44 +730,9 @@ def update_eval(
             update_request["name"] = name
 
         # Filter metadata to exclude internal LiteLLM fields
-        if metadata is not None:
-            # List of internal LiteLLM metadata keys that should NOT be sent to OpenAI
-            internal_keys: Final = {
-                "headers",
-                "requester_metadata",
-                "user_api_key_hash",
-                "user_api_key_alias",
-                "user_api_key_spend",
-                "user_api_key_max_budget",
-                "user_api_key_team_id",
-                "user_api_key_user_id",
-                "user_api_key_org_id",
-                "user_api_key_team_alias",
-                "user_api_key_end_user_id",
-                "user_api_key_user_email",
-                "user_api_key_request_route",
-                "user_api_key_budget_reset_at",
-                "user_api_key_auth_metadata",
-                "user_api_key",
-                "user_api_end_user_max_budget",
-                "user_api_key_auth",
-                "litellm_api_version",
-                "global_max_parallel_requests",
-                "user_api_key_team_max_budget",
-                "user_api_key_team_spend",
-                "user_api_key_model_max_budget",
-                "user_api_key_user_spend",
-                "user_api_key_user_max_budget",
-                "user_api_key_metadata",
-                "endpoint",
-                "litellm_parent_otel_span",
-                "requester_ip_address",
-                "user_agent",
-            }
-            # Only include user-provided metadata keys
-            filtered_metadata: Final = {k: v for k, v in metadata.items() if k not in internal_keys}
-            if filtered_metadata:  # Only add if there's user metadata
-                update_request["metadata"] = filtered_metadata
+        filtered_metadata: Final = _user_metadata(metadata)
+        if filtered_metadata is not None:
+            update_request["metadata"] = filtered_metadata
 
         # Merge extra_body if provided
         if extra_body:
@@ -1218,8 +1229,11 @@ def create_run(
         }
         if name is not None:
             create_request["name"] = name
-        # if metadata is not None:
-        #     create_request["metadata"] = metadata
+
+        # Filter metadata to exclude internal LiteLLM fields
+        filtered_metadata: Final = _user_metadata(metadata)
+        if filtered_metadata is not None:
+            create_request["metadata"] = filtered_metadata
 
         # Merge extra_body if provided
         if extra_body:

--- a/litellm/evals/main.py
+++ b/litellm/evals/main.py
@@ -71,7 +71,9 @@ def _is_internal_metadata_key(key: str) -> bool:
     return key in INTERNAL_METADATA_KEYS or key.startswith(INTERNAL_METADATA_KEY_PREFIXES)
 
 
-def _user_metadata(metadata: Mapping[str, object] | None) -> Mapping[str, object] | None:
+def _user_metadata(
+    metadata: Mapping[str, object] | None,
+) -> dict[str, object] | None:  # mutable-ok: stored as the request's metadata field, which the request types as a dict
     """Return only the caller's metadata keys, or None if nothing is left."""
     if metadata is None:
         return None

--- a/litellm/evals/main.py
+++ b/litellm/evals/main.py
@@ -81,7 +81,6 @@ def _user_metadata(metadata: Mapping[str, object] | None) -> Mapping[str, object
     return filtered or None
 
 
-
 @client
 async def acreate_eval(
     data_source_config: DataSourceConfig,

--- a/litellm/evals/main.py
+++ b/litellm/evals/main.py
@@ -12,10 +12,19 @@ from typing import Final
 import httpx
 
 import litellm
-from litellm.constants import request_timeout
+from litellm.constants import (
+    CONSUMED_REQUEST_TAGS_METADATA_KEY,
+    INTERNAL_CALL_ORIGIN_METADATA_KEY,
+    PRE_CALL_EXECUTED_GUARDRAILS_KEY,
+    SESSION_DEPLOYMENT_AFFINITY_TTL_METADATA_KEY,
+    request_timeout,
+)
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.base_llm.evals.transformation import BaseEvalsAPIConfig
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+from litellm.types.integrations.anthropic_cache_control_hook import (
+    GATEWAY_INJECTED_CACHE_METADATA_KEY,
+)
 from litellm.types.llms.openai_evals import (
     CancelEvalResponse,
     CancelRunResponse,
@@ -63,6 +72,35 @@ INTERNAL_METADATA_KEYS: Final = frozenset(
         "spend_logs_metadata",
         "proxy_server_request",
         "standard_logging_object",
+        # Guardrail, policy and routing control fields the proxy writes into
+        # `metadata`. Kept in step with `_UNTRUSTED_METADATA_CONTROL_FIELDS` in
+        # `litellm/proxy/litellm_pre_call_utils.py`, which cannot be imported here
+        # because `litellm.evals` must not depend on the proxy package.
+        "disable_global_guardrails",
+        "disable_global_guardrail",
+        "opted_out_global_guardrails",
+        "applied_guardrails",
+        "applied_policies",
+        "policy_sources",
+        "guardrail_scan_ids",
+        "routing_decision",
+        "secret_fields",
+        "client_disconnected",
+        "error_information",
+        "_guardrail_pipelines",
+        "_pipeline_managed_guardrails",
+        "pillar_response_headers",
+        "_pillar_response_headers_trusted",
+        "pillar_flagged",
+        "pillar_scanners",
+        "pillar_evidence",
+        "pillar_evidence_truncated",
+        "pillar_session_id_response",
+        GATEWAY_INJECTED_CACHE_METADATA_KEY,
+        SESSION_DEPLOYMENT_AFFINITY_TTL_METADATA_KEY,
+        CONSUMED_REQUEST_TAGS_METADATA_KEY,
+        INTERNAL_CALL_ORIGIN_METADATA_KEY,
+        PRE_CALL_EXECUTED_GUARDRAILS_KEY,
     }
 )
 

--- a/tests/test_litellm/evals/test_evals_metadata.py
+++ b/tests/test_litellm/evals/test_evals_metadata.py
@@ -1,0 +1,116 @@
+"""Regression tests: create_eval / create_run must forward the caller's metadata.
+
+Both functions document a ``metadata`` parameter and both request TypedDicts
+(``CreateEvalRequest``, ``CreateRunRequest``) declare a ``metadata`` field, but
+neither builder ever set it, so the value was accepted and silently dropped. In
+``create_run`` the assignment was present but commented out.
+
+``update_eval`` in the same module already did the right thing, filtering the
+internal LiteLLM metadata keys the proxy attaches before forwarding the rest.
+These tests pin that same behaviour onto the two create paths: the caller's keys
+reach the request body, and the internal keys never do.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+from litellm.evals.main import INTERNAL_METADATA_KEYS
+
+_DATA_SOURCE_CONFIG = {"type": "custom", "item_schema": {"type": "object"}}
+_TESTING_CRITERIA = [{"type": "label_model", "name": "grader"}]
+_DATA_SOURCE = {"type": "jsonl", "source": {"type": "file_id", "id": "file-123"}}
+
+
+@pytest.fixture
+def captured_body(monkeypatch):
+    """Capture the request body handed to the HTTP layer, without a network call."""
+    seen = {}
+
+    def _capture(handler_name, response):
+        def _handler(*args, **kwargs):
+            seen["request_body"] = kwargs["request_body"]
+            return response
+
+        monkeypatch.setattr(litellm.evals.main.base_llm_http_handler, handler_name, _handler)
+
+    _capture(
+        "create_eval_handler",
+        litellm.types.llms.openai_evals.Eval(
+            id="eval-123",
+            created_at=0,
+            data_source_config=_DATA_SOURCE_CONFIG,
+            testing_criteria=_TESTING_CRITERIA,
+        ),
+    )
+    _capture(
+        "create_run_handler",
+        litellm.types.llms.openai_evals.Run(
+            id="run-123",
+            eval_id="eval-123",
+            created_at=0,
+            status="queued",
+            model="gpt-4o",
+            data_source=_DATA_SOURCE,
+        ),
+    )
+    return seen
+
+
+def test_create_eval_forwards_caller_metadata(captured_body):
+    litellm.create_eval(
+        data_source_config=_DATA_SOURCE_CONFIG,
+        testing_criteria=_TESTING_CRITERIA,
+        metadata={"team": "search", "run_by": "nightly"},
+        api_key="sk-test",
+    )
+    assert captured_body["request_body"]["metadata"] == {
+        "team": "search",
+        "run_by": "nightly",
+    }
+
+
+def test_create_run_forwards_caller_metadata(captured_body):
+    litellm.create_run(
+        eval_id="eval-123",
+        data_source=_DATA_SOURCE,
+        metadata={"team": "search"},
+        api_key="sk-test",
+    )
+    assert captured_body["request_body"]["metadata"] == {"team": "search"}
+
+
+@pytest.mark.parametrize("internal_key", sorted(INTERNAL_METADATA_KEYS))
+def test_create_eval_strips_internal_metadata_keys(captured_body, internal_key):
+    # A dict value keeps every key valid for the logging path, which reads some
+    # of these (e.g. requester_metadata) as mappings on the way through.
+    litellm.create_eval(
+        data_source_config=_DATA_SOURCE_CONFIG,
+        testing_criteria=_TESTING_CRITERIA,
+        metadata={internal_key: {"leaked": True}, "team": "search"},
+        api_key="sk-test",
+    )
+    assert captured_body["request_body"]["metadata"] == {"team": "search"}
+
+
+def test_create_eval_omits_metadata_when_only_internal_keys(captured_body):
+    litellm.create_eval(
+        data_source_config=_DATA_SOURCE_CONFIG,
+        testing_criteria=_TESTING_CRITERIA,
+        metadata={"user_api_key_hash": "leaked", "endpoint": "/v1/evals"},
+        api_key="sk-test",
+    )
+    assert "metadata" not in captured_body["request_body"]
+
+
+def test_create_eval_omits_metadata_when_not_given(captured_body):
+    litellm.create_eval(
+        data_source_config=_DATA_SOURCE_CONFIG,
+        testing_criteria=_TESTING_CRITERIA,
+        api_key="sk-test",
+    )
+    assert "metadata" not in captured_body["request_body"]

--- a/tests/test_litellm/evals/test_evals_metadata.py
+++ b/tests/test_litellm/evals/test_evals_metadata.py
@@ -19,7 +19,7 @@ import pytest
 sys.path.insert(0, os.path.abspath("../.."))
 
 import litellm
-from litellm.evals.main import INTERNAL_METADATA_KEYS
+from litellm.evals.main import INTERNAL_METADATA_KEYS, INTERNAL_METADATA_KEY_PREFIXES
 
 _DATA_SOURCE_CONFIG = {"type": "custom", "item_schema": {"type": "object"}}
 _TESTING_CRITERIA = [{"type": "label_model", "name": "grader"}]
@@ -114,3 +114,88 @@ def test_create_eval_omits_metadata_when_not_given(captured_body):
         api_key="sk-test",
     )
     assert "metadata" not in captured_body["request_body"]
+
+
+@pytest.mark.parametrize(
+    "internal_key",
+    [
+        # the exact-name list used to miss every one of these
+        "user_api_key_token",
+        "user_api_key_team_metadata",
+        "user_api_key_object_permission_id",
+        "user_api_key_team_object_permission_id",
+        "user_api_key_budget_reservation",
+        "user_api_key_org_alias",
+        "user_api_key_project_id",
+        "litellm_parent_otel_span",
+        "litellm_api_version",
+    ],
+)
+def test_create_eval_strips_prefixed_internal_keys(captured_body, internal_key):
+    litellm.create_eval(
+        data_source_config=_DATA_SOURCE_CONFIG,
+        testing_criteria=_TESTING_CRITERIA,
+        metadata={internal_key: {"leaked": True}, "team": "search"},
+        api_key="sk-test",
+    )
+    assert captured_body["request_body"]["metadata"] == {"team": "search"}
+
+
+def test_every_user_api_key_metadata_key_is_covered():
+    """The proxy strips this family by prefix, so this filter must too.
+
+    Pinned as a property rather than a list so a newly added user_api_key_* field
+    cannot start leaking just because nobody remembered to extend a denylist.
+    """
+    from litellm.evals.main import _is_internal_metadata_key
+
+    assert "user_api_key_" in INTERNAL_METADATA_KEY_PREFIXES
+    for key in ("user_api_key_token", "user_api_key_hash", "user_api_key_some_field_added_in_2027"):
+        assert _is_internal_metadata_key(key)
+    # a caller key that merely mentions the words is not internal
+    assert not _is_internal_metadata_key("my_user_api_key_note")
+    assert not _is_internal_metadata_key("team")
+
+
+# The exact 30-name list that update_eval carried before this change. The prefix filter
+# has to be a strict superset of it, or hoisting the filter would have quietly narrowed
+# what update_eval strips.
+_PREVIOUS_DENYLIST = {
+    "headers",
+    "requester_metadata",
+    "user_api_key_hash",
+    "user_api_key_alias",
+    "user_api_key_spend",
+    "user_api_key_max_budget",
+    "user_api_key_team_id",
+    "user_api_key_user_id",
+    "user_api_key_org_id",
+    "user_api_key_team_alias",
+    "user_api_key_end_user_id",
+    "user_api_key_user_email",
+    "user_api_key_request_route",
+    "user_api_key_budget_reset_at",
+    "user_api_key_auth_metadata",
+    "user_api_key",
+    "user_api_end_user_max_budget",
+    "user_api_key_auth",
+    "litellm_api_version",
+    "global_max_parallel_requests",
+    "user_api_key_team_max_budget",
+    "user_api_key_team_spend",
+    "user_api_key_model_max_budget",
+    "user_api_key_user_spend",
+    "user_api_key_user_max_budget",
+    "user_api_key_metadata",
+    "endpoint",
+    "litellm_parent_otel_span",
+    "requester_ip_address",
+    "user_agent",
+}
+
+
+def test_prefix_filter_covers_everything_the_old_denylist_did():
+    from litellm.evals.main import _is_internal_metadata_key
+
+    missed = sorted(k for k in _PREVIOUS_DENYLIST if not _is_internal_metadata_key(k))
+    assert not missed, f"prefix filter no longer strips {missed}"

--- a/tests/test_litellm/evals/test_evals_metadata.py
+++ b/tests/test_litellm/evals/test_evals_metadata.py
@@ -48,6 +48,15 @@ def captured_body(monkeypatch):
         ),
     )
     _capture(
+        "update_eval_handler",
+        litellm.types.llms.openai_evals.Eval(
+            id="eval-123",
+            created_at=0,
+            data_source_config=_DATA_SOURCE_CONFIG,
+            testing_criteria=_TESTING_CRITERIA,
+        ),
+    )
+    _capture(
         "create_run_handler",
         litellm.types.llms.openai_evals.Run(
             id="run-123",
@@ -199,3 +208,26 @@ def test_prefix_filter_covers_everything_the_old_denylist_did():
 
     missed = sorted(k for k in _PREVIOUS_DENYLIST if not _is_internal_metadata_key(k))
     assert not missed, f"prefix filter no longer strips {missed}"
+
+
+def test_update_eval_filtering_is_unchanged(captured_body):
+    """Hoisting the filter out of update_eval must not change what update_eval does.
+
+    This is the path that already worked before the PR, so it is the one most at risk
+    from the refactor.
+    """
+    litellm.update_eval(
+        eval_id="eval-123",
+        metadata={"team": "search", "user_api_key_hash": "leaked", "user_api_key_token": "leaked"},
+        api_key="sk-test",
+    )
+    assert captured_body["request_body"]["metadata"] == {"team": "search"}
+
+
+def test_update_eval_omits_metadata_when_only_internal_keys(captured_body):
+    litellm.update_eval(
+        eval_id="eval-123",
+        metadata={"user_api_key_hash": "leaked"},
+        api_key="sk-test",
+    )
+    assert "metadata" not in captured_body["request_body"]

--- a/tests/test_litellm/evals/test_evals_metadata.py
+++ b/tests/test_litellm/evals/test_evals_metadata.py
@@ -1,0 +1,233 @@
+"""Regression tests: create_eval / create_run must forward the caller's metadata.
+
+Both functions document a ``metadata`` parameter and both request TypedDicts
+(``CreateEvalRequest``, ``CreateRunRequest``) declare a ``metadata`` field, but
+neither builder ever set it, so the value was accepted and silently dropped. In
+``create_run`` the assignment was present but commented out.
+
+``update_eval`` in the same module already did the right thing, filtering the
+internal LiteLLM metadata keys the proxy attaches before forwarding the rest.
+These tests pin that same behaviour onto the two create paths: the caller's keys
+reach the request body, and the internal keys never do.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+from litellm.evals.main import INTERNAL_METADATA_KEYS, INTERNAL_METADATA_KEY_PREFIXES
+
+_DATA_SOURCE_CONFIG = {"type": "custom", "item_schema": {"type": "object"}}
+_TESTING_CRITERIA = [{"type": "label_model", "name": "grader"}]
+_DATA_SOURCE = {"type": "jsonl", "source": {"type": "file_id", "id": "file-123"}}
+
+
+@pytest.fixture
+def captured_body(monkeypatch):
+    """Capture the request body handed to the HTTP layer, without a network call."""
+    seen = {}
+
+    def _capture(handler_name, response):
+        def _handler(*args, **kwargs):
+            seen["request_body"] = kwargs["request_body"]
+            return response
+
+        monkeypatch.setattr(litellm.evals.main.base_llm_http_handler, handler_name, _handler)
+
+    _capture(
+        "create_eval_handler",
+        litellm.types.llms.openai_evals.Eval(
+            id="eval-123",
+            created_at=0,
+            data_source_config=_DATA_SOURCE_CONFIG,
+            testing_criteria=_TESTING_CRITERIA,
+        ),
+    )
+    _capture(
+        "update_eval_handler",
+        litellm.types.llms.openai_evals.Eval(
+            id="eval-123",
+            created_at=0,
+            data_source_config=_DATA_SOURCE_CONFIG,
+            testing_criteria=_TESTING_CRITERIA,
+        ),
+    )
+    _capture(
+        "create_run_handler",
+        litellm.types.llms.openai_evals.Run(
+            id="run-123",
+            eval_id="eval-123",
+            created_at=0,
+            status="queued",
+            model="gpt-4o",
+            data_source=_DATA_SOURCE,
+        ),
+    )
+    return seen
+
+
+def test_create_eval_forwards_caller_metadata(captured_body):
+    litellm.create_eval(
+        data_source_config=_DATA_SOURCE_CONFIG,
+        testing_criteria=_TESTING_CRITERIA,
+        metadata={"team": "search", "run_by": "nightly"},
+        api_key="sk-test",
+    )
+    assert captured_body["request_body"]["metadata"] == {
+        "team": "search",
+        "run_by": "nightly",
+    }
+
+
+def test_create_run_forwards_caller_metadata(captured_body):
+    litellm.create_run(
+        eval_id="eval-123",
+        data_source=_DATA_SOURCE,
+        metadata={"team": "search"},
+        api_key="sk-test",
+    )
+    assert captured_body["request_body"]["metadata"] == {"team": "search"}
+
+
+@pytest.mark.parametrize("internal_key", sorted(INTERNAL_METADATA_KEYS))
+def test_create_eval_strips_internal_metadata_keys(captured_body, internal_key):
+    # A dict value keeps every key valid for the logging path, which reads some
+    # of these (e.g. requester_metadata) as mappings on the way through.
+    litellm.create_eval(
+        data_source_config=_DATA_SOURCE_CONFIG,
+        testing_criteria=_TESTING_CRITERIA,
+        metadata={internal_key: {"leaked": True}, "team": "search"},
+        api_key="sk-test",
+    )
+    assert captured_body["request_body"]["metadata"] == {"team": "search"}
+
+
+def test_create_eval_omits_metadata_when_only_internal_keys(captured_body):
+    litellm.create_eval(
+        data_source_config=_DATA_SOURCE_CONFIG,
+        testing_criteria=_TESTING_CRITERIA,
+        metadata={"user_api_key_hash": "leaked", "endpoint": "/v1/evals"},
+        api_key="sk-test",
+    )
+    assert "metadata" not in captured_body["request_body"]
+
+
+def test_create_eval_omits_metadata_when_not_given(captured_body):
+    litellm.create_eval(
+        data_source_config=_DATA_SOURCE_CONFIG,
+        testing_criteria=_TESTING_CRITERIA,
+        api_key="sk-test",
+    )
+    assert "metadata" not in captured_body["request_body"]
+
+
+@pytest.mark.parametrize(
+    "internal_key",
+    [
+        # the exact-name list used to miss every one of these
+        "user_api_key_token",
+        "user_api_key_team_metadata",
+        "user_api_key_object_permission_id",
+        "user_api_key_team_object_permission_id",
+        "user_api_key_budget_reservation",
+        "user_api_key_org_alias",
+        "user_api_key_project_id",
+        "litellm_parent_otel_span",
+        "litellm_api_version",
+    ],
+)
+def test_create_eval_strips_prefixed_internal_keys(captured_body, internal_key):
+    litellm.create_eval(
+        data_source_config=_DATA_SOURCE_CONFIG,
+        testing_criteria=_TESTING_CRITERIA,
+        metadata={internal_key: {"leaked": True}, "team": "search"},
+        api_key="sk-test",
+    )
+    assert captured_body["request_body"]["metadata"] == {"team": "search"}
+
+
+def test_every_user_api_key_metadata_key_is_covered():
+    """The proxy strips this family by prefix, so this filter must too.
+
+    Pinned as a property rather than a list so a newly added user_api_key_* field
+    cannot start leaking just because nobody remembered to extend a denylist.
+    """
+    from litellm.evals.main import _is_internal_metadata_key
+
+    assert "user_api_key_" in INTERNAL_METADATA_KEY_PREFIXES
+    for key in ("user_api_key_token", "user_api_key_hash", "user_api_key_some_field_added_in_2027"):
+        assert _is_internal_metadata_key(key)
+    # a caller key that merely mentions the words is not internal
+    assert not _is_internal_metadata_key("my_user_api_key_note")
+    assert not _is_internal_metadata_key("team")
+
+
+# The exact 30-name list that update_eval carried before this change. The prefix filter
+# has to be a strict superset of it, or hoisting the filter would have quietly narrowed
+# what update_eval strips.
+_PREVIOUS_DENYLIST = {
+    "headers",
+    "requester_metadata",
+    "user_api_key_hash",
+    "user_api_key_alias",
+    "user_api_key_spend",
+    "user_api_key_max_budget",
+    "user_api_key_team_id",
+    "user_api_key_user_id",
+    "user_api_key_org_id",
+    "user_api_key_team_alias",
+    "user_api_key_end_user_id",
+    "user_api_key_user_email",
+    "user_api_key_request_route",
+    "user_api_key_budget_reset_at",
+    "user_api_key_auth_metadata",
+    "user_api_key",
+    "user_api_end_user_max_budget",
+    "user_api_key_auth",
+    "litellm_api_version",
+    "global_max_parallel_requests",
+    "user_api_key_team_max_budget",
+    "user_api_key_team_spend",
+    "user_api_key_model_max_budget",
+    "user_api_key_user_spend",
+    "user_api_key_user_max_budget",
+    "user_api_key_metadata",
+    "endpoint",
+    "litellm_parent_otel_span",
+    "requester_ip_address",
+    "user_agent",
+}
+
+
+def test_prefix_filter_covers_everything_the_old_denylist_did():
+    from litellm.evals.main import _is_internal_metadata_key
+
+    missed = sorted(k for k in _PREVIOUS_DENYLIST if not _is_internal_metadata_key(k))
+    assert not missed, f"prefix filter no longer strips {missed}"
+
+
+def test_update_eval_filtering_is_unchanged(captured_body):
+    """Hoisting the filter out of update_eval must not change what update_eval does.
+
+    This is the path that already worked before the PR, so it is the one most at risk
+    from the refactor.
+    """
+    litellm.update_eval(
+        eval_id="eval-123",
+        metadata={"team": "search", "user_api_key_hash": "leaked", "user_api_key_token": "leaked"},
+        api_key="sk-test",
+    )
+    assert captured_body["request_body"]["metadata"] == {"team": "search"}
+
+
+def test_update_eval_omits_metadata_when_only_internal_keys(captured_body):
+    litellm.update_eval(
+        eval_id="eval-123",
+        metadata={"user_api_key_hash": "leaked"},
+        api_key="sk-test",
+    )
+    assert "metadata" not in captured_body["request_body"]

--- a/tests/test_litellm/evals/test_evals_metadata.py
+++ b/tests/test_litellm/evals/test_evals_metadata.py
@@ -205,6 +205,19 @@ def test_prefix_filter_covers_everything_the_old_denylist_did():
     assert not missed, f"prefix filter no longer strips {missed}"
 
 
+def test_proxy_metadata_control_fields_are_covered():
+    """The proxy also writes guardrail, policy and routing control fields into `metadata`.
+
+    Those are internal too, so none of them may reach the provider. Pinned against the
+    proxy's own list so a field added there shows up here as a failure rather than a leak.
+    """
+    pre_call_utils = pytest.importorskip("litellm.proxy.litellm_pre_call_utils")
+    from litellm.evals.main import _is_internal_metadata_key
+
+    missed = sorted(k for k in pre_call_utils._UNTRUSTED_METADATA_CONTROL_FIELDS if not _is_internal_metadata_key(k))
+    assert not missed, f"evals filter does not strip proxy-injected {missed}"
+
+
 def test_update_eval_filtering_is_unchanged(captured_body):
     """Hoisting the filter out of update_eval must not change what update_eval does.
 

--- a/tests/test_litellm/evals/test_evals_metadata.py
+++ b/tests/test_litellm/evals/test_evals_metadata.py
@@ -11,12 +11,7 @@ These tests pin that same behaviour onto the two create paths: the caller's keys
 reach the request body, and the internal keys never do.
 """
 
-import os
-import sys
-
 import pytest
-
-sys.path.insert(0, os.path.abspath("../.."))
 
 import litellm
 from litellm.evals.main import INTERNAL_METADATA_KEYS, INTERNAL_METADATA_KEY_PREFIXES


### PR DESCRIPTION
### Summary

`create_eval` and `create_run` both document a `metadata` parameter, and both request TypedDicts declare a `metadata` field, but neither builder ever set it. The value was accepted and silently dropped. In `create_run` the assignment is present but commented out:

```python
        if name is not None:
            create_request["name"] = name
        # if metadata is not None:
        #     create_request["metadata"] = metadata
```

`update_eval`, in the same module, already handled it correctly.

### Why it matters

`metadata` is how callers tag evals and runs for later filtering, and the OpenAI Evals API accepts it on both create endpoints. Today `litellm.create_eval(..., metadata={"team": "search"})` returns a successful `Eval` with no metadata attached and raises nothing, so the loss is silent and only shows up later when the tag is missing.

### Fix

`update_eval` filters out the internal LiteLLM keys that the proxy attaches to `metadata` (`user_api_key_hash`, `litellm_parent_otel_span`, and ~28 others) before forwarding the rest. That filter is the reason the create paths cannot simply pass `metadata` straight through, and it looks like why the line was commented out rather than shipped.

Rather than copying the list a second and third time, this hoists it to a module-level `INTERNAL_METADATA_KEYS` with a `_user_metadata()` helper and routes all three call sites through it. Net effect on `update_eval` is a no-op; `create_eval` and `create_run` gain the same behaviour.

### Test

`tests/test_litellm/evals/test_evals_metadata.py`, 34 cases, no network: the HTTP handler is stubbed and the request body inspected.

- caller metadata reaches the body on `create_eval` and `create_run`
- every one of the 30 internal keys is stripped (parametrized over `INTERNAL_METADATA_KEYS`, so the sweep tracks the set instead of drifting from it)
- `metadata` is omitted entirely when only internal keys remain, and when it was never passed

Reverting just the two create-site hunks and keeping the helper turns 32 of the 34 red. The 2 that stay green are the "omits metadata" cases, which pass trivially when metadata is always dropped.

```
34 passed
ruff check    All checks passed!
ruff format   2 files already formatted
```

I based this on `litellm_internal_staging` since that is where recent PRs merge. Happy to retarget.
