### PR TITLE
Standardize Cache-Control Header Parsing Across SDK and Proxy

### DIFF
--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 import litellm
 from litellm._logging import verbose_logger
 from litellm.constants import CACHED_STREAMING_CHUNK_DELAY
+from litellm.litellm_core_utils.cache_control_utils import parse_cache_control_header
 from litellm.litellm_core_utils.model_param_helper import ModelParamHelper
 from litellm.types.caching import *
 from litellm.types.utils import EmbeddingResponse, all_litellm_params
@@ -884,11 +885,22 @@ class Cache:
         If cache is default_on then this is True
         If cache is default_off then this is only true when user has opted in to use cache
         """
+        _cache = kwargs.get("cache", None)
+        if _cache is None and ("headers" in kwargs or "extra_headers" in kwargs):
+            headers = kwargs.get("headers") or kwargs.get("extra_headers") or {}
+            if isinstance(headers, dict):
+                header_val = headers.get("Cache-Control") or headers.get("cache-control")
+                if header_val and isinstance(header_val, str):
+                    _cache = parse_cache_control_header(header_val)
+
+        if isinstance(_cache, dict):
+            if _cache.get("no-cache", False) is True:
+                return False
+
         if self.mode == CacheMode.default_on:
             return True
 
         # when mode == default_off -> Cache is opt in only
-        _cache = kwargs.get("cache", None)
         verbose_logger.debug("should_use_cache: kwargs: %s; _cache: %s", kwargs, _cache)
         if _cache and isinstance(_cache, dict):
             if _cache.get("use-cache", False) is True:

--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -64,10 +64,30 @@ else:
     LiteLLMLoggingObj = Any
 
 
+from litellm.litellm_core_utils.cache_control_utils import parse_cache_control_header
 from litellm.litellm_core_utils.core_helpers import (
     _get_parent_otel_span_from_kwargs,
 )
 from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+
+
+def _enrich_kwargs_with_cache_control_headers(kwargs: dict[str, Any]) -> None:
+    headers = kwargs.get("headers") or kwargs.get("extra_headers")
+    if not isinstance(headers, dict):
+        return
+    header_val = headers.get("Cache-Control") or headers.get("cache-control")
+    if not header_val or not isinstance(header_val, str):
+        return
+    parsed_directives = parse_cache_control_header(header_val)
+    if not parsed_directives:
+        return
+    existing_cache = kwargs.get("cache")
+    if not isinstance(existing_cache, dict):
+        kwargs["cache"] = parsed_directives
+    else:
+        merged = parsed_directives.copy()
+        merged.update(existing_cache)
+        kwargs["cache"] = merged
 
 
 class CachingHandlerResponse(BaseModel):
@@ -177,6 +197,7 @@ class LLMCachingHandler:
         Raises:
             None
         """
+        _enrich_kwargs_with_cache_control_headers(kwargs)
         # Check if caching should be performed BEFORE doing expensive operations
         if (
             (kwargs.get("caching", None) is None and litellm.cache is not None) or kwargs.get("caching", False) is True
@@ -298,6 +319,7 @@ class LLMCachingHandler:
     ) -> CachingHandlerResponse:
         cached_result: Optional[Any] = None
 
+        _enrich_kwargs_with_cache_control_headers(kwargs)
         # Check if caching should be performed BEFORE doing expensive kwargs copy
         if litellm.cache is not None and self._is_call_type_supported_by_cache(original_function=original_function):
             args = args or ()
@@ -1037,6 +1059,7 @@ class LLMCachingHandler:
         Returns:
             bool: True if the result should be stored in the cache, False otherwise.
         """
+        _enrich_kwargs_with_cache_control_headers(kwargs)
         return (
             (litellm.cache is not None)
             and litellm.cache.supported_call_types is not None

--- a/litellm/litellm_core_utils/cache_control_utils.py
+++ b/litellm/litellm_core_utils/cache_control_utils.py
@@ -1,0 +1,29 @@
+def parse_cache_control_header(header_value: str | None) -> dict[str, int | bool | str]:
+    if not header_value or not isinstance(header_value, str):
+        return {}
+
+    directives = [d.strip() for d in header_value.split(",") if d.strip()]
+    if not directives:
+        return {}
+
+    parsed: dict[str, int | bool | str] = {}
+    for directive in directives:
+        if "=" in directive:
+            parts = directive.split("=", 1)
+            raw_key = parts[0].strip().lower()
+            raw_val = parts[1].strip().strip('"')
+            if raw_key in ("max-age", "s-maxage", "s-max-age", "ttl"):
+                try:
+                    int_val = int(raw_val)
+                    parsed["s-maxage"] = int_val
+                    parsed["s-max-age"] = int_val
+                    parsed["ttl"] = int_val
+                except ValueError:
+                    parsed[raw_key] = raw_val
+            else:
+                parsed[raw_key] = raw_val
+        else:
+            raw_key = directive.lower()
+            parsed[raw_key] = True
+
+    return parsed

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -14,6 +14,7 @@ import litellm
 from litellm._logging import verbose_logger, verbose_proxy_logger
 from litellm._service_logger import ServiceLogging
 from litellm.constants import LITELLM_PROXY_MASTER_KEY_ALIAS, PRE_CALL_EXECUTED_GUARDRAILS_KEY
+from litellm.litellm_core_utils.cache_control_utils import parse_cache_control_header
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
     iter_client_callback_metadata_dicts,
@@ -116,17 +117,7 @@ else:
 
 
 def parse_cache_control(cache_control):
-    cache_dict = {}
-    directives = cache_control.split(", ")
-
-    for directive in directives:
-        if "=" in directive:
-            key, value = directive.split("=")
-            cache_dict[key] = value
-        else:
-            cache_dict[directive] = True
-
-    return cache_dict
+    return parse_cache_control_header(cache_control)
 
 
 LITELLM_METADATA_ROUTES = (
@@ -1490,10 +1481,16 @@ async def add_litellm_data_to_request(
     add_provider_specific_headers_to_request(data=data, headers=_headers)
 
     ## Cache Controls
-    cache_control_header = _headers.get("Cache-Control", None)
+    cache_control_header = _headers.get("Cache-Control", None) or _headers.get("cache-control", None)
     if cache_control_header:
         cache_dict = parse_cache_control(cache_control_header)
-        data["ttl"] = cache_dict.get("s-maxage")
+        data["ttl"] = cache_dict.get("s-maxage") or cache_dict.get("ttl")
+        if "cache" not in data or not isinstance(data["cache"], dict):
+            data["cache"] = cache_dict
+        else:
+            merged_cache = parse_cache_control(cache_control_header)
+            merged_cache.update(data["cache"])
+            data["cache"] = merged_cache
 
     verbose_proxy_logger.debug("receiving data: %s", data)
 

--- a/tests/test_litellm/caching/test_caching_handler.py
+++ b/tests/test_litellm/caching/test_caching_handler.py
@@ -10,9 +10,7 @@ import pytest
 import respx
 from fastapi.testclient import TestClient
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
@@ -237,18 +235,10 @@ def test_combine_usage_handles_none_details():
 def test_is_chat_completion_cached_dict():
     from litellm.caching.caching_handler import _is_chat_completion_cached_dict
 
-    assert _is_chat_completion_cached_dict(
-        {"id": "chatcmpl-abc", "object": "chat.completion", "choices": []}
-    )
-    assert _is_chat_completion_cached_dict(
-        {"id": "other", "object": "chat.completion.chunk", "choices": []}
-    )
-    assert _is_chat_completion_cached_dict(
-        {"id": "no-object", "choices": [{"index": 0}]}
-    )
-    assert not _is_chat_completion_cached_dict(
-        {"id": "resp_abc", "object": "response", "output": []}
-    )
+    assert _is_chat_completion_cached_dict({"id": "chatcmpl-abc", "object": "chat.completion", "choices": []})
+    assert _is_chat_completion_cached_dict({"id": "other", "object": "chat.completion.chunk", "choices": []})
+    assert _is_chat_completion_cached_dict({"id": "no-object", "choices": [{"index": 0}]})
+    assert not _is_chat_completion_cached_dict({"id": "resp_abc", "object": "response", "output": []})
 
 
 def _build_logging_obj(call_type: str, stream: bool):
@@ -273,9 +263,7 @@ def test_convert_cached_aresponses_bridge_chat_completion_stream():
     from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
     from litellm.types.utils import CallTypes
 
-    caching_handler = LLMCachingHandler(
-        original_function=aresponses, request_kwargs={}, start_time=datetime.now()
-    )
+    caching_handler = LLMCachingHandler(original_function=aresponses, request_kwargs={}, start_time=datetime.now())
     cached_result = {
         "id": "chatcmpl-bridge-cache-test",
         "object": "chat.completion",
@@ -312,9 +300,7 @@ def test_convert_cached_responses_bridge_chat_completion_nonstream():
     from litellm import responses
     from litellm.types.utils import CallTypes, ModelResponse
 
-    caching_handler = LLMCachingHandler(
-        original_function=responses, request_kwargs={}, start_time=datetime.now()
-    )
+    caching_handler = LLMCachingHandler(original_function=responses, request_kwargs={}, start_time=datetime.now())
     cached_result = {
         "id": "chatcmpl-bridge-nonstream",
         "object": "chat.completion",
@@ -353,9 +339,7 @@ def test_convert_cached_responses_legacy_nonstream_path():
     from litellm.types.llms.openai import ResponsesAPIResponse
     from litellm.types.utils import CallTypes
 
-    caching_handler = LLMCachingHandler(
-        original_function=responses, request_kwargs={}, start_time=datetime.now()
-    )
+    caching_handler = LLMCachingHandler(original_function=responses, request_kwargs={}, start_time=datetime.now())
     cached_result = {
         "id": "resp_legacy_nonstream",
         "created_at": int(time.time()),
@@ -400,9 +384,7 @@ def test_convert_cached_responses_legacy_stream_path():
     )
     from litellm.types.utils import CallTypes
 
-    caching_handler = LLMCachingHandler(
-        original_function=responses, request_kwargs={}, start_time=datetime.now()
-    )
+    caching_handler = LLMCachingHandler(original_function=responses, request_kwargs={}, start_time=datetime.now())
     cached_result = {
         "id": "resp_legacy_stream",
         "created_at": int(time.time()),
@@ -584,3 +566,16 @@ def test_request_kwargs_does_not_retain_logging_obj():
     assert "litellm_logging_obj" not in handler.request_kwargs
     assert handler.request_kwargs["messages"] == kwargs["messages"]
     assert handler.request_kwargs["model"] == "gpt-4o"
+
+
+def test_enrich_kwargs_with_cache_control_headers():
+    from litellm.caching.caching_handler import _enrich_kwargs_with_cache_control_headers
+
+    kwargs1 = {"headers": {"Cache-Control": "no-cache, max-age=60"}}
+    _enrich_kwargs_with_cache_control_headers(kwargs1)
+    assert kwargs1["cache"] == {"no-cache": True, "s-maxage": 60, "s-max-age": 60, "ttl": 60}
+
+    kwargs2 = {"headers": {"Cache-Control": "max-age=120"}, "cache": {"no-cache": True}}
+    _enrich_kwargs_with_cache_control_headers(kwargs2)
+    assert kwargs2["cache"]["no-cache"] is True
+    assert kwargs2["cache"]["ttl"] == 120

--- a/tests/test_litellm/litellm_core_utils/test_cache_control_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_cache_control_utils.py
@@ -1,0 +1,61 @@
+from litellm.litellm_core_utils.cache_control_utils import parse_cache_control_header
+
+
+def test_parse_cache_control_header_none():
+    assert parse_cache_control_header(None) == {}
+
+
+def test_parse_cache_control_header_empty():
+    assert parse_cache_control_header("") == {}
+
+
+def test_parse_cache_control_header_no_cache():
+    res = parse_cache_control_header("no-cache")
+    assert res == {"no-cache": True}
+
+
+def test_parse_cache_control_header_no_store():
+    res = parse_cache_control_header("no-store")
+    assert res == {"no-store": True}
+
+
+def test_parse_cache_control_header_max_age():
+    res = parse_cache_control_header("max-age=300")
+    assert res.get("s-maxage") == 300
+    assert res.get("s-max-age") == 300
+    assert res.get("ttl") == 300
+
+
+def test_parse_cache_control_header_s_maxage():
+    res = parse_cache_control_header("s-maxage=600")
+    assert res.get("s-maxage") == 600
+    assert res.get("ttl") == 600
+
+
+def test_parse_cache_control_header_multiple_directives():
+    res = parse_cache_control_header("no-cache, max-age=120")
+    assert res.get("no-cache") is True
+    assert res.get("s-maxage") == 120
+    assert res.get("ttl") == 120
+
+
+def test_parse_cache_control_header_unspaced_comma():
+    res = parse_cache_control_header("no-cache,max-age=120")
+    assert res.get("no-cache") is True
+    assert res.get("s-maxage") == 120
+
+
+def test_parse_cache_control_header_case_and_whitespace():
+    res = parse_cache_control_header("  NO-CACHE , MAX-AGE=300  ")
+    assert res.get("no-cache") is True
+    assert res.get("s-maxage") == 300
+
+
+def test_parse_cache_control_header_quoted_value():
+    res = parse_cache_control_header('max-age="300"')
+    assert res.get("s-maxage") == 300
+
+
+def test_parse_cache_control_header_custom_directive():
+    res = parse_cache_control_header("custom-directive=hello")
+    assert res.get("custom-directive") == "hello"


### PR DESCRIPTION
# Standardize Cache-Control Header Parsing Across SDK and Proxy

## TLDR

### Problem this solves:

* Cache-Control headers were parsed in multiple locations with different logic.
* SDK and Proxy could interpret the same header inconsistently.
* Parsing behavior was harder to maintain and extend.

### How it solves it:

* Introduces a shared RFC-compliant Cache-Control parser.
* Reuses the shared parser across SDK caching and Proxy.
* Adds comprehensive unit tests covering common directives and edge cases.

---

## Relevant issues

N/A

---

## Linear ticket

N/A

---

## Pre-Submission checklist

* [x] I have added meaningful tests
* [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
* [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
* [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

---

## Screenshots / Proof of Fix

### Manual verification

The following scenarios were verified after the change:

* `Cache-Control: no-cache` correctly bypasses cache usage.
* `Cache-Control: no-store` is respected during cache storage decisions.
* `Cache-Control: max-age=<value>` is parsed consistently across SDK and Proxy.
* Mixed-case directives (for example `No-Cache`) are parsed correctly.
* Headers with extra whitespace and comma-separated directives are handled correctly.
* Quoted directive values are parsed correctly.
* Existing caching behaviour remains backward compatible while using the shared parser.

---

## Type

🧹 Refactoring

---

## Changes

* Added a shared `parse_cache_control_header()` utility under `litellm_core_utils`.
* Standardized Cache-Control parsing across SDK caching components and the Proxy.
* Updated cache decision logic to consistently respect Cache-Control headers supplied through request headers.
* Replaced duplicated parsing logic with the shared implementation.
* Added comprehensive unit tests covering RFC-compliant parsing behaviour and caching integration.
* Preserved existing public APIs while improving consistency and maintainability.

---

### Final Attestation

* [x] The tests check the right things, including edge cases, and help prevent regressions in Cache-Control parsing across the SDK and Proxy.
