### PR TITLE
chore: add soniox stt-rt-v5 pricing

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -45711,6 +45711,14 @@
         ],
         "supports_audio_input": true
     },
+    "soniox/stt-rt-v5": {
+        "litellm_provider": "soniox",
+        "input_cost_per_second": 0.0,
+        "output_cost_per_second": 3.33333e-05,
+        "mode": "audio_transcription",
+        "source": "https://soniox.com/pricing",
+        "supports_audio_input": true
+    },
     "tensormesh/Qwen/Qwen3.5-397B-A17B-FP8": {
         "litellm_provider": "tensormesh",
         "mode": "chat",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -45833,6 +45833,14 @@
         ],
         "supports_audio_input": true
     },
+    "soniox/stt-rt-v5": {
+        "litellm_provider": "soniox",
+        "input_cost_per_second": 0.0,
+        "output_cost_per_second": 3.33333e-05,
+        "mode": "audio_transcription",
+        "source": "https://soniox.com/pricing",
+        "supports_audio_input": true
+    },
     "tensormesh/Qwen/Qwen3.5-397B-A17B-FP8": {
         "litellm_provider": "tensormesh",
         "mode": "chat",

--- a/tests/test_litellm/llms/soniox/test_soniox_stt_rt_pricing.py
+++ b/tests/test_litellm/llms/soniox/test_soniox_stt_rt_pricing.py
@@ -1,0 +1,74 @@
+"""Regression tests for the soniox/stt-rt-v5 pricing entry.
+
+The realtime model is pricing metadata only (not invocable through LiteLLM),
+so these tests pin the two things downstream spend tracking depends on:
+provider-qualified model lookup, and duration-based cost calculation at the
+published $0.12/hr realtime rate — 20% above the async rate.
+"""
+
+import pytest
+
+from litellm.types.utils import TranscriptionResponse
+
+REALTIME_RATE_PER_HOUR = 0.12
+ASYNC_RATE_PER_HOUR = 0.10
+
+
+@pytest.fixture(autouse=True)
+def _use_local_model_cost_map(monkeypatch):
+    import litellm
+
+    original_model_cost = litellm.model_cost
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    litellm.get_model_info.cache_clear()
+    try:
+        yield
+    finally:
+        litellm.model_cost = original_model_cost
+        litellm.get_model_info.cache_clear()
+
+
+def test_provider_qualified_lookup_resolves_realtime_model():
+    import litellm
+
+    model_info = litellm.get_model_info("soniox/stt-rt-v5")
+
+    assert model_info["litellm_provider"] == "soniox"
+    assert model_info["mode"] == "audio_transcription"
+    assert model_info["input_cost_per_second"] == 0.0
+    assert model_info["output_cost_per_second"] == pytest.approx(
+        REALTIME_RATE_PER_HOUR / 3600, rel=1e-3
+    )
+
+
+def test_should_charge_realtime_transcription_by_audio_duration():
+    import litellm
+
+    ten_minutes = 600.0
+    response = TranscriptionResponse(text="hello world")
+    response._hidden_params = {"audio_transcription_duration": ten_minutes}
+
+    cost = litellm.completion_cost(
+        completion_response=response,
+        model="soniox/stt-rt-v5",
+        call_type="transcription",
+    )
+
+    assert cost > 0
+    assert cost == pytest.approx((REALTIME_RATE_PER_HOUR / 3600) * ten_minutes, rel=1e-3)
+
+
+def test_realtime_rate_stays_above_async_rate():
+    """Guards against the realtime entry regressing to the cheaper async rate."""
+    import litellm
+
+    realtime = litellm.get_model_info("soniox/stt-rt-v5")
+    async_v5 = litellm.get_model_info("soniox/stt-async-v5")
+
+    assert (
+        realtime["output_cost_per_second"] > async_v5["output_cost_per_second"]
+    )
+    assert async_v5["output_cost_per_second"] == pytest.approx(
+        ASYNC_RATE_PER_HOUR / 3600, rel=1e-3
+    )

--- a/tests/test_litellm/llms/soniox/test_soniox_stt_rt_pricing.py
+++ b/tests/test_litellm/llms/soniox/test_soniox_stt_rt_pricing.py
@@ -1,23 +1,37 @@
 """Regression tests for the soniox/stt-rt-v5 pricing entry.
 
 The realtime model is pricing metadata only (not invocable through LiteLLM),
-so these tests pin the two things downstream spend tracking depends on:
+so these tests pin what downstream spend tracking depends on: the entry's
+shape in BOTH cost-map files (runtime consumers fetch the root file, the SDK
+falls back to the bundled backup — a divergence breaks one silently),
 provider-qualified model lookup, and duration-based cost calculation at the
 published $0.12/hr realtime rate — 20% above the async rate.
 """
 
+import json
+import os
+
 import pytest
 
+import litellm
+from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
 from litellm.types.utils import TranscriptionResponse
 
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "../../../..")
+
+MODEL_KEY = "soniox/stt-rt-v5"
 REALTIME_RATE_PER_HOUR = 0.12
 ASYNC_RATE_PER_HOUR = 0.10
 
 
+def _load_root_cost_map() -> dict:
+    json_path = os.path.join(REPO_ROOT, "model_prices_and_context_window.json")
+    with open(json_path) as f:
+        return json.load(f)
+
+
 @pytest.fixture(autouse=True)
 def _use_local_model_cost_map(monkeypatch):
-    import litellm
-
     original_model_cost = litellm.model_cost
     monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
     litellm.model_cost = litellm.get_model_cost_map(url="")
@@ -29,10 +43,32 @@ def _use_local_model_cost_map(monkeypatch):
         litellm.get_model_info.cache_clear()
 
 
-def test_provider_qualified_lookup_resolves_realtime_model():
-    import litellm
+@pytest.mark.parametrize(
+    "cost_map",
+    [_load_root_cost_map(), GetModelCostMap.load_local_model_cost_map()],
+    ids=["root", "bundled_backup"],
+)
+def test_realtime_entry_present_and_priced_in_both_cost_maps(cost_map):
+    """The root file is what runtime consumers fetch; the bundled backup is
+    the SDK fallback. An entry missing from either breaks that consumer
+    silently, so both are pinned."""
+    assert MODEL_KEY in cost_map, f"{MODEL_KEY} missing from cost map"
+    entry = cost_map[MODEL_KEY]
 
-    model_info = litellm.get_model_info("soniox/stt-rt-v5")
+    assert entry["litellm_provider"] == "soniox"
+    assert entry["mode"] == "audio_transcription"
+    assert entry["supports_audio_input"] is True
+    # Soniox carries the rate on the output side (matching the async rows);
+    # a rate moved to input_cost_per_second would double-charge any consumer
+    # that sums both sides.
+    assert entry["input_cost_per_second"] == 0.0
+    assert entry["output_cost_per_second"] == pytest.approx(
+        REALTIME_RATE_PER_HOUR / 3600, rel=1e-3
+    )
+
+
+def test_provider_qualified_lookup_resolves_realtime_model():
+    model_info = litellm.get_model_info(MODEL_KEY)
 
     assert model_info["litellm_provider"] == "soniox"
     assert model_info["mode"] == "audio_transcription"
@@ -43,32 +79,28 @@ def test_provider_qualified_lookup_resolves_realtime_model():
 
 
 def test_should_charge_realtime_transcription_by_audio_duration():
-    import litellm
-
     ten_minutes = 600.0
     response = TranscriptionResponse(text="hello world")
     response._hidden_params = {"audio_transcription_duration": ten_minutes}
 
     cost = litellm.completion_cost(
         completion_response=response,
-        model="soniox/stt-rt-v5",
+        model=MODEL_KEY,
         call_type="transcription",
     )
 
     assert cost > 0
-    assert cost == pytest.approx((REALTIME_RATE_PER_HOUR / 3600) * ten_minutes, rel=1e-3)
+    assert cost == pytest.approx(
+        (REALTIME_RATE_PER_HOUR / 3600) * ten_minutes, rel=1e-3
+    )
 
 
 def test_realtime_rate_stays_above_async_rate():
     """Guards against the realtime entry regressing to the cheaper async rate."""
-    import litellm
-
-    realtime = litellm.get_model_info("soniox/stt-rt-v5")
+    realtime = litellm.get_model_info(MODEL_KEY)
     async_v5 = litellm.get_model_info("soniox/stt-async-v5")
 
-    assert (
-        realtime["output_cost_per_second"] > async_v5["output_cost_per_second"]
-    )
+    assert realtime["output_cost_per_second"] > async_v5["output_cost_per_second"]
     assert async_v5["output_cost_per_second"] == pytest.approx(
         ASYNC_RATE_PER_HOUR / 3600, rel=1e-3
     )


### PR DESCRIPTION
## Relevant issues

Fixes #34817

## What does this PR do?

Adds `soniox/stt-rt-v5` (real-time streaming STT) to `model_prices_and_context_window.json` and the backup copy. The async models were added in #29508 / #30672; the realtime model is priced 20% higher and was missing entirely.

- Rate: **$0.12/hr** → `output_cost_per_second: 3.33333e-05`, per https://soniox.com/pricing (model name and rate both stated on the page; diarization/language-ID/formatting are bundled, no surcharges)
- Follows the existing Soniox rows' convention: rate carried on `output_cost_per_second`, `input_cost_per_second: 0.0`
- No `supported_endpoints` claimed — realtime STT (stt-rt.soniox.com) is not invocable through LiteLLM today (matches the Soniox tooltip in `provider_create_fields.json`); this entry is pricing metadata so cost tracking resolves the correct rate
- Omitting `max_tokens`/`supported_endpoints` follows existing precedent (58 / 8 `audio_transcription` rows respectively)

## Pre-Submission checklist

- [x] I have added meaningful tests — `tests/test_litellm/llms/soniox/test_soniox_stt_rt_pricing.py` pins provider-qualified lookup, duration-based cost at $0.12/hr, and realtime > async rate ordering
- [x] My PR passes all unit tests on `make test-unit` — full suite not run locally; `tests/test_litellm/llms/soniox/` passes in full (85 passed)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have requested a Greptile review by commenting `@greptileai` — will comment after opening
