### PR TITLE
feat: add FuturMix provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -80,6 +80,14 @@
     "base_url": "https://api.gmi-serving.com/v1",
     "api_key_env": "GMI_API_KEY"
   },
+  "futurmix": {
+    "base_url": "https://futurmix.ai/v1",
+    "api_key_env": "FUTURMIX_API_KEY",
+    "api_base_env": "FUTURMIX_API_BASE",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    }
+  },
   "sarvam": {
     "base_url": "https://api.sarvam.ai/v1",
     "api_key_env": "SARVAM_API_KEY",

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -1141,6 +1141,24 @@
         "interactions": true
       }
     },
+    "futurmix": {
+      "display_name": "FuturMix (`futurmix`)",
+      "url": "https://futurmix.ai",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": true,
+        "responses": true,
+        "embeddings": true,
+        "image_generations": true,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false,
+        "interactions": false
+      }
+    },
     "vertex_ai": {
       "display_name": "Google - Vertex AI (`vertex_ai`)",
       "url": "https://docs.litellm.ai/docs/providers/vertex",


### PR DESCRIPTION
Adds **FuturMix** (https://futurmix.ai) as an OpenAI-compatible provider.

## Changes
- `litellm/llms/openai_like/providers.json`: base_url `https://futurmix.ai/v1`, `FUTURMIX_API_KEY`, `FUTURMIX_API_BASE`, `max_completion_tokens`→`max_tokens` mapping
- `provider_endpoints_support.json`: endpoint support matrix (chat/completions, messages, responses, embeddings, image_generations)

FuturMix is a unified gateway exposing 25+ frontier models (Claude, GPT, Gemini, DeepSeek, Kimi) behind one OpenAI-compatible key. Config-only change following the existing `openai_like` provider pattern (mirrors `gmi`/`sarvam`).