### PR TITLE
chore(deps): bump gitpython to 3.1.55 and brace-expansion to 5.0.8

### DIFF
--- a/ui/litellm-dashboard/package-lock.json
+++ b/ui/litellm-dashboard/package-lock.json
@@ -5529,16 +5529,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/ui/litellm-dashboard/package.json
+++ b/ui/litellm-dashboard/package.json
@@ -90,7 +90,7 @@
   "overrides": {
     "prismjs": "1.30.0",
     "js-yaml": "4.3.0",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.8",
     "glob": "13.0.0",
     "minimatch": "10.2.4",
     "ws": "8.21.0",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-22T23:28:30.575519Z"
+exclude-newer = "2026-07-24T16:43:28.506903Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -2378,14 +2378,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.54"
+version = "3.1.55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/d5/3da0b92033887033f4c27f2dd109a303c4ca62813c7b3bb2511edb4777de/gitpython-3.1.54.tar.gz", hash = "sha256:53f2085e24a2cda300eed7c3fc5f1559ae289634b725e98acaf4791940247aa0", size = 225076, upload-time = "2026-07-22T04:08:51.403Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", size = 225071, upload-time = "2026-07-23T02:52:43.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/b9/876f442a28df5c068ca69b0122d5c35e65fd2d2fa9992ea5cb5944ea00a6/gitpython-3.1.54-py3-none-any.whl", hash = "sha256:b90d7b3d9bc0238681d24369130826f0dcdb0ceaa45db67cf1d4ffa4c302dedf", size = 216575, upload-time = "2026-07-22T04:08:50.05Z" },
+    { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", size = 216590, upload-time = "2026-07-23T02:52:41.932Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## TLDR

Problem this solves:

- osv-scan flags gitpython 3.1.54 and brace-expansion 5.0.7
- both advisories have published fixes we can already take
- the dashboard pins brace-expansion, so a lockfile-only bump would revert

How it solves it:

- re-resolve gitpython to 3.1.55 with uv, single-package lock diff
- bump the brace-expansion `overrides` pin to 5.0.8, regenerate the lock

## Relevant issues

Overlaps #34683, #34593 and #34538, which cover the same ground and can be closed in favour of this one

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests <!-- N/A: lockfile and pin bump only, no source change to test; the dashboard build and `uv lock --check` are the meaningful checks and are shown below -->
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at c9d067fccc091aa7afdebfe30d7db39bed76a7e0

Both fixed versions were published on 2026-07-23, so they clear the dependency lockout windows this repo enforces (`exclude-newer = "3 days"` in `pyproject.toml`, `min-release-age=3` in `ui/litellm-dashboard/.npmrc`). uv's cooldown is why gitpython lands on 3.1.55 rather than the newer 3.1.56/3.1.57, which are still inside the window; 3.1.55 is the fixed version, so that is the correct landing spot regardless.

Python resolve, one package moved:

```
$ uv lock --upgrade-package gitpython
Using CPython 3.13.13
Resolved 447 packages in 747ms
Updated gitpython v3.1.54 -> v3.1.55

$ git diff uv.lock | grep -E '^[+-]version = '
-version = "3.1.54"
+version = "3.1.55"

$ uv lock --check
Using CPython 3.13.13
Resolved 447 packages in 9ms
```

Dashboard install off the regenerated lockfile, then a full build:

```
$ npm ci
added 835 packages, and audited 836 packages in 24s
found 0 vulnerabilities

$ node -e "console.log(require('./node_modules/brace-expansion/package.json').version)"
5.0.8

$ npm run build
...
├ ○ /vector-stores
└ ○ /workflows

○  (Static)  prerendered as static content
```

One behavioural note for reviewers: brace-expansion 5.0.8 narrows its `engines` range from `18 || 20 || >=22` to `20 || >=22`. The dashboard already declares `node >=20.9.0` and every CI job pins node 20, so nothing loses support.

## Type

🚄 Infrastructure

## Changes

`uv.lock` moves gitpython 3.1.54 to 3.1.55. It is a transitive dependency reached through mlflow-skinny, so there is no direct requirement to edit; re-resolving that single package is enough and `pyproject.toml` is untouched.

`ui/litellm-dashboard/package.json` moves the brace-expansion entry in `overrides` from 5.0.7 to 5.0.8, with `package-lock.json` regenerated to match. The pin has to move too, because the dashboard re-pins this package in `overrides` and a lockfile-only edit gets undone on the next install.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
