### PR TITLE
fix(anthropic): preserve optional Responses tool properties

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -742,6 +742,7 @@ class LiteLLMAnthropicMessagesAdapter:
             "input_schema",
             "description",
             "cache_control",
+            "strict",
             "type",
         ]
 
@@ -771,6 +772,8 @@ class LiteLLMAnthropicMessagesAdapter:
                 function_chunk["parameters"] = tool["input_schema"]  # type: ignore
             if "description" in tool:
                 function_chunk["description"] = tool["description"]  # type: ignore
+            if "strict" in tool:
+                function_chunk["strict"] = tool["strict"]
 
             for k, v in tool.items():
                 if k not in mapped_tool_params:  # pass additional computer kwargs

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -187,7 +187,11 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             if (isinstance(tool_type, str) and tool_type.startswith("web_search")) or tool_name == "web_search":
                 result.append({"type": "web_search_preview"})
                 continue
-            func_tool: Dict[str, Any] = {"type": "function", "name": tool_name}
+            func_tool: Dict[str, Any] = {
+                "type": "function",
+                "name": tool_name,
+                "strict": tool_dict.get("strict", False),
+            }
             if "description" in tool_dict:
                 func_tool["description"] = tool_dict["description"]
             if "input_schema" in tool_dict:

--- a/litellm/types/llms/anthropic.py
+++ b/litellm/types/llms/anthropic.py
@@ -47,6 +47,7 @@ class AnthropicMessagesTool(TypedDict, total=False):
     name: Required[str]
     description: str
     input_schema: Optional[AnthropicInputSchema]
+    strict: bool
     type: Literal["custom"]
     cache_control: Optional[Union[dict, ChatCompletionCachedContent]]
     defer_loading: bool

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/adapters/test_anthropic_experimental_pass_through_adapters_transformation.py
@@ -3147,3 +3147,27 @@ def test_translate_anthropic_tools_to_openai_preserves_parameters_type():
     params = new_tools[0]["function"]["parameters"]
     assert params["type"] == "object"
     assert new_tools[0]["type"] == "function"
+
+
+def test_translate_anthropic_tools_to_openai_preserves_top_level_strict():
+    """Anthropic strict validation must remain a function-level option."""
+    adapter = LiteLLMAnthropicMessagesAdapter()
+    tools = [
+        {
+            "type": "custom",
+            "name": "get_weather",
+            "strict": True,
+            "input_schema": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        }
+    ]
+
+    new_tools, _ = adapter.translate_anthropic_tools_to_openai(tools=tools)
+
+    function = new_tools[0]["function"]
+    assert function["strict"] is True
+    assert "strict" not in function["parameters"]

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/responses_adapters/test_responses_adapters_transformation.py
@@ -502,6 +502,7 @@ class TestTranslateToolsToResponsesAPI:
             {
                 "type": "function",
                 "name": "get_weather",
+                "strict": False,
                 "description": "Get current weather for a city.",
                 "parameters": {
                     "type": "object",
@@ -510,6 +511,57 @@ class TestTranslateToolsToResponsesAPI:
                 },
             }
         ]
+
+    def test_tool_with_optional_properties_disables_responses_strict_default(self):
+        """Responses must not promote optional Anthropic properties to required."""
+        tools = [
+            {
+                "name": "search",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "cursor": {"type": "string"},
+                    },
+                    "required": ["query"],
+                    "additionalProperties": False,
+                },
+            }
+        ]
+
+        result = _ADAPTER.translate_tools_to_responses_api(tools)  # type: ignore[arg-type]
+
+        assert result[0]["strict"] is False
+        assert result[0]["parameters"]["required"] == ["query"]
+
+    def test_tool_preserves_explicit_strict_validation(self):
+        """Anthropic's explicit strict setting is forwarded to Responses."""
+        tools = [
+            {
+                "name": "search",
+                "strict": True,
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                    "additionalProperties": False,
+                },
+            }
+        ]
+
+        result = _ADAPTER.translate_tools_to_responses_api(tools)  # type: ignore[arg-type]
+
+        assert result[0] == {
+            "type": "function",
+            "name": "search",
+            "strict": True,
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+                "additionalProperties": False,
+            },
+        }
 
     def test_tool_without_description(self):
         """Tool without a description omits the description key."""


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A live OpenAI Responses API probe using a synthetic search-tool schema reproduced the provider behavior behind this bug:

- When `strict` was omitted, Responses normalized the tool to `strict: true`, changed `required` from `["query"]` to `["query", "cursor", "context_channel_id"]`, and generated empty strings for the optional fields.
- With `strict: false`, Responses preserved `required: ["query"]` and generated only `{"query":"zz_responses_probe"}`.

The patched adapter now emits `strict: false` for ordinary Anthropic tools while preserving an explicit top-level Anthropic `strict: true` request. The sibling Chat Completions adapter also keeps an explicit `strict` value at function level rather than placing it inside the JSON Schema.

After rebasing onto `litellm_internal_staging`, focused verification against commit `6dbd305f` passed:

```text
........................................................................ [ 40%]
........................................................................ [ 80%]
...................................                                      [100%]
179 passed, 1 warning in 3.84s
```

The edited modules pass `py_compile`, and `git diff --check` reports no errors.

## Type

🐛 Bug Fix

## Changes

- Explicitly disable the OpenAI Responses API's strict-by-default normalization when translating ordinary Anthropic tools.
- Preserve explicitly requested Anthropic strict tool validation across both Responses and Chat Completions routes.
- Add the top-level `strict` field to the Anthropic tool type.
- Add regressions proving optional properties stay optional, explicit strict validation remains enabled, and `strict` does not leak into the parameters schema.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR