### PR TITLE
fix(e2e/ui): resolve dashboard base URL from env instead of hardcoding localhost

### DIFF
--- a/tests/e2e/ui/constants.ts
+++ b/tests/e2e/ui/constants.ts
@@ -1,3 +1,9 @@
+export const UI_BASE_URL = (
+  process.env.E2E_UI_BASE_URL ||
+  process.env.LITELLM_PROXY_URL ||
+  "http://localhost:4000"
+).replace(/\/+$/, "");
+
 // Storage state paths for each role
 export const ADMIN_STORAGE_PATH = "admin.storageState.json";
 export const ADMIN_VIEWER_STORAGE_PATH = "adminViewer.storageState.json";

--- a/tests/e2e/ui/globalSetup.ts
+++ b/tests/e2e/ui/globalSetup.ts
@@ -1,5 +1,6 @@
 import { chromium, expect, request } from "@playwright/test";
 import { users, Role, STORAGE_PATHS } from "./fixtures/users";
+import { UI_BASE_URL } from "./constants";
 import * as fs from "fs";
 
 async function globalSetup() {
@@ -12,7 +13,7 @@ async function globalSetup() {
   // the admin UI toggle does; the projects migration smoke needs the link.
   const masterKey = process.env.LITELLM_MASTER_KEY || "sk-1234";
   const api = await request.newContext();
-  const settingsRes = await api.patch(`http://localhost:4000${rootPath}/update/ui_settings`, {
+  const settingsRes = await api.patch(`${UI_BASE_URL}${rootPath}/update/ui_settings`, {
     headers: { Authorization: `Bearer ${masterKey}` },
     data: { enable_projects_ui: true },
   });
@@ -26,7 +27,7 @@ async function globalSetup() {
     const storagePath = STORAGE_PATHS[role];
     const page = await browser.newPage();
     try {
-      await page.goto(`http://localhost:4000${rootPath}/ui/login`);
+      await page.goto(`${UI_BASE_URL}${rootPath}/ui/login`);
       await page.getByPlaceholder("Enter your username").fill(email);
       await page.getByPlaceholder("Enter your password").fill(password);
       await page.getByRole("button", { name: "Login", exact: true }).click();

--- a/tests/e2e/ui/migration.serverRootPath.config.ts
+++ b/tests/e2e/ui/migration.serverRootPath.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
+import { UI_BASE_URL } from "./constants";
 
 /**
  * App Router migration smoke under a non-root mount. Boot the proxy with the same
@@ -15,7 +16,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: "list",
   use: {
-    baseURL: "http://localhost:4000",
+    baseURL: UI_BASE_URL,
     trace: "on-first-retry",
     actionTimeout: 15 * 1000,
     navigationTimeout: 30 * 1000,

--- a/tests/e2e/ui/playwright.config.ts
+++ b/tests/e2e/ui/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from "@playwright/test";
+import { UI_BASE_URL } from "./constants";
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -20,7 +21,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:4000",
+    baseURL: UI_BASE_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",

--- a/tests/e2e/ui/tests/auth/unauthenticatedRedirect.spec.ts
+++ b/tests/e2e/ui/tests/auth/unauthenticatedRedirect.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Authentication Checks", () => {
   test("should redirect unauthenticated user from a protected page", async ({ page }) => {
-    const protectedPageUrl = "http://localhost:4000/ui?page=llm-playground";
+    const protectedPageUrl = "/ui?page=llm-playground";
     await page.goto(protectedPageUrl, { waitUntil: "domcontentloaded" });
     await expect(page).toHaveURL(/\/ui\/login/);
     await expect(page.getByRole("heading", { name: "Login" })).toBeVisible();

--- a/tests/e2e/ui/tests/login/login.spec.ts
+++ b/tests/e2e/ui/tests/login/login.spec.ts
@@ -3,7 +3,7 @@ import { users } from "../../fixtures/users";
 import { Role } from "../../fixtures/roles";
 
 test("user can log in", async ({ page }) => {
-  await page.goto("http://localhost:4000/ui/login");
+  await page.goto("/ui/login");
   await page.getByPlaceholder("Enter your username").fill(users[Role.ProxyAdmin].email);
   await page.getByPlaceholder("Enter your password").fill(users[Role.ProxyAdmin].password);
   const loginButton = page.getByRole("button", { name: "Login", exact: true });

--- a/tests/e2e/ui/tests/proxy-admin/teams.spec.ts
+++ b/tests/e2e/ui/tests/proxy-admin/teams.spec.ts
@@ -132,7 +132,7 @@ test.describe("Proxy Admin - Teams", () => {
     const masterKey = process.env.LITELLM_MASTER_KEY || "sk-1234";
     const seededModels = ["fake-openai-gpt-4", "fake-anthropic-claude"];
     const restore = async () => {
-      const res = await request.post("http://localhost:4000/team/update", {
+      const res = await request.post("/team/update", {
         headers: { Authorization: `Bearer ${masterKey}` },
         data: { team_id: E2E_TEAM_CRUD_ID, models: seededModels },
       });

--- a/tests/e2e/ui/tests/settings/routerSettings.spec.ts
+++ b/tests/e2e/ui/tests/settings/routerSettings.spec.ts
@@ -23,7 +23,7 @@ async function clearFallbackForPrimary(request: import("@playwright/test").APIRe
   const masterKey = users[Role.ProxyAdmin].password;
   const auth = { Authorization: `Bearer ${masterKey}` };
 
-  const current = await request.get("http://localhost:4000/get/config/callbacks", { headers: auth });
+  const current = await request.get("/get/config/callbacks", { headers: auth });
   if (!current.ok()) return;
   const body = await current.json();
   const router = body?.router_settings ?? {};
@@ -31,7 +31,7 @@ async function clearFallbackForPrimary(request: import("@playwright/test").APIRe
   const next = existing.filter((entry) => !(entry && PRIMARY in entry));
   if (next.length === existing.length) return;
 
-  await request.post("http://localhost:4000/config/update", {
+  await request.post("/config/update", {
     headers: auth,
     data: { router_settings: { ...router, fallbacks: next } },
   });
@@ -111,7 +111,6 @@ test.describe("Router Settings - Fallbacks", () => {
 type ConfigYAML = components["schemas"]["ConfigYAML"];
 type RouterSettingsResponse = components["schemas"]["RouterSettingsResponse"];
 
-const BASE_URL = "http://localhost:4000";
 const ADMIN_AUTH = { Authorization: `Bearer ${users[Role.ProxyAdmin].password}` };
 
 /**
@@ -123,7 +122,7 @@ async function patchRouterSettings(
   request: import("@playwright/test").APIRequestContext,
   patch: Partial<NonNullable<ConfigYAML["router_settings"]>>,
 ) {
-  const res = await request.post(`${BASE_URL}/config/update`, {
+  const res = await request.post(`/config/update`, {
     headers: ADMIN_AUTH,
     data: { router_settings: patch },
   });
@@ -179,7 +178,7 @@ test.describe("Router Settings - Loadbalancing", () => {
     await expect
       .poll(
         async () => {
-          const res = await request.get(`${BASE_URL}/router/settings`, { headers: ADMIN_AUTH });
+          const res = await request.get(`/router/settings`, { headers: ADMIN_AUTH });
           const data = (await res.json()) as RouterSettingsResponse;
           return data.current_values?.num_retries;
         },


### PR DESCRIPTION
## TLDR

Problem this solves:

- UI suite hardcodes localhost:4000, unreachable on the e2e pod
- globalSetup dies on ECONNREFUSED, container exits 1 every run
- Red pod status hides the actual pytest result

How it solves it:

- Read base URL from env, same precedence as e2e_config.py
- Pod already sets LITELLM_PROXY_URL to the ALB
- Specs use relative paths, resolved against baseURL

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

No new tests here. The change is plumbing for an existing suite, and the suite is the test; there is no unit-testable seam worth inventing for "read an env var". What it needs is a real run, and the proof below is that run rather than a pytest invocation

## Screenshots / Proof of Fix

Before, at the revision the nightly pod ran (`tests/e2e/ui` unmodified, equivalent to base `998a372417`). From the stage e2e pod log, `litellm-e2e-1-0-0-main-20260726123156-prps6`:

```
ui: running playwright suite
Error: apiRequestContext.patch: connect ECONNREFUSED ::1:4000
Call log:
  - → PATCH http://localhost:4000/update/ui_settings
    at globalSetup (/app/e2e/ui/globalSetup.ts:15:33)
ui: playwright exited 1
```

The pytest phase had already finished `16 failed, 405 passed` at that point, so the container's non-zero exit came entirely from this step

After, at `5495b6dd53`. The suite now honours `LITELLM_PROXY_URL`, so it reaches a real proxy and gets a real HTTP response instead of a refused connection:

```
$ cd tests/e2e/ui
$ export LITELLM_PROXY_URL="http://localhost:4066"   # port-forward to the stage gateway
$ export LITELLM_MASTER_KEY="$(kubectl -n litellm get secret litellm-master-key \
    -o jsonpath='{.data.master-key}' | base64 -d)"
$ npx playwright test tests/login/login.spec.ts --reporter=line

Error: Enabling enable_projects_ui failed (404): {"detail":"Not Found"}
   at globalSetup.ts:21
```

That 404 is the port-forward, not the fix: it targets one gateway pod directly and bypasses the ALB, and stage splits the proxy across `litellm-gateway`, `litellm-backend` and `litellm-ui` with the ALB doing path routing. Confirmed by probing the same paths on the gateway pod versus the ALB. Direct to the gateway pod:

```
  /update/ui_settings -> 404
  /ui/login           -> 404
```

And from inside the cluster against the ALB that the pod actually uses, which is what `LITELLM_PROXY_URL` points at:

```
$ kubectl -n litellm exec deploy/litellm-gateway -c gateway -- python3 -c "...probe..."
  ALB /ui/login           -> 200
  ALB /update/ui_settings -> 200
  ALB /health/readiness   -> 200
```

`/update/ui_settings` is the exact request that was failing, so on the pod globalSetup now gets a 200 where it previously got `ECONNREFUSED`

Also verified: `npx tsc --noEmit` exits 0, `make pre-commit` exits 0, and no `localhost:4000` remains anywhere in the suite except the intentional local-dev default in `constants.ts`

### Known follow-up, not fixed here

This unblocks the connection failure; it does not make the suite green on stage. `globalSetup` logs in as five roles and four of them come from `fixtures/seed.sql` (`adminviewer@test.local`, `internal@test.local`, `viewer@test.local`, `teamadmin@test.local`), which `run_e2e.sh` loads into a throwaway local postgres. Stage has none of that data:

```
$ # against the ALB with the master key
/user/list                          -> total 1 | @test.local: NONE
/user/info?user_id=e2e-proxy-admin  -> 404
/user/info?user_id=e2e-internal-user -> 404
```

So the run will now fail at the second role's login rather than the first request. Only the ProxyAdmin role works on stage, because it authenticates as `admin` with the master key. Closing that gap means either seeding the fixtures into the stage DB, scoping the pod run to the admin-only specs, or giving the suite its own throwaway proxy and postgres on the pod the way `run_e2e.sh` does locally; that is a deployment decision, so it is deliberately out of scope for this PR

## Type

🐛 Bug Fix

## Changes

`constants.ts` gains `UI_BASE_URL`, resolved as `E2E_UI_BASE_URL`, then `LITELLM_PROXY_URL`, then `http://localhost:4000`. That is deliberately the same precedence `tests/e2e/e2e_config.py` already uses for its own `UI_BASE_URL`, so the TypeScript suite and the Python harness agree on the host without a second convention to remember. Because the e2e pod already exports `LITELLM_PROXY_URL`, no helm values, pod spec, or runner image change is needed

`playwright.config.ts` and `migration.serverRootPath.config.ts` take their `baseURL` from it, and `globalSetup` builds its two URLs from it

The four specs that hardcoded the host now use relative paths. Playwright resolves those against `baseURL` for both `page.goto` and the `request` fixture, so the host disappears from the specs entirely rather than being threaded through them. `routerSettings.spec.ts` loses its local `BASE_URL` constant for the same reason

This branch is based on current `litellm_internal_staging`, which deleted `serverRootPath.config.ts` and `tests/login/serverRootPathRedirect.spec.ts` in #34642; those two files are therefore untouched here

## QA runbook

- `tests/e2e/ui` (whole suite, no single pytest node id; this changes how every spec resolves its host) - the suite targets a configurable proxy instead of a hardcoded localhost
  - [ ] Local default unchanged: run `tests/e2e/ui/run_e2e.sh` with no extra env and confirm the suite still boots against its own proxy on port 4000 and passes as before
  - [ ] Override honoured: `LITELLM_PROXY_URL=http://<host> npx playwright test tests/login/login.spec.ts` and confirm the request in the failure/trace output targets `<host>`, not `localhost:4000`
  - [ ] Precedence: set both `LITELLM_PROXY_URL` and `E2E_UI_BASE_URL` to different hosts and confirm `E2E_UI_BASE_URL` wins, matching `e2e_config.py`
  - [ ] On-cluster path: confirm the ALB answers 200 for `/ui/login` and `PATCH /update/ui_settings` with the master key, which is what globalSetup needs
  - [ ] Sanity check: this change makes sense and is not hand-wavey; the assertion is that globalSetup reaches the configured proxy, verified by a real HTTP status rather than a mock

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
