### PR TITLE
fix(proxy): avoid DB outage during planned RDS IAM rotation

### DIFF
--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -188,6 +188,8 @@ class PrismaWrapper:
     # Fallback refresh interval if token parsing fails (10 minutes)
     FALLBACK_REFRESH_INTERVAL_SECONDS = 600
 
+    ENGINE_RETIREMENT_DRAIN_TIMEOUT_SECONDS = 90
+
     def __init__(
         self,
         original_prisma: Any,
@@ -281,7 +283,18 @@ class PrismaWrapper:
 
     async def _retire_engine_when_drained(self, pid: int, tracker: _PrismaDrainTracker | None) -> None:
         if tracker is not None:
-            await tracker.wait_until_drained()
+            try:
+                await asyncio.wait_for(
+                    tracker.wait_until_drained(),
+                    timeout=self.ENGINE_RETIREMENT_DRAIN_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                verbose_proxy_logger.warning(
+                    "%sReplaced prisma engine PID %s did not drain within %ss; killing it with work still in flight.",
+                    self._log_prefix,
+                    pid,
+                    self.ENGINE_RETIREMENT_DRAIN_TIMEOUT_SECONDS,
+                )
         await self._kill_engine_process(pid)
 
     def _schedule_engine_retirement(self, pid: int, tracker: _PrismaDrainTracker | None) -> None:

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -88,6 +88,8 @@ class PrismaWrapper:
     # Fallback refresh interval if token parsing fails (10 minutes)
     FALLBACK_REFRESH_INTERVAL_SECONDS = 600
 
+    PLANNED_REPLACEMENT_DRAIN_SECONDS = 0.5
+
     def __init__(
         self,
         original_prisma: Any,
@@ -425,6 +427,38 @@ class PrismaWrapper:
 
         return True
 
+    async def _replace_prisma_client_for_token_refresh_locked(
+        self,
+        new_db_url: str,
+        http_client: Any | None = None,
+    ) -> None:
+        from prisma import Prisma
+
+        kwargs: dict[str, Any] = {}
+        if http_client is not None:
+            kwargs["http"] = http_client
+        if self._recreate_uses_datasource:
+            kwargs["datasource"] = {"url": new_db_url}
+
+        old_engine_pid = self._get_engine_pid()
+        replacement_prisma = Prisma(**kwargs)
+        await replacement_prisma.connect()
+
+        if old_engine_pid > 0:
+            if len(self._expected_engine_deaths) >= 64:
+                self._expected_engine_deaths.clear()
+            self._expected_engine_deaths.add(old_engine_pid)
+
+        self._original_prisma = replacement_prisma
+        self._engine_generation += 1
+
+        if self.on_engine_replaced is not None:
+            self.on_engine_replaced()
+
+        if old_engine_pid > 0:
+            await asyncio.sleep(self.PLANNED_REPLACEMENT_DRAIN_SECONDS)
+            await self._kill_engine_process(old_engine_pid)
+
     async def start_token_refresh_task(self) -> None:
         """
         Start the background token refresh task.
@@ -527,11 +561,17 @@ class PrismaWrapper:
                 )
                 return
 
+            previous_db_url = os.getenv(self._db_url_env_var)
             new_db_url = self.get_rds_iam_token()
             if new_db_url:
-                # We already hold `_reconnection_lock`; call the locked core
-                # directly (the public method would re-acquire and deadlock).
-                await self._recreate_prisma_client_locked(new_db_url)
+                try:
+                    await self._replace_prisma_client_for_token_refresh_locked(new_db_url)
+                except Exception:
+                    if previous_db_url is None:
+                        os.environ.pop(self._db_url_env_var, None)
+                    else:
+                        os.environ[self._db_url_env_var] = previous_db_url
+                    raise
                 self._last_refresh_time = datetime.utcnow()
                 verbose_proxy_logger.info(
                     "%sRDS IAM token refreshed successfully. New token valid for ~15 minutes.",

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -12,7 +12,7 @@ import urllib
 import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, Callable, Union
+from typing import Any, Callable, Protocol, Union
 
 from litellm._logging import verbose_proxy_logger
 from litellm.secret_managers.main import str_to_bool
@@ -38,6 +38,106 @@ class IAMEndpoint:
         if self.schema:
             url += f"?schema={self.schema}"
         return url
+
+
+class _PrismaProcess(Protocol):
+    pid: object
+
+
+class _PrismaEngine(Protocol):
+    @property
+    def process(self) -> _PrismaProcess: ...
+
+    async def query(self, content: str, *, tx_id: str | None) -> object: ...
+
+    async def start_transaction(self, *, content: str) -> str: ...
+
+    async def commit_transaction(self, tx_id: str) -> None: ...
+
+    async def rollback_transaction(self, tx_id: str) -> None: ...
+
+
+class _PrismaClient(Protocol):
+    _Prisma__engine: _PrismaEngine
+
+    @property
+    def _engine(self) -> _PrismaEngine: ...
+
+
+class _PrismaDrainTracker:
+    def __init__(self) -> None:
+        self._active_operations = 0
+        self._transactions: frozenset[str] = frozenset()
+        self._drained = asyncio.Event()
+        self._drained.set()
+
+    def begin_operation(self) -> None:
+        if self._active_operations == 0:
+            self._drained.clear()
+        self._active_operations += 1
+
+    def end_operation(self) -> None:
+        self._active_operations -= 1
+        if self._active_operations == 0:
+            self._drained.set()
+
+    def transaction_started(self, transaction_id: str) -> None:
+        self._transactions = self._transactions.union((transaction_id,))
+
+    def transaction_finished(self, transaction_id: str) -> None:
+        if transaction_id not in self._transactions:
+            return
+        self._transactions = self._transactions.difference((transaction_id,))
+        self.end_operation()
+
+    async def wait_until_drained(self) -> None:
+        await self._drained.wait()
+
+
+class _TrackedPrismaEngine:
+    def __init__(self, engine: _PrismaEngine, tracker: _PrismaDrainTracker) -> None:
+        self._engine = engine
+        self.tracker = tracker
+
+    @property
+    def process(self) -> _PrismaProcess:
+        return self._engine.process
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._engine, name)
+
+    async def query(self, content: str, *, tx_id: str | None) -> object:
+        self.tracker.begin_operation()
+        try:
+            return await self._engine.query(content, tx_id=tx_id)
+        finally:
+            self.tracker.end_operation()
+
+    async def start_transaction(self, *, content: str) -> str:
+        self.tracker.begin_operation()
+        try:
+            transaction_id = await self._engine.start_transaction(content=content)
+        except (Exception, asyncio.CancelledError):
+            self.tracker.end_operation()
+            raise
+        self.tracker.transaction_started(transaction_id)
+        return transaction_id
+
+    async def commit_transaction(self, tx_id: str) -> None:
+        self.tracker.begin_operation()
+        try:
+            await self._engine.commit_transaction(tx_id)
+        finally:
+            self.tracker.end_operation()
+            self.tracker.transaction_finished(tx_id)
+
+    async def rollback_transaction(self, tx_id: str) -> None:
+        self.tracker.begin_operation()
+        try:
+            await self._engine.rollback_transaction(tx_id)
+        finally:
+            self.tracker.end_operation()
+            self.tracker.transaction_finished(tx_id)
 
 
 def parse_iam_endpoint_from_url(url: str) -> IAMEndpoint:
@@ -88,8 +188,6 @@ class PrismaWrapper:
     # Fallback refresh interval if token parsing fails (10 minutes)
     FALLBACK_REFRESH_INTERVAL_SECONDS = 600
 
-    PLANNED_REPLACEMENT_DRAIN_SECONDS = 0.5
-
     def __init__(
         self,
         original_prisma: Any,
@@ -121,6 +219,8 @@ class PrismaWrapper:
         self._token_refresh_task: asyncio.Task | None = None
         self._reconnection_lock = asyncio.Lock()
         self._last_refresh_time: datetime | None = None
+        self._active_drain_tracker = self._instrument_prisma_client(original_prisma)
+        self._retirement_tasks: frozenset[asyncio.Task[None]] = frozenset()
 
         # Coordination for planned engine restarts (issue #29176). Every
         # `recreate_prisma_client` SIGTERMs the running query-engine on
@@ -138,7 +238,28 @@ class PrismaWrapper:
         self._engine_generation: int = 0
         self.on_engine_replaced: Callable[[], None] | None = None
 
-    def _get_engine_pid(self) -> int:
+    @staticmethod
+    def _read_engine(prisma_client: _PrismaClient) -> _PrismaEngine:
+        return prisma_client._engine
+
+    @staticmethod
+    def _write_engine(prisma_client: _PrismaClient, engine: _PrismaEngine) -> None:
+        prisma_client._Prisma__engine = engine
+
+    def _instrument_prisma_client(self, prisma_client: _PrismaClient) -> _PrismaDrainTracker | None:
+        from prisma.errors import ClientNotConnectedError
+
+        try:
+            engine = self._read_engine(prisma_client)
+        except (AttributeError, ClientNotConnectedError):
+            return None
+        if isinstance(engine, _TrackedPrismaEngine):
+            return engine.tracker
+        tracker = _PrismaDrainTracker()
+        self._write_engine(prisma_client, _TrackedPrismaEngine(engine, tracker))
+        return tracker
+
+    def _get_engine_pid(self, prisma_client: _PrismaClient | None = None) -> int:
         """Get the PID of the current Prisma engine subprocess, or 0 if unavailable.
 
         Must never raise: it runs inside the reconnect path, where the client
@@ -147,18 +268,38 @@ class PrismaWrapper:
         escaped here, ``recreate_prisma_client`` would fail before it could
         build a replacement client and the reconnect loop could never recover.
         """
+        from prisma.errors import ClientNotConnectedError
+
         try:
-            if self._original_prisma.is_connected() is not True:
-                return 0
-            engine = self._original_prisma._engine
-            process = getattr(engine, "process", None) if engine is not None else None
-            if process is not None:
-                pid = process.pid
-                if isinstance(pid, int):
-                    return pid
-        except (AttributeError, TypeError):
+            target_prisma = self._original_prisma if prisma_client is None else prisma_client
+            pid = self._read_engine(target_prisma).process.pid
+            if isinstance(pid, int):
+                return pid
+        except (AttributeError, ClientNotConnectedError, TypeError):
             pass
         return 0
+
+    async def _retire_engine_when_drained(self, pid: int, tracker: _PrismaDrainTracker | None) -> None:
+        if tracker is not None:
+            await tracker.wait_until_drained()
+        await self._kill_engine_process(pid)
+
+    def _schedule_engine_retirement(self, pid: int, tracker: _PrismaDrainTracker | None) -> None:
+        if pid <= 0:
+            return
+        retirement_task = asyncio.create_task(self._retire_engine_when_drained(pid, tracker))
+        self._retirement_tasks = self._retirement_tasks.union((retirement_task,))
+        retirement_task.add_done_callback(self._retirement_finished)
+
+    def _retirement_finished(self, retirement_task: asyncio.Task[None]) -> None:
+        self._retirement_tasks = self._retirement_tasks.difference((retirement_task,))
+
+    async def connect(self, timeout: int | timedelta | None = None) -> None:
+        if timeout is None:
+            await self._original_prisma.connect()
+        else:
+            await self._original_prisma.connect(timeout)
+        self._active_drain_tracker = self._instrument_prisma_client(self._original_prisma)
 
     @staticmethod
     async def _kill_engine_process(pid: int) -> None:
@@ -417,6 +558,7 @@ class PrismaWrapper:
         self._original_prisma = Prisma(**kwargs)
 
         await self._original_prisma.connect()
+        self._active_drain_tracker = self._instrument_prisma_client(self._original_prisma)
         self._engine_generation += 1
 
         # Let the owner (PrismaClient) re-arm its engine-death watcher on the
@@ -430,19 +572,27 @@ class PrismaWrapper:
     async def _replace_prisma_client_for_token_refresh_locked(
         self,
         new_db_url: str,
-        http_client: Any | None = None,
     ) -> None:
         from prisma import Prisma
+        from prisma.types import DatasourceOverride
 
-        kwargs: dict[str, Any] = {}
-        if http_client is not None:
-            kwargs["http"] = http_client
         if self._recreate_uses_datasource:
-            kwargs["datasource"] = {"url": new_db_url}
+            datasource = DatasourceOverride(url=new_db_url)
+            replacement_prisma = Prisma(datasource=datasource)
+        else:
+            replacement_prisma = Prisma()
 
-        old_engine_pid = self._get_engine_pid()
-        replacement_prisma = Prisma(**kwargs)
-        await replacement_prisma.connect()
+        old_prisma = self._original_prisma
+        old_engine_pid = self._get_engine_pid(old_prisma)
+        old_drain_tracker = self._active_drain_tracker
+        if old_drain_tracker is None:
+            old_drain_tracker = self._instrument_prisma_client(old_prisma)
+        try:
+            await replacement_prisma.connect()
+        except (Exception, asyncio.CancelledError):
+            self._schedule_engine_retirement(self._get_engine_pid(replacement_prisma), None)
+            raise
+        replacement_drain_tracker = self._instrument_prisma_client(replacement_prisma)
 
         if old_engine_pid > 0:
             if len(self._expected_engine_deaths) >= 64:
@@ -450,14 +600,13 @@ class PrismaWrapper:
             self._expected_engine_deaths.add(old_engine_pid)
 
         self._original_prisma = replacement_prisma
+        self._active_drain_tracker = replacement_drain_tracker
         self._engine_generation += 1
 
         if self.on_engine_replaced is not None:
             self.on_engine_replaced()
 
-        if old_engine_pid > 0:
-            await asyncio.sleep(self.PLANNED_REPLACEMENT_DRAIN_SECONDS)
-            await self._kill_engine_process(old_engine_pid)
+        self._schedule_engine_retirement(old_engine_pid, old_drain_tracker)
 
     async def start_token_refresh_task(self) -> None:
         """
@@ -566,7 +715,7 @@ class PrismaWrapper:
             if new_db_url:
                 try:
                     await self._replace_prisma_client_for_token_refresh_locked(new_db_url)
-                except Exception:
+                except (Exception, asyncio.CancelledError):
                     if previous_db_url is None:
                         os.environ.pop(self._db_url_env_var, None)
                     else:

--- a/tests/test_litellm/proxy/conftest.py
+++ b/tests/test_litellm/proxy/conftest.py
@@ -13,6 +13,7 @@ from typing import Dict, Optional
 import pytest
 import yaml
 from fastapi.testclient import TestClient
+from prisma.errors import ClientNotConnectedError
 
 _PROXY_MODULE_GLOBALS_TO_ISOLATE = (
     "master_key",
@@ -20,7 +21,7 @@ _PROXY_MODULE_GLOBALS_TO_ISOLATE = (
 )
 
 
-class StubClientNotConnectedError(Exception):
+class StubClientNotConnectedError(ClientNotConnectedError):
     pass
 
 
@@ -33,10 +34,7 @@ class DisconnectedPrisma:
 
     @property
     def _engine(self) -> None:
-        raise StubClientNotConnectedError(
-            "Client is not connected to the query engine, you must call `connect()` "
-            "before attempting to query data."
-        )
+        raise StubClientNotConnectedError()
 
 
 @pytest.fixture

--- a/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
+++ b/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
@@ -24,6 +24,7 @@ from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+from prisma import Prisma as GeneratedPrisma
 
 sys.path.insert(
     0, os.path.abspath("../../../..")
@@ -41,12 +42,11 @@ def mock_prisma_binary():
 
 
 def _make_wrapper(engine_pid: int = 111, iam: bool = False) -> PrismaWrapper:
-    mock_prisma = MagicMock()
-    mock_prisma.connect = AsyncMock()
-    mock_prisma.is_connected = MagicMock(return_value=True)
-    mock_prisma._engine = MagicMock()
-    mock_prisma._engine.process.pid = engine_pid
-    return PrismaWrapper(original_prisma=mock_prisma, iam_token_db_auth=iam)
+    prisma = GeneratedPrisma(use_dotenv=False)
+    engine = MagicMock()
+    engine.process.pid = engine_pid
+    setattr(prisma, "_Prisma__engine", engine)
+    return PrismaWrapper(original_prisma=prisma, iam_token_db_auth=iam)
 
 
 def _token_db_url(created: datetime, expires_in: int = 900) -> str:
@@ -57,6 +57,21 @@ def _token_db_url(created: datetime, expires_in: int = 900) -> str:
     )
     quoted = urllib.parse.quote(token, safe="")
     return f"postgresql://user:{quoted}@host:5432/db"
+
+
+def test_wrapper_instruments_generated_prisma_engine() -> None:
+    prisma = GeneratedPrisma(use_dotenv=False)
+    engine = MagicMock()
+    setattr(prisma, "_Prisma__engine", engine)
+
+    wrapper = PrismaWrapper(original_prisma=prisma, iam_token_db_auth=False)
+
+    assert wrapper._active_drain_tracker is not None
+    assert prisma._engine._engine is engine
+
+
+async def _wait_for_retirements(wrapper: PrismaWrapper) -> None:
+    await asyncio.gather(*tuple(wrapper._retirement_tasks))
 
 
 @pytest.mark.asyncio
@@ -237,6 +252,7 @@ async def test_safe_refresh_token_refreshes_when_token_expired(
         patch("asyncio.sleep", new_callable=AsyncMock),
     ):
         await wrapper._safe_refresh_token()
+        await _wait_for_retirements(wrapper)
 
     pinned = {
         "token_minted": wrapper.get_rds_iam_token.call_count,
@@ -274,6 +290,7 @@ async def test_safe_refresh_connects_replacement_before_swapping_and_killing(
         patch("asyncio.sleep", new_callable=AsyncMock),
     ):
         await wrapper._safe_refresh_token()
+        await _wait_for_retirements(wrapper)
 
     assert wrapper._original_prisma is replacement_prisma
     mock_kill.assert_any_call(111, signal.SIGTERM)
@@ -309,6 +326,122 @@ async def test_safe_refresh_failure_keeps_old_client_and_token(
 
 
 @pytest.mark.asyncio
+async def test_safe_refresh_waits_for_active_query_before_retiring_old_engine(
+    mock_prisma_binary, monkeypatch
+):
+    wrapper = _make_wrapper(engine_pid=111, iam=True)
+    old_engine = wrapper._original_prisma._engine
+    query_started = asyncio.Event()
+    release_query = asyncio.Event()
+
+    async def run_query(content: str, *, tx_id: object | None) -> dict[str, str]:
+        query_started.set()
+        await release_query.wait()
+        return {"status": "complete"}
+
+    old_engine._engine.query = AsyncMock(side_effect=run_query)
+    query_task = asyncio.create_task(old_engine.query("query", tx_id=None))
+    await query_started.wait()
+
+    expired = datetime.utcnow() - timedelta(seconds=1200)
+    monkeypatch.setenv("DATABASE_URL", _token_db_url(created=expired, expires_in=900))
+    wrapper.get_rds_iam_token = MagicMock(return_value="postgresql://fresh")
+    replacement_prisma = MagicMock(connect=AsyncMock())
+    replacement_prisma._engine = MagicMock()
+    replacement_prisma._engine.process.pid = 222
+    mock_prisma_binary.Prisma.return_value = replacement_prisma
+
+    with (
+        patch("os.kill") as mock_kill,
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await wrapper._safe_refresh_token()
+        assert mock_kill.call_count == 0
+        assert not query_task.done()
+        release_query.set()
+        await query_task
+        await _wait_for_retirements(wrapper)
+
+    mock_kill.assert_any_call(111, signal.SIGTERM)
+
+
+@pytest.mark.asyncio
+async def test_safe_refresh_waits_for_open_transaction_before_retiring_old_engine(
+    mock_prisma_binary, monkeypatch
+):
+    wrapper = _make_wrapper(engine_pid=111, iam=True)
+    old_engine = wrapper._original_prisma._engine
+    old_engine._engine.start_transaction = AsyncMock(return_value="transaction-1")
+    old_engine._engine.commit_transaction = AsyncMock()
+    transaction_id = await old_engine.start_transaction(content="transaction")
+
+    expired = datetime.utcnow() - timedelta(seconds=1200)
+    monkeypatch.setenv("DATABASE_URL", _token_db_url(created=expired, expires_in=900))
+    wrapper.get_rds_iam_token = MagicMock(return_value="postgresql://fresh")
+    replacement_prisma = MagicMock(connect=AsyncMock())
+    replacement_prisma._engine = MagicMock()
+    replacement_prisma._engine.process.pid = 222
+    mock_prisma_binary.Prisma.return_value = replacement_prisma
+
+    with (
+        patch("os.kill") as mock_kill,
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await wrapper._safe_refresh_token()
+        assert mock_kill.call_count == 0
+        await old_engine.commit_transaction(transaction_id)
+        await _wait_for_retirements(wrapper)
+
+    mock_kill.assert_any_call(111, signal.SIGTERM)
+
+
+@pytest.mark.asyncio
+async def test_safe_refresh_cancellation_restores_token_and_cleans_replacement(
+    mock_prisma_binary, monkeypatch
+):
+    wrapper = _make_wrapper(engine_pid=111, iam=True)
+    old_prisma = wrapper._original_prisma
+    expired = datetime.utcnow() - timedelta(seconds=1200)
+    previous_db_url = _token_db_url(created=expired, expires_in=900)
+    monkeypatch.setenv("DATABASE_URL", previous_db_url)
+    connect_started = asyncio.Event()
+    block_connect = asyncio.Event()
+
+    def mint_token() -> str:
+        monkeypatch.setenv("DATABASE_URL", "postgresql://fresh")
+        return "postgresql://fresh"
+
+    async def connect_replacement() -> None:
+        connect_started.set()
+        await block_connect.wait()
+
+    wrapper.get_rds_iam_token = MagicMock(side_effect=mint_token)
+    replacement_prisma = MagicMock(connect=AsyncMock(side_effect=connect_replacement))
+    replacement_prisma._engine = MagicMock()
+    replacement_prisma._engine.process.pid = 222
+    mock_prisma_binary.Prisma.return_value = replacement_prisma
+
+    with (
+        patch("os.kill") as mock_kill,
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        refresh_task = asyncio.create_task(wrapper._safe_refresh_token())
+        await connect_started.wait()
+        refresh_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await refresh_task
+        await _wait_for_retirements(wrapper)
+
+    assert wrapper._original_prisma is old_prisma
+    assert os.environ["DATABASE_URL"] == previous_db_url
+    assert wrapper._engine_generation == 0
+    assert mock_kill.call_args_list == [
+        call(222, signal.SIGTERM),
+        call(222, signal.SIGKILL),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_repeated_safe_refreshes_retire_each_replaced_engine(
     mock_prisma_binary, monkeypatch
 ):
@@ -331,6 +464,7 @@ async def test_repeated_safe_refreshes_retire_each_replaced_engine(
         for _ in range(2):
             monkeypatch.setenv("DATABASE_URL", _token_db_url(created=expired, expires_in=900))
             await wrapper._safe_refresh_token()
+        await _wait_for_retirements(wrapper)
 
     assert mock_kill.call_args_list == [
         call(111, signal.SIGTERM),
@@ -358,6 +492,7 @@ async def test_safe_refresh_token_refreshes_when_token_unparseable(
         patch("asyncio.sleep", new_callable=AsyncMock),
     ):
         await wrapper._safe_refresh_token()
+        await _wait_for_retirements(wrapper)
 
     assert wrapper.get_rds_iam_token.call_count == 1
 

--- a/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
+++ b/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
@@ -396,6 +396,36 @@ async def test_safe_refresh_waits_for_open_transaction_before_retiring_old_engin
 
 
 @pytest.mark.asyncio
+async def test_retirement_kills_old_engine_when_drain_never_completes(
+    mock_prisma_binary, monkeypatch
+):
+    """A leaked drain count (e.g. a transaction whose owner was hard-cancelled
+    before commit/rollback) must not keep the replaced engine alive forever."""
+    wrapper = _make_wrapper(engine_pid=111, iam=True)
+    monkeypatch.setattr(wrapper, "ENGINE_RETIREMENT_DRAIN_TIMEOUT_SECONDS", 0.05)
+    old_engine = wrapper._original_prisma._engine
+    old_engine._engine.start_transaction = AsyncMock(return_value="transaction-1")
+    await old_engine.start_transaction(content="transaction")
+
+    expired = datetime.utcnow() - timedelta(seconds=1200)
+    monkeypatch.setenv("DATABASE_URL", _token_db_url(created=expired, expires_in=900))
+    wrapper.get_rds_iam_token = MagicMock(return_value="postgresql://fresh")
+    replacement_prisma = MagicMock(connect=AsyncMock())
+    replacement_prisma._engine = MagicMock()
+    replacement_prisma._engine.process.pid = 222
+    mock_prisma_binary.Prisma.return_value = replacement_prisma
+
+    with (
+        patch("os.kill") as mock_kill,
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await wrapper._safe_refresh_token()
+        await asyncio.wait_for(_wait_for_retirements(wrapper), timeout=2)
+
+    mock_kill.assert_any_call(111, signal.SIGTERM)
+
+
+@pytest.mark.asyncio
 async def test_safe_refresh_cancellation_restores_token_and_cleans_replacement(
     mock_prisma_binary, monkeypatch
 ):

--- a/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
+++ b/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
@@ -17,10 +17,11 @@ Symbols pinned here:
 
 import asyncio
 import os
+import signal
 import sys
 import urllib.parse
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -242,6 +243,103 @@ async def test_safe_refresh_token_refreshes_when_token_expired(
         "prisma_constructed": mock_prisma_binary.Prisma.call_count,
     }
     assert pinned == {"token_minted": 1, "prisma_constructed": 1}
+
+
+@pytest.mark.asyncio
+async def test_safe_refresh_connects_replacement_before_swapping_and_killing(
+    mock_prisma_binary, monkeypatch
+):
+    wrapper = _make_wrapper(engine_pid=111, iam=True)
+    old_prisma = wrapper._original_prisma
+    expired = datetime.utcnow() - timedelta(seconds=1200)
+    monkeypatch.setenv("DATABASE_URL", _token_db_url(created=expired, expires_in=900))
+    wrapper.get_rds_iam_token = MagicMock(return_value="postgresql://fresh")
+    replacement_prisma = MagicMock()
+
+    async def connect_replacement() -> None:
+        assert wrapper._original_prisma is old_prisma
+        assert mock_kill.call_count == 0
+
+    replacement_prisma.connect = AsyncMock(side_effect=connect_replacement)
+    replacement_prisma.is_connected = MagicMock(return_value=True)
+    replacement_prisma._engine = MagicMock()
+    replacement_prisma._engine.process.pid = 222
+    mock_prisma_binary.Prisma.return_value = replacement_prisma
+
+    def observe_kill(pid: int, sent_signal: int) -> None:
+        assert wrapper._original_prisma is replacement_prisma
+
+    with (
+        patch("os.kill", side_effect=observe_kill) as mock_kill,
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        await wrapper._safe_refresh_token()
+
+    assert wrapper._original_prisma is replacement_prisma
+    mock_kill.assert_any_call(111, signal.SIGTERM)
+    assert wrapper._engine_generation == 1
+
+
+@pytest.mark.asyncio
+async def test_safe_refresh_failure_keeps_old_client_and_token(
+    mock_prisma_binary, monkeypatch
+):
+    wrapper = _make_wrapper(engine_pid=111, iam=True)
+    old_prisma = wrapper._original_prisma
+    expired = datetime.utcnow() - timedelta(seconds=1200)
+    previous_db_url = _token_db_url(created=expired, expires_in=900)
+    monkeypatch.setenv("DATABASE_URL", previous_db_url)
+
+    def mint_token() -> str:
+        monkeypatch.setenv("DATABASE_URL", "postgresql://fresh")
+        return "postgresql://fresh"
+
+    wrapper.get_rds_iam_token = MagicMock(side_effect=mint_token)
+    replacement_prisma = MagicMock(connect=AsyncMock(side_effect=RuntimeError("database unavailable")))
+    mock_prisma_binary.Prisma.return_value = replacement_prisma
+
+    with patch("os.kill") as mock_kill:
+        with pytest.raises(RuntimeError, match="database unavailable"):
+            await wrapper._safe_refresh_token()
+
+    assert wrapper._original_prisma is old_prisma
+    assert os.environ["DATABASE_URL"] == previous_db_url
+    assert wrapper._engine_generation == 0
+    mock_kill.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_repeated_safe_refreshes_retire_each_replaced_engine(
+    mock_prisma_binary, monkeypatch
+):
+    wrapper = _make_wrapper(engine_pid=111, iam=True)
+    replacement_clients = []
+    for engine_pid in (222, 333):
+        replacement_prisma = MagicMock(connect=AsyncMock())
+        replacement_prisma.is_connected = MagicMock(return_value=True)
+        replacement_prisma._engine = MagicMock()
+        replacement_prisma._engine.process.pid = engine_pid
+        replacement_clients.append(replacement_prisma)
+    mock_prisma_binary.Prisma.side_effect = replacement_clients
+    wrapper.get_rds_iam_token = MagicMock(side_effect=("postgresql://first", "postgresql://second"))
+    expired = datetime.utcnow() - timedelta(seconds=1200)
+
+    with (
+        patch("os.kill") as mock_kill,
+        patch("asyncio.sleep", new_callable=AsyncMock),
+    ):
+        for _ in range(2):
+            monkeypatch.setenv("DATABASE_URL", _token_db_url(created=expired, expires_in=900))
+            await wrapper._safe_refresh_token()
+
+    assert mock_kill.call_args_list == [
+        call(111, signal.SIGTERM),
+        call(111, signal.SIGKILL),
+        call(222, signal.SIGTERM),
+        call(222, signal.SIGKILL),
+    ]
+    assert wrapper._original_prisma is replacement_clients[-1]
+    assert wrapper._engine_generation == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- IAM rotation terminated engines with active database work
- Cancellation could leave token and client state inconsistent

How it solves it:
- keep the old prisma engine pid active and serving traffic
- generate a new token / add db credential
- Drain active queries and transactions before engine retirement
- start prisma engine with that token 
- Roll back pre-swap cancellation and clean replacements
- confirm the new engine can connect
- then route db calls to new engine


## Relevant issues

Follow-up to #29176

Prior incident: https://docs.litellm.ai/blog/prisma-reconnect-blocking-incident

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Live IAM-enabled RDS validation is pending. This PR remains a draft until continuous database operations pass across at least three forced token rotations

## Type

Bug Fix

Test

## Changes

Planned IAM refresh connects and instruments a replacement Prisma client while the current client keeps serving. The swap occurs only after connect succeeds

The replaced engine is retired by a retained background task after its active queries and interactive transactions drain, or after a 90 second drain deadline so a leaked drain count (for example a transaction whose owner was cancelled before commit or rollback) cannot keep the old engine's connection pool alive indefinitely. Cold recovery keeps its existing kill-first ordering because that path starts from an unhealthy engine

Cancellation before the swap restores the previous database URL, keeps the current client active, and schedules any partially started replacement engine for cleanup. There is no cancellation point between successful connect and the client swap

Regression coverage exercises generated Prisma instrumentation, long-running queries, open transactions, replacement failure, refresh cancellation, replacement cleanup, and repeated retirement. The focused database suites cover 74 tests at `2e1c1a47d2`

## RCA

Notion RCA: https://app.notion.com/p/3aa43b8acdab8175bb5cf40a87cda81c

The latest completed Rust run reported 346 passed, 75 failed, and 28 skipped. Database-backed operations failed together around planned Prisma SIGTERM events with `All connection attempts failed`

Grafana showed the failure every 720 seconds, matching the 15-minute RDS IAM token lifetime minus the 3-minute refresh buffer. Liveness and readiness stayed healthy, and there was no corresponding memory or CPU pressure. A newly rolled gateway reproduced the issue at its first rotation, ruling out long gateway uptime as the cause

The proactive IAM refresh path reused the cold Prisma recovery primitive. That primitive intentionally terminates the current engine before constructing its replacement to avoid prisma-client-py's event-loop-blocking `disconnect()` behavior. The ordering is correct for an already broken engine but creates an availability gap when the engine is healthy and the restart is planned

The prior incident fix preserved gateway liveness by replacing blocking shutdown with direct process signals. This follow-up addresses database continuity by separating planned warm rotation from unplanned cold recovery

The test gap was continuous database traffic across a token boundary. Existing verification covered liveness, eventual reconnect, and refresh coordination but did not assert that active queries and transactions finish on the replaced engine

Grafana evidence: https://berriai.grafana.net/d/mu5lrjt?from=1785113400000&to=1785121800000

## Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

