### PR TITLE
fix(anthropic): stop injecting empty-content placeholder into tool-call-only assistant turns

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2023,16 +2023,24 @@ def _is_empty_text_block(block: object) -> bool:
     return not isinstance(text, str) or not text.strip()
 
 
+def _survives_assistant_conversion(block: object) -> bool:
+    if not isinstance(block, dict):
+        return False
+    block_type = block.get("type")
+    if not isinstance(block_type, str) or block_type == "text":
+        return False
+    if block_type == "thinking":
+        return bool(block.get("thinking")) and not _is_unsignable_thinking_block(block)
+    return block_type == "server_tool_use" or block_type.endswith("_tool_result")
+
+
 def _carries_non_text_content(message: AllMessageValues) -> bool:
     if message.get("tool_calls"):
         return True
     content = message.get("content")
     if not isinstance(content, list):
         return False
-    return any(
-        isinstance(block, dict) and isinstance(block.get("type"), str) and block.get("type") != "text"
-        for block in content
-    )
+    return any(_survives_assistant_conversion(block) for block in content)
 
 
 def _with_content(message: AllMessageValues, content: object, action: str) -> AllMessageValues:

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2016,15 +2016,48 @@ def anthropic_process_openai_file_message(
 _EMPTY_TEXT_PLACEHOLDER = "[System: Empty message content sanitised to satisfy protocol]"
 
 
+def _is_empty_text_block(block: object) -> bool:
+    if not isinstance(block, dict) or block.get("type") != "text":
+        return False
+    text = block.get("text")
+    return not isinstance(text, str) or not text.strip()
+
+
+def _carries_non_text_content(message: AllMessageValues) -> bool:
+    if message.get("tool_calls"):
+        return True
+    content = message.get("content")
+    if not isinstance(content, list):
+        return False
+    return any(
+        isinstance(block, dict) and isinstance(block.get("type"), str) and block.get("type") != "text"
+        for block in content
+    )
+
+
+def _with_content(message: AllMessageValues, content: object, action: str) -> AllMessageValues:
+    sanitized = cast(AllMessageValues, {**message, "content": content})
+    verbose_logger.debug(f"_sanitize_empty_text_content: {action} in {message.get('role')} message")
+    return sanitized
+
+
 def _sanitize_empty_text_content(
     message: AllMessageValues,
 ) -> AllMessageValues:
     """
     Case C: Sanitize empty text content
-    - Replace empty or whitespace-only text content with a placeholder message.
-    - Handles both string content and list-of-blocks content (rewriting only
-      the empty text blocks in place; non-text blocks like images are left
-      untouched).
+
+    Anthropic rejects empty text blocks, so empty or whitespace-only text must never be
+    forwarded verbatim. What replaces it depends on what else the turn carries.
+
+    Assistant turns that already carry substantive content (``tool_calls``, or non-text
+    blocks such as ``tool_use``) get the empty text dropped. Anthropic accepts an assistant
+    turn whose content is just ``tool_use``, so there is nothing to substitute, and
+    substituting anyway leaks a protocol diagnostic into the conversation as though the
+    assistant had said it, which the model then echoes on later turns.
+
+    Every other empty turn would otherwise end up with no content at all, which Anthropic
+    also rejects, so the placeholder is still substituted there.
 
     Returns:
         The message with sanitized content if needed, otherwise the original message
@@ -2033,41 +2066,26 @@ def _sanitize_empty_text_content(
         return message
 
     content = message.get("content")
+    drop_empty_text = message.get("role") == "assistant" and _carries_non_text_content(message)
 
     if isinstance(content, str):
-        if not content or not content.strip():
-            message = cast(AllMessageValues, dict(message))  # Make a copy
-            message["content"] = _EMPTY_TEXT_PLACEHOLDER
-            verbose_logger.debug(
-                f"_sanitize_empty_text_content: Replaced empty text content in {message.get('role')} message"
-            )
+        if content.strip():
+            return message
+        if drop_empty_text:
+            return _with_content(message, None, "Dropped empty text content")
+        return _with_content(message, _EMPTY_TEXT_PLACEHOLDER, "Replaced empty text content")
+
+    if not isinstance(content, list) or not any(_is_empty_text_block(block) for block in content):
         return message
 
-    if isinstance(content, list):
-        # Walk the blocks and rewrite any empty text blocks. We rewrite (rather
-        # than drop) so callers don't end up with an entirely empty content
-        # list, which Anthropic also rejects.
-        new_blocks: List[Any] = []
-        rewrote_any = False
-        for block in content:
-            if isinstance(block, dict) and block.get("type") == "text":
-                text = block.get("text")
-                if not isinstance(text, str) or not text or not text.strip():
-                    new_block = dict(block)
-                    new_block["text"] = _EMPTY_TEXT_PLACEHOLDER
-                    new_blocks.append(new_block)
-                    rewrote_any = True
-                    continue
-            new_blocks.append(block)
+    if drop_empty_text:
+        kept = [block for block in content if not _is_empty_text_block(block)]
+        return _with_content(message, kept, "Dropped empty text block(s)")
 
-        if rewrote_any:
-            message = cast(AllMessageValues, dict(message))  # Make a copy
-            message["content"] = new_blocks  # type: ignore
-            verbose_logger.debug(
-                f"_sanitize_empty_text_content: Replaced empty text block(s) in {message.get('role')} message"
-            )
-
-    return message
+    rewritten = [
+        {**block, "text": _EMPTY_TEXT_PLACEHOLDER} if _is_empty_text_block(block) else block for block in content
+    ]
+    return _with_content(message, rewritten, "Replaced empty text block(s)")
 
 
 def _add_missing_tool_results(

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -2024,9 +2024,7 @@ def _is_empty_text_block(block: object) -> bool:
 
 
 def _survives_assistant_conversion(block: object) -> bool:
-    if not isinstance(block, dict):
-        return False
-    block_type = block.get("type")
+    block_type = block.get("type") if isinstance(block, dict) else None
     if not isinstance(block_type, str) or block_type == "text":
         return False
     if block_type == "thinking":

--- a/tests/test_litellm/llms/anthropic/test_message_sanitization.py
+++ b/tests/test_litellm/llms/anthropic/test_message_sanitization.py
@@ -7,6 +7,8 @@ B. Orphaned tool_result without matching tool_use
 C. Empty text content
 """
 
+import copy
+import json
 import pytest
 import sys
 import os
@@ -18,6 +20,8 @@ sys.path.insert(
 
 import litellm
 from litellm.litellm_core_utils.prompt_templates.factory import (
+    _EMPTY_TEXT_PLACEHOLDER as PLACEHOLDER,
+    _sanitize_empty_text_content,
     sanitize_messages_for_tool_calling,
     anthropic_messages_pt,
 )
@@ -427,6 +431,200 @@ class TestMessageSanitization:
         assert result[0]["content"][0]["text"] == "Hello"
         assert result[1]["content"][0]["text"] == "Hi there"
         assert result[2]["content"][0]["text"] == "How are you?"
+
+    @pytest.mark.parametrize("modify_params", [True, False])
+    @pytest.mark.parametrize(
+        "empty_content",
+        [None, "", "   \n  \t  ", [], [{"type": "text", "text": ""}]],
+        ids=["none", "empty_str", "whitespace_str", "empty_list", "empty_text_block"],
+    )
+    def test_tool_call_only_assistant_turn_never_gets_placeholder(
+        self, modify_params, empty_content
+    ):
+        """
+        Regression for the placeholder leaking into tool-call-only assistant turns.
+
+        An OpenAI-format assistant turn that carries tool_calls but no text is the normal
+        shape emitted by coding agents. Anthropic accepts an assistant turn whose content
+        is just tool_use, so there is nothing to substitute; injecting the placeholder made
+        it look like the assistant had said it, and the model echoed it on later turns.
+        """
+        litellm.modify_params = modify_params
+
+        messages = [
+            {"role": "user", "content": "list the files"},
+            {
+                "role": "assistant",
+                "content": empty_content,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "run_bash", "arguments": '{"cmd": "ls"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "a.txt"},
+        ]
+
+        result = anthropic_messages_pt(
+            messages=messages, model="claude-sonnet-4-6", llm_provider="anthropic"
+        )
+
+        assistant_turns = [m for m in result if m["role"] == "assistant"]
+        assert len(assistant_turns) == 1
+        blocks = assistant_turns[0]["content"]
+
+        assert [b["type"] for b in blocks] == ["tool_use"]
+        assert blocks[0]["id"] == "call_1"
+        assert blocks[0]["name"] == "run_bash"
+
+        assert PLACEHOLDER not in json.dumps(result)
+
+    def test_empty_text_dropped_alongside_non_text_blocks(self):
+        """
+        An assistant turn already carrying a non-text block has enough content for
+        Anthropic once the empty text block is dropped, so the placeholder must not be
+        substituted in its place.
+        """
+        litellm.modify_params = True
+
+        message = {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "  "},
+                {"type": "thinking", "thinking": "weighing options", "signature": "sig"},
+            ],
+        }
+
+        sanitized = _sanitize_empty_text_content(message)
+
+        assert [b["type"] for b in sanitized["content"]] == ["thinking"]
+        assert PLACEHOLDER not in json.dumps(sanitized)
+
+    def test_assistant_text_preserved_alongside_tool_calls(self):
+        """
+        Dropping empty text must not drop real text: an assistant turn that says something
+        *and* calls a tool keeps both blocks.
+        """
+        litellm.modify_params = True
+
+        messages = [
+            {"role": "user", "content": "list the files"},
+            {
+                "role": "assistant",
+                "content": "Let me check.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "run_bash", "arguments": '{"cmd": "ls"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "a.txt"},
+        ]
+
+        result = anthropic_messages_pt(
+            messages=messages, model="claude-sonnet-4-6", llm_provider="anthropic"
+        )
+
+        assistant_turns = [m for m in result if m["role"] == "assistant"]
+        blocks = assistant_turns[0]["content"]
+
+        assert [b["type"] for b in blocks] == ["text", "tool_use"]
+        assert blocks[0]["text"] == "Let me check."
+        assert PLACEHOLDER not in json.dumps(result)
+
+    @pytest.mark.parametrize(
+        "messages",
+        [
+            [{"role": "user", "content": ""}],
+            [{"role": "user", "content": [{"type": "text", "text": "  "}]}],
+            [{"role": "user", "content": "hi"}, {"role": "assistant", "content": ""}],
+        ],
+        ids=["user_str", "user_block", "assistant_without_tool_calls"],
+    )
+    def test_placeholder_still_used_when_turn_would_be_empty(self, messages):
+        """
+        The placeholder is still required where dropping the empty text would leave the
+        turn with no content at all, which Anthropic also rejects.
+        """
+        litellm.modify_params = True
+
+        result = anthropic_messages_pt(
+            messages=messages, model="claude-sonnet-4-6", llm_provider="anthropic"
+        )
+
+        assert PLACEHOLDER in json.dumps(result)
+        for message in result:
+            assert message["content"]
+
+    def test_no_empty_text_block_or_content_reaches_anthropic(self):
+        """
+        The invariant Anthropic actually enforces, over a conversation mixing every shape:
+        no empty content list and no empty text block may survive the conversion.
+        """
+        litellm.modify_params = True
+
+        messages = [
+            {"role": "user", "content": ""},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "run_bash", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "out"},
+            {"role": "assistant", "content": [{"type": "text", "text": "   "}]},
+            {"role": "user", "content": [{"type": "text", "text": "thanks"}]},
+        ]
+
+        result = anthropic_messages_pt(
+            messages=messages, model="claude-sonnet-4-6", llm_provider="anthropic"
+        )
+
+        for message in result:
+            content = message["content"]
+            assert content
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    assert block["text"].strip()
+
+    def test_sanitization_does_not_mutate_caller_messages(self):
+        """
+        Callers reuse their message list across retries and fallbacks, so sanitization has
+        to stay copy-on-write.
+        """
+        litellm.modify_params = True
+
+        messages = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "run_bash", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "out"},
+        ]
+        before = copy.deepcopy(messages)
+
+        anthropic_messages_pt(
+            messages=messages, model="claude-sonnet-4-6", llm_provider="anthropic"
+        )
+
+        assert messages == before
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/llms/anthropic/test_message_sanitization.py
+++ b/tests/test_litellm/llms/anthropic/test_message_sanitization.py
@@ -502,6 +502,37 @@ class TestMessageSanitization:
         assert [b["type"] for b in sanitized["content"]] == ["thinking"]
         assert PLACEHOLDER not in json.dumps(sanitized)
 
+    @pytest.mark.parametrize(
+        "sibling_block",
+        [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,aGk="}},
+            {"type": "thinking", "thinking": ""},
+            {"type": "unknown_future_block"},
+        ],
+        ids=["image_url", "unsignable_thinking", "unknown_type"],
+    )
+    def test_empty_text_kept_when_sibling_block_would_not_survive(self, sibling_block):
+        """
+        Dropping empty text is only safe when something else in the turn actually reaches
+        Anthropic. Blocks the assistant conversion discards (assistant-side images,
+        signature-less thinking, unrecognised types) would leave an empty turn that gets
+        dropped from the request entirely, so the placeholder has to stay.
+        """
+        litellm.modify_params = True
+
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": [{"type": "text", "text": "  "}, sibling_block]},
+            {"role": "user", "content": "and now?"},
+        ]
+
+        result = anthropic_messages_pt(
+            messages=messages, model="claude-haiku-4-5", llm_provider="anthropic"
+        )
+
+        assert [m["role"] for m in result] == ["user", "assistant", "user"]
+        assert PLACEHOLDER in json.dumps(result)
+
     def test_assistant_text_preserved_alongside_tool_calls(self):
         """
         Dropping empty text must not drop real text: an assistant turn that says something

--- a/tests/test_litellm/llms/anthropic/test_message_sanitization.py
+++ b/tests/test_litellm/llms/anthropic/test_message_sanitization.py
@@ -508,8 +508,9 @@ class TestMessageSanitization:
             {"type": "image_url", "image_url": {"url": "data:image/png;base64,aGk="}},
             {"type": "thinking", "thinking": ""},
             {"type": "unknown_future_block"},
+            {"no_type_key": "malformed"},
         ],
-        ids=["image_url", "unsignable_thinking", "unknown_type"],
+        ids=["image_url", "unsignable_thinking", "unknown_type", "missing_type"],
     )
     def test_empty_text_kept_when_sibling_block_would_not_survive(self, sibling_block):
         """


### PR DESCRIPTION
## TLDR

Problem this solves:

- Tool-call-only assistant turns got a fake `[System: ...]` utterance
- That text reached Anthropic, got persisted, and the model echoed it
- Placeholder applies even with `modify_params=False`, so nothing disabled it

How it solves it:

- Drop empty text instead of replacing it when the turn carries tool_calls
- Same for assistant turns holding non-text blocks such as tool_use
- Keep the placeholder only where the turn would otherwise be empty

## Relevant issues

Fixes #24498

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy against a real Anthropic-protocol endpoint, no mocks. The interesting artifact is the
request LiteLLM sends upstream, which `--detailed_debug` prints as the actual curl, so the before
and after are read straight off the wire rather than inferred from the reply

Config used for both runs:

```yaml
model_list:
  - model_name: claude-proof
    litellm_params:
      model: anthropic/claude-haiku-4-5
      api_base: <anthropic-protocol endpoint>
      api_key: os.environ/PROOF_UPSTREAM_KEY
litellm_settings:
  modify_params: true
general_settings:
  master_key: sk-proof-1234
```

Request replaying the shape an OpenAI-format agent produces, an assistant turn with `tool_calls`
and no text:

```bash
cat > req.json <<'JSON'
{
  "model": "claude-proof",
  "max_tokens": 100,
  "temperature": 0,
  "messages": [
    {"role": "user", "content": "call the tool"},
    {"role": "assistant", "content": "", "tool_calls": [
      {"id": "call_1", "type": "function", "function": {"name": "run_bash", "arguments": "{\"cmd\":\"ls\"}"}}]},
    {"role": "tool", "tool_call_id": "call_1", "content": "a.txt"},
    {"role": "user", "content": "Quote every sentence in this conversation that begins with the word System. If there are none, reply NONE."}
  ],
  "tools": [{"type": "function", "function": {"name": "run_bash",
    "parameters": {"type": "object", "properties": {"cmd": {"type": "string"}}}}}]
}
JSON

python litellm/proxy/proxy_cli.py --config config.yaml --port 4000 --detailed_debug 2>&1 | tee litellm.log

curl -sS http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-proof-1234" \
  -H "Content-Type: application/json" -d @req.json
```

