### PR TITLE
fix: handle dict response in Responses API streaming and logging

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -494,7 +494,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         accumulated_tool_calls: List[Dict[str, Any]] = []
         tool_call_index = 0
 
-        for item in output_items:
+        for item in (output_items or []):
             if isinstance(item, ResponseReasoningItem):
                 pending_reasoning_item = _build_reasoning_item(
                     item_id=item.id,
@@ -1323,7 +1323,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
 
             # Extract reasoning items with encrypted_content for round-tripping
             completed_reasoning_items: Optional[List[Dict[str, Any]]] = None
-            for item in output_items:
+            for item in (output_items or []):
                 if not isinstance(item, dict) or item.get("type") != "reasoning":
                     continue
                 if completed_reasoning_items is None:

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -494,7 +494,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
         accumulated_tool_calls: List[Dict[str, Any]] = []
         tool_call_index = 0
 
-        for item in (output_items or []):
+        for item in output_items or []:
             if isinstance(item, ResponseReasoningItem):
                 pending_reasoning_item = _build_reasoning_item(
                     item_id=item.id,
@@ -1313,7 +1313,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
             # Check if response contains function_call items in output
             # to determine correct finish_reason
             response_data = parsed_chunk.get("response", {})
-            output_items = response_data.get("output", []) if response_data else []
+            output_items = response_data.get("output") or [] if response_data else []
 
             has_function_calls = any(
                 item.get("type") == "function_call" for item in output_items if isinstance(item, dict)
@@ -1323,7 +1323,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
 
             # Extract reasoning items with encrypted_content for round-tripping
             completed_reasoning_items: Optional[List[Dict[str, Any]]] = None
-            for item in (output_items or []):
+            for item in output_items or []:
                 if not isinstance(item, dict) or item.get("type") != "reasoning":
                     continue
                 if completed_reasoning_items is None:

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3225,7 +3225,7 @@ class Logging(LiteLLMLoggingBaseClass):
         ):
             ## return unified Usage object
             if isinstance(result.response, dict):
-                return result.response
+                return None
             if isinstance(result.response.usage, ResponseAPIUsage):
                 transformed_usage = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
                     result.response.usage

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3212,7 +3212,7 @@ class Logging(LiteLLMLoggingBaseClass):
         end_time: datetime.datetime,
         is_async: bool,
         streaming_chunks: List[Any],
-    ) -> Optional[Union[ModelResponse, TextCompletionResponse, ResponsesAPIResponse]]:
+    ) -> Optional[Union[ModelResponse, TextCompletionResponse, ResponsesAPIResponse, dict]]:
         if self.stream is not True:
             return None
         if isinstance(result, ModelResponse):

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3224,6 +3224,8 @@ class Logging(LiteLLMLoggingBaseClass):
             (ResponseCompletedEvent, ResponseIncompleteEvent, ResponseFailedEvent),
         ):
             ## return unified Usage object
+            if isinstance(result.response, dict):
+                return result.response
             if isinstance(result.response.usage, ResponseAPIUsage):
                 transformed_usage = ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(
                     result.response.usage

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3212,7 +3212,7 @@ class Logging(LiteLLMLoggingBaseClass):
         end_time: datetime.datetime,
         is_async: bool,
         streaming_chunks: List[Any],
-    ) -> Optional[Union[ModelResponse, TextCompletionResponse, ResponsesAPIResponse, dict]]:
+    ) -> Optional[Union[ModelResponse, TextCompletionResponse, ResponsesAPIResponse]]:
         if self.stream is not True:
             return None
         if isinstance(result, ModelResponse):

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2283,6 +2283,8 @@ class Router:
             completed,
             (ResponseCompletedEvent, ResponseFailedEvent, ResponseIncompleteEvent),
         ):
+            if isinstance(completed.response, dict):
+                return completed.response.get("usage", None)
             return completed.response.usage
         return None
 

--- a/tests/router_unit_tests/test_router_aresponses_streaming_fallback.py
+++ b/tests/router_unit_tests/test_router_aresponses_streaming_fallback.py
@@ -49,9 +49,7 @@ def _make_router() -> Router:
     )
 
 
-def _make_completed_event(
-    input_tokens: int, output_tokens: int, total_tokens: int
-) -> ResponseCompletedEvent:
+def _make_completed_event(input_tokens: int, output_tokens: int, total_tokens: int) -> ResponseCompletedEvent:
     response = ResponsesAPIResponse.model_construct(
         usage=ResponseAPIUsage(
             input_tokens=input_tokens,
@@ -149,9 +147,7 @@ def test_combine_responses_fallback_usage_passthrough_for_unknown_event():
 
 
 def test_build_responses_continuation_input_from_string():
-    out = Router._build_responses_continuation_input(
-        "Hello world", "partial assistant text"
-    )
+    out = Router._build_responses_continuation_input("Hello world", "partial assistant text")
     assert len(out) == 3
     assert out[0]["role"] == "user"
     assert out[0]["content"][0]["text"] == "Hello world"
@@ -231,9 +227,7 @@ async def test_aresponses_streaming_iterator_passthrough():
     router = _make_router()
     source = _FakeSource()
 
-    wrapper = await router._aresponses_streaming_iterator(
-        source, initial_kwargs={"model": "primary"}
-    )
+    wrapper = await router._aresponses_streaming_iterator(source, initial_kwargs={"model": "primary"})
     assert isinstance(wrapper, BaseResponsesAPIStreamingIterator)
 
     collected = [ev async for ev in wrapper]
@@ -280,15 +274,18 @@ async def test_aresponses_with_streaming_fallbacks_wraps_streaming_iterator():
     async def fake_original(**_kwargs):
         return streaming_iter
 
-    with patch.object(
-        router,
-        "_ageneric_api_call_with_fallbacks",
-        new=AsyncMock(return_value=streaming_iter),
-    ), patch.object(
-        router,
-        "_aresponses_streaming_iterator",
-        new=AsyncMock(return_value=wrapped),
-    ) as mock_wrap:
+    with (
+        patch.object(
+            router,
+            "_ageneric_api_call_with_fallbacks",
+            new=AsyncMock(return_value=streaming_iter),
+        ),
+        patch.object(
+            router,
+            "_aresponses_streaming_iterator",
+            new=AsyncMock(return_value=wrapped),
+        ) as mock_wrap,
+    ):
         out = await router._aresponses_with_streaming_fallbacks(
             original_function=fake_original,
             model="primary",

--- a/tests/router_unit_tests/test_router_aresponses_streaming_fallback.py
+++ b/tests/router_unit_tests/test_router_aresponses_streaming_fallback.py
@@ -90,6 +90,36 @@ def test_extract_partial_responses_usage_no_completed_response():
     assert usage is None
 
 
+def test_extract_partial_responses_usage_dict_response():
+    """Regression #34754: some upstream providers return a plain dict
+    instead of a Pydantic ResponsesAPIResponse. The guard should extract
+    usage from the dict via .get() instead of accessing .usage as an
+    attribute."""
+    dict_usage = ResponseAPIUsage(input_tokens=5, output_tokens=3, total_tokens=8)
+    completed = ResponseCompletedEvent.model_construct(
+        type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+        response={"usage": dict_usage, "status": "completed"},
+    )
+    source = MagicMock()
+    source.completed_response = completed
+
+    usage = Router._extract_partial_responses_usage(source)
+    assert usage is dict_usage
+
+
+def test_extract_partial_responses_usage_dict_response_no_usage_key():
+    """A dict response without a 'usage' key should return None, not raise."""
+    completed = ResponseCompletedEvent.model_construct(
+        type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+        response={"status": "completed"},
+    )
+    source = MagicMock()
+    source.completed_response = completed
+
+    usage = Router._extract_partial_responses_usage(source)
+    assert usage is None
+
+
 # -------- _combine_responses_fallback_usage --------
 
 

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -9,9 +9,7 @@ from unittest.mock import ANY, MagicMock, Mock, patch
 import httpx
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system-path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system-path
 import litellm
 from litellm.completion_extras.litellm_responses_transformation.transformation import (
     LiteLLMResponsesTransformationHandler,
@@ -122,9 +120,7 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_imag
             function_call_output = item
             break
 
-    assert (
-        function_call_output is not None
-    ), "function_call_output not found in response"
+    assert function_call_output is not None, "function_call_output not found in response"
     assert function_call_output["call_id"] == "call_abc123"
 
     # Check that the output is correctly transformed
@@ -134,12 +130,8 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_imag
 
     image_item = output[0]
     # Should be transformed to Responses API format
-    assert (
-        image_item["type"] == "input_image"
-    ), f"Expected type 'input_image', got '{image_item.get('type')}'"
-    assert (
-        image_item["image_url"] == test_image_base64
-    ), "image_url should be a flat string, not a nested object"
+    assert image_item["type"] == "input_image", f"Expected type 'input_image', got '{image_item.get('type')}'"
+    assert image_item["image_url"] == test_image_base64, "image_url should be a flat string, not a nested object"
     assert "detail" in image_item, "detail field should be present"
 
     print("✓ Tool result with image correctly transformed to Responses API format")
@@ -201,9 +193,7 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_text
             function_call_output = item
             break
 
-    assert (
-        function_call_output is not None
-    ), "function_call_output not found in response"
+    assert function_call_output is not None, "function_call_output not found in response"
     assert function_call_output["call_id"] == "call_abc123"
 
     # Check that the output is correctly transformed to use input_text, not output_text
@@ -213,16 +203,12 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_text
 
     text_item = output[0]
     # Should be transformed to use input_text for tool results in Responses API format
-    assert (
-        text_item["type"] == "input_text"
-    ), f"Expected type 'input_text' for tool result, got '{text_item.get('type')}'"
-    assert (
-        text_item["text"] == "15 degrees"
-    ), f"Expected text '15 degrees', got '{text_item.get('text')}'"
-
-    print(
-        "✓ Tool result with text correctly transformed to use input_text for Responses API format"
+    assert text_item["type"] == "input_text", (
+        f"Expected type 'input_text' for tool result, got '{text_item.get('type')}'"
     )
+    assert text_item["text"] == "15 degrees", f"Expected text '15 degrees', got '{text_item.get('text')}'"
+
+    print("✓ Tool result with text correctly transformed to use input_text for Responses API format")
 
 
 def test_openai_responses_chunk_parser_reasoning_summary():
@@ -231,9 +217,7 @@ def test_openai_responses_chunk_parser_reasoning_summary():
     )
     from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
 
     chunk = {
         "delta": "**Compar",
@@ -265,9 +249,7 @@ def test_chunk_parser_string_output_text_delta_produces_text():
     )
     from litellm.types.utils import ModelResponseStream
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
 
     chunk = {"type": "response.output_text.delta", "delta": "literal text"}
 
@@ -288,9 +270,7 @@ def test_chunk_parser_enum_output_text_delta_produces_text():
     from litellm.types.llms.openai import ResponsesAPIStreamEvents
     from litellm.types.utils import ModelResponseStream
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
 
     chunk = {"type": ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA, "delta": "enum text"}
 
@@ -311,9 +291,7 @@ def test_chunk_parser_function_call_added_produces_tool_use():
     from litellm.types.llms.openai import ResponsesAPIStreamEvents
     from litellm.types.utils import ModelResponseStream
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
 
     chunk = {
         "type": ResponsesAPIStreamEvents.OUTPUT_ITEM_ADDED,
@@ -398,9 +376,7 @@ Tomorrow will bring its petitions and promises,
 but for now the city breathes slow and wide,
 and I learn to carry this small calm home."""
 
-    output_text = ResponseOutputText(
-        annotations=[], text=poem_text, type="output_text", logprobs=[]
-    )
+    output_text = ResponseOutputText(annotations=[], text=poem_text, type="output_text", logprobs=[])
     output_message = ResponseOutputMessage(
         id="msg_04c8021b8b3188a00068e9ae0b92f4819dac64d85b4abb67ec",
         content=[output_text],
@@ -412,9 +388,7 @@ and I learn to carry this small calm home."""
     # Create usage information
     usage = ResponseAPIUsage(
         input_tokens=16,
-        input_tokens_details=InputTokensDetails(
-            audio_tokens=None, cached_tokens=0, text_tokens=None
-        ),
+        input_tokens_details=InputTokensDetails(audio_tokens=None, cached_tokens=0, text_tokens=None),
         output_tokens=195,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0, text_tokens=None),
         total_tokens=211,
@@ -763,11 +737,7 @@ def test_recover_output_items_merges_text_only_items_at_distinct_indices():
         ]
     )
 
-    recovered = (
-        LiteLLMResponsesTransformationHandler._recover_output_items_from_raw_sse(
-            raw_sse
-        )
-    )
+    recovered = LiteLLMResponsesTransformationHandler._recover_output_items_from_raw_sse(raw_sse)
 
     assert len(recovered) == 2
     assert recovered[0]["id"] == "msg_item_0"
@@ -887,9 +857,7 @@ def test_transform_request_system_only_message_maps_to_system_input_item():
         {
             "type": "message",
             "role": "system",
-            "content": [
-                {"type": "input_text", "text": "You are a helpful assistant."}
-            ],
+            "content": [{"type": "input_text", "text": "You are a helpful assistant."}],
         }
     ]
     # System content lives in input only; not duplicated into instructions.
@@ -961,9 +929,7 @@ def test_transform_request_single_char_keys_not_matched():
     assert result_correct.get("metadata") == {"user_id": "123"}
     assert result_correct.get("previous_response_id") == "resp_abc"
 
-    print(
-        "✓ Single-character keys are not incorrectly matched to metadata/previous_response_id"
-    )
+    print("✓ Single-character keys are not incorrectly matched to metadata/previous_response_id")
 
 
 # =============================================================================
@@ -983,9 +949,7 @@ def test_message_done_does_not_emit_is_finished():
         OpenAiResponsesToChatCompletionStreamIterator,
     )
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
 
     chunk = {
         "type": "response.output_item.done",
@@ -997,9 +961,9 @@ def test_message_done_does_not_emit_is_finished():
     # After the fix, message completion should NOT set finish_reason
     # ModelResponseStream doesn't have is_finished - check finish_reason instead
     assert len(result.choices) > 0, "result should have choices"
-    assert (
-        result.choices[0].finish_reason is None or result.choices[0].finish_reason == ""
-    ), "message completion should not emit finish_reason"
+    assert result.choices[0].finish_reason is None or result.choices[0].finish_reason == "", (
+        "message completion should not emit finish_reason"
+    )
 
 
 def test_response_completed_emits_is_finished():
@@ -1011,9 +975,7 @@ def test_response_completed_emits_is_finished():
         OpenAiResponsesToChatCompletionStreamIterator,
     )
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
 
     chunk = {"type": "response.completed"}
 
@@ -1021,9 +983,7 @@ def test_response_completed_emits_is_finished():
 
     # response.completed should emit finish_reason='stop'
     assert len(result.choices) > 0, "result should have choices"
-    assert (
-        result.choices[0].finish_reason == "stop"
-    ), "response.completed should emit finish_reason='stop'"
+    assert result.choices[0].finish_reason == "stop", "response.completed should emit finish_reason='stop'"
 
 
 def test_response_completed_with_function_calls_emits_tool_calls_finish_reason():
@@ -1042,9 +1002,7 @@ def test_response_completed_with_function_calls_emits_tool_calls_finish_reason()
         OpenAiResponsesToChatCompletionStreamIterator,
     )
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
 
     # Simulate a response.completed event with function_call in output
     # This matches what Azure/OpenAI sends for gpt-5.1-codex-mini and similar models
@@ -1070,9 +1028,9 @@ def test_response_completed_with_function_calls_emits_tool_calls_finish_reason()
 
     # response.completed with function_call should emit finish_reason='tool_calls'
     assert len(result.choices) > 0, "result should have choices"
-    assert (
-        result.choices[0].finish_reason == "tool_calls"
-    ), "response.completed with function_call output should emit finish_reason='tool_calls'"
+    assert result.choices[0].finish_reason == "tool_calls", (
+        "response.completed with function_call output should emit finish_reason='tool_calls'"
+    )
 
 
 def test_response_completed_with_message_only_emits_stop_finish_reason():
@@ -1083,9 +1041,7 @@ def test_response_completed_with_message_only_emits_stop_finish_reason():
         OpenAiResponsesToChatCompletionStreamIterator,
     )
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
 
     # Simulate a response.completed event with only message output
     chunk = {
@@ -1109,9 +1065,9 @@ def test_response_completed_with_message_only_emits_stop_finish_reason():
 
     # response.completed with only message should emit finish_reason='stop'
     assert len(result.choices) > 0, "result should have choices"
-    assert (
-        result.choices[0].finish_reason == "stop"
-    ), "response.completed with only message output should emit finish_reason='stop'"
+    assert result.choices[0].finish_reason == "stop", (
+        "response.completed with only message output should emit finish_reason='stop'"
+    )
 
 
 def test_response_completed_preserves_usage_with_cached_tokens():
@@ -1127,9 +1083,7 @@ def test_response_completed_preserves_usage_with_cached_tokens():
         OpenAiResponsesToChatCompletionStreamIterator,
     )
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
 
     chunk = {
         "type": "response.completed",
@@ -1158,18 +1112,12 @@ def test_response_completed_preserves_usage_with_cached_tokens():
     result = iterator.chunk_parser(chunk)
 
     assert result.usage is not None, "usage should be set on response.completed chunk"
-    assert (
-        result.usage.prompt_tokens == 1226
-    ), "prompt_tokens should map from input_tokens"
-    assert (
-        result.usage.completion_tokens == 5
-    ), "completion_tokens should map from output_tokens"
-    assert (
-        result.usage.prompt_tokens_details is not None
-    ), "prompt_tokens_details should be set"
-    assert (
-        result.usage.prompt_tokens_details.cached_tokens == 1024
-    ), "cached_tokens should be preserved from input_tokens_details"
+    assert result.usage.prompt_tokens == 1226, "prompt_tokens should map from input_tokens"
+    assert result.usage.completion_tokens == 5, "completion_tokens should map from output_tokens"
+    assert result.usage.prompt_tokens_details is not None, "prompt_tokens_details should be set"
+    assert result.usage.prompt_tokens_details.cached_tokens == 1024, (
+        "cached_tokens should be preserved from input_tokens_details"
+    )
 
 
 def test_function_call_done_emits_is_finished():
@@ -1183,9 +1131,7 @@ def test_function_call_done_emits_is_finished():
         OpenAiResponsesToChatCompletionStreamIterator,
     )
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
 
     chunk = {
         "type": "response.output_item.done",
@@ -1205,9 +1151,9 @@ def test_function_call_done_emits_is_finished():
         "output_item.done for function_call must not emit finish_reason; "
         "response.completed is responsible for the terminal finish_reason"
     )
-    assert not result.choices[
-        0
-    ].delta.tool_calls, "output_item.done for function_call must not include a duplicate tool_calls delta"
+    assert not result.choices[0].delta.tool_calls, (
+        "output_item.done for function_call must not include a duplicate tool_calls delta"
+    )
 
 
 def test_text_plus_tool_calls_sequence():
@@ -1222,9 +1168,7 @@ def test_text_plus_tool_calls_sequence():
         OpenAiResponsesToChatCompletionStreamIterator,
     )
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
 
     # Simulate the sequence from OpenAI Responses API
     chunks = [
@@ -1263,28 +1207,23 @@ def test_text_plus_tool_calls_sequence():
     # Check message done (index 2) does NOT have finish_reason set
     message_done_result = results[2]
     assert len(message_done_result.choices) > 0, "message done should have choices"
-    assert (
-        message_done_result.choices[0].finish_reason is None
-        or message_done_result.choices[0].finish_reason == ""
-    ), "message done should not have finish_reason"
+    assert message_done_result.choices[0].finish_reason is None or message_done_result.choices[0].finish_reason == "", (
+        "message done should not have finish_reason"
+    )
 
     # Check function_call done (index 5) does NOT have finish_reason set
     # (response.completed is responsible for the terminal finish_reason)
     function_done_result = results[5]
-    assert (
-        len(function_done_result.choices) > 0
-    ), "function_call done should have choices"
-    assert (
-        function_done_result.choices[0].finish_reason is None
-    ), "output_item.done for function_call must not emit finish_reason"
+    assert len(function_done_result.choices) > 0, "function_call done should have choices"
+    assert function_done_result.choices[0].finish_reason is None, (
+        "output_item.done for function_call must not emit finish_reason"
+    )
 
     # Check response.completed (index 6) has finish_reason='stop'
     # (the mock chunk has no nested 'response' data, so has_function_calls is False → 'stop')
     completed_result = results[6]
     assert len(completed_result.choices) > 0, "response.completed should have choices"
-    assert (
-        completed_result.choices[0].finish_reason == "stop"
-    ), "response.completed should have finish_reason='stop'"
+    assert completed_result.choices[0].finish_reason == "stop", "response.completed should have finish_reason='stop'"
 
 
 # =============================================================================
@@ -1350,9 +1289,7 @@ def test_tool_message_output_uses_input_text_not_output_text():
     output = function_call_output["output"]
     assert isinstance(output, list), f"output should be a list, got {type(output)}"
     assert len(output) == 1
-    assert (
-        output[0]["type"] == "input_text"
-    ), f"Expected input_text, got {output[0].get('type')}"
+    assert output[0]["type"] == "input_text", f"Expected input_text, got {output[0].get('type')}"
     assert output[0]["text"] == '{"temperature": 15, "condition": "sunny"}'
 
     print("✓ Tool message output correctly uses input_text type")
@@ -1538,13 +1475,9 @@ def test_map_reasoning_effort_adds_summary_detailed():
 
             assert result is not None, f"Result should not be None for effort={effort}"
             assert result["effort"] == effort, f"Effort should be {effort}"
-            assert (
-                "summary" not in result
-            ), f"Summary should NOT be present by default for effort={effort}"
+            assert "summary" not in result, f"Summary should NOT be present by default for effort={effort}"
 
-            print(
-                f"✓ reasoning_effort='{effort}' correctly maps to effort='{effort}' (no summary by default)"
-            )
+            print(f"✓ reasoning_effort='{effort}' correctly maps to effort='{effort}' (no summary by default)")
 
         # Test 2: With flag enabled - summary IS added
         litellm.reasoning_auto_summary = True
@@ -1554,9 +1487,9 @@ def test_map_reasoning_effort_adds_summary_detailed():
 
             assert result is not None, f"Result should not be None for effort={effort}"
             assert result["effort"] == effort, f"Effort should be {effort}"
-            assert (
-                result["summary"] == "detailed"
-            ), f"Summary should be 'detailed' when flag is enabled for effort={effort}"
+            assert result["summary"] == "detailed", (
+                f"Summary should be 'detailed' when flag is enabled for effort={effort}"
+            )
 
             print(
                 f"✓ reasoning_effort='{effort}' correctly maps to effort='{effort}', summary='detailed' (flag enabled)"
@@ -1567,9 +1500,7 @@ def test_map_reasoning_effort_adds_summary_detailed():
         os.environ["LITELLM_REASONING_AUTO_SUMMARY"] = "true"
 
         result = handler._map_reasoning_effort("high")
-        assert (
-            result["summary"] == "detailed"
-        ), "Summary should be 'detailed' when env var is enabled"
+        assert result["summary"] == "detailed", "Summary should be 'detailed' when env var is enabled"
         print("✓ LITELLM_REASONING_AUTO_SUMMARY env var works correctly")
 
         # Test 4: Dict input is passed through as-is (no modification)
@@ -1588,9 +1519,7 @@ def test_map_reasoning_effort_adds_summary_detailed():
         assert result_unknown is None
         print("✓ Unknown reasoning_effort values return None")
 
-        print(
-            "✓ All reasoning_effort behaviors work correctly with flag/env var control"
-        )
+        print("✓ All reasoning_effort behaviors work correctly with flag/env var control")
 
     finally:
         # Restore original values
@@ -1666,9 +1595,7 @@ def test_transform_response_preserves_annotations():
     # Create usage information
     usage = ResponseAPIUsage(
         input_tokens=10,
-        input_tokens_details=InputTokensDetails(
-            audio_tokens=None, cached_tokens=0, text_tokens=None
-        ),
+        input_tokens_details=InputTokensDetails(audio_tokens=None, cached_tokens=0, text_tokens=None),
         output_tokens=20,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0, text_tokens=None),
         total_tokens=30,
@@ -1755,13 +1682,9 @@ def test_transform_response_preserves_annotations():
     assert choice.message.content == "Here is some information with citations."
 
     # Check that annotations are preserved
-    assert hasattr(
-        choice.message, "annotations"
-    ), "Message should have annotations attribute"
+    assert hasattr(choice.message, "annotations"), "Message should have annotations attribute"
     assert choice.message.annotations is not None, "Annotations should not be None"
-    assert (
-        len(choice.message.annotations) == 2
-    ), f"Expected 2 annotations, got {len(choice.message.annotations)}"
+    assert len(choice.message.annotations) == 2, f"Expected 2 annotations, got {len(choice.message.annotations)}"
 
     # Verify annotation content
     annotation1 = choice.message.annotations[0]
@@ -1783,9 +1706,7 @@ def test_transform_response_preserves_annotations():
     assert result.usage.completion_tokens == 20
     assert result.usage.total_tokens == 30
 
-    print(
-        "✓ Annotations from Responses API are correctly preserved in Chat Completions format"
-    )
+    print("✓ Annotations from Responses API are correctly preserved in Chat Completions format")
 
 
 def test_apply_patch_tool_call_converted_to_chat_completion_tool_call():
@@ -1950,9 +1871,7 @@ def test_multi_tool_call_stream_no_premature_finish():
         OpenAiResponsesToChatCompletionStreamIterator,
     )
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
 
     chunks = [
         # 0: response created
@@ -2028,12 +1947,10 @@ def test_multi_tool_call_stream_no_premature_finish():
         r = results[done_idx]
         assert r is not None, f"{label}: chunk_parser must return a result"
         assert len(r.choices) > 0, f"{label}: result must have choices"
-        assert (
-            r.choices[0].finish_reason is None
-        ), f"{label}: output_item.done must not emit finish_reason (stream would terminate prematurely)"
-        assert not r.choices[
-            0
-        ].delta.tool_calls, (
+        assert r.choices[0].finish_reason is None, (
+            f"{label}: output_item.done must not emit finish_reason (stream would terminate prematurely)"
+        )
+        assert not r.choices[0].delta.tool_calls, (
             f"{label}: output_item.done must not include a duplicate tool_calls delta"
         )
 
@@ -2045,12 +1962,8 @@ def test_multi_tool_call_stream_no_premature_finish():
         r = results[added_idx]
         if r is not None and r.choices and r.choices[0].delta.tool_calls:
             tc = r.choices[0].delta.tool_calls[0]
-            assert (
-                tc.function.name == expected_name
-            ), f"output_item.added for {expected_name}: tool_call name mismatch"
-            assert (
-                tc.id == expected_call_id
-            ), f"output_item.added for {expected_name}: call_id mismatch"
+            assert tc.function.name == expected_name, f"output_item.added for {expected_name}: tool_call name mismatch"
+            assert tc.id == expected_call_id, f"output_item.added for {expected_name}: call_id mismatch"
 
     # 3. argument delta events (indices 2 and 5) should carry arguments
     for delta_idx, expected_args, label in [
@@ -2060,17 +1973,15 @@ def test_multi_tool_call_stream_no_premature_finish():
         r = results[delta_idx]
         if r is not None and r.choices and r.choices[0].delta.tool_calls:
             tc = r.choices[0].delta.tool_calls[0]
-            assert (
-                tc.function.arguments == expected_args
-            ), f"{label}: argument delta mismatch"
+            assert tc.function.arguments == expected_args, f"{label}: argument delta mismatch"
 
     # 4. Only response.completed (index 7) emits the terminal finish_reason
     completed_result = results[7]
     assert completed_result is not None, "response.completed must return a result"
     assert len(completed_result.choices) > 0, "response.completed must have choices"
-    assert (
-        completed_result.choices[0].finish_reason == "tool_calls"
-    ), "response.completed with function_call outputs must emit finish_reason='tool_calls'"
+    assert completed_result.choices[0].finish_reason == "tool_calls", (
+        "response.completed with function_call outputs must emit finish_reason='tool_calls'"
+    )
 
     # 5. No chunk before the last one should have finish_reason set
     for idx, r in enumerate(results[:-1]):
@@ -2080,9 +1991,7 @@ def test_multi_tool_call_stream_no_premature_finish():
                 f"— only response.completed should terminate the stream"
             )
 
-    print(
-        "✓ Multi-tool-call stream completes without premature finish_reason termination"
-    )
+    print("✓ Multi-tool-call stream completes without premature finish_reason termination")
 
 
 # =============================================================================
@@ -2163,16 +2072,13 @@ def test_streaming_parallel_tool_calls_have_distinct_indices():
     ]
 
     for chunk in chunks:
-        result = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
-            chunk
-        )
+        result = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(chunk)
         expected_index = chunk["output_index"]
         for choice in result.choices:
             if choice.delta.tool_calls:
                 for tc in choice.delta.tool_calls:
                     assert tc.index == expected_index, (
-                        f"Event {chunk['type']}: expected tool_call.index={expected_index}, "
-                        f"got {tc.index}"
+                        f"Event {chunk['type']}: expected tool_call.index={expected_index}, got {tc.index}"
                     )
 
 
@@ -2300,9 +2206,7 @@ def test_parallel_tool_calls_comprehensive_streaming_integration():
         },
     ]
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
     results = [iterator.chunk_parser(chunk) for chunk in chunks]
 
     # 1. output_item.done events (indices 4 and 8) must NOT emit finish_reason
@@ -2314,9 +2218,7 @@ def test_parallel_tool_calls_comprehensive_streaming_integration():
             f"{label}: output_item.done must not emit finish_reason "
             f"(would prematurely terminate stream before subsequent tool calls arrive)"
         )
-        assert not r.choices[
-            0
-        ].delta.tool_calls, (
+        assert not r.choices[0].delta.tool_calls, (
             f"{label}: output_item.done must not emit a duplicate tool_calls delta"
         )
 
@@ -2350,19 +2252,15 @@ def test_parallel_tool_calls_comprehensive_streaming_integration():
         for tc in tool_calls:
             if tc.function and tc.function.arguments:
                 idx = tc.index
-                assembled_args[idx] = (
-                    assembled_args.get(idx, "") + tc.function.arguments
-                )
+                assembled_args[idx] = assembled_args.get(idx, "") + tc.function.arguments
 
     # delta 1 = '{"path":' + delta 2 = '"/etc/foo"}' → '{"path":"/etc/foo"}'
     assert assembled_args.get(0) == '{"path":"/etc/foo"}', (
-        f"Assembled args for index 0 (read_file): "
-        f"expected '{{\"path\":\"/etc/foo\"}}', got '{assembled_args.get(0)}'"
+        f"Assembled args for index 0 (read_file): expected '{{\"path\":\"/etc/foo\"}}', got '{assembled_args.get(0)}'"
     )
     # delta 1 = '{"path":' + delta 2 = '"/tmp"}' → '{"path":"/tmp"}'
     assert assembled_args.get(1) == '{"path":"/tmp"}', (
-        f"Assembled args for index 1 (list_dir): "
-        f"expected '{{\"path\":\"/tmp\"}}', got '{assembled_args.get(1)}'"
+        f"Assembled args for index 1 (list_dir): expected '{{\"path\":\"/tmp\"}}', got '{assembled_args.get(1)}'"
     )
 
     # 4. Stream terminates with exactly one finish event, at the final response.completed chunk
@@ -2371,16 +2269,13 @@ def test_parallel_tool_calls_comprehensive_streaming_integration():
         for i, r in enumerate(results)
         if r is not None and r.choices and r.choices[0].finish_reason
     ]
-    assert (
-        len(finish_events) == 1
-    ), f"Expected exactly 1 finish event, got {len(finish_events)}: {finish_events}"
+    assert len(finish_events) == 1, f"Expected exactly 1 finish event, got {len(finish_events)}: {finish_events}"
     assert finish_events[0][0] == len(chunks) - 1, (
-        f"Finish event must be at the last chunk (index {len(chunks) - 1}), "
-        f"but was at index {finish_events[0][0]}"
+        f"Finish event must be at the last chunk (index {len(chunks) - 1}), but was at index {finish_events[0][0]}"
     )
-    assert (
-        finish_events[0][1] == "tool_calls"
-    ), f"Terminal finish_reason must be 'tool_calls', got '{finish_events[0][1]}'"
+    assert finish_events[0][1] == "tool_calls", (
+        f"Terminal finish_reason must be 'tool_calls', got '{finish_events[0][1]}'"
+    )
 
     # 5. Parallel tool calls have distinct indices matching output_index (0 and 1)
     # Collect indices from output_item.added chunks only (they carry the call id)
@@ -2396,9 +2291,7 @@ def test_parallel_tool_calls_comprehensive_streaming_integration():
         1,
     }, f"Parallel tool calls must have distinct indices {{0, 1}}, got: {set(added_tool_call_indices)}"
 
-    print(
-        "✓ Parallel tool calls with split argument deltas stream correctly end-to-end"
-    )
+    print("✓ Parallel tool calls with split argument deltas stream correctly end-to-end")
 
 
 def test_map_optional_params_preserves_reasoning_summary():
@@ -2422,9 +2315,7 @@ def test_map_optional_params_preserves_reasoning_summary():
     }
 
     responses_api_request = ResponsesAPIOptionalRequestParams()
-    handler._map_optional_params_to_responses_api_request(
-        optional_params, responses_api_request
-    )
+    handler._map_optional_params_to_responses_api_request(optional_params, responses_api_request)
 
     # Verify reasoning_effort dict with summary was fully preserved
     assert "reasoning" in responses_api_request
@@ -2636,9 +2527,7 @@ def test_reasoning_items_non_streaming_round_trip():
     )
     usage = ResponseAPIUsage(
         input_tokens=10,
-        input_tokens_details=InputTokensDetails(
-            audio_tokens=None, cached_tokens=0, text_tokens=None
-        ),
+        input_tokens_details=InputTokensDetails(audio_tokens=None, cached_tokens=0, text_tokens=None),
         output_tokens=20,
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0, text_tokens=None),
         total_tokens=30,
@@ -2702,9 +2591,7 @@ def test_reasoning_items_non_streaming_round_trip():
     assert len(result.choices) == 1
     msg = result.choices[0].message
 
-    assert (
-        msg.reasoning_content == summary_text
-    ), "reasoning_content should equal summary text"
+    assert msg.reasoning_content == summary_text, "reasoning_content should equal summary text"
 
     assert msg.reasoning_items is not None, "reasoning_items should be set"
     assert len(msg.reasoning_items) == 1
@@ -2729,13 +2616,9 @@ def test_reasoning_items_non_streaming_round_trip():
 
     # The reasoning input item must appear before the assistant message item
     types = [item.get("type") for item in input_items]
-    assert (
-        "reasoning" in types
-    ), "reasoning input item must be emitted for the assistant turn"
+    assert "reasoning" in types, "reasoning input item must be emitted for the assistant turn"
 
-    reasoning_input = next(
-        item for item in input_items if item.get("type") == "reasoning"
-    )
+    reasoning_input = next(item for item in input_items if item.get("type") == "reasoning")
     assert reasoning_input["id"] == "rs_test001"
     assert reasoning_input["encrypted_content"] == encrypted
     assert reasoning_input["summary"][0]["text"] == summary_text
@@ -2743,13 +2626,9 @@ def test_reasoning_items_non_streaming_round_trip():
     # reasoning item must come before the assistant message item
     reasoning_idx = types.index("reasoning")
     assistant_msg_idx = next(
-        i
-        for i, item in enumerate(input_items)
-        if item.get("type") == "message" and item.get("role") == "assistant"
+        i for i, item in enumerate(input_items) if item.get("type") == "message" and item.get("role") == "assistant"
     )
-    assert (
-        reasoning_idx < assistant_msg_idx
-    ), "reasoning input item must precede the assistant message item"
+    assert reasoning_idx < assistant_msg_idx, "reasoning input item must precede the assistant message item"
 
 
 def test_reasoning_items_streaming_emitted_on_response_completed():
@@ -2762,9 +2641,7 @@ def test_reasoning_items_streaming_emitted_on_response_completed():
         OpenAiResponsesToChatCompletionStreamIterator,
     )
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
 
     encrypted = "gAAAAABpw5xyz987FAKE=="
     summary_text = "**Reasoning summary**\n\nModel thought about this carefully."
@@ -2808,16 +2685,14 @@ def test_reasoning_items_streaming_emitted_on_response_completed():
     assert result.choices[0].finish_reason == "stop"
 
     # reasoning_items must be on the delta
-    assert (
-        getattr(delta, "reasoning_items", None) is not None
-    ), "reasoning_items must be present on the response.completed delta"
+    assert getattr(delta, "reasoning_items", None) is not None, (
+        "reasoning_items must be present on the response.completed delta"
+    )
     assert len(delta.reasoning_items) == 1
     ri = delta.reasoning_items[0]
     assert ri["type"] == "reasoning"
     assert ri["id"] == "rs_stream001"
-    assert (
-        ri["encrypted_content"] == encrypted
-    ), "encrypted_content must be preserved in streaming"
+    assert ri["encrypted_content"] == encrypted, "encrypted_content must be preserved in streaming"
     assert ri["summary"][0]["text"] == summary_text
 
 
@@ -2844,15 +2719,46 @@ def test_streaming_function_call_tool_id_for_degenerate_call_id():
                 "arguments": "",
             },
         }
-        out = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(
-            chunk
-        )
+        out = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(chunk)
         tool_calls = out.model_dump()["choices"][0]["delta"]["tool_calls"]
         assert tool_calls, "expected a tool_call chunk in the streaming delta"
         return tool_calls[0]["id"]
 
     assert stream_tool_id("fc_unique_abc123", "call_0") == "fc_unique_abc123"
     assert stream_tool_id("fc_2", "call_tokyo") == "call_tokyo"
+
+
+def test_convert_response_output_to_choices_none_output_items():
+    """Regression #34754: output_items can be None when a client calls
+    /chat/completions but upstream only supports /responses. The guard
+    should treat None as an empty list instead of raising TypeError."""
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    result = LiteLLMResponsesTransformationHandler._convert_response_output_to_choices(
+        output_items=None,  # type: ignore[arg-type]
+    )
+    assert result == []
+
+
+def test_translate_responses_chunk_handles_none_output_items():
+    """Regression #34754: when response.output is None in a response.completed
+    chunk, the reasoning-items loop should skip gracefully via the or [] guard
+    instead of raising TypeError."""
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        OpenAiResponsesToChatCompletionStreamIterator,
+    )
+
+    chunk = {
+        "type": "response.completed",
+        "response": {
+            "status": "completed",
+            "output": None,
+        },
+    }
+    result = OpenAiResponsesToChatCompletionStreamIterator.translate_responses_chunk_to_openai_stream(chunk)
+    assert result is not None
 
 
 def test_streaming_chunks_share_one_chat_completion_id():
@@ -2865,9 +2771,7 @@ def test_streaming_chunks_share_one_chat_completion_id():
         OpenAiResponsesToChatCompletionStreamIterator,
     )
 
-    iterator = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
-    )
+    iterator = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
     events = [
         {"type": "response.created", "response": {"id": "resp_abc", "output": []}},
         {"type": "response.output_text.delta", "delta": "Hel"},
@@ -2883,12 +2787,10 @@ def test_streaming_chunks_share_one_chat_completion_id():
     assert len(set(ids)) == 1, f"streamed chunks carried different ids: {ids}"
     assert ids[0], "streamed chunks carried an empty id"
 
-    other_stream = OpenAiResponsesToChatCompletionStreamIterator(
-        streaming_response=None, sync_stream=True
+    other_stream = OpenAiResponsesToChatCompletionStreamIterator(streaming_response=None, sync_stream=True)
+    assert other_stream.chunk_parser(events[1]).id != ids[0], (
+        "a separate stream must get its own id, not a process-wide one"
     )
-    assert (
-        other_stream.chunk_parser(events[1]).id != ids[0]
-    ), "a separate stream must get its own id, not a process-wide one"
 
 
 @pytest.mark.asyncio
@@ -2899,9 +2801,7 @@ def test_streaming_chunks_share_one_chat_completion_id():
         ({"include_usage": True}, None),
     ],
 )
-async def test_acompletion_bridge_normalizes_stream_options_on_the_wire(
-    stream_options, expected_wire_stream_options
-):
+async def test_acompletion_bridge_normalizes_stream_options_on_the_wire(stream_options, expected_wire_stream_options):
     """include_usage must be stripped from the /v1/responses body; include_obfuscation must survive as a dict."""
     from unittest.mock import AsyncMock
 

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -2694,6 +2694,32 @@ def test_get_assembled_streaming_response_returns_none_for_non_streaming_text_co
     assert assembled is None
 
 
+def test_get_assembled_streaming_response_returns_none_for_dict_response():
+    """Regression #34754: when a ResponseCompletedEvent carries a plain dict
+    as .response (some upstream providers do this), the guard should return
+    None instead of raising AttributeError on .usage access."""
+    import datetime
+
+    from litellm.types.llms.openai import (
+        ResponseCompletedEvent,
+        ResponsesAPIStreamEvents,
+    )
+
+    logging_obj = _make_logging_obj(stream=True)
+    completed = ResponseCompletedEvent.model_construct(
+        type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+        response={"id": "resp-1", "status": "completed"},
+    )
+    assembled = logging_obj._get_assembled_streaming_response(
+        result=completed,
+        start_time=datetime.datetime.now(),
+        end_time=datetime.datetime.now(),
+        is_async=True,
+        streaming_chunks=[],
+    )
+    assert assembled is None
+
+
 @pytest.mark.asyncio
 async def test_non_streaming_computes_standard_logging_object_once():
     """

--- a/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
+++ b/tests/test_litellm/litellm_core_utils/test_litellm_logging.py
@@ -5,9 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../.."))  # Adds the parent directory to the system path
 
 import time
 
@@ -272,9 +270,7 @@ def test_response_cost_calculator_uses_router_model_id_from_litellm_metadata():
 
         assert cost is not None, "Cost should not be None"
         expected_cost = (10 * custom_input_cost) + (5 * custom_output_cost)
-        assert cost == pytest.approx(
-            expected_cost
-        ), f"Expected {expected_cost}, got {cost}"
+        assert cost == pytest.approx(expected_cost), f"Expected {expected_cost}, got {cost}"
     finally:
         litellm.model_cost.pop(custom_model_id, None)
 
@@ -565,13 +561,8 @@ async def test_datadog_logger_not_shadowed_by_llm_obs(monkeypatch):
 
         # Regression check: we expect a distinct DataDogLogger, not the LLM Obs logger
         assert type(datadog_logger) is DataDogLogger
-        assert any(
-            isinstance(cb, DataDogLLMObsLogger)
-            for cb in logging_module._in_memory_loggers
-        )
-        assert any(
-            type(cb) is DataDogLogger for cb in logging_module._in_memory_loggers
-        )
+        assert any(isinstance(cb, DataDogLLMObsLogger) for cb in logging_module._in_memory_loggers)
+        assert any(type(cb) is DataDogLogger for cb in logging_module._in_memory_loggers)
     finally:
         logging_module._in_memory_loggers.clear()
 
@@ -582,9 +573,7 @@ async def test_logfire_logger_accepts_env_vars_for_base_url(monkeypatch):
 
     # Required env vars for Logfire integration
     monkeypatch.setenv("LOGFIRE_TOKEN", "test-token")
-    monkeypatch.setenv(
-        "LOGFIRE_BASE_URL", "https://logfire-api-custom.pydantic.dev"
-    )  # no trailing slash on purpose
+    monkeypatch.setenv("LOGFIRE_BASE_URL", "https://logfire-api-custom.pydantic.dev")  # no trailing slash on purpose
 
     # Import after env vars are set (important if module-level caching exists)
     from litellm.integrations.opentelemetry import OpenTelemetry  # logger class
@@ -603,9 +592,7 @@ async def test_logfire_logger_accepts_env_vars_for_base_url(monkeypatch):
 
         # Sanity: we got the right logger type and it is cached
         assert type(logger) is OpenTelemetry
-        assert any(
-            type(cb) is OpenTelemetry for cb in logging_module._in_memory_loggers
-        )
+        assert any(type(cb) is OpenTelemetry for cb in logging_module._in_memory_loggers)
 
         # Core regression check: base URL env var should influence the exporter endpoint.
         #
@@ -616,9 +603,7 @@ async def test_logfire_logger_accepts_env_vars_for_base_url(monkeypatch):
             or getattr(logger, "config", None)
             or getattr(logger, "_otel_config", None)
         )
-        assert (
-            cfg is not None
-        ), "Expected OpenTelemetry logger to keep an otel config on the instance"
+        assert cfg is not None, "Expected OpenTelemetry logger to keep an otel config on the instance"
 
         endpoint = getattr(cfg, "endpoint", None) or getattr(cfg, "otlp_endpoint", None)
         assert endpoint is not None, "Expected otel config to expose the OTLP endpoint"
@@ -776,9 +761,7 @@ async def test_logging_non_streaming_request():
 
             # Use the filtered call for assertions
             call_args = calls_with_expected_input[0]
-            standard_logging_object = call_args.kwargs["kwargs"][
-                "standard_logging_object"
-            ]
+            standard_logging_object = call_args.kwargs["kwargs"]["standard_logging_object"]
             assert standard_logging_object["stream"] is not True
     finally:
         # Restore original callbacks to ensure test isolation
@@ -796,18 +779,14 @@ async def test_logging_non_streaming_request():
         "agenerate_content_stream",
     ],
 )
-def test_success_handler_skips_sync_callbacks_for_async_requests(
-    logging_obj, async_flag
-):
+def test_success_handler_skips_sync_callbacks_for_async_requests(logging_obj, async_flag):
     """Ensure sync success callbacks are skipped when async call type flags are set."""
     from litellm.integrations.custom_logger import CustomLogger
 
     class DummyLogger(CustomLogger):
         pass
 
-    logging_obj.stream = (
-        False  # simulate non-streaming request where sync callbacks would normally run
-    )
+    logging_obj.stream = False  # simulate non-streaming request where sync callbacks would normally run
     logging_obj.model_call_details["litellm_params"] = {async_flag: True}
     logging_obj.litellm_params = logging_obj.model_call_details["litellm_params"]
 
@@ -883,21 +862,11 @@ def test_success_handler_runs_sync_callbacks_for_sync_requests(logging_obj, call
 def test_is_sync_litellm_request():
     assert LitellmLogging._is_sync_litellm_request({}) is True
     assert LitellmLogging._is_sync_litellm_request({"acompletion": True}) is False
-    assert (
-        LitellmLogging._is_sync_litellm_request({"allm_passthrough_route": True})
-        is False
-    )
-    assert (
-        LitellmLogging._is_sync_litellm_request({"aanthropic_messages": True}) is False
-    )
+    assert LitellmLogging._is_sync_litellm_request({"allm_passthrough_route": True}) is False
+    assert LitellmLogging._is_sync_litellm_request({"aanthropic_messages": True}) is False
     assert LitellmLogging._is_sync_litellm_request({"agenerate_content": True}) is False
-    assert (
-        LitellmLogging._is_sync_litellm_request({"agenerate_content_stream": True})
-        is False
-    )
-    assert (
-        LitellmLogging._is_sync_litellm_request({"aanthropic_messages": False}) is True
-    )
+    assert LitellmLogging._is_sync_litellm_request({"agenerate_content_stream": True}) is False
+    assert LitellmLogging._is_sync_litellm_request({"aanthropic_messages": False}) is True
 
 
 def test_get_litellm_params_propagates_allm_passthrough_route():
@@ -944,9 +913,7 @@ async def test_dispatch_success_handlers_invokes_callbacks_once_for_final_stream
         logging_obj.model_call_details["litellm_params"] = {"acompletion": True}
 
         with (
-            patch.object(
-                mock_callback, "async_log_success_event", new_callable=AsyncMock
-            ) as mock_async_log,
+            patch.object(mock_callback, "async_log_success_event", new_callable=AsyncMock) as mock_async_log,
             patch.object(mock_callback, "log_success_event") as mock_sync_log,
             patch.object(
                 logging_obj,
@@ -1007,9 +974,7 @@ async def test_dispatch_success_handlers_sync_path_invokes_callback_once_for_fin
 
         with (
             patch.object(mock_callback, "log_success_event") as mock_sync_log,
-            patch.object(
-                mock_callback, "async_log_success_event", new_callable=AsyncMock
-            ) as mock_async_log,
+            patch.object(mock_callback, "async_log_success_event", new_callable=AsyncMock) as mock_async_log,
             patch.object(
                 logging_obj,
                 "_success_handler_helper_fn",
@@ -1051,20 +1016,14 @@ async def test_dispatch_prefer_async_handlers_runs_legacy_callbacks(
     logging_obj.model_call_details["litellm_params"] = {}
 
     with (
-        patch.object(
-            logging_obj, "async_success_handler", new_callable=AsyncMock
-        ) as mock_async,
-        patch.object(
-            logging_obj, "success_handler", new_callable=MagicMock
-        ) as mock_sync,
+        patch.object(logging_obj, "async_success_handler", new_callable=AsyncMock) as mock_async,
+        patch.object(logging_obj, "success_handler", new_callable=MagicMock) as mock_sync,
         patch.object(
             logging_obj,
             "_should_run_sync_callbacks_for_async_calls",
             return_value=True,
         ),
-        patch(
-            "litellm.litellm_core_utils.litellm_logging.executor.submit"
-        ) as mock_submit,
+        patch("litellm.litellm_core_utils.litellm_logging.executor.submit") as mock_submit,
     ):
         await logging_obj.dispatch_success_handlers(
             result=result,
@@ -1098,9 +1057,7 @@ async def test_dispatch_success_handlers_invokes_async_callback_for_pass_through
 
     try:
         with (
-            patch.object(
-                mock_callback, "async_log_success_event", new_callable=AsyncMock
-            ) as mock_async_log,
+            patch.object(mock_callback, "async_log_success_event", new_callable=AsyncMock) as mock_async_log,
             patch.object(mock_callback, "log_success_event") as mock_sync_log,
         ):
             await logging_obj.dispatch_success_handlers(result={"id": "pt-1"})
@@ -1310,14 +1267,10 @@ def test_success_handler_skips_guardrail_logging_hook_when_disabled(logging_obj)
         event_hook=GuardrailEventHooks.logging_only,
     )
     guardrail.should_run_guardrail = MagicMock(return_value=False)
-    guardrail.logging_hook = MagicMock(
-        return_value=(logging_obj.model_call_details, model_response)
-    )
+    guardrail.logging_hook = MagicMock(return_value=(logging_obj.model_call_details, model_response))
 
     dummy_logger = DummyLogger()
-    dummy_logger.logging_hook = MagicMock(
-        return_value=(logging_obj.model_call_details, model_response)
-    )
+    dummy_logger.logging_hook = MagicMock(return_value=(logging_obj.model_call_details, model_response))
 
     with patch.object(
         logging_obj,
@@ -1451,11 +1404,7 @@ def test_get_request_tags_from_metadata_and_litellm_metadata():
 
     # Test case 2: Tags in litellm_metadata only
     tags = StandardLoggingPayloadSetup._get_request_tags(
-        litellm_params={
-            "litellm_metadata": {
-                "tags": ["litellm-metadata-tag-1", "litellm-metadata-tag-2"]
-            }
-        },
+        litellm_params={"litellm_metadata": {"tags": ["litellm-metadata-tag-1", "litellm-metadata-tag-2"]}},
         proxy_server_request={},
     )
     assert "litellm-metadata-tag-1" in tags
@@ -1560,15 +1509,9 @@ def test_get_request_tags_does_not_mutate_original_tags():
     user_agent_count_2 = len([t for t in tags2 if t.startswith("User-Agent:")])
     user_agent_count_3 = len([t for t in tags3 if t.startswith("User-Agent:")])
 
-    assert (
-        user_agent_count_1 == 2
-    ), f"Expected 2 User-Agent tags, got {user_agent_count_1}"
-    assert (
-        user_agent_count_2 == 2
-    ), f"Expected 2 User-Agent tags, got {user_agent_count_2}"
-    assert (
-        user_agent_count_3 == 2
-    ), f"Expected 2 User-Agent tags, got {user_agent_count_3}"
+    assert user_agent_count_1 == 2, f"Expected 2 User-Agent tags, got {user_agent_count_1}"
+    assert user_agent_count_2 == 2, f"Expected 2 User-Agent tags, got {user_agent_count_2}"
+    assert user_agent_count_3 == 2, f"Expected 2 User-Agent tags, got {user_agent_count_3}"
 
     # Verify all returned lists are independent (different objects)
     assert tags1 is not tags2
@@ -1601,9 +1544,7 @@ def test_get_extra_header_tags():
 
         # Test case 3: Extra headers configured but request has no headers dict
         litellm.extra_spend_tag_headers = ["x-custom", "x-tenant"]
-        result = StandardLoggingPayloadSetup._get_extra_header_tags(
-            proxy_server_request={"headers": "not-a-dict"}
-        )
+        result = StandardLoggingPayloadSetup._get_extra_header_tags(proxy_server_request={"headers": "not-a-dict"})
         assert result is None
 
         # Test case 4: Extra headers configured but none match request headers
@@ -1850,9 +1791,7 @@ def test_get_masked_values():
         "presidio_anonymizer_api_base": None,
         "vertex_credentials": "{sensitive_api_key}",
     }
-    masked_values = _get_masked_values(
-        sensitive_object, unmasked_length=4, number_of_asterisks=4
-    )
+    masked_values = _get_masked_values(sensitive_object, unmasked_length=4, number_of_asterisks=4)
     assert masked_values["presidio_anonymizer_api_base"] is None
     assert masked_values["vertex_credentials"] == "{s****y}"
 
@@ -1877,9 +1816,7 @@ async def test_e2e_generate_cold_storage_object_key_successful():
         patch("litellm.integrations.s3.get_s3_object_key") as mock_get_s3_key,
     ):
         # Mock the S3 object key generation to return a predictable result
-        mock_get_s3_key.return_value = (
-            "2025-01-15/time-10-30-45-123456_chatcmpl-test-12345.json"
-        )
+        mock_get_s3_key.return_value = "2025-01-15/time-10-30-45-123456_chatcmpl-test-12345.json"
 
         # Call the function
         result = StandardLoggingPayloadSetup._generate_cold_storage_object_key(
@@ -1920,16 +1857,12 @@ async def test_e2e_generate_cold_storage_object_key_with_custom_logger_s3_path()
 
     with (
         patch("litellm.cold_storage_custom_logger", "s3_v2"),
-        patch(
-            "litellm.logging_callback_manager.get_active_custom_logger_for_callback_name"
-        ) as mock_get_logger,
+        patch("litellm.logging_callback_manager.get_active_custom_logger_for_callback_name") as mock_get_logger,
         patch("litellm.integrations.s3.get_s3_object_key") as mock_get_s3_key,
     ):
         # Setup mocks
         mock_get_logger.return_value = mock_custom_logger
-        mock_get_s3_key.return_value = (
-            "storage/2025-01-15/time-10-30-45-123456_chatcmpl-test-12345.json"
-        )
+        mock_get_s3_key.return_value = "storage/2025-01-15/time-10-30-45-123456_chatcmpl-test-12345.json"
 
         # Call the function
         result = StandardLoggingPayloadSetup._generate_cold_storage_object_key(
@@ -1948,9 +1881,7 @@ async def test_e2e_generate_cold_storage_object_key_with_custom_logger_s3_path()
         )
 
         # Verify the result
-        assert (
-            result == "storage/2025-01-15/time-10-30-45-123456_chatcmpl-test-12345.json"
-        )
+        assert result == "storage/2025-01-15/time-10-30-45-123456_chatcmpl-test-12345.json"
 
 
 @pytest.mark.asyncio
@@ -1973,16 +1904,12 @@ async def test_e2e_generate_cold_storage_object_key_with_logger_no_s3_path():
 
     with (
         patch("litellm.cold_storage_custom_logger", "s3_v2"),
-        patch(
-            "litellm.logging_callback_manager.get_active_custom_logger_for_callback_name"
-        ) as mock_get_logger,
+        patch("litellm.logging_callback_manager.get_active_custom_logger_for_callback_name") as mock_get_logger,
         patch("litellm.integrations.s3.get_s3_object_key") as mock_get_s3_key,
     ):
         # Setup mocks
         mock_get_logger.return_value = mock_custom_logger
-        mock_get_s3_key.return_value = (
-            "2025-01-15/time-10-30-45-123456_chatcmpl-test-12345.json"
-        )
+        mock_get_s3_key.return_value = "2025-01-15/time-10-30-45-123456_chatcmpl-test-12345.json"
 
         # Call the function
         result = StandardLoggingPayloadSetup._generate_cold_storage_object_key(
@@ -2098,9 +2025,7 @@ def test_get_usage_as_dict():
     assert result == {"prompt_tokens": 20, "completion_tokens": 30}
 
     # Test case 5: response_obj with no usage key returns empty
-    result = StandardLoggingPayloadSetup.get_usage_as_dict(
-        response_obj={"id": "resp-1", "choices": []}
-    )
+    result = StandardLoggingPayloadSetup.get_usage_as_dict(response_obj={"id": "resp-1", "choices": []})
     assert result == {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
 
@@ -2113,26 +2038,20 @@ def test_append_system_prompt_messages():
     # Test case 1: system in kwargs with existing messages
     kwargs = {"system": "You are a helpful assistant"}
     messages = [{"role": "user", "content": "Hello"}]
-    result = StandardLoggingPayloadSetup.append_system_prompt_messages(
-        kwargs=kwargs, messages=messages
-    )
+    result = StandardLoggingPayloadSetup.append_system_prompt_messages(kwargs=kwargs, messages=messages)
     assert len(result) == 2
     assert result[0] == {"role": "system", "content": "You are a helpful assistant"}
     assert result[1] == {"role": "user", "content": "Hello"}
 
     # Test case 2: system in kwargs with None messages
     kwargs = {"system": "You are a helpful assistant"}
-    result = StandardLoggingPayloadSetup.append_system_prompt_messages(
-        kwargs=kwargs, messages=None
-    )
+    result = StandardLoggingPayloadSetup.append_system_prompt_messages(kwargs=kwargs, messages=None)
     assert len(result) == 1
     assert result[0] == {"role": "system", "content": "You are a helpful assistant"}
 
     # Test case 3: system in kwargs with empty messages list
     kwargs = {"system": "You are a helpful assistant"}
-    result = StandardLoggingPayloadSetup.append_system_prompt_messages(
-        kwargs=kwargs, messages=[]
-    )
+    result = StandardLoggingPayloadSetup.append_system_prompt_messages(kwargs=kwargs, messages=[])
     assert len(result) == 1
     assert result[0] == {"role": "system", "content": "You are a helpful assistant"}
 
@@ -2142,24 +2061,18 @@ def test_append_system_prompt_messages():
         {"role": "system", "content": "You are a helpful assistant"},
         {"role": "user", "content": "Hello"},
     ]
-    result = StandardLoggingPayloadSetup.append_system_prompt_messages(
-        kwargs=kwargs, messages=messages
-    )
+    result = StandardLoggingPayloadSetup.append_system_prompt_messages(kwargs=kwargs, messages=messages)
     assert len(result) == 2
     assert result[0] == {"role": "system", "content": "You are a helpful assistant"}
 
     # Test case 5: no system in kwargs returns messages unchanged
     kwargs = {}
     messages = [{"role": "user", "content": "Hello"}]
-    result = StandardLoggingPayloadSetup.append_system_prompt_messages(
-        kwargs=kwargs, messages=messages
-    )
+    result = StandardLoggingPayloadSetup.append_system_prompt_messages(kwargs=kwargs, messages=messages)
     assert result == messages
 
     # Test case 6: None kwargs returns messages unchanged
-    result = StandardLoggingPayloadSetup.append_system_prompt_messages(
-        kwargs=None, messages=messages
-    )
+    result = StandardLoggingPayloadSetup.append_system_prompt_messages(kwargs=None, messages=messages)
     assert result == messages
 
 
@@ -2220,12 +2133,11 @@ async def test_async_success_handler_sets_standard_logging_object_for_pass_throu
 
     # Verify that standard_logging_object was set
     assert "standard_logging_object" in logging_obj.model_call_details, (
-        "standard_logging_object should be set for pass-through endpoints "
-        "even when complete_streaming_response is None"
+        "standard_logging_object should be set for pass-through endpoints even when complete_streaming_response is None"
     )
-    assert (
-        logging_obj.model_call_details["standard_logging_object"] is not None
-    ), "standard_logging_object should not be None for pass-through endpoints"
+    assert logging_obj.model_call_details["standard_logging_object"] is not None, (
+        "standard_logging_object should not be None for pass-through endpoints"
+    )
 
     # Verify that async_complete_streaming_response was set to prevent re-processing
     # This is consistent with the existing code pattern for regular streaming
@@ -2233,15 +2145,13 @@ async def test_async_success_handler_sets_standard_logging_object_for_pass_throu
         "async_complete_streaming_response should be set to prevent re-processing, "
         "consistent with the existing code pattern"
     )
-    assert (
-        logging_obj.model_call_details["async_complete_streaming_response"] is result
-    ), "async_complete_streaming_response should be set to the result"
+    assert logging_obj.model_call_details["async_complete_streaming_response"] is result, (
+        "async_complete_streaming_response should be set to the result"
+    )
 
     # Verify that response_cost is set to None (cost calculation not possible for pass-through)
     # This is consistent with the error handling in the non-pass-through code path
-    assert (
-        "response_cost" in logging_obj.model_call_details
-    ), "response_cost should be set for pass-through endpoints"
+    assert "response_cost" in logging_obj.model_call_details, "response_cost should be set for pass-through endpoints"
     assert logging_obj.model_call_details["response_cost"] is None, (
         "response_cost should be None for pass-through endpoints since "
         "StandardPassThroughResponseObject doesn't have standard usage info"
@@ -2300,14 +2210,10 @@ async def test_async_success_handler_prevents_reprocessing_for_pass_through_endp
     # Verify first call set the values
     assert "standard_logging_object" in logging_obj.model_call_details
     assert "async_complete_streaming_response" in logging_obj.model_call_details
-    first_standard_logging_object = logging_obj.model_call_details[
-        "standard_logging_object"
-    ]
+    first_standard_logging_object = logging_obj.model_call_details["standard_logging_object"]
 
     # Second call - should return early due to async_complete_streaming_response guard
-    with patch.object(
-        logging_obj, "get_combined_callback_list", return_value=[]
-    ) as mock_callbacks:
+    with patch.object(logging_obj, "get_combined_callback_list", return_value=[]) as mock_callbacks:
         await logging_obj.async_success_handler(
             result=result,
             start_time=start_time,
@@ -2318,10 +2224,9 @@ async def test_async_success_handler_prevents_reprocessing_for_pass_through_endp
         mock_callbacks.assert_not_called()
 
     # Verify standard_logging_object wasn't modified by second call
-    assert (
-        logging_obj.model_call_details["standard_logging_object"]
-        is first_standard_logging_object
-    ), "standard_logging_object should not be modified on re-processing"
+    assert logging_obj.model_call_details["standard_logging_object"] is first_standard_logging_object, (
+        "standard_logging_object should not be modified on re-processing"
+    )
 
 
 @pytest.mark.asyncio
@@ -2360,9 +2265,7 @@ async def test_async_success_handler_sets_standard_logging_object_for_streaming_
     }
 
     # Create a pass-through response object (simulating unparseable streaming response)
-    result = StandardPassThroughResponseObject(
-        response='data: {"chunk": 1}\ndata: {"chunk": 2}\ndata: [DONE]'
-    )
+    result = StandardPassThroughResponseObject(response='data: {"chunk": 1}\ndata: {"chunk": 2}\ndata: [DONE]')
 
     start_time = datetime.now()
     end_time = datetime.now()
@@ -2382,9 +2285,9 @@ async def test_async_success_handler_sets_standard_logging_object_for_streaming_
         "standard_logging_object should be set for streaming pass-through endpoints "
         "even when the response cannot be parsed into a ModelResponse"
     )
-    assert (
-        logging_obj.model_call_details["standard_logging_object"] is not None
-    ), "standard_logging_object should not be None for streaming pass-through endpoints"
+    assert logging_obj.model_call_details["standard_logging_object"] is not None, (
+        "standard_logging_object should not be None for streaming pass-through endpoints"
+    )
 
 
 def test_get_error_information_error_code_priority():
@@ -2426,30 +2329,22 @@ def test_get_error_information_error_code_priority():
             self.message = message
             super().__init__(message)
 
-    both_exception = BothAttributesException(
-        code="400", status_code=500, message="Bad Request"
-    )
+    both_exception = BothAttributesException(code="400", status_code=500, message="Bad Request")
     result = StandardLoggingPayloadSetup.get_error_information(both_exception)
     assert result["error_code"] == "400"  # Should prefer 'code' over 'status_code'
 
     # Test case 4: Exception with 'code' as empty string - should fall back to 'status_code'
-    empty_code_exception = BothAttributesException(
-        code="", status_code=404, message="Not Found"
-    )
+    empty_code_exception = BothAttributesException(code="", status_code=404, message="Not Found")
     result = StandardLoggingPayloadSetup.get_error_information(empty_code_exception)
     assert result["error_code"] == "404"  # Should fall back to status_code
 
     # Test case 5: Exception with 'code' as "None" string - should fall back to 'status_code'
-    none_string_exception = BothAttributesException(
-        code="None", status_code=503, message="Service Unavailable"
-    )
+    none_string_exception = BothAttributesException(code="None", status_code=503, message="Service Unavailable")
     result = StandardLoggingPayloadSetup.get_error_information(none_string_exception)
     assert result["error_code"] == "503"  # Should fall back to status_code
 
     # Test case 6: Exception with 'code' as None - should fall back to 'status_code'
-    none_code_exception = BothAttributesException(
-        code=None, status_code=401, message="Unauthorized"
-    )
+    none_code_exception = BothAttributesException(code=None, status_code=401, message="Unauthorized")
     result = StandardLoggingPayloadSetup.get_error_information(none_code_exception)
     assert result["error_code"] == "401"  # Should fall back to status_code
 
@@ -2498,9 +2393,7 @@ def test_get_error_information_prefers_message_attribute_over_str():
     )
 
     result = StandardLoggingPayloadSetup.get_error_information(exc)
-    assert (
-        result["error_message"] == msg
-    ), f"expected message from .message attribute, got {result['error_message']!r}"
+    assert result["error_message"] == msg, f"expected message from .message attribute, got {result['error_message']!r}"
     assert result["error_code"] == "401"
     assert result["error_class"] == "ProxyExceptionLike"
 
@@ -2575,8 +2468,7 @@ def test_get_error_information_preserves_explicit_empty_message():
     exc = ProxyExceptionLike(message="", code=500)
     result = StandardLoggingPayloadSetup.get_error_information(exc)
     assert result["error_message"] == "", (
-        "explicit empty .message must survive verbatim; got "
-        f"{result['error_message']!r}"
+        f"explicit empty .message must survive verbatim; got {result['error_message']!r}"
     )
 
 
@@ -2865,9 +2757,7 @@ def test_process_hidden_params_recalculates_cost_after_failure_handler_zero():
         choices=[{"message": {"role": "assistant", "content": "ok"}}],
         usage=Usage(prompt_tokens=9698, completion_tokens=30, total_tokens=9728),
     )
-    logging_obj._process_hidden_params_and_response_cost(
-        result, datetime.now(), datetime.now()
-    )
+    logging_obj._process_hidden_params_and_response_cost(result, datetime.now(), datetime.now())
 
     cost = logging_obj.model_call_details.get("response_cost")
     assert cost is not None and cost > 0
@@ -2891,9 +2781,7 @@ def test_process_hidden_params_preserves_zero_cost_in_hidden_params():
         litellm_call_id="test-hidden-zero-cost",
         function_id="test-hidden-zero-cost",
     )
-    logging_obj.model_call_details["litellm_params"] = {
-        "model": "gemini-2.5-flash-lite"
-    }
+    logging_obj.model_call_details["litellm_params"] = {"model": "gemini-2.5-flash-lite"}
     logging_obj.optional_params = {}
 
     result = ModelResponse(
@@ -2903,9 +2791,7 @@ def test_process_hidden_params_preserves_zero_cost_in_hidden_params():
     )
     result._hidden_params = {"response_cost": 0.0}
 
-    logging_obj._process_hidden_params_and_response_cost(
-        result, datetime.now(), datetime.now()
-    )
+    logging_obj._process_hidden_params_and_response_cost(result, datetime.now(), datetime.now())
 
     assert logging_obj.model_call_details.get("response_cost") == 0.0
     slo = logging_obj.model_call_details.get("standard_logging_object") or {}
@@ -2954,9 +2840,7 @@ def test_process_hidden_params_uses_hidden_params_cost_after_failure_handler_zer
     )
     result._hidden_params = {"response_cost": passthrough_cost}
 
-    logging_obj._process_hidden_params_and_response_cost(
-        result, datetime.now(), datetime.now()
-    )
+    logging_obj._process_hidden_params_and_response_cost(result, datetime.now(), datetime.now())
 
     assert logging_obj.model_call_details.get("response_cost") == passthrough_cost
     slo = logging_obj.model_call_details.get("standard_logging_object") or {}
@@ -3013,9 +2897,7 @@ def test_function_setup_litellm_metadata_populates_metadata():
     assert litellm_metadata.get("user_api_key_hash") == test_api_key_hash
 
     # metadata should be a COPY, not an alias — mutating one must not affect the other
-    assert (
-        metadata is not litellm_metadata
-    ), "litellm_params['metadata'] should be a copy, not the same object"
+    assert metadata is not litellm_metadata, "litellm_params['metadata'] should be a copy, not the same object"
 
 
 def test_function_setup_metadata_takes_precedence_over_litellm_metadata():
@@ -3179,9 +3061,7 @@ def test_failure_handler_skips_sync_callbacks_for_pass_through_requests(logging_
 
 
 @pytest.mark.parametrize("call_type", ["completion", "acompletion"])
-def test_failure_handler_runs_sync_callbacks_for_non_pass_through_requests(
-    logging_obj, call_type
-):
+def test_failure_handler_runs_sync_callbacks_for_non_pass_through_requests(logging_obj, call_type):
     """Ensure sync failure callbacks still fire for normal (non-pass-through) requests."""
     from litellm.integrations.custom_logger import CustomLogger
 
@@ -3297,9 +3177,7 @@ def test_standard_logging_hidden_params_backfills_response_cost_without_mutating
     )
     response._hidden_params = {"response_cost": None, "model_id": "mid-test"}
 
-    payload = logging_obj._build_standard_logging_payload(
-        response, datetime.now(), datetime.now()
-    )
+    payload = logging_obj._build_standard_logging_payload(response, datetime.now(), datetime.now())
 
     assert payload is not None
     assert payload["hidden_params"]["response_cost"] == 0.002
@@ -3353,10 +3231,7 @@ def test_merge_hidden_params_from_response_into_metadata_no_op_when_empty():
         _hidden_params = {}
 
     logging_obj._merge_hidden_params_from_response_into_metadata(_NoHp())
-    assert (
-        "hidden_params"
-        not in logging_obj.model_call_details["litellm_params"]["metadata"]
-    )
+    assert "hidden_params" not in logging_obj.model_call_details["litellm_params"]["metadata"]
 
 
 # ── StandardLoggingPayloadSetup.get_additional_headers ───────────────────────
@@ -3469,9 +3344,7 @@ def test_success_handler_computes_cost_for_dict_response():
             "_build_standard_logging_payload",
             return_value={"response_cost": expected_cost},
         ),
-        patch(
-            "litellm.litellm_core_utils.litellm_logging.emit_standard_logging_payload"
-        ),
+        patch("litellm.litellm_core_utils.litellm_logging.emit_standard_logging_payload"),
         patch.object(
             logging_obj,
             "_is_recognized_call_type_for_logging",
@@ -3508,9 +3381,7 @@ def test_success_handler_preserves_precomputed_cost_for_dict_response():
             "_build_standard_logging_payload",
             return_value={"response_cost": precomputed_cost},
         ),
-        patch(
-            "litellm.litellm_core_utils.litellm_logging.emit_standard_logging_payload"
-        ),
+        patch("litellm.litellm_core_utils.litellm_logging.emit_standard_logging_payload"),
         patch.object(
             logging_obj,
             "_is_recognized_call_type_for_logging",
@@ -3549,9 +3420,7 @@ def test_success_handler_unified_helper_runs_for_typed_results():
             "_build_standard_logging_payload",
             return_value={"response_cost": expected_cost},
         ),
-        patch(
-            "litellm.litellm_core_utils.litellm_logging.emit_standard_logging_payload"
-        ),
+        patch("litellm.litellm_core_utils.litellm_logging.emit_standard_logging_payload"),
         patch.object(
             logging_obj,
             "_is_recognized_call_type_for_logging",
@@ -3606,9 +3475,7 @@ class TestFirstApiCallStartTimeSetOnce:
         assert first == obj.model_call_details["api_call_start_time"]
         # Set on the logging object only — user metadata untouched.
         assert user_meta == {}
-        assert (
-            "first_api_call_start_time" not in obj.model_call_details["litellm_params"]
-        )
+        assert "first_api_call_start_time" not in obj.model_call_details["litellm_params"]
 
         time.sleep(0.002)  # ensure a distinct retry timestamp
         obj.pre_call(input="hi", api_key="sk-test")
@@ -3625,18 +3492,16 @@ def test_get_error_information_for_logging_payload_ignores_spoofed_disconnect_wi
     baseline = StandardLoggingPayloadSetup.get_error_information(
         original_exception=ValueError("provider failure"),
     )
-    error_information, error_str = (
-        StandardLoggingPayloadSetup.get_error_information_for_logging_payload(
-            metadata={
-                "error_information": {
-                    "error_code": "499",
-                    "error_message": "Client disconnected the request",
-                    "error_class": "ClientDisconnected",
-                }
-            },
-            original_exception=ValueError("provider failure"),
-            error_str="provider failure",
-        )
+    error_information, error_str = StandardLoggingPayloadSetup.get_error_information_for_logging_payload(
+        metadata={
+            "error_information": {
+                "error_code": "499",
+                "error_message": "Client disconnected the request",
+                "error_class": "ClientDisconnected",
+            }
+        },
+        original_exception=ValueError("provider failure"),
+        error_str="provider failure",
     )
     assert error_information == baseline
     assert error_str == "provider failure"
@@ -3650,22 +3515,18 @@ def test_get_error_information_for_logging_payload_client_disconnect():
         "error_message": "Client disconnected the request",
         "error_class": "ClientDisconnected",
     }
-    error_information, error_str = (
-        StandardLoggingPayloadSetup.get_error_information_for_logging_payload(
-            metadata={"client_disconnected": True, "error_information": custom_error},
-            original_exception=None,
-            error_str=None,
-        )
+    error_information, error_str = StandardLoggingPayloadSetup.get_error_information_for_logging_payload(
+        metadata={"client_disconnected": True, "error_information": custom_error},
+        original_exception=None,
+        error_str=None,
     )
     assert error_information == custom_error
     assert error_str == "Client disconnected the request"
 
-    error_information, error_str = (
-        StandardLoggingPayloadSetup.get_error_information_for_logging_payload(
-            metadata={"client_disconnected": True},
-            original_exception=None,
-            error_str="existing error",
-        )
+    error_information, error_str = StandardLoggingPayloadSetup.get_error_information_for_logging_payload(
+        metadata={"client_disconnected": True},
+        original_exception=None,
+        error_str="existing error",
     )
     assert error_information["error_code"] == "499"
     assert error_str == "existing error"
@@ -3673,12 +3534,10 @@ def test_get_error_information_for_logging_payload_client_disconnect():
     baseline = StandardLoggingPayloadSetup.get_error_information(
         original_exception=None,
     )
-    error_information, error_str = (
-        StandardLoggingPayloadSetup.get_error_information_for_logging_payload(
-            metadata={},
-            original_exception=None,
-            error_str=None,
-        )
+    error_information, error_str = StandardLoggingPayloadSetup.get_error_information_for_logging_payload(
+        metadata={},
+        original_exception=None,
+        error_str=None,
     )
     assert error_information == baseline
     assert error_str is None
@@ -3713,9 +3572,7 @@ def test_get_error_information_prefers_message_attribute_over_empty_str():
         def __str__(self):
             return ""
 
-    info = StandardLoggingPayloadSetup.get_error_information(
-        original_exception=_SilentExc()
-    )
+    info = StandardLoggingPayloadSetup.get_error_information(original_exception=_SilentExc())
     assert info["error_message"] == "real failure detail"
     assert info["error_code"] == "401"
 
@@ -3746,9 +3603,7 @@ def _responses_api_response_with_text(text="hello world"):
                 type="message",
                 role="assistant",
                 status="completed",
-                content=[
-                    ResponseOutputText(annotations=[], text=text, type="output_text")
-                ],
+                content=[ResponseOutputText(annotations=[], text=text, type="output_text")],
             )
         ],
         usage=ResponseAPIUsage(input_tokens=11, output_tokens=7, total_tokens=18),
@@ -3763,9 +3618,7 @@ def _responses_api_response_with_text(text="hello world"):
         ("ResponseFailedEvent", "response.failed"),
     ],
 )
-def test_handle_anthropic_messages_response_logging_translates_terminal_responses_api_event(
-    event_cls, event_type
-):
+def test_handle_anthropic_messages_response_logging_translates_terminal_responses_api_event(event_cls, event_type):
     """Regression for #28595 / #28943. When anthropic_messages routes to the OpenAI
     Responses backend and stream=True, success_handler receives a terminal Responses
     API event. The handler must translate it to a ModelResponse whose choices carry
@@ -3804,10 +3657,7 @@ def test_handle_anthropic_messages_response_logging_passes_model_response_throug
     """Anthropic-native path already yields a ModelResponse; it must be returned unchanged."""
     logging_obj = _anthropic_messages_logging_obj()
     model_response = ModelResponse()
-    assert (
-        logging_obj._handle_anthropic_messages_response_logging(result=model_response)
-        is model_response
-    )
+    assert logging_obj._handle_anthropic_messages_response_logging(result=model_response) is model_response
 
 
 def test_handle_anthropic_messages_response_logging_degrades_on_unparseable_responses_payload():
@@ -4103,9 +3953,7 @@ def test_non_image_response_has_no_output_image_count(logging_obj):
 
 def test_zero_token_video_usage_preserves_duration_seconds(logging_obj):
     """Video usage bills by duration; the payload must keep duration_seconds even with zero tokens."""
-    payload = _build_payload_for_media_response(
-        logging_obj, {"id": "video-1", "usage": {"duration_seconds": 4.0}}
-    )
+    payload = _build_payload_for_media_response(logging_obj, {"id": "video-1", "usage": {"duration_seconds": 4.0}})
 
     assert payload is not None
     assert payload["metadata"]["usage_object"]["duration_seconds"] == 4.0


### PR DESCRIPTION
Fixes #34754

Three code paths assumed `response` is a Pydantic object but some upstream providers return a plain `dict`, causing `AttributeError: 'dict' object has no attribute 'usage'`.

- `router.py`: add `isinstance(completed.response, dict)` guard before `.usage` access
- `litellm_logging.py`: add `isinstance(result.response, dict)` guard before `.usage` access
- `transformation.py`: add `or []` fallback for None `output_items`
