### PR TITLE
fix(model-prices): correct replicate model key typo

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -32896,7 +32896,7 @@
         "supports_tool_choice": true,
         "supports_response_schema": true
     },
-    "replicateopenai/gpt-oss-20b": {
+    "replicate/openai/gpt-oss-20b": {
         "input_cost_per_token": 9e-08,
         "output_cost_per_token": 3.6e-07,
         "litellm_provider": "replicate",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -32987,7 +32987,7 @@
         "supports_tool_choice": true,
         "supports_response_schema": true
     },
-    "replicateopenai/gpt-oss-20b": {
+    "replicate/openai/gpt-oss-20b": {
         "input_cost_per_token": 9e-08,
         "output_cost_per_token": 3.6e-07,
         "litellm_provider": "replicate",

--- a/tests/test_litellm/test_replicate_model_key_format.py
+++ b/tests/test_litellm/test_replicate_model_key_format.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture()
+def model_cost() -> dict[str, Any]:
+    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    with open(json_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_replicate_models_have_valid_key_prefix(model_cost: dict[str, Any]) -> None:
+    replicate_models = {k for k, v in model_cost.items() if v.get("litellm_provider") == "replicate"}
+    malformed = [k for k in replicate_models if not k.startswith("replicate/")]
+    assert not malformed, (
+        f"Replicate models must use 'replicate/owner/model' key format, found malformed keys: {malformed}"
+    )
+
+
+def test_replicate_openai_gpt_oss_20b_key_exists(model_cost: dict[str, Any]) -> None:
+    assert "replicate/openai/gpt-oss-20b" in model_cost
+    info = model_cost["replicate/openai/gpt-oss-20b"]
+    assert info["litellm_provider"] == "replicate"
+    assert info["mode"] == "chat"
+    assert info["supports_function_calling"] is True
+
+
+def test_replicate_backup_matches_main() -> None:
+    repo_root = Path(__file__).parents[2]
+    main_path = repo_root / "model_prices_and_context_window.json"
+    backup_path = repo_root / "litellm" / "model_prices_and_context_window_backup.json"
+
+    with open(main_path, encoding="utf-8") as f:
+        main_cost: dict[str, Any] = json.load(f)
+    with open(backup_path, encoding="utf-8") as f:
+        backup_cost: dict[str, Any] = json.load(f)
+
+    for key in main_cost:
+        if main_cost[key].get("litellm_provider") == "replicate":
+            assert backup_cost.get(key) == main_cost.get(key), f"{key} differs between main and backup model cost maps"


### PR DESCRIPTION
## TLDR

Problem this solves:

- `replicateopenai/gpt-oss-20b` is missing the `/` separator in model_prices_and_context_window.json, making the model unreachable through provider routing

How it solves it:

- Renames the key to `replicate/openai/gpt-oss-20b` in both JSON files and adds regression tests

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

```bash
# Before fix - model does not resolve
python -c "import json; d=json.load(open('model_prices_and_context_window.json')); print('replicate/openai/gpt-oss-20b' in d)"
# False

# After fix - model resolves correctly
python -c "import json; d=json.load(open('model_prices_and_context_window.json')); print('replicate/openai/gpt-oss-20b' in d)"
# True
```

## Type

Bug Fix

## Changes

- Fixed model key typo: `replicateopenai/gpt-oss-20b` -> `replicate/openai/gpt-oss-20b`
- Added `tests/test_litellm/test_replicate_model_key_format.py` with 3 regression tests

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
