### PR TITLE
fix(complexity_router): escalate a session pin when a turn scores higher

### DIFF
--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -753,31 +753,37 @@ class ComplexityRouter(CustomLogger):
             return pinned_model, "session_affinity_pin"
         return self.get_model_for_tier(classified_tier), "session_affinity_complexity_escalation"
 
-    def _more_severe_model(self, current_model: str, candidate_model: str) -> str:
-        """Return whichever of the two models maps to the more severe configured tier."""
-        current_tier = self._tier_for_model(current_model)
-        candidate_tier = self._tier_for_model(candidate_model)
-        if current_tier is None or candidate_tier is None:
-            return candidate_model
-        if TIER_SEVERITY_ORDER.index(current_tier) > TIER_SEVERITY_ORDER.index(candidate_tier):
-            return current_model
-        return candidate_model
+    def _session_pin_keys(self, cache_key: str) -> tuple[str, ...]:
+        """Per-tier pin keys for one session, ordered least to most severe."""
+        return tuple(f"{cache_key}:{tier.value}" for tier in TIER_SEVERITY_ORDER if tier.value in self.config.tiers)
+
+    async def _get_session_pin(self, cache_key: str) -> str | None:
+        """Read a session's pin as the most severe tier it has been routed to."""
+        keys = self._session_pin_keys(cache_key)
+        if not keys:
+            return None
+        cached = await self.litellm_router_instance.cache.async_batch_get_cache(keys=list(keys))
+        if not isinstance(cached, list):
+            return None
+        return next((model for model in reversed(cached) if isinstance(model, str)), None)
 
     async def _persist_session_pin(self, cache_key: str, routed_model: str) -> None:
-        """Write the session pin, refreshing its TTL, without ever lowering it.
+        """Record the model this turn served under the key for its own tier.
 
-        Concurrent turns in one session all resolve against the same cached pin and then
-        write back, so an unconditional write lets a turn that resolved before another
-        turn's escalation land last and revert the session to the weaker model. Re-reading
-        at write time and keeping the more severe tier makes the pin monotonic.
+        Holding the pin in a single key forces a read-modify-write, and concurrent turns in
+        one session can both read before either writes, so the weaker turn lands last and
+        reverts an escalation. Writing one key per tier drops the read: a turn only ever
+        touches the tier it served, and the session resolves to the most severe tier written,
+        which cannot fall while those keys live.
+
+        Skips models outside the configured tiers, which have no severity to resolve against.
         """
-        current_model = await self.litellm_router_instance.cache.async_get_cache(key=cache_key)
-        winner = (
-            self._more_severe_model(current_model, routed_model) if isinstance(current_model, str) else routed_model
-        )
+        tier = self._tier_for_model(routed_model)
+        if tier is None:
+            return
         await self.litellm_router_instance.cache.async_set_cache(
-            key=cache_key,
-            value=winner,
+            key=f"{cache_key}:{tier.value}",
+            value=routed_model,
             ttl=self.config.session_affinity_ttl_seconds,
         )
 
@@ -1027,8 +1033,8 @@ class ComplexityRouter(CustomLogger):
         cache_key = self._get_session_affinity_cache_key(session_id, request_kwargs) if session_id is not None else None
 
         if cache_key is not None:
-            pinned_model = await self.litellm_router_instance.cache.async_get_cache(key=cache_key)
-            if isinstance(pinned_model, str):
+            pinned_model = await self._get_session_pin(cache_key)
+            if pinned_model is not None:
                 resolved_messages = self._resolve_messages(messages, request_kwargs)
                 user_message, system_prompt = (
                     self._extract_user_message_and_system_prompt(resolved_messages)

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -753,6 +753,34 @@ class ComplexityRouter(CustomLogger):
             return pinned_model, "session_affinity_pin"
         return self.get_model_for_tier(classified_tier), "session_affinity_complexity_escalation"
 
+    def _more_severe_model(self, current_model: str, candidate_model: str) -> str:
+        """Return whichever of the two models maps to the more severe configured tier."""
+        current_tier = self._tier_for_model(current_model)
+        candidate_tier = self._tier_for_model(candidate_model)
+        if current_tier is None or candidate_tier is None:
+            return candidate_model
+        if TIER_SEVERITY_ORDER.index(current_tier) > TIER_SEVERITY_ORDER.index(candidate_tier):
+            return current_model
+        return candidate_model
+
+    async def _persist_session_pin(self, cache_key: str, routed_model: str) -> None:
+        """Write the session pin, refreshing its TTL, without ever lowering it.
+
+        Concurrent turns in one session all resolve against the same cached pin and then
+        write back, so an unconditional write lets a turn that resolved before another
+        turn's escalation land last and revert the session to the weaker model. Re-reading
+        at write time and keeping the more severe tier makes the pin monotonic.
+        """
+        current_model = await self.litellm_router_instance.cache.async_get_cache(key=cache_key)
+        winner = (
+            self._more_severe_model(current_model, routed_model) if isinstance(current_model, str) else routed_model
+        )
+        await self.litellm_router_instance.cache.async_set_cache(
+            key=cache_key,
+            value=winner,
+            ttl=self.config.session_affinity_ttl_seconds,
+        )
+
     def _lexical_tier_override(self, user_message: str) -> ComplexityTier | None:
         """When keyword_tier_rules match literally, the most-severe matched tier wins.
 
@@ -1009,13 +1037,7 @@ class ComplexityRouter(CustomLogger):
                 )
                 routed_model, cause = self._resolve_pinned_model(pinned_model, user_message, system_prompt)
                 if routed_model is not None:
-                    # Refresh the TTL on every hit so an active session doesn't lose its
-                    # pin mid-conversation just because it outlives the original write.
-                    await self.litellm_router_instance.cache.async_set_cache(
-                        key=cache_key,
-                        value=routed_model,
-                        ttl=self.config.session_affinity_ttl_seconds,
-                    )
+                    await self._persist_session_pin(cache_key, routed_model)
                     if self.config.adaptive:
                         from litellm.router_strategy.adaptive_router.config import (
                             ADAPTIVE_ROUTER_CHOSEN_MODEL_KEY,
@@ -1041,11 +1063,7 @@ class ComplexityRouter(CustomLogger):
             specific_deployment=specific_deployment,
         )
         if cache_key is not None and response is not None:
-            await self.litellm_router_instance.cache.async_set_cache(
-                key=cache_key,
-                value=response.model,
-                ttl=self.config.session_affinity_ttl_seconds,
-            )
+            await self._persist_session_pin(cache_key, response.model)
         return response
 
     async def _classify_and_route(

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -722,6 +722,37 @@ class ComplexityRouter(CustomLogger):
             return pinned_model
         return self.get_model_for_tier(escalated_tier)
 
+    def _resolve_pinned_model(
+        self,
+        pinned_model: str,
+        user_message: str | None,
+        system_prompt: str | None,
+    ) -> tuple[str | None, str]:
+        """Resolve the model a pinned session serves this turn, with its routing cause.
+
+        A pin is a floor rather than a lock: the heuristic scorer runs on each pinned turn
+        and raises the pin when the turn scores above the pinned tier, so a session pinned
+        on a trivial opening turn is not held on that tier for the rest of its life. The pin
+        is never lowered, so a provider prompt cache is only invalidated on the way up.
+
+        Scores with ``classify`` rather than ``aclassify`` so a pinned turn never pays for an
+        LLM classifier call or an embedding lookup.
+
+        Returns ``None`` when the pin no longer maps to a configured tier, signalling a full
+        reclassification instead.
+        """
+        if user_message is None:
+            return pinned_model, "session_affinity_pin"
+        if self.escalation_keywords and self._escalation_triggered(user_message):
+            return self._escalated_pin(pinned_model), "session_affinity_escalation"
+        pinned_tier = self._tier_for_model(pinned_model)
+        if pinned_tier is None:
+            return pinned_model, "session_affinity_pin"
+        classified_tier, _, _ = self.classify(user_message, system_prompt)
+        if TIER_SEVERITY_ORDER.index(classified_tier) <= TIER_SEVERITY_ORDER.index(pinned_tier):
+            return pinned_model, "session_affinity_pin"
+        return self.get_model_for_tier(classified_tier), "session_affinity_complexity_escalation"
+
     def _lexical_tier_override(self, user_message: str) -> ComplexityTier | None:
         """When keyword_tier_rules match literally, the most-severe matched tier wins.
 
@@ -970,16 +1001,13 @@ class ComplexityRouter(CustomLogger):
         if cache_key is not None:
             pinned_model = await self.litellm_router_instance.cache.async_get_cache(key=cache_key)
             if isinstance(pinned_model, str):
-                routed_model: str | None = pinned_model
-                if self.escalation_keywords:
-                    resolved_messages = self._resolve_messages(messages, request_kwargs)
-                    user_message = (
-                        self._extract_user_message_and_system_prompt(resolved_messages)[0]
-                        if resolved_messages
-                        else None
-                    )
-                    if user_message is not None and self._escalation_triggered(user_message):
-                        routed_model = self._escalated_pin(pinned_model)
+                resolved_messages = self._resolve_messages(messages, request_kwargs)
+                user_message, system_prompt = (
+                    self._extract_user_message_and_system_prompt(resolved_messages)
+                    if resolved_messages
+                    else (None, None)
+                )
+                routed_model, cause = self._resolve_pinned_model(pinned_model, user_message, system_prompt)
                 if routed_model is not None:
                     # Refresh the TTL on every hit so an active session doesn't lose its
                     # pin mid-conversation just because it outlives the original write.
@@ -996,7 +1024,6 @@ class ComplexityRouter(CustomLogger):
                         kwargs_metadata = request_kwargs.setdefault("metadata", {})
                         if isinstance(kwargs_metadata, dict):
                             kwargs_metadata[ADAPTIVE_ROUTER_CHOSEN_MODEL_KEY] = routed_model
-                    cause = "session_affinity_escalation" if routed_model != pinned_model else "session_affinity_pin"
                     verbose_router_logger.info(
                         f"ComplexityRouter: routing decision cause={cause}, routed_model={routed_model}"
                     )

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -794,12 +794,37 @@ class ComplexityRouter(CustomLogger):
         The tier comes from the caller because a model may sit in several tier pools, and
         recovering it from the model would promote the pin to that model's highest tier and
         hold later turns above the tier the session actually needed.
+
+        Tier keys expire independently, so a weaker turn that resolved before an escalation
+        but wrote after it would outlive the stronger key and hand the session back to the
+        cheaper model. A turn whose tier already sits below a live key therefore skips the
+        write, and writing a tier drops the keys beneath it. The cache has no
+        compare-and-swap, so a turn that escalates between this read and this write can
+        still leave a weaker key behind; the session's next turn drops it.
         """
+        keyed_tiers = self._session_pin_keys(cache_key)
+        cached = await self.litellm_router_instance.cache.async_batch_get_cache(keys=[key for _, key in keyed_tiers])
+        pinned = cached if isinstance(cached, list) and len(cached) == len(keyed_tiers) else [None] * len(keyed_tiers)
+        rank = TIER_SEVERITY_ORDER.index(tier)
+        if any(
+            isinstance(model, str) and TIER_SEVERITY_ORDER.index(key_tier) > rank
+            for (key_tier, _), model in zip(keyed_tiers, pinned)
+        ):
+            return
         await self.litellm_router_instance.cache.async_set_cache(
             key=f"{cache_key}:{tier.value}",
             value=routed_model,
             ttl=self.config.session_affinity_ttl_seconds,
         )
+        subordinate_keys = tuple(
+            key
+            for (key_tier, key), model in zip(keyed_tiers, pinned)
+            if isinstance(model, str) and TIER_SEVERITY_ORDER.index(key_tier) < rank
+        )
+        if subordinate_keys:
+            await asyncio.gather(
+                *(self.litellm_router_instance.cache.async_delete_cache(key) for key in subordinate_keys)
+            )
 
     def _lexical_tier_override(self, user_message: str) -> ComplexityTier | None:
         """When keyword_tier_rules match literally, the most-severe matched tier wins.

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -725,9 +725,10 @@ class ComplexityRouter(CustomLogger):
     def _resolve_pinned_model(
         self,
         pinned_model: str,
+        pinned_tier: ComplexityTier,
         user_message: str | None,
         system_prompt: str | None,
-    ) -> tuple[str | None, str]:
+    ) -> tuple[str | None, ComplexityTier, str]:
         """Resolve the model a pinned session serves this turn, with its routing cause.
 
         A pin is a floor rather than a lock: the heuristic scorer runs on each pinned turn
@@ -738,37 +739,51 @@ class ComplexityRouter(CustomLogger):
         Scores with ``classify`` rather than ``aclassify`` so a pinned turn never pays for an
         LLM classifier call or an embedding lookup.
 
-        Returns ``None`` when the pin no longer maps to a configured tier, signalling a full
-        reclassification instead.
+        ``pinned_tier`` is the tier the pin was stored under rather than one re-derived from
+        the model, so a model shared across tier pools is compared at the tier that actually
+        selected it.
+
+        Returns ``None`` for the model when the pin no longer maps to a configured tier,
+        signalling a full reclassification instead.
         """
         if user_message is None:
-            return pinned_model, "session_affinity_pin"
+            return pinned_model, pinned_tier, "session_affinity_pin"
         if self.escalation_keywords and self._escalation_triggered(user_message):
-            return self._escalated_pin(pinned_model), "session_affinity_escalation"
-        pinned_tier = self._tier_for_model(pinned_model)
-        if pinned_tier is None:
-            return pinned_model, "session_affinity_pin"
+            return self._escalated_pin(pinned_model), self._escalate_tier(pinned_tier), "session_affinity_escalation"
         classified_tier, _, _ = self.classify(user_message, system_prompt)
         if TIER_SEVERITY_ORDER.index(classified_tier) <= TIER_SEVERITY_ORDER.index(pinned_tier):
-            return pinned_model, "session_affinity_pin"
-        return self.get_model_for_tier(classified_tier), "session_affinity_complexity_escalation"
+            return pinned_model, pinned_tier, "session_affinity_pin"
+        return (
+            self.get_model_for_tier(classified_tier),
+            classified_tier,
+            "session_affinity_complexity_escalation",
+        )
 
-    def _session_pin_keys(self, cache_key: str) -> tuple[str, ...]:
+    def _session_pin_keys(self, cache_key: str) -> tuple[tuple[ComplexityTier, str], ...]:
         """Per-tier pin keys for one session, ordered least to most severe."""
-        return tuple(f"{cache_key}:{tier.value}" for tier in TIER_SEVERITY_ORDER if tier.value in self.config.tiers)
+        return tuple(
+            (tier, f"{cache_key}:{tier.value}") for tier in TIER_SEVERITY_ORDER if tier.value in self.config.tiers
+        )
 
-    async def _get_session_pin(self, cache_key: str) -> str | None:
-        """Read a session's pin as the most severe tier it has been routed to."""
-        keys = self._session_pin_keys(cache_key)
-        if not keys:
+    async def _get_session_pin(self, cache_key: str) -> tuple[str, ComplexityTier] | None:
+        """Read a session's pin: the model held under its most severe written tier."""
+        keyed_tiers = self._session_pin_keys(cache_key)
+        if not keyed_tiers:
             return None
-        cached = await self.litellm_router_instance.cache.async_batch_get_cache(keys=list(keys))
-        if not isinstance(cached, list):
+        cached = await self.litellm_router_instance.cache.async_batch_get_cache(keys=[key for _, key in keyed_tiers])
+        if not isinstance(cached, list) or len(cached) != len(keyed_tiers):
             return None
-        return next((model for model in reversed(cached) if isinstance(model, str)), None)
+        return next(
+            (
+                (model, tier)
+                for (tier, _), model in zip(reversed(keyed_tiers), reversed(cached))
+                if isinstance(model, str)
+            ),
+            None,
+        )
 
-    async def _persist_session_pin(self, cache_key: str, routed_model: str) -> None:
-        """Record the model this turn served under the key for its own tier.
+    async def _persist_session_pin(self, cache_key: str, routed_model: str, tier: ComplexityTier) -> None:
+        """Record the model this turn served under the key for the tier that selected it.
 
         Holding the pin in a single key forces a read-modify-write, and concurrent turns in
         one session can both read before either writes, so the weaker turn lands last and
@@ -776,11 +791,10 @@ class ComplexityRouter(CustomLogger):
         touches the tier it served, and the session resolves to the most severe tier written,
         which cannot fall while those keys live.
 
-        Skips models outside the configured tiers, which have no severity to resolve against.
+        The tier comes from the caller because a model may sit in several tier pools, and
+        recovering it from the model would promote the pin to that model's highest tier and
+        hold later turns above the tier the session actually needed.
         """
-        tier = self._tier_for_model(routed_model)
-        if tier is None:
-            return
         await self.litellm_router_instance.cache.async_set_cache(
             key=f"{cache_key}:{tier.value}",
             value=routed_model,
@@ -1033,17 +1047,20 @@ class ComplexityRouter(CustomLogger):
         cache_key = self._get_session_affinity_cache_key(session_id, request_kwargs) if session_id is not None else None
 
         if cache_key is not None:
-            pinned_model = await self._get_session_pin(cache_key)
-            if pinned_model is not None:
+            pinned = await self._get_session_pin(cache_key)
+            if pinned is not None:
+                pinned_model, pinned_tier = pinned
                 resolved_messages = self._resolve_messages(messages, request_kwargs)
                 user_message, system_prompt = (
                     self._extract_user_message_and_system_prompt(resolved_messages)
                     if resolved_messages
                     else (None, None)
                 )
-                routed_model, cause = self._resolve_pinned_model(pinned_model, user_message, system_prompt)
+                routed_model, routed_tier, cause = self._resolve_pinned_model(
+                    pinned_model, pinned_tier, user_message, system_prompt
+                )
                 if routed_model is not None:
-                    await self._persist_session_pin(cache_key, routed_model)
+                    await self._persist_session_pin(cache_key, routed_model, routed_tier)
                     if self.config.adaptive:
                         from litellm.router_strategy.adaptive_router.config import (
                             ADAPTIVE_ROUTER_CHOSEN_MODEL_KEY,
@@ -1061,15 +1078,15 @@ class ComplexityRouter(CustomLogger):
                         messages=messages if has_original_messages else None,
                     )
 
-        response = await self._classify_and_route(
+        response, routed_tier = await self._classify_and_route(
             model=model,
             request_kwargs=request_kwargs,
             messages=messages,
             input=input,
             specific_deployment=specific_deployment,
         )
-        if cache_key is not None and response is not None:
-            await self._persist_session_pin(cache_key, response.model)
+        if cache_key is not None and response is not None and routed_tier is not None:
+            await self._persist_session_pin(cache_key, response.model, routed_tier)
         return response
 
     async def _classify_and_route(
@@ -1079,7 +1096,7 @@ class ComplexityRouter(CustomLogger):
         messages: list[dict[str, Any]] | None = None,
         input: Union[str, list] | None = None,
         specific_deployment: bool | None = False,
-    ) -> PreRoutingHookResponse | None:
+    ) -> tuple[PreRoutingHookResponse | None, ComplexityTier | None]:
         """
         Classifies the request by complexity and returns the appropriate model.
         Supports chat completions (messages), Responses API (input), and other
@@ -1093,7 +1110,10 @@ class ComplexityRouter(CustomLogger):
             specific_deployment: Whether a specific deployment was requested.
 
         Returns:
-            PreRoutingHookResponse with the routed model, or None if no routing needed.
+            The PreRoutingHookResponse with the routed model, or None if no routing needed,
+            paired with the tier that selected it so a session pin can be keyed by it. The
+            tier is None when routing bypassed classification entirely, which leaves a
+            session unpinned rather than pinning it at a guessed tier.
         """
         from litellm.types.router import PreRoutingHookResponse
 
@@ -1101,7 +1121,7 @@ class ComplexityRouter(CustomLogger):
 
         if not resolved_messages:
             verbose_router_logger.debug("ComplexityRouter: No messages could be resolved, skipping routing")
-            return None
+            return None, None
 
         # Determine whether the original request used messages directly
         has_original_messages = messages is not None and len(messages) > 0
@@ -1122,9 +1142,12 @@ class ComplexityRouter(CustomLogger):
                 routed_model = await self._pick_model_for_tier(
                     ComplexityTier.MEDIUM, messages, resolved_messages, request_kwargs
                 )
-            return PreRoutingHookResponse(
-                model=routed_model,
-                messages=messages if has_original_messages else None,
+            return (
+                PreRoutingHookResponse(
+                    model=routed_model,
+                    messages=messages if has_original_messages else None,
+                ),
+                None,
             )
 
         escalate = self._escalation_triggered(user_message)
@@ -1139,9 +1162,12 @@ class ComplexityRouter(CustomLogger):
                 f"ComplexityRouter: routing decision cause={cause}, "
                 f"tier={routed_tier.value}, routed_model={routed_model}"
             )
-            return PreRoutingHookResponse(
-                model=routed_model,
-                messages=messages if has_original_messages else None,
+            return (
+                PreRoutingHookResponse(
+                    model=routed_model,
+                    messages=messages if has_original_messages else None,
+                ),
+                routed_tier,
             )
 
         tier, score, signals = await self.aclassify(user_message, system_prompt, request_kwargs)
@@ -1168,7 +1194,10 @@ class ComplexityRouter(CustomLogger):
                 f"score={score:.3f}, signals={signals}, routed_model={routed_model}"
             )
 
-        return PreRoutingHookResponse(
-            model=routed_model,
-            messages=messages if has_original_messages else None,
+        return (
+            PreRoutingHookResponse(
+                model=routed_model,
+                messages=messages if has_original_messages else None,
+            ),
+            tier,
         )

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2748,6 +2748,75 @@ class TestSessionAffinity:
         assert second.model == "o1-preview"
 
     @pytest.mark.asyncio
+    async def test_pin_escalates_when_a_later_turn_scores_higher(self, mock_router_instance, session_affinity_config):
+        """Regression: a session whose first turn was trivial stayed on the cheap model for
+        the rest of the session, because a pinned turn returned the pin without scoring the
+        request. A later turn scoring above the pinned tier must raise the pin."""
+        mock_router_instance.cache = DualCache()
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=session_affinity_config,
+        )
+        request_kwargs = self._request_kwargs("session-1")
+        first = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=self.SIMPLE_MESSAGE
+        )
+        assert first.model == "gpt-4o-mini"
+
+        second = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=self.REASONING_MESSAGE
+        )
+        assert second.model == "o1-preview"
+
+    @pytest.mark.asyncio
+    async def test_escalated_pin_is_reused_by_later_turns(self, mock_router_instance, session_affinity_config):
+        """Escalating rewrites the pin, so the session keeps the strongest model it has
+        needed instead of dropping back to the cheap tier on the next trivial turn."""
+        mock_router_instance.cache = DualCache()
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=session_affinity_config,
+        )
+        request_kwargs = self._request_kwargs("session-1")
+        await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=self.SIMPLE_MESSAGE
+        )
+        escalated = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=self.REASONING_MESSAGE
+        )
+        assert escalated.model == "o1-preview"
+
+        third = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=self.SIMPLE_MESSAGE
+        )
+        assert third.model == "o1-preview"
+
+    @pytest.mark.asyncio
+    async def test_pin_escalation_check_does_not_call_the_llm_classifier(
+        self, mock_router_instance, session_affinity_config
+    ):
+        """The escalation check runs the local heuristic scorer, so a pinned turn never pays
+        for an LLM classifier call or an embedding lookup."""
+        mock_router_instance.cache = DualCache()
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=session_affinity_config,
+        )
+        request_kwargs = self._request_kwargs("session-1")
+        await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=self.SIMPLE_MESSAGE
+        )
+        with patch.object(router, "aclassify", wraps=router.aclassify) as spy_aclassify:
+            escalated = await router.async_pre_routing_hook(
+                model="test-model", request_kwargs=request_kwargs, messages=self.REASONING_MESSAGE
+            )
+            spy_aclassify.assert_not_called()
+        assert escalated.model == "o1-preview"
+
+    @pytest.mark.asyncio
     async def test_different_sessions_classify_independently(self, mock_router_instance, session_affinity_config):
         mock_router_instance.cache = DualCache()
         router = ComplexityRouter(

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2985,6 +2985,77 @@ class TestSessionAffinity:
         assert later.model == "o1-preview"
 
     @pytest.mark.asyncio
+    async def test_session_pin_is_absent_when_no_tiers_are_configured(self, mock_router_instance):
+        """With no tiers configured there are no pin keys to read, so the session has no pin
+        and the router falls through to classification rather than reading a stray key."""
+        mock_router_instance.cache = DualCache()
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={"tiers": {}, "session_affinity": True},
+        )
+        assert router._session_pin_keys("session-1") == ()
+        assert await router._get_session_pin("session-1") is None
+
+    @pytest.mark.asyncio
+    async def test_session_pin_is_absent_when_the_cache_returns_a_short_batch(
+        self, mock_router_instance, session_affinity_config
+    ):
+        """A batch read that does not line up with the keys requested cannot be zipped back
+        to its tiers, so the pin is treated as absent instead of mapped to the wrong tier."""
+        cache = AsyncMock()
+        cache.async_batch_get_cache = AsyncMock(return_value=["gpt-4o-mini"])
+        mock_router_instance.cache = cache
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=session_affinity_config,
+        )
+        assert await router._get_session_pin("session-1") is None
+
+    @pytest.mark.asyncio
+    async def test_a_stale_weaker_write_is_skipped_once_the_session_escalated(
+        self, mock_router_instance, session_affinity_config
+    ):
+        """Regression: tier keys expire independently, so a weaker turn that resolved before
+        an escalation but wrote after it would outlive the stronger key and hand the session
+        back to the cheap model once that key expired."""
+        mock_router_instance.cache = DualCache()
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=session_affinity_config,
+        )
+        request_kwargs = self._request_kwargs("session-1")
+        cache_key = router._get_session_affinity_cache_key("session-1", request_kwargs)
+        await router._persist_session_pin(cache_key, "o1-preview", ComplexityTier.REASONING)
+
+        await router._persist_session_pin(cache_key, "gpt-4o-mini", ComplexityTier.SIMPLE)
+
+        assert await mock_router_instance.cache.async_get_cache(key=f"{cache_key}:SIMPLE") is None
+        assert await router._get_session_pin(cache_key) == ("o1-preview", ComplexityTier.REASONING)
+
+    @pytest.mark.asyncio
+    async def test_escalating_drops_the_subordinate_tier_key(self, mock_router_instance, session_affinity_config):
+        """A key beneath the escalated tier must not survive the escalation, otherwise it can
+        outlive the stronger key and become the highest pin the session resolves to."""
+        mock_router_instance.cache = DualCache()
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=session_affinity_config,
+        )
+        request_kwargs = self._request_kwargs("session-1")
+        cache_key = router._get_session_affinity_cache_key("session-1", request_kwargs)
+        await router._persist_session_pin(cache_key, "gpt-4o-mini", ComplexityTier.SIMPLE)
+        assert await mock_router_instance.cache.async_get_cache(key=f"{cache_key}:SIMPLE") == "gpt-4o-mini"
+
+        await router._persist_session_pin(cache_key, "o1-preview", ComplexityTier.REASONING)
+
+        assert await mock_router_instance.cache.async_get_cache(key=f"{cache_key}:SIMPLE") is None
+        assert await router._get_session_pin(cache_key) == ("o1-preview", ComplexityTier.REASONING)
+
+    @pytest.mark.asyncio
     async def test_pin_escalation_check_does_not_call_the_llm_classifier(
         self, mock_router_instance, session_affinity_config
     ):

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2794,6 +2794,84 @@ class TestSessionAffinity:
         assert third.model == "o1-preview"
 
     @pytest.mark.asyncio
+    async def test_pinned_turn_without_a_user_message_keeps_the_pin(
+        self, mock_router_instance, session_affinity_config
+    ):
+        """A turn carrying no user text has nothing to score, so the pin is served unchanged
+        rather than being re-derived from an empty prompt."""
+        mock_router_instance.cache = DualCache()
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=session_affinity_config,
+        )
+        request_kwargs = self._request_kwargs("session-1")
+        await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=self.REASONING_MESSAGE
+        )
+        result = await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs=request_kwargs,
+            messages=[{"role": "assistant", "content": "continuing"}],
+        )
+        assert result.model == "o1-preview"
+
+    @pytest.mark.asyncio
+    async def test_pin_that_no_longer_maps_to_a_tier_is_served_unchanged(
+        self, mock_router_instance, session_affinity_config
+    ):
+        """A pin written before the tier config changed no longer resolves to a tier, so it
+        cannot be compared against; serve it as-is instead of guessing an escalation."""
+        mock_router_instance.cache = DualCache()
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=session_affinity_config,
+        )
+        request_kwargs = self._request_kwargs("session-1")
+        cache_key = router._get_session_affinity_cache_key("session-1", request_kwargs)
+        await mock_router_instance.cache.async_set_cache(key=cache_key, value="retired-model", ttl=60)
+
+        result = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=self.REASONING_MESSAGE
+        )
+        assert result.model == "retired-model"
+        assert await mock_router_instance.cache.async_get_cache(key=cache_key) == "retired-model"
+
+    @pytest.mark.asyncio
+    async def test_a_turn_that_resolved_pre_escalation_cannot_lower_the_pin(
+        self, mock_router_instance, session_affinity_config
+    ):
+        """Regression: concurrent turns in one session all resolve against the same cached
+        pin and then write back. A turn that resolved before another turn escalated must not
+        land last and revert the session to the weaker model."""
+        mock_router_instance.cache = DualCache()
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=session_affinity_config,
+        )
+        request_kwargs = self._request_kwargs("session-1")
+        await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=self.SIMPLE_MESSAGE
+        )
+        cache_key = router._get_session_affinity_cache_key("session-1", request_kwargs)
+        # A concurrent turn escalates the session while a trivial turn is still in flight.
+        escalated = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=self.REASONING_MESSAGE
+        )
+        assert escalated.model == "o1-preview"
+
+        # The in-flight turn now writes back the cheap model it resolved before the escalation.
+        await router._persist_session_pin(cache_key, "gpt-4o-mini")
+        assert await mock_router_instance.cache.async_get_cache(key=cache_key) == "o1-preview"
+
+        later = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=self.SIMPLE_MESSAGE
+        )
+        assert later.model == "o1-preview"
+
+    @pytest.mark.asyncio
     async def test_pin_escalation_check_does_not_call_the_llm_classifier(
         self, mock_router_instance, session_affinity_config
     ):

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2863,7 +2863,40 @@ class TestSessionAffinity:
             model="test-model", request_kwargs=request_kwargs, messages=self.REASONING_MESSAGE
         )
         assert result.model == "retired-model"
-        assert await router._get_session_pin(cache_key) == "retired-model"
+        assert await router._get_session_pin(cache_key) == ("retired-model", ComplexityTier.REASONING)
+
+    @pytest.mark.asyncio
+    async def test_pin_records_the_routing_tier_not_the_models_highest_tier(self, mock_router_instance):
+        """Regression: a model may sit in several tier pools, and keying the pin by the
+        model's highest configured tier promoted the session above the tier that actually
+        routed it, holding later turns on the more expensive tier."""
+        mock_router_instance.cache = DualCache()
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {
+                    "SIMPLE": "gpt-4o-mini",
+                    "MEDIUM": "gpt-4o-mini",
+                    "COMPLEX": "shared-model",
+                    "REASONING": "shared-model",
+                },
+                "session_affinity": True,
+            },
+        )
+        cache_key = router._get_session_affinity_cache_key("session-1", self._request_kwargs("session-1"))
+
+        await router._persist_session_pin(cache_key, "shared-model", ComplexityTier.COMPLEX)
+
+        assert await mock_router_instance.cache.async_get_cache(key=f"{cache_key}:COMPLEX") == "shared-model"
+        assert await mock_router_instance.cache.async_get_cache(key=f"{cache_key}:REASONING") is None
+        assert await router._get_session_pin(cache_key) == ("shared-model", ComplexityTier.COMPLEX)
+
+        _, routed_tier, cause = router._resolve_pinned_model(
+            "shared-model", ComplexityTier.COMPLEX, self.REASONING_MESSAGE[0]["content"], None
+        )
+        assert routed_tier == ComplexityTier.REASONING
+        assert cause == "session_affinity_complexity_escalation"
 
     @pytest.mark.asyncio
     async def test_pin_writes_do_not_race_on_a_shared_read(self, mock_router_instance, session_affinity_config):
@@ -2880,11 +2913,11 @@ class TestSessionAffinity:
 
         # The trivial turn resolves first but writes last, after the escalation has landed.
         await asyncio.gather(
-            router._persist_session_pin(cache_key, "gpt-4o-mini"),
-            router._persist_session_pin(cache_key, "o1-preview"),
+            router._persist_session_pin(cache_key, "gpt-4o-mini", ComplexityTier.SIMPLE),
+            router._persist_session_pin(cache_key, "o1-preview", ComplexityTier.REASONING),
         )
 
-        assert await router._get_session_pin(cache_key) == "o1-preview"
+        assert await router._get_session_pin(cache_key) == ("o1-preview", ComplexityTier.REASONING)
 
     @pytest.mark.asyncio
     async def test_concurrent_turns_cannot_lower_an_escalated_pin(
@@ -2943,8 +2976,8 @@ class TestSessionAffinity:
         assert escalated.model == "o1-preview"
 
         # The in-flight turn now writes back the cheap model it resolved before the escalation.
-        await router._persist_session_pin(cache_key, "gpt-4o-mini")
-        assert await router._get_session_pin(cache_key) == "o1-preview"
+        await router._persist_session_pin(cache_key, "gpt-4o-mini", ComplexityTier.SIMPLE)
+        assert await router._get_session_pin(cache_key) == ("o1-preview", ComplexityTier.REASONING)
 
         later = await router.async_pre_routing_hook(
             model="test-model", request_kwargs=request_kwargs, messages=self.SIMPLE_MESSAGE

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2659,6 +2659,31 @@ class TestRoutingDecisionCauseLogging:
         assert "cause=semantic_keyword_match" not in router_log_capture.text
 
 
+class _ReadGatedCache:
+    """DualCache wrapper that holds every read open until `readers` of them are in flight.
+
+    Forces concurrent writers to resolve against the same pre-write state, which is the
+    interleaving a read-modify-write pin loses an escalation on.
+    """
+
+    def __init__(self, inner: DualCache, readers: int) -> None:
+        self._inner = inner
+        self._readers = readers
+        self._arrived = 0
+        self._all_arrived = asyncio.Event()
+
+    async def async_get_cache(self, *args, **kwargs):
+        value = await self._inner.async_get_cache(*args, **kwargs)
+        self._arrived += 1
+        if self._arrived >= self._readers:
+            self._all_arrived.set()
+        await self._all_arrived.wait()
+        return value
+
+    def __getattr__(self, name: str):
+        return getattr(self._inner, name)
+
+
 class TestSessionAffinity:
     """Test the session_affinity sticky-routing behavior (on by default)."""
 
@@ -2830,13 +2855,68 @@ class TestSessionAffinity:
         )
         request_kwargs = self._request_kwargs("session-1")
         cache_key = router._get_session_affinity_cache_key("session-1", request_kwargs)
-        await mock_router_instance.cache.async_set_cache(key=cache_key, value="retired-model", ttl=60)
+        await mock_router_instance.cache.async_set_cache(
+            key=f"{cache_key}:{ComplexityTier.REASONING.value}", value="retired-model", ttl=60
+        )
 
         result = await router.async_pre_routing_hook(
             model="test-model", request_kwargs=request_kwargs, messages=self.REASONING_MESSAGE
         )
         assert result.model == "retired-model"
-        assert await mock_router_instance.cache.async_get_cache(key=cache_key) == "retired-model"
+        assert await router._get_session_pin(cache_key) == "retired-model"
+
+    @pytest.mark.asyncio
+    async def test_pin_writes_do_not_race_on_a_shared_read(self, mock_router_instance, session_affinity_config):
+        """Regression: holding the pin in one key made the write a read-modify-write, so two
+        turns could both read before either wrote and the weaker write landed last, undoing
+        the escalation for the rest of the session."""
+        mock_router_instance.cache = _ReadGatedCache(DualCache(), readers=2)
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=session_affinity_config,
+        )
+        cache_key = router._get_session_affinity_cache_key("session-1", self._request_kwargs("session-1"))
+
+        # The trivial turn resolves first but writes last, after the escalation has landed.
+        await asyncio.gather(
+            router._persist_session_pin(cache_key, "gpt-4o-mini"),
+            router._persist_session_pin(cache_key, "o1-preview"),
+        )
+
+        assert await router._get_session_pin(cache_key) == "o1-preview"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_turns_cannot_lower_an_escalated_pin(
+        self, mock_router_instance, session_affinity_config
+    ):
+        """Regression: two turns resolving against the same pin used to race a shared key, so
+        the trivial one could write last and undo the escalation for the rest of the session."""
+        mock_router_instance.cache = DualCache()
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=session_affinity_config,
+        )
+        request_kwargs = self._request_kwargs("session-1")
+        await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=self.SIMPLE_MESSAGE
+        )
+
+        escalated, _ = await asyncio.gather(
+            router.async_pre_routing_hook(
+                model="test-model", request_kwargs=request_kwargs, messages=self.REASONING_MESSAGE
+            ),
+            router.async_pre_routing_hook(
+                model="test-model", request_kwargs=request_kwargs, messages=self.SIMPLE_MESSAGE
+            ),
+        )
+        assert escalated.model == "o1-preview"
+
+        later = await router.async_pre_routing_hook(
+            model="test-model", request_kwargs=request_kwargs, messages=self.SIMPLE_MESSAGE
+        )
+        assert later.model == "o1-preview"
 
     @pytest.mark.asyncio
     async def test_a_turn_that_resolved_pre_escalation_cannot_lower_the_pin(
@@ -2864,7 +2944,7 @@ class TestSessionAffinity:
 
         # The in-flight turn now writes back the cheap model it resolved before the escalation.
         await router._persist_session_pin(cache_key, "gpt-4o-mini")
-        assert await mock_router_instance.cache.async_get_cache(key=cache_key) == "o1-preview"
+        assert await router._get_session_pin(cache_key) == "o1-preview"
 
         later = await router.async_pre_routing_hook(
             model="test-model", request_kwargs=request_kwargs, messages=self.SIMPLE_MESSAGE
@@ -2914,7 +2994,7 @@ class TestSessionAffinity:
     @pytest.mark.asyncio
     async def test_respects_ttl_seconds(self, mock_router_instance, basic_config):
         cache = AsyncMock()
-        cache.async_get_cache = AsyncMock(return_value=None)
+        cache.async_batch_get_cache = AsyncMock(return_value=[None, None, None, None])
         mock_router_instance.cache = cache
         router = ComplexityRouter(
             model_name="test-router",
@@ -2932,13 +3012,14 @@ class TestSessionAffinity:
         call_kwargs = cache.async_set_cache.call_args.kwargs
         assert call_kwargs["ttl"] == 120
         assert call_kwargs["value"] == "gpt-4o-mini"
+        assert call_kwargs["key"].endswith(f":{ComplexityTier.SIMPLE.value}")
 
     @pytest.mark.asyncio
     async def test_ttl_refreshed_on_cache_hit(self, mock_router_instance, basic_config):
         """Regression: a pinned turn must refresh the TTL, not just the first write --
         otherwise a session outliving session_affinity_ttl_seconds silently loses its pin."""
         cache = AsyncMock()
-        cache.async_get_cache = AsyncMock(return_value="o1-preview")
+        cache.async_batch_get_cache = AsyncMock(return_value=[None, None, None, "o1-preview"])
         mock_router_instance.cache = cache
         router = ComplexityRouter(
             model_name="test-router",
@@ -2957,6 +3038,7 @@ class TestSessionAffinity:
         call_kwargs = cache.async_set_cache.call_args.kwargs
         assert call_kwargs["value"] == "o1-preview"
         assert call_kwargs["ttl"] == 90
+        assert call_kwargs["key"].endswith(f":{ComplexityTier.REASONING.value}")
 
     @pytest.mark.asyncio
     async def test_different_api_keys_do_not_share_pin(self, mock_router_instance, session_affinity_config):
@@ -2996,7 +3078,7 @@ class TestSessionAffinity:
             model="test-model", request_kwargs={}, messages=self.SIMPLE_MESSAGE
         )
         assert result.model == "gpt-4o-mini"
-        cache.async_get_cache.assert_not_called()
+        cache.async_batch_get_cache.assert_not_called()
         cache.async_set_cache.assert_not_called()
 
     @pytest.mark.asyncio
@@ -3540,7 +3622,9 @@ class TestEscalationKeywords:
             },
         )
         cache_key = router._get_session_affinity_cache_key("session-top", {})
-        await mock_router_instance.cache.async_set_cache(key=cache_key, value="o1-b")
+        await mock_router_instance.cache.async_set_cache(
+            key=f"{cache_key}:{ComplexityTier.REASONING.value}", value="o1-b"
+        )
         result = await router.async_pre_routing_hook(
             model="test-model",
             request_kwargs=self._request_kwargs("session-top"),


### PR DESCRIPTION
## TLDR

Problem this solves:

- Session affinity pins a session to its first turn's model
- Later turns reuse that pin without ever being scored
- A trivial opening turn locks the session to the cheap tier
- Only the literal `LITELLM ESCALATE` keyword can raise it

How it solves it:

- Score each pinned turn with the local heuristic scorer
- Raise the pin when a turn scores above the pinned tier
- Never lower it, so the pin stays cache-stable
- Store the pin per tier, so concurrent turns cannot undo an escalation
- 
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Config for both runs, with `session_affinity` left at its default (on):

```yaml
model_list:
  - model_name: cheap-model
    litellm_params:
      model: gemini/gemini-3.5-flash-lite
      api_key: os.environ/GEMINI_API_KEY
  - model_name: strong-model
    litellm_params:
      model: gemini/gemini-3.6-flash
      api_key: os.environ/GEMINI_API_KEY
  - model_name: auto-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        tiers:
          SIMPLE: cheap-model
          MEDIUM: cheap-model
          COMPLEX: strong-model
          REASONING: strong-model
```

Proxy started with `python litellm/proxy/proxy_cli.py --config proof_config.yaml --detailed_debug`. Three turns against it, hitting the real Gemini API. Turn 1 is trivial and sets the pin, turn 2 is a reasoning request on the same `session_id`, turn 3 is trivial again to confirm the pin does not fall back down:

```bash
# turn 1, session demo-1, trivial: sets the pin
curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
  "model": "auto-router",
  "messages": [{"role":"user","content":"Hello!"}],
  "max_tokens": 200, "metadata": {"session_id": "demo-1"}}'

# turn 2, SAME session, reasoning request
curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
  "model": "auto-router",
  "messages": [{"role":"user","content":"Let'\''s think step by step and reason through the tradeoffs of a distributed rate limiter carefully"}],
  "max_tokens": 200, "metadata": {"session_id": "demo-1"}}'

# turn 3, SAME session, trivial again: pin must not drop back to cheap
curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
  "model": "auto-router",
  "messages": [{"role":"user","content":"thanks"}],
  "max_tokens": 200, "metadata": {"session_id": "demo-1"}}'
```

Before, captured at commit `24123269cc`, routing decisions from the proxy log (`grep "ComplexityRouter: routing decision"`). Turn 2 asks to reason step by step through a distributed rate limiter and still lands on the cheap model, because the pinned branch returns before scoring it:

```
ComplexityRouter: routing decision cause=complexity_scorer, tier=SIMPLE, score=-0.150, signals=['short (1 tokens)', 'simple (hello)'], routed_model=cheap-model
ComplexityRouter: routing decision cause=session_affinity_pin, routed_model=cheap-model
ComplexityRouter: routing decision cause=session_affinity_pin, routed_model=cheap-model
```

After, captured at commit `5eeedb3182`. Turn 2 scores above the pinned tier and escalates, and turn 3 holds the escalated model rather than dropping back to the cheap tier:

```
ComplexityRouter: routing decision cause=complexity_scorer, tier=SIMPLE, score=-0.150, signals=['short (1 tokens)', 'simple (hello)'], routed_model=cheap-model
ComplexityRouter: routing decision cause=session_affinity_complexity_escalation, routed_model=strong-model
ComplexityRouter: routing decision cause=session_affinity_pin, routed_model=strong-model
```

`12afbfef8b` changes only where the pin is stored, so these routing decisions and their log output are unchanged

## Type

🐛 Bug Fix

## Changes

`session_affinity` returns the pinned model and skips classification for every turn after the first, so the model a session runs on is decided entirely by its opening turn. That turn is the one carrying the least context, and in a long agentic session it is frequently a greeting or a one-line question that scores SIMPLE. Everything after it inherits that decision, and the only way out is for the user to type the literal `LITELLM ESCALATE` phrase, which was the sole path `_escalated_pin` was wired to.

The router's own scorer often disagrees with the pin it is holding. Replaying `ComplexityRouter.classify` over a local corpus of 120 real agentic coding sessions (aggregate metrics only, no transcript content), 85% of sessions classify SIMPLE or MEDIUM on their first turn. Inside those sessions the user goes on to send 951 distinct prompts, 59 of which the same scorer rates COMPLEX, and 30% of the cheap-pinned sessions contain at least one. None of them are ever scored, because the pinned branch returns before classification runs.

`_resolve_pinned_model` makes the pin a floor instead of a lock. On a pinned turn it scores the request and returns the higher of the pinned tier and the classified tier, so a session can climb to a stronger model when the work gets harder and can never slide back down to a weaker one. Escalating rewrites the pin, so the session keeps the strongest model it has needed. Since the pin only moves upward across four tiers, a session invalidates a provider prompt cache at most three times, against the alternative of spending its whole life on a model chosen by its first turn.

Scoring uses `classify` rather than `aclassify`, so a pinned turn never triggers an LLM classifier call or an embedding lookup, and a test asserts `aclassify` is not called during escalation. Message resolution on the pinned path is unchanged in the default configuration, since `escalation_keywords` defaults to `["LITELLM ESCALATE"]` and already resolved messages on every pinned turn. The keyword path keeps its existing precedence and behavior, and the routing-decision log gains a `session_affinity_complexity_escalation` cause so the two escalation paths stay distinguishable.

Concurrent turns in one session all resolve against the same cached pin and then write back, so holding the pin in one key makes every write a read-modify-write that another turn can invalidate: both turns read before either writes, the weaker one lands last, and the session drops back to the cheaper model for the rest of its life. The cache exposes no compare-and-swap, so re-reading at write time would only narrow that window

Each tier now holds its own key, `<session key>:SIMPLE` through `<session key>:REASONING`, and a turn writes only the key for the tier it served. That takes the read out of the write path, so no ordering of concurrent writes can lower the pin. `_get_session_pin` reads the configured tiers in one `async_batch_get_cache` and resolves the session to the most severe key present, which is where the "never lower it" guarantee now lives. A model outside the configured tiers is not written, since it carries no severity to resolve against, and a pin left behind by a tier config change is still served unchanged until it expires

The cost is cross-worker propagation. `async_batch_get_cache` re-reads Redis for keys that missed in memory at most once per `default_redis_batch_cache_expiry`, 10s by default, so on a multi-worker deployment another worker can keep serving the lower pin for up to that window after an escalation, where the single-key read hit Redis every turn. The delay is bounded and the escalation itself is never lost, against a single-key write that could drop it permanently

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR