### PR TITLE
fix(ui): stabilize AI Hub feature pill colors by capability name

### DIFF
--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
@@ -35,6 +35,7 @@ import { useUISettings } from "@/app/(dashboard)/hooks/uiSettings/useUISettings"
 import { checkTokenValidity } from "@/utils/jwtUtils";
 import { getCookie } from "@/utils/cookieUtils";
 import { getLoginUrl } from "@/utils/returnUrlUtils";
+import { getCapabilityColor } from "./capabilityColors";
 
 interface ModelHubTableProps {
   accessToken: string | null;
@@ -674,14 +675,13 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
               <div className="flex flex-wrap gap-2">
                 {(() => {
                   const capabilities = getModelCapabilities(selectedModel);
-                  const colors = ["green", "blue", "purple", "orange", "red", "yellow"];
 
                   if (capabilities.length === 0) {
                     return <Text className="text-gray-500">No special capabilities listed</Text>;
                   }
 
-                  return capabilities.map((capability, index) => (
-                    <Badge key={capability} color={colors[index % colors.length]}>
+                  return capabilities.map((capability) => (
+                    <Badge key={capability} color={getCapabilityColor(capability)}>
                       {formatCapabilityName(capability)}
                     </Badge>
                   ));

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTableColumns.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTableColumns.test.tsx
@@ -59,6 +59,22 @@ describe("getModelHubTableColumns", () => {
     expect(screen.queryByText("Parallel Function Calling")).not.toBeInTheDocument();
   });
 
+  it("uses the same badge color for the same feature across rows", () => {
+    renderTable([
+      mockModel,
+      {
+        ...mockModel,
+        model_group: "claude-sonnet",
+        supports_vision: false,
+        supports_function_calling: true,
+        supports_reasoning: true,
+      } as ModelHubData,
+    ]);
+    const functionCallingBadges = screen.getAllByText("Function Calling");
+    expect(functionCallingBadges).toHaveLength(2);
+    expect(functionCallingBadges[0].className).toBe(functionCallingBadges[1].className);
+  });
+
   it("shows the public status badge", () => {
     renderTable([mockModel]);
     expect(screen.getByText("Yes")).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTableColumns.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/cva.config";
 import { copyToClipboard } from "@/utils/dataUtils";
+import { getCapabilityBadgeClassName } from "./capabilityColors";
 
 export interface ModelHubData {
   model_group: string;
@@ -200,7 +201,7 @@ export const getModelHubTableColumns = ({ onModelClick }: ModelHubTableColumnsDe
       return (
         <div className="flex flex-wrap gap-1">
           {capabilities.map((capability) => (
-            <Badge key={capability} variant="outline">
+            <Badge key={capability} variant="outline" className={getCapabilityBadgeClassName(capability)}>
               {formatCapabilityName(capability)}
             </Badge>
           ))}

--- a/ui/litellm-dashboard/src/components/AIHub/capabilityColors.test.ts
+++ b/ui/litellm-dashboard/src/components/AIHub/capabilityColors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { getCapabilityBadgeClassName, getCapabilityColor } from "./capabilityColors";
+
+describe("getCapabilityColor", () => {
+  it("returns the same color for the same feature across different rows / order", () => {
+    expect(getCapabilityColor("supports_function_calling")).toBe(getCapabilityColor("Function Calling"));
+    expect(getCapabilityColor("supports_vision")).toBe(getCapabilityColor("Vision"));
+    expect(getCapabilityColor("supports_reasoning")).toBe(getCapabilityColor("Reasoning"));
+  });
+
+  it("keeps Function Calling the same color whether it is first or second in a list", () => {
+    const featuresA = ["supports_function_calling", "supports_reasoning"];
+    const featuresB = ["supports_vision", "supports_function_calling"];
+    expect(getCapabilityColor(featuresA[0])).toBe(getCapabilityColor(featuresB[1]));
+    expect(getCapabilityColor(featuresA[0])).not.toBe(getCapabilityColor(featuresB[0]));
+  });
+
+  it("uses stable semantic colors for common capabilities", () => {
+    expect(getCapabilityColor("supports_function_calling")).toBe("blue");
+    expect(getCapabilityColor("supports_vision")).toBe("purple");
+    expect(getCapabilityColor("supports_reasoning")).toBe("orange");
+  });
+
+  it("falls back to a deterministic palette color for unknown capabilities", () => {
+    expect(getCapabilityColor("supports_custom_widget")).toBe(getCapabilityColor("Custom Widget"));
+  });
+});
+
+describe("getCapabilityBadgeClassName", () => {
+  it("returns a non-empty class for known capabilities", () => {
+    expect(getCapabilityBadgeClassName("supports_vision")).toContain("bg-purple-100");
+  });
+});

--- a/ui/litellm-dashboard/src/components/AIHub/capabilityColors.test.ts
+++ b/ui/litellm-dashboard/src/components/AIHub/capabilityColors.test.ts
@@ -1,5 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { getCapabilityBadgeClassName, getCapabilityColor } from "./capabilityColors";
+import { CAPABILITY_COLOR_PALETTE, getCapabilityBadgeClassName, getCapabilityColor } from "./capabilityColors";
+
+const ANTD_TAG_PRESET_COLORS = new Set([
+  "blue",
+  "purple",
+  "cyan",
+  "green",
+  "magenta",
+  "pink",
+  "red",
+  "orange",
+  "yellow",
+  "volcano",
+  "geekblue",
+  "lime",
+  "gold",
+]);
 
 describe("getCapabilityColor", () => {
   it("returns the same color for the same feature across different rows / order", () => {
@@ -23,6 +39,15 @@ describe("getCapabilityColor", () => {
 
   it("falls back to a deterministic palette color for unknown capabilities", () => {
     expect(getCapabilityColor("supports_custom_widget")).toBe(getCapabilityColor("Custom Widget"));
+  });
+
+  it("only returns colors that Ant Design Tag treats as presets", () => {
+    for (const color of CAPABILITY_COLOR_PALETTE) {
+      expect(ANTD_TAG_PRESET_COLORS.has(color)).toBe(true);
+    }
+    expect(ANTD_TAG_PRESET_COLORS.has(getCapabilityColor("supports_response_schema"))).toBe(true);
+    expect(ANTD_TAG_PRESET_COLORS.has(getCapabilityColor("supports_system_messages"))).toBe(true);
+    expect(ANTD_TAG_PRESET_COLORS.has(getCapabilityColor("supports_custom_widget"))).toBe(true);
   });
 });
 

--- a/ui/litellm-dashboard/src/components/AIHub/capabilityColors.ts
+++ b/ui/litellm-dashboard/src/components/AIHub/capabilityColors.ts
@@ -1,0 +1,69 @@
+export const CAPABILITY_COLOR_PALETTE = [
+  "blue",
+  "green",
+  "purple",
+  "orange",
+  "red",
+  "yellow",
+  "cyan",
+  "indigo",
+  "pink",
+  "amber",
+] as const;
+
+export type CapabilityColor = (typeof CAPABILITY_COLOR_PALETTE)[number];
+
+const SEMANTIC_CAPABILITY_COLORS: Record<string, CapabilityColor> = {
+  function_calling: "blue",
+  parallel_function_calling: "cyan",
+  vision: "purple",
+  reasoning: "orange",
+  prompt_caching: "green",
+  system_messages: "indigo",
+  tool_choice: "pink",
+  response_schema: "amber",
+  audio_input: "yellow",
+  audio_output: "yellow",
+  pdf_input: "red",
+  web_search: "green",
+};
+
+const CAPABILITY_BADGE_CLASSES: Record<CapabilityColor, string> = {
+  blue: "border-transparent bg-blue-100 text-blue-800",
+  green: "border-transparent bg-green-100 text-green-800",
+  purple: "border-transparent bg-purple-100 text-purple-800",
+  orange: "border-transparent bg-orange-100 text-orange-800",
+  red: "border-transparent bg-red-100 text-red-800",
+  yellow: "border-transparent bg-yellow-100 text-yellow-800",
+  cyan: "border-transparent bg-cyan-100 text-cyan-800",
+  indigo: "border-transparent bg-indigo-100 text-indigo-800",
+  pink: "border-transparent bg-pink-100 text-pink-800",
+  amber: "border-transparent bg-amber-100 text-amber-800",
+};
+
+const normalizeCapabilityKey = (capability: string): string =>
+  capability
+    .replace(/^supports_/, "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+
+const hashCapabilityKey = (key: string): number => {
+  let hash = 0;
+  for (const ch of key) {
+    hash = (hash * 31 + ch.charCodeAt(0)) >>> 0;
+  }
+  return hash;
+};
+
+export const getCapabilityColor = (capability: string): CapabilityColor => {
+  const key = normalizeCapabilityKey(capability);
+  const semantic = SEMANTIC_CAPABILITY_COLORS[key];
+  if (semantic) {
+    return semantic;
+  }
+  return CAPABILITY_COLOR_PALETTE[hashCapabilityKey(key) % CAPABILITY_COLOR_PALETTE.length];
+};
+
+export const getCapabilityBadgeClassName = (capability: string): string =>
+  CAPABILITY_BADGE_CLASSES[getCapabilityColor(capability)];

--- a/ui/litellm-dashboard/src/components/AIHub/capabilityColors.ts
+++ b/ui/litellm-dashboard/src/components/AIHub/capabilityColors.ts
@@ -6,9 +6,8 @@ export const CAPABILITY_COLOR_PALETTE = [
   "red",
   "yellow",
   "cyan",
-  "indigo",
   "pink",
-  "amber",
+  "lime",
 ] as const;
 
 export type CapabilityColor = (typeof CAPABILITY_COLOR_PALETTE)[number];
@@ -19,11 +18,11 @@ const SEMANTIC_CAPABILITY_COLORS: Record<string, CapabilityColor> = {
   vision: "purple",
   reasoning: "orange",
   prompt_caching: "green",
-  system_messages: "indigo",
+  system_messages: "lime",
   tool_choice: "pink",
-  response_schema: "amber",
-  audio_input: "yellow",
-  audio_output: "yellow",
+  response_schema: "yellow",
+  audio_input: "cyan",
+  audio_output: "cyan",
   pdf_input: "red",
   web_search: "green",
 };
@@ -36,9 +35,8 @@ const CAPABILITY_BADGE_CLASSES: Record<CapabilityColor, string> = {
   red: "border-transparent bg-red-100 text-red-800",
   yellow: "border-transparent bg-yellow-100 text-yellow-800",
   cyan: "border-transparent bg-cyan-100 text-cyan-800",
-  indigo: "border-transparent bg-indigo-100 text-indigo-800",
   pink: "border-transparent bg-pink-100 text-pink-800",
-  amber: "border-transparent bg-amber-100 text-amber-800",
+  lime: "border-transparent bg-lime-100 text-lime-800",
 };
 
 const normalizeCapabilityKey = (capability: string): string =>

--- a/ui/litellm-dashboard/src/components/public_model_hub.tsx
+++ b/ui/litellm-dashboard/src/components/public_model_hub.tsx
@@ -19,6 +19,7 @@ import {
 } from "./networking";
 import { Plugin } from "./claude_code_plugins/types";
 import SkillHubDashboard from "./AIHub/SkillHubDashboard";
+import { getCapabilityColor } from "./AIHub/capabilityColors";
 import {
   AgentCard,
   MCPServerData,
@@ -963,14 +964,13 @@ const PublicModelHub: React.FC<PublicModelHubProps> = ({ accessToken, isEmbedded
                 <div className="flex flex-wrap gap-2">
                   {(() => {
                     const capabilities = getModelCapabilities(selectedModel);
-                    const colors = ["green", "blue", "purple", "orange", "red", "yellow"];
 
                     if (capabilities.length === 0) {
                       return <Text className="text-gray-500">No special capabilities listed</Text>;
                     }
 
-                    return capabilities.map((capability, index) => (
-                      <Tag key={capability} color={colors[index % colors.length]}>
+                    return capabilities.map((capability) => (
+                      <Tag key={capability} color={getCapabilityColor(capability)}>
                         {formatCapabilityName(capability)}
                       </Tag>
                     ));


### PR DESCRIPTION
## TLDR

Problem this solves:

- Feature pills changed color based on list position
- Same feature looked different across models

How it solves it:

- Color each pill from the capability name
- Keep semantic colors for common features

## Relevant issues

Fixes #34231

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

UI change on AI Hub / Model Hub Features column and model detail modal

1. Run Admin UI: `npm run dev` in `ui/litellm-dashboard` (http://localhost:3000) with proxy on :4000
2. Open AI Hub / Model Hub and compare two models that both support Function Calling but expose different feature sets
3. Before: Function Calling pill color depended on its index in the list
4. After: Function Calling is the same color on every row and in the detail modal
5. Public model hub Tags also stay on Ant Design preset colors (no `amber`/`indigo` raw-CSS fallback)

Commit for proof: `afe9c9c569`

## Type

🐛 Bug Fix

## Changes

AI Hub and public model hub were coloring feature pills with `colors[index % colors.length]`, so a capability like Function Calling changed color when vision or reasoning appeared before it

`capabilityColors.ts` maps known capabilities to fixed semantic colors and hashes unknown ones into a stable palette shared by Tremor Badge and Ant Design Tag presets. Wired into `ModelHubTableColumns` (table Features column), `ModelHubTable` (detail modal Tremor badges), and `public_model_hub` (Ant Tags)

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

