### PR TITLE
test(e2e): cover router retry behavior across failure classes

### DIFF
--- a/tests/e2e/router/test_reliability_retries_e2e.py
+++ b/tests/e2e/router/test_reliability_retries_e2e.py
@@ -1,0 +1,403 @@
+"""Live e2e: retries absorb a failing deployment inside a model group.
+
+Every test registers a model group holding two REAL deployments: one that always
+fails in a specific way, and a healthy `gpt-5.5`. Each test first drives the group
+with retries switched off until the failing deployment answers, which pins the
+failure class the rest of the test is about, then turns retries on and drives it
+until the proxy reports a retry, requiring that every response in the meantime was
+a real completion. That is the product promise this covers: a caller of a group
+that contains a broken deployment never sees the breakage.
+
+Each failure is produced by a real deployment, never a mock:
+
+- 5xx        an api_base nothing listens on, which the gateway surfaces as a 500
+- timeout    a 1ms deadline the real backend always exceeds (408)
+- 429        a deployment pointed back at this proxy with a virtual key whose
+             rpm limit is 0, so the upstream really does rate-limit it. The key is
+             polled until it answers 429 before any traffic runs, because a key
+             that has not propagated yet answers 401, and a 401 is retryable too
+- auth       a deliberately wrong api_key, which the real OpenAI API rejects (401)
+- context    a small-context deployment (gpt-3.5-turbo, 16385 tokens) plus a prompt
+             that exceeds it, which the real OpenAI API rejects
+
+The 5xx case rides the flat `num_retries`; the others ride the router's
+`model_group_retry_policy`, the per-exception-class retry budget. For the
+context-window case that policy is what makes the failure retryable at all, since
+the provider's 400 is otherwise terminal.
+
+Cooldowns are disabled on the failing deployment (`cooldown_time: 0`) so the
+behavior under test is the retry loop alone. The output budget is roomy for the
+same reason the assertions do not look at message content: gpt-5.5 spends output
+tokens on reasoning, and a tight cap makes the provider itself reject the call.
+
+The deployment is re-picked at random on every attempt, so both bounds here are
+sized to make a correct build failing by chance negligible rather than merely
+unlikely. With two deployments each pick is even, so across `MAX_REQUESTS` = 24
+requests the odds of never once landing on the failing deployment are 2**-24,
+about 6e-8, and with `RETRY_BUDGET` = 24 retries the odds of a single request
+exhausting them all on the failing deployment are 2**-25. Biasing selection toward
+the failing deployment would trade one of those risks for the other, since the
+same bias that makes the first attempt fail also makes the rescue less likely,
+so the bounds are raised instead. Both bounds are ceilings: a typical run needs
+two requests and two attempts.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from complexity_router_client import ComplexityRouterClient
+from e2e_config import CHEAP_OPENAI_MODEL, PROXY_BASE_URL, unique_marker
+from e2e_http import NoBody, StreamingResponse, Success, unwrap
+from lifecycle import ResourceManager
+from models import (
+    ChatBody,
+    ChatMessage,
+    ChatResponse,
+    KeyGenerateBody,
+    LiteLLMParamsBody,
+    ModelNewResponse,
+    ModelsListResponse,
+)
+from proxy_client import ProxyClient
+from reliability_support import REAL_KEY, REAL_MODEL
+
+pytestmark = pytest.mark.e2e
+
+UNREACHABLE_BASE = "http://127.0.0.1:9/v1"
+SMALL_CONTEXT_MODEL = "openai/gpt-3.5-turbo"
+OVERSIZED_PROMPT = "word " * 20000
+RETRY_BUDGET = 24
+MAX_REQUESTS = 24
+MAX_TOKENS = 256
+KEY_POLL_INTERVAL = 1.0
+
+
+class RetryDeploymentParams(LiteLLMParamsBody):
+    """Deployment params plus the router's per-deployment `cooldown_time`.
+
+    A zero cooldown keeps the router from taking the failing deployment out of
+    rotation mid-test, so what the assertions see is the retry loop and nothing
+    else."""
+
+    cooldown_time: float = 0.0
+
+
+class RetryPolicyBody(BaseModel):
+    """The router's per-exception retry counts, one field per exception class the
+    tests exercise. Aliased to the router's wire names."""
+
+    authentication: int | None = Field(default=None, serialization_alias="AuthenticationErrorRetries")
+    timeout: int | None = Field(default=None, serialization_alias="TimeoutErrorRetries")
+    rate_limit: int | None = Field(default=None, serialization_alias="RateLimitErrorRetries")
+    bad_request: int | None = Field(default=None, serialization_alias="BadRequestErrorRetries")
+
+
+class RetryRouterSettings(BaseModel):
+    """The `router_settings_override` slice these tests drive: a flat retry count,
+    or a per-model-group retry policy keyed by exception class."""
+
+    num_retries: int | None = None
+    model_group_retry_policy: dict[str, RetryPolicyBody] | None = None
+
+
+class RetryChatBody(ChatBody):
+    """A /chat/completions body carrying the retry-only router override."""
+
+    router_settings_override: RetryRouterSettings
+
+
+class RetryModelNewBody(BaseModel):
+    """POST /model/new body whose litellm_params carry `cooldown_time`."""
+
+    model_config = ConfigDict(protected_namespaces=())
+
+    model_name: str
+    litellm_params: RetryDeploymentParams
+
+
+NO_RETRIES = RetryRouterSettings(num_retries=0)
+
+
+def _await_servable(proxy: ProxyClient, model_name: str) -> None:
+    deadline = time.monotonic() + proxy.poll_timeout
+    while time.monotonic() < deadline:
+        listed = proxy.transport.get(
+            "/v1/models",
+            headers=proxy.transport.master,
+            params=NoBody(),
+            response_type=ModelsListResponse,
+        )
+        if isinstance(listed, Success) and any(entry.id == model_name for entry in listed.data.data):
+            return
+        time.sleep(proxy.poll_interval)
+    raise AssertionError(f"model {model_name!r} never became servable on the data plane")
+
+
+def _register(proxy: ProxyClient, model_name: str, params: RetryDeploymentParams) -> str:
+    model_id = unwrap(
+        proxy.transport.post(
+            "/model/new",
+            headers=proxy.transport.master,
+            json=RetryModelNewBody(model_name=model_name, litellm_params=params),
+            response_type=ModelNewResponse,
+        )
+    ).model_id
+    _await_servable(proxy, model_name)
+    return model_id
+
+
+def _group_with_failing_deployment(
+    proxy: ProxyClient, resources: ResourceManager, label: str, failing: RetryDeploymentParams
+) -> tuple[str, str]:
+    """Register a model group holding `failing` alongside a healthy gpt-5.5, and
+    return the group name and the healthy deployment's model_id."""
+    group = f"reliability-retry-{label}-{unique_marker()}"
+    failing_id = _register(proxy, group, failing)
+    resources.defer(lambda: proxy.delete_model(failing_id))
+    healthy_id = _register(proxy, group, RetryDeploymentParams(model=REAL_MODEL, api_key=REAL_KEY))
+    resources.defer(lambda: proxy.delete_model(healthy_id))
+    return group, healthy_id
+
+
+def _chat(
+    proxy: ProxyClient, key: str, group: str, settings: RetryRouterSettings, content: str
+) -> StreamingResponse:
+    return proxy.transport.send(
+        "/chat/completions",
+        headers=proxy.transport.bearer(key),
+        json=RetryChatBody(
+            model=group,
+            messages=[ChatMessage(role="user", content=content)],
+            max_tokens=MAX_TOKENS,
+            router_settings_override=settings,
+        ),
+    )
+
+
+def _assert_real_completion(resp: StreamingResponse) -> None:
+    """The body is a completion the provider actually produced: a chat-completion
+    id, a choice, and usage the gateway billed. Content is not asserted because a
+    reasoning model can spend a small max_tokens budget without emitting text."""
+    try:
+        parsed = ChatResponse.model_validate_json(resp.body)
+    except ValidationError as exc:
+        raise AssertionError(f"expected a chat completion body, got: {resp.body[:300]}") from exc
+    assert parsed.id and parsed.choices, f"expected a completion with choices, got: {resp.body[:300]}"
+    assert parsed.usage is not None and (parsed.usage.prompt_tokens or 0) > 0, (
+        f"expected billed prompt tokens from a real provider call, got: {resp.body[:300]}"
+    )
+
+
+def _await_rate_limited_key(proxy: ProxyClient, key: str) -> None:
+    """Block until `key` is live on the data plane and really answers 429.
+
+    A key created a moment ago can answer 401 until it propagates, and a 401 is
+    retryable as well, so a test that started driving traffic straight away could
+    watch a retry absorb an auth failure and call it a rate limit."""
+    deadline = time.monotonic() + proxy.poll_timeout
+    last = ""
+    while time.monotonic() < deadline:
+        resp = proxy.transport.send(
+            "/chat/completions",
+            headers=proxy.transport.bearer(key),
+            json=ChatBody(
+                model=CHEAP_OPENAI_MODEL,
+                messages=[ChatMessage(role="user", content=f"say hi {unique_marker()}")],
+                max_tokens=MAX_TOKENS,
+            ),
+        )
+        if resp.status_code == 429 and "rate limit" in resp.body.lower():
+            return
+        last = f"{resp.status_code}: {resp.body[:300]}"
+        time.sleep(KEY_POLL_INTERVAL)
+    raise AssertionError(f"the rpm-limited key never answered a rate limit within {proxy.poll_timeout}s; last was {last}")
+
+
+def _observe_raw_failure(
+    proxy: ProxyClient, key: str, group: str, expected_status: int, expected_error: str, prompt: str
+) -> None:
+    """Drive the group with retries off until the failing deployment answers, and
+    pin what it answered.
+
+    This is what ties a test to its registry cell: without it an observed retry
+    only proves that something in the group failed, and any retryable failure
+    would satisfy the assertion equally well."""
+    for _ in range(MAX_REQUESTS):
+        resp = _chat(proxy, key, group, NO_RETRIES, f"{prompt} {unique_marker()}")
+        if resp.status_code == 200:
+            _assert_real_completion(resp)
+            continue
+        assert resp.status_code == expected_status, (
+            f"the failing deployment in {group!r} should answer {expected_status} with retries off, "
+            f"got {resp.status_code}: {resp.body[:300]}"
+        )
+        assert expected_error in resp.body, (
+            f"expected {expected_error!r} in the failure {group!r} absorbs, got: {resp.body[:300]}"
+        )
+        return
+    raise AssertionError(
+        f"{MAX_REQUESTS} requests to {group!r} with retries off all succeeded; the failing deployment "
+        f"was never selected, so the failure class under test was never established"
+    )
+
+
+def _drive_until_rescued_by_retry(
+    proxy: ProxyClient,
+    key: str,
+    group: str,
+    settings: RetryRouterSettings,
+    healthy_id: str,
+    prompt: str = "say hi",
+) -> None:
+    """Send real traffic at `group` until the gateway reports it retried, failing
+    if any response along the way was not a real completion.
+
+    The router picks a deployment at random per attempt, so which request first
+    lands on the failing deployment is not fixed; what is fixed is that no caller
+    ever sees the failure, and that the request the retry rescued was served by
+    the healthy deployment."""
+    for _ in range(MAX_REQUESTS):
+        resp = _chat(proxy, key, group, settings, f"{prompt} {unique_marker()}")
+        assert resp.status_code == 200, (
+            f"a group holding a failing deployment must still answer 200, got {resp.status_code}: {resp.body[:300]}"
+        )
+        _assert_real_completion(resp)
+        attempted = resp.headers.get("x-litellm-attempted-retries")
+        assert attempted is not None, "response is missing the x-litellm-attempted-retries header"
+        if int(attempted) >= 1:
+            assert resp.headers.get("x-litellm-model-id") == healthy_id, (
+                f"the retry should have landed on the healthy deployment {healthy_id!r}, "
+                f"got {resp.headers.get('x-litellm-model-id')!r}"
+            )
+            return
+    raise AssertionError(
+        f"{MAX_REQUESTS} requests to {group!r} never reported a retry; the failing deployment "
+        f"was never selected, or retries are not running"
+    )
+
+
+def _assert_retry_absorbs(
+    proxy: ProxyClient,
+    key: str,
+    group: str,
+    healthy_id: str,
+    settings: RetryRouterSettings,
+    expected_status: int,
+    expected_error: str,
+    prompt: str = "say hi",
+) -> None:
+    """Establish which failure the group produces, then show that retries hide it."""
+    _observe_raw_failure(proxy, key, group, expected_status, expected_error, prompt)
+    _drive_until_rescued_by_retry(proxy, key, group, settings, healthy_id, prompt)
+
+
+class TestReliabilityRetries:
+    @pytest.mark.covers("reliability.retry.5xx.succeeds_within_retries")
+    def test_5xx_succeeds_within_retries(
+        self, client: ComplexityRouterClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        group, healthy_id = _group_with_failing_deployment(
+            client.proxy,
+            resources,
+            "5xx",
+            RetryDeploymentParams(model=REAL_MODEL, api_key=REAL_KEY, api_base=UNREACHABLE_BASE),
+        )
+        _assert_retry_absorbs(
+            client.proxy,
+            scoped_key,
+            group,
+            healthy_id,
+            RetryRouterSettings(num_retries=RETRY_BUDGET),
+            expected_status=500,
+            expected_error="InternalServerError",
+        )
+
+    @pytest.mark.covers("reliability.retry.timeout.succeeds_within_retries")
+    def test_timeout_succeeds_within_retries(
+        self, client: ComplexityRouterClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        group, healthy_id = _group_with_failing_deployment(
+            client.proxy,
+            resources,
+            "timeout",
+            RetryDeploymentParams(model=REAL_MODEL, api_key=REAL_KEY, timeout=0.001),
+        )
+        _assert_retry_absorbs(
+            client.proxy,
+            scoped_key,
+            group,
+            healthy_id,
+            RetryRouterSettings(model_group_retry_policy={group: RetryPolicyBody(timeout=RETRY_BUDGET)}),
+            expected_status=408,
+            expected_error="Timeout",
+        )
+
+    @pytest.mark.covers("reliability.retry.429.succeeds_within_retries")
+    def test_429_succeeds_within_retries(
+        self, client: ComplexityRouterClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        throttled_key = client.proxy.generate_key(
+            KeyGenerateBody(models=[CHEAP_OPENAI_MODEL], rpm_limit=0, user_id="e2e-reliability-retry")
+        )
+        resources.defer(lambda: client.proxy.delete_key(throttled_key))
+        _await_rate_limited_key(client.proxy, throttled_key)
+        group, healthy_id = _group_with_failing_deployment(
+            client.proxy,
+            resources,
+            "429",
+            RetryDeploymentParams(model=REAL_MODEL, api_key=throttled_key, api_base=f"{PROXY_BASE_URL}/v1"),
+        )
+        _assert_retry_absorbs(
+            client.proxy,
+            scoped_key,
+            group,
+            healthy_id,
+            RetryRouterSettings(model_group_retry_policy={group: RetryPolicyBody(rate_limit=RETRY_BUDGET)}),
+            expected_status=429,
+            expected_error="RateLimitError",
+        )
+
+    @pytest.mark.covers("reliability.retry.auth.succeeds_within_retries")
+    def test_auth_succeeds_within_retries(
+        self, client: ComplexityRouterClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        group, healthy_id = _group_with_failing_deployment(
+            client.proxy,
+            resources,
+            "auth",
+            RetryDeploymentParams(model=REAL_MODEL, api_key=f"sk-invalid-{unique_marker()}"),
+        )
+        _assert_retry_absorbs(
+            client.proxy,
+            scoped_key,
+            group,
+            healthy_id,
+            RetryRouterSettings(model_group_retry_policy={group: RetryPolicyBody(authentication=RETRY_BUDGET)}),
+            expected_status=401,
+            expected_error="AuthenticationError",
+        )
+
+    @pytest.mark.covers("reliability.retry.context_window.succeeds_within_retries")
+    def test_context_window_succeeds_within_retries(
+        self, client: ComplexityRouterClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        group, healthy_id = _group_with_failing_deployment(
+            client.proxy,
+            resources,
+            "ctx",
+            RetryDeploymentParams(model=SMALL_CONTEXT_MODEL, api_key=REAL_KEY),
+        )
+        _assert_retry_absorbs(
+            client.proxy,
+            scoped_key,
+            group,
+            healthy_id,
+            RetryRouterSettings(model_group_retry_policy={group: RetryPolicyBody(bad_request=RETRY_BUDGET)}),
+            expected_status=400,
+            expected_error="ContextWindowExceededError",
+            prompt=OVERSIZED_PROMPT,
+        )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Router retry behavior had no live end-to-end coverage
- Five retry cells sat uncovered in the coverage registry
- A naive retry test passes even when no retry ran
- Retry policy per exception class was never exercised live

How it solves it:

- Five live tests, one per real failure class
- Each proves the failure first, then proves retries absorb it
- Every failure comes from a real deployment; no mocks
- Reliability registry coverage moves from 8/26 to 13/26

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR only adds tests, so the honest proof is the suite itself running green against a live proxy that talks to the real OpenAI API and spends real money on every rescued request. Captured at commit `0b52310097`, against a proxy started from `litellm/proxy/proxy_cli.py` with `store_model_in_db: true`, a redis cache, and `gpt-5.5` wired to `os.environ/OPENAI_API_KEY`

```
$ cd tests/e2e
$ set -a; source .env; set +a
$ PYTHONPATH=. LITELLM_PROXY_URL=http://localhost:4057 python -m pytest router/test_reliability_retries_e2e.py -v

============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /.../tests/e2e
configfile: pytest.ini
plugins: anyio-4.14.2
collecting ... collected 5 items

router/test_reliability_retries_e2e.py::TestReliabilityRetries::test_5xx_succeeds_within_retries PASSED [ 20%]
router/test_reliability_retries_e2e.py::TestReliabilityRetries::test_timeout_succeeds_within_retries PASSED [ 40%]
router/test_reliability_retries_e2e.py::TestReliabilityRetries::test_429_succeeds_within_retries PASSED [ 60%]
router/test_reliability_retries_e2e.py::TestReliabilityRetries::test_auth_succeeds_within_retries PASSED [ 80%]
router/test_reliability_retries_e2e.py::TestReliabilityRetries::test_context_window_succeeds_within_retries PASSED [100%]

============================== 5 passed in 61.14s (0:01:01) ==============================
```

The suite takes about 61s, up from about 31s in the first revision of this PR. The extra half minute is the phase that establishes each failure class before turning retries on, described under Changes. It buys the thing that makes these tests worth having, so please do not optimize it away

`basedpyright tests/e2e` reports 0 errors, and the coverage collector moves Reliability & Performance from `8/26 (30.8%)` to `13/26 (50.0%)`, exactly the five cells claimed here

### Mutation checks

A retry test that cannot fail is worse than no test, so each mutation below was applied by a script that asserts the target text exists and that the file content actually changed, exited 0, and was reverted from a backup with a diff confirming the restore

- Point the healthy deployment at the unreachable base as well, so the group has no working member: `5 failed in 3.84s`, every one of the five named FAILED
- Set the retry budget to zero everywhere: `5 failed in 8.89s`, again all five
- Swap the rpm-limited virtual key in the 429 test for an invalid one, so the deployment answers 401 instead of 429: `1 failed`, with the message `the failing deployment in 'reliability-retry-429-...' should answer 429 with retries off, got 401`. This mutation passed under the first revision of this PR, because a 401 is retryable too and the assertion only checked that some retry had happened. It fails now, which is what the failure-class phase exists to guarantee
- Replace the four retry policy wire names with a name the router ignores: `1 failed, 4 passed`. Only `test_context_window_succeeds_within_retries` died

That last result is reported as it happened rather than dressed up. LiteLLM's default retry budget already retries 401, 408 and 429, so for those three cells the per exception policy sets the budget instead of being what makes the retry happen at all; the context window case is the one where the policy is load bearing, since a provider 400 is otherwise terminal. The module docstring says exactly that

## Type

✅ Test

## Changes

Adds `tests/e2e/router/test_reliability_retries_e2e.py`, covering five coverage registry cells: `reliability.retry.5xx.succeeds_within_retries`, `reliability.retry.timeout.succeeds_within_retries`, `reliability.retry.429.succeeds_within_retries`, `reliability.retry.auth.succeeds_within_retries` and `reliability.retry.context_window.succeeds_within_retries`. Every test registers one model group holding two real deployments, a broken one and a healthy `gpt-5.5`, drives real traffic at the group, and tears both down through `resources.defer`. Nothing outside the new file changed; the request, override and `/model/new` body shapes it needs beyond the shared models are declared locally in the file

Each failure class is produced by a genuine deployment. The 5xx case points `api_base` at a port nothing listens on, which the gateway surfaces as a 500. The timeout case gives the deployment a 1ms deadline that the real backend always exceeds. The auth case ships a deliberately wrong `api_key` that the real OpenAI API rejects with a 401. The context window case registers `openai/gpt-3.5-turbo` next to `gpt-5.5` and sends a prompt of roughly 20k tokens, which the real API rejects against the smaller model's 16385 token limit while the larger one serves it

### Each test runs in two phases, and they must stay separate

The design is two phases per test, and collapsing them back into one is the review comment to resist. Phase one drives the group with retries switched off until the failing deployment is selected, and asserts what it answered: 500 `InternalServerError`, 408 `Timeout`, 429 `RateLimitError`, 401 `AuthenticationError`, or 400 `ContextWindowExceededError` depending on the cell. Phase two turns retries on and drives the group until the gateway reports one

Phase one is what ties each test to its registry cell. Without it, an observed retry only proves that something in the group failed, and any retryable failure would satisfy the assertion equally well; the timeout test would pass on an auth failure, and the 429 test would pass on anything at all that got retried. Phase two on its own measures the retry machinery; phase one is what says which failure the machinery absorbed

### Why the retry driver is shaped the way it is

`_drive_until_rescued_by_retry` looks more elaborate than a single request and a single assertion, and it has to be. The router picks a deployment at random on every attempt, so a request sent at a group holding one broken and one healthy deployment returns 200 whether or not a retry ever ran; roughly half of them never touch the broken deployment at all. A test that sent one request and asserted 200 would pass with retries switched off entirely, which is the vacuous pass this design exists to rule out

So the driver sends real traffic until the gateway reports `x-litellm-attempted-retries >= 1`, requires every response along the way to be a real completion carrying an id, a choice and billed prompt tokens, pins the rescued request's `x-litellm-model-id` to the healthy deployment so the retry is shown to have moved the traffic, and raises explicitly if the budget of requests runs out without a retry ever being observed. That raise is load bearing and should not be softened

Both bounds are sized so that a correct build failing by chance is negligible rather than merely unlikely. Each pick between two deployments is even, so across 24 requests the odds of never once landing on the failing deployment are 2**-24, about 6e-8, and with 24 retries the odds of one request exhausting them all on the failing deployment are 2**-25. Biasing selection toward the failing deployment was considered and rejected, since the same bias that makes the first attempt fail also makes the rescue less likely, which trades one flake for the other. Both numbers are ceilings; a typical run needs two requests and two attempts

Cooldowns are switched off on the failing deployment with `cooldown_time: 0` so the retry loop is the only thing under test. Message content is deliberately not asserted, because `gpt-5.5` spends output tokens on reasoning and can legitimately return an empty string; the assertion looks at billed usage instead

### The 429 deployment

Deployment level `rpm` is not a way to produce a retryable 429. With `rpm: 1` on a single deployment group the second call inside the window blocks for about a minute rather than erroring, and in a multi deployment group the exhausted deployment is quietly filtered out of selection, so no rate limit error is ever raised and there is nothing to retry

The test instead registers a deployment whose `api_base` points back at the proxy itself, authenticated with a virtual key created at `rpm_limit: 0`. Every call through that key is genuinely rate limited by the gateway's own limiter and comes back 429, so the outer router sees a real `RateLimitError` from its upstream. Chaining a gateway in front of a gateway is a supported deployment shape, the key is created and deleted by the test, and no mock is involved

Two guards make that failure class provable rather than assumed. The key is polled until it actually answers 429 with a rate limit message before any deployment is registered, because a key that has not yet propagated to the data plane answers 401, and a 401 is retryable as well. Then phase one asserts that the failure this group produces really is a 429 naming a `RateLimitError`. Without both, a retry observed in phase two could have been rescuing an auth failure, and the test would have claimed rate limit coverage it did not have

### Cooldown cells left uncovered, and why

Four cooldown cells were in scope and none of them ship here: `reliability.cooldown.5xx.trips_then_recovers`, `.429.`, `.auth.` and `.timeout.`. They are blocked by product defects rather than by test difficulty. Cooldown state is perfectly observable from outside the proxy, by weighting the failing deployment heavily and reading `x-litellm-model-id` on each response, and per deployment `cooldown_time` is honored, so short windows of 15 to 30 seconds are testable. A cooldown test was written, run and then deleted rather than weakened into something that would pass while documenting the broken behavior as correct

The first defect is that a 5xx or a timeout never cools a deployment down at all. Neither takes an immediate cooldown branch, since `litellm._should_retry` returns True for both 500 and 408, so they depend on the failure rate branch of `_should_cooldown_deployment`, which needs at least five requests for that deployment in the current minute. The counter never gets there. `increment_deployment_failures_for_current_minute` writes with `local_only=True, ttl=60` into the router's `InMemoryCache`, which is capped at 200 entries and evicts the earliest expiring entries first, so a 60 second counter is evicted before the next request reads it. Thirteen consecutive failures on one deployment inside the same second each logged the same thing

```
13:46:19 cooldown_handlers.py:195 - percent fails for deployment = c3c76871-..., percent fails = 1.0, num successes = 0, num fails = 1
13:46:19 cooldown_handlers.py:195 - percent fails for deployment = c3c76871-..., percent fails = 1.0, num successes = 0, num fails = 1
(11 more, identical)
```

Twenty five consecutive 500s left that deployment fully in rotation

The second defect is that a 429 or a 401 does get recorded as a cooldown, and the redis key `deployment:<id>:cooldown` holds the status, timestamp and window, yet the cooldown is only enforced on roughly a ten second cycle. `DualCache.async_batch_get_cache` throttles its redis read per key to `redis_batch_cache_expiry`, ten seconds by default, and the in memory copy is evicted in between, so requests that land in the gap see a healthy deployment. With the failing deployment weighted 200 to 1 against the healthy one, `cooldown_time: 15`, and one request every five seconds, traffic alternates

```
t=0.1   429   failure recorded, cooldown written
t=5.1   429   cooled deployment served again
t=11.2  200   healthy deployment
t=16.3  429
t=22.3  200   healthy deployment
t=27.4  429   cooldown refreshed at 16.3, should have been out until 31.3
t=38.2  429
t=43.3  429
t=48.4  429
```

The router log for that deployment id prints `cooldown deployments: ['<id>']` only at about 10.5 second intervals and returns an empty list on the requests in between, which lines up exactly with the throttled redis read. About half the traffic keeps hitting a deployment that is inside its cooldown window, so there is no honest way to assert that a cooled deployment stops receiving traffic

One smaller finding while wiring the retry policies: `RetryPolicy.InternalServerErrorRetries` is declared in `litellm/types/router.py` but never read by `get_num_retries_from_retry_policy`, so configuring it has no effect. The 5xx test uses the flat `num_retries` for that reason

## QA runbook

Prerequisites for every checklist below: a live proxy on `http://localhost:4000` started with `store_model_in_db: true` and a master key, `OPENAI_API_KEY` in the environment, and a `gpt-5.5` deployment already in the config. Each checklist mirrors the two phases of its test, raw failure first and rescue second. Two nuances a manual run will hit. Prompts must be unique per request, because the proxy's response cache will otherwise hand back the first answer and short circuit routing entirely. `max_tokens` must be roomy, around 256, because `gpt-5.5` spends output tokens on reasoning and the provider itself returns a 400 when the budget is too small to finish. Each run below registers two deployments under one group name; delete both with `POST /model/delete` when finished. Selection between the two deployments is random per attempt, so a step that expects the broken deployment may need repeating a few times

- tests/e2e/router/test_reliability_retries_e2e.py::TestReliabilityRetries::test_5xx_succeeds_within_retries - a group holding a deployment whose base URL refuses connections answers every caller, because retries move the request to the healthy deployment
  - [ ] Register the broken deployment: `curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model_name":"retry-5xx-demo","litellm_params":{"model":"openai/gpt-5.5","api_key":"os.environ/OPENAI_API_KEY","api_base":"http://127.0.0.1:9/v1","cooldown_time":0}}'` and keep the returned model id
  - [ ] Register the healthy deployment under the same group: same call without `api_base`, and keep that model id too
  - [ ] Establish the failure first, with retries off: send requests carrying `"router_settings_override":{"num_retries":0}` until one comes back non-200, and expect a 500 naming `InternalServerError` and a connection failure
  - [ ] Now turn retries on and send eight requests with unique prompts: `for i in $(seq 1 8); do curl -sS -D - -o /dev/null -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{\"model\":\"retry-5xx-demo\",\"messages\":[{\"role\":\"user\",\"content\":\"say hi $i-$RANDOM\"}],\"max_tokens\":256,\"router_settings_override\":{\"num_retries\":24}}" | grep -iE "^HTTP/|x-litellm-attempted-retries|x-litellm-model-id"; done`
  - [ ] Expect every response to be 200, and at least one to carry `x-litellm-attempted-retries: 1` or higher with `x-litellm-model-id` equal to the healthy deployment id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/router/test_reliability_retries_e2e.py::TestReliabilityRetries::test_timeout_succeeds_within_retries - a deployment with a 1ms deadline never reaches the caller, because the timeout retry policy sends the request to the healthy deployment
  - [ ] Register the timing out deployment: `curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model_name":"retry-timeout-demo","litellm_params":{"model":"openai/gpt-5.5","api_key":"os.environ/OPENAI_API_KEY","timeout":0.001,"cooldown_time":0}}'`
  - [ ] Register the healthy deployment under the same group: same call without `timeout`
  - [ ] Establish the failure first, with retries off: send requests carrying `"router_settings_override":{"num_retries":0}` until one comes back non-200, and expect a 408 naming a timeout
  - [ ] Now send eight requests carrying the timeout policy: body `{"model":"retry-timeout-demo","messages":[{"role":"user","content":"say hi <unique>"}],"max_tokens":256,"router_settings_override":{"model_group_retry_policy":{"retry-timeout-demo":{"TimeoutErrorRetries":24}}}}`
  - [ ] Expect every response to be 200, and at least one to carry `x-litellm-attempted-retries: 1` or higher with `x-litellm-model-id` equal to the healthy deployment id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/router/test_reliability_retries_e2e.py::TestReliabilityRetries::test_429_succeeds_within_retries - a deployment whose upstream really is rate limiting it never reaches the caller, because the rate limit retry policy reroutes to the healthy deployment
  - [ ] Create a virtual key that is rate limited to nothing: `curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"models":["gpt-5.5"],"rpm_limit":0}'`
  - [ ] Confirm the key is live and really throttled before going further: call `/v1/chat/completions` with that key and expect 429 naming the requests limit with current limit 0. A freshly created key can answer 401 for a moment, and a 401 would be retried too, so do not skip this step
  - [ ] Register the throttled deployment pointing back at this proxy: `curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model_name":"retry-429-demo","litellm_params":{"model":"openai/gpt-5.5","api_key":"<the rpm_limit 0 key>","api_base":"http://localhost:4000/v1","cooldown_time":0}}'`
  - [ ] Register the healthy deployment under the same group, with `api_key` set to `os.environ/OPENAI_API_KEY` and no `api_base`
  - [ ] Establish the failure first, with retries off: send requests carrying `"router_settings_override":{"num_retries":0}` until one comes back non-200, and expect a 429 naming `RateLimitError`
  - [ ] Now send eight requests carrying the rate limit policy: `"router_settings_override":{"model_group_retry_policy":{"retry-429-demo":{"RateLimitErrorRetries":24}}}`
  - [ ] Expect every response to be 200, and at least one to carry `x-litellm-attempted-retries: 1` or higher with `x-litellm-model-id` equal to the healthy deployment id
  - [ ] Delete the throttled key as well as both deployments
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/router/test_reliability_retries_e2e.py::TestReliabilityRetries::test_auth_succeeds_within_retries - a deployment carrying a wrong provider key never reaches the caller, because the authentication retry policy reroutes to the healthy deployment
  - [ ] Register the misconfigured deployment: `curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model_name":"retry-auth-demo","litellm_params":{"model":"openai/gpt-5.5","api_key":"sk-invalid-manual-check","cooldown_time":0}}'`
  - [ ] Register the healthy deployment under the same group with the real `os.environ/OPENAI_API_KEY`
  - [ ] Establish the failure first, with retries off: send requests carrying `"router_settings_override":{"num_retries":0}` until one comes back non-200, and expect a 401 naming `AuthenticationError` and an incorrect API key, which confirms the rejection comes from the real provider
  - [ ] Now send eight requests carrying the authentication policy: `"router_settings_override":{"model_group_retry_policy":{"retry-auth-demo":{"AuthenticationErrorRetries":24}}}`
  - [ ] Expect every response to be 200, and at least one to carry `x-litellm-attempted-retries: 1` or higher with `x-litellm-model-id` equal to the healthy deployment id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/router/test_reliability_retries_e2e.py::TestReliabilityRetries::test_context_window_succeeds_within_retries - a prompt too large for the small context deployment in a group is still answered, because the bad request retry policy sends it to the large context deployment
  - [ ] Register the small context deployment: `curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model_name":"retry-ctx-demo","litellm_params":{"model":"openai/gpt-3.5-turbo","api_key":"os.environ/OPENAI_API_KEY","cooldown_time":0}}'`
  - [ ] Register `openai/gpt-5.5` under the same group name
  - [ ] Build a prompt of roughly 20k tokens, for example 20000 repetitions of the word `word` plus a unique suffix
  - [ ] Establish the failure first, with retries off: send that prompt with `"router_settings_override":{"num_retries":0}` until one request comes back non-200, and expect a 400 naming `ContextWindowExceededError` and the 16385 token limit
  - [ ] Now send eight requests with the same oversized prompt and `"router_settings_override":{"model_group_retry_policy":{"retry-ctx-demo":{"BadRequestErrorRetries":24}}}`
  - [ ] Expect every response to be 200, and at least one to carry `x-litellm-attempted-retries: 1` or higher with `x-litellm-model-id` equal to the `gpt-5.5` deployment id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
