### PR TITLE
fix(vertex_ai): surface Gemini code execution parts instead of dropping them

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -3,7 +3,7 @@
 ## Initial implementation - covers gemini + image gen calls
 import json
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
 from functools import partial
 from typing import (
@@ -1504,6 +1504,58 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         return invocations if invocations else None
 
+    @staticmethod
+    def _code_execution_entry(part: HttpxPartType) -> Mapping[str, Any] | None:
+        """Map one part to its code execution entry, or None when it is neither type.
+
+        The entries stay plain dicts: they are handed to the caller inside
+        `provider_specific_fields`, which is serialised to JSON. A read-only
+        wrapper such as MappingProxyType is rejected by both pydantic and
+        json.dumps, so freezing them here would break the response.
+        """
+        if "executableCode" in part:
+            executable_code = part["executableCode"]
+            return {  # mutable-ok: must stay a plain dict, this is serialised to JSON
+                "type": "executable_code",
+                "language": executable_code.get("language"),
+                "code": executable_code.get("code"),
+            }
+        if "codeExecutionResult" in part:
+            execution_result = part["codeExecutionResult"]
+            return {  # mutable-ok: must stay a plain dict, this is serialised to JSON
+                "type": "code_execution_result",
+                "outcome": execution_result.get("outcome"),
+                "output": execution_result.get("output"),
+            }
+        return None
+
+    @staticmethod
+    def _extract_code_execution_parts(
+        parts: Sequence[HttpxPartType],
+    ) -> tuple[Mapping[str, Any], ...] | None:
+        """Extract code execution parts (executableCode/codeExecutionResult) from parts.
+
+        Gemini returns these when the `codeExecution` tool is enabled: the model
+        writes Python, Google runs it server-side, and the response carries both
+        the source and the console output alongside the regular `text` parts.
+
+        Neither part type is handled by get_assistant_content_message() or
+        _transform_parts(), so today they are dropped. The console output is the
+        only trustworthy source for the computed values - when it is dropped, the
+        caller is left with whatever numbers the model restates from memory.
+
+        Parts are returned in wire order so a consumer can pair each snippet with
+        the result that follows it.
+
+        Returns:
+            Tuple of code execution entries if any found, None otherwise.
+        """
+        code_execution = tuple(
+            entry for part in parts if (entry := VertexGeminiConfig._code_execution_entry(part)) is not None
+        )
+
+        return code_execution or None
+
     def _extract_image_response_from_parts(self, parts: list[HttpxPartType]) -> list[ImageURLListItem] | None:
         """Extract image response from parts if present"""
         images: list[ImageURLListItem] = []
@@ -2234,6 +2286,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         reasoning_content: str | None = None
         thought_signatures: Any | None = None
         server_side_tool_invocations: list[dict[str, Any]] | None = None
+        code_execution: tuple[Mapping[str, Any], ...] | None = None
 
         for idx, candidate in enumerate(_candidates):
             if "content" not in candidate:
@@ -2278,6 +2331,9 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 server_side_tool_invocations = VertexGeminiConfig._extract_server_side_tool_invocations(
                     parts=candidate["content"]["parts"]
                 )
+
+                # Extract code execution parts (executableCode / codeExecutionResult)
+                code_execution = VertexGeminiConfig._extract_code_execution_parts(parts=candidate["content"]["parts"])
 
                 if audio_response is not None:
                     cast(dict[str, Any], chat_completion_message)["audio"] = audio_response
@@ -2346,6 +2402,13 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 tool_invocation_fields = chat_completion_message.get("provider_specific_fields") or {}
                 tool_invocation_fields["server_side_tool_invocations"] = server_side_tool_invocations
                 chat_completion_message["provider_specific_fields"] = tool_invocation_fields
+
+            # Store code execution parts in provider_specific_fields
+            if code_execution is not None:
+                existing_fields = chat_completion_message.get("provider_specific_fields")
+                code_execution_fields = existing_fields or {}  # mutable-ok: accumulator shared with siblings
+                code_execution_fields["code_execution"] = code_execution
+                chat_completion_message["provider_specific_fields"] = code_execution_fields
 
             if isinstance(model_response, ModelResponseStream):
                 choice = VertexGeminiConfig._create_streaming_choice(

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_code_execution.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_code_execution.py
@@ -1,0 +1,194 @@
+"""
+Tests for Gemini code execution parts (executableCode / codeExecutionResult).
+
+When the `codeExecution` tool is enabled, Gemini writes Python, Google runs it
+server-side, and the response carries `executableCode` + `codeExecutionResult`
+parts alongside the regular `text` parts.
+
+Neither part type was handled by the response transformation, so both were
+dropped: the console output - the only trustworthy source for the computed
+values - never reached the caller.
+
+They must now be surfaced in provider_specific_fields["code_execution"], in
+wire order, for both streaming and non-streaming responses.
+"""
+
+from unittest.mock import MagicMock
+
+from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+    ModelResponseIterator,
+    VertexGeminiConfig,
+)
+from litellm.types.llms.vertex_ai import HttpxPartType
+from litellm.types.utils import ModelResponse
+
+CODE = "import numpy as np\nprint(np.linalg.solve(A, B))"
+OUTPUT = "x = 13.835714\ny = -6.000000\n"
+
+
+def _make_logging_obj(**kwargs):
+    """Create a minimal mock logging object for ModelResponseIterator."""
+    logging_obj = MagicMock()
+    logging_obj.optional_params = kwargs.get("optional_params", {})
+    return logging_obj
+
+
+def _code_execution_parts() -> list[HttpxPartType]:
+    return [
+        {"text": "Let me compute this with Python."},
+        {"executableCode": {"language": "PYTHON", "code": CODE}},
+        {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": OUTPUT}},
+        {"text": "The exact solution is x = 13.84, y = -6.00."},
+    ]
+
+
+class TestExtractCodeExecutionParts:
+    """Test _extract_code_execution_parts from response parts."""
+
+    def test_extracts_code_and_result_in_wire_order(self):
+        result = VertexGeminiConfig._extract_code_execution_parts(_code_execution_parts())
+
+        # a tuple, not a list: the entries are handed to the caller and must not be
+        # grown or rewritten downstream
+        assert result == (
+            {"type": "executable_code", "language": "PYTHON", "code": CODE},
+            {
+                "type": "code_execution_result",
+                "outcome": "OUTCOME_OK",
+                "output": OUTPUT,
+            },
+        )
+
+    def test_returns_none_when_no_code_execution_parts(self):
+        parts: list[HttpxPartType] = [
+            {"text": "Hello world"},
+            {"functionCall": {"name": "get_weather", "args": {"location": "Paris"}}},
+        ]
+
+        assert VertexGeminiConfig._extract_code_execution_parts(parts) is None
+
+    def test_returns_none_for_empty_parts(self):
+        assert VertexGeminiConfig._extract_code_execution_parts([]) is None
+
+    def test_handles_failed_execution(self):
+        """A failed run still carries its outcome and stderr - it must not be dropped."""
+        parts: list[HttpxPartType] = [
+            {
+                "codeExecutionResult": {
+                    "outcome": "OUTCOME_FAILED",
+                    "output": "ZeroDivisionError: division by zero",
+                }
+            }
+        ]
+
+        result = VertexGeminiConfig._extract_code_execution_parts(parts)
+
+        assert result is not None
+        assert result[0]["outcome"] == "OUTCOME_FAILED"
+        assert "ZeroDivisionError" in result[0]["output"]
+
+    def test_handles_multiple_execution_rounds(self):
+        """Gemini can iterate: code, result, code, result. Order must be preserved."""
+        parts: list[HttpxPartType] = [
+            {"executableCode": {"language": "PYTHON", "code": "print(1)"}},
+            {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "1\n"}},
+            {"executableCode": {"language": "PYTHON", "code": "print(2)"}},
+            {"codeExecutionResult": {"outcome": "OUTCOME_OK", "output": "2\n"}},
+        ]
+
+        result = VertexGeminiConfig._extract_code_execution_parts(parts)
+
+        assert result is not None
+        assert [item["type"] for item in result] == [
+            "executable_code",
+            "code_execution_result",
+            "executable_code",
+            "code_execution_result",
+        ]
+        assert result[2]["code"] == "print(2)"
+
+    def test_missing_fields_do_not_raise(self):
+        """Vertex may omit `language`; extraction must stay defensive."""
+        parts: list[HttpxPartType] = [
+            {"executableCode": {"code": "print(1)"}},  # type: ignore[typeddict-item]
+            {"codeExecutionResult": {"outcome": "OUTCOME_OK"}},  # type: ignore[typeddict-item]
+        ]
+
+        result = VertexGeminiConfig._extract_code_execution_parts(parts)
+
+        assert result is not None
+        assert result[0]["language"] is None
+        assert result[1]["output"] is None
+
+
+class TestCodeExecutionInResponse:
+    """Test that code execution parts reach the transformed response."""
+
+    def test_non_streaming_response_carries_code_execution(self):
+        candidates = [
+            {
+                "content": {"role": "model", "parts": _code_execution_parts()},
+                "finishReason": "STOP",
+            }
+        ]
+        model_response = ModelResponse()
+
+        VertexGeminiConfig._process_candidates(
+            candidates,
+            model_response,
+            standard_optional_params={},
+        )
+
+        # _process_candidates appends to the (pre-seeded) choices list
+        choice = model_response.choices[-1]
+        message = choice.message
+        code_execution = message.provider_specific_fields["code_execution"]
+
+        assert code_execution[0]["code"] == CODE
+        assert code_execution[1]["output"] == OUTPUT
+        # text parts keep their existing behaviour: concatenated into content
+        assert message.content == ("Let me compute this with Python.The exact solution is x = 13.84, y = -6.00.")
+        assert choice.finish_reason == "stop"
+
+    def test_streaming_chunk_carries_code_execution(self):
+        iterator = ModelResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+            logging_obj=_make_logging_obj(),
+        )
+
+        chunk = {
+            "candidates": [
+                {
+                    "content": {"role": "model", "parts": _code_execution_parts()},
+                    "index": 0,
+                }
+            ]
+        }
+
+        response = iterator.chunk_parser(chunk)
+
+        assert response is not None
+        code_execution = response.choices[0].delta.provider_specific_fields["code_execution"]
+        assert code_execution[1]["output"] == OUTPUT
+
+    def test_response_without_code_execution_is_unchanged(self):
+        """Backwards compatibility: no code execution parts, no new field."""
+        candidates = [
+            {
+                "content": {"role": "model", "parts": [{"text": "Hello world"}]},
+                "finishReason": "STOP",
+            }
+        ]
+        model_response = ModelResponse()
+
+        VertexGeminiConfig._process_candidates(
+            candidates,
+            model_response,
+            standard_optional_params={},
+        )
+
+        message = model_response.choices[-1].message
+        assert message.content == "Hello world"
+        provider_specific_fields = message.provider_specific_fields or {}
+        assert "code_execution" not in provider_specific_fields


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini code execution output is silently dropped by the Vertex/AI Studio transformation
- `executableCode` / `codeExecutionResult` parts never reach the caller
- A response made only of those parts comes back as `content: null`
- Callers are left with numbers the model restates from memory, not the ones it computed

How it solves it:

- Extract both part types into `provider_specific_fields["code_execution"]`, in wire order
- Wire it in `_process_candidates()`, shared by streaming and non-streaming
- Mirrors the existing `server_side_tool_invocations` / `thought_signatures` handling
- `content` is untouched, so responses without code execution are byte-identical

## Relevant issues

Closes #6434 (code_execution support for Gemini) on the response side — the request
side already works: `codeExecution` is accepted as a tool and Google does execute the
code, it is only the response transformation that drops the result.

Related: #15517 (generalising server-side tool specs across providers), and the
Anthropic equivalent #24012 / #23784, where code execution results were likewise
captured in `provider_specific_fields` before being surfaced further up.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (5/5, no actionable defects)

## Screenshots / Proof of Fix

Real `gemini/gemini-2.5-pro` calls through Google AI Studio, no mocks. Same prompt in
both runs: a 4x4 linear system whose exact solution is independently verifiable
(`x = 13.835714…, y = -6, z = -16.392857…, w = -4.35`).

**Before — base commit `24123269cc`**

```
finish_reason      : stop
usage              : ... prompt_tokens_details=...tool_use_tokens=2835...
content is None    : False
code_execution     : ABSENT (bug)
--- content ---
...
Je vais maintenant utiliser Python et NumPy pour calculer le vecteur x.
### 2. Résolution du système
Voici le code pour résoudre le système d'équations.
### 3. Présentation des Résultats
...
### 4. Vérification des Solutions
...
Comme le montre la vérification, les résultats de la réinjection ... correspondent
```

`tool_use_tokens=2835` shows Google really did run the code. The assistant announces a
code block ("Voici le code…") and then a verification ("Comme le montre la
vérification…") — neither ever arrives, because both parts were dropped in transit.

**After — this branch, commit `0f530064ef`**

```
finish_reason      : stop
content is None    : True
code_execution     : present
[
  {"type": "executable_code", "language": "PYTHON", "code": "..."},
  {"type": "code_execution_result", "outcome": "OUTCOME_FAILED",
   "output": "Traceback (most recent call last):\n ... SyntaxError: invalid syntax\n"},
  {"type": "executable_code", "language": "PYTHON",
   "code": "import numpy as np\n\nA = np.array([...])\nsolutions = np.linalg.solve(A, b)\n..."},
  {"type": "code_execution_result", "outcome": "OUTCOME_OK",
   "output": "### Solutions du système ###\nx = 13.835714285714284\ny = -5.999999999999995\nz = -16.39285714285714\nw = -4.35\n\n### Vérification ###\nVecteur b original    : [28.5 -5.3 22.7 31.1]\nRésultat de A*solutions : [28.5 -5.3 22.7 31.1]\n\nLes résultats sont-ils corrects (en utilisant np.allclose) ? True\n"}
]
```

This run is the worst case for the current behaviour: Gemini returned **only** code
execution parts, no text part at all, so `content` is `null`. On the base commit that
response reaches the caller completely empty. With the patch the whole computation is
recovered — including a first attempt that failed with a `SyntaxError` and the retry
that succeeded, which is exactly the kind of signal a caller needs to trust the numbers.

The recovered console values match the independently computed solution to the last digit.

## Type

🐛 Bug Fix

## Changes

`litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py`

- new `VertexGeminiConfig._extract_code_execution_parts()`, built on the
  `HttpxExecutableCode` / `HttpxCodeExecutionResult` types that already exist in
  `litellm/types/llms/vertex_ai.py` but were never consumed
- called from `_process_candidates()`, result stored under
  `provider_specific_fields["code_execution"]`

`tests/test_litellm/llms/vertex_ai/gemini/test_code_execution.py` (new)

- extraction: wire order preserved, multiple execution rounds, failed outcome,
  missing optional fields, no parts → `None`
- end to end through `_process_candidates()` for a non-streaming response and
  through `ModelResponseIterator.chunk_parser()` for a streaming chunk
- backwards compatibility: a response with no code execution parts keeps its
  exact previous `content` and gains no new field

### Shape of the new field

```json
{
  "code_execution": [
    {"type": "executable_code", "language": "PYTHON", "code": "import numpy as np\n..."},
    {"type": "code_execution_result", "outcome": "OUTCOME_OK", "output": "x = 13.835714\n"}
  ]
}
```

Parts are kept in wire order rather than paired into calls, because Gemini gives no
correlation id between an `executableCode` part and the `codeExecutionResult` that
follows it — order is the only pairing signal the API provides.

### Why not put it in `content`

Inlining the code and its output into `content` (behind markers of some sort) would
reach consumers with no client change, but it is lossy, it collides with any model
output that happens to contain the same markers, and it breaks callers that compute on
`content`. `provider_specific_fields` is what this file already does for
`thought_signatures` and `server_side_tool_invocations`, and what the Anthropic
transformation does for its own code execution results.

### Follow-up, deliberately out of scope

Mapping these parts to `code_interpreter_call` in the Responses API, as #23784 did for
Anthropic, so that Gemini and Anthropic code execution look the same to a Responses API
consumer. That needs a pairing heuristic over consecutive parts and belongs in its own PR.

## QA runbook

```bash
pytest tests/test_litellm/llms/vertex_ai/gemini/test_code_execution.py -q   # 9 passed
pytest tests/test_litellm/llms/vertex_ai/gemini/ -q                        # 258 passed, 1 skipped
ruff check litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py  # no new findings vs base
ruff format --check <both files>                                            # clean
```