Before, at `079003b` (this PR's merge base). Reading the assistant turn out of the upstream request
body in `litellm.log`. The sanitizer behaviour proven here is unchanged by the follow-up commit
`fd83156`, which only narrows which sibling blocks count as substantive:

```
$ grep -oE "'role': 'assistant', 'content': \[[^]]*\]" litellm.log | head -1
'role': 'assistant', 'content': [{'type': 'text', 'text': '[System: Empty message content sanitised to satisfy protocol]'}, {'type': 'tool_use', 'id': 'call_1', 'name': 'run_bash', 'input': {'cmd': 'ls'}}]

$ grep -c 'sanitised to satisfy protocol' litellm.log
1
```

The turn is sent to Anthropic as though the assistant had said the placeholder out loud, so any
client persisting history keeps it and replays it on the next turn

After, at `f23b518`:

```
$ grep -oE "'role': 'assistant', 'content': \[[^]]*\]" litellm.log | head -1
'role': 'assistant', 'content': [{'type': 'tool_use', 'id': 'call_1', 'name': 'run_bash', 'input': {'cmd': 'ls'}}]

$ grep -c 'sanitised to satisfy protocol' litellm.log
0
```

Only the `tool_use` block is sent, which Anthropic accepts on its own, and the response is a plain
`NONE` with no placeholder anywhere in the exchange:

```
$ curl -sS http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-proof-1234" \
    -H "Content-Type: application/json" -d @req.json | jq -r '.choices[0].message.content'
NONE
```

## Type

🐛 Bug Fix

## Changes

`_sanitize_empty_text_content` replaced empty or whitespace-only text with
`_EMPTY_TEXT_PLACEHOLDER` for every user and assistant turn. `anthropic_messages_pt` calls it
unconditionally, deliberately independent of `modify_params`, because an empty text block always
makes Anthropic 400; that part is correct and stays

What was wrong is treating both roles the same. An assistant turn carrying `tool_calls` and no text
is the ordinary shape an OpenAI-format agent emits between a tool call and its result, and Anthropic
accepts an assistant turn whose content is just `tool_use`, so there was never anything to
substitute. Substituting anyway wrote a protocol diagnostic into `content`, which both the model and
the client read as the assistant's own words, and there is no field in the OpenAI protocol where a
diagnostic like that belongs

So the empty text is now dropped rather than rewritten whenever the assistant turn already carries
substantive content, meaning `tool_calls` or a non-text block such as `tool_use`. Everything else
keeps the previous behaviour, because a turn left with no content at all is rejected by Anthropic
just the same; that includes user turns, which have no equivalent of `tool_calls` to fall back on

Dropping is only safe when something else in the turn genuinely reaches Anthropic, which is what
`_carries_non_text_content` checks. That check is narrower than "not a text block", because the
assistant list-content converter only keeps `thinking` (when signable), `server_tool_use` and
`*_tool_result`; an assistant-side `image_url`, a signature-less `thinking` block, or an unrecognised
type gets discarded there. Treating those as substantive would drop the empty text and leave nothing
behind, so the turn would vanish from the request entirely. The predicate mirrors the conversion
instead, and those turns keep the placeholder and survive, which is also an improvement on the
previous behaviour where such a turn was dropped outright

On tests: the regression cases are the point of this PR, so they are written to fail on the current
`litellm_internal_staging` tree rather than just to raise the coverage number. Reverting only
`factory.py` and re-running the suite fails 7 of them, across both `modify_params` settings and every
empty-content shape an agent actually sends (`None`, `""`, whitespace, `[]`, and a list holding one
empty text block). The rest pin the invariants that make dropping safe: no empty text block and no
empty content list survives the conversion, sibling blocks the converter discards keep the
placeholder, real assistant text is never dropped alongside a tool call, and sanitization stays
copy-on-write so callers can reuse a message list across retries and fallbacks

Credit to @oakimov, who diagnosed the same root cause in #28987. This PR is the sanitizer half of
that work, kept deliberately narrow; the streaming `Delta(content=...)` change from #28987 is a
separate behavioural change with a much wider blast radius and is better reviewed on its own

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


