### PR TITLE
fix(prometheus): populate cache write token metrics for OpenAI-style usage

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -16,6 +16,7 @@ from typing import (
     Dict,
     List,
     Literal,
+    Mapping,
     Optional,
     Sequence,
     Tuple,
@@ -1449,6 +1450,8 @@ class PrometheusLogger(CustomLogger):
         prompt_details = usage_object.get("prompt_tokens_details") or {}
         completion_details = usage_object.get("completion_tokens_details") or {}
 
+        cache_creation_detail_tokens = PrometheusLogger._resolve_cache_write_tokens(prompt_details)
+
         detail_metrics: List[Tuple[Any, DEFINED_PROMETHEUS_METRICS, Any]] = [
             (
                 self.litellm_input_cached_tokens_metric,
@@ -1458,7 +1461,7 @@ class PrometheusLogger(CustomLogger):
             (
                 self.litellm_input_cache_creation_tokens_metric,
                 "litellm_input_cache_creation_tokens_metric",
-                (prompt_details.get("cache_creation_tokens") if isinstance(prompt_details, dict) else None),
+                cache_creation_detail_tokens,
             ),
             (
                 self.litellm_input_audio_tokens_metric,
@@ -1597,27 +1600,12 @@ class PrometheusLogger(CustomLogger):
             )
 
         # Provider prompt caching metrics are independent of LiteLLM cache_hit.
-        provider_cache_read_tokens = 0
-        provider_cache_creation_tokens = 0
         usage_obj = (standard_logging_payload.get("metadata", {}) or {}).get("usage_object")
         if isinstance(usage_obj, dict):
-            # Prefer explicit provider cache fields when available.
-            _read = usage_obj.get("cache_read_input_tokens")
-            _write = usage_obj.get("cache_creation_input_tokens")
-
-            if isinstance(_read, int):
-                provider_cache_read_tokens = _read
-            if isinstance(_write, int):
-                provider_cache_creation_tokens = _write
-
-            # Fallback to prompt_tokens_details.cached_tokens (common normalization point).
-            # Only fallback when the explicit field is genuinely absent (None).
-            if _read is None:
-                prompt_details = usage_obj.get("prompt_tokens_details")
-                if isinstance(prompt_details, dict):
-                    cached_tokens = prompt_details.get("cached_tokens")
-                    if isinstance(cached_tokens, int):
-                        provider_cache_read_tokens = cached_tokens
+            (
+                provider_cache_read_tokens,
+                provider_cache_creation_tokens,
+            ) = PrometheusLogger._resolve_provider_cache_tokens(usage_obj)
 
             if provider_cache_read_tokens > 0:
                 PrometheusLogger._inc_labeled_counter(
@@ -1638,6 +1626,40 @@ class PrometheusLogger(CustomLogger):
                     label_context=label_context,
                     amount=float(provider_cache_creation_tokens),
                 )
+
+    @staticmethod
+    def _resolve_provider_cache_tokens(usage_obj: Mapping[str, object]) -> tuple[int, int]:
+        # Prefer explicit provider cache fields when available.
+        _read = usage_obj.get("cache_read_input_tokens")
+        _write = usage_obj.get("cache_creation_input_tokens")
+
+        provider_cache_read_tokens = _read if isinstance(_read, int) else 0
+        provider_cache_creation_tokens = _write if isinstance(_write, int) else 0
+
+        # Fallback to prompt_tokens_details (common normalization point).
+        # Only fallback when the explicit field is genuinely absent (None).
+        prompt_details = usage_obj.get("prompt_tokens_details")
+        if _read is None and isinstance(prompt_details, dict):
+            cached_tokens = prompt_details.get("cached_tokens")
+            if isinstance(cached_tokens, int):
+                provider_cache_read_tokens = cached_tokens
+
+        if _write is None:
+            write_tokens = PrometheusLogger._resolve_cache_write_tokens(prompt_details)
+            if write_tokens is not None:
+                provider_cache_creation_tokens = write_tokens
+
+        return provider_cache_read_tokens, provider_cache_creation_tokens
+
+    @staticmethod
+    def _resolve_cache_write_tokens(prompt_details: object) -> int | None:
+        if not isinstance(prompt_details, dict):
+            return None
+        for key in ("cache_write_tokens", "cache_creation_tokens"):
+            value = prompt_details.get(key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                return value
+        return None
 
     def _increment_mcp_tool_call_metrics(
         self,

--- a/tests/test_litellm/integrations/test_prometheus_cache_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_cache_metrics.py
@@ -258,6 +258,158 @@ class TestPrometheusCacheMetrics:
         # Should not emit read metric, because explicit provider value is zero.
         mock_logger.litellm_provider_cache_read_input_tokens_metric.labels.assert_not_called()
 
+    def test_provider_cache_creation_fallback_to_cache_write_tokens(
+        self, sample_enum_values
+    ):
+        """OpenAI-style usage (prompt_tokens_details.cache_write_tokens, no top-level
+        cache_creation_input_tokens) must populate the provider cache creation metric."""
+        mock_logger = MagicMock()
+
+        from litellm.integrations.prometheus import PrometheusLogger
+
+        standard_logging_payload = {
+            "cache_hit": False,
+            "total_tokens": 12100,
+            "prompt_tokens": 12000,
+            "completion_tokens": 100,
+            "model_group": "openai",
+            "request_tags": [],
+            "metadata": {
+                "usage_object": {
+                    "prompt_tokens_details": {
+                        "cached_tokens": 0,
+                        "cache_write_tokens": 800,
+                    },
+                }
+            },
+        }
+
+        mock_logger.litellm_cache_hits_metric = MagicMock()
+        mock_logger.litellm_cache_misses_metric = MagicMock()
+        mock_logger.litellm_cached_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_read_input_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric = MagicMock()
+        mock_logger.get_labels_for_metric = MagicMock(
+            return_value=[
+                "model",
+                "hashed_api_key",
+                "api_key_alias",
+                "team",
+                "team_alias",
+                "end_user",
+                "user",
+            ]
+        )
+
+        PrometheusLogger._increment_cache_metrics(
+            mock_logger,
+            standard_logging_payload=standard_logging_payload,
+            enum_values=sample_enum_values,
+        )
+
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric.labels().inc.assert_called_once_with(
+            800
+        )
+
+    def test_provider_cache_creation_fallback_to_cache_creation_tokens(
+        self, sample_enum_values
+    ):
+        """Normalized litellm usage dumps carry cache_creation_tokens in
+        prompt_tokens_details; the fallback must read it when cache_write_tokens is absent."""
+        mock_logger = MagicMock()
+
+        from litellm.integrations.prometheus import PrometheusLogger
+
+        standard_logging_payload = {
+            "cache_hit": False,
+            "total_tokens": 100,
+            "prompt_tokens": 50,
+            "completion_tokens": 50,
+            "model_group": "openai",
+            "request_tags": [],
+            "metadata": {
+                "usage_object": {
+                    "prompt_tokens_details": {"cache_creation_tokens": 42},
+                }
+            },
+        }
+
+        mock_logger.litellm_cache_hits_metric = MagicMock()
+        mock_logger.litellm_cache_misses_metric = MagicMock()
+        mock_logger.litellm_cached_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_read_input_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric = MagicMock()
+        mock_logger.get_labels_for_metric = MagicMock(
+            return_value=[
+                "model",
+                "hashed_api_key",
+                "api_key_alias",
+                "team",
+                "team_alias",
+                "end_user",
+                "user",
+            ]
+        )
+
+        PrometheusLogger._increment_cache_metrics(
+            mock_logger,
+            standard_logging_payload=standard_logging_payload,
+            enum_values=sample_enum_values,
+        )
+
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric.labels().inc.assert_called_once_with(
+            42
+        )
+
+    def test_provider_cache_creation_does_not_fallback_on_explicit_zero(
+        self, sample_enum_values
+    ):
+        """Explicit cache_creation_input_tokens=0 must not trigger fallback to
+        prompt_tokens_details, mirroring the cache-read semantics."""
+        mock_logger = MagicMock()
+
+        from litellm.integrations.prometheus import PrometheusLogger
+
+        standard_logging_payload = {
+            "cache_hit": False,
+            "total_tokens": 100,
+            "prompt_tokens": 50,
+            "completion_tokens": 50,
+            "model_group": "openai",
+            "request_tags": [],
+            "metadata": {
+                "usage_object": {
+                    "cache_creation_input_tokens": 0,
+                    "prompt_tokens_details": {"cache_write_tokens": 800},
+                }
+            },
+        }
+
+        mock_logger.litellm_cache_hits_metric = MagicMock()
+        mock_logger.litellm_cache_misses_metric = MagicMock()
+        mock_logger.litellm_cached_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_read_input_tokens_metric = MagicMock()
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric = MagicMock()
+        mock_logger.get_labels_for_metric = MagicMock(
+            return_value=[
+                "model",
+                "hashed_api_key",
+                "api_key_alias",
+                "team",
+                "team_alias",
+                "end_user",
+                "user",
+            ]
+        )
+
+        PrometheusLogger._increment_cache_metrics(
+            mock_logger,
+            standard_logging_payload=standard_logging_payload,
+            enum_values=sample_enum_values,
+        )
+
+        mock_logger.litellm_provider_cache_creation_input_tokens_metric.labels.assert_not_called()
+
     def test_increment_cache_metrics_when_cache_hit_is_none(self, sample_enum_values):
         """Test that no metrics are incremented when cache_hit is None"""
         # Create mock for PrometheusLogger instance

--- a/tests/test_litellm/integrations/test_prometheus_token_detail_metrics.py
+++ b/tests/test_litellm/integrations/test_prometheus_token_detail_metrics.py
@@ -150,6 +150,57 @@ class TestIncrementTokenDetailMetrics:
             10.0
         )
 
+    def test_cache_creation_falls_back_to_cache_write_tokens(self, sample_enum_values):
+        logger = _make_mock_logger()
+        payload = {
+            "metadata": {
+                "usage_object": {
+                    "prompt_tokens": 12000,
+                    "completion_tokens": 100,
+                    "total_tokens": 12100,
+                    "prompt_tokens_details": {
+                        "cached_tokens": 0,
+                        "cache_write_tokens": 800,
+                    },
+                }
+            },
+        }
+
+        PrometheusLogger._increment_token_detail_metrics(
+            logger,
+            standard_logging_payload=payload,
+            enum_values=sample_enum_values,
+        )
+
+        logger.litellm_input_cache_creation_tokens_metric.labels().inc.assert_called_once_with(
+            800.0
+        )
+
+    def test_cache_write_tokens_takes_precedence_over_cache_creation_tokens(
+        self, sample_enum_values
+    ):
+        logger = _make_mock_logger()
+        payload = {
+            "metadata": {
+                "usage_object": {
+                    "prompt_tokens_details": {
+                        "cache_creation_tokens": 25,
+                        "cache_write_tokens": 800,
+                    },
+                }
+            },
+        }
+
+        PrometheusLogger._increment_token_detail_metrics(
+            logger,
+            standard_logging_payload=payload,
+            enum_values=sample_enum_values,
+        )
+
+        logger.litellm_input_cache_creation_tokens_metric.labels().inc.assert_called_once_with(
+            800.0
+        )
+
     def test_skips_metrics_when_value_is_zero(self, sample_enum_values):
         logger = _make_mock_logger()
         payload = {


### PR DESCRIPTION
## TLDR

Problem this solves:

- OpenAI GPT-5.6 bills prompt cache writes, reported in `prompt_tokens_details.cache_write_tokens`
- `litellm_provider_cache_creation_input_tokens_metric` only read Anthropic's top-level `cache_creation_input_tokens`
- so the cache write metric never fired for OpenAI models

How it solves it:

- resolve cache write tokens with a `prompt_tokens_details` fallback, mirroring the cache read twin
- fallback order `cache_write_tokens` then `cache_creation_tokens`, matching cost and spend trackers
- same fallback for `litellm_input_cache_creation_tokens_metric` on raw usage dicts

## Relevant issues

## Linear ticket

Resolves LIT-4348

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Behavior changes

Additive only. The two Prometheus counters gain series for responses whose usage carries a cache write count only inside `prompt_tokens_details` (OpenAI GPT-5.6 and later, kimi-k2 style OpenAI-compatible providers). Anthropic, Bedrock, and Databricks set the top-level field, which still wins, so their series are byte-identical to before. An explicit top-level `cache_creation_input_tokens: 0` still suppresses the fallback, mirroring the pre-existing cache read semantics; note `db_spend_update_writer._extract_cache_creation_tokens` falls back on any falsy value instead, a pre-existing divergence tracked in LIT-4834. No API, config, DB, or SDK surface changes

## Screenshots / Proof of Fix

Live proxy (real Postgres, `prometheus` callback) with two deployments: `claude-sonnet-4-5` hitting the real Bedrock API as the Anthropic-style control, and `gpt-5.6` routed to a local upstream replaying the exact GPT-5.6 usage wire shape (`prompt_tokens_details.cache_write_tokens`), since no funded OpenAI key was available on this rig; the Bedrock leg is a real paid provider call. Same two curls before and after

```bash
# call 1: gpt-5.6, usage carries prompt_tokens_details.cache_write_tokens=1755
curl -sS http://127.0.0.1:20348/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"What is this document about?"}]}'
# call 2: bedrock claude-sonnet-4-5 with a >1024 token cache_control system prompt (real cache write)
curl -sS http://127.0.0.1:20348/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @claude_payload.json
# scrape
curl -sS http://127.0.0.1:20348/metrics/ -H "Authorization: Bearer sk-1234" | grep cache_creation
```

Before (unfixed `litellm/integrations/prometheus.py`, base commit 19348db0a6; file identical at current base 079003b82d): the provider cache write counter has a bedrock series only, no openai series exists

```
litellm_input_cache_creation_tokens_metric_total{api_provider="bedrock",model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",...} 3255.0
litellm_input_cache_creation_tokens_metric_total{api_provider="openai",model="gpt-5.6",...} 1755.0
litellm_provider_cache_creation_input_tokens_metric_total{api_provider="bedrock",model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",...} 3255.0
```

After (fixed, captured at bd2fc080da, code-identical to this PR's HEAD 5c37e8151d): the openai series appears with the exact cache write count, bedrock unchanged

```
litellm_input_cache_creation_tokens_metric_total{api_provider="bedrock",model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",...} 3255.0
litellm_input_cache_creation_tokens_metric_total{api_provider="openai",model="gpt-5.6",...} 1755.0
litellm_provider_cache_creation_input_tokens_metric_total{api_provider="openai",model="gpt-5.6",...} 1755.0
litellm_provider_cache_creation_input_tokens_metric_total{api_provider="bedrock",model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",...} 3255.0
```

A streamed Bedrock cache write (`stream: true` with `stream_options.include_usage`) was also verified to increment the counter (3255 -> 6510), covering the chunk-builder usage path

Independent e2e verification (Devin): [screen recording](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctNThkZGJiMTRjYzY5NDRiNjg0ZjgxZTk0MTlhZmU4YmUvZGViMTU4NGQtYjMxZC00ZGVjLTkyZWEtYzdkN2Q5NDc0MDkzIiwiaWF0IjoxNzg1MTc1NzMwLCJleHAiOjE3ODU3ODA1MzAsImZpbGVuYW1lIjoibGl0NDM0OC1xYS1lZGl0ZWQubXA0In0.ZCKD5KGW8mE02j9gU2brYR5cR0XreOE1mz_7890cP7w) of a live proxy (real Postgres, `prometheus` callback, real license) started alternately from this PR's HEAD 5c37e8151d and from the merge base 079003b82d via two worktrees, driven with real provider calls and no mocks. On the PR commit a real OpenAI `gpt-5.6-sol` call reporting `prompt_tokens_details.cache_write_tokens: 5135` produced both `litellm_provider_cache_creation_input_tokens_metric_total` and `litellm_input_cache_creation_tokens_metric_total` at 5135.0; a real Anthropic `claude-sonnet-5` call with `cache_control` on a >1024 token system block kept the provider counter at exactly its top-level `cache_creation_input_tokens: 9444` (no double counting); a plain short `gpt-4.1-nano` call created no cache-creation series; and the identical OpenAI call on the merge base produced zero provider-level series while the input-level counter still read 5135.0. The OpenAI leg here was a real paid API call against `gpt-5.6-sol`, not a replayed wire shape; the one branch the video does not reach is explicit top-level `cache_creation_input_tokens: 0` suppressing the fallback, which no real response shape produced, so it stays covered by the unit tests

## Type

🐛 Bug Fix

## Changes

`litellm/integrations/prometheus.py`: `_increment_cache_metrics` now resolves provider cache read and write tokens through a new `_resolve_provider_cache_tokens` helper. Read semantics are unchanged (explicit top-level int wins, `prompt_tokens_details.cached_tokens` fallback only when the explicit field is None); write tokens gain the symmetric fallback the read side already had. The fallback key order lives in one shared `_resolve_cache_write_tokens` helper (`cache_write_tokens` first, then `cache_creation_tokens`, ints only, bools rejected) which `_increment_token_detail_metrics` also uses, so both counters resolve the pair identically. `cache_write_tokens` first matches `cost_calculator.py`, `db_spend_update_writer.py`, and `spend_tracking_utils.py`, and it is the documented canonical field on `PromptTokensDetailsWrapper`

Tests extend the two mapped files. The three fallback tests plus the precedence test fail on the unfixed module and pass with the fix; explicit-zero suppression and the Anthropic top-level path are pinned as regressions

Follow-ups deliberately out of scope, tracked in LIT-4834: Langfuse, Arize, and OTEL gen_ai semconv still read only the top-level field; the cost double-count guard in `llm_cost_calc/utils.py` is gated on cache reads; `azure/*gpt-5.6*` pricing entries lack `cache_creation_input_token_cost`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


Link to Devin session: https://app.devin.ai/sessions/b9689b0d66194d1a9a4e43fc3fed7b01
Requested by: @yucheng-berri
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/34803" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only additive metric emission with preserved semantics for providers that set top-level fields; no API, auth, or billing path changes in this diff.
> 
> **Overview**
> Fixes **missing Prometheus cache-write series** when providers only report writes inside `prompt_tokens_details` (e.g. OpenAI `cache_write_tokens`), not top-level `cache_creation_input_tokens`.
> 
> **`PrometheusLogger`** now resolves cache-write counts through shared helpers: `_resolve_cache_write_tokens` prefers `cache_write_tokens`, then `cache_creation_tokens` (ints only). `_resolve_provider_cache_tokens` centralizes provider read/write resolution; write fallback runs only when `cache_creation_input_tokens` is **absent** (`None`), not when it is explicitly `0`, matching existing cache-read behavior.
> 
> Both **`litellm_provider_cache_creation_input_tokens_metric`** and **`litellm_input_cache_creation_tokens_metric`** use the same resolution path. Top-level Anthropic/Bedrock fields still win when present.
> 
> Unit tests cover OpenAI-style fallback, `cache_creation_tokens` fallback, `cache_write_tokens` precedence, and explicit-zero suppression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c37e8151d00be757bea07cf8083551b5ed28bb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->