### PR TITLE
fix(install): pass an explicit Python version request to uv tool install

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -95,9 +95,10 @@ if [ -z "$UV_BIN" ] || [ "${CURRENT_UV_VERSION:-}" != "$UV_VERSION" ]; then
 fi
 
 # ── install ────────────────────────────────────────────────────────────────
-# --python-preference system: reuse a compatible system Python when present,
-# otherwise download a managed one. Either way uv honours litellm's requires-python,
-# so a too-old (3.9) or too-new (3.14+) system Python is skipped, not forced.
+# --python mirrors requires-python in pyproject.toml (keep in sync): uv selects the
+# interpreter before resolving, so an unconstrained request accepts a too-old system
+# Python (stock macOS ships 3.9) and fails resolution instead of downloading a
+# managed one. --python-preference system still reuses a compatible system Python.
 echo ""
 if [ -n "${LITELLM_CLI_REF:-}" ]; then
   header "Installing litellm[cli] from ${LITELLM_CLI_REF}…"
@@ -106,8 +107,8 @@ else
 fi
 echo ""
 
-"$UV_BIN" tool install --python-preference system --force "${LITELLM_PACKAGE}" \
-  || die "uv tool install failed. Try manually: $UV_BIN tool install '${LITELLM_PACKAGE}'"
+"$UV_BIN" tool install --python '>=3.10,<3.15' --python-preference system --force "${LITELLM_PACKAGE}" \
+  || die "uv tool install failed. Try manually: $UV_BIN tool install --python '>=3.10,<3.15' '${LITELLM_PACKAGE}'"
 
 # ── find the lite binary installed by uv tool ──────────────────────────────
 SCRIPTS_DIR="$("$UV_BIN" tool dir --bin)"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -100,11 +100,12 @@ else
 fi
 echo ""
 
-# --python-preference system: reuse a compatible system Python when present,
-# otherwise download a managed one. Either way uv honours litellm's requires-python,
-# so a too-old (3.9) or too-new (3.14+) system Python is skipped, not forced.
-"$UV_BIN" tool install --python-preference system --force "${LITELLM_PACKAGE}" \
-  || die "uv tool install failed. Try manually: $UV_BIN tool install '${LITELLM_PACKAGE}'"
+# --python mirrors requires-python in pyproject.toml (keep in sync): uv selects the
+# interpreter before resolving, so an unconstrained request accepts a too-old system
+# Python (stock macOS ships 3.9) and fails resolution instead of downloading a
+# managed one. --python-preference system still reuses a compatible system Python.
+"$UV_BIN" tool install --python '>=3.10,<3.15' --python-preference system --force "${LITELLM_PACKAGE}" \
+  || die "uv tool install failed. Try manually: $UV_BIN tool install --python '>=3.10,<3.15' '${LITELLM_PACKAGE}'"
 
 # ── find the litellm binary installed by uv tool ───────────────────────────
 SCRIPTS_DIR="$("$UV_BIN" tool dir --bin)"


### PR DESCRIPTION
## TLDR

Problem this solves:

- CLI installer fails on stock macOS (system Python 3.9)
- Default PyPI path silently installs stale litellm 1.83.9 instead

How it solves it:

- uv tool install now requests Python >=3.10,<3.15 explicitly
- Compatible system Pythons still reused; managed one downloaded otherwise

## Relevant issues

- `uv tool install` picks an interpreter before resolving, so with no `--python` request stock macOS Python 3.9.6 satisfies the unconstrained request and resolution then fails against litellm's `requires-python = ">=3.10, <3.15"` instead of downloading a managed Python
- Reported by a user running the CLI installer on a stock Mac; the manual fallback command printed by the error message reproduced the same failure, so it now carries the flag too
- The same invocation exists in both `scripts/install-cli.sh` and `scripts/install.sh`; both are fixed identically

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
  - 73 of 74 checks pass; the only red is osv-scan, which currently fails on every branch (gitpython and brace-expansion lockfile CVEs that predate this PR and are untouched by it)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

All runs simulate a stock Mac: fresh `HOME`, `PATH=/usr/bin:/bin:/usr/sbin:/sbin` so the only interpreter uv can discover is `/usr/bin/python3` (3.9.6), and `LITELLM_CLI_REF=litellm_internal_staging`

Before, at commit 24123269cc (staging head, unfixed):

```
$ env -i HOME="$(mktemp -d)" PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
    LITELLM_CLI_REF=litellm_internal_staging sh scripts/install-cli.sh
  Installing litellm[cli] from litellm_internal_staging…
    Updated https://github.com/BerriAI/litellm.git (24123269ccb76f36298a2457589f08bd3141072c)
  × No solution found when resolving dependencies:
  ╰─▶ Because only litellm[cli]==1.95.0 is available and the current Python
      version (3.9.6) does not satisfy Python>=3.10,<3.15, we can conclude
      that all versions of litellm[cli] cannot be used.
      And because you require litellm[cli], we can conclude that your
      requirements are unsatisfiable.
  Error: uv tool install failed. Try manually: .../uv tool install 'litellm[cli] @ git+https://github.com/BerriAI/litellm.git@litellm_internal_staging'
```

`scripts/install.sh` fails identically with `litellm[proxy]`

After, at commit b0899923f8 (fixed), same environment:

```
$ env -i HOME="$(mktemp -d)" PATH="/usr/bin:/bin:/usr/sbin:/sbin" \
    LITELLM_CLI_REF=litellm_internal_staging sh scripts/install-cli.sh
  Installing litellm[cli] from litellm_internal_staging…
Downloading cpython-3.14.3-macos-aarch64-none (download) (17.3MiB)
Installed 3 executables: lite, litellm, litellm-proxy
  ✔ LiteLLM CLI installed
  Version: 1.95.0
$ echo $?
0
```

System Python reuse still works at b0899923f8 (same run with `/opt/homebrew/bin` prepended to `PATH`): no cpython download happens, `~/.local/share/uv/python` is never created, and the tool venv's `pyvenv.cfg` shows `home = /opt/homebrew/opt/python@3.14/bin` with `version_info = 3.14.5`

`scripts/install.sh` in the stock environment at b0899923f8 downloads cpython-3.14.3 the same way and reaches `✔ LiteLLM installed` with `Installed 3 executables: lite, litellm, litellm-proxy` (that run then stops at the script's pre-existing interactive `--setup` prompt, which needs a real terminal and is unrelated to this change)

## Type

🐛 Bug Fix

## Changes

- Add `--python '>=3.10,<3.15'` to the `uv tool install` invocation in `scripts/install-cli.sh` and `scripts/install.sh`
- Add the same flag to the manual fallback command in each `die` message, which previously suggested a command that reproduced the failure
- Rewrite the comment that claimed uv honours `requires-python` on its own; uv selects the interpreter before resolving, so it does not

The range duplicates `requires-python` from `pyproject.toml` because a curl-to-sh bootstrap has nothing on disk to read it from; the comment marks it keep-in-sync. Without the explicit request, the default PyPI path fails worse than the git path: uv quietly resolves the newest release whose metadata admits Python 3.9, which today installs litellm 1.83.9 instead of 1.93.0

There is no test harness for `scripts/*.sh` and CI does not execute these scripts, so the proof above is live installer runs rather than unit tests

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to bootstrap shell installers and error-message hints; no proxy, auth, or application runtime code is touched.
> 
> **Overview**
> **Fixes curl-to-sh installs on hosts where the only discoverable Python is too old (e.g. stock macOS 3.9)** by passing `--python '>=3.10,<3.15'` to `uv tool install` in `scripts/install-cli.sh` and `scripts/install.sh`, matching `requires-python` in `pyproject.toml`.
> 
> Without that flag, uv picks an interpreter before dependency resolution, so 3.9 can be selected and install fails—or on the default PyPI path, an older litellm that still allows 3.9 can be installed. **`--python-preference system` is unchanged**, so a compatible system Python is still reused when available.
> 
> Comments are updated to document the behavior, and the manual retry text in each `die` message includes the same `--python` flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0899923f87664ff22e707d5a97316ecc8e03b37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->