### PR TITLE
fix(otel): cap tool-definition attributes so they cannot evict gen_ai.* from the LLM span

### DIFF
--- a/litellm/integrations/otel/README.md
+++ b/litellm/integrations/otel/README.md
@@ -267,7 +267,10 @@ lives in [`plumbing/`](./plumbing):
 
 - **A new attribute vocabulary for a backend**: add a mapper in `mappers/`
   (a class with a `map(data) -> AttributeMap` method, typically built from
-  `key -> extractor` tables) and register it in `mappers/__init__._MAPPER_BY_NAME`.
+  `key -> extractor` tables) and register it in `mappers/__init__._PLAIN_MAPPERS`.
+  If it spells declared tool definitions out per index, register it in
+  `_TOOL_DEFINITION_MAPPERS` instead and take the shared attribute budget in its
+  constructor, so the family stays bounded span-wide rather than per vocabulary.
 - **A new integration**: add a preset in `presets/` that returns an
   `OpenTelemetryV2Config`, and register it in `presets/__init__.PRESET_BY_CALLBACK`.
   If it supports dynamic credentials, add a header builder to

--- a/litellm/integrations/otel/mappers/__init__.py
+++ b/litellm/integrations/otel/mappers/__init__.py
@@ -18,13 +18,19 @@ from litellm.integrations.otel.mappers.langfuse import LangfuseMapper
 from litellm.integrations.otel.mappers.langtrace import LangtraceMapper
 from litellm.integrations.otel.mappers.legacy import LegacyMapper
 from litellm.integrations.otel.mappers.openinference import OpenInferenceMapper
+from litellm.integrations.otel.mappers.utils import tool_attr_budget
 from litellm.integrations.otel.mappers.weave import WeaveMapper
 
-# Registry keyed by ``config.mapper_names`` entries.
-_MAPPER_BY_NAME: dict[str, Callable[[], AttributeMapper]] = {
+# Registries keyed by ``config.mapper_names`` entries, split by whether the
+# vocabulary spells declared tool definitions out per index. Those share one
+# span-wide attribute ceiling, so resolution has to know how many of them are
+# active before it can build them.
+_TOOL_DEFINITION_MAPPERS: dict[str, Callable[[int], AttributeMapper]] = {
     "genai": GenAIMapper,
     "legacy": LegacyMapper,
     "openinference": OpenInferenceMapper,
+}
+_PLAIN_MAPPERS: dict[str, Callable[[], AttributeMapper]] = {
     "langfuse": LangfuseMapper,
     "weave": WeaveMapper,
     "langtrace": LangtraceMapper,
@@ -33,13 +39,19 @@ _MAPPER_BY_NAME: dict[str, Callable[[], AttributeMapper]] = {
 
 def resolve_mappers(names: Iterable[str]) -> list[AttributeMapper]:
     """Resolve mapper names to instances. Unknown names raise ``ValueError``."""
-    out: list[AttributeMapper] = []
-    for name in names:
-        factory = _MAPPER_BY_NAME.get(name)
-        if factory is None:
-            raise ValueError(f"unknown mapper name {name!r}; known: {sorted(_MAPPER_BY_NAME)}")
-        out.append(factory())
-    return out
+    ordered = tuple(names)
+    for name in ordered:
+        if name not in _TOOL_DEFINITION_MAPPERS and name not in _PLAIN_MAPPERS:
+            known = sorted((*_TOOL_DEFINITION_MAPPERS, *_PLAIN_MAPPERS))
+            raise ValueError(f"unknown mapper name {name!r}; known: {known}")
+    # Distinct vocabularies each write the tool family under their own keys, so
+    # the ceiling is split by how many of them are configured. Repeating a name
+    # rewrites the same keys, so only distinct ones count.
+    budget = tool_attr_budget(len({*ordered} & _TOOL_DEFINITION_MAPPERS.keys()))
+    return [
+        _TOOL_DEFINITION_MAPPERS[name](budget) if name in _TOOL_DEFINITION_MAPPERS else _PLAIN_MAPPERS[name]()
+        for name in ordered
+    ]
 
 
 __all__ = [

--- a/litellm/integrations/otel/mappers/genai.py
+++ b/litellm/integrations/otel/mappers/genai.py
@@ -12,9 +12,9 @@ from typing import Callable
 from litellm.integrations.otel.mappers.base import AttributeMap, AttrValue, SpanData
 from litellm.integrations.otel.mappers.utils import (
     collect,
-    drop_none,
     output_messages,
     serialize_messages,
+    tool_definition_attrs,
 )
 from litellm.integrations.otel.model.payloads import (
     GuardrailSpanData,
@@ -153,15 +153,15 @@ class GenAIMapper:
     @classmethod
     def _llm_call(cls, data: LLMCallSpanData) -> AttributeMap:
         attrs = collect(cls._LLM_CALL_ATTRS, data)
-        attrs.update(
-            drop_none(
-                {
-                    f"gen_ai.tool.{idx}.{suffix}": extract(tool)
-                    for idx, tool in enumerate(data.tools)
-                    for suffix, extract in cls._TOOL_ATTRS.items()
-                }
+        if data.tools:
+            attrs[LiteLLM.TOOLS_DECLARED] = len(data.tools)
+            attrs.update(
+                tool_definition_attrs(
+                    lambda idx, suffix: f"gen_ai.tool.{idx}.{suffix}",
+                    data.tools,
+                    cls._TOOL_ATTRS,
+                )
             )
-        )
         return attrs
 
     @classmethod

--- a/litellm/integrations/otel/mappers/genai.py
+++ b/litellm/integrations/otel/mappers/genai.py
@@ -11,6 +11,7 @@ from typing import Callable
 
 from litellm.integrations.otel.mappers.base import AttributeMap, AttrValue, SpanData
 from litellm.integrations.otel.mappers.utils import (
+    MAX_TOOL_DEFINITION_ATTRS_PER_SPAN,
     collect,
     output_messages,
     serialize_messages,
@@ -135,6 +136,9 @@ class GenAIMapper:
         LiteLLM.SERVICE_CALL_TYPE: lambda d: d.call_type,
     }
 
+    def __init__(self, tool_attr_budget: int = MAX_TOOL_DEFINITION_ATTRS_PER_SPAN) -> None:
+        self._tool_attr_budget = tool_attr_budget
+
     def map(self, data: SpanData) -> AttributeMap:
         match data:
             case LLMCallSpanData():
@@ -150,16 +154,16 @@ class GenAIMapper:
             case _:
                 return {}
 
-    @classmethod
-    def _llm_call(cls, data: LLMCallSpanData) -> AttributeMap:
-        attrs = collect(cls._LLM_CALL_ATTRS, data)
+    def _llm_call(self, data: LLMCallSpanData) -> AttributeMap:
+        attrs = collect(self._LLM_CALL_ATTRS, data)
         if data.tools:
             attrs[LiteLLM.TOOLS_DECLARED] = len(data.tools)
             attrs.update(
                 tool_definition_attrs(
                     lambda idx, suffix: f"gen_ai.tool.{idx}.{suffix}",
                     data.tools,
-                    cls._TOOL_ATTRS,
+                    self._TOOL_ATTRS,
+                    self._tool_attr_budget,
                 )
             )
         return attrs

--- a/litellm/integrations/otel/mappers/legacy.py
+++ b/litellm/integrations/otel/mappers/legacy.py
@@ -12,7 +12,7 @@ Like ``GenAIMapper``, each span kind declares its schema as a flat
 from typing import Callable, Final
 
 from litellm.integrations.otel.mappers.base import AttributeMap, AttrValue, SpanData
-from litellm.integrations.otel.mappers.utils import collect, drop_none
+from litellm.integrations.otel.mappers.utils import collect, tool_definition_attrs
 from litellm.integrations.otel.model.payloads import (
     LLMCallSpanData,
     ServiceSpanData,
@@ -76,12 +76,10 @@ class LegacyMapper:
     def _llm_call(cls, data: LLMCallSpanData) -> AttributeMap:
         attrs = collect(cls._LLM_CALL_ATTRS, data)
         attrs.update(
-            drop_none(
-                {
-                    f"llm.request.functions.{idx}.{suffix}": extract(tool)
-                    for idx, tool in enumerate(data.tools)
-                    for suffix, extract in cls._TOOL_ATTRS.items()
-                }
+            tool_definition_attrs(
+                lambda idx, suffix: f"llm.request.functions.{idx}.{suffix}",
+                data.tools,
+                cls._TOOL_ATTRS,
             )
         )
         return attrs

--- a/litellm/integrations/otel/mappers/legacy.py
+++ b/litellm/integrations/otel/mappers/legacy.py
@@ -12,7 +12,11 @@ Like ``GenAIMapper``, each span kind declares its schema as a flat
 from typing import Callable, Final
 
 from litellm.integrations.otel.mappers.base import AttributeMap, AttrValue, SpanData
-from litellm.integrations.otel.mappers.utils import collect, tool_definition_attrs
+from litellm.integrations.otel.mappers.utils import (
+    MAX_TOOL_DEFINITION_ATTRS_PER_SPAN,
+    collect,
+    tool_definition_attrs,
+)
 from litellm.integrations.otel.model.payloads import (
     LLMCallSpanData,
     ServiceSpanData,
@@ -63,6 +67,9 @@ class LegacyMapper:
         _LEGACY_ERROR: lambda d: d.error.message if d.error is not None and d.error.message else None,
     }
 
+    def __init__(self, tool_attr_budget: int = MAX_TOOL_DEFINITION_ATTRS_PER_SPAN) -> None:
+        self._tool_attr_budget = tool_attr_budget
+
     def map(self, data: SpanData) -> AttributeMap:
         match data:
             case LLMCallSpanData():
@@ -72,14 +79,14 @@ class LegacyMapper:
             case _:
                 return {}
 
-    @classmethod
-    def _llm_call(cls, data: LLMCallSpanData) -> AttributeMap:
-        attrs = collect(cls._LLM_CALL_ATTRS, data)
+    def _llm_call(self, data: LLMCallSpanData) -> AttributeMap:
+        attrs = collect(self._LLM_CALL_ATTRS, data)
         attrs.update(
             tool_definition_attrs(
                 lambda idx, suffix: f"llm.request.functions.{idx}.{suffix}",
                 data.tools,
-                cls._TOOL_ATTRS,
+                self._TOOL_ATTRS,
+                self._tool_attr_budget,
             )
         )
         return attrs

--- a/litellm/integrations/otel/mappers/openinference.py
+++ b/litellm/integrations/otel/mappers/openinference.py
@@ -16,6 +16,7 @@ from litellm.integrations.otel.mappers.utils import (
     json_if,
     message_content,
     output_messages,
+    tool_definition_attrs,
 )
 from litellm.integrations.otel.model.payloads import (
     LLMCallSpanData,
@@ -110,10 +111,8 @@ class OpenInferenceMapper:
 
     @classmethod
     def _tools(cls, data: LLMCallSpanData) -> AttributeMap:
-        return drop_none(
-            {
-                f"llm.tools.{idx}.{suffix}": extract(tool)
-                for idx, tool in enumerate(data.tools)
-                for suffix, extract in cls._TOOL_ATTRS.items()
-            }
+        return tool_definition_attrs(
+            lambda idx, suffix: f"llm.tools.{idx}.{suffix}",
+            data.tools,
+            cls._TOOL_ATTRS,
         )

--- a/litellm/integrations/otel/mappers/openinference.py
+++ b/litellm/integrations/otel/mappers/openinference.py
@@ -13,6 +13,7 @@ from litellm.integrations.otel.mappers.base import AttributeMap, AttrValue, Span
 from litellm.integrations.otel.mappers.utils import (
     collect,
     drop_none,
+    MAX_TOOL_DEFINITION_ATTRS_PER_SPAN,
     json_if,
     message_content,
     output_messages,
@@ -71,6 +72,9 @@ class OpenInferenceMapper:
         ),
     }
 
+    def __init__(self, tool_attr_budget: int = MAX_TOOL_DEFINITION_ATTRS_PER_SPAN) -> None:
+        self._tool_attr_budget = tool_attr_budget
+
     def map(self, data: SpanData) -> AttributeMap:
         match data:
             case LLMCallSpanData():
@@ -78,14 +82,13 @@ class OpenInferenceMapper:
             case _:
                 return {}
 
-    @classmethod
-    def _llm_call(cls, data: LLMCallSpanData) -> AttributeMap:
+    def _llm_call(self, data: LLMCallSpanData) -> AttributeMap:
         return {
-            **collect(cls._LLM_CALL_ATTRS, data),
-            **collect(cls._BLOB_ATTRS, data),
-            **cls._messages("llm.input_messages", "input.value", data.messages_in),
-            **cls._messages("llm.output_messages", "output.value", output_messages(data)),
-            **cls._tools(data),
+            **collect(self._LLM_CALL_ATTRS, data),
+            **collect(self._BLOB_ATTRS, data),
+            **self._messages("llm.input_messages", "input.value", data.messages_in),
+            **self._messages("llm.output_messages", "output.value", output_messages(data)),
+            **self._tools(data),
         }
 
     @staticmethod
@@ -109,10 +112,10 @@ class OpenInferenceMapper:
             attrs[value_key] = json.dumps([{"role": role, "content": content} for role, content in parsed])
         return attrs
 
-    @classmethod
-    def _tools(cls, data: LLMCallSpanData) -> AttributeMap:
+    def _tools(self, data: LLMCallSpanData) -> AttributeMap:
         return tool_definition_attrs(
             lambda idx, suffix: f"llm.tools.{idx}.{suffix}",
             data.tools,
-            cls._TOOL_ATTRS,
+            self._TOOL_ATTRS,
+            self._tool_attr_budget,
         )

--- a/litellm/integrations/otel/mappers/utils.py
+++ b/litellm/integrations/otel/mappers/utils.py
@@ -11,16 +11,29 @@ from typing import Callable, Final, Mapping, Sequence
 from litellm.integrations.otel.mappers.base import AttributeMap, AttrValue
 from litellm.integrations.otel.model.payloads import LLMCallSpanData, ToolDefinition
 
-MAX_TOOL_DEFINITIONS_PER_SPAN: Final = 8
-"""How many declared tools get their definition spelled out on a span.
+DEFAULT_SPAN_ATTRIBUTE_LIMIT: Final = 128
+"""The OTel SDK's default per-span attribute count limit."""
+
+MAX_TOOL_DEFINITION_ATTRS_PER_SPAN: Final = DEFAULT_SPAN_ATTRIBUTE_LIMIT // 4
+"""Span-wide ceiling on attributes spent spelling out declared tool definitions.
 
 Tool definitions are an unbounded attribute family: one entry per declared
 tool, per field, per active vocabulary. Agentic clients declare hundreds, which
-overruns the OTel SDK's default 128-attribute span limit. That limit evicts
-oldest-first, so an uncapped family silently destroys the core ``gen_ai.*``
-attributes written before it. Capping the family keeps core telemetry intact;
-requests declaring fewer tools than this keep full per-tool detail.
+overruns the span attribute limit. That limit evicts oldest-first, so an
+uncapped family silently destroys the core ``gen_ai.*`` attributes written
+before it.
+
+The ceiling is span-wide rather than per-mapper because several vocabularies
+can be active at once and each spells the same tools out under its own keys, so
+a per-mapper allowance multiplies by the number of vocabularies and reaches the
+limit again. Reserving a quarter of the span for tool detail leaves the rest to
+core telemetry no matter how many vocabularies are configured.
 """
+
+
+def tool_attr_budget(vocabularies: int) -> int:
+    """Split the span-wide tool-definition ceiling across active vocabularies."""
+    return MAX_TOOL_DEFINITION_ATTRS_PER_SPAN // max(vocabularies, 1)
 
 
 def drop_none(values: Mapping[str, AttrValue | None]) -> AttributeMap:
@@ -32,16 +45,20 @@ def tool_definition_attrs(
     key_for: Callable[[int, str], str],
     tools: Sequence[ToolDefinition],
     extractors: Mapping[str, Callable[[ToolDefinition], AttrValue | None]],
+    attr_budget: int,
 ) -> AttributeMap:
-    """Per-index attributes for the first ``MAX_TOOL_DEFINITIONS_PER_SPAN`` tools.
+    """Per-index attributes for as many tools as ``attr_budget`` affords.
 
     ``key_for`` builds a vocabulary's key from the tool's index and the field
-    name, so each mapper keeps its own naming while sharing the cap.
+    name, so each mapper keeps its own naming while sharing the budget. One tool
+    always keeps its detail, so the family stays legible even when many
+    vocabularies split the ceiling.
     """
+    max_tools = max(attr_budget // max(len(extractors), 1), 1)
     return drop_none(
         {
             key_for(idx, suffix): extract(tool)
-            for idx, tool in enumerate(tools[:MAX_TOOL_DEFINITIONS_PER_SPAN])
+            for idx, tool in enumerate(tools[:max_tools])
             for suffix, extract in extractors.items()
         }
     )

--- a/litellm/integrations/otel/mappers/utils.py
+++ b/litellm/integrations/otel/mappers/utils.py
@@ -6,15 +6,45 @@ they live in one place.
 """
 
 import json
-from typing import Callable, Mapping, Sequence
+from typing import Callable, Final, Mapping, Sequence
 
 from litellm.integrations.otel.mappers.base import AttributeMap, AttrValue
-from litellm.integrations.otel.model.payloads import LLMCallSpanData
+from litellm.integrations.otel.model.payloads import LLMCallSpanData, ToolDefinition
+
+MAX_TOOL_DEFINITIONS_PER_SPAN: Final = 8
+"""How many declared tools get their definition spelled out on a span.
+
+Tool definitions are an unbounded attribute family: one entry per declared
+tool, per field, per active vocabulary. Agentic clients declare hundreds, which
+overruns the OTel SDK's default 128-attribute span limit. That limit evicts
+oldest-first, so an uncapped family silently destroys the core ``gen_ai.*``
+attributes written before it. Capping the family keeps core telemetry intact;
+requests declaring fewer tools than this keep full per-tool detail.
+"""
 
 
 def drop_none(values: Mapping[str, AttrValue | None]) -> AttributeMap:
     """Return ``values`` with ``None``-valued entries removed."""
     return {k: v for k, v in values.items() if v is not None}
+
+
+def tool_definition_attrs(
+    key_for: Callable[[int, str], str],
+    tools: Sequence[ToolDefinition],
+    extractors: Mapping[str, Callable[[ToolDefinition], AttrValue | None]],
+) -> AttributeMap:
+    """Per-index attributes for the first ``MAX_TOOL_DEFINITIONS_PER_SPAN`` tools.
+
+    ``key_for`` builds a vocabulary's key from the tool's index and the field
+    name, so each mapper keeps its own naming while sharing the cap.
+    """
+    return drop_none(
+        {
+            key_for(idx, suffix): extract(tool)
+            for idx, tool in enumerate(tools[:MAX_TOOL_DEFINITIONS_PER_SPAN])
+            for suffix, extract in extractors.items()
+        }
+    )
 
 
 def collect(table: Mapping[str, Callable], source: object) -> AttributeMap:

--- a/litellm/integrations/otel/model/semconv.py
+++ b/litellm/integrations/otel/model/semconv.py
@@ -233,6 +233,7 @@ class LiteLLM:
     # ``litellm_params.model``), distinct from the user-facing ``gen_ai.request.model``.
     PROVIDER_MODEL: Final = "litellm.provider.model"
     REQUEST_STREAMING: Final = "litellm.request.streaming"
+    TOOLS_DECLARED: Final = "litellm.request.tools.declared"
     GUARDRAIL_NAME: Final = "litellm.guardrail.name"
     GUARDRAIL_MODE: Final = "litellm.guardrail.mode"
     GUARDRAIL_STATUS: Final = "litellm.guardrail.status"

--- a/tests/test_litellm/integrations/otel/test_otel_v2_emitter.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_emitter.py
@@ -305,3 +305,68 @@ def test_guardrail_success_span_is_unset():
     )
     (span,) = exporter.get_finished_spans()
     assert span.status.status_code is StatusCode.UNSET
+
+
+def _tools_payload(count):
+    """A request declaring ``count`` tools, in the chat-completion shape."""
+    return _payload(
+        model_parameters={
+            "temperature": 0.7,
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": f"tool_{i}",
+                        "description": f"description for tool {i}",
+                        "parameters": {"type": "object", "properties": {}},
+                    },
+                }
+                for i in range(count)
+            ],
+        }
+    )
+
+
+def test_many_tools_do_not_evict_core_attributes():
+    """Tool definitions must never crowd core telemetry off the span.
+
+    An agentic client declares hundreds of tools. Spelling each one out as
+    per-index attributes overruns the OTel SDK's 128-attribute span limit,
+    which evicts oldest-first and so destroys the ``gen_ai.*`` attributes
+    written before it. Capping the tool family keeps the core intact.
+    """
+    engine, exporter = _engine()
+    data = LLMCallSpanData.from_standard_logging_payload(_tools_payload(127))
+    engine.emit(SpanRole.LLM_CALL, data)
+    (span,) = exporter.get_finished_spans()
+    a = span.attributes
+
+    assert a[GenAI.REQUEST_MODEL] == "gpt-4o"
+    assert a[GenAI.PROVIDER_NAME] == "openai"
+    assert a[GenAI.USAGE_INPUT_TOKENS] == 10
+    assert a[GenAI.USAGE_OUTPUT_TOKENS] == 5
+    assert a[GenAI.RESPONSE_FINISH_REASONS] == ("stop",)
+    assert a[f"{LiteLLM.COST_PREFIX}total"] == 0.002
+    assert a["gen_ai.usage.prompt_tokens"] == 10
+
+    assert span.dropped_attributes == 0
+    assert a[LiteLLM.TOOLS_DECLARED] == 127
+    assert a["gen_ai.tool.0.name"] == "tool_0"
+    assert "gen_ai.tool.126.name" not in a
+    assert "llm.request.functions.126.name" not in a
+
+
+def test_tool_definitions_kept_in_full_below_the_cap():
+    """A handful of tools keeps full per-index detail in both vocabularies."""
+    engine, exporter = _engine()
+    data = LLMCallSpanData.from_standard_logging_payload(_tools_payload(3))
+    engine.emit(SpanRole.LLM_CALL, data)
+    (span,) = exporter.get_finished_spans()
+    a = span.attributes
+
+    assert a[LiteLLM.TOOLS_DECLARED] == 3
+    for idx in range(3):
+        assert a[f"gen_ai.tool.{idx}.name"] == f"tool_{idx}"
+        assert a[f"gen_ai.tool.{idx}.description"] == f"description for tool {idx}"
+        assert a[f"gen_ai.tool.{idx}.parameters"]
+        assert a[f"llm.request.functions.{idx}.name"] == f"tool_{idx}"

--- a/tests/test_litellm/integrations/otel/test_otel_v2_emitter.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_emitter.py
@@ -370,3 +370,32 @@ def test_tool_definitions_kept_in_full_below_the_cap():
         assert a[f"gen_ai.tool.{idx}.description"] == f"description for tool {idx}"
         assert a[f"gen_ai.tool.{idx}.parameters"]
         assert a[f"llm.request.functions.{idx}.name"] == f"tool_{idx}"
+
+
+def test_many_tools_do_not_evict_core_attributes_with_vendor_mappers():
+    """The cap has to hold for every vocabulary that emits tool definitions.
+
+    Arize and Phoenix layer the OpenInference vocabulary on top of the default
+    two, so its own per-tool family would otherwise reintroduce the eviction
+    that the cap exists to prevent.
+    """
+    cfg = OpenTelemetryV2Config(
+        exporter="in_memory",
+        legacy_compat=True,
+        mapper_names=["genai", "openinference"],
+    )
+    provider, exporter = providers.in_memory_provider(cfg)
+    engine = SpanEmitter(providers.get_tracer(provider, "litellm-test"), cfg)
+    engine.emit(
+        SpanRole.LLM_CALL,
+        LLMCallSpanData.from_standard_logging_payload(_tools_payload(127)),
+    )
+    (span,) = exporter.get_finished_spans()
+    a = span.attributes
+
+    assert a[GenAI.REQUEST_MODEL] == "gpt-4o"
+    assert a[GenAI.USAGE_INPUT_TOKENS] == 10
+    assert a[LiteLLM.TOOLS_DECLARED] == 127
+    assert span.dropped_attributes == 0
+    assert a["llm.tools.0.tool.name"] == "tool_0"
+    assert "llm.tools.126.tool.name" not in a

--- a/tests/test_litellm/integrations/otel/test_otel_v2_emitter.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_emitter.py
@@ -17,6 +17,9 @@ from litellm.integrations.otel.plumbing import context as ctx_mod  # noqa: E402
 from litellm.integrations.otel.plumbing import providers  # noqa: E402
 from litellm.integrations.otel.emitter import SpanEmitter  # noqa: E402
 from litellm.integrations.otel.emitter import stamp_error  # noqa: E402
+from litellm.integrations.otel.mappers.utils import (  # noqa: E402
+    MAX_TOOL_DEFINITION_ATTRS_PER_SPAN,
+)
 from litellm.integrations.otel.model.payloads import (  # noqa: E402
     GuardrailSpanData,
     LLMCallSpanData,
@@ -372,30 +375,68 @@ def test_tool_definitions_kept_in_full_below_the_cap():
         assert a[f"llm.request.functions.{idx}.name"] == f"tool_{idx}"
 
 
-def test_many_tools_do_not_evict_core_attributes_with_vendor_mappers():
-    """The cap has to hold for every vocabulary that emits tool definitions.
-
-    Arize and Phoenix layer the OpenInference vocabulary on top of the default
-    two, so its own per-tool family would otherwise reintroduce the eviction
-    that the cap exists to prevent.
-    """
+def _tool_span(mapper_names, tool_count):
+    """The exported LLM-call span for ``mapper_names`` and ``tool_count`` tools."""
     cfg = OpenTelemetryV2Config(
         exporter="in_memory",
         legacy_compat=True,
-        mapper_names=["genai", "openinference"],
+        mapper_names=list(mapper_names),
     )
     provider, exporter = providers.in_memory_provider(cfg)
     engine = SpanEmitter(providers.get_tracer(provider, "litellm-test"), cfg)
     engine.emit(
         SpanRole.LLM_CALL,
-        LLMCallSpanData.from_standard_logging_payload(_tools_payload(127)),
+        LLMCallSpanData.from_standard_logging_payload(_tools_payload(tool_count)),
     )
     (span,) = exporter.get_finished_spans()
+    return span
+
+
+def _tool_definition_keys(attributes):
+    return [
+        key
+        for key in attributes
+        if key.startswith(("gen_ai.tool.", "llm.request.functions.", "llm.tools."))
+    ]
+
+
+@pytest.mark.parametrize(
+    "mapper_names",
+    [
+        ["genai"],
+        ["genai", "openinference"],
+        ["genai", "openinference", "langfuse", "weave", "langtrace"],
+    ],
+)
+def test_tool_definitions_stay_within_one_span_wide_budget(mapper_names):
+    """Every supported composition has to leave core telemetry on the span.
+
+    Each vocabulary spells the same tools out under its own keys, so an
+    allowance handed to each mapper separately multiplies by the number of
+    configured vocabularies and reaches the attribute limit again. Arize and
+    Phoenix already layer OpenInference on top of the default two, and every
+    vendor vocabulary can be listed at once. One budget shared across them all
+    is what keeps the total bounded.
+    """
+    span = _tool_span(mapper_names, 127)
     a = span.attributes
 
-    assert a[GenAI.REQUEST_MODEL] == "gpt-4o"
-    assert a[GenAI.USAGE_INPUT_TOKENS] == 10
-    assert a[LiteLLM.TOOLS_DECLARED] == 127
     assert span.dropped_attributes == 0
+    assert a[GenAI.REQUEST_MODEL] == "gpt-4o"
+    assert a[GenAI.PROVIDER_NAME] == "openai"
+    assert a[GenAI.USAGE_INPUT_TOKENS] == 10
+    assert a[GenAI.USAGE_OUTPUT_TOKENS] == 5
+    assert a[f"{LiteLLM.COST_PREFIX}total"] == 0.002
+    assert a[LiteLLM.TOOLS_DECLARED] == 127
+
+    emitted = _tool_definition_keys(a)
+    assert emitted, "some tool detail should survive in every composition"
+    assert len(emitted) <= MAX_TOOL_DEFINITION_ATTRS_PER_SPAN
+
+
+def test_vendor_tool_definitions_are_truncated_not_dropped():
+    """The OpenInference vocabulary keeps its leading tools and loses the tail."""
+    a = _tool_span(["genai", "openinference"], 127).attributes
     assert a["llm.tools.0.tool.name"] == "tool_0"
+    assert a["llm.tools.0.tool.json_schema"]
     assert "llm.tools.126.tool.name" not in a


### PR DESCRIPTION
## TLDR

Problem this solves:

- Agent requests lose every `gen_ai.*` attribute on the LLM span
- Model, tokens, cost and finish reason silently vanish from traces
- Tool definitions overrun the OTel 128-attribute span limit
- The limit evicts oldest-first, so core telemetry dies first

How it solves it:

- Reserve a quarter of the span for tool detail, shared by every vocabulary
- Split that ceiling across the vocabularies that are actually configured
- Carry the declared total so truncation is visible, not silent
- Small requests keep full per-tool detail, unchanged

## Relevant issues

## Linear ticket

Resolves LIT-4840

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Every capture below is one real request through a local proxy on port 4840 against a real OpenAI model, billed at 3412 prompt tokens each, sent with a virtual key scoped to a team so the span carries the identity attributes a real deployment carries. The request declares 127 tools, matching the trace in the ticket. `LITELLM_OTEL_V2=true` with the console exporter, so the exported span is read straight out of the proxy's own stdout, at the SDK's default `SpanLimits`.

Setup, once:

```bash
docker run -d --name litfix-4840-pg -e POSTGRES_PASSWORD=litellm -e POSTGRES_USER=litellm \
  -e POSTGRES_DB=litellm -p 6273:5432 postgres:16
prisma db push --schema litellm/proxy/schema.prisma --accept-data-loss --skip-generate

TEAM_ID=$(curl -s -X POST http://127.0.0.1:4840/team/new \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d '{"team_alias":"agent-platform"}' | jq -r .team_id)
VKEY=$(curl -s -X POST http://127.0.0.1:4840/key/generate \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H 'Content-Type: application/json' \
  -d "{\"team_id\":\"$TEAM_ID\",\"key_alias\":\"coding-agent\",\"user_id\":\"agent-user-1\",\"models\":[\"gpt-5.1\"]}" | jq -r .key)
```

The request, in every run:

```bash
curl -s -m 120 -X POST http://127.0.0.1:4840/v1/chat/completions \
  -H "Authorization: Bearer $VKEY" -H 'Content-Type: application/json' \
  -d @req_agent.json -o /dev/null -w 'http=%{http_code}\n'
# http=200
```

`req_agent.json` is a normal chat completion carrying `temperature`, `top_p`, `max_tokens`, `seed`, a `user`, and 127 function tools named `tool_0` through `tool_126`.

### 1. The reported bug, on `litellm_internal_staging`

Default config, so `genai` plus `legacy` as `legacy_compat` ships it:

```
span: chat gpt-5.1   attrs=128
  tool-definition attributes = 128
  first attribute key        = llm.request.functions.84.description
  gen_ai.request.model             = *** ABSENT ***
  gen_ai.provider.name             = *** ABSENT ***
  gen_ai.usage.input_tokens        = *** ABSENT ***
  gen_ai.usage.output_tokens       = *** ABSENT ***
  gen_ai.response.finish_reasons   = *** ABSENT ***
  litellm.cost.total               = *** ABSENT ***
```

All 128 surviving attributes are tool schemas and the surviving range starts mid-list, which is the signature of oldest-first eviction. This is the ticket's production trace reproduced end to end.

### 2. Same request, same config, on this branch

```
span: chat gpt-5.1   attrs=66
  tool-definition attributes = 30
  first attribute key        = litellm.team.id
  gen_ai.request.model             = gpt-5.1
  gen_ai.provider.name             = openai
  gen_ai.usage.input_tokens        = 3412
  gen_ai.usage.output_tokens       = 10
  gen_ai.response.finish_reasons   = ['stop']
  litellm.cost.total               = 0.004365
  litellm.request.tools.declared   = 127
```

62 attribute slots to spare, every core key intact, and the declared total says the detail was truncated.

### 3. Why a per-mapper cap was not enough

Greptile flagged that a cap applied per mapper still multiplies by the number of active vocabularies. That is exactly right, and it reproduces live. Same request, with every vendor vocabulary configured:

```yaml
callback_settings:
  otel:
    mapper_names: ["genai", "openinference", "langfuse", "weave", "langtrace"]
```

On commit b17e85b, the per-mapper cap:

```
span: chat gpt-5.1   attrs=128
  tool-definition attributes = 72
  first attribute key        = gen_ai.request.temperature
  gen_ai.request.model             = *** ABSENT ***
  gen_ai.provider.name             = *** ABSENT ***
  litellm.request.tools.declared   = 127
```

Three vocabularies spell the same tools out under three key families, 8 tools times 3 fields times 3 vocabularies, and the span is back at the limit with the model and provider evicted again.

### 4. The same worst case on this branch

```
span: chat gpt-5.1   attrs=91
  tool-definition attributes = 27
  first attribute key        = litellm.team.id
  gen_ai.request.model             = gpt-5.1
  gen_ai.provider.name             = openai
  gen_ai.usage.input_tokens        = 3412
  gen_ai.usage.output_tokens       = 10
  litellm.cost.total               = 0.000621
  litellm.request.tools.declared   = 127
```

37 slots to spare with every vocabulary in the registry active at once.

## Type

🐛 Bug Fix

## Changes

Three mappers each expanded the request's tool list into per-index span attributes with no bound: `gen_ai.tool.<idx>.{name,description,parameters}` in `mappers/genai.py`, `llm.request.functions.<idx>.{name,description,parameters}` in `mappers/legacy.py`, and `llm.tools.<idx>.tool.{name,description,json_schema}` in `mappers/openinference.py`, which Arize and Phoenix layer on top of the other two. Since `legacy_compat` defaults on, two families are live for every OTel v2 user, so a request declaring 127 tools produced roughly 500 attributes against a 128-attribute limit. `emitter.py` sets attributes in mapper order and the SDK's `BoundedAttributes` evicts oldest-first, so the canonical `gen_ai.*` set written first was always the first thing discarded.

The bound is span-wide rather than per-mapper. `mappers/utils.py` reserves a quarter of the default span attribute limit for tool detail, and `resolve_mappers` splits that ceiling across the distinct vocabularies that actually spell tools out, handing each one its share at construction time. A vocabulary that emits no tool definitions takes nothing, so the total the family can claim is fixed no matter how many are configured, and the arithmetic no longer depends on which combination an operator picked. The genai mapper also stamps `litellm.request.tools.declared` with the full count so a consumer can tell the detail was capped.

Registration is now split in two, `_TOOL_DEFINITION_MAPPERS` and `_PLAIN_MAPPERS`, so it is a compile-time decision whether a new vocabulary draws on the shared budget rather than something a future mapper can forget.

Raising `SpanLimits` was considered and rejected: it moves the cliff rather than removing it, backends enforce their own attribute limits downstream, and emitting hundreds of JSON schemas per span is a storage cost on exactly the agentic traffic that hits this.

## QA runbook

The regression test drives the real mapper chain through a real `TracerProvider` at default `SpanLimits` and a real exporter, parametrized over one, two and every vocabulary, asserting nothing is dropped, the core keys survive, and the tool family stays inside the span-wide ceiling. Mutating `tool_attr_budget` back to a per-mapper allowance fails all three cases.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
