### PR TITLE
fix(proxy): emit sse keepalive comments during slow time-to-first-token

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -314,6 +314,7 @@ user_url_allowed_hosts: List[str] = []
 provider_url_destination_allowed_hosts: List[str] = []
 ssl_ecdh_curve: Optional[str] = None  # Set to 'X25519' to disable PQC and improve performance
 disable_streaming_logging: bool = False
+sse_keepalive_interval_seconds: Optional[float] = None
 disable_token_counter: bool = False
 disable_add_transform_inline_image_block: bool = False
 disable_add_user_agent_to_request_tags: bool = False

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -549,9 +549,16 @@ async def _buffer_first_chunk_honoring_disconnect(
 
     Returns ``(first_chunk, None)`` once a chunk is in hand, or ``(None, chunk_task)``
     when ``keepalive_interval`` elapses first. A disconnect takes priority over both.
+    Callers without a ``request`` still get the keepalive arm, just no disconnect arm.
     """
     if request is None:
-        return await generator.__anext__(), None
+        if keepalive_interval is None:
+            return await generator.__anext__(), None
+        chunk_only_task: asyncio.Task[str] = asyncio.ensure_future(generator.__anext__())
+        done, _ = await asyncio.wait({chunk_only_task}, timeout=keepalive_interval)
+        if not done:
+            return None, chunk_only_task
+        return chunk_only_task.result(), None
 
     chunk_task: asyncio.Task[str] = asyncio.ensure_future(generator.__anext__())
     disconnect_task: asyncio.Task[None] = asyncio.ensure_future(_wait_for_http_disconnect(request))

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -491,9 +491,64 @@ def _resolve_sse_keepalive_interval() -> float | None:
     return max(interval, MIN_SSE_KEEPALIVE_INTERVAL_SECONDS)
 
 
+async def _stream_body_with_keepalive(
+    generator: AsyncGenerator[str, None], interval: float | None
+) -> AsyncGenerator[str, None]:
+    """Forward a stream, re-arming a keepalive comment on every idle gap.
+
+    The first-chunk arms cover time-to-first-token only. Sparse mid-stream gaps
+    (extended thinking, long tool-use turns) idle out the same edge timeouts, so
+    the timer has to re-arm for the whole stream rather than stop once the status
+    line is committed. ``None`` forwards unchanged.
+    """
+    if interval is None:
+        async for chunk in generator:
+            yield chunk
+        return
+    iterator = generator.__aiter__()
+    pending: asyncio.Task[str] = asyncio.ensure_future(iterator.__anext__())
+    try:
+        while True:
+            done, _ = await asyncio.wait({pending}, timeout=interval)
+            if not done:
+                yield SSE_KEEPALIVE_COMMENT
+                continue
+            try:
+                chunk = pending.result()
+            except StopAsyncIteration:
+                return
+            pending = asyncio.ensure_future(iterator.__anext__())
+            yield chunk
+    finally:
+        if not pending.done():
+            pending.cancel()
+        with anyio.CancelScope(shield=True):
+            try:
+                await pending
+            except BaseException:  # noqa: BLE001  # teardown must swallow whatever the cancelled fetch raises
+                pass
+
+
+async def _aclose_quietly(target: AsyncGenerator[str, None] | None) -> None:
+    """Close a nested keepalive generator so its pending fetch is released.
+
+    Closing the outer generator does not cascade into one it is iterating, so
+    without this the inner ``__anext__`` task stays live and the upstream
+    ``aclose()`` in teardown raises "asynchronous generator is already running".
+    """
+    if target is None:
+        return
+    with anyio.CancelScope(shield=True):
+        try:
+            await target.aclose()
+        except BaseException as exc:  # noqa: BLE001
+            verbose_proxy_logger.debug("error closing keepalive body generator: %s", exc)
+
+
 async def _stream_with_pending_first_chunk(
     generator: AsyncGenerator[str, None], chunk_task: asyncio.Task[str], interval: float
 ) -> AsyncGenerator[str, None]:
+    body: AsyncGenerator[str, None] | None = None
     try:
         while not chunk_task.done():
             yield SSE_KEEPALIVE_COMMENT
@@ -502,18 +557,23 @@ async def _stream_with_pending_first_chunk(
             first_chunk = chunk_task.result()
         except StopAsyncIteration:
             return
+        body = _stream_body_with_keepalive(generator, interval)
         if not _DD_STREAMING_TRACE_ENABLED:
             # Fast path: no per-chunk span object / context-manager overhead.
             yield first_chunk
-            async for chunk in generator:
+            async for chunk in body:
                 yield chunk
             return
         with tracer.trace(DD_TRACER_STREAMING_CHUNK_YIELD_RESOURCE):
             yield first_chunk
-        async for chunk in generator:
+        async for chunk in body:
+            if chunk == SSE_KEEPALIVE_COMMENT:
+                yield chunk
+                continue
             with tracer.trace(DD_TRACER_STREAMING_CHUNK_YIELD_RESOURCE):
                 yield chunk
     finally:
+        await _aclose_quietly(body)
         if not chunk_task.done():
             chunk_task.cancel()
         with anyio.CancelScope(shield=True):
@@ -728,19 +788,26 @@ async def create_response(
         )
 
     async def combined_generator() -> AsyncGenerator[str, None]:
-        if not _DD_STREAMING_TRACE_ENABLED:
-            # Fast path: no per-chunk span object / context-manager overhead.
+        body = _stream_body_with_keepalive(generator, keepalive_interval)
+        try:
+            if not _DD_STREAMING_TRACE_ENABLED:
+                # Fast path: no per-chunk span object / context-manager overhead.
+                if first_chunk_value is not None:
+                    yield first_chunk_value
+                async for chunk in body:
+                    yield chunk
+                return
             if first_chunk_value is not None:
-                yield first_chunk_value
-            async for chunk in generator:
-                yield chunk
-            return
-        if first_chunk_value is not None:
-            with tracer.trace(DD_TRACER_STREAMING_CHUNK_YIELD_RESOURCE):
-                yield first_chunk_value
-        async for chunk in generator:
-            with tracer.trace(DD_TRACER_STREAMING_CHUNK_YIELD_RESOURCE):
-                yield chunk
+                with tracer.trace(DD_TRACER_STREAMING_CHUNK_YIELD_RESOURCE):
+                    yield first_chunk_value
+            async for chunk in body:
+                if chunk == SSE_KEEPALIVE_COMMENT:
+                    yield chunk
+                    continue
+                with tracer.trace(DD_TRACER_STREAMING_CHUNK_YIELD_RESOURCE):
+                    yield chunk
+        finally:
+            await _aclose_quietly(body)
 
     return _UpstreamClosingStreamingResponse(
         combined_generator(),

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -84,6 +84,9 @@ from litellm.types.utils import (
 # is off (the default).
 _DD_STREAMING_TRACE_ENABLED = not isinstance(tracer, NullTracer)
 
+SSE_KEEPALIVE_COMMENT = ": keepalive\n\n"
+MIN_SSE_KEEPALIVE_INTERVAL_SECONDS = 1.0
+
 
 _CLIENT_DISCONNECTED_ERROR_INFORMATION: StandardLoggingPayloadErrorInformation = {
     "error_code": str(LITELLM_HTTP_STATUS_CLIENT_DISCONNECTED),
@@ -393,6 +396,12 @@ def _extract_error_from_sse_chunk(event_line: Union[str, bytes]) -> dict:
     return default_error
 
 
+def _consume_task_outcome(task: asyncio.Task[str]) -> None:
+    if task.cancelled():
+        return
+    task.exception()
+
+
 class _UpstreamClosingStreamingResponse(StreamingResponse):
     """StreamingResponse that always closes its body iterator and the wrapped
     upstream generator.
@@ -414,15 +423,25 @@ class _UpstreamClosingStreamingResponse(StreamingResponse):
         headers: Optional[dict] = None,
         status_code: int = status.HTTP_200_OK,
         upstream_generator: Optional[AsyncGenerator[str, None]] = None,
+        pending_first_chunk: asyncio.Task[str] | None = None,
     ) -> None:
         super().__init__(content, status_code=status_code, headers=headers, media_type=media_type)
         self._upstream_generator = upstream_generator
+        self._pending_first_chunk = pending_first_chunk
+        if pending_first_chunk is not None:
+            pending_first_chunk.add_done_callback(_consume_task_outcome)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         try:
             await super().__call__(scope, receive, send)
         finally:
             with anyio.CancelScope(shield=True):
+                if self._pending_first_chunk is not None and not self._pending_first_chunk.done():
+                    self._pending_first_chunk.cancel()
+                    try:
+                        await self._pending_first_chunk
+                    except BaseException:  # noqa: BLE001  # the cancelled fetch must release the generator before aclose
+                        pass
                 for target in (self.body_iterator, self._upstream_generator):
                     aclose = getattr(target, "aclose", None)
                     if aclose is None:
@@ -457,10 +476,66 @@ async def _wait_for_http_disconnect(request: Request) -> None:
         await asyncio.Event().wait()
 
 
+def _resolve_sse_keepalive_interval() -> float | None:
+    interval = getattr(litellm, "sse_keepalive_interval_seconds", None)
+    if interval is None or isinstance(interval, bool):
+        return None
+    try:
+        interval = float(interval)
+    except Exception:  # noqa: BLE001  # a config value of any shape must not break streaming
+        verbose_proxy_logger.warning(
+            "create_response: ignoring non-numeric sse_keepalive_interval_seconds %r",
+            interval,
+        )
+        return None
+    if not math.isfinite(interval) or interval <= 0:
+        verbose_proxy_logger.warning(
+            "create_response: ignoring out-of-range sse_keepalive_interval_seconds %r",
+            interval,
+        )
+        return None
+    return max(interval, MIN_SSE_KEEPALIVE_INTERVAL_SECONDS)
+
+
+async def _stream_with_pending_first_chunk(
+    generator: AsyncGenerator[str, None],
+    chunk_task: asyncio.Task[str],
+    interval: float,
+) -> AsyncGenerator[str, None]:
+    try:
+        while not chunk_task.done():
+            yield SSE_KEEPALIVE_COMMENT
+            await asyncio.wait({chunk_task}, timeout=interval)
+        try:
+            first_chunk = chunk_task.result()
+        except StopAsyncIteration:
+            return
+        if not _DD_STREAMING_TRACE_ENABLED:
+            # Fast path: no per-chunk span object / context-manager overhead.
+            yield first_chunk
+            async for chunk in generator:
+                yield chunk
+            return
+        with tracer.trace(DD_TRACER_STREAMING_CHUNK_YIELD_RESOURCE):
+            yield first_chunk
+        async for chunk in generator:
+            with tracer.trace(DD_TRACER_STREAMING_CHUNK_YIELD_RESOURCE):
+                yield chunk
+    finally:
+        if not chunk_task.done():
+            chunk_task.cancel()
+        with anyio.CancelScope(shield=True):
+            try:
+                await chunk_task
+            except BaseException:  # noqa: BLE001  # teardown must swallow whatever the cancelled task raises
+                pass
+
+
 async def _buffer_first_chunk_honoring_disconnect(
     generator: AsyncGenerator[str, None],
     request: Optional[Request],
-) -> str:
+    keepalive_interval: float | None = None,
+) -> tuple[str | None, asyncio.Task[str] | None]:
     """Fetch the first streamed chunk, cancelling the upstream LLM call if the
     client disconnects before it arrives.
 
@@ -471,19 +546,27 @@ async def _buffer_first_chunk_honoring_disconnect(
     until the request timeout (LIT-3568). Cancelling the fetch propagates into
     async_streaming_data_generator, whose finally block records the 499 and
     closes the upstream stream.
+
+    Returns ``(first_chunk, None)`` once a chunk is in hand, or ``(None, chunk_task)``
+    when ``keepalive_interval`` elapses first. A disconnect takes priority over both.
     """
     if request is None:
-        return await generator.__anext__()
+        return await generator.__anext__(), None
 
     chunk_task: asyncio.Task[str] = asyncio.ensure_future(generator.__anext__())
     disconnect_task: asyncio.Task[None] = asyncio.ensure_future(_wait_for_http_disconnect(request))
     try:
-        await asyncio.wait({chunk_task, disconnect_task}, return_when=asyncio.FIRST_COMPLETED)
+        done, _ = await asyncio.wait(
+            {chunk_task, disconnect_task},
+            timeout=keepalive_interval,
+            return_when=asyncio.FIRST_COMPLETED,
+        )
         # A completed disconnect_task has already consumed the http.disconnect
         # message, so Starlette's later listen_for_disconnect would never see it.
         # Take the cancellation path whenever a disconnect was observed, even if
         # the first chunk landed in the same scheduler turn.
         disconnect_observed = disconnect_task.done()
+        keepalive_due = not done
     finally:
         disconnect_task.cancel()
         try:
@@ -491,8 +574,11 @@ async def _buffer_first_chunk_honoring_disconnect(
         except BaseException:  # noqa: BLE001
             pass
 
-    if not disconnect_observed and chunk_task.done() and not chunk_task.cancelled():
-        return chunk_task.result()
+    if not disconnect_observed:
+        if keepalive_due and not chunk_task.done():
+            return None, chunk_task
+        if chunk_task.done() and not chunk_task.cancelled():
+            return chunk_task.result(), None
 
     chunk_task.cancel()
     with anyio.CancelScope(shield=True):
@@ -529,6 +615,8 @@ async def create_response(
     }
     first_chunk_value: Optional[str] = None
     final_status_code = default_status_code
+    keepalive_interval = _resolve_sse_keepalive_interval() if media_type == "text/event-stream" else None
+    pending_first_chunk: asyncio.Task[str] | None = None
 
     try:
         # Handle coroutine that returns a generator
@@ -536,7 +624,19 @@ async def create_response(
             generator = await generator
 
         # Now get the first chunk from the actual generator
-        first_chunk_value = await _buffer_first_chunk_honoring_disconnect(generator, request)
+        first_chunk_value, pending_first_chunk = await _buffer_first_chunk_honoring_disconnect(
+            generator, request, keepalive_interval
+        )
+
+        if pending_first_chunk is not None and keepalive_interval is not None:
+            return _UpstreamClosingStreamingResponse(
+                _stream_with_pending_first_chunk(generator, pending_first_chunk, keepalive_interval),
+                media_type=media_type,
+                headers=streaming_headers,
+                status_code=default_status_code,
+                upstream_generator=generator,
+                pending_first_chunk=pending_first_chunk,
+            )
 
         if first_chunk_value is not None:
             try:

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -483,24 +483,16 @@ def _resolve_sse_keepalive_interval() -> float | None:
     try:
         interval = float(interval)
     except Exception:  # noqa: BLE001  # a config value of any shape must not break streaming
-        verbose_proxy_logger.warning(
-            "create_response: ignoring non-numeric sse_keepalive_interval_seconds %r",
-            interval,
-        )
+        verbose_proxy_logger.warning("ignoring non-numeric sse_keepalive_interval_seconds %r", interval)
         return None
     if not math.isfinite(interval) or interval <= 0:
-        verbose_proxy_logger.warning(
-            "create_response: ignoring out-of-range sse_keepalive_interval_seconds %r",
-            interval,
-        )
+        verbose_proxy_logger.warning("ignoring out-of-range sse_keepalive_interval_seconds %r", interval)
         return None
     return max(interval, MIN_SSE_KEEPALIVE_INTERVAL_SECONDS)
 
 
 async def _stream_with_pending_first_chunk(
-    generator: AsyncGenerator[str, None],
-    chunk_task: asyncio.Task[str],
-    interval: float,
+    generator: AsyncGenerator[str, None], chunk_task: asyncio.Task[str], interval: float
 ) -> AsyncGenerator[str, None]:
     try:
         while not chunk_task.done():
@@ -564,9 +556,7 @@ async def _buffer_first_chunk_honoring_disconnect(
     disconnect_task: asyncio.Task[None] = asyncio.ensure_future(_wait_for_http_disconnect(request))
     try:
         done, _ = await asyncio.wait(
-            {chunk_task, disconnect_task},
-            timeout=keepalive_interval,
-            return_when=asyncio.FIRST_COMPLETED,
+            {chunk_task, disconnect_task}, timeout=keepalive_interval, return_when=asyncio.FIRST_COMPLETED
         )
         # A completed disconnect_task has already consumed the http.disconnect
         # message, so Starlette's later listen_for_disconnect would never see it.
@@ -631,9 +621,8 @@ async def create_response(
             generator = await generator
 
         # Now get the first chunk from the actual generator
-        first_chunk_value, pending_first_chunk = await _buffer_first_chunk_honoring_disconnect(
-            generator, request, keepalive_interval
-        )
+        buffered = await _buffer_first_chunk_honoring_disconnect(generator, request, keepalive_interval)
+        first_chunk_value, pending_first_chunk = buffered
 
         if pending_first_chunk is not None and keepalive_interval is not None:
             return _UpstreamClosingStreamingResponse(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13409,14 +13409,16 @@ async def async_queue_request(
         response = await llm_router.schedule_acompletion(**data)
 
         if "stream" in data and data["stream"] is True:  # use generate_responses to stream responses
-            return StreamingResponse(
-                async_data_generator(
+            return await create_response(
+                generator=async_data_generator(
                     user_api_key_dict=user_api_key_dict,
                     response=response,
                     request_data=data,
                     request=request,
                 ),
                 media_type="text/event-stream",
+                headers={},
+                request=request,
             )
 
         fastapi_response.headers.update({"x-litellm-priority": str(data["priority"])})

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5752,3 +5752,257 @@ class TestSSEKeepalive:
     def test_interval_resolution(self, monkeypatch, value, expected):
         monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", value, raising=False)
         assert _resolve_sse_keepalive_interval() == expected
+
+    @staticmethod
+    async def _gen_with_midstream_gap(gap: float, closed: Optional[asyncio.Event] = None):
+        try:
+            yield "data: first\n\n"
+            await asyncio.sleep(gap)
+            yield "data: second\n\n"
+            yield "data: [DONE]\n\n"
+        finally:
+            if closed is not None:
+                closed.set()
+
+    async def test_midstream_gap_after_a_fast_first_chunk_emits_keepalives(self, monkeypatch):
+        """A fast TTFT commits the status line, but a later gap idles out the same
+        edge timeout, so the timer has to re-arm past the first chunk."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        response = await create_response(
+            generator=self._gen_with_midstream_gap(2.5),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+        chunks = await self._collect(response)
+
+        assert chunks.count(SSE_KEEPALIVE_COMMENT) >= 2
+        assert [c for c in chunks if c != SSE_KEEPALIVE_COMMENT] == [
+            "data: first\n\n",
+            "data: second\n\n",
+            "data: [DONE]\n\n",
+        ]
+        assert chunks.index("data: first\n\n") < chunks.index(SSE_KEEPALIVE_COMMENT)
+
+    async def test_midstream_gap_after_a_slow_first_chunk_keeps_emitting(self, monkeypatch):
+        """Both arms must re-arm: a stream can stall for TTFT *and* mid-body."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        async def stall_then_gap():
+            await asyncio.sleep(2.2)
+            yield "data: first\n\n"
+            await asyncio.sleep(2.2)
+            yield "data: [DONE]\n\n"
+
+        response = await create_response(
+            generator=stall_then_gap(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+        chunks = await self._collect(response)
+        first_at = chunks.index("data: first\n\n")
+
+        assert SSE_KEEPALIVE_COMMENT in chunks[:first_at]
+        assert SSE_KEEPALIVE_COMMENT in chunks[first_at:]
+
+    async def test_midstream_keepalive_is_off_when_interval_unset(self, monkeypatch):
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", None, raising=False)
+
+        response = await create_response(
+            generator=self._gen_with_midstream_gap(0.05),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        assert await self._collect(response) == [
+            "data: first\n\n",
+            "data: second\n\n",
+            "data: [DONE]\n\n",
+        ]
+
+    async def test_midstream_keepalive_is_off_for_non_sse_media_types(self, monkeypatch):
+        """Only text/event-stream may carry SSE comments — a JSON body would corrupt."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        response = await create_response(
+            generator=self._gen_with_midstream_gap(2.5),
+            media_type="application/json",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        assert SSE_KEEPALIVE_COMMENT not in await self._collect(response)
+
+    async def test_consumer_exit_during_midstream_gap_closes_upstream(self, monkeypatch):
+        """Abandoning the response mid-gap must release the nested fetch and the
+        upstream generator, or the LLM connection leaks until GC."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        closed = asyncio.Event()
+
+        response = await create_response(
+            generator=self._gen_with_midstream_gap(30, closed),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        iterator = response.body_iterator.__aiter__()
+        assert await iterator.__anext__() == "data: first\n\n"
+        assert await iterator.__anext__() == SSE_KEEPALIVE_COMMENT
+        await response.body_iterator.aclose()
+
+        # Deterministic, not GC-dependent: aclose() must have released the nested
+        # fetch and closed upstream by the time it returns, with no pending task
+        # left behind to be reaped later.
+        assert closed.is_set()
+        assert [t for t in asyncio.all_tasks() if t is not asyncio.current_task() and not t.done()] == []
+
+    async def test_midstream_upstream_exception_still_propagates(self, monkeypatch):
+        """The keepalive wrapper must not swallow a mid-stream provider failure."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        async def gap_then_raise():
+            yield "data: first\n\n"
+            await asyncio.sleep(1.5)
+            raise ValueError("upstream died mid-stream")
+
+        response = await create_response(
+            generator=gap_then_raise(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        with pytest.raises(ValueError, match="upstream died mid-stream"):
+            await self._collect(response)
+
+    async def test_midstream_keepalive_keeps_datadog_chunk_spans(self, monkeypatch):
+        """Wrapping the body must not cost the per-chunk spans on the normal path."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        spans = []
+
+        class FakeSpan:
+            def __enter__(self):
+                spans.append("span")
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        class FakeTracer:
+            def trace(self, *args, **kwargs):
+                return FakeSpan()
+
+        import litellm.proxy.common_request_processing as crp
+
+        monkeypatch.setattr(crp, "_DD_STREAMING_TRACE_ENABLED", True, raising=False)
+        monkeypatch.setattr(crp, "tracer", FakeTracer(), raising=False)
+
+        response = await create_response(
+            generator=self._gen_with_midstream_gap(2.5),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+        chunks = await self._collect(response)
+        real = [c for c in chunks if c != SSE_KEEPALIVE_COMMENT]
+
+        assert len(real) == 3
+        assert len(spans) == len(real)
+
+    async def test_midstream_keepalives_do_not_open_datadog_chunk_spans(self, monkeypatch):
+        """Keepalives are protocol filler, not model output — tracing them inflates
+        the chunk-span count and skews per-chunk latency stats."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        spans = []
+
+        class FakeSpan:
+            def __enter__(self):
+                spans.append("span")
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        class FakeTracer:
+            def trace(self, *args, **kwargs):
+                return FakeSpan()
+
+        import litellm.proxy.common_request_processing as crp
+
+        monkeypatch.setattr(crp, "_DD_STREAMING_TRACE_ENABLED", True, raising=False)
+        monkeypatch.setattr(crp, "tracer", FakeTracer(), raising=False)
+
+        async def stall_then_gap():
+            await asyncio.sleep(2.2)
+            yield "data: first\n\n"
+            await asyncio.sleep(2.2)
+            yield "data: [DONE]\n\n"
+
+        response = await create_response(
+            generator=stall_then_gap(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+        chunks = await self._collect(response)
+
+        assert chunks.count(SSE_KEEPALIVE_COMMENT) >= 2
+        assert len(spans) == len([c for c in chunks if c != SSE_KEEPALIVE_COMMENT]) == 2
+
+    @pytest.mark.parametrize("dd_tracing", [False, True])
+    async def test_none_first_chunk_is_skipped_but_the_body_still_streams(self, monkeypatch, dd_tracing):
+        """A None first chunk must not be emitted as a literal frame, and the
+        keepalive-wrapped body must still be forwarded after it — on both the
+        fast path and the Datadog-traced path."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        import litellm.proxy.common_request_processing as crp
+
+        monkeypatch.setattr(crp, "_DD_STREAMING_TRACE_ENABLED", dd_tracing, raising=False)
+
+        async def none_then_data():
+            yield None
+            yield "data: second\n\n"
+
+        response = await create_response(
+            generator=none_then_data(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        assert await self._collect(response) == ["data: second\n\n"]
+
+    async def test_body_close_failure_does_not_break_teardown(self):
+        """Teardown runs while the client is already gone — a raising aclose() must
+        be logged and swallowed, never propagated into the ASGI layer."""
+        import litellm.proxy.common_request_processing as crp
+
+        class ExplodingBody:
+            async def aclose(self):
+                raise RuntimeError("aclose exploded")
+
+        await crp._aclose_quietly(ExplodingBody())
+        await crp._aclose_quietly(None)
+
+    async def test_error_only_stream_still_becomes_json_with_midstream_wrapper(self, monkeypatch):
+        """Contract A: a fast error-only first chunk keeps its provider status code
+        even though the body is now keepalive-wrapped."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        async def error_first():
+            yield 'data: {"error": {"message": "bad request", "code": "400"}}\n\n'
+
+        response = await create_response(
+            generator=error_first(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 400

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1,9 +1,12 @@
 import asyncio
 import copy
 import datetime
+import gc
+import logging
 from typing import AsyncGenerator, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import anyio
 import httpx
 import pytest
 from fastapi import HTTPException, Request, Response, status
@@ -15,6 +18,8 @@ from litellm.constants import RETURN_RAW_MODEL_NAME_METADATA_KEY
 from litellm.integrations.custom_logger import CustomLogger
 from litellm.integrations.opentelemetry import UserAPIKeyAuth
 from litellm.proxy.common_request_processing import (
+    MIN_SSE_KEEPALIVE_INTERVAL_SECONDS,
+    SSE_KEEPALIVE_COMMENT,
     ProxyBaseLLMRequestProcessing,
     ProxyConfig,
     _await_llm_call_cancelling_on_disconnect,
@@ -28,6 +33,7 @@ from litellm.proxy.common_request_processing import (
     _is_azure_model_router_request,
     _override_openai_response_model,
     _parse_event_data_for_error,
+    _resolve_sse_keepalive_interval,
     _should_return_raw_model_name,
     _UpstreamClosingStreamingResponse,
     create_response,
@@ -2778,8 +2784,9 @@ class TestStreamCloseOnDisconnect:
         async def gen():
             yield "data: first\n\n"
 
-        first = await _buffer_first_chunk_honoring_disconnect(gen(), request=None)
+        first, pending = await _buffer_first_chunk_honoring_disconnect(gen(), request=None)
         assert first == "data: first\n\n"
+        assert pending is None
 
     async def test_create_response_prioritizes_disconnect_in_same_scheduler_turn(self):
         """Same-turn race: the first chunk and the disconnect both resolve before
@@ -5111,3 +5118,524 @@ class TestStreamingClientDisconnectBilling:
         )
 
         proxy_logging_obj._arelease_max_parallel_requests_on_disconnect.assert_awaited_once()
+
+
+class TestSSEKeepalive:
+    @staticmethod
+    def _request_never_disconnects() -> Request:
+        async def receive():
+            await asyncio.Event().wait()
+
+        return Request({"type": "http"}, receive=receive)
+
+    @staticmethod
+    def _request_that_disconnects() -> Request:
+        async def receive():
+            return {"type": "http.disconnect"}
+
+        return Request({"type": "http"}, receive=receive)
+
+    @staticmethod
+    async def _stalling_gen(stall: float, closed: Optional[asyncio.Event] = None):
+        try:
+            await asyncio.sleep(stall)
+            yield "data: first\n\n"
+            yield "data: [DONE]\n\n"
+        finally:
+            if closed is not None:
+                closed.set()
+
+    async def _collect(self, response) -> list:
+        return [chunk async for chunk in response.body_iterator]
+
+    async def test_interval_unset_leaves_stream_byte_identical(self, monkeypatch):
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", None, raising=False)
+
+        response = await create_response(
+            generator=self._stalling_gen(0.05),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        assert await self._collect(response) == ["data: first\n\n", "data: [DONE]\n\n"]
+
+    async def test_keepalive_emitted_before_first_chunk(self, monkeypatch):
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        response = await create_response(
+            generator=self._stalling_gen(2.5),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+        chunks = await self._collect(response)
+
+        assert chunks[0] == SSE_KEEPALIVE_COMMENT
+        assert chunks.count(SSE_KEEPALIVE_COMMENT) >= 1
+        assert [c for c in chunks if c != SSE_KEEPALIVE_COMMENT] == [
+            "data: first\n\n",
+            "data: [DONE]\n\n",
+        ]
+
+    async def test_fast_first_chunk_emits_no_keepalive(self, monkeypatch):
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        response = await create_response(
+            generator=self._stalling_gen(0.0),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        assert await self._collect(response) == ["data: first\n\n", "data: [DONE]\n\n"]
+
+    async def test_non_sse_media_type_is_never_wrapped(self, monkeypatch):
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        response = await create_response(
+            generator=self._stalling_gen(2.5),
+            media_type="application/json",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        assert SSE_KEEPALIVE_COMMENT not in await self._collect(response)
+
+    async def test_fast_error_only_stream_still_returns_json_response(self, monkeypatch):
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        async def error_gen():
+            yield 'data: {"error": {"message": "blocked", "code": 400}}\n\n'
+
+        response = await create_response(
+            generator=error_gen(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 400
+
+    async def test_slow_error_only_stream_degrades_to_sse_frame(self, monkeypatch):
+        """Once a keepalive ships the status line, a late error can no longer be
+        downgraded to JSON. Pinned so the trade-off stays a decision."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        async def slow_error_gen():
+            await asyncio.sleep(2.5)
+            yield 'data: {"error": {"message": "blocked", "code": 400}}\n\n'
+
+        response = await create_response(
+            generator=slow_error_gen(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+        chunks = await self._collect(response)
+
+        assert response.status_code == 200
+        assert SSE_KEEPALIVE_COMMENT in chunks
+        assert 'data: {"error": {"message": "blocked", "code": 400}}\n\n' in chunks
+
+    async def test_disconnect_before_timer_still_returns_499_when_keepalive_enabled(
+        self, monkeypatch
+    ):
+        """A disconnect that beats the timer resolves the wait, so keepalive_due is
+        False and the pre-existing 499 path must be reached unchanged."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        closed = asyncio.Event()
+
+        with pytest.raises(_ClientDisconnectedBeforeFirstChunk):
+            await asyncio.wait_for(
+                _buffer_first_chunk_honoring_disconnect(
+                    self._stalling_gen(5.0, closed),
+                    self._request_that_disconnects(),
+                    1.0,
+                ),
+                timeout=5,
+            )
+
+        assert closed.is_set()
+
+    async def test_disconnect_after_timer_hands_back_task_then_closes_upstream(
+        self, monkeypatch
+    ):
+        """The (disconnect, keepalive_due) pair cannot both be true: an elapsed timer
+        means neither task resolved. Pin that the timer arm hands the task back and
+        that a later disconnect still closes the upstream generator."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        closed = asyncio.Event()
+
+        first, pending = await _buffer_first_chunk_honoring_disconnect(
+            self._stalling_gen(5.0, closed),
+            self._request_never_disconnects(),
+            1.0,
+        )
+
+        assert first is None
+        assert pending is not None and not pending.done()
+
+        pending.cancel()
+        try:
+            await pending
+        except BaseException:
+            pass
+        await asyncio.sleep(0)
+
+        assert closed.is_set()
+
+    async def test_upstream_generator_is_not_the_keepalive_wrapper(self, monkeypatch):
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        generator = self._stalling_gen(2.5)
+
+        response = await create_response(
+            generator=generator,
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        assert isinstance(response, _UpstreamClosingStreamingResponse)
+        assert response._upstream_generator is generator
+        assert response._pending_first_chunk is not None
+        await self._collect(response)
+
+    async def test_early_consumer_exit_cancels_pending_and_closes_upstream(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        closed = asyncio.Event()
+
+        response = await create_response(
+            generator=self._stalling_gen(5.0, closed),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        body = response.body_iterator
+        assert await body.__anext__() == SSE_KEEPALIVE_COMMENT
+        await body.aclose()
+
+        assert response._pending_first_chunk.done()
+        assert closed.is_set()
+
+    async def test_raising_fetch_outcome_is_consumed_so_asyncio_stays_quiet(
+        self, monkeypatch, caplog
+    ):
+        """A never-iterated response whose upstream raises is the only shape that
+        makes asyncio log an unretrieved task exception."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        async def raises_after_timer():
+            await asyncio.sleep(1.5)
+            raise RuntimeError("upstream broke")
+            yield  # pragma: no cover
+
+        response = await create_response(
+            generator=raises_after_timer(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+        task = response._pending_first_chunk
+        assert task is not None
+
+        with caplog.at_level(logging.ERROR, logger="asyncio"):
+            # Never await the task: the callback is the only thing that consumes
+            # the exception, so dropping the task must not tickle asyncio's
+            # unretrieved-exception reporter.
+            while not task.done():
+                await asyncio.sleep(0.1)
+            del response, task
+            gc.collect()
+            await asyncio.sleep(0)
+            gc.collect()
+
+        assert "Task exception was never retrieved" not in caplog.text
+
+    async def test_upstream_exception_during_stall_propagates(self, monkeypatch):
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        async def boom():
+            await asyncio.sleep(2.5)
+            raise ValueError("upstream broke")
+            yield  # pragma: no cover
+
+        response = await create_response(
+            generator=boom(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        with pytest.raises(ValueError, match="upstream broke"):
+            await self._collect(response)
+
+    async def test_empty_stream_during_stall_terminates_cleanly(self, monkeypatch):
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        async def empty_after_stall():
+            await asyncio.sleep(2.5)
+            return
+            yield  # pragma: no cover
+
+        response = await create_response(
+            generator=empty_after_stall(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+        chunks = await self._collect(response)
+
+        assert chunks == [SSE_KEEPALIVE_COMMENT, SSE_KEEPALIVE_COMMENT]
+
+    async def test_teardown_awaits_cancelled_fetch_before_closing_upstream(
+        self, monkeypatch, caplog
+    ):
+        """The cancelled fetch still owns an __anext__ frame on the upstream
+        generator, so aclose() would raise "already running" and defer cleanup
+        past __call__ unless the teardown awaits the cancellation first."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        events = []
+
+        async def upstream():
+            try:
+                await asyncio.sleep(30)
+                yield "data: never\n\n"
+            finally:
+                events.append("upstream_closed")
+
+        response = await create_response(
+            generator=upstream(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        async def send(message):
+            raise anyio.get_cancelled_exc_class()()
+
+        async def receive():
+            return {"type": "http.disconnect"}
+
+        with caplog.at_level(logging.DEBUG, logger="LiteLLM Proxy"):
+            try:
+                await response({"type": "http"}, receive, send)
+            except BaseException:
+                pass
+            events.append("call_returned")
+
+        assert events == ["upstream_closed", "call_returned"], (
+            f"cleanup escaped __call__: {events}"
+        )
+        assert "asynchronous generator is already running" not in caplog.text
+
+    async def test_chunk_landing_during_disconnect_teardown_is_not_discarded(
+        self, monkeypatch
+    ):
+        """keepalive_due is latched before the finally awaits the disconnect watcher,
+        which suspends. A chunk resolving in that window must still take the normal
+        path, or a 200 ships with no keepalive and Contract A is lost for nothing."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        real_wait = asyncio.wait
+
+        async def wait_then_let_chunk_land(aws, **kwargs):
+            done, pending = await real_wait(aws, **kwargs)
+            if not done:
+                # Simulate the chunk resolving during the finally's suspension point.
+                await real_wait(aws, return_when=asyncio.FIRST_COMPLETED)
+            return done, pending
+
+        async def error_after_timer():
+            await asyncio.sleep(1.2)
+            yield 'data: {"error": {"message": "blocked", "code": 400}}\n\n'
+
+        monkeypatch.setattr(asyncio, "wait", wait_then_let_chunk_land)
+        response = await create_response(
+            generator=error_after_timer(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+        monkeypatch.setattr(asyncio, "wait", real_wait)
+
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 400
+
+    async def test_disconnect_during_keepalive_window_completes_shielded_cleanup(
+        self, monkeypatch
+    ):
+        """The upstream generator's finally is driven from the cancelled first-chunk
+        task, so its shielded cleanup must survive anyio re-delivering cancellation."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        committed = []
+
+        async def upstream():
+            completed = False
+            try:
+                await asyncio.sleep(30)
+                yield "data: never\n\n"
+                completed = True
+            finally:
+                with anyio.CancelScope(shield=True):
+                    try:
+                        if not completed:
+                            await asyncio.sleep(0)
+                            committed.append("record_499")
+                            await asyncio.sleep(0)
+                            committed.append("release_slot")
+                        await asyncio.sleep(0)
+                        committed.append("close_upstream")
+                    except BaseException:
+                        committed.append("ABORTED")
+
+        response = await create_response(
+            generator=upstream(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        disconnected = asyncio.Event()
+
+        async def send(message):
+            if message["type"] == "http.response.body" and message.get("body"):
+                disconnected.set()
+
+        async def receive():
+            await disconnected.wait()
+            await asyncio.sleep(0.02)
+            return {"type": "http.disconnect"}
+
+        try:
+            await response(
+                {"type": "http", "method": "POST", "path": "/", "headers": []},
+                receive,
+                send,
+            )
+        except BaseException:
+            pass
+        for _ in range(50):
+            await asyncio.sleep(0)
+        await asyncio.sleep(0.1)
+
+        assert committed == ["record_499", "release_slot", "close_upstream"], (
+            f"disconnect accounting was cut short: {committed}"
+        )
+
+    async def test_response_carries_pending_task_so_it_cannot_be_orphaned(
+        self, monkeypatch
+    ):
+        """The body generator's try/finally only runs once someone iterates it, so
+        the response itself must own the in-flight first-chunk task."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        work = {"n": 0}
+        finalized = asyncio.Event()
+
+        async def burning():
+            try:
+                for _ in range(5000):
+                    work["n"] += 1
+                    await asyncio.sleep(0.001)
+                yield "data: first\n\n"
+            finally:
+                finalized.set()
+
+        response = await create_response(
+            generator=burning(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        assert response._pending_first_chunk is not None
+
+        async def send(message):
+            raise RuntimeError("client gone")
+
+        async def receive():
+            return {"type": "http.disconnect"}
+
+        try:
+            await response({"type": "http"}, receive, send)
+        except BaseException:
+            pass
+
+        at_teardown = work["n"]
+        await asyncio.sleep(0.05)
+
+        assert work["n"] == at_teardown
+        assert finalized.is_set()
+        assert response._pending_first_chunk.done()
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf"), "infinity"])
+    def test_non_finite_interval_is_rejected(self, monkeypatch, value):
+        """A non-finite timeout makes asyncio.wait never fire, which would silently
+        disable the feature instead of protecting the stream."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", value, raising=False)
+        assert _resolve_sse_keepalive_interval() is None
+
+    def test_interval_whose_float_raises_is_rejected(self, monkeypatch):
+        class Hostile:
+            def __float__(self):
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", Hostile(), raising=False)
+        assert _resolve_sse_keepalive_interval() is None
+
+    async def test_keepalive_path_keeps_datadog_chunk_spans(self, monkeypatch):
+        """The keepalive path bypasses combined_generator, so it has to carry the
+        per-chunk tracing itself or a stalled stream silently loses every span."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        spans = []
+
+        class FakeSpan:
+            def __enter__(self):
+                spans.append("span")
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        class FakeTracer:
+            def trace(self, *args, **kwargs):
+                return FakeSpan()
+
+        import litellm.proxy.common_request_processing as crp
+
+        monkeypatch.setattr(crp, "_DD_STREAMING_TRACE_ENABLED", True, raising=False)
+        monkeypatch.setattr(crp, "tracer", FakeTracer(), raising=False)
+
+        response = await create_response(
+            generator=self._stalling_gen(2.5),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+        chunks = await self._collect(response)
+        real = [c for c in chunks if c != SSE_KEEPALIVE_COMMENT]
+
+        assert len(real) == 2
+        assert len(spans) == len(real)
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (None, None),
+            (True, None),
+            (False, None),
+            (0, None),
+            (-5, None),
+            ("not-a-number", None),
+            (0.1, MIN_SSE_KEEPALIVE_INTERVAL_SECONDS),
+            (15, 15.0),
+            ("20", 20.0),
+        ],
+    )
+    def test_interval_resolution(self, monkeypatch, value, expected):
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", value, raising=False)
+        assert _resolve_sse_keepalive_interval() == expected

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5587,6 +5587,50 @@ class TestSSEKeepalive:
         monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", Hostile(), raising=False)
         assert _resolve_sse_keepalive_interval() is None
 
+    async def test_keepalive_applies_without_a_request_object(self, monkeypatch):
+        """Callers that omit request have no disconnect arm, but a configured
+        interval must still keep their stream alive."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        response = await create_response(
+            generator=self._stalling_gen(2.5),
+            media_type="text/event-stream",
+            headers={},
+        )
+        chunks = await self._collect(response)
+
+        assert chunks[0] == SSE_KEEPALIVE_COMMENT
+        assert [c for c in chunks if c != SSE_KEEPALIVE_COMMENT] == [
+            "data: first\n\n",
+            "data: [DONE]\n\n",
+        ]
+
+    async def test_no_request_and_interval_unset_stays_byte_identical(self, monkeypatch):
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", None, raising=False)
+
+        response = await create_response(
+            generator=self._stalling_gen(0.05),
+            media_type="text/event-stream",
+            headers={},
+        )
+
+        assert await self._collect(response) == ["data: first\n\n", "data: [DONE]\n\n"]
+
+    async def test_no_request_fast_chunk_still_returns_json_error(self, monkeypatch):
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        async def error_gen():
+            yield 'data: {"error": {"message": "blocked", "code": 400}}\n\n'
+
+        response = await create_response(
+            generator=error_gen(),
+            media_type="text/event-stream",
+            headers={},
+        )
+
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 400
+
     async def test_keepalive_path_keeps_datadog_chunk_spans(self, monkeypatch):
         """The keepalive path bypasses combined_generator, so it has to carry the
         per-chunk tracing itself or a stalled stream silently loses every span."""

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5587,6 +5587,31 @@ class TestSSEKeepalive:
         monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", Hostile(), raising=False)
         assert _resolve_sse_keepalive_interval() is None
 
+    async def test_cancelled_fetch_is_not_read_as_a_delivered_chunk(self, monkeypatch):
+        """A fetch that reports done only because it was cancelled must fall through
+        to the cancel-and-close path rather than have its result read."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        real_wait = asyncio.wait
+
+        async def cancel_the_fetch(aws, **kwargs):
+            ordered = sorted(aws, key=lambda t: int(t.get_name().rsplit("-", 1)[-1]))
+            fetch = ordered[0]
+            fetch.cancel()
+            try:
+                await fetch
+            except BaseException:
+                pass
+            return {fetch}, set(ordered[1:])
+
+        monkeypatch.setattr(asyncio, "wait", cancel_the_fetch)
+        try:
+            with pytest.raises(_ClientDisconnectedBeforeFirstChunk):
+                await _buffer_first_chunk_honoring_disconnect(
+                    self._stalling_gen(5.0), self._request_never_disconnects(), 1.0
+                )
+        finally:
+            monkeypatch.setattr(asyncio, "wait", real_wait)
+
     async def test_keepalive_applies_without_a_request_object(self, monkeypatch):
         """Callers that omit request have no disconnect arm, but a configured
         interval must still keep their stream alive."""

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5466,6 +5466,50 @@ class TestSSEKeepalive:
         assert isinstance(response, JSONResponse)
         assert response.status_code == 400
 
+    async def test_raise_before_the_timer_keeps_its_status_code(self, monkeypatch):
+        """An exception raised while create_response is still buffering is mapped to
+        its own status, exactly as it is with the feature off."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 2.0, raising=False)
+
+        async def raises_fast():
+            await asyncio.sleep(0.05)
+            raise HTTPException(status_code=400, detail={"error": "blocked"})
+            yield  # pragma: no cover
+
+        response = await create_response(
+            generator=raises_fast(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+        chunks = await self._collect(response)
+
+        assert response.status_code == 400
+        assert SSE_KEEPALIVE_COMMENT not in chunks
+
+    async def test_raise_after_the_timer_loses_its_status_code(self, monkeypatch):
+        """Committing to a response to send a keepalive gives up the ability to map a
+        later exception onto a status code, so it escapes instead. Pinned so the
+        trade-off stays a decision: keep the interval below the time a guardrail
+        needs to reject a request and this stays unreachable."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+
+        async def raises_slow():
+            await asyncio.sleep(2.5)
+            raise HTTPException(status_code=400, detail={"error": "blocked"})
+            yield  # pragma: no cover
+
+        response = await create_response(
+            generator=raises_slow(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        assert response.status_code == 200
+        with pytest.raises(HTTPException):
+            await self._collect(response)
+
     async def test_disconnect_during_keepalive_window_completes_shielded_cleanup(
         self, monkeypatch
     ):

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5148,6 +5148,11 @@ class TestSSEKeepalive:
     async def _collect(self, response) -> list:
         return [chunk async for chunk in response.body_iterator]
 
+    @staticmethod
+    def _pending_tasks_since(before: set) -> list:
+        """Tasks this test started and left running, ignoring the harness's own."""
+        return [t for t in asyncio.all_tasks() if t not in before and t is not asyncio.current_task() and not t.done()]
+
     async def test_interval_unset_leaves_stream_byte_identical(self, monkeypatch):
         monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", None, raising=False)
 
@@ -5769,8 +5774,10 @@ class TestSSEKeepalive:
         edge timeout, so the timer has to re-arm past the first chunk."""
         monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
 
+        # 4x the interval: at 2.5s a single slow scheduler wake-up pushed the
+        # second expiry past the end of the gap and left only one comment.
         response = await create_response(
-            generator=self._gen_with_midstream_gap(2.5),
+            generator=self._gen_with_midstream_gap(4.0),
             media_type="text/event-stream",
             headers={},
             request=self._request_never_disconnects(),
@@ -5808,10 +5815,12 @@ class TestSSEKeepalive:
         assert SSE_KEEPALIVE_COMMENT in chunks[first_at:]
 
     async def test_midstream_keepalive_is_off_when_interval_unset(self, monkeypatch):
+        """The gap has to out-wait the interval floor, or 'disabled' silently
+        becoming a 1s keepalive would look identical to genuinely disabled."""
         monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", None, raising=False)
 
         response = await create_response(
-            generator=self._gen_with_midstream_gap(0.05),
+            generator=self._gen_with_midstream_gap(MIN_SSE_KEEPALIVE_INTERVAL_SECONDS * 2.5),
             media_type="text/event-stream",
             headers={},
             request=self._request_never_disconnects(),
@@ -5834,13 +5843,18 @@ class TestSSEKeepalive:
             request=self._request_never_disconnects(),
         )
 
-        assert SSE_KEEPALIVE_COMMENT not in await self._collect(response)
+        assert await self._collect(response) == [
+            "data: first\n\n",
+            "data: second\n\n",
+            "data: [DONE]\n\n",
+        ]
 
     async def test_consumer_exit_during_midstream_gap_closes_upstream(self, monkeypatch):
         """Abandoning the response mid-gap must release the nested fetch and the
         upstream generator, or the LLM connection leaks until GC."""
         monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
         closed = asyncio.Event()
+        before = set(asyncio.all_tasks())
 
         response = await create_response(
             generator=self._gen_with_midstream_gap(30, closed),
@@ -5858,7 +5872,95 @@ class TestSSEKeepalive:
         # fetch and closed upstream by the time it returns, with no pending task
         # left behind to be reaped later.
         assert closed.is_set()
-        assert [t for t in asyncio.all_tasks() if t is not asyncio.current_task() and not t.done()] == []
+        assert self._pending_tasks_since(before) == []
+
+    async def test_consumer_exit_mid_gap_after_a_slow_first_chunk_closes_upstream(self, monkeypatch):
+        """Same leak as the fast-TTFT case, on the path that stalled for the first
+        token: the nested fetch must be released before the upstream aclose(), or
+        that aclose() raises "asynchronous generator is already running"."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        closed = asyncio.Event()
+        before = set(asyncio.all_tasks())
+
+        async def slow_then_gap():
+            try:
+                await asyncio.sleep(2.2)
+                yield "data: first\n\n"
+                await asyncio.sleep(30)
+                yield "data: [DONE]\n\n"
+            finally:
+                closed.set()
+
+        response = await create_response(
+            generator=slow_then_gap(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+
+        iterator = response.body_iterator.__aiter__()
+        seen = []
+        while "data: first\n\n" not in seen:
+            seen.append(await iterator.__anext__())
+        assert await iterator.__anext__() == SSE_KEEPALIVE_COMMENT
+        await response.body_iterator.aclose()
+
+        assert closed.is_set()
+        assert self._pending_tasks_since(before) == []
+
+    async def test_resolved_interval_is_what_arms_the_timer(self, monkeypatch):
+        """A resolved interval that never reaches the timer would flood the client
+        with comments; nothing else pins the value actually passed to asyncio.wait."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 2.0, raising=False)
+        import litellm.proxy.common_request_processing as crp
+
+        timeouts = []
+        real_wait = asyncio.wait
+
+        async def recording_wait(aws, **kwargs):
+            if "timeout" in kwargs:
+                timeouts.append(kwargs["timeout"])
+            return await real_wait(aws, **kwargs)
+
+        monkeypatch.setattr(crp.asyncio, "wait", recording_wait)
+
+        response = await create_response(
+            generator=self._gen_with_midstream_gap(5.0),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+        chunks = await self._collect(response)
+
+        assert timeouts, "the keepalive timer never armed"
+        assert set(timeouts) == {2.0}
+        # A 5s gap at a 2s interval yields two comments, not a flood.
+        assert 2 <= chunks.count(SSE_KEEPALIVE_COMMENT) <= 3
+
+    async def test_empty_stream_after_a_slow_first_chunk_wait_terminates(self, monkeypatch):
+        """Reaches the body-is-None teardown organically: the fetch resolves as
+        StopAsyncIteration after the keepalive loop, so no body was ever built."""
+        monkeypatch.setattr(litellm, "sse_keepalive_interval_seconds", 1.0, raising=False)
+        closed = asyncio.Event()
+
+        async def stall_then_end():
+            try:
+                await asyncio.sleep(2.2)
+                return
+                yield  # pragma: no cover
+            finally:
+                closed.set()
+
+        response = await create_response(
+            generator=stall_then_end(),
+            media_type="text/event-stream",
+            headers={},
+            request=self._request_never_disconnects(),
+        )
+        chunks = await self._collect(response)
+
+        assert chunks and set(chunks) == {SSE_KEEPALIVE_COMMENT}
+        assert closed.is_set()
 
     async def test_midstream_upstream_exception_still_propagates(self, monkeypatch):
         """The keepalive wrapper must not swallow a mid-stream provider failure."""

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -16,6 +16,7 @@ import httpx
 import pytest
 import yaml
 from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.testclient import TestClient
 
@@ -10669,5 +10670,94 @@ async def test_queue_streaming_routes_through_create_response():
             "data: first\n\n",
             "data: [DONE]\n\n",
         ]
+    finally:
+        litellm.sse_keepalive_interval_seconds = None
+
+
+def _queue_request(receive_messages):
+    """A /queue/chat/completions Request that yields the given ASGI messages in
+    order, then blocks — request.json() drains the body from the same channel the
+    disconnect arm later listens on."""
+    remaining = list(receive_messages)
+
+    async def receive():
+        if remaining:
+            return remaining.pop(0)
+        await asyncio.Event().wait()
+
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "headers": [(b"content-type", b"application/json")],
+            "query_string": b"",
+            "path": "/queue/chat/completions",
+        },
+        receive=receive,
+    )
+
+
+def _queue_body():
+    body = json.dumps({"model": "gpt-3.5-turbo", "stream": True, "priority": 0}).encode()
+    return {"type": "http.request", "body": body, "more_body": False}
+
+
+async def _call_queue_with(generator, receive_messages):
+    router = MagicMock()
+    router.schedule_acompletion = AsyncMock(return_value=MagicMock())
+    with (
+        patch.object(proxy_server_module, "llm_router", router),
+        patch.object(proxy_server_module, "async_data_generator", lambda **kwargs: generator),
+        patch.object(proxy_server_module.proxy_logging_obj, "post_call_failure_hook", AsyncMock()),
+    ):
+        return await proxy_server_module.async_queue_request(
+            request=_queue_request(receive_messages),
+            fastapi_response=Response(),
+            model=None,
+            user_api_key_dict=UserAPIKeyAuth(api_key="sk-test", user_id="u1"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_queue_streaming_error_only_first_chunk_becomes_json_error():
+    """Contract A on /queue: an error-only stream must carry the provider status
+    code as a JSON error, not a 200 with an SSE frame."""
+    litellm.sse_keepalive_interval_seconds = 1.0
+    try:
+
+        async def error_first():
+            yield 'data: {"error": {"message": "bad request", "code": "400"}}\n\n'
+
+        response = await _call_queue_with(error_first(), [_queue_body()])
+
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 400
+    finally:
+        litellm.sse_keepalive_interval_seconds = None
+
+
+@pytest.mark.asyncio
+async def test_queue_streaming_disconnect_during_ttft_returns_499():
+    """Contract B on /queue: a client that hangs up during time-to-first-token
+    gets a 499 and the upstream generator is closed rather than left running."""
+    litellm.sse_keepalive_interval_seconds = 1.0
+    closed = asyncio.Event()
+    try:
+
+        async def slow_first_token():
+            try:
+                await asyncio.sleep(30)
+                yield "data: first\n\n"
+            finally:
+                closed.set()
+
+        response = await _call_queue_with(
+            slow_first_token(),
+            [_queue_body(), {"type": "http.disconnect"}],
+        )
+
+        assert isinstance(response, JSONResponse)
+        assert response.status_code == 499
+        assert closed.is_set()
     finally:
         litellm.sse_keepalive_interval_seconds = None

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -15,7 +15,7 @@ import click
 import httpx
 import pytest
 import yaml
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
 from fastapi.staticfiles import StaticFiles
 from fastapi.testclient import TestClient
 
@@ -31,6 +31,7 @@ from litellm.caching.dual_cache import DualCache
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.proxy_server import app, initialize
+from litellm.proxy.common_request_processing import SSE_KEEPALIVE_COMMENT
 from litellm.utils import _invalidate_model_cost_lowercase_map
 
 example_embedding_result = {
@@ -10604,3 +10605,69 @@ async def test_startup_survives_database_read_failure_for_coordination_redis():
         )
 
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_queue_streaming_routes_through_create_response():
+    """/queue/chat/completions returned a bare StreamingResponse, bypassing
+    create_response — so it got no keepalive on a slow first token, and neither
+    the error-only-stream nor the disconnect-during-TTFT contract applied."""
+    litellm.sse_keepalive_interval_seconds = 1.0
+    try:
+
+        async def slow_first_token():
+            await asyncio.sleep(2.2)
+            yield "data: first\n\n"
+            yield "data: [DONE]\n\n"
+
+        router = MagicMock()
+        router.schedule_acompletion = AsyncMock(return_value=MagicMock())
+
+        body = json.dumps({"model": "gpt-3.5-turbo", "stream": True, "priority": 0}).encode()
+        sent_body = False
+
+        async def receive():
+            # Deliver the body once, then block: request.json() consumes the body
+            # and create_response's disconnect arm then awaits the same channel.
+            nonlocal sent_body
+            if not sent_body:
+                sent_body = True
+                return {"type": "http.request", "body": body, "more_body": False}
+            await asyncio.Event().wait()
+
+        request = Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "headers": [(b"content-type", b"application/json")],
+                "query_string": b"",
+                "path": "/queue/chat/completions",
+            },
+            receive=receive,
+        )
+
+        with (
+            patch.object(proxy_server_module, "llm_router", router),
+            patch.object(
+                proxy_server_module,
+                "async_data_generator",
+                lambda **kwargs: slow_first_token(),
+            ),
+        ):
+            response = await proxy_server_module.async_queue_request(
+                request=request,
+                fastapi_response=Response(),
+                model=None,
+                user_api_key_dict=UserAPIKeyAuth(api_key="sk-test", user_id="u1"),
+            )
+
+        chunks = [chunk async for chunk in response.body_iterator]
+
+        assert SSE_KEEPALIVE_COMMENT in chunks
+        assert chunks.index(SSE_KEEPALIVE_COMMENT) < chunks.index("data: first\n\n")
+        assert [c for c in chunks if c != SSE_KEEPALIVE_COMMENT] == [
+            "data: first\n\n",
+            "data: [DONE]\n\n",
+        ]
+    finally:
+        litellm.sse_keepalive_interval_seconds = None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streaming responses emit zero bytes during a long time-to-first-token
- Idle-timeout hops then abort a connection that is perfectly healthy
- Existing keepalive settings act on sockets, not on the response

How it solves it:

- Optional interval emits an SSE comment whenever the stream is silent
- Races the timer alongside the existing first-chunk and disconnect arms
- Re-arms past the first token, so mid-stream gaps are covered too
- Off by default, so the streaming path stays byte-identical

## Relevant issues

Fixes #34819

Related reports of the same symptom from different root causes: #32004, #32491, #24929

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Driving the real `create_response` with a generator that stays silent for 30s
before its first frame, printing when each byte reaches the response body. Same
command all three times, only the commit and the setting change.

**Before, at `daf22ec871` (the base commit).** Nothing reaches the wire for the whole
think, so an intermediary watching for idle connections closes a stream that was
never unhealthy

```
sse_keepalive_interval_seconds = None
model stays silent for 30s before the first token

[ 30.002s] data: {"type":"content_block_delta","delta":{"text":"84"}}
[ 30.002s] data: [DONE]
[ 30.002s] <stream closed>
```

**After, at `6f9557c901`, setting unset.** The default path is unchanged, byte for
byte, which is what keeps this safe to ship off by default

```
sse_keepalive_interval_seconds = None
model stays silent for 30s before the first token

[ 30.002s] data: {"type":"content_block_delta","delta":{"text":"84"}}
[ 30.002s] data: [DONE]
[ 30.002s] <stream closed>
```

**After, at `6f9557c901`, interval 5s.** Comments fill the silence and stop the moment
the real frame lands. The token still arrives at 30s, so nothing was sped up or
substituted, the connection was simply kept visible

```
sse_keepalive_interval_seconds = 5.0
model stays silent for 30s before the first token

[  5.001s] : keepalive
[ 10.002s] : keepalive
[ 15.004s] : keepalive
[ 20.005s] : keepalive
[ 25.005s] : keepalive
[ 30.001s] data: {"type":"content_block_delta","delta":{"text":"84"}}
[ 30.001s] data: [DONE]
[ 30.012s] <stream closed>
```

Soaked on a live proxy behind an ALB with a 60s idle timeout, three pods, serving
extended-thinking traffic with the interval set to 15s. The abort class this fixes
stopped occurring; a client that hangs up mid-think still records a 499 and
releases its parallel-request slot

<img width="1297" height="733" alt="image" src="https://github.com/user-attachments/assets/5db41d94-38dd-4336-890d-d4f66b3920d9" />
<img width="793" height="526" alt="image" src="https://github.com/user-attachments/assets/701f7168-1b0e-418e-bacc-57ae8c0ed394" />

## Type

🐛 Bug Fix

## Changes

Streaming responses that have connected but not yet produced a token put nothing
on the wire. Reasoning and extended-thinking models can stay silent for minutes,
and providers that deliver large tool arguments as a trailing burst do the same
mid-stream. Any hop between the client and the proxy that watches for idle
connections then closes one that is perfectly healthy, and the client sees a
truncated stream while the upstream request was still on its way

Nothing shipped today can prevent that. `AIOHTTP_KEEPALIVE_TIMEOUT`,
`AIOHTTP_SO_KEEPALIVE` and uvicorn's `timeout_keep_alive` all act on sockets, and
none of them write a byte to an in-flight response, so a connected but silent
stream is invisible to every idle watchdog in the path. This is the same class of
problem as #28384, where the proxy was the only component positioned to tell an
intermediary how to treat the stream. That fix does not help here: it tells a
reverse proxy not to buffer chunks that exist, and during the wait there are none

`litellm.sse_keepalive_interval_seconds` (also settable as `litellm_settings:
sse_keepalive_interval_seconds`) defaults to unset, which leaves behavior exactly
as it is today and is pinned by a test. When an operator sets it,
`_buffer_first_chunk_honoring_disconnect` races the keepalive timer alongside the
two arms it already had, and returns the still-pending fetch on a genuine stall
instead of a chunk. `create_response` then commits to a response whose body emits
a comment line until that fetch resolves, yields it, and falls through to plain
iteration, so nothing is added to the per-chunk hot path. Comment lines are
ignored by conforming SSE parsers per the HTML specification, so nothing a client
parses changes

The two contracts `create_response` owns are preserved. A disconnect keeps
priority over the timer, so the client-disconnect path and the cleanup it drives
are untouched, and a chunk that lands inside the interval still reaches the
error-only detection and its status-code mapping unchanged

One consequence is worth stating plainly, because it is inherent to sending
anything at all during the wait rather than incidental to how this is written.
Emitting a keepalive commits the status line, so nothing that arrives afterwards
can still choose a status code. Two cases follow from that, and both are pinned
by tests so they stay decisions rather than surprises. A guardrail that yields
`data: {"error": {..., "code": 400}}` later than the interval is delivered as an
SSE error frame under a 200 instead of being downgraded to a JSON 400. A
guardrail that raises instead of yielding loses its status code entirely and the
exception escapes, where with the feature off it would have been mapped. Both are
reachable only when the interval is shorter than the time a guardrail needs to
reject a request; measured against a request-scanning guardrail that answers in
well under a second, an interval in the tens of seconds never reaches either.
Anyone setting a sub-second interval on a deployment with slow request-scanning
guardrails should know the trade-off exists

The timer re-arms for the whole stream rather than stopping once the status line
is committed. A stream can start promptly and then go quiet — extended thinking, a
long tool-use turn, a provider that delivers large tool arguments as a trailing
burst — and those gaps idle out exactly the same watchdogs a slow first token
does. Both the buffered-first-chunk and pending-first-chunk paths run the body
through the same wrapper, and with the setting unset it forwards the stream
unchanged. Two details are load-bearing there: closing a generator does not
cascade into one it is iterating, so the nested fetch is released explicitly or
the upstream `aclose()` raises "asynchronous generator is already running" and the
provider connection survives until garbage collection; and keepalives are
protocol filler rather than model output, so they are excluded from the per-chunk
spans to keep the chunk count and its latency stats honest

Scope is the shared `create_response` return path, which covers `/v1/messages`,
`/chat/completions`, `/v1/responses` and streaming assistant runs together, gated
on `media_type == "text/event-stream"`. `/queue/chat/completions` returned a bare
`StreamingResponse` and so was the one streaming route that skipped first-chunk
buffering altogether — no keepalive, an error-only stream delivered as 200 + SSE
rather than a JSON error carrying the provider status code, and a disconnect
during time-to-first-token leaving the upstream call running. It now goes through
`create_response` like every other route. Pass-through routes return their own
`StreamingResponse` and remain deliberately out of scope

Two notes for the reviewer, since both look odd out of context. The done-callback
on the pending fetch exists only to consume its outcome so asyncio never reports
an unretrieved exception when the response tears the fetch down, and a test
asserts that. The `isinstance(interval, bool)` guard is there because `bool` is an
`int` subclass, so a config value of `true` would otherwise coerce to a
one-second interval instead of being rejected

`asyncio.wait` is awaited from two coroutines across the handoff, the pending
fetch is cancelled and awaited under a shield in every teardown path, and the
response owns the fetch so it cannot be orphaned when the body is never iterated.
Each of those is a separate regression test, and each was checked by mutating its
guard narrowly and confirming the test fails — including the leak one, which
asserts the upstream generator is closed by the time `aclose()` returns and that
no task is left pending, rather than relying on garbage collection to reap it

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR



