### PR TITLE
fix: match exact class in callback dedup so a custom subclass does not block a built-in logger

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -558,10 +558,10 @@ def _custom_logger_class_exists_in_success_callbacks(
     e.g if `LangfusePromptManagement` is passed in, it will return True if an instance of `LangfusePromptManagement` exists in litellm.success_callback or litellm._async_success_callback
 
     Prevents double adding a custom logger callback to the litellm callbacks
+
+    Matches on the exact class; an instance of a subclass does not count as registered
     """
-    return any(
-        isinstance(cb, type(callback_class)) for cb in litellm.success_callback + litellm._async_success_callback
-    )
+    return any(type(cb) is type(callback_class) for cb in litellm.success_callback + litellm._async_success_callback)
 
 
 def _custom_logger_class_exists_in_failure_callbacks(
@@ -573,10 +573,10 @@ def _custom_logger_class_exists_in_failure_callbacks(
     e.g if `LangfusePromptManagement` is passed in, it will return True if an instance of `LangfusePromptManagement` exists in litellm.failure_callback or litellm._async_failure_callback
 
     Prevents double adding a custom logger callback to the litellm callbacks
+
+    Matches on the exact class; an instance of a subclass does not count as registered
     """
-    return any(
-        isinstance(cb, type(callback_class)) for cb in litellm.failure_callback + litellm._async_failure_callback
-    )
+    return any(type(cb) is type(callback_class) for cb in litellm.failure_callback + litellm._async_failure_callback)
 
 
 def get_request_guardrails(kwargs: Dict[str, Any]) -> List[str]:
@@ -766,7 +766,7 @@ def function_setup(
                         llm_router=None,  # type: ignore
                     )
                     if callback is None or any(
-                        isinstance(cb, type(callback)) for cb in litellm._async_success_callback
+                        type(cb) is type(callback) for cb in litellm._async_success_callback
                     ):  # don't double add a callback
                         continue
                 if callback not in litellm.input_callback:

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4916,3 +4916,94 @@ def test_is_prompt_caching_valid_prompt_explicit_min_token_count_overrides_model
         is_prompt_caching_valid_prompt(model="claude-opus-4-8", messages=PROMPT_CACHE_MESSAGES, min_token_count=8192)
         is False
     )
+
+
+def test_custom_logger_guards_ignore_subclass_instances(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Regression LIT-4392: the success/failure existence guards used isinstance, so a user
+    subclass of a built-in logger already promoted into the callback lists made the guard
+    report the built-in itself as registered and the configured logger was silently skipped.
+    The exact-class assertions must hold alongside the subclass assertions: the guards still
+    have to dedup a second instance of the same class, only a subclass must stop matching."""
+    from litellm.integrations.custom_logger import CustomLogger
+    from litellm.utils import (
+        _custom_logger_class_exists_in_failure_callbacks,
+        _custom_logger_class_exists_in_success_callbacks,
+    )
+
+    class BuiltinLogger(CustomLogger):
+        pass
+
+    class UserSubclassLogger(BuiltinLogger):
+        pass
+
+    builtin_instance = BuiltinLogger()
+
+    monkeypatch.setattr(litellm, "success_callback", [UserSubclassLogger()])
+    monkeypatch.setattr(litellm, "failure_callback", [UserSubclassLogger()])
+    monkeypatch.setattr(litellm, "_async_success_callback", [])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [])
+    assert _custom_logger_class_exists_in_success_callbacks(builtin_instance) is False
+    assert _custom_logger_class_exists_in_failure_callbacks(builtin_instance) is False
+
+    monkeypatch.setattr(litellm, "success_callback", [BuiltinLogger()])
+    monkeypatch.setattr(litellm, "failure_callback", [BuiltinLogger()])
+    assert _custom_logger_class_exists_in_success_callbacks(builtin_instance) is True
+    assert _custom_logger_class_exists_in_failure_callbacks(builtin_instance) is True
+
+
+@pytest.mark.asyncio
+async def test_s3_v2_success_callback_registers_alongside_user_subclass(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression LIT-4392: with a user S3Logger subclass registered via litellm_settings.callbacks
+    and success_callback ["s3_v2"], the built-in s3_v2 logger was never added and S3 logs were
+    silently dropped while requests kept returning 200."""
+    from litellm.integrations.s3_v2 import S3Logger
+    from litellm.utils import _add_custom_logger_callback_to_specific_event
+
+    class UserS3Logger(S3Logger):
+        async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+            pass
+
+    user_logger = UserS3Logger()
+    monkeypatch.setattr(litellm, "success_callback", [user_logger, "s3_v2"])
+    monkeypatch.setattr(litellm, "_async_success_callback", [user_logger])
+    monkeypatch.setattr(litellm, "failure_callback", [])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [])
+
+    _add_custom_logger_callback_to_specific_event("s3_v2", "success")
+
+    assert any(type(cb) is S3Logger for cb in litellm.success_callback)
+    assert any(type(cb) is S3Logger for cb in litellm._async_success_callback)
+    assert "s3_v2" not in litellm.success_callback
+    assert user_logger in litellm.success_callback
+
+
+@pytest.mark.asyncio
+async def test_builtin_string_callback_registers_when_subclass_already_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression LIT-4392, litellm.callbacks path: the inline dedup in function_setup also
+    matched subclass instances, so a built-in name in litellm.callbacks was dropped whenever a
+    user subclass was already promoted into _async_success_callback."""
+    from litellm.integrations.s3_v2 import S3Logger
+
+    class UserS3Logger(S3Logger):
+        async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
+            pass
+
+    user_logger = UserS3Logger()
+    monkeypatch.setattr(litellm, "callbacks", ["s3_v2"])
+    monkeypatch.setattr(litellm, "input_callback", [])
+    monkeypatch.setattr(litellm, "success_callback", [user_logger])
+    monkeypatch.setattr(litellm, "failure_callback", [])
+    monkeypatch.setattr(litellm, "_async_success_callback", [user_logger])
+    monkeypatch.setattr(litellm, "_async_failure_callback", [])
+
+    await litellm.acompletion(
+        model="gpt-5.6",
+        messages=[{"role": "user", "content": "hi"}],
+        mock_response="ok",
+    )
+
+    assert any(type(cb) is S3Logger for cb in litellm._async_success_callback)


### PR DESCRIPTION
## TLDR

Problem this solves:

- A custom callback that subclasses a built-in logger (e.g. `class CustomFailureS3Logger(litellm.integrations.s3_v2.S3Logger)`) registered via `litellm_settings.callbacks` silently prevented the explicitly configured `success_callback: ["s3_v2"]` logger from registering. Requests kept returning 200 while S3 logs were dropped with no error
- Root cause: the callback dedup guards `_custom_logger_class_exists_in_success_callbacks` / `_custom_logger_class_exists_in_failure_callbacks` (and an inline copy in `function_setup`) used `isinstance(cb, type(callback_class))`, so a subclass instance already promoted into the callback lists made the guard report the built-in itself as registered

How it solves it:

- The three dedup checks now compare exact classes (`type(cb) is type(callback_class)`), so a subclass no longer counts as the built-in. This matches the exact-type convention the codebase already uses for the same problem elsewhere (`litellm_logging.py`: "Use exact type check to avoid matching ArizePhoenixLogger (subclass)")
- Exact-class dedup is preserved: a second instance of the same class still does not double-register, and `LoggingCallbackManager._add_custom_logger_to_list` remains the second dedup layer

## Relevant issues

## Linear ticket

Resolves LIT-4392

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on this branch, real Postgres, real Bedrock model (`bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0`), real S3 bucket. Config is the ticket's repro: a user subclass of the s3_v2 `S3Logger` in `callbacks` plus `success_callback: ["s3_v2"]`

```yaml
litellm_settings:
  success_callback: ["s3_v2"]
  callbacks: custom_failure_s3_logger.instance
  s3_callback_params:
    s3_bucket_name: litellm-logs-test2
    s3_region_name: us-east-2
    s3_path: lit4392-repro
```

Bug present (before this fix), 3 non-streaming + 3 streaming `/v1/chat/completions` requests:

```
$ for i in 1 2 3; do curl -sS http://localhost:20392/v1/chat/completions -H "Authorization: Bearer sk-1234" \
    -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"say REPRO-4392-'$i'"}]}' ...; done
200 OK chatcmpl-8941ffbe-3669-46e2-96e6-046481aa77d5 'REPRO-4392-1'
200 OK chatcmpl-8aeb3430-6f20-4a68-a5b7-922931909c99 'REPRO-4392-2'
200 OK chatcmpl-24c45d85-4328-45ce-918d-af1e20546a43 'REPRO-4392-3'
stream 4 HTTP 200
stream 5 HTTP 200
stream 6 HTTP 200

$ aws s3 ls s3://litellm-logs-test2/lit4392-repro/ --recursive | wc -l
       0        # 6/6 requests returned 200, 0/6 S3 objects written
```

Control on the same unfixed build with the subclass removed from `callbacks` proves the rig itself writes fine: 2/2 requests produced 2/2 S3 objects

After the fix, same config with the subclass still registered, same 6 requests:

```
200 OK chatcmpl-1a43a68a-ffa0-4d1b-bedc-83d63c4a3d5e 'VERIFY-4392-1'
200 OK chatcmpl-cb7dc4c9-5339-414e-96bd-9d2aeb55185c 'VERIFY-4392-2'
200 OK chatcmpl-d0d64494-84c0-40b2-b2c3-c14ee21654eb 'VERIFY-4392-3'
stream 4 HTTP 200
stream 5 HTTP 200
stream 6 HTTP 200

$ aws s3 ls s3://litellm-logs-test2/lit4392-repro/ --recursive | wc -l
       8        # 2 control objects + 6 new, one per request, streaming included

2026-07-27 10:10:20  9236 lit4392-repro/2026-07-27/time-10-10-13-466313_chatcmpl-46d32fa7-....json
2026-07-27 10:10:20  9236 lit4392-repro/2026-07-27/time-10-10-14-748409_chatcmpl-6587ecfc-....json
```

`/v1/messages` (the surface from the customer report) also verified on the fixed build: non-streaming and streaming both produced S3 objects (8 -> 10), with the user subclass still active

### Local e2e evidence pass

A second pass on the fixed build with a fresh database and a deliberately different request order (`/v1/messages` streaming first, then `/v1/messages` non-streaming, then `/v1/chat/completions` streaming, then non-streaming) against a clean `s3_path`. Contract: exactly one S3 object per successful request within flush_interval + 10s, no double-writes from the dedup layers

```
messages stream HTTP 200
id: msg_bdrk_0172jx7JmqNy2WycV5RTXV1r
chat stream HTTP 200
id: chatcmpl-17cc0096-b877-4a67-b79d-fede21d558fc

$ aws s3 ls s3://litellm-logs-test2/lit4392-evidence/ --recursive
2026-07-27 10:53:20  9154 lit4392-evidence/2026-07-27/time-10-53-10-530143_6bf4124c-....json
2026-07-27 10:53:20  9641 lit4392-evidence/2026-07-27/time-10-53-10-663003_chatcmpl-635a2c30-....json
2026-07-27 10:53:20  9239 lit4392-evidence/2026-07-27/time-10-53-11-785917_chatcmpl-03758440-....json
2026-07-27 10:53:20  9001 lit4392-evidence/2026-07-27/time-10-53-13-045635_chatcmpl-17cc0096-....json
```

4/4 requests, 4/4 objects, no extras. The proxy's admin UI Logs page for the same run, all four requests Success against the real Bedrock model, request IDs matching the S3 object names:

![Request Logs page showing the four evidence requests](https://raw.githubusercontent.com/yucheng-berri/litellm/assets-pr34804/lit4392-ui-logs.png)

## Type

🐛 Bug Fix

## Changes

- `litellm/utils.py`: `_custom_logger_class_exists_in_success_callbacks`, `_custom_logger_class_exists_in_failure_callbacks`, and the inline dedup in `function_setup` compare `type(cb) is type(...)` instead of `isinstance(cb, type(...))`
- `tests/test_litellm/test_utils.py`: three regression tests; all fail on the unfixed code and pass with the fix (guard-level subclass vs exact-class, the ticket's s3_v2 scenario through `_add_custom_logger_callback_to_specific_event`, and the `litellm.callbacks` string path through `function_setup`)

## Behavior changes

- Intended fix: a user subclass of a built-in logger no longer blocks the configured built-in from registering, on both the success and failure paths
- Side effect worth knowing: configuring two built-ins where one subclasses the other (`["otel", "arize"]`, `["focus", "vantage"]`, `["focus", "mavvrik"]`, and other legacy OTel-family pairs) now registers both. Previously the outcome was order-dependent: the base logger was dropped when the subclass registered first. Anyone relying on that accidental suppression will now see both exporters emit. The dedup rule was never documented and the new behavior honors the explicit two-callback config. This applies to the legacy OTel logger classes only: with `LITELLM_OTEL_V2` enabled all OTel destinations share the `OpenTelemetryV2` class and the second destination is still dropped by the class-keyed guard; that gap is pre-existing (isinstance was equally blind to it) and tracked in LIT-4833
- Known remaining hole, pre-existing: the second dedup layer (`LoggingCallbackManager._add_custom_logger_to_list`) keys on class name plus fundamental attrs, so a user subclass literally named `S3Logger` with matching attrs would still block the built-in there. Not addressed here

## QA runbook

1. Start the proxy with a config that has `success_callback: ["s3_v2"]`, `s3_callback_params` pointing at a real bucket, and `callbacks: <module>.instance` where `instance` subclasses `litellm.integrations.s3_v2.S3Logger`
2. Send a few `/v1/chat/completions` and `/v1/messages` requests (streaming and non-streaming) with a real model
3. Wait one flush interval (default 10s) and list the bucket path: one JSON object per request must appear
4. Remove the fix (revert `litellm/utils.py`) and repeat: no objects appear, which is the bug

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global callback registration used by proxy logging and observability; fix is narrow but can change which exporters run for some multi-callback OTel-family configs.
> 
> **Overview**
> Fixes **silent loss of built-in success/failure loggers** when a user registers a **subclass** of that built-in (e.g. custom `S3Logger` in `callbacks` plus `success_callback: ["s3_v2"]`). Dedup guards in `litellm/utils.py` now use **`type(cb) is type(callback_class)`** instead of **`isinstance`**, matching the existing exact-type pattern in `litellm_logging.py`. A second instance of the **same** class still dedupes; only subclasses stop counting as the base.
> 
> The same change applies to the inline dedup in **`function_setup`** when promoting string callbacks from `litellm.callbacks`. Regression tests cover the guard helpers, the `s3_v2` registration path, and `acompletion` with an active user subclass.
> 
> **Behavior note:** configs that list two built-ins where one subclasses the other (legacy OTel-family pairs) may now register **both** exporters instead of order-dependent suppression of the base.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb89b5359082c8b679a6737b4dc826892770dd7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->