### PR TITLE
feat(schema): declare user relation on verification tokens

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260727000000_add_verification_token_user_fkey/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260727000000_add_verification_token_user_fkey/migration.sql
@@ -1,15 +1,23 @@
--- Null out user_ids that reference users that no longer exist; the foreign key
--- below cannot be added over them, and ON DELETE SET NULL would have produced
--- the same rows had the constraint existed when those users were deleted
-UPDATE "LiteLLM_VerificationToken" vt
-SET "user_id" = NULL
-WHERE vt."user_id" IS NOT NULL
-  AND NOT EXISTS (SELECT 1 FROM "LiteLLM_UserTable" u WHERE u."user_id" = vt."user_id");
-
 -- AddForeignKey
+-- NOT VALID so no existing row is touched or judged: keys whose user_id points
+-- at a user that no longer existed before this migration keep their value, and
+-- the constraint only enforces new INSERTs and UPDATEs of user_id.
 DO $$
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'LiteLLM_VerificationToken_user_id_fkey') THEN
-        ALTER TABLE "LiteLLM_VerificationToken" ADD CONSTRAINT "LiteLLM_VerificationToken_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "LiteLLM_UserTable"("user_id") ON DELETE SET NULL ON UPDATE CASCADE;
+        ALTER TABLE "LiteLLM_VerificationToken" ADD CONSTRAINT "LiteLLM_VerificationToken_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "LiteLLM_UserTable"("user_id") ON DELETE SET NULL ON UPDATE CASCADE NOT VALID;
     END IF;
+END $$;
+
+-- Best-effort validation: on databases with no orphaned user_ids (the normal
+-- case; user deletion removes the user's keys) this marks the constraint fully
+-- valid. Where orphans exist the constraint simply stays NOT VALID and keeps
+-- enforcing go-forward writes; the migration never fails and never mutates data.
+DO $$
+BEGIN
+    BEGIN
+        ALTER TABLE "LiteLLM_VerificationToken" VALIDATE CONSTRAINT "LiteLLM_VerificationToken_user_id_fkey";
+    EXCEPTION WHEN foreign_key_violation THEN
+        RAISE NOTICE 'LiteLLM_VerificationToken has user_ids referencing missing users; constraint left NOT VALID';
+    END;
 END $$;

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260727000000_add_verification_token_user_fkey/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260727000000_add_verification_token_user_fkey/migration.sql
@@ -1,0 +1,15 @@
+-- Null out user_ids that reference users that no longer exist; the foreign key
+-- below cannot be added over them, and ON DELETE SET NULL would have produced
+-- the same rows had the constraint existed when those users were deleted
+UPDATE "LiteLLM_VerificationToken" vt
+SET "user_id" = NULL
+WHERE vt."user_id" IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM "LiteLLM_UserTable" u WHERE u."user_id" = vt."user_id");
+
+-- AddForeignKey
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'LiteLLM_VerificationToken_user_id_fkey') THEN
+        ALTER TABLE "LiteLLM_VerificationToken" ADD CONSTRAINT "LiteLLM_VerificationToken_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "LiteLLM_UserTable"("user_id") ON DELETE SET NULL ON UPDATE CASCADE;
+    END IF;
+END $$;

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -265,6 +265,7 @@ model LiteLLM_UserTable {
     invitations_updated LiteLLM_InvitationLink[] @relation("UpdatedBy")
     invitations_user    LiteLLM_InvitationLink[] @relation("UserId")
     object_permission LiteLLM_ObjectPermissionTable?   @relation(fields: [object_permission_id], references: [object_permission_id])
+    keys LiteLLM_VerificationToken[]
 }
 
 model LiteLLM_ObjectPermissionTable {
@@ -462,6 +463,7 @@ model LiteLLM_VerificationToken {
     litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
     litellm_organization_table LiteLLM_OrganizationTable?   @relation(fields: [organization_id], references: [organization_id])
     litellm_project_table LiteLLM_ProjectTable?   @relation(fields: [project_id], references: [project_id])
+    litellm_user_table LiteLLM_UserTable?   @relation(fields: [user_id], references: [user_id])
     object_permission LiteLLM_ObjectPermissionTable?   @relation(fields: [object_permission_id], references: [object_permission_id])
     jwt_key_mappings LiteLLM_JWTKeyMapping[]
 

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2179,6 +2179,7 @@ async def _process_single_key_update(
             detail={"error": "Database not connected"},
         )
 
+    await _ensure_user_row_for_key_write(prisma_client, non_default_values.get("user_id"), existing_key_row.user_id)
     _data = {**non_default_values, "token": update_key_request.key}
     response = await prisma_client.update_data(token=update_key_request.key, data=_data)
 
@@ -2648,6 +2649,7 @@ async def update_key_fn(
         _data = {**non_default_values, "token": key}
         if prisma_client is None:
             raise Exception("Not connected to DB!")
+        await _ensure_user_row_for_key_write(prisma_client, non_default_values.get("user_id"), existing_key_row.user_id)
         response = await prisma_client.update_data(token=key, data=_data)
 
         # Delete - key from cache, since it's been updated!
@@ -3531,6 +3533,24 @@ def _check_model_access_group(
     return True
 
 
+async def _ensure_user_row_for_key_write(
+    prisma_client: PrismaClient, user_id: object, existing_user_id: str | None = None
+) -> None:
+    """Key rows carry a foreign key to LiteLLM_UserTable, so every write path
+    that sets user_id without provisioning the user (table_name="key" minting
+    such as JWT auto-register, admin user_id rebinds on update/regenerate)
+    must create the referenced user row first. Create-only upsert: an existing
+    user is never modified, and a user_id unchanged from existing_user_id is
+    already satisfied by the constraint so no lookup is made.
+    """
+    if not user_id or not isinstance(user_id, str) or user_id == existing_user_id:
+        return
+    await prisma_client.db.litellm_usertable.upsert(
+        where={"user_id": user_id},
+        data={"create": {"user_id": user_id}, "update": {}},
+    )
+
+
 async def generate_key_helper_fn(
     request_type: Literal["user", "key"],  # identifies if this request is from /user/new or /key/generate
     duration: Optional[str] = None,
@@ -3793,6 +3813,8 @@ async def generate_key_helper_fn(
                 "prisma_client: Creating Key= %s",
                 {**key_data, "token": hash_token(token=token)},
             )
+            if table_name == "key":
+                await _ensure_user_row_for_key_write(prisma_client, key_data.get("user_id"))
             create_key_response = await prisma_client.insert_data(data=key_data, table_name="key")
 
             key_data["token_id"] = getattr(create_key_response, "token", None)
@@ -4520,6 +4542,7 @@ async def _execute_virtual_key_regeneration(
         grace_period=data.grace_period if data else None,
     )
 
+    await _ensure_user_row_for_key_write(prisma_client, update_data.get("user_id"), key_in_db.user_id)
     updated_token = await VerificationTokenRepository(prisma_client).table.update(
         where={"token": hashed_api_key},
         data=update_data,  # type: ignore

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -265,6 +265,7 @@ model LiteLLM_UserTable {
     invitations_updated LiteLLM_InvitationLink[] @relation("UpdatedBy")
     invitations_user    LiteLLM_InvitationLink[] @relation("UserId")
     object_permission LiteLLM_ObjectPermissionTable?   @relation(fields: [object_permission_id], references: [object_permission_id])
+    keys LiteLLM_VerificationToken[]
 }
 
 model LiteLLM_ObjectPermissionTable {
@@ -462,6 +463,7 @@ model LiteLLM_VerificationToken {
     litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
     litellm_organization_table LiteLLM_OrganizationTable?   @relation(fields: [organization_id], references: [organization_id])
     litellm_project_table LiteLLM_ProjectTable?   @relation(fields: [project_id], references: [project_id])
+    litellm_user_table LiteLLM_UserTable?   @relation(fields: [user_id], references: [user_id])
     object_permission LiteLLM_ObjectPermissionTable?   @relation(fields: [object_permission_id], references: [object_permission_id])
     jwt_key_mappings LiteLLM_JWTKeyMapping[]
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -265,6 +265,7 @@ model LiteLLM_UserTable {
     invitations_updated LiteLLM_InvitationLink[] @relation("UpdatedBy")
     invitations_user    LiteLLM_InvitationLink[] @relation("UserId")
     object_permission LiteLLM_ObjectPermissionTable?   @relation(fields: [object_permission_id], references: [object_permission_id])
+    keys LiteLLM_VerificationToken[]
 }
 
 model LiteLLM_ObjectPermissionTable {
@@ -462,6 +463,7 @@ model LiteLLM_VerificationToken {
     litellm_budget_table LiteLLM_BudgetTable?   @relation(fields: [budget_id], references: [budget_id])
     litellm_organization_table LiteLLM_OrganizationTable?   @relation(fields: [organization_id], references: [organization_id])
     litellm_project_table LiteLLM_ProjectTable?   @relation(fields: [project_id], references: [project_id])
+    litellm_user_table LiteLLM_UserTable?   @relation(fields: [user_id], references: [user_id])
     object_permission LiteLLM_ObjectPermissionTable?   @relation(fields: [object_permission_id], references: [object_permission_id])
     jwt_key_mappings LiteLLM_JWTKeyMapping[]
 

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -780,6 +780,7 @@ async def test_generate_key_helper_fn_with_access_group_ids(monkeypatch):
     mock_prisma_client.db.litellm_objectpermissiontable.create = AsyncMock(
         return_value=MagicMock(object_permission_id=None)
     )
+    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock()
 
     captured_key_data = {}
 
@@ -830,6 +831,7 @@ async def test_generate_key_helper_fn_with_budget_fallbacks(monkeypatch):
     mock_prisma_client.db.litellm_objectpermissiontable.create = AsyncMock(
         return_value=MagicMock(object_permission_id=None)
     )
+    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock()
 
     captured_key_data = {}
 
@@ -6256,6 +6258,62 @@ def test_build_key_filter_conditions_agent_id_narrows_visibility():
 
 
 @pytest.mark.asyncio
+async def test_ensure_user_row_for_key_write_create_only_upsert():
+    """
+    The FK on LiteLLM_VerificationToken.user_id means key writes must
+    provision the referenced user row: create it when missing, never touch
+    an existing one, and no-op for empty or non-string user ids.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        _ensure_user_row_for_key_write,
+    )
+
+    mock_prisma_client = AsyncMock()
+    mock_upsert = AsyncMock()
+    mock_prisma_client.db.litellm_usertable.upsert = mock_upsert
+
+    await _ensure_user_row_for_key_write(mock_prisma_client, "ghost-user")
+    mock_upsert.assert_called_once_with(
+        where={"user_id": "ghost-user"},
+        data={"create": {"user_id": "ghost-user"}, "update": {}},
+    )
+
+    mock_upsert.reset_mock()
+    await _ensure_user_row_for_key_write(mock_prisma_client, None)
+    await _ensure_user_row_for_key_write(mock_prisma_client, "")
+    await _ensure_user_row_for_key_write(mock_prisma_client, 42)
+    mock_upsert.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_key_helper_fn_table_name_key_provisions_user_row():
+    """
+    Regression for the FK on user_id: table_name="key" minting (admin
+    /key/generate with an arbitrary user_id, JWT auto-register) skips the
+    user-creation branch, so the helper must provision the user row before
+    inserting the key or the insert violates the constraint.
+    """
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.insert_data = AsyncMock(
+        return_value=MagicMock(token="hashed-token", litellm_budget_table=None, created_at=None, updated_at=None)
+    )
+    mock_upsert = AsyncMock()
+    mock_prisma_client.db.litellm_usertable.upsert = mock_upsert
+
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma_client):
+        await generate_key_helper_fn(
+            request_type="key",
+            user_id="ghost-user",
+            table_name="key",
+        )
+
+    assert mock_upsert.call_args.kwargs["where"] == {"user_id": "ghost-user"}
+    insert_tables = [c.kwargs.get("table_name") for c in mock_prisma_client.insert_data.call_args_list]
+    assert "user" not in insert_tables, "table_name='key' must not run the full user-creation branch"
+    assert "key" in insert_tables
+
+
+@pytest.mark.asyncio
 async def test_generate_key_negative_max_budget():
     """
     Test that GenerateKeyRequest model allows negative max_budget values.
@@ -8274,6 +8332,7 @@ async def test_default_key_generate_params_object_permission_not_rejected_for_no
     mock_prisma_client.db.litellm_objectpermissiontable.create = AsyncMock(
         return_value=MagicMock(object_permission_id="objperm-4")
     )
+    mock_prisma_client.db.litellm_usertable.upsert = AsyncMock()
 
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Keys reference their owner by a bare user_id string
- No declared relation means no DB integrity and no joins

How it solves it:

- Declares the keys-to-users relation in schema.prisma (FK, SET NULL)
- Migration adds the FK NOT VALID: zero rows read or written
- Best-effort VALIDATE upgrades it on clean databases, never fails
- Key writes that set user_id now provision the user row first

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)



## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Applied at 90ba89e1cc to a live dev database with pre-existing keys, and separately proven on a scratch database seeded with an orphaned key (user_id referencing no user):

```
rows after migration (must be unchanged): [('key-null', None), ('key-ok', 'real-user'), ('key-orphan', 'ghost-user')]
constraint exists, convalidated: False
new insert with missing user rejected
new insert with real user accepted
after user delete, SET NULL applied: [('key-ok', None), ('key-good2', None)]
```

On the dev database, which has no orphans, the constraint validates fully:

```
$ python -m prisma db execute --file litellm-proxy-extras/litellm_proxy_extras/migrations/20260727000000_add_verification_token_user_fkey/migration.sql --schema schema.prisma
Script executed successfully.

$ SELECT conname, pg_get_constraintdef(oid) FROM pg_constraint WHERE conname = 'LiteLLM_VerificationToken_user_id_fkey';
LiteLLM_VerificationToken_user_id_fkey
FOREIGN KEY (user_id) REFERENCES "LiteLLM_UserTable"(user_id) ON UPDATE CASCADE ON DELETE SET NULL

$ SELECT COUNT(*) FROM "LiteLLM_VerificationToken" vt WHERE vt.user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM "LiteLLM_UserTable" u WHERE u.user_id = vt.user_id);
0
```

Runtime flows against a proxy on the migrated database, all behaving exactly as before the constraint:

```
$ curl -s http://localhost:4093/user/new -H 'Authorization: Bearer sk-1234' -d '{"user_email":"qa-carol-20463@example.com","auto_create_key":false}'   # ok
$ curl -s http://localhost:4093/key/generate -H 'Authorization: Bearer sk-1234' -d '{"user_id":"<carol>","key_alias":"qa-key-carol-20463"}'                  # ok
$ curl -s http://localhost:4093/key/delete -H 'Authorization: Bearer sk-1234' -d '{"keys":["<carol key>"]}'                                                  # ok
$ curl -s http://localhost:4093/user/delete -H 'Authorization: Bearer sk-1234' -d '{"user_ids":["<bob>"]}'                                                   # 1, bob's keys removed as before
$ curl -s 'http://localhost:4093/key/list?return_full_object=true&size=100' -H 'Authorization: Bearer sk-1234'                                               # all keys, unchanged
```

Write-path guards, verified live against a database with the constraint enforcing:

```
$ curl -s http://localhost:4093/key/generate -H 'Authorization: Bearer sk-1234' -d '{"user_id":"ghost-user-3-20463","key_alias":"qa-key-ghost3-20463"}'    # 200, user row auto-provisioned
$ curl -s 'http://localhost:4093/user/info?user_id=ghost-user-3-20463' -H 'Authorization: Bearer sk-1234'                                                    # user row exists
$ curl -s http://localhost:4093/key/update -H 'Authorization: Bearer sk-1234' -d '{"key":"<key>","user_id":"ghost-user-4-20463"}'                            # 200 (FK-violated 400 before the guard)
$ curl -s http://localhost:4093/key/regenerate -H 'Authorization: Bearer sk-1234' -d '{"key":"<key>","user_id":"ghost-user-5-20463"}'                        # 200, user row auto-provisioned
```

## Type

🚄 Infrastructure

## Changes

schema.prisma (and the litellm/proxy copy) gain the relation both ways: `litellm_user_table` on LiteLLM_VerificationToken (fields user_id, references user_id) and a `keys` back-relation on LiteLLM_UserTable. This matches the FK style the token table already uses for budget, organization, project and object_permission (ON DELETE SET NULL ON UPDATE CASCADE); the owner link was the one reference on this table never declared

The migration adds the constraint NOT VALID inside the usual pg_constraint idempotency guard, which means Postgres does not read or judge a single existing row: keys whose user_id references a user that no longer exists keep their value, and the constraint enforces only new INSERTs and UPDATEs of user_id. A second best-effort step VALIDATEs the constraint, upgrading it to fully valid on databases with no orphans (the normal case, since user deletion removes the user's keys); where orphans exist the exception is swallowed and the constraint simply stays NOT VALID. Under no database state can this migration fail a deploy or mutate customer data, which matters because the product is self-hosted and these are the two most important tables in it

The constraint enforces new writes even while NOT VALID, so an audit of every code path that writes LiteLLM_VerificationToken was done before enabling it. All inserts funnel through generate_key_helper_fn, which only provisions the user row when called for /user/new; callers passing table_name="key" (admin /key/generate with an arbitrary user_id, JWT auto-register key minting) inserted keys with dangling user_ids, and admin user_id rebinds on /key/update and /key/regenerate could write one too. A create-only upsert (_ensure_user_row_for_key_write) now provisions the referenced user row at those sites: an existing user is never modified, and a user_id unchanged from the existing key skips the lookup. Unit tests pin the helper semantics and that table_name="key" minting provisions the row without running the full user-creation branch

Behavior note: admin key minting with a user_id that had no user row previously left a dangling reference; it now creates a minimal user row, which is the integrity the constraint exists to guarantee

The relation itself is not consumed by any query yet; it makes the database enforce the keys-to-users link and unlocks relation queries (for example filtering or including a key's user in one query) for the stacked follow-up
