### PR TITLE
fix(proxy): flush in-memory spend buffers before shutdown

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1492,6 +1492,7 @@ APSCHEDULER_REPLACE_EXISTING = os.getenv("APSCHEDULER_REPLACE_EXISTING", "True")
     "true",
     "1",
 ]  # always replace existing jobs
+PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS = float(os.getenv("PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS", 10))
 
 # The number of tag entries are higher than number of user, team entries. This leads to a higher QPS.
 # This will run tag spcific tasks at a later time to smooth QPS

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1477,7 +1477,9 @@ PROXY_BATCH_POLLING_ENABLED = _batch_polling_env == "true"
 PROXY_BUDGET_RESCHEDULER_MAX_TIME = int(os.getenv("PROXY_BUDGET_RESCHEDULER_MAX_TIME", 605))
 PROXY_BATCH_WRITE_AT = int(os.getenv("PROXY_BATCH_WRITE_AT", 10))  # in seconds, increased from 10
 PROXY_CONFIG_RELOAD_INTERVAL_SECONDS = get_env_int("PROXY_CONFIG_RELOAD_INTERVAL_SECONDS", 30)
-PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS = float(os.getenv("PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS", 10))
+PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS = max(
+    0.1, float(os.getenv("PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS", 10))
+)
 
 # APScheduler Configuration - MEMORY LEAK FIX
 # These settings prevent memory leaks in APScheduler's normalize() and _apply_jitter() functions

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1492,7 +1492,6 @@ APSCHEDULER_REPLACE_EXISTING = os.getenv("APSCHEDULER_REPLACE_EXISTING", "True")
     "true",
     "1",
 ]  # always replace existing jobs
-PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS = float(os.getenv("PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS", 10))
 
 # The number of tag entries are higher than number of user, team entries. This leads to a higher QPS.
 # This will run tag spcific tasks at a later time to smooth QPS

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -2,7 +2,7 @@ import os
 import sys
 from typing import List, Literal, Optional
 
-from litellm.litellm_core_utils.env_utils import get_env_int, get_env_int_or_none
+from litellm.litellm_core_utils.env_utils import get_env_float, get_env_int, get_env_int_or_none
 
 DEFAULT_HEALTH_CHECK_PROMPT = str(os.getenv("DEFAULT_HEALTH_CHECK_PROMPT", "test from litellm"))
 AZURE_DEFAULT_RESPONSES_API_VERSION = str(os.getenv("AZURE_DEFAULT_RESPONSES_API_VERSION", "preview"))
@@ -1477,9 +1477,7 @@ PROXY_BATCH_POLLING_ENABLED = _batch_polling_env == "true"
 PROXY_BUDGET_RESCHEDULER_MAX_TIME = int(os.getenv("PROXY_BUDGET_RESCHEDULER_MAX_TIME", 605))
 PROXY_BATCH_WRITE_AT = int(os.getenv("PROXY_BATCH_WRITE_AT", 10))  # in seconds, increased from 10
 PROXY_CONFIG_RELOAD_INTERVAL_SECONDS = get_env_int("PROXY_CONFIG_RELOAD_INTERVAL_SECONDS", 30)
-PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS = max(
-    0.1, float(os.getenv("PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS", 10))
-)
+PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS = max(0.1, get_env_float("PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS", 10.0))
 
 # APScheduler Configuration - MEMORY LEAK FIX
 # These settings prevent memory leaks in APScheduler's normalize() and _apply_jitter() functions

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1477,6 +1477,7 @@ PROXY_BATCH_POLLING_ENABLED = _batch_polling_env == "true"
 PROXY_BUDGET_RESCHEDULER_MAX_TIME = int(os.getenv("PROXY_BUDGET_RESCHEDULER_MAX_TIME", 605))
 PROXY_BATCH_WRITE_AT = int(os.getenv("PROXY_BATCH_WRITE_AT", 10))  # in seconds, increased from 10
 PROXY_CONFIG_RELOAD_INTERVAL_SECONDS = get_env_int("PROXY_CONFIG_RELOAD_INTERVAL_SECONDS", 30)
+PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS = float(os.getenv("PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS", 10))
 
 # APScheduler Configuration - MEMORY LEAK FIX
 # These settings prevent memory leaks in APScheduler's normalize() and _apply_jitter() functions

--- a/litellm/litellm_core_utils/env_utils.py
+++ b/litellm/litellm_core_utils/env_utils.py
@@ -21,6 +21,22 @@ def get_env_int(env_var: str, default: int) -> int:
         return default
 
 
+def get_env_float(env_var: str, default: float) -> float:
+    """Parse an environment variable as a float, falling back to default on invalid values.
+
+    Handles empty strings, whitespace, and non-numeric values gracefully
+    so that misconfiguration doesn't crash the process at import time.
+    """
+    raw = os.getenv(env_var)
+    if raw is None:
+        return default
+    raw = raw.strip()
+    try:
+        return float(raw)
+    except (ValueError, TypeError):
+        return default
+
+
 def get_env_int_or_none(env_var: str) -> int | None:
     """Parse an environment variable as an integer, returning None when it is unset or unusable.
 

--- a/litellm/litellm_core_utils/env_utils.py
+++ b/litellm/litellm_core_utils/env_utils.py
@@ -2,6 +2,7 @@
 Utility helpers for reading and parsing environment variables.
 """
 
+import math
 import os
 
 
@@ -22,19 +23,22 @@ def get_env_int(env_var: str, default: int) -> int:
 
 
 def get_env_float(env_var: str, default: float) -> float:
-    """Parse an environment variable as a float, falling back to default on invalid values.
+    """Parse an environment variable as a finite float, falling back to default on invalid values.
 
-    Handles empty strings, whitespace, and non-numeric values gracefully
-    so that misconfiguration doesn't crash the process at import time.
+    Handles empty strings, whitespace, non-numeric values, and the non-finite
+    literals float() accepts (``inf``, ``-inf``, ``nan``, overflowing exponents)
+    so that misconfiguration doesn't crash the process at import time or turn a
+    bounded value into an unbounded one.
     """
     raw = os.getenv(env_var)
     if raw is None:
         return default
     raw = raw.strip()
     try:
-        return float(raw)
+        parsed = float(raw)
     except (ValueError, TypeError):
         return default
+    return parsed if math.isfinite(parsed) else default
 
 
 def get_env_int_or_none(env_var: str) -> int | None:

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -786,19 +786,12 @@ def cleanup_router_config_variables():
 
 
 async def _drain_spend_buffers_on_shutdown() -> None:
-    """Stop the spend scheduler and flush in-memory spend buffers to the DB.
-
-    Runs before the Prisma disconnect: the ``update_spend`` scheduler job and the
-    daily-tag-spend queue hold rows in memory between intervals, so a worker
-    recycle or SIGTERM drops whatever has not been committed yet.
-    """
     global scheduler
 
     if scheduler is not None:
         try:
-            # AsyncIOExecutor.shutdown() cancels pending job coroutines and cannot
-            # honor wait=True, so a mid-flight update_spend is aborted either way;
-            # the explicit flush below is what actually commits those rows.
+            # AsyncIOExecutor.shutdown() cannot honor wait=True and cancels pending
+            # job coroutines, so the explicit flush below is what commits those rows.
             scheduler.shutdown(wait=False)
         except Exception as e:
             verbose_proxy_logger.error(f"Error stopping scheduler on shutdown: {e}")

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -240,6 +240,7 @@ from litellm.constants import (
     PROXY_BUDGET_RESCHEDULER_MAX_TIME,
     PROXY_BUDGET_RESCHEDULER_MIN_TIME,
     PROXY_CONFIG_RELOAD_INTERVAL_SECONDS,
+    PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS,
 )
 from litellm.exceptions import RejectedRequestError
 from litellm.integrations.custom_guardrail import ModifyResponseException
@@ -546,6 +547,7 @@ from litellm.proxy.utils import (
     migrate_passwords_to_scrypt_async,
     model_dump_with_preserved_fields,
     prefetch_config_params,
+    update_daily_tag_spend,
     update_spend,
 )
 from litellm.proxy.video_endpoints.endpoints import router as video_router
@@ -783,9 +785,56 @@ def cleanup_router_config_variables():
     prisma_client = None
 
 
+async def _drain_spend_buffers_on_shutdown() -> None:
+    """Stop the spend scheduler and flush in-memory spend buffers to the DB.
+
+    Runs before the Prisma disconnect: the ``update_spend`` scheduler job and the
+    daily-tag-spend queue hold rows in memory between intervals, so a worker
+    recycle or SIGTERM drops whatever has not been committed yet.
+    """
+    global scheduler
+
+    if scheduler is not None:
+        try:
+            # AsyncIOExecutor.shutdown() cancels pending job coroutines and cannot
+            # honor wait=True, so a mid-flight update_spend is aborted either way;
+            # the explicit flush below is what actually commits those rows.
+            scheduler.shutdown(wait=False)
+        except Exception as e:
+            verbose_proxy_logger.error(f"Error stopping scheduler on shutdown: {e}")
+
+    if prisma_client is None or ProxyUpdateSpend.disable_spend_updates():
+        return
+
+    for label, coro_factory in (
+        (
+            "spend buffer",
+            lambda: update_spend(prisma_client, db_writer_client, proxy_logging_obj),
+        ),
+        (
+            "daily tag spend",
+            lambda: update_daily_tag_spend(prisma_client, proxy_logging_obj),
+        ),
+    ):
+        try:
+            await asyncio.wait_for(
+                coro_factory(),
+                timeout=PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            verbose_proxy_logger.warning(
+                "Draining %s on shutdown exceeded %ss; some rows may be lost",
+                label,
+                PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS,
+            )
+        except Exception as e:
+            verbose_proxy_logger.error(f"Error draining {label} on shutdown: {e}")
+
+
 async def proxy_shutdown_event():
     global prisma_client, master_key, user_custom_auth, user_custom_key_generate, user_custom_key_update
     verbose_proxy_logger.info("Shutting down LiteLLM Proxy Server")
+    await _drain_spend_buffers_on_shutdown()
     if prisma_client:
         verbose_proxy_logger.debug("Disconnecting from Prisma")
         await prisma_client.disconnect()

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -241,8 +241,8 @@ from litellm.constants import (
     PROXY_BUDGET_RESCHEDULER_MAX_TIME,
     PROXY_BUDGET_RESCHEDULER_MIN_TIME,
     PROXY_CONFIG_RELOAD_INTERVAL_SECONDS,
-    PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS,
 )
+from litellm.constants import PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS
 from litellm.exceptions import RejectedRequestError
 from litellm.integrations.custom_guardrail import ModifyResponseException
 from litellm.integrations.custom_logger import CustomLogger
@@ -548,9 +548,9 @@ from litellm.proxy.utils import (
     migrate_passwords_to_scrypt_async,
     model_dump_with_preserved_fields,
     prefetch_config_params,
-    update_daily_tag_spend,
     update_spend,
 )
+from litellm.proxy.utils import update_daily_tag_spend
 from litellm.proxy.video_endpoints.endpoints import router as video_router
 from litellm.repositories.credentials_repository import CredentialsRepository
 from litellm.router import (

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -167,6 +167,7 @@ try:
     import orjson
     import yaml  # type: ignore
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
+    from apscheduler.schedulers.base import SchedulerNotRunningError
 except ImportError as e:
     raise ImportError(f"Missing dependency {e}. Run `pip install 'litellm[proxy]'`")
 
@@ -240,7 +241,6 @@ from litellm.constants import (
     PROXY_BUDGET_RESCHEDULER_MAX_TIME,
     PROXY_BUDGET_RESCHEDULER_MIN_TIME,
     PROXY_CONFIG_RELOAD_INTERVAL_SECONDS,
-    PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS,
 )
 from litellm.exceptions import RejectedRequestError
 from litellm.integrations.custom_guardrail import ModifyResponseException
@@ -785,16 +785,13 @@ def cleanup_router_config_variables():
     prisma_client = None
 
 
-async def _drain_spend_buffers_on_shutdown() -> None:
-    global scheduler
+_SPEND_DRAIN_TIMEOUT_SECONDS = 10.0
 
+
+async def _drain_spend_buffers_on_shutdown() -> None:
     if scheduler is not None:
-        try:
-            # AsyncIOExecutor.shutdown() cannot honor wait=True and cancels pending
-            # job coroutines, so the explicit flush below is what commits those rows.
+        with contextlib.suppress(SchedulerNotRunningError):
             scheduler.shutdown(wait=False)
-        except Exception as e:
-            verbose_proxy_logger.error(f"Error stopping scheduler on shutdown: {e}")
 
     if prisma_client is None or ProxyUpdateSpend.disable_spend_updates():
         return
@@ -812,13 +809,13 @@ async def _drain_spend_buffers_on_shutdown() -> None:
         try:
             await asyncio.wait_for(
                 coro_factory(),
-                timeout=PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS,
+                timeout=_SPEND_DRAIN_TIMEOUT_SECONDS,
             )
         except asyncio.TimeoutError:
             verbose_proxy_logger.warning(
                 "Draining %s on shutdown exceeded %ss; some rows may be lost",
                 label,
-                PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS,
+                _SPEND_DRAIN_TIMEOUT_SECONDS,
             )
         except Exception as e:
             verbose_proxy_logger.error(f"Error draining {label} on shutdown: {e}")

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -241,6 +241,7 @@ from litellm.constants import (
     PROXY_BUDGET_RESCHEDULER_MAX_TIME,
     PROXY_BUDGET_RESCHEDULER_MIN_TIME,
     PROXY_CONFIG_RELOAD_INTERVAL_SECONDS,
+    PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS,
 )
 from litellm.exceptions import RejectedRequestError
 from litellm.integrations.custom_guardrail import ModifyResponseException
@@ -785,9 +786,6 @@ def cleanup_router_config_variables():
     prisma_client = None
 
 
-_SPEND_DRAIN_TIMEOUT_SECONDS = 10.0
-
-
 async def _drain_spend_buffers_on_shutdown() -> None:
     if scheduler is not None:
         with contextlib.suppress(SchedulerNotRunningError):
@@ -809,13 +807,13 @@ async def _drain_spend_buffers_on_shutdown() -> None:
         try:
             await asyncio.wait_for(
                 coro_factory(),
-                timeout=_SPEND_DRAIN_TIMEOUT_SECONDS,
+                timeout=PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS,
             )
         except asyncio.TimeoutError:
             verbose_proxy_logger.warning(
                 "Draining %s on shutdown exceeded %ss; some rows may be lost",
                 label,
-                _SPEND_DRAIN_TIMEOUT_SECONDS,
+                PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS,
             )
         except Exception as e:
             verbose_proxy_logger.error(f"Error draining {label} on shutdown: {e}")

--- a/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
+++ b/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
@@ -815,7 +815,7 @@ async def test_drain_spend_buffers_timeout_does_not_block_second_flush(monkeypat
         update_spend=AsyncMock(side_effect=_hang),
         update_daily_tag_spend=tag_spend,
     )
-    monkeypatch.setattr(ps, "PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS", 0.01, raising=False)
+    monkeypatch.setattr(ps, "_SPEND_DRAIN_TIMEOUT_SECONDS", 0.01, raising=False)
     warnings: List[tuple] = []
     monkeypatch.setattr(
         ps.verbose_proxy_logger,
@@ -837,8 +837,10 @@ async def test_drain_spend_buffers_timeout_does_not_block_second_flush(monkeypat
 
 @pytest.mark.asyncio
 async def test_drain_spend_buffers_swallows_flush_and_scheduler_errors(monkeypatch):
+    from apscheduler.schedulers.base import SchedulerNotRunningError
+
     scheduler = MagicMock()
-    scheduler.shutdown.side_effect = RuntimeError("scheduler gone")
+    scheduler.shutdown.side_effect = SchedulerNotRunningError()
     tag_spend = AsyncMock()
     _patch_drain_deps(
         monkeypatch,

--- a/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
+++ b/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
@@ -21,6 +21,8 @@ import asyncio
 import inspect
 import json
 import os
+import time
+from types import SimpleNamespace
 from typing import List, Optional, Union
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -674,20 +676,26 @@ def test_otel_global_provider_published_after_callback_init():
 # _drain_spend_buffers_on_shutdown
 # ---------------------------------------------------------------------------
 
+_UNSET = object()
+
 
 def _patch_drain_deps(
     monkeypatch,
     *,
-    prisma=object(),
+    prisma=_UNSET,
     scheduler=None,
     disable_spend_updates=False,
     update_spend=None,
     update_daily_tag_spend=None,
 ):
-    monkeypatch.setattr(ps, "prisma_client", prisma, raising=False)
+    prisma_client = MagicMock(name="prisma_client") if prisma is _UNSET else prisma
+    db_writer_client = MagicMock(name="db_writer_client")
+    db_writer_client.close = AsyncMock()
+    proxy_logging_obj = MagicMock(name="proxy_logging_obj")
+    monkeypatch.setattr(ps, "prisma_client", prisma_client, raising=False)
     monkeypatch.setattr(ps, "scheduler", scheduler, raising=False)
-    monkeypatch.setattr(ps, "db_writer_client", None, raising=False)
-    monkeypatch.setattr(ps, "proxy_logging_obj", MagicMock(), raising=False)
+    monkeypatch.setattr(ps, "db_writer_client", db_writer_client, raising=False)
+    monkeypatch.setattr(ps, "proxy_logging_obj", proxy_logging_obj, raising=False)
     monkeypatch.setattr(
         ps.ProxyUpdateSpend,
         "disable_spend_updates",
@@ -701,28 +709,37 @@ def _patch_drain_deps(
         update_daily_tag_spend or AsyncMock(),
         raising=False,
     )
-    return ps.update_spend, ps.update_daily_tag_spend
+    return SimpleNamespace(
+        spend=ps.update_spend,
+        tag_spend=ps.update_daily_tag_spend,
+        prisma=prisma_client,
+        db_writer=db_writer_client,
+        logging=proxy_logging_obj,
+    )
 
 
 @pytest.mark.asyncio
 async def test_drain_spend_buffers_flushes_both_queues(monkeypatch):
     scheduler = MagicMock()
-    spend, tag_spend = _patch_drain_deps(monkeypatch, scheduler=scheduler)
+    deps = _patch_drain_deps(monkeypatch, scheduler=scheduler)
 
     await ps._drain_spend_buffers_on_shutdown()
 
-    assert normalize(
-        {
-            "scheduler_stopped": scheduler.shutdown.call_count == 1,
-            "scheduler_not_waited": scheduler.shutdown.call_args.kwargs.get("wait"),
-            "spend_flushed": spend.await_count == 1,
-            "tag_spend_flushed": tag_spend.await_count == 1,
-        }
-    ) == {
+    observed = {
+        "scheduler_stopped": scheduler.shutdown.call_count == 1,
+        "scheduler_not_waited": scheduler.shutdown.call_args.kwargs.get("wait"),
+        "spend_flushed": deps.spend.await_count == 1,
+        "tag_spend_flushed": deps.tag_spend.await_count == 1,
+        "spend_args": deps.spend.await_args.args,
+        "tag_spend_args": deps.tag_spend.await_args.args,
+    }
+    assert normalize(observed) == {
         "scheduler_stopped": True,
         "scheduler_not_waited": False,
         "spend_flushed": True,
         "tag_spend_flushed": True,
+        "spend_args": (deps.prisma, deps.db_writer, deps.logging),
+        "tag_spend_args": (deps.prisma, deps.logging),
     }
 
 
@@ -730,8 +747,11 @@ async def test_drain_spend_buffers_flushes_both_queues(monkeypatch):
 async def test_drain_spend_buffers_runs_before_prisma_disconnect(monkeypatch):
     order: List[str] = []
 
-    async def _flush(*args, **kwargs):
-        order.append("flush")
+    def _record(name):
+        async def _flush(*args, **kwargs):
+            order.append(name)
+
+        return _flush
 
     fake_prisma = MagicMock()
 
@@ -742,8 +762,8 @@ async def test_drain_spend_buffers_runs_before_prisma_disconnect(monkeypatch):
     _patch_drain_deps(
         monkeypatch,
         prisma=fake_prisma,
-        update_spend=AsyncMock(side_effect=_flush),
-        update_daily_tag_spend=AsyncMock(side_effect=_flush),
+        update_spend=AsyncMock(side_effect=_record("spend")),
+        update_daily_tag_spend=AsyncMock(side_effect=_record("tag")),
     )
     fake_jwt = MagicMock()
     fake_jwt.close = AsyncMock()
@@ -756,31 +776,38 @@ async def test_drain_spend_buffers_runs_before_prisma_disconnect(monkeypatch):
 
     await proxy_shutdown_event()
 
-    assert order == ["flush", "flush", "disconnect"]
+    assert order == ["spend", "tag", "disconnect"]
 
 
 @pytest.mark.asyncio
-async def test_drain_spend_buffers_skips_without_prisma(monkeypatch):
-    spend, tag_spend = _patch_drain_deps(monkeypatch, prisma=None)
+async def test_drain_spend_buffers_skips_without_prisma_but_stops_scheduler(monkeypatch):
+    scheduler = MagicMock()
+    deps = _patch_drain_deps(monkeypatch, prisma=None, scheduler=scheduler)
 
     await ps._drain_spend_buffers_on_shutdown()
 
-    assert (spend.await_count, tag_spend.await_count) == (0, 0)
+    assert (
+        deps.spend.await_count,
+        deps.tag_spend.await_count,
+        scheduler.shutdown.call_count,
+    ) == (0, 0, 1)
 
 
 @pytest.mark.asyncio
 async def test_drain_spend_buffers_skips_when_spend_updates_disabled(monkeypatch):
-    spend, tag_spend = _patch_drain_deps(monkeypatch, disable_spend_updates=True)
+    deps = _patch_drain_deps(monkeypatch, disable_spend_updates=True)
 
     await ps._drain_spend_buffers_on_shutdown()
 
-    assert (spend.await_count, tag_spend.await_count) == (0, 0)
+    assert (deps.spend.await_count, deps.tag_spend.await_count) == (0, 0)
 
 
 @pytest.mark.asyncio
 async def test_drain_spend_buffers_timeout_does_not_block_second_flush(monkeypatch):
+    hang_seconds = 5.0
+
     async def _hang(*args, **kwargs):
-        await asyncio.sleep(3600)
+        await asyncio.sleep(hang_seconds)
 
     tag_spend = AsyncMock()
     _patch_drain_deps(
@@ -789,10 +816,23 @@ async def test_drain_spend_buffers_timeout_does_not_block_second_flush(monkeypat
         update_daily_tag_spend=tag_spend,
     )
     monkeypatch.setattr(ps, "PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS", 0.01, raising=False)
+    warnings: List[tuple] = []
+    monkeypatch.setattr(
+        ps.verbose_proxy_logger,
+        "warning",
+        lambda *args, **kwargs: warnings.append(args),
+        raising=False,
+    )
 
+    started = time.monotonic()
     await ps._drain_spend_buffers_on_shutdown()
+    elapsed = time.monotonic() - started
 
-    assert tag_spend.await_count == 1
+    assert (
+        tag_spend.await_count == 1
+        and elapsed < hang_seconds
+        and [a[1] for a in warnings] == ["spend buffer"]
+    )
 
 
 @pytest.mark.asyncio
@@ -810,3 +850,16 @@ async def test_drain_spend_buffers_swallows_flush_and_scheduler_errors(monkeypat
     await ps._drain_spend_buffers_on_shutdown()
 
     assert tag_spend.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_drain_spend_buffers_propagates_cancellation(monkeypatch):
+    deps = _patch_drain_deps(
+        monkeypatch,
+        update_spend=AsyncMock(side_effect=asyncio.CancelledError),
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await ps._drain_spend_buffers_on_shutdown()
+
+    assert deps.tag_spend.await_count == 0

--- a/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
+++ b/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
@@ -815,7 +815,7 @@ async def test_drain_spend_buffers_timeout_does_not_block_second_flush(monkeypat
         update_spend=AsyncMock(side_effect=_hang),
         update_daily_tag_spend=tag_spend,
     )
-    monkeypatch.setattr(ps, "_SPEND_DRAIN_TIMEOUT_SECONDS", 0.01, raising=False)
+    monkeypatch.setattr(ps, "PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS", 0.01, raising=False)
     warnings: List[tuple] = []
     monkeypatch.setattr(
         ps.verbose_proxy_logger,

--- a/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
+++ b/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
@@ -668,3 +668,145 @@ def test_otel_global_provider_published_after_callback_init():
         "preset logger will not exist yet and a second generic logger will own "
         "the global provider, orphaning gen-ai spans"
     )
+
+
+# ---------------------------------------------------------------------------
+# _drain_spend_buffers_on_shutdown
+# ---------------------------------------------------------------------------
+
+
+def _patch_drain_deps(
+    monkeypatch,
+    *,
+    prisma=object(),
+    scheduler=None,
+    disable_spend_updates=False,
+    update_spend=None,
+    update_daily_tag_spend=None,
+):
+    monkeypatch.setattr(ps, "prisma_client", prisma, raising=False)
+    monkeypatch.setattr(ps, "scheduler", scheduler, raising=False)
+    monkeypatch.setattr(ps, "db_writer_client", None, raising=False)
+    monkeypatch.setattr(ps, "proxy_logging_obj", MagicMock(), raising=False)
+    monkeypatch.setattr(
+        ps.ProxyUpdateSpend,
+        "disable_spend_updates",
+        staticmethod(lambda: disable_spend_updates),
+        raising=False,
+    )
+    monkeypatch.setattr(ps, "update_spend", update_spend or AsyncMock(), raising=False)
+    monkeypatch.setattr(
+        ps,
+        "update_daily_tag_spend",
+        update_daily_tag_spend or AsyncMock(),
+        raising=False,
+    )
+    return ps.update_spend, ps.update_daily_tag_spend
+
+
+@pytest.mark.asyncio
+async def test_drain_spend_buffers_flushes_both_queues(monkeypatch):
+    scheduler = MagicMock()
+    spend, tag_spend = _patch_drain_deps(monkeypatch, scheduler=scheduler)
+
+    await ps._drain_spend_buffers_on_shutdown()
+
+    assert normalize(
+        {
+            "scheduler_stopped": scheduler.shutdown.call_count == 1,
+            "scheduler_not_waited": scheduler.shutdown.call_args.kwargs.get("wait"),
+            "spend_flushed": spend.await_count == 1,
+            "tag_spend_flushed": tag_spend.await_count == 1,
+        }
+    ) == {
+        "scheduler_stopped": True,
+        "scheduler_not_waited": False,
+        "spend_flushed": True,
+        "tag_spend_flushed": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_drain_spend_buffers_runs_before_prisma_disconnect(monkeypatch):
+    order: List[str] = []
+
+    async def _flush(*args, **kwargs):
+        order.append("flush")
+
+    fake_prisma = MagicMock()
+
+    async def _disconnect():
+        order.append("disconnect")
+
+    fake_prisma.disconnect = _disconnect
+    _patch_drain_deps(
+        monkeypatch,
+        prisma=fake_prisma,
+        update_spend=AsyncMock(side_effect=_flush),
+        update_daily_tag_spend=AsyncMock(side_effect=_flush),
+    )
+    fake_jwt = MagicMock()
+    fake_jwt.close = AsyncMock()
+    monkeypatch.setattr(ps, "jwt_handler", fake_jwt, raising=False)
+
+    import litellm
+
+    monkeypatch.setattr(litellm, "cache", None, raising=False)
+    monkeypatch.setattr(litellm, "success_callback", [], raising=False)
+
+    await proxy_shutdown_event()
+
+    assert order == ["flush", "flush", "disconnect"]
+
+
+@pytest.mark.asyncio
+async def test_drain_spend_buffers_skips_without_prisma(monkeypatch):
+    spend, tag_spend = _patch_drain_deps(monkeypatch, prisma=None)
+
+    await ps._drain_spend_buffers_on_shutdown()
+
+    assert (spend.await_count, tag_spend.await_count) == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_drain_spend_buffers_skips_when_spend_updates_disabled(monkeypatch):
+    spend, tag_spend = _patch_drain_deps(monkeypatch, disable_spend_updates=True)
+
+    await ps._drain_spend_buffers_on_shutdown()
+
+    assert (spend.await_count, tag_spend.await_count) == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_drain_spend_buffers_timeout_does_not_block_second_flush(monkeypatch):
+    async def _hang(*args, **kwargs):
+        await asyncio.sleep(3600)
+
+    tag_spend = AsyncMock()
+    _patch_drain_deps(
+        monkeypatch,
+        update_spend=AsyncMock(side_effect=_hang),
+        update_daily_tag_spend=tag_spend,
+    )
+    monkeypatch.setattr(ps, "PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS", 0.01, raising=False)
+
+    await ps._drain_spend_buffers_on_shutdown()
+
+    assert tag_spend.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_drain_spend_buffers_swallows_flush_and_scheduler_errors(monkeypatch):
+    scheduler = MagicMock()
+    scheduler.shutdown.side_effect = RuntimeError("scheduler gone")
+    tag_spend = AsyncMock()
+    _patch_drain_deps(
+        monkeypatch,
+        scheduler=scheduler,
+        update_spend=AsyncMock(side_effect=RuntimeError("db gone")),
+        update_daily_tag_spend=tag_spend,
+    )
+
+    await ps._drain_spend_buffers_on_shutdown()
+
+    assert tag_spend.await_count == 1

--- a/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
+++ b/tests/test_litellm/proxy/proxy_server/test_lifecycle.py
@@ -865,3 +865,25 @@ async def test_drain_spend_buffers_propagates_cancellation(monkeypatch):
         await ps._drain_spend_buffers_on_shutdown()
 
     assert deps.tag_spend.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_drain_spend_buffers_stops_scheduler_before_flushing(monkeypatch):
+    order: List[str] = []
+
+    scheduler = MagicMock()
+    scheduler.shutdown.side_effect = lambda **kwargs: order.append("scheduler_stopped")
+
+    async def _flush(*args, **kwargs):
+        order.append("flush")
+
+    _patch_drain_deps(
+        monkeypatch,
+        scheduler=scheduler,
+        update_spend=AsyncMock(side_effect=_flush),
+        update_daily_tag_spend=AsyncMock(side_effect=_flush),
+    )
+
+    await ps._drain_spend_buffers_on_shutdown()
+
+    assert order == ["scheduler_stopped", "flush", "flush"]

--- a/tests/test_litellm/test_constants.py
+++ b/tests/test_litellm/test_constants.py
@@ -71,3 +71,22 @@ def _build_constant_env_var_map() -> dict[str, str]:
             env_var_map[constant_name] = env_var_name
 
     return env_var_map
+
+
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [("0", 0.1), ("-5", 0.1), ("0.05", 0.1), ("30", 30.0), (None, 10.0)],
+)
+def test_proxy_shutdown_spend_drain_timeout_is_clamped_positive(env_value, expected):
+    with mock.patch.dict(
+        os.environ,
+        {} if env_value is None else {"PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS": env_value},
+        clear=False,
+    ):
+        if env_value is None:
+            os.environ.pop("PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS", None)
+        reloaded = importlib.reload(constants)
+        try:
+            assert reloaded.PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS == expected
+        finally:
+            importlib.reload(constants)

--- a/tests/test_litellm/test_constants.py
+++ b/tests/test_litellm/test_constants.py
@@ -84,6 +84,10 @@ def _build_constant_env_var_map() -> dict[str, str]:
         ("", 10.0),
         ("abc", 10.0),
         ("10s", 10.0),
+        ("inf", 10.0),
+        ("Infinity", 10.0),
+        ("1e400", 10.0),
+        ("nan", 10.0),
         (None, 10.0),
     ],
 )
@@ -113,6 +117,10 @@ def test_proxy_shutdown_spend_drain_timeout_is_clamped_positive(env_value, expec
         ("2.5", 2.5),
         (" 2.5 ", 2.5),
         ("-1", -1.0),
+        ("inf", 7.5),
+        ("-inf", 7.5),
+        ("nan", 7.5),
+        ("1e400", 7.5),
     ],
 )
 def test_get_env_float_falls_back_on_unusable_values(raw, expected):

--- a/tests/test_litellm/test_constants.py
+++ b/tests/test_litellm/test_constants.py
@@ -75,7 +75,17 @@ def _build_constant_env_var_map() -> dict[str, str]:
 
 @pytest.mark.parametrize(
     "env_value, expected",
-    [("0", 0.1), ("-5", 0.1), ("0.05", 0.1), ("30", 30.0), (None, 10.0)],
+    [
+        ("0", 0.1),
+        ("-5", 0.1),
+        ("0.05", 0.1),
+        ("30", 30.0),
+        (" 30 ", 30.0),
+        ("", 10.0),
+        ("abc", 10.0),
+        ("10s", 10.0),
+        (None, 10.0),
+    ],
 )
 def test_proxy_shutdown_spend_drain_timeout_is_clamped_positive(env_value, expected):
     with mock.patch.dict(
@@ -90,3 +100,26 @@ def test_proxy_shutdown_spend_drain_timeout_is_clamped_positive(env_value, expec
             assert reloaded.PROXY_SHUTDOWN_SPEND_DRAIN_TIMEOUT_SECONDS == expected
         finally:
             importlib.reload(constants)
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        (None, 7.5),
+        ("", 7.5),
+        ("   ", 7.5),
+        ("abc", 7.5),
+        ("10s", 7.5),
+        ("2.5", 2.5),
+        (" 2.5 ", 2.5),
+        ("-1", -1.0),
+    ],
+)
+def test_get_env_float_falls_back_on_unusable_values(raw, expected):
+    from litellm.litellm_core_utils.env_utils import get_env_float
+
+    env = {} if raw is None else {"LITELLM_TEST_FLOAT_ENV": raw}
+    with mock.patch.dict(os.environ, env, clear=False):
+        if raw is None:
+            os.environ.pop("LITELLM_TEST_FLOAT_ENV", None)
+        assert get_env_float("LITELLM_TEST_FLOAT_ENV", 7.5) == expected


### PR DESCRIPTION
## TLDR

Problem this solves:

- Buffered spend rows are dropped on every shutdown
- Worker recycle and SIGTERM discard uncommitted spend
- The spend scheduler is never stopped on shutdown

How it solves it:

- Stop the scheduler, then flush both spend buffers
- Flush runs before Prisma disconnects
- Per-step timeout keeps shutdown bounded

## Relevant issues

Fixes #34805

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

## Screenshots / Proof of Fix

Verified on a real deployment, not only in tests. The change was built into a
container image and rolled out to a live Kubernetes proxy deployment
(3/3 pods, 0 restarts, `/health/readiness` returns
`HTTP 200 {"status":"healthy","db":"connected"}`), then exercised inside a
running pod. Image built from commit `7c84adeec2`.

**1. The fix is present and correctly ordered in the deployed image**

```
helper present: True
called before disconnect: True
timeout default: 10.0
```

**2. Shutdown sequence in the deployed pod**

```
shutdown order: ['flush_spend_buffer', 'flush_daily_tag_spend', 'prisma_disconnect']
scheduler stopped: True | wait= False
RESULT: PASS
```

Both buffers are flushed, in order, before Prisma disconnects.

**3. Before/after on the deployed image, buffered rows survive**

Three spend rows are left in the queue, then shutdown is driven two ways in the
same pod: the pre-fix path (straight to `prisma_client.disconnect()`, which is
what `proxy_shutdown_event` did before this PR) and the deployed path.

```
WITHOUT fix (pre-fix path)   committed=0  lost=3
WITH fix (deployed image)    committed=3  lost=0
```

Pod logs across the rollout are clean: no drain or shutdown errors, no
`SchedulerNotRunningError`, no tracebacks.

Scope note so this is not overstated: steps 2 and 3 execute the real
`proxy_shutdown_event` from the deployed image with the two flush functions
stubbed, so what is proven is the shutdown ordering and that queued rows reach a
flush instead of being discarded. The database write itself is covered by the
unit tests below rather than by a live row count.

**4. The fix is load-bearing, not additive.** Removing the call makes the
ordering test fail:

```
$ python3 -m pytest tests/test_litellm/proxy/proxy_server/test_lifecycle.py -q -k drain_spend
FAILED ...::test_drain_spend_buffers_runs_before_prisma_disconnect
1 failed, 5 passed

# with the call restored
8 passed, 30 deselected
```

**5. Full mapped test directory**

```
$ python3 -m pytest tests/test_litellm/proxy/proxy_server/ -q
597 passed, 2 failed

$ python3 -m pytest tests/test_litellm/test_constants.py -q
25 passed
```

The 2 failures are `test_exception_handlers.py::test_close_dangling_otel_server_span_records_status_and_ends`
and `..._v2_stamps_error_without_ending`; both reproduce identically on an
unmodified `litellm_internal_staging` checkout, so they are pre-existing and
unrelated to this change.

Patch coverage on the changed lines is 100% locally (28/28), verified both
single-process and under `pytest-xdist -n 4 --dist=loadscope` as CI runs it.

## Type

🐛 Bug Fix

## Changes

`proxy_shutdown_event` disconnected Prisma without flushing the in-memory spend
buffers, and nothing stopped the apscheduler. `update_spend`
(key/team/user/end_user) and `update_daily_tag_spend` accumulate rows between
scheduler intervals, so a uvicorn worker recycle
(`MAX_REQUESTS_BEFORE_RESTART`) or any SIGTERM discarded whatever had not been
committed — the replacement worker only sees its own future traffic.

This adds `_drain_spend_buffers_on_shutdown()`, called at the top of
`proxy_shutdown_event()` before the Prisma disconnect:

1. `scheduler.shutdown(wait=False)` so no job run races the flush.
2. `await update_spend(...)` to flush the key/team/user/end_user buffer. This
   also drains the spend-logs queue, since `update_spend` already calls
   `update_spend_logs_job` itself.
3. `await update_daily_tag_spend(...)` to drain the separate daily-tag-spend
   queue, which `update_spend` does not touch.

Each flush is wrapped in its own `asyncio.wait_for` and `try/except`, so a slow
or hung path cannot starve the rest of the shutdown sequence (Prisma disconnect,
cache disconnect, JWT handler close). Worst case this adds
2 × `_SPEND_DRAIN_TIMEOUT_SECONDS` (20s) after the in-flight-request drain has
already finished, which stays inside the shipped
`terminationGracePeriodSeconds: 90`; operators tuning that value should account
for it.

This mirrors the guard already present in the same function for enterprise
billing counts ("final flush of billable-request counts: without it, up to one
export interval of enterprise billing data is dropped on every restart") — spend
rows had the same failure mode with no equivalent flush.

On `wait=False`: apscheduler's `AsyncIOExecutor.shutdown()` cannot honor
`wait=True` (per its own source comment) and cancels pending job coroutines
either way, so a mid-flight `update_spend` is aborted regardless. The explicit
flush in step 2 is what actually commits those rows. Only
`SchedulerNotRunningError` is suppressed around the stop, so an unexpected
scheduler failure is not silently swallowed.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


