### PR TITLE
fix(ui): correct Claude Code skills install and settings snippet

### DIFF
--- a/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.test.ts
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatInstallCommand,
+  formatMarketplaceSettingsSnippet,
   extractCategories,
   validatePluginName,
   getSourceDisplayText,
@@ -18,31 +19,44 @@ import {
   parseSkillSource,
   isValidSubPath,
 } from "./helpers";
-import { MarketplacePluginEntry, PluginSource } from "./types";
+import { MarketplacePluginEntry } from "./types";
 
 describe("formatInstallCommand", () => {
-  it("formats github source with repo", () => {
-    const source: PluginSource = { source: "github", repo: "org/repo" };
-    expect(formatInstallCommand({ name: "my-plugin", source })).toBe("/plugin marketplace add org/repo");
+  it("installs the skill from the litellm marketplace by name", () => {
+    expect(formatInstallCommand({ name: "my-plugin" })).toBe("/plugin install my-plugin@litellm");
   });
 
-  it("formats url source", () => {
-    const source: PluginSource = { source: "url", url: "https://example.com/plugin" };
-    expect(formatInstallCommand({ name: "my-plugin", source })).toBe(
-      "/plugin marketplace add https://example.com/plugin",
-    );
+  it("uses the skill name regardless of source shape on the plugin object", () => {
+    expect(
+      formatInstallCommand({
+        name: "code-review",
+      }),
+    ).toBe("/plugin install code-review@litellm");
+  });
+});
+
+describe("formatMarketplaceSettingsSnippet", () => {
+  it("uses litellm as the marketplace key and nests source as an object", () => {
+    expect(formatMarketplaceSettingsSnippet("http://localhost:4000")).toEqual({
+      extraKnownMarketplaces: {
+        litellm: {
+          source: {
+            source: "url",
+            url: "http://localhost:4000/claude-code/marketplace.json",
+          },
+        },
+      },
+    });
   });
 
-  it("formats git-subdir source using its url", () => {
-    const source: PluginSource = { source: "git-subdir", url: "https://github.com/org/repo", path: "plugins/x" };
-    expect(formatInstallCommand({ name: "my-plugin", source })).toBe(
-      "/plugin marketplace add https://github.com/org/repo",
-    );
-  });
-
-  it("falls back to plugin name when no repo or url", () => {
-    const source: PluginSource = { source: "github" };
-    expect(formatInstallCommand({ name: "my-plugin", source })).toBe("/plugin marketplace add my-plugin");
+  it("never uses my-org or a flat string source", () => {
+    const snippet = formatMarketplaceSettingsSnippet("https://proxy.example.com");
+    const marketplaces = snippet.extraKnownMarketplaces;
+    expect(Object.keys(marketplaces)).toEqual(["litellm"]);
+    expect(marketplaces).not.toHaveProperty("my-org");
+    expect(typeof marketplaces.litellm.source).toBe("object");
+    expect(marketplaces.litellm.source).not.toBe("url");
+    expect(marketplaces.litellm.source.url).toBe("https://proxy.example.com/claude-code/marketplace.json");
   });
 });
 

--- a/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.test.ts
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatInstallCommand,
+  formatClaudeCodeMarketplaceUrl,
   formatMarketplaceSettingsSnippet,
   extractCategories,
   validatePluginName,
@@ -35,6 +36,26 @@ describe("formatInstallCommand", () => {
   });
 });
 
+describe("formatClaudeCodeMarketplaceUrl", () => {
+  it("appends the marketplace path to the resolved proxy base", () => {
+    expect(formatClaudeCodeMarketplaceUrl("http://localhost:4000")).toBe(
+      "http://localhost:4000/claude-code/marketplace.json",
+    );
+  });
+
+  it("preserves a server root path prefix on the proxy base", () => {
+    expect(formatClaudeCodeMarketplaceUrl("https://proxy.example.com/litellm")).toBe(
+      "https://proxy.example.com/litellm/claude-code/marketplace.json",
+    );
+  });
+
+  it("trims trailing slashes before appending the marketplace path", () => {
+    expect(formatClaudeCodeMarketplaceUrl("http://localhost:4000/")).toBe(
+      "http://localhost:4000/claude-code/marketplace.json",
+    );
+  });
+});
+
 describe("formatMarketplaceSettingsSnippet", () => {
   it("uses litellm as the marketplace key and nests source as an object", () => {
     expect(formatMarketplaceSettingsSnippet("http://localhost:4000")).toEqual({
@@ -57,6 +78,12 @@ describe("formatMarketplaceSettingsSnippet", () => {
     expect(typeof marketplaces.litellm.source).toBe("object");
     expect(marketplaces.litellm.source).not.toBe("url");
     expect(marketplaces.litellm.source.url).toBe("https://proxy.example.com/claude-code/marketplace.json");
+  });
+
+  it("uses the proxy base with a root path prefix", () => {
+    expect(
+      formatMarketplaceSettingsSnippet("https://proxy.example.com/api/v1").extraKnownMarketplaces.litellm.source.url,
+    ).toBe("https://proxy.example.com/api/v1/claude-code/marketplace.json");
   });
 });
 

--- a/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.ts
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.ts
@@ -178,17 +178,24 @@ export const parseSkillSource = (rawUrl: string, subPath?: string): SkillSourceP
 
 export const CLAUDE_CODE_MARKETPLACE_NAME = "litellm";
 
+export const CLAUDE_CODE_MARKETPLACE_PATH = "/claude-code/marketplace.json";
+
 export const formatInstallCommand = (plugin: { name: string }): string => {
   return `/plugin install ${plugin.name}@${CLAUDE_CODE_MARKETPLACE_NAME}`;
 };
 
-export const formatMarketplaceSettingsSnippet = (proxyOrigin: string) => {
+export const formatClaudeCodeMarketplaceUrl = (proxyBaseUrl: string): string => {
+  const normalizedBase = proxyBaseUrl.trim().replace(/\/+$/, "");
+  return normalizedBase ? `${normalizedBase}${CLAUDE_CODE_MARKETPLACE_PATH}` : CLAUDE_CODE_MARKETPLACE_PATH;
+};
+
+export const formatMarketplaceSettingsSnippet = (proxyBaseUrl: string) => {
   return {
     extraKnownMarketplaces: {
       [CLAUDE_CODE_MARKETPLACE_NAME]: {
         source: {
           source: "url" as const,
-          url: `${proxyOrigin}/claude-code/marketplace.json`,
+          url: formatClaudeCodeMarketplaceUrl(proxyBaseUrl),
         },
       },
     },

--- a/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.ts
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/helpers.ts
@@ -176,20 +176,23 @@ export const parseSkillSource = (rawUrl: string, subPath?: string): SkillSourceP
   return parseRawGitSource(url, subPath);
 };
 
-/**
- * Generate install command for Claude Code CLI
- * Format: /plugin marketplace add org/repo OR /plugin marketplace add url
- */
-export const formatInstallCommand = (plugin: { name: string; source: PluginSource }): string => {
-  const { source } = plugin;
-  if (source.source === "github" && source.repo) {
-    return `/plugin marketplace add ${source.repo}`;
-  }
-  if ((source.source === "url" || source.source === "git-subdir") && source.url) {
-    return `/plugin marketplace add ${source.url}`;
-  }
-  // Fallback to plugin name
-  return `/plugin marketplace add ${plugin.name}`;
+export const CLAUDE_CODE_MARKETPLACE_NAME = "litellm";
+
+export const formatInstallCommand = (plugin: { name: string }): string => {
+  return `/plugin install ${plugin.name}@${CLAUDE_CODE_MARKETPLACE_NAME}`;
+};
+
+export const formatMarketplaceSettingsSnippet = (proxyOrigin: string) => {
+  return {
+    extraKnownMarketplaces: {
+      [CLAUDE_CODE_MARKETPLACE_NAME]: {
+        source: {
+          source: "url" as const,
+          url: `${proxyOrigin}/claude-code/marketplace.json`,
+        },
+      },
+    },
+  };
 };
 
 /**

--- a/ui/litellm-dashboard/src/components/claude_code_plugins/skill_detail.tsx
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/skill_detail.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { ArrowLeftOutlined, CopyOutlined, CheckOutlined, LinkOutlined } from "@ant-design/icons";
-import { formatInstallCommand } from "./helpers";
+import { formatInstallCommand, formatMarketplaceSettingsSnippet } from "./helpers";
 import { Plugin } from "./types";
 
 interface SkillDetailProps {
@@ -30,6 +30,12 @@ const SkillDetail: React.FC<SkillDetailProps> = ({ skill, onBack }) => {
   })();
 
   const installCommand = formatInstallCommand(skill);
+  const proxyOrigin = typeof window !== "undefined" ? window.location.origin : "<proxy-url>";
+  const settingsSnippet = JSON.stringify(formatMarketplaceSettingsSnippet(proxyOrigin), null, 2);
+
+  const copySettingsSnippet = () => {
+    copyToClipboard(settingsSnippet, "settings");
+  };
 
   const detailRows = [
     ...(skill.category ? [{ property: "Category", value: skill.category }] : []),
@@ -298,21 +304,7 @@ const SkillDetail: React.FC<SkillDetailProps> = ({ skill, onBack }) => {
             >
               <span style={{ fontSize: 13, color: "#3c4043", fontWeight: 500 }}>~/.claude/settings.json</span>
               <button
-                onClick={() => {
-                  const snippet = JSON.stringify(
-                    {
-                      extraKnownMarketplaces: {
-                        "my-org": {
-                          source: "url",
-                          url: `${typeof window !== "undefined" ? window.location.origin : ""}/claude-code/marketplace.json`,
-                        },
-                      },
-                    },
-                    null,
-                    2,
-                  );
-                  copyToClipboard(snippet, "settings");
-                }}
+                onClick={copySettingsSnippet}
                 style={{
                   display: "flex",
                   alignItems: "center",
@@ -339,18 +331,7 @@ const SkillDetail: React.FC<SkillDetailProps> = ({ skill, onBack }) => {
                 backgroundColor: "#fff",
               }}
             >
-              {JSON.stringify(
-                {
-                  extraKnownMarketplaces: {
-                    "my-org": {
-                      source: "url",
-                      url: `${typeof window !== "undefined" ? window.location.origin : "<proxy-url>"}/claude-code/marketplace.json`,
-                    },
-                  },
-                },
-                null,
-                2,
-              )}
+              {settingsSnippet}
             </pre>
           </div>
         </div>

--- a/ui/litellm-dashboard/src/components/claude_code_plugins/skill_detail.tsx
+++ b/ui/litellm-dashboard/src/components/claude_code_plugins/skill_detail.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { ArrowLeftOutlined, CopyOutlined, CheckOutlined, LinkOutlined } from "@ant-design/icons";
+import { getProxyBaseUrl } from "@/components/networking";
 import { formatInstallCommand, formatMarketplaceSettingsSnippet } from "./helpers";
 import { Plugin } from "./types";
 
@@ -30,8 +31,8 @@ const SkillDetail: React.FC<SkillDetailProps> = ({ skill, onBack }) => {
   })();
 
   const installCommand = formatInstallCommand(skill);
-  const proxyOrigin = typeof window !== "undefined" ? window.location.origin : "<proxy-url>";
-  const settingsSnippet = JSON.stringify(formatMarketplaceSettingsSnippet(proxyOrigin), null, 2);
+  const proxyBaseUrl = getProxyBaseUrl() || "<proxy-url>";
+  const settingsSnippet = JSON.stringify(formatMarketplaceSettingsSnippet(proxyBaseUrl), null, 2);
 
   const copySettingsSnippet = () => {
     copyToClipboard(settingsSnippet, "settings");


### PR DESCRIPTION
## TLDR

Problem this solves:

- Skills page showed a marketplace-add command instead of install
- Settings snippet used my-org and a flat string source
- Claude Code rejected the generated settings.json entirely

How it solves it:

- Install command is now /plugin install {name}@litellm
- Settings snippet uses marketplace key litellm
- source is a nested object Claude Code accepts
- Marketplace URL comes from getProxyBaseUrl(), not window.location.origin

## Relevant issues

Fixes #33512

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Commit: `4c7b6d4a5d`

Start the proxy and Admin UI
Open http://localhost:4000/ui/?page=skills
Click any skill
Open the How to Use tab
Expect `/plugin install <skill-name>@litellm` (not `/plugin marketplace add ...`)
Click See one-time setup
Expect this settings shape:
```json
{
  "extraKnownMarketplaces": {
    "litellm": {
      "source": {
        "source": "url",
        "url": "http://localhost:4000/claude-code/marketplace.json"
      }
    }
  }
}
```

Unit proof:

```bash
cd ui/litellm-dashboard && npm test -- --run src/components/claude_code_plugins/helpers.test.ts
# 93 passed
```

## Type

🐛 Bug Fix

## Changes

The Skills detail page told users to run `/plugin marketplace add ...`, which registers a marketplace source instead of installing a skill. It also generated a settings.json snippet with key `my-org` and a flat string source, which Claude Code rejects

This switches the install command to `/plugin install {name}@litellm`, generates a settings snippet with marketplace key `litellm` and a nested source object matching what the proxy returns in marketplace.json, and derives the marketplace URL from `getProxyBaseUrl()` so worker overrides and `server_root_path` prefixes are included

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR



