### PR TITLE
fix(spend_tracking): store messages for all call types when enabled

### DIFF
--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -657,17 +657,23 @@ def _get_messages_for_spend_logs_payload(
     standard_logging_payload: Optional[StandardLoggingPayload],
     metadata: Optional[dict] = None,
 ) -> str:
-    if _should_store_prompts_and_responses_in_spend_logs():
-        if standard_logging_payload is not None:
-            call_type = standard_logging_payload.get("call_type", "")
-            if call_type == "_arealtime":
-                messages = standard_logging_payload.get("messages")
-                if messages is not None:
-                    try:
-                        return safe_dumps(messages)
-                    except Exception:
-                        return "{}"
-    return "{}"
+    """Return request messages for SpendLogs when prompt storage is enabled.
+
+    Historically only ``_arealtime`` rows filled ``LiteLLM_SpendLogs.messages``.
+    With ``store_prompts_in_spend_logs: true``, chat/completions and responses
+    must also persist the request messages (see issue #34747).
+    """
+    if not _should_store_prompts_and_responses_in_spend_logs():
+        return "{}"
+    if standard_logging_payload is None:
+        return "{}"
+    messages = standard_logging_payload.get("messages")
+    if messages is None:
+        return "{}"
+    try:
+        return safe_dumps(messages)
+    except Exception:
+        return "{}"
 
 
 _SENSITIVE_REQUEST_BODY_KEYS = frozenset({"secret_fields"})

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -544,10 +544,10 @@ def test_get_messages_for_spend_logs_realtime_empty_when_disabled(mock_should_st
 @patch(
     "litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs"
 )
-def test_get_messages_for_spend_logs_non_realtime_returns_empty(mock_should_store):
+def test_get_messages_for_spend_logs_acompletion_returns_messages(mock_should_store):
     """
-    Test that _get_messages_for_spend_logs_payload returns '{}' for non-realtime
-    calls even when store_prompts_in_spend_logs is True.
+    When store_prompts_in_spend_logs is True, chat/completions (and other
+    non-realtime) call types must persist messages into SpendLogs (#34747).
     """
     mock_should_store.return_value = True
     payload = cast(
@@ -558,7 +558,26 @@ def test_get_messages_for_spend_logs_non_realtime_returns_empty(mock_should_stor
         },
     )
     result = _get_messages_for_spend_logs_payload(payload)
-    assert result == "{}"
+    parsed = json.loads(result)
+    assert parsed == [{"role": "user", "content": "Hello"}]
+
+
+@patch(
+    "litellm.proxy.spend_tracking.spend_tracking_utils._should_store_prompts_and_responses_in_spend_logs"
+)
+def test_get_messages_for_spend_logs_aresponses_returns_messages(mock_should_store):
+    """Responses API spend rows should also store messages when the gate is on."""
+    mock_should_store.return_value = True
+    payload = cast(
+        StandardLoggingPayload,
+        {
+            "call_type": "aresponses",
+            "messages": [{"role": "user", "content": "test responses prompt log"}],
+        },
+    )
+    result = _get_messages_for_spend_logs_payload(payload)
+    parsed = json.loads(result)
+    assert parsed[0]["content"] == "test responses prompt log"
 
 
 @patch(


### PR DESCRIPTION
## Summary

Fixes #34747

With `general_settings.store_prompts_in_spend_logs: true`, spend log rows for `acompletion` / `aresponses` still persisted `LiteLLM_SpendLogs.messages` as `{}`.

Root cause: `_get_messages_for_spend_logs_payload` only returned messages when `call_type == "_arealtime"`.

## Change

When the store gate is on, dump `standard_logging_payload["messages"]` for **all** call types (still `{}` when disabled, missing, or dump fails). Response storage was already gated correctly.

## Test plan

- [x] Logic coverage: acompletion / aresponses / realtime messages stored when gate on
- [x] Gate off still returns `{}`
- [x] Null-byte stripping still works via `safe_dumps`
- [x] Unit tests updated in `tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py`