### PR TITLE
test(e2e): cover bedrock guardrail post-call and during-call hooks

### DIFF
--- a/tests/e2e/guardrails/test_bedrock_guardrail_hooks_e2e.py
+++ b/tests/e2e/guardrails/test_bedrock_guardrail_hooks_e2e.py
@@ -1,0 +1,167 @@
+"""Live e2e: the Bedrock guardrail at its two non-pre_call hook points.
+
+`test_bedrock_guardrail_e2e.py` covers pre_call. The same real AWS guardrail is
+wired here at `during_call` (async_moderation_hook, which scans the INPUT while
+the LLM call runs) and at `post_call` (async_post_call_success_hook, which scans
+only the model's OUTPUT).
+
+Each block is asserted through `provider_specific_fields.guardrail_mode`, so a
+test can never claim a hook point the gateway did not actually run. Each hook is
+also driven with the prompt the *other* hook catches, which is where the two
+differ in production: the denied word `cake` reaches the caller untouched under
+`during_call` (nothing scans the output) and is blocked under `post_call`.
+
+No AWS keys are passed: the gateway signs ApplyGuardrail and Converse with its
+own credentials, so only the region reference travels in the deployment body.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from pydantic import BaseModel
+
+from e2e_config import unique_marker
+from e2e_http import Result, Success, UnknownApiError
+from guardrails_client import BedrockGuardrailParamsBody, GuardrailMode, GuardrailsClient
+from lifecycle import ResourceManager
+from models import ChatResponse, LiteLLMParamsBody
+
+pytestmark = pytest.mark.e2e
+
+BEDROCK_BACKEND = "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+
+# The guardrail this suite points at denies the topic "bread" and the custom
+# words "bread" and "cake", on input and on output alike.
+DENIED_INPUT_PROMPT = "Give me a recipe for sourdough bread."
+
+# Carries no denied word or topic itself, so every input scan lets it through;
+# the answer the model writes is the denied word, so only an output scan catches
+# it. That asymmetry is what separates post_call from pre_call/during_call.
+DENIED_OUTPUT_PROMPT = (
+    "Reverse the letters of this string and reply with only the reversed string, nothing else: ekac"
+)
+DENIED_OUTPUT_WORD = "cake"
+
+
+class BlockMatch(BaseModel):
+    action: str | None = None
+
+
+class BlockAssessment(BaseModel):
+    policy: str | None = None
+    matches: list[BlockMatch] = []
+
+
+class BlockFields(BaseModel):
+    guardrail_name: str | None = None
+    guardrail_mode: str | None = None
+    assessments: list[BlockAssessment] = []
+
+
+class BlockError(BaseModel):
+    message: str
+    provider_specific_fields: BlockFields | None = None
+
+
+class GuardrailBlockBody(BaseModel):
+    """The 400 body the gateway returns when a bedrock guardrail intervenes."""
+
+    error: BlockError
+
+
+def _assert_blocked_by(result: Result[ChatResponse], *, name: str, mode: GuardrailMode) -> None:
+    match result:
+        case UnknownApiError(status_code=status, body=body):
+            assert status == 400, f"expected a guardrail block status, got {status}: {body[:400]}"
+            blocked = GuardrailBlockBody.model_validate_json(body)
+            fields = blocked.error.provider_specific_fields
+            assert fields is not None, f"block body carried no guardrail detail: {body[:400]}"
+            assert fields.guardrail_name == name, (
+                f"block came from guardrail {fields.guardrail_name!r}, expected {name!r}"
+            )
+            assert fields.guardrail_mode == mode, (
+                f"block ran at hook {fields.guardrail_mode!r}, expected {mode!r}"
+            )
+            assert any(
+                match.action == "BLOCKED" for assessment in fields.assessments for match in assessment.matches
+            ), f"block body reported no BLOCKED assessment: {body[:400]}"
+        case _:
+            pytest.fail(f"bedrock {mode} guardrail did not block; got {result}")
+
+
+def _assert_answered(result: Result[ChatResponse], *, contains: str) -> None:
+    match result:
+        case Success(data=response):
+            assert response.choices, f"model returned no choices: {response}"
+            message = response.choices[0].message
+            assert message is not None and message.content is not None, (
+                f"model returned no content: {response}"
+            )
+            content = message.content
+            assert contains in content.lower(), f"expected {contains!r} in the answer, got {content!r}"
+        case _:
+            pytest.fail(f"request should have been served, got {result}")
+
+
+class TestBedrockGuardrailHooks:
+    def _bedrock_model(self, client: GuardrailsClient, resources: ResourceManager) -> str:
+        model_name = f"e2e-bedrock-guard-backend-{unique_marker()}"
+        model_id = client.proxy.create_model(
+            model_name,
+            LiteLLMParamsBody(model=BEDROCK_BACKEND, aws_region_name="os.environ/AWS_REGION"),
+        )
+        resources.defer(lambda: client.proxy.delete_model(model_id))
+        return model_name
+
+    def _guardrail(self, client: GuardrailsClient, resources: ResourceManager, mode: GuardrailMode) -> str:
+        name = f"e2e-bedrock-{mode}-{unique_marker()}"
+        guardrail_id = client.register(
+            name,
+            BedrockGuardrailParamsBody(
+                mode=mode,
+                default_on=False,
+                guardrailIdentifier=os.environ["BEDROCK_GUARDRAIL_IDENTIFIER"],
+                guardrailVersion=os.environ["BEDROCK_GUARDRAIL_VERSION"],
+            ),
+        )
+        resources.defer(lambda: client.delete_guardrail(guardrail_id))
+        return name
+
+    @pytest.mark.covers(
+        "guardrail.bedrock.during.blocks",
+        exercised_on=["chat_completions"],
+    )
+    def test_bedrock_during_call_blocks_denied_input(
+        self, client: GuardrailsClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        model = self._bedrock_model(client, resources)
+        name = self._guardrail(client, resources, "during_call")
+
+        blocked = client.chat(scoped_key, model, DENIED_INPUT_PROMPT, guardrails=[name])
+        _assert_blocked_by(blocked, name=name, mode="during_call")
+
+        served = client.chat(scoped_key, model, DENIED_OUTPUT_PROMPT, guardrails=[name], max_tokens=64)
+        _assert_answered(served, contains=DENIED_OUTPUT_WORD)
+
+    @pytest.mark.covers(
+        "guardrail.bedrock.post_call.blocks",
+        exercised_on=["chat_completions"],
+    )
+    def test_bedrock_post_call_blocks_denied_output(
+        self, client: GuardrailsClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        model = self._bedrock_model(client, resources)
+        pre_call_name = self._guardrail(client, resources, "pre_call")
+        post_call_name = self._guardrail(client, resources, "post_call")
+
+        served = client.chat(
+            scoped_key, model, DENIED_OUTPUT_PROMPT, guardrails=[pre_call_name], max_tokens=64
+        )
+        _assert_answered(served, contains=DENIED_OUTPUT_WORD)
+
+        blocked = client.chat(
+            scoped_key, model, DENIED_OUTPUT_PROMPT, guardrails=[post_call_name], max_tokens=64
+        )
+        _assert_blocked_by(blocked, name=post_call_name, mode="post_call")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock guardrail only had e2e coverage at pre_call
- Registry cells for post_call and during hooks sat uncovered
- Nothing proved post_call actually inspects model output

How it solves it:

- Adds two live tests against a real AWS guardrail
- Asserts the gateway's reported hook point on every block
- Pairs each block with the other hook's prompt as control

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a test-only PR. Everything below runs against a live proxy holding real AWS credentials and a real provisioned Bedrock guardrail; every chat call is a real Bedrock Converse call plus a real ApplyGuardrail call, and nothing is mocked

All transcripts captured at commit `237655edddebaefee457a1004faec9c308c8b530`

### Setup, reproducible by hand

```
$ curl -sS -X POST http://localhost:4059/model/new \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model_name": "qa-bedrock-guard", "litellm_params": {"model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0", "aws_region_name": "os.environ/AWS_REGION"}}' \
    -o /tmp/r.json -w 'HTTP %{http_code}\n'; jq '.model_info.id' /tmp/r.json
HTTP 200
"0d78a471-7004-41e6-99ab-961a7807a02b"

$ curl -sS -X POST http://localhost:4059/key/generate \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"models": ["qa-bedrock-guard"]}' -o /tmp/k.json -w 'HTTP %{http_code}\n'; jq -r '.key' /tmp/k.json
HTTP 200
sk-<generated key>

$ curl -sS -X POST http://localhost:4059/guardrails \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"guardrail": {"guardrail_name": "qa-during_call", "litellm_params": {"guardrail": "bedrock", "mode": "during_call", "default_on": false, "guardrailIdentifier": "'"$BEDROCK_GUARDRAIL_IDENTIFIER"'", "guardrailVersion": "'"$BEDROCK_GUARDRAIL_VERSION"'"}}}' \
    -o /tmp/g.json -w 'HTTP %{http_code}\n'; jq -r '.guardrail_id' /tmp/g.json
HTTP 200
c751dd59-3ed4-46d6-a98c-f87c919b4b7b

$ curl -sS -X POST http://localhost:4059/guardrails \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"guardrail": {"guardrail_name": "qa-pre_call", "litellm_params": {"guardrail": "bedrock", "mode": "pre_call", "default_on": false, "guardrailIdentifier": "'"$BEDROCK_GUARDRAIL_IDENTIFIER"'", "guardrailVersion": "'"$BEDROCK_GUARDRAIL_VERSION"'"}}}' \
    -o /tmp/g.json -w 'HTTP %{http_code}\n'; jq -r '.guardrail_id' /tmp/g.json
HTTP 200
3bb4b51d-999e-47e9-a1f6-f4200863a9f9

$ curl -sS -X POST http://localhost:4059/guardrails \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"guardrail": {"guardrail_name": "qa-post_call", "litellm_params": {"guardrail": "bedrock", "mode": "post_call", "default_on": false, "guardrailIdentifier": "'"$BEDROCK_GUARDRAIL_IDENTIFIER"'", "guardrailVersion": "'"$BEDROCK_GUARDRAIL_VERSION"'"}}}' \
    -o /tmp/g.json -w 'HTTP %{http_code}\n'; jq -r '.guardrail_id' /tmp/g.json
HTTP 200
92989727-2aa6-4039-a087-d0f9180a111b
```

### 1. during_call blocks the denied input

The bread recipe trips the guardrail's input scan. Note `guardrail_mode` reads `during_call`, and both the topic policy and the word policy report `BLOCKED`

```
$ curl -sS -X POST http://localhost:4059/v1/chat/completions \
    -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
    -d '{"model": "qa-bedrock-guard", "messages": [{"role": "user", "content": "Give me a recipe for sourdough bread."}], "max_tokens": 16, "guardrails": ["qa-during_call"]}' \
    -o /tmp/c.json -w 'HTTP %{http_code}\n'; jq . /tmp/c.json
HTTP 400
{
    "error": {
        "message": "Violated guardrail policy",
        "type": "None",
        "param": "None",
        "code": "400",
        "provider_specific_fields": {
            "error": "Violated guardrail policy",
            "bedrock_guardrail_response": "<the guardrail's configured blocked message>",
            "guardrailIdentifier": "<identifier>",
            "guardrailVersion": "DRAFT",
            "assessments": [
                {
                    "policy": "topicPolicy",
                    "matches": [
                        {
                            "category": "topics",
                            "name": "bread",
                            "type": "DENY",
                            "action": "BLOCKED"
                        }
                    ]
                },
                {
                    "policy": "wordPolicy",
                    "matches": [
                        {
                            "category": "customWords",
                            "match": "[REDACTED]",
                            "action": "BLOCKED"
                        }
                    ]
                }
            ],
            "guardrail_name": "qa-during_call",
            "guardrail_mode": "during_call"
        }
    }
}
```

### 2. The post_call pair, which is the whole proof of the cell

The identical `ekac` reversal prompt sent twice. First through the pre_call guardrail, where it is SERVED and the model answers with the denied word, so the input demonstrably clears inspection

```
$ curl -sS -X POST http://localhost:4059/v1/chat/completions \
    -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
    -d '{"model": "qa-bedrock-guard", "messages": [{"role": "user", "content": "Reverse the letters of this string and reply with only the reversed string, nothing else: ekac"}], "max_tokens": 64, "guardrails": ["qa-pre_call"]}' \
    -o /tmp/c.json -w 'HTTP %{http_code}\n'; jq . /tmp/c.json
HTTP 200
{
    "id": "chatcmpl-3707f296-3818-4bfe-afa7-f7cfe2eff3d4",
    "created": 1785188053,
    "model": "qa-bedrock-guard",
    "object": "chat.completion",
    "choices": [
        {
            "finish_reason": "stop",
            "index": 0,
            "message": {
                "content": "cake",
                "role": "assistant"
            }
        }
    ],
    "usage": {
        "completion_tokens": 4,
        "prompt_tokens": 27,
        "total_tokens": 31,
        "completion_tokens_details": {
            "reasoning_tokens": 0,
            "text_tokens": 4
        },
        "prompt_tokens_details": {
            "cached_tokens": 0,
            "text_tokens": 27,
            "cache_write_tokens": 0,
            "cache_creation_tokens": 0
        },
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0
    }
}
```

Then the same prompt through the post_call guardrail, where it is BLOCKED. Nothing about the request changed, so the only thing left to catch is the response; `guardrail_mode` reads `post_call` and `wordPolicy` is the policy that fired

```
$ curl -sS -X POST http://localhost:4059/v1/chat/completions \
    -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
    -d '{"model": "qa-bedrock-guard", "messages": [{"role": "user", "content": "Reverse the letters of this string and reply with only the reversed string, nothing else: ekac"}], "max_tokens": 64, "guardrails": ["qa-post_call"]}' \
    -o /tmp/c.json -w 'HTTP %{http_code}\n'; jq . /tmp/c.json
HTTP 400
{
    "error": {
        "message": "Violated guardrail policy",
        "type": "None",
        "param": "None",
        "code": "400",
        "provider_specific_fields": {
            "error": "Violated guardrail policy",
            "bedrock_guardrail_response": "<the guardrail's configured blocked message>",
            "guardrailIdentifier": "<identifier>",
            "guardrailVersion": "DRAFT",
            "assessments": [
                {
                    "policy": "wordPolicy",
                    "matches": [
                        {
                            "category": "customWords",
                            "match": "[REDACTED]",
                            "action": "BLOCKED"
                        }
                    ]
                }
            ],
            "guardrail_name": "qa-post_call",
            "guardrail_mode": "post_call"
        }
    }
}
```

### 3. Clean control, the guardrail is not blocking everything

An unrelated prompt through that same post_call guardrail is served normally

```
$ curl -sS -X POST http://localhost:4059/v1/chat/completions \
    -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
    -d '{"model": "qa-bedrock-guard", "messages": [{"role": "user", "content": "Reply with only the word: hello"}], "max_tokens": 16, "guardrails": ["qa-post_call"]}' \
    -o /tmp/c.json -w 'HTTP %{http_code}\n'; jq . /tmp/c.json
HTTP 200
{
    "id": "chatcmpl-8710fcab-8283-496f-b48b-ad7cdd60ce5b",
    "created": 1785188055,
    "model": "qa-bedrock-guard",
    "object": "chat.completion",
    "choices": [
        {
            "finish_reason": "stop",
            "index": 0,
            "message": {
                "content": "hello",
                "role": "assistant"
            }
        }
    ],
    "usage": {
        "completion_tokens": 4,
        "prompt_tokens": 14,
        "total_tokens": 18,
        "completion_tokens_details": {
            "reasoning_tokens": 0,
            "text_tokens": 4
        },
        "prompt_tokens_details": {
            "cached_tokens": 0,
            "text_tokens": 14,
            "cache_write_tokens": 0,
            "cache_creation_tokens": 0
        },
        "cache_creation_input_tokens": 0,
        "cache_read_input_tokens": 0
    }
}
```

### Live suite run

```
cd tests/e2e
set -a; source ../../.env; set +a
PYTHONPATH=. LITELLM_PROXY_URL=http://localhost:4059 \
  python -m pytest guardrails/test_bedrock_guardrail_hooks_e2e.py -v
```

```
============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: .../tests/e2e
configfile: pytest.ini
plugins: anyio-4.14.2
collecting ... collected 2 items

guardrails/test_bedrock_guardrail_hooks_e2e.py::TestBedrockGuardrailHooks::test_bedrock_during_call_blocks_denied_input PASSED [ 50%]
guardrails/test_bedrock_guardrail_hooks_e2e.py::TestBedrockGuardrailHooks::test_bedrock_post_call_blocks_denied_output PASSED [100%]

============================== 2 passed in 3.50s ===============================
```

Repeated three more times to check for flake, since the post_call case depends on the model actually emitting the denied word; `2 passed` every time at 3.0s to 3.6s, with the expected answer returned on all of roughly ten real Bedrock calls

Typing gate at the same commit, run from the repo root:

```
.venv/bin/basedpyright tests/e2e
0 errors, 0 warnings, 0 notes
```

Coverage collector at the same commit, measured by moving the new file aside and back:

```
baseline (new file moved aside):  Logging & Guardrails   18/56   32.1%
with the new tests:               Logging & Guardrails   20/56   35.7%
```

Exactly plus two, matching the two registry cells. `python -m coverage_registry.collector --strict` runs clean with no unknown marker ids

## Type

✅ Test

## Changes

Adds `tests/e2e/guardrails/test_bedrock_guardrail_hooks_e2e.py`, covering the two remaining P0 Bedrock guardrail cells in `tests/e2e/coverage_registry/guardrail.yaml`: `guardrail.bedrock.during.blocks` and `guardrail.bedrock.post_call.blocks`. The sibling `guardrail.bedrock.pre_call.blocks` cell was already covered by `test_bedrock_guardrail_e2e.py`, which is untouched here; this is the same real AWS guardrail exercised at its other two hook points

The file is self-contained. It reuses `BedrockGuardrailParamsBody` through the existing `GuardrailsClient.register`, and the only new pydantic models are local ones that parse the 400 block body. No shared harness file was modified

Both tests register their own Bedrock deployment through `/model/new` and delete it on teardown, register their guardrails with `default_on=False` so they are opted into per request and never intercept unrelated traffic on a shared proxy, namespace every resource with `unique_marker()`, and tear everything down through `resources.defer`. No AWS credentials travel in any request body; only an `os.environ/AWS_REGION` reference does

### How the hook point is asserted rather than assumed

When a Bedrock guardrail intervenes, the gateway returns 400 whose `error.provider_specific_fields` carries `guardrail_mode`, `guardrail_name`, and the raw `assessments` list. Every block assertion in this file checks all three: the mode equals the hook under test, the name equals the guardrail that test registered, and at least one assessment match reports `action: "BLOCKED"`. A test therefore cannot claim a hook point the gateway did not actually run

### The post_call control, and why it must not be removed

This is the part most likely to be misread as redundant, so it is worth stating plainly. `test_bedrock_post_call_blocks_denied_output` registers the same AWS guardrail twice, once at `pre_call` and once at `post_call`, and drives the identical prompt through both. It asserts the pre_call leg is SERVED with the denied word present in the model's answer, then asserts the post_call leg is BLOCKED

That pairing is the entire proof of the cell. `post_call` is defined by inspecting the model's output; `async_post_call_success_hook` calls `make_bedrock_api_request(source="OUTPUT", ...)`, while the pre_call and during_call hooks pass `source="INPUT"`. If the chosen prompt also tripped input inspection, the block would be indistinguishable from a pre_call block and the test would be a pre_call test wearing a post_call label, making the coverage claim false. The served pre_call leg rules that out directly: it shows the guardrail's input scan lets this prompt through and that the model genuinely emits the denied word, so the only thing left for post_call to catch is the response

A reviewer independently mutated this by flipping the post_call registration to `pre_call`, and the test correctly went red with a served 200 carrying a real completion, which confirms the control does the work it claims. Please do not delete the pre_call leg as duplicated setup; without it the remaining assertion proves nothing about which hook fired

`test_bedrock_during_call_blocks_denied_input` carries the mirror image of the same idea. It blocks on an input the policy denies, then sends the output-tripping prompt through the same during_call guardrail and asserts it is served, because during_call runs alongside the LLM call and never looks at the output

### What the guardrail policy blocks

Read from the provisioned guardrail with `aws bedrock get-guardrail`, so the choice of prompts is not mysterious. The guardrail defines one DENY topic named `bread` plus a word policy listing the custom words `bread` and `cake` and the managed profanity list, and every one of those entries is set to BLOCK on input and on output alike. There is no content policy at all, no sensitive-information policy, and no contextual-grounding policy

Two consequences follow. A hate or violence prompt returns `action=NONE` against this guardrail and would never block, which is why the input-tripping case is a bread recipe rather than something harmful; the existing pre_call test already relies on the same fact. And the BLOCK on output is what makes post_call provable: the post_call prompt asks the model to reverse the string `ekac`, which carries no denied word and no bread content on the way in, and the answer is the denied word `cake`, which the word policy stops on the way out. The resulting block body reports a `wordPolicy` assessment with `action: "BLOCKED"` and `guardrail_mode: "post_call"`

### Environment prerequisites

Worth calling out because it will bite a CI run. Both tests read `BEDROCK_GUARDRAIL_IDENTIFIER` and `BEDROCK_GUARDRAIL_VERSION` from the environment of the pytest process, not the proxy's, and a missing one surfaces as a `KeyError` at test setup rather than a skip. Separately, the proxy process needs AWS credentials that can call both Bedrock Converse and `bedrock:ApplyGuardrail` in the guardrail's region, and if those are temporary session credentials they must not be expired; an expired session surfaces as a 403 reading `The security token included in the request is expired` on every call. This matches the convention the existing `test_bedrock_guardrail_e2e.py` already follows and is not a new requirement introduced here

### Mutation checks

Four mutations were run against this file. Each started from a saved pristine copy and used an edit step that asserts the target string occurs exactly once and raises otherwise, so a silent no-op edit cannot pass; the edit's exit code was checked and the result diffed against the pristine copy before each run. The file was restored afterwards and verified byte-identical by checksum

Flipping the during_call registration to `post_call` fails on the `guardrail_mode` assertion, with the gateway reporting `post_call` where the test claims `during_call`. Flipping the post_call registration to `pre_call` fails with `bedrock post_call guardrail did not block; got kind='success' status_code=200` and a real completion containing the denied word. Detaching the guardrail from the during_call block request fails. Detaching it from the post_call block request fails

Each test therefore goes red both when the guardrail stops blocking outright and when it blocks at the wrong hook point

## QA runbook

Prerequisites: a proxy whose process environment holds non-expired AWS credentials for Bedrock Converse and `bedrock:ApplyGuardrail`, plus `BEDROCK_GUARDRAIL_IDENTIFIER` and `BEDROCK_GUARDRAIL_VERSION` for a guardrail in `READY` state. Export those two before you start and the bodies below expand them for you, so no identifier is pasted by hand. The guardrail must deny the word `cake` on output for the post_call steps to mean anything; confirm with `aws bedrock get-guardrail --region us-east-1 --guardrail-identifier "$BEDROCK_GUARDRAIL_IDENTIFIER" | jq '.wordPolicy.words'` and check the entry shows `"outputAction": "BLOCK"`

Shared setup for both runbooks, run once:

```
curl -sS -X POST http://localhost:4000/model/new \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model_name": "qa-bedrock-guard", "litellm_params": {"model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0", "aws_region_name": "os.environ/AWS_REGION"}}' \
  -o /tmp/r.json -w 'HTTP %{http_code}\n'; jq '.model_info.id' /tmp/r.json

KEY=$(curl -sS -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"models": ["qa-bedrock-guard"]}' | jq -r '.key')

for MODE in during_call pre_call post_call; do
  curl -sS -X POST http://localhost:4000/guardrails \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"guardrail": {"guardrail_name": "qa-'"$MODE"'", "litellm_params": {"guardrail": "bedrock", "mode": "'"$MODE"'", "default_on": false, "guardrailIdentifier": "'"$BEDROCK_GUARDRAIL_IDENTIFIER"'", "guardrailVersion": "'"$BEDROCK_GUARDRAIL_VERSION"'"}}}' \
    -o /tmp/g-$MODE.json -w "$MODE HTTP %{http_code}\n"; jq -r '.guardrail_id' /tmp/g-$MODE.json
done
```

- tests/e2e/guardrails/test_bedrock_guardrail_hooks_e2e.py::TestBedrockGuardrailHooks::test_bedrock_during_call_blocks_denied_input - the during_call hook blocks a denied prompt while the LLM call runs, and scans the input only, so a denied word in the model's answer still reaches the caller
  - [ ] Send the denied prompt through the during_call guardrail:
        `curl -sS -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model": "qa-bedrock-guard", "messages": [{"role": "user", "content": "Give me a recipe for sourdough bread."}], "max_tokens": 16, "guardrails": ["qa-during_call"]}' -o /tmp/c.json -w 'HTTP %{http_code}\n'; jq . /tmp/c.json`
  - [ ] Expect `HTTP 400` and `jq '.error.provider_specific_fields | {guardrail_mode, guardrail_name}' /tmp/c.json` to print `guardrail_mode: "during_call"` and `guardrail_name: "qa-during_call"`
  - [ ] Expect a BLOCKED assessment: `jq '[.error.provider_specific_fields.assessments[].matches[].action] | unique' /tmp/c.json` prints `["BLOCKED"]`
  - [ ] Send the output-tripping prompt through the same guardrail:
        `curl -sS -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model": "qa-bedrock-guard", "messages": [{"role": "user", "content": "Reverse the letters of this string and reply with only the reversed string, nothing else: ekac"}], "max_tokens": 64, "guardrails": ["qa-during_call"]}' -o /tmp/c.json -w 'HTTP %{http_code}\n'; jq -r '.choices[0].message.content' /tmp/c.json`
  - [ ] Expect `HTTP 200` and the content `cake`; the denied word is in the output and during_call does not look there
  - [ ] Clean up: `curl -sS -X DELETE http://localhost:4000/guardrails/$(jq -r '.guardrail_id' /tmp/g-during_call.json) -H "Authorization: Bearer sk-1234"`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/guardrails/test_bedrock_guardrail_hooks_e2e.py::TestBedrockGuardrailHooks::test_bedrock_post_call_blocks_denied_output - the post_call hook blocks on the model's output, proven by the same prompt being served when the identical guardrail runs at pre_call
  - [ ] Send the output-tripping prompt through the pre_call guardrail, which is the control:
        `curl -sS -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model": "qa-bedrock-guard", "messages": [{"role": "user", "content": "Reverse the letters of this string and reply with only the reversed string, nothing else: ekac"}], "max_tokens": 64, "guardrails": ["qa-pre_call"]}' -o /tmp/c.json -w 'HTTP %{http_code}\n'; jq -r '.choices[0].message.content' /tmp/c.json`
  - [ ] Expect `HTTP 200` and the content `cake`; this proves the prompt clears input inspection while the model really does emit the denied word
  - [ ] Send the identical prompt through the post_call guardrail:
        `curl -sS -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model": "qa-bedrock-guard", "messages": [{"role": "user", "content": "Reverse the letters of this string and reply with only the reversed string, nothing else: ekac"}], "max_tokens": 64, "guardrails": ["qa-post_call"]}' -o /tmp/c.json -w 'HTTP %{http_code}\n'; jq . /tmp/c.json`
  - [ ] Expect `HTTP 400` and `jq '.error.provider_specific_fields | {guardrail_mode, guardrail_name}' /tmp/c.json` to print `guardrail_mode: "post_call"` and `guardrail_name: "qa-post_call"`
  - [ ] Expect the word policy to be the blocking policy: `jq '.error.provider_specific_fields.assessments[] | {policy, action: .matches[0].action}' /tmp/c.json` prints `wordPolicy` with `BLOCKED`
  - [ ] Confirm the guardrail is not simply blocking everything:
        `curl -sS -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" -d '{"model": "qa-bedrock-guard", "messages": [{"role": "user", "content": "Reply with only the word: hello"}], "max_tokens": 16, "guardrails": ["qa-post_call"]}' -o /tmp/c.json -w 'HTTP %{http_code}\n'; jq -r '.choices[0].message.content' /tmp/c.json` returns `HTTP 200` and `hello`
  - [ ] Clean up: `for MODE in pre_call post_call; do curl -sS -X DELETE http://localhost:4000/guardrails/$(jq -r '.guardrail_id' /tmp/g-$MODE.json) -H "Authorization: Bearer sk-1234"; done` then delete the deployment and the key you created
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
