### PR TITLE
test(e2e): cover anthropic, azure and vertex chat and responses cells

### DIFF
--- a/tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py
+++ b/tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py
@@ -1,0 +1,718 @@
+"""Live /chat/completions coverage for the provider routes a customer reaches by
+registering their own deployment: Anthropic's first-party API, Azure OpenAI,
+Vertex AI Gemini, and Azure AI Foundry.
+
+Each class is one route's translation contract. The gateway speaks the
+OpenAI-compatible request shape to the caller and the provider's native shape
+upstream, so every capability here (tool calls, vision, streaming, extended
+thinking, prompt caching, schema-constrained output) is a translation that can
+break per provider while the other routes keep passing. Each test registers the
+deployment it needs through /model/new with `os.environ/...` credential
+references the proxy resolves at call time, and deletes it on teardown.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel
+
+from e2e_config import unique_marker
+from e2e_http import StreamingResponse, unwrap
+from lifecycle import ResourceManager
+from models import (
+    ChatBody,
+    ChatMessage,
+    ChatResponse,
+    ChatTool,
+    ChatToolFunction,
+    ImageContentPart,
+    ImageUrl,
+    LiteLLMParamsBody,
+    TextContentPart,
+    ThinkingParam,
+)
+from passthrough_client import PassthroughClient
+
+pytestmark = pytest.mark.e2e
+
+ANTHROPIC_BACKEND = "anthropic/claude-haiku-4-5"
+AZURE_OPENAI_BACKEND = "azure/gpt-5.6-sol-e2e"
+VERTEX_BACKEND = "vertex_ai/gemini-2.5-flash"
+AZURE_FOUNDRY_BACKEND = "azure_ai/claude-haiku-4-5"
+
+CACHE_READ_DEADLINE_SECONDS = 30.0
+CACHE_READ_INTERVAL_SECONDS = 3.0
+
+SPLIT_COLOR_IMAGE = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAAmklEQVR42u3QQQkAAAgEMJNcEvtjLFuIj8ES"
+    "rCZ5JT2vlCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBB"
+    "ggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBB"
+    "dxaTpa47LOh2vwAAAABJRU5ErkJggg=="
+)
+
+
+def _anthropic_params() -> LiteLLMParamsBody:
+    return LiteLLMParamsBody(model=ANTHROPIC_BACKEND, api_key="os.environ/ANTHROPIC_API_KEY")
+
+
+def _azure_openai_params() -> LiteLLMParamsBody:
+    return LiteLLMParamsBody(
+        model=AZURE_OPENAI_BACKEND,
+        api_base="os.environ/AZURE_API_BASE",
+        api_key="os.environ/AZURE_API_KEY",
+    )
+
+
+def _vertex_params() -> LiteLLMParamsBody:
+    return LiteLLMParamsBody(
+        model=VERTEX_BACKEND,
+        vertex_project="os.environ/VERTEXAI_PROJECT",
+        vertex_credentials="os.environ/VERTEXAI_CREDENTIALS",
+    )
+
+
+def _azure_foundry_params() -> LiteLLMParamsBody:
+    return LiteLLMParamsBody(
+        model=AZURE_FOUNDRY_BACKEND,
+        api_base="os.environ/AZURE_AI_API_BASE",
+        api_key="os.environ/AZURE_AI_API_KEY",
+    )
+
+
+def _register(
+    client: PassthroughClient,
+    resources: ResourceManager,
+    prefix: str,
+    params: LiteLLMParamsBody,
+) -> tuple[str, str]:
+    """Register a deployment for one test and hand back its model name plus a key
+    that may call it. Both are torn down by the resources fixture."""
+    model = f"{prefix}-{unique_marker()}"
+    model_id = client.proxy.create_model(model, params)
+    resources.defer(lambda: client.proxy.delete_model(model_id))
+    return model, resources.key()
+
+
+class _StreamToolCallFunction(BaseModel):
+    name: str | None = None
+    arguments: str | None = None
+
+
+class _StreamToolCall(BaseModel):
+    function: _StreamToolCallFunction = _StreamToolCallFunction()
+
+
+class _StreamDelta(BaseModel):
+    content: str | None = None
+    tool_calls: list[_StreamToolCall] | None = None
+
+
+class _StreamChoice(BaseModel):
+    delta: _StreamDelta = _StreamDelta()
+
+
+class _StreamChunk(BaseModel):
+    choices: list[_StreamChoice] = []
+
+
+def _streamed_text(events: list[str]) -> str:
+    """Concatenate the delta content across streamed chunks. Parsing every event as
+    JSON also fails loudly on a truncated or garbled chunk, so an incomplete stream
+    cannot pass as content."""
+    chunks = [_StreamChunk.model_validate_json(event) for event in events]
+    return "".join(choice.delta.content or "" for chunk in chunks for choice in chunk.choices)
+
+
+def _streamed_tool_call(events: list[str]) -> tuple[str, str]:
+    """Reassemble the tool call streamed across chunks: the name arrives once and the
+    arguments arrive as fragments, so concatenating both and parsing the arguments as
+    JSON catches a stream that never completes the call or splits its argument JSON."""
+    chunks = [_StreamChunk.model_validate_json(event) for event in events]
+    calls = [call for chunk in chunks for choice in chunk.choices for call in (choice.delta.tool_calls or [])]
+    name = "".join(call.function.name or "" for call in calls)
+    arguments = "".join(call.function.arguments or "" for call in calls)
+    return name, arguments
+
+
+def _assert_streamed_completion(result: StreamingResponse) -> None:
+    """A streamed /chat/completions must deliver real content, not a clean-but-empty
+    stream."""
+    assert result.ok and result.is_streaming, f"stream was not established: {result}"
+    assert result.stream_error is None, f"stream carried an error event: {result.stream_error}"
+    assert len(result.stream_events) > 1, f"stream did not deliver multiple data events: {result}"
+    assert _streamed_text(result.stream_events).strip(), (
+        f"stream completed with no content deltas: {result.stream_events[:3]}"
+    )
+
+
+class _WeatherArgs(BaseModel):
+    location: str
+
+
+_WEATHER_TOOL = ChatTool(
+    function=ChatToolFunction(
+        name="get_weather",
+        description="Get the current weather for a location",
+        parameters={
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+        },
+    )
+)
+
+_WEATHER_PROMPT = "What is the weather in San Francisco? Use the get_weather tool."
+
+_AZURE_HOSTED_PROMPT = "Reply with the single word pong."
+"""Plain prose, with none of the random hex uniquifier the other routes append:
+Azure runs Microsoft's prompt shields in front of both its OpenAI and its Foundry
+deployments, and a random token in an otherwise trivial prompt intermittently
+trips the jailbreak classifier into a 400. Each test registers its own uniquely
+named deployment, which is what actually keeps runs from sharing a cached
+response."""
+
+
+def _assert_weather_tool_call(response: ChatResponse) -> None:
+    """The model, forced to call the tool, must return a get_weather call whose
+    arguments parse as JSON and carry a location. A translation that drops tool_calls
+    or emits malformed argument JSON fails here rather than passing on a 200."""
+    assert response.choices, f"chat returned no choices: {response}"
+    message = response.choices[0].message
+    calls = message.tool_calls if message else None
+    assert calls, f"model returned no tool call for a tool-forced prompt: {response}"
+    weather = next((call for call in calls if call.function.name == "get_weather"), None)
+    assert weather is not None, f"expected a get_weather call, got {[c.function.name for c in calls]}"
+    assert weather.function.arguments, f"get_weather call carried no arguments: {weather}"
+    args = _WeatherArgs.model_validate_json(weather.function.arguments)
+    assert args.location.strip(), f"get_weather arguments missing location: {weather.function.arguments}"
+
+
+def _vision_messages() -> list[ChatMessage]:
+    """A base64 data URI rather than a hosted image: Anthropic and Vertex fetch a
+    remote image_url from their own side, and both are blocked by the usual public
+    image hosts, so a link makes the test measure the host's crawler policy instead
+    of the gateway's image translation."""
+    return [
+        ChatMessage(
+            role="user",
+            content=[
+                TextContentPart(
+                    text=(
+                        "This image is split into two halves of different solid colors. "
+                        "Name the two colors and nothing else."
+                    )
+                ),
+                ImageContentPart(image_url=ImageUrl(url=SPLIT_COLOR_IMAGE)),
+            ],
+        )
+    ]
+
+
+def _assert_reads_split_colors(response: ChatResponse) -> None:
+    assert response.choices, f"vision returned no choices: {response}"
+    message = response.choices[0].message
+    content = ((message.content if message else None) or "").lower()
+    assert "red" in content and "blue" in content, (
+        f"vision response did not read the two halves of the image: {content[:200]}"
+    )
+
+
+def _assert_answered(response: ChatResponse) -> None:
+    assert response.model, f"response carried no model name: {response}"
+    assert response.choices, f"response had no choices: {response}"
+    message = response.choices[0].message
+    assert message and message.content and message.content.strip(), (
+        f"200 with an empty completion: {response}"
+    )
+
+
+class _Person(BaseModel):
+    name: str
+    age: int
+
+
+_PERSON_SCHEMA: dict[str, object] = {
+    "type": "json_schema",
+    "json_schema": {
+        "name": "person",
+        "strict": True,
+        "schema": {
+            "type": "object",
+            "properties": {"name": {"type": "string"}, "age": {"type": "integer"}},
+            "required": ["name", "age"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+class _CacheControl(BaseModel):
+    type: Literal["ephemeral"] = "ephemeral"
+
+
+class _CacheableTextPart(BaseModel):
+    """A text content part carrying Anthropic's cache_control breakpoint. Anthropic
+    caches only what a breakpoint marks, so the OpenAI-shaped body has to carry it
+    through the translation; the shared TextContentPart has no such field."""
+
+    type: Literal["text"] = "text"
+    text: str
+    cache_control: _CacheControl | None = None
+
+
+class _CacheableMessage(BaseModel):
+    role: str
+    content: list[_CacheableTextPart]
+
+
+class _CacheableChatBody(BaseModel):
+    model: str
+    messages: list[_CacheableMessage]
+    max_tokens: int = 16
+
+
+def _cacheable_prefix(marker: str) -> str:
+    """A system prompt past Anthropic's 2048-token minimum cacheable size for Haiku,
+    unique per run so no other run's cache entry can satisfy the read."""
+    return " ".join(f"Standing instruction {index} for run {marker}: stay concise." for index in range(400))
+
+
+def _cached_prefix_body(model: str, prefix: str, turn: str) -> _CacheableChatBody:
+    return _CacheableChatBody(
+        model=model,
+        messages=[
+            _CacheableMessage(role="system", content=[_CacheableTextPart(text=prefix, cache_control=_CacheControl())]),
+            _CacheableMessage(role="user", content=[_CacheableTextPart(text=turn)]),
+        ],
+    )
+
+
+class _ThinkingBlock(BaseModel):
+    """One entry of `thinking_blocks`: Anthropic's own thinking representation as
+    LiteLLM carries it onto the OpenAI-shaped response. `signature` is the token
+    Anthropic issues for a genuine thinking block, so its presence is what separates
+    a translated thinking block from prose the model happened to write."""
+
+    type: str
+    thinking: str | None = None
+    signature: str | None = None
+
+
+class _ThinkingMessage(BaseModel):
+    content: str | None = None
+    reasoning_content: str | None = None
+    thinking_blocks: list[_ThinkingBlock] | None = None
+
+
+class _ThinkingChoice(BaseModel):
+    message: _ThinkingMessage = _ThinkingMessage()
+
+
+class _ThinkingUsageDetails(BaseModel):
+    reasoning_tokens: int | None = None
+
+
+class _ThinkingUsage(BaseModel):
+    completion_tokens_details: _ThinkingUsageDetails = _ThinkingUsageDetails()
+
+
+class _ThinkingChatResponse(BaseModel):
+    """The slice of a /chat/completions answer that carries extended thinking: the
+    answer text, Anthropic's reasoning content and thinking blocks, and the reasoning
+    token accounting. The shared ChatResponse models neither thinking_blocks nor the
+    reasoning-token count, and both are needed to prove thinking actually happened."""
+
+    choices: list[_ThinkingChoice] = []
+    usage: _ThinkingUsage = _ThinkingUsage()
+
+    @property
+    def message(self) -> _ThinkingMessage:
+        assert self.choices, f"chat returned no choices: {self}"
+        return self.choices[0].message
+
+    @property
+    def reasoning_tokens(self) -> int:
+        return self.usage.completion_tokens_details.reasoning_tokens or 0
+
+    @property
+    def blocks(self) -> tuple[_ThinkingBlock, ...]:
+        return tuple(self.message.thinking_blocks or ())
+
+
+_THINKING_PROMPT = "What is 17 times 23? Think it through step by step."
+
+
+class TestAnthropicChatCompletions:
+    """Anthropic's first-party API through the OpenAI-compatible /chat/completions
+    translation - the path a customer keeps when they point an OpenAI SDK at the
+    gateway but bill Claude."""
+
+    @pytest.mark.covers(
+        "llm.chat_completions.anthropic.basic.stream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_anthropic_chat_streams_real_content(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(client, resources, "e2e-anthropic-stream", _anthropic_params())
+
+        result = client.proxy.chat_stream(
+            key,
+            ChatBody(
+                model=model,
+                messages=[
+                    ChatMessage(role="user", content=f"Count from 1 to 5, one number per line. {unique_marker()}")
+                ],
+                max_tokens=64,
+                stream=True,
+            ),
+        )
+        _assert_streamed_completion(result)
+
+    @pytest.mark.covers(
+        "llm.chat_completions.anthropic.tool_use.nonstream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_anthropic_chat_returns_tool_call(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(client, resources, "e2e-anthropic-tool", _anthropic_params())
+
+        response = unwrap(
+            client.proxy.chat(
+                key,
+                ChatBody(
+                    model=model,
+                    messages=[ChatMessage(role="user", content=_WEATHER_PROMPT)],
+                    tools=[_WEATHER_TOOL],
+                    tool_choice="required",
+                    max_tokens=256,
+                ),
+            )
+        )
+        _assert_weather_tool_call(response)
+
+    @pytest.mark.covers(
+        "llm.chat_completions.anthropic.tool_use.stream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_anthropic_chat_streams_tool_call(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(client, resources, "e2e-anthropic-tool-stream", _anthropic_params())
+
+        result = client.proxy.chat_stream(
+            key,
+            ChatBody(
+                model=model,
+                messages=[ChatMessage(role="user", content=_WEATHER_PROMPT)],
+                tools=[_WEATHER_TOOL],
+                tool_choice="required",
+                max_tokens=256,
+                stream=True,
+            ),
+        )
+        assert result.ok and result.is_streaming, f"tool stream was not established: {result}"
+        assert result.stream_error is None, f"tool stream carried an error event: {result.stream_error}"
+        name, arguments = _streamed_tool_call(result.stream_events)
+        assert name == "get_weather", f"streamed tool call named {name!r}: {result.stream_events[:5]}"
+        args = _WeatherArgs.model_validate_json(arguments)
+        assert args.location.strip(), f"streamed tool call arguments missing location: {arguments!r}"
+
+    @pytest.mark.covers(
+        "llm.chat_completions.anthropic.vision.nonstream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_anthropic_chat_vision_describes_image(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(client, resources, "e2e-anthropic-vision", _anthropic_params())
+
+        response = unwrap(client.proxy.chat(key, ChatBody(model=model, messages=_vision_messages(), max_tokens=32)))
+        _assert_reads_split_colors(response)
+
+    @pytest.mark.covers(
+        "llm.chat_completions.anthropic.prompt_cache_5m.nonstream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_anthropic_chat_prompt_cache_hits_on_repeat(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        """A cache_control breakpoint on the system prefix must survive the
+        translation, so the first call writes the prefix to Anthropic's cache and a
+        later call reads it back instead of re-billing it at write price.
+
+        Every call carries a fresh user turn after the breakpoint: that is both how a
+        customer actually uses a cached prefix and what keeps the gateway's own
+        response cache from replaying the first answer, which would hand the test
+        turn one's write usage again and hide whether a read ever happened.
+        """
+        model, key = _register(client, resources, "e2e-anthropic-cache", _anthropic_params())
+        prefix = _cacheable_prefix(unique_marker())
+
+        def call() -> ChatResponse:
+            return unwrap(
+                client.proxy.transport.post(
+                    "/chat/completions",
+                    headers=client.proxy.transport.bearer(key),
+                    json=_cached_prefix_body(
+                        model, prefix, f"Reply with the single word pong. {unique_marker()}"
+                    ),
+                    response_type=ChatResponse,
+                )
+            )
+
+        first = call()
+        written = first.usage.cache_creation_input_tokens if first.usage else None
+        assert written and written > 0, (
+            f"a cache_control breakpoint must write the prefix to the cache, got usage={first.usage}"
+        )
+
+        deadline = time.monotonic() + CACHE_READ_DEADLINE_SECONDS
+        while True:
+            usage = call().usage
+            read = usage.cache_read_input_tokens if usage else None
+            if read and read >= written:
+                return
+            if time.monotonic() >= deadline:
+                pytest.fail(
+                    f"a later call must read the whole {written}-token cached prefix back, but the "
+                    f"cache never became readable within {CACHE_READ_DEADLINE_SECONDS}s (last usage: {usage})"
+                )
+            time.sleep(CACHE_READ_INTERVAL_SECONDS)
+
+    @pytest.mark.covers(
+        "llm.chat_completions.anthropic.structured_output.nonstream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_anthropic_chat_structured_output_conforms_to_schema(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(client, resources, "e2e-anthropic-schema", _anthropic_params())
+
+        response = unwrap(
+            client.proxy.chat(
+                key,
+                ChatBody(
+                    model=model,
+                    messages=[ChatMessage(role="user", content="Extract the person. John Doe is 42 years old.")],
+                    response_format=_PERSON_SCHEMA,
+                    max_tokens=256,
+                ),
+            )
+        )
+        assert response.choices, f"structured output returned no choices: {response}"
+        content = response.choices[0].message.content if response.choices[0].message else None
+        assert content, f"structured output returned empty content: {response}"
+        person = _Person.model_validate_json(content)
+        assert person.name.strip() and person.age == 42, (
+            f"schema-constrained extraction was wrong: {person}"
+        )
+
+    @pytest.mark.covers(
+        "llm.chat_completions.anthropic.thinking.nonstream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_anthropic_chat_thinking_changes_the_translated_response(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        """Enabling extended thinking has to change what comes back, so the same
+        question is asked twice: once plain and once with a thinking budget.
+
+        Asserting only that a thinking-enabled call returned some text would pass
+        against a gateway that dropped the thinking parameter entirely, so each half
+        of the contrast is pinned to Anthropic's own representation as translated
+        onto the OpenAI-shaped response: the reasoning text, a thinking block
+        carrying the signature Anthropic issues for it, and the reasoning-token
+        accounting. The plain call must carry none of the three.
+        """
+        model, key = _register(client, resources, "e2e-anthropic-thinking", _anthropic_params())
+
+        def ask(thinking: ThinkingParam | None) -> _ThinkingChatResponse:
+            return unwrap(
+                client.proxy.transport.post(
+                    "/chat/completions",
+                    headers=client.proxy.transport.bearer(key),
+                    json=ChatBody(
+                        model=model,
+                        messages=[
+                            ChatMessage(role="user", content=f"{_THINKING_PROMPT} {unique_marker()}")
+                        ],
+                        thinking=thinking,
+                        max_tokens=2048,
+                    ),
+                    response_type=_ThinkingChatResponse,
+                )
+            )
+
+        plain = ask(None)
+        thought = ask(ThinkingParam(type="enabled", budget_tokens=1024))
+
+        assert plain.message.content and plain.message.content.strip(), (
+            f"the baseline call returned no answer: {plain}"
+        )
+        assert thought.message.content and thought.message.content.strip(), (
+            f"the thinking call returned no answer: {thought}"
+        )
+
+        assert not (plain.message.reasoning_content or "").strip(), (
+            f"thinking was never requested, so reasoning_content must be empty: {plain.message}"
+        )
+        assert not plain.blocks, f"thinking was never requested, so no thinking blocks may come back: {plain.blocks}"
+        assert plain.reasoning_tokens == 0, (
+            f"thinking was never requested, so no reasoning tokens may be billed: {plain.usage}"
+        )
+
+        assert (thought.message.reasoning_content or "").strip(), (
+            "thinking was enabled but no reasoning_content came back on the Anthropic path"
+        )
+        signed = [block for block in thought.blocks if block.type == "thinking" and block.signature]
+        assert signed, (
+            f"thinking was enabled but no signed Anthropic thinking block survived the "
+            f"translation: {thought.blocks}"
+        )
+        assert thought.reasoning_tokens > 0, (
+            f"thinking was enabled but no reasoning tokens were reported: {thought.usage}"
+        )
+
+
+class TestAzureOpenAIChatCompletions:
+    """Azure OpenAI, where the model lives behind a per-resource deployment name and
+    the gateway authenticates with the resource's api_base plus api_key."""
+
+    @pytest.mark.covers(
+        "llm.chat_completions.azure_openai.basic.nonstream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_azure_openai_chat_returns_content(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(client, resources, "e2e-azure-openai-chat", _azure_openai_params())
+
+        response = unwrap(
+            client.proxy.chat(
+                key,
+                ChatBody(
+                    model=model,
+                    messages=[ChatMessage(role="user", content=_AZURE_HOSTED_PROMPT)],
+                    max_tokens=512,
+                ),
+            )
+        )
+        _assert_answered(response)
+
+    @pytest.mark.covers(
+        "llm.chat_completions.azure_openai.tool_use.nonstream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_azure_openai_chat_returns_tool_call(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(client, resources, "e2e-azure-openai-tool", _azure_openai_params())
+
+        response = unwrap(
+            client.proxy.chat(
+                key,
+                ChatBody(
+                    model=model,
+                    messages=[ChatMessage(role="user", content=_WEATHER_PROMPT)],
+                    tools=[_WEATHER_TOOL],
+                    tool_choice="required",
+                    max_tokens=1024,
+                    reasoning_effort="low",
+                ),
+            )
+        )
+        _assert_weather_tool_call(response)
+
+
+class TestVertexChatCompletions:
+    """Vertex AI Gemini, where the gateway mints a Google token from the project's
+    service account instead of sending an API key."""
+
+    @pytest.mark.covers(
+        "llm.chat_completions.vertex.basic.stream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_vertex_chat_streams_real_content(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(client, resources, "e2e-vertex-stream", _vertex_params())
+
+        result = client.proxy.chat_stream(
+            key,
+            ChatBody(
+                model=model,
+                messages=[
+                    ChatMessage(role="user", content=f"Count from 1 to 5, one number per line. {unique_marker()}")
+                ],
+                max_tokens=512,
+                stream=True,
+            ),
+        )
+        _assert_streamed_completion(result)
+
+    @pytest.mark.covers(
+        "llm.chat_completions.vertex.tool_use.nonstream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_vertex_chat_returns_tool_call(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(client, resources, "e2e-vertex-tool", _vertex_params())
+
+        response = unwrap(
+            client.proxy.chat(
+                key,
+                ChatBody(
+                    model=model,
+                    messages=[ChatMessage(role="user", content=_WEATHER_PROMPT)],
+                    tools=[_WEATHER_TOOL],
+                    tool_choice="required",
+                    max_tokens=512,
+                ),
+            )
+        )
+        _assert_weather_tool_call(response)
+
+    @pytest.mark.covers(
+        "llm.chat_completions.vertex.vision.nonstream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_vertex_chat_vision_describes_image(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(client, resources, "e2e-vertex-vision", _vertex_params())
+
+        response = unwrap(client.proxy.chat(key, ChatBody(model=model, messages=_vision_messages(), max_tokens=512)))
+        _assert_reads_split_colors(response)
+
+
+class TestAzureFoundryChatCompletions:
+    """Azure AI Foundry (azure_ai), which serves Claude on Azure's own contract; the
+    OpenAI-compatible route has to translate to it rather than to Anthropic's."""
+
+    @pytest.mark.covers(
+        "llm.chat_completions.azure_foundry.basic.nonstream.works",
+        exercised_on=["chat_completions"],
+    )
+    def test_azure_foundry_chat_returns_content(
+        self, client: PassthroughClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(client, resources, "e2e-azure-foundry-chat", _azure_foundry_params())
+
+        response = unwrap(
+            client.proxy.chat(
+                key,
+                ChatBody(
+                    model=model,
+                    messages=[ChatMessage(role="user", content=_AZURE_HOSTED_PROMPT)],
+                    max_tokens=512,
+                ),
+            )
+        )
+        _assert_answered(response)

--- a/tests/e2e/llm_translation/test_responses_provider_matrix_e2e.py
+++ b/tests/e2e/llm_translation/test_responses_provider_matrix_e2e.py
@@ -1,0 +1,135 @@
+"""Live /v1/responses coverage for the cloud providers that have no native
+Responses API of their own: Azure OpenAI and Vertex AI Gemini.
+
+The gateway accepts the OpenAI Responses request shape and translates it to
+whatever the deployment's provider speaks, so a customer can keep one client
+across clouds. Each test registers its deployment through /model/new with
+`os.environ/...` credential references the proxy resolves at call time, drives
+the endpoint, and deletes the deployment on teardown.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import cast
+
+import pytest
+from pydantic import BaseModel
+
+from e2e_config import unique_marker
+from e2e_http import require_successful_call
+from endpoints_client import (
+    EndpointsClient,
+    FunctionParameterProperty,
+    FunctionParameters,
+    ResponsesFunctionTool,
+    ResponsesResult,
+)
+from lifecycle import ResourceManager
+from models import LiteLLMParamsBody
+
+pytestmark = pytest.mark.e2e
+
+AZURE_OPENAI_BACKEND = "azure/gpt-5.6-sol-e2e"
+VERTEX_BACKEND = "vertex_ai/gemini-2.5-flash"
+
+WEATHER_TOOL = ResponsesFunctionTool(
+    name="get_weather",
+    description="Get the weather for a location",
+    parameters=FunctionParameters(
+        properties={"location": FunctionParameterProperty(type="string")},
+        required=["location"],
+    ),
+)
+
+WEATHER_PROMPT = "What is the weather in San Francisco? Use the get_weather tool."
+
+BASIC_PROMPT = "Reply with one word."
+
+
+class WeatherArguments(BaseModel):
+    location: str
+
+
+def _azure_openai_params() -> LiteLLMParamsBody:
+    return LiteLLMParamsBody(
+        model=AZURE_OPENAI_BACKEND,
+        api_base="os.environ/AZURE_API_BASE",
+        api_key="os.environ/AZURE_API_KEY",
+    )
+
+
+def _vertex_params() -> LiteLLMParamsBody:
+    return LiteLLMParamsBody(
+        model=VERTEX_BACKEND,
+        vertex_project="os.environ/VERTEXAI_PROJECT",
+        vertex_credentials="os.environ/VERTEXAI_CREDENTIALS",
+    )
+
+
+def _register(
+    endpoints_client: EndpointsClient,
+    resources: ResourceManager,
+    prefix: str,
+    params: LiteLLMParamsBody,
+) -> tuple[str, str]:
+    model = f"{prefix}-{unique_marker()}"
+    model_id = endpoints_client.create_model(model, params)
+    resources.defer(lambda: endpoints_client.delete_model(model_id))
+    return model, resources.key()
+
+
+def _assert_weather_function_call(body: str) -> None:
+    parsed = ResponsesResult.model_validate_json(body)
+    function_call = next((call for call in parsed.function_calls if call.name == "get_weather"), None)
+    assert function_call is not None, f"no get_weather function call: {body[:500]}"
+    assert function_call.arguments is not None
+    raw_arguments = cast(object, json.loads(function_call.arguments))
+    arguments = WeatherArguments.model_validate(raw_arguments)
+    assert arguments.location, f"function call arguments missing location: {function_call.arguments}"
+
+
+class TestAzureOpenAIResponses:
+    @pytest.mark.covers("llm.responses.azure_openai.basic.nonstream.works")
+    def test_azure_openai_responses_returns_completion(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(endpoints_client, resources, "e2e-responses-azure", _azure_openai_params())
+
+        result = endpoints_client.responses(key, model, BASIC_PROMPT)
+        require_successful_call(result)
+        parsed = ResponsesResult.model_validate_json(result.body)
+        assert parsed.text.strip(), f"/responses over azure openai returned no output text: {result.body[:300]}"
+
+    @pytest.mark.covers("llm.responses.azure_openai.tool_use.nonstream.works")
+    def test_azure_openai_responses_returns_function_call(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(endpoints_client, resources, "e2e-responses-azure-tool", _azure_openai_params())
+
+        result = endpoints_client.responses_with_tools(key, model, WEATHER_PROMPT, [WEATHER_TOOL])
+        require_successful_call(result)
+        _assert_weather_function_call(result.body)
+
+
+class TestVertexResponses:
+    @pytest.mark.covers("llm.responses.vertex.basic.nonstream.works")
+    def test_vertex_responses_returns_completion(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(endpoints_client, resources, "e2e-responses-vertex", _vertex_params())
+
+        result = endpoints_client.responses(key, model, BASIC_PROMPT)
+        require_successful_call(result)
+        parsed = ResponsesResult.model_validate_json(result.body)
+        assert parsed.text.strip(), f"/responses over vertex returned no output text: {result.body[:300]}"
+
+    @pytest.mark.covers("llm.responses.vertex.tool_use.nonstream.works")
+    def test_vertex_responses_returns_function_call(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model, key = _register(endpoints_client, resources, "e2e-responses-vertex-tool", _vertex_params())
+
+        result = endpoints_client.responses_with_tools(key, model, WEATHER_PROMPT, [WEATHER_TOOL])
+        require_successful_call(result)
+        _assert_weather_function_call(result.body)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Anthropic, Azure, Vertex chat translation had no live e2e coverage
- 17 Core LLMs registry cells sat uncovered, all P0/P1
- Regressions in per-provider tool, vision, thinking paths shipped silently
- /responses over Azure OpenAI and Vertex was never exercised

How it solves it:

- Adds 17 live tests, one per uncovered registry cell
- Four provider classes on /chat/completions plus two on /responses
- Each test registers its own deployment and deletes it
- Takes Core LLMs coverage from 116/133 to 133/133

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Everything below comes from one capture session against a live proxy holding real provider credentials, at commit `c97e44a78e5aeea6e06a080bc5962950f4ce6eb4`. The proxy ran on port 4058; the master key is shown as `sk-1234`. Every call is billed provider traffic to Anthropic, Azure OpenAI, Azure AI Foundry, or Vertex AI, with no mocks and no recorded responses. Response bodies are piped through `jq` to keep the interesting fields readable; nothing else is edited

Each deployment used below is registered first, exactly as the tests do it:

```bash
$ export PROXY=http://localhost:4058
$ curl -s -X POST $PROXY/model/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model_name": "e2e-doc-anthropic", "model_info": {},
       "litellm_params": {"model": "anthropic/claude-haiku-4-5", "api_key": "os.environ/ANTHROPIC_API_KEY"}}'
```

**1. Anthropic extended thinking: what enabling it actually changes**

The same question twice, once plain and once with a thinking budget. The answer text is the same either way, so the answer alone proves nothing; the delta is entirely in Anthropic's thinking representation and its token accounting

```bash
$ Q="What is 17 times 23? Think it through step by step."
$ curl -s -X POST $PROXY/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{
  \"model\":\"e2e-doc-anthropic\",
  \"messages\":[{\"role\":\"user\",\"content\":\"$Q\"}],
  \"max_tokens\":2048}" \
  | jq '{answer: (.choices[0].message.content | .[0:38]), reasoning_content: .choices[0].message.reasoning_content,
         thinking_blocks: .choices[0].message.thinking_blocks, reasoning_tokens: .usage.completion_tokens_details.reasoning_tokens}'

{
  "answer": "# 17 × 23\n\nLet me break this down:\n\n**",
  "reasoning_content": null,
  "thinking_blocks": null,
  "reasoning_tokens": 0
}

$ curl -s -X POST $PROXY/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{
  \"model\":\"e2e-doc-anthropic\",
  \"messages\":[{\"role\":\"user\",\"content\":\"$Q\"}],
  \"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},
  \"max_tokens\":2048}" \
  | jq '{answer: (.choices[0].message.content | .[0:38]), reasoning_content: (.choices[0].message.reasoning_content | .[0:60]),
         thinking_block_type: .choices[0].message.thinking_blocks[0].type,
         signature_present: (.choices[0].message.thinking_blocks[0].signature != null),
         reasoning_tokens: .usage.completion_tokens_details.reasoning_tokens}'

{
  "answer": "# 17 × 23\n\nLet me break this down:\n\n**",
  "reasoning_content": "I need to calculate 17 × 23.\n\nLet me break this down:\n17 × 2",
  "thinking_block_type": "thinking",
  "signature_present": true,
  "reasoning_tokens": 111
}
```

`test_anthropic_chat_thinking_changes_the_translated_response` asserts exactly that delta, and it is load bearing: replacing the thinking-enabled call with a plain one turns it red at the first reasoning assertion, with the model still returning a correct answer ("**The answer is 391.**") alongside `reasoning_content=None`, `thinking_blocks=None` and `reasoning_tokens=0`

**2. Anthropic tool call: the real tool_calls payload**

```bash
$ curl -s -X POST $PROXY/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
  "model": "e2e-doc-anthropic",
  "messages": [{"role": "user", "content": "What is the weather in San Francisco? Use the get_weather tool."}],
  "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get the current weather for a location",
    "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}}}],
  "tool_choice": "required",
  "max_tokens": 256
}' | jq '{model, tool_calls: .choices[0].message.tool_calls, finish_reason: .choices[0].finish_reason}'

{
  "model": "e2e-doc-anthropic",
  "tool_calls": [
    {
      "index": 0,
      "caller": {
        "type": "direct"
      },
      "function": {
        "arguments": "{\"location\": \"San Francisco\"}",
        "name": "get_weather"
      },
      "id": "toolu_01Q9J9Pnrtyv8guxVx7bTzav",
      "type": "function"
    }
  ],
  "finish_reason": "tool_calls"
}
```

**3. Anthropic prompt cache: the write, then the read**

This is the pair worth reading closely. The system block is identical across both calls and carries the `cache_control` breakpoint; only the user turn after the breakpoint changes. First call writes 5202 tokens, second call reads the same 5202 back, and `ephemeral_5m_input_tokens` confirms it landed in the 5 minute tier the registry cell names

```bash
$ PREFIX=""; for i in $(seq 1 400); do PREFIX="${PREFIX}Standing instruction ${i} for run demo: stay concise. "; done
$ mk_body() { jq -n --arg p "$PREFIX" --arg turn "$1" \
    '{model:"e2e-doc-anthropic", max_tokens:16, messages:[
       {role:"system", content:[{type:"text", text:$p, cache_control:{type:"ephemeral"}}]},
       {role:"user", content:[{type:"text", text:$turn}]}]}'; }

$ mk_body "Reply with the single word pong. turn-1" \
  | curl -s -X POST $PROXY/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @- \
  | jq '.usage'

{
  "completion_tokens": 5,
  "prompt_tokens": 5219,
  "total_tokens": 5224,
  "prompt_tokens_details": {
    "cached_tokens": 0,
    "text_tokens": 17,
    "cache_write_tokens": 5202,
    "cache_creation_tokens": 5202,
    "cache_creation_token_details": {
      "ephemeral_5m_input_tokens": 5202,
      "ephemeral_1h_input_tokens": 0
    }
  },
  "cache_creation_input_tokens": 5202,
  "cache_read_input_tokens": 0
}

$ mk_body "Reply with the single word pong. turn-2" \
  | curl -s -X POST $PROXY/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @- \
  | jq '.usage'

{
  "completion_tokens": 5,
  "prompt_tokens": 5219,
  "total_tokens": 5224,
  "prompt_tokens_details": {
    "cached_tokens": 5202,
    "text_tokens": 17,
    "cache_write_tokens": 0,
    "cache_creation_tokens": 0,
    "cache_creation_token_details": {
      "ephemeral_5m_input_tokens": 0,
      "ephemeral_1h_input_tokens": 0
    }
  },
  "cache_creation_input_tokens": 0,
  "cache_read_input_tokens": 5202
}
```

Send `turn-1` twice instead of `turn-1` then `turn-2` and the second response comes back from the gateway's own response cache carrying turn one's usage block, so it reports another 5202 token write and no read. That is the trap the test's per-call marker exists to avoid

**4. Vertex vision: the model names both halves of an inline image**

```bash
$ IMG="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAAmklEQVR42u3QQQkAAAgEMJNcEvtjLFuIj8ESrCZ5JT2vlCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBdxaTpa47LOh2vwAAAABJRU5ErkJggg=="
$ jq -n --arg img "$IMG" '{model:"e2e-doc-vertex", max_tokens:512, messages:[{role:"user", content:[
    {type:"text", text:"This image is split into two halves of different solid colors. Name the two colors and nothing else."},
    {type:"image_url", image_url:{url:$img}}]}]}' \
  | curl -s -X POST $PROXY/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d @- \
  | jq '{model, content: .choices[0].message.content}'

{
  "model": "e2e-doc-vertex",
  "content": "Red, Blue"
}
```

**5. Azure OpenAI on /v1/responses, and Azure AI Foundry Claude on /v1/chat/completions**

```bash
$ curl -s -X POST $PROXY/v1/responses -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
  "model": "e2e-doc-azure",
  "input": "Reply with one word.",
  "instructions": "You are a helpful assistant"
}' | jq '{model, status, text: [.output[]?.content[]?.text] | join("")}'

{
  "model": "e2e-doc-azure",
  "status": "completed",
  "text": "Okay."
}

$ curl -s -X POST $PROXY/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
  "model": "e2e-doc-foundry",
  "messages": [{"role": "user", "content": "Reply with the single word pong."}],
  "max_tokens": 512
}' | jq '{model, content: .choices[0].message.content}'

{
  "model": "e2e-doc-foundry",
  "content": "pong"
}
```

**6. A streamed Anthropic completion**

```bash
$ curl -s -N -X POST $PROXY/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{
  "model": "e2e-doc-anthropic",
  "messages": [{"role": "user", "content": "Count from 1 to 5, one number per line."}],
  "max_tokens": 64,
  "stream": true
}' | head -6

data: {"id":"chatcmpl-a8d3f9f2-cc99-4fdb-96f5-bd0bba7da4b8","object":"chat.completion.chunk","created":1785197938,"model":"e2e-doc-anthropic","choices":[{"index":0,"delta":{"role":"assistant","content":"1\n2\n3\n4"}}]}

data: {"id":"chatcmpl-a8d3f9f2-cc99-4fdb-96f5-bd0bba7da4b8","object":"chat.completion.chunk","created":1785197938,"model":"e2e-doc-anthropic","choices":[{"index":0,"delta":{"content":"\n5"}}]}

data: {"id":"chatcmpl-a8d3f9f2-cc99-4fdb-96f5-bd0bba7da4b8","object":"chat.completion.chunk","created":1785197938,"model":"e2e-doc-anthropic","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
```

**The suite itself**, same commit, same proxy:

```
$ cd tests/e2e
$ set -a; source .env; set +a
$ PYTHONPATH=. LITELLM_PROXY_URL=http://localhost:4058 python -m pytest \
    llm_translation/test_chat_completions_provider_matrix_e2e.py \
    llm_translation/test_responses_provider_matrix_e2e.py -v

============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
configfile: pytest.ini
plugins: anyio-4.14.2
collecting ... collected 17 items

TestAnthropicChatCompletions::test_anthropic_chat_streams_real_content PASSED [  5%]
TestAnthropicChatCompletions::test_anthropic_chat_returns_tool_call PASSED [ 11%]
TestAnthropicChatCompletions::test_anthropic_chat_streams_tool_call PASSED [ 17%]
TestAnthropicChatCompletions::test_anthropic_chat_vision_describes_image PASSED [ 23%]
TestAnthropicChatCompletions::test_anthropic_chat_prompt_cache_hits_on_repeat PASSED [ 29%]
TestAnthropicChatCompletions::test_anthropic_chat_structured_output_conforms_to_schema PASSED [ 35%]
TestAnthropicChatCompletions::test_anthropic_chat_thinking_changes_the_translated_response PASSED [ 41%]
TestAzureOpenAIChatCompletions::test_azure_openai_chat_returns_content PASSED [ 47%]
TestAzureOpenAIChatCompletions::test_azure_openai_chat_returns_tool_call PASSED [ 52%]
TestVertexChatCompletions::test_vertex_chat_streams_real_content PASSED [ 58%]
TestVertexChatCompletions::test_vertex_chat_returns_tool_call PASSED [ 64%]
TestVertexChatCompletions::test_vertex_chat_vision_describes_image PASSED [ 70%]
TestAzureFoundryChatCompletions::test_azure_foundry_chat_returns_content PASSED [ 76%]
TestAzureOpenAIResponses::test_azure_openai_responses_returns_completion PASSED [ 82%]
TestAzureOpenAIResponses::test_azure_openai_responses_returns_function_call PASSED [ 88%]
TestVertexResponses::test_vertex_responses_returns_completion PASSED [ 94%]
TestVertexResponses::test_vertex_responses_returns_function_call PASSED [100%]

============================= 17 passed in 16.35s ==============================
```

The suite was run repeatedly at this commit to rule out flakiness, most recently alongside the capture session above. The coverage collector moves Core LLMs from 116/133 to 133/133 and the headline from 314/431 to 331/431, with `--strict` reporting no orphan markers. `basedpyright tests/e2e` reports zero errors

## Type

✅ Test

## Changes

Two new files under `tests/e2e/llm_translation/`, both self-contained; no shared harness module, no existing test file, and no product code is touched. `test_chat_completions_provider_matrix_e2e.py` holds 13 tests across four classes, one class per provider route, and `test_responses_provider_matrix_e2e.py` holds 4 tests across two. Every test registers the deployment it needs through `/model/new`, drives it with a scoped virtual key, and tears both down through the `resources` fixture, so nothing is baked into the gateway config

The backends are the current cheapest member of each family: `anthropic/claude-haiku-4-5`, `azure/gpt-5.6-sol-e2e`, `vertex_ai/gemini-2.5-flash`, and `azure_ai/claude-haiku-4-5`

**Credentials a reviewer needs.** Deployments carry `os.environ/NAME` references that the proxy process resolves at call time, so the credentials must be present in the proxy's environment rather than the test runner's. `TestAnthropicChatCompletions` needs `ANTHROPIC_API_KEY`; `TestAzureOpenAIChatCompletions` and `TestAzureOpenAIResponses` need `AZURE_API_BASE` and `AZURE_API_KEY`, plus a deployment actually named `gpt-5.6-sol-e2e` on that resource; `TestAzureFoundryChatCompletions` needs `AZURE_AI_API_BASE` and `AZURE_AI_API_KEY`; `TestVertexChatCompletions` and `TestVertexResponses` need `VERTEXAI_PROJECT` and `VERTEXAI_CREDENTIALS`. A reviewer missing any of these sees that class go red rather than skip, which is the harness rule for this directory

**How the prompt-cache test works, and why it must stay that way.** `test_anthropic_chat_prompt_cache_hits_on_repeat` asserts on Anthropic's own usage fields: the first call must report `cache_creation_input_tokens > 0` for a system block carrying a `cache_control` breakpoint, and a later call must report `cache_read_input_tokens` at least as large as that written count, polled to a 30 second deadline. Every call carries a fresh `unique_marker()` in the user turn that follows the breakpoint. That is deliberate and load-bearing. Repeating a byte-identical body instead makes the gateway answer the second request from its own response cache and replay turn one's usage block, which hands the test a cache write a second time and hides whether Anthropic ever served a read; the test then fails for a reason that looks exactly like a provider bug. Anything that removes the marker, or reuses one body object across both calls, silently breaks this test's meaning while leaving it green-looking in review. Transcript 3 in Proof of Fix shows both halves of that contract on real traffic

**How the thinking test proves a delta.** `test_anthropic_chat_thinking_changes_the_translated_response` asks the same question twice, once plain and once with a thinking budget, because a single thinking-enabled call that comes back with text proves nothing; a gateway that silently dropped the `thinking` parameter would still return a well-reasoned-looking answer. Each half is pinned to Anthropic's own representation as translated onto the OpenAI-shaped response: `reasoning_content`, a `thinking_blocks` entry of type `thinking` carrying the signature Anthropic issues for it, and `completion_tokens_details.reasoning_tokens`. The plain call must carry none of the three, and the thinking call must carry all three. Transcript 1 shows the contrast on real traffic, including that the answer text itself is identical across the two calls

**Registry route mapping.** The `vertex` cells are exercised through the `vertex_ai/` path with `vertex_project` and `vertex_credentials`, rather than through AI Studio's `gemini/` path. The mapping for every id was taken from the rows in `tests/e2e/coverage_registry/llm_conversational.yaml`, which carry an explicit `route` field and a rationale naming the product ("Vertex Gemini function_calling", "Azure Foundry (azure_ai)", "Azure OpenAI deployments"), cross-checked against which ids existing tests already claim so no cell is double-claimed by two different model families. Worth flagging for a follow-up: `llm.chat_completions.vertex.basic.nonstream.works` is claimed today by the `CHAT_MODELS` matrix in `test_chat_completions_regression_e2e.py` using an AI Studio `gemini-2.5-flash` deployment, which does not exercise Vertex; that pre-existing claim is out of scope here and left untouched

**Two assertions that are deliberately narrower than the rest.** The vision tests send a generated 211 byte PNG as a base64 data URI, split into a red half and a blue half, and assert the model names both colors. That proves image decode and spatial reading rather than object recognition in a photograph, which is a slightly narrower claim than the hosted-image vision tests elsewhere in this suite. It is the only shape that works here: Anthropic and Vertex both fetch a remote `image_url` from their own side and both are refused by the usual public image hosts, so a link would make the test measure a host's crawler policy instead of the gateway's image translation. Separately, the two Azure-hosted basic prompts carry no random marker, because Microsoft's prompt shields intermittently classify a random hex token in an otherwise trivial prompt as a jailbreak attempt and return a 400; uniqueness for those two comes from the per-test deployment name, which is what keys the response cache

## QA runbook

Prerequisites: a live proxy started with `STORE_MODEL_IN_DB=True`, the master key `sk-1234`, and the provider credentials listed under Changes present in the proxy's own environment. Set the shared shell variables once, including the image and cache-prefix helpers the vision and caching steps reuse:

```bash
export PROXY=http://localhost:4000
export AUTH='Authorization: Bearer sk-1234'
export CT='Content-Type: application/json'
export IMG="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAIAAABt+uBvAAAAmklEQVR42u3QQQkAAAgEMJNcEvtjLFuIj8ESrCZ5JT2vlCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBggQJEiRIkCBBdxaTpa47LOh2vwAAAABJRU5ErkJggg=="
export TOOL='{"type":"function","function":{"name":"get_weather","description":"Get the current weather for a location","parameters":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}}'
```

Register the four deployments once; each runbook entry names the one it uses, and `POST /model/delete` with the returned `model_id` cleans up at the end:

```bash
curl -s -X POST $PROXY/model/new -H "$AUTH" -H "$CT" -d '{"model_name":"qa-anthropic","model_info":{},"litellm_params":{"model":"anthropic/claude-haiku-4-5","api_key":"os.environ/ANTHROPIC_API_KEY"}}'
curl -s -X POST $PROXY/model/new -H "$AUTH" -H "$CT" -d '{"model_name":"qa-azure","model_info":{},"litellm_params":{"model":"azure/gpt-5.6-sol-e2e","api_base":"os.environ/AZURE_API_BASE","api_key":"os.environ/AZURE_API_KEY"}}'
curl -s -X POST $PROXY/model/new -H "$AUTH" -H "$CT" -d '{"model_name":"qa-vertex","model_info":{},"litellm_params":{"model":"vertex_ai/gemini-2.5-flash","vertex_project":"os.environ/VERTEXAI_PROJECT","vertex_credentials":"os.environ/VERTEXAI_CREDENTIALS"}}'
curl -s -X POST $PROXY/model/new -H "$AUTH" -H "$CT" -d '{"model_name":"qa-foundry","model_info":{},"litellm_params":{"model":"azure_ai/claude-haiku-4-5","api_base":"os.environ/AZURE_AI_API_BASE","api_key":"os.environ/AZURE_AI_API_KEY"}}'
```

- tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py::TestAnthropicChatCompletions::test_anthropic_chat_streams_real_content - a streamed Anthropic completion delivers real content deltas rather than a clean but empty stream
  - [ ] `curl -s -N -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d '{"model":"qa-anthropic","messages":[{"role":"user","content":"Count from 1 to 5, one number per line."}],"max_tokens":64,"stream":true}'`
  - [ ] Expect `content-type: text/event-stream`, more than one `data:` event, and `delta.content` fragments that concatenate to the numbers
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py::TestAnthropicChatCompletions::test_anthropic_chat_returns_tool_call - a forced tool call over Anthropic comes back as a usable OpenAI-shaped tool_calls entry
  - [ ] `curl -s -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d '{"model":"qa-anthropic","messages":[{"role":"user","content":"What is the weather in San Francisco? Use the get_weather tool."}],"tools":['"$TOOL"'],"tool_choice":"required","max_tokens":256}' | jq '.choices[0].message.tool_calls'`
  - [ ] Expect one entry named `get_weather` whose `arguments` parse as JSON carrying a non-empty `location`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py::TestAnthropicChatCompletions::test_anthropic_chat_streams_tool_call - a streamed Anthropic tool call reassembles into a complete call with valid argument JSON
  - [ ] `curl -s -N -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d '{"model":"qa-anthropic","messages":[{"role":"user","content":"What is the weather in San Francisco? Use the get_weather tool."}],"tools":['"$TOOL"'],"tool_choice":"required","max_tokens":256,"stream":true}'`
  - [ ] Concatenate the streamed `delta.tool_calls` fragments and expect the name `get_weather` plus argument JSON carrying a `location`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py::TestAnthropicChatCompletions::test_anthropic_chat_vision_describes_image - Anthropic reads an inline base64 image sent in OpenAI content-part form
  - [ ] `jq -n --arg img "$IMG" '{model:"qa-anthropic",max_tokens:512,messages:[{role:"user",content:[{type:"text",text:"This image is split into two halves of different solid colors. Name the two colors and nothing else."},{type:"image_url",image_url:{url:$img}}]}]}' | curl -s -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d @- | jq '.choices[0].message.content'`
  - [ ] Expect an answer naming both red and blue
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py::TestAnthropicChatCompletions::test_anthropic_chat_prompt_cache_hits_on_repeat - a cache_control breakpoint survives translation, so a later call reads the prefix back instead of re-billing it at write price
  - [ ] Build the prefix and a body helper: `PREFIX=""; for i in $(seq 1 400); do PREFIX="${PREFIX}Standing instruction ${i} for run demo: stay concise. "; done` then `mk_body() { jq -n --arg p "$PREFIX" --arg turn "$1" '{model:"qa-anthropic",max_tokens:16,messages:[{role:"system",content:[{type:"text",text:$p,cache_control:{type:"ephemeral"}}]},{role:"user",content:[{type:"text",text:$turn}]}]}'; }`
  - [ ] `mk_body "Reply with the single word pong. turn-1" | curl -s -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d @- | jq '.usage'` and expect `cache_creation_input_tokens` above zero
  - [ ] `mk_body "Reply with the single word pong. turn-2" | curl -s -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d @- | jq '.usage'` and expect `cache_read_input_tokens` at least equal to the first call's creation count
  - [ ] Repeat the second command with `turn-1` instead and watch it report a write again; that is the gateway's response cache replaying the first answer, and it is why the test varies the user turn
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py::TestAnthropicChatCompletions::test_anthropic_chat_structured_output_conforms_to_schema - response_format json_schema constrains Anthropic's answer to the requested shape
  - [ ] `curl -s -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d '{"model":"qa-anthropic","messages":[{"role":"user","content":"Extract the person. John Doe is 42 years old."}],"max_tokens":256,"response_format":{"type":"json_schema","json_schema":{"name":"person","strict":true,"schema":{"type":"object","properties":{"name":{"type":"string"},"age":{"type":"integer"}},"required":["name","age"],"additionalProperties":false}}}}' | jq -r '.choices[0].message.content'`
  - [ ] Expect the content to parse as JSON with a non-empty `name` and `age` exactly 42
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py::TestAnthropicChatCompletions::test_anthropic_chat_thinking_changes_the_translated_response - enabling extended thinking changes the translated response, proven against the same question asked without it
  - [ ] `Q="What is 17 times 23? Think it through step by step."`
  - [ ] Baseline: `curl -s -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d "{\"model\":\"qa-anthropic\",\"messages\":[{\"role\":\"user\",\"content\":\"$Q\"}],\"max_tokens\":2048}" | jq '{reasoning_content: .choices[0].message.reasoning_content, thinking_blocks: .choices[0].message.thinking_blocks, reasoning_tokens: .usage.completion_tokens_details.reasoning_tokens}'`
  - [ ] Expect a real answer but `reasoning_content` null, `thinking_blocks` null, and `reasoning_tokens` zero
  - [ ] Thinking enabled: re-send the same body with `"thinking":{"type":"enabled","budget_tokens":1024}` added
  - [ ] Expect non-empty `reasoning_content`, a `thinking_blocks[0]` of type `thinking` carrying a `signature`, and `reasoning_tokens` above zero, while the answer text stays much the same
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py::TestAzureOpenAIChatCompletions::test_azure_openai_chat_returns_content - a deployment behind an Azure resource name answers with a real completion
  - [ ] `curl -s -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d '{"model":"qa-azure","messages":[{"role":"user","content":"Reply with the single word pong."}],"max_tokens":512}' | jq '{model, content: .choices[0].message.content}'`
  - [ ] Expect a model name in the body and non-empty content
  - [ ] Append a random hex token to that prompt and expect an intermittent 400 from Azure's prompt shields reporting a jailbreak detection, which is why the test prompt is plain prose
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py::TestAzureOpenAIChatCompletions::test_azure_openai_chat_returns_tool_call - function calling works over the Azure deployment path
  - [ ] `curl -s -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d '{"model":"qa-azure","messages":[{"role":"user","content":"What is the weather in San Francisco? Use the get_weather tool."}],"tools":['"$TOOL"'],"tool_choice":"required","reasoning_effort":"low","max_tokens":1024}' | jq '.choices[0].message.tool_calls'`
  - [ ] Expect a `get_weather` call whose arguments parse as JSON with a `location`
  - [ ] Swap `reasoning_effort` to `none` and expect a 400 naming low, medium and high as the supported values; that is why the test uses low
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py::TestVertexChatCompletions::test_vertex_chat_streams_real_content - a streamed Vertex completion delivers real content deltas
  - [ ] `curl -s -N -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d '{"model":"qa-vertex","messages":[{"role":"user","content":"Count from 1 to 5, one number per line."}],"max_tokens":512,"stream":true}'`
  - [ ] Expect an SSE response with several data events and non-blank concatenated deltas
  - [ ] Drop `max_tokens` to 16 and expect a 200 with empty content, since Gemini spends the budget on thinking; that is why the test uses 512
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py::TestVertexChatCompletions::test_vertex_chat_returns_tool_call - Gemini function calling over Vertex returns an OpenAI-shaped tool call
  - [ ] `curl -s -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d '{"model":"qa-vertex","messages":[{"role":"user","content":"What is the weather in San Francisco? Use the get_weather tool."}],"tools":['"$TOOL"'],"tool_choice":"required","max_tokens":512}' | jq '.choices[0].message.tool_calls'`
  - [ ] Expect a `get_weather` call whose arguments parse as JSON with a `location`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py::TestVertexChatCompletions::test_vertex_chat_vision_describes_image - Vertex reads an inline base64 image sent in OpenAI content-part form
  - [ ] `jq -n --arg img "$IMG" '{model:"qa-vertex",max_tokens:512,messages:[{role:"user",content:[{type:"text",text:"This image is split into two halves of different solid colors. Name the two colors and nothing else."},{type:"image_url",image_url:{url:$img}}]}]}' | curl -s -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d @- | jq '.choices[0].message.content'`
  - [ ] Expect an answer naming both red and blue
  - [ ] Swap the data URI for a hosted image link and expect a 400 reporting `URL_UNREACHABLE`, since Vertex fetches the link itself and honours robots.txt
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_chat_completions_provider_matrix_e2e.py::TestAzureFoundryChatCompletions::test_azure_foundry_chat_returns_content - Claude served from Azure AI Foundry answers on the OpenAI-compatible route
  - [ ] `curl -s -X POST $PROXY/v1/chat/completions -H "$AUTH" -H "$CT" -d '{"model":"qa-foundry","messages":[{"role":"user","content":"Reply with the single word pong."}],"max_tokens":512}' | jq '{model, content: .choices[0].message.content}'`
  - [ ] Expect a model name in the body and non-empty content
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_responses_provider_matrix_e2e.py::TestAzureOpenAIResponses::test_azure_openai_responses_returns_completion - the Responses API returns real output text over an Azure deployment
  - [ ] `curl -s -X POST $PROXY/v1/responses -H "$AUTH" -H "$CT" -d '{"model":"qa-azure","input":"Reply with one word.","instructions":"You are a helpful assistant"}' | jq '{status, text: [.output[]?.content[]?.text] | join("")}'`
  - [ ] Expect `status` completed and non-empty text
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_responses_provider_matrix_e2e.py::TestAzureOpenAIResponses::test_azure_openai_responses_returns_function_call - the Responses API emits a function call over an Azure deployment
  - [ ] `curl -s -X POST $PROXY/v1/responses -H "$AUTH" -H "$CT" -d '{"model":"qa-azure","input":"What is the weather in San Francisco? Use the get_weather tool.","instructions":"You are a helpful assistant","tools":[{"type":"function","name":"get_weather","description":"Get the weather for a location","parameters":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}]}' | jq '.output[] | select(.type=="function_call")'`
  - [ ] Expect an item named `get_weather` whose `arguments` parse as JSON with a `location`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_responses_provider_matrix_e2e.py::TestVertexResponses::test_vertex_responses_returns_completion - the Responses API returns real output text over a Vertex deployment
  - [ ] `curl -s -X POST $PROXY/v1/responses -H "$AUTH" -H "$CT" -d '{"model":"qa-vertex","input":"Reply with one word.","instructions":"You are a helpful assistant"}' | jq '{status, text: [.output[]?.content[]?.text] | join("")}'`
  - [ ] Expect `status` completed and non-empty text
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_responses_provider_matrix_e2e.py::TestVertexResponses::test_vertex_responses_returns_function_call - the Responses API emits a function call over a Vertex deployment
  - [ ] `curl -s -X POST $PROXY/v1/responses -H "$AUTH" -H "$CT" -d '{"model":"qa-vertex","input":"What is the weather in San Francisco? Use the get_weather tool.","instructions":"You are a helpful assistant","tools":[{"type":"function","name":"get_weather","description":"Get the weather for a location","parameters":{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}}]}' | jq '.output[] | select(.type=="function_call")'`
  - [ ] Expect an item named `get_weather` whose `arguments` parse as JSON with a `location`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
