### PR TITLE
test(e2e): cover cohere embeddings and vertex speech and image endpoints

### DIFF
--- a/tests/e2e/e2e_http.py
+++ b/tests/e2e/e2e_http.py
@@ -122,7 +122,15 @@ class StreamingResponse(BaseModel):
     non-streaming `application/json`), the response headers (lowercased names, e.g.
     the x-ratelimit-* pacing headers and retry-after on a 429), and the body.
     SpendLogs.request_id is the completion body id, not call_id. Used by passthrough
-    and streaming, where one validated JSON model does not fit."""
+    and streaming, where one validated JSON model does not fit.
+
+    `body` is the text decoding of the response, which mangles a binary payload
+    (audio, images) beyond recovery, so `content` carries the undecoded bytes of a
+    non-streamed body. That lets a caller assert the payload really is the format
+    its content-type claims, including walking a container whose structure runs past
+    any fixed-size prefix. It holds the object requests already materialized for
+    `body`, so keeping it costs no second read and no copy of the wire. It stays
+    empty for a streamed body, whose bytes are consumed as events."""
 
     status_code: int
     call_id: str | None = None  # x-litellm-call-id header
@@ -130,6 +138,7 @@ class StreamingResponse(BaseModel):
     content_type: str | None = None
     headers: dict[str, str] = {}
     body: str
+    content: bytes = b""
     chunks: int = 0  # streamed events (0 for non-streaming)
     stream_events: list[str] = []
     # First in-stream error event, if any. A streamed call commits its HTTP 200
@@ -403,6 +412,7 @@ def _streaming_outcome(resp: requests.Response, stream: bool) -> StreamingRespon
             content_type=content_type,
             headers=headers,
             body=resp.text,
+            content=resp.content,
         )
     lines = cast("Iterator[bytes]", resp.iter_lines())
     chunks = 0

--- a/tests/e2e/llm_translation/test_nonconversational_provider_matrix_e2e.py
+++ b/tests/e2e/llm_translation/test_nonconversational_provider_matrix_e2e.py
@@ -1,0 +1,277 @@
+"""Live e2e: the non-conversational endpoints on the providers the OpenAI-only tests
+in this directory never reach; Cohere embeddings, and Vertex AI speech and images.
+
+Each test registers its own deployment through /model/new (deleted on teardown) and
+asserts the customer-observable payload: a real non-zero vector for /embeddings, and
+for the two binary endpoints the decoded bytes themselves. A content-type header is
+the provider's claim rather than evidence, and so is a magic number on its own, so
+the audio and image cases read the container's own structure and check it against
+itself: a RIFF/WAVE whose declared sizes match the bytes that arrived, whose fmt
+chunk describes a coherent stream, and whose chunk list carries a data chunk holding
+real samples, and a PNG whose IHDR gives real dimensions and whose final chunk is
+the IEND that marks a complete file. Credentials stay in the proxy's env and are
+referenced as `os.environ/...`, so no secret travels in the request.
+
+Structural checks stop where a real decoder would begin. They prove the container is
+internally consistent and complete rather than that every sample decodes, which is
+the line worth holding in a coverage test.
+
+Vertex text-to-speech goes to the Google Cloud synthesize endpoint rather than a
+regional Vertex endpoint, so the deployment only needs the project; image generation
+is served by gemini-2.5-flash-image, the image model this project has access to.
+Vertex synthesizes LINEAR16, so the audio arrives as a RIFF/WAVE container even
+though the gateway labels every non-gemini speech response audio/mpeg.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from e2e_config import unique_marker
+from e2e_http import StreamingResponse, require_successful_call
+from endpoints_client import EmbeddingsResult, EndpointsClient, ImagesResult
+from lifecycle import ResourceManager
+from models import LiteLLMParamsBody
+
+pytestmark = pytest.mark.e2e
+
+VERTEX_LOCATION = "us-central1"
+
+MIN_AUDIO_BYTES = 4096
+MIN_IMAGE_BYTES = 1024
+
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+PNG_IEND = b"IEND\xaeB`\x82"
+PNG_MAX_DIMENSION = 16384
+
+WAV_PCM_FORMATS = (1, 3, 0xFFFE)
+WAV_BIT_DEPTHS = (8, 16, 24, 32)
+WAV_MIN_SAMPLE_RATE = 8000
+WAV_MAX_SAMPLE_RATE = 192000
+WAV_MAX_CHANNELS = 8
+WAV_MIN_DATA_BYTES = 1024
+
+
+def _wav_fmt_defect(raw: bytes, at: int, size: int) -> str | None:
+    if size < 16 or at + 16 > len(raw):
+        return f"fmt chunk declares {size} bytes, too few to describe a stream"
+    audio_format = int.from_bytes(raw[at : at + 2], "little")
+    channels = int.from_bytes(raw[at + 2 : at + 4], "little")
+    sample_rate = int.from_bytes(raw[at + 4 : at + 8], "little")
+    byte_rate = int.from_bytes(raw[at + 8 : at + 12], "little")
+    block_align = int.from_bytes(raw[at + 12 : at + 14], "little")
+    bits_per_sample = int.from_bytes(raw[at + 14 : at + 16], "little")
+    if audio_format not in WAV_PCM_FORMATS:
+        return f"fmt chunk declares audio format {audio_format}, which is not PCM"
+    if not 1 <= channels <= WAV_MAX_CHANNELS:
+        return f"fmt chunk declares {channels} channels"
+    if not WAV_MIN_SAMPLE_RATE <= sample_rate <= WAV_MAX_SAMPLE_RATE:
+        return f"fmt chunk declares a {sample_rate} Hz sample rate"
+    if bits_per_sample not in WAV_BIT_DEPTHS:
+        return f"fmt chunk declares {bits_per_sample} bits per sample"
+    expected_align = channels * bits_per_sample // 8
+    if block_align != expected_align:
+        return (
+            f"fmt chunk declares a {block_align} byte block for {channels} channels "
+            f"of {bits_per_sample} bits, which needs {expected_align}"
+        )
+    if byte_rate != sample_rate * expected_align:
+        return (
+            f"fmt chunk declares {byte_rate} bytes per second, but {sample_rate} Hz "
+            f"at {expected_align} bytes per frame is {sample_rate * expected_align}"
+        )
+    return None
+
+
+def _wav_defect(raw: bytes) -> str | None:
+    """The self-consistency a real RIFF/WAVE clip has and a malformed blob does not:
+    the container's declared sizes agree with the bytes that arrived, every chunk
+    fits inside the payload, the chunk list consumes the payload exactly, the fmt
+    chunk describes a stream whose rates multiply out, and a data chunk actually
+    carries samples. The chunk list is walked rather than probed at fixed offsets,
+    since a valid file may carry LIST or fact chunks before its data.
+
+    Each chunk's pad byte to the next even boundary is part of the chunk, so a walk
+    that lands one byte past the end has read a final odd-length chunk whose trailing
+    pad was omitted at EOF, which carries no samples and is left to pass. Landing
+    short is different: 1 to 7 bytes cannot begin another chunk, so the response was
+    cut off mid-header."""
+    size = len(raw)
+    if raw[:4] != b"RIFF" or raw[8:12] != b"WAVE":
+        return f"not a RIFF/WAVE container; first bytes are {raw[:12]!r}"
+    riff_size = int.from_bytes(raw[4:8], "little")
+    if riff_size != size - 8:
+        return (
+            f"RIFF declares {riff_size} bytes but {size - 8} arrived after the "
+            f"8 byte header, so the payload is truncated or padded"
+        )
+    seen: tuple[bytes, ...] = ()
+    data_bytes = 0
+    offset = 12
+    while offset + 8 <= size:
+        chunk_id = raw[offset : offset + 4]
+        chunk_size = int.from_bytes(raw[offset + 4 : offset + 8], "little")
+        payload_at = offset + 8
+        if payload_at + chunk_size > size:
+            return (
+                f"{chunk_id!r} chunk declares {chunk_size} bytes with only "
+                f"{size - payload_at} left in the response, so it overruns the end"
+            )
+        if chunk_id == b"fmt ":
+            defect = _wav_fmt_defect(raw, payload_at, chunk_size)
+            if defect is not None:
+                return defect
+        elif chunk_id == b"data":
+            if chunk_size < WAV_MIN_DATA_BYTES:
+                return f"data chunk carries only {chunk_size} bytes of samples"
+            data_bytes = chunk_size
+        seen = (*seen, chunk_id)
+        offset = payload_at + chunk_size + chunk_size % 2
+    if b"fmt " not in seen:
+        return f"no fmt chunk in the chunk list {seen!r}"
+    if data_bytes == 0:
+        return f"no data chunk in the chunk list {seen!r}, so it carries no audio"
+    trailing = size - offset
+    if trailing > 0:
+        return (
+            f"the response carries {trailing} more byte{'s' if trailing > 1 else ''} "
+            f"than the chunk list {seen!r} accounts for, too few to form another "
+            f"chunk header, so it was cut off mid-chunk"
+        )
+    return None
+
+
+def _png_defect(raw: bytes) -> str | None:
+    """A PNG states its own dimensions in the IHDR chunk that must open the file and
+    ends with the IEND marker, so a truncated or corrupted image fails one of them."""
+    if not raw.startswith(PNG_MAGIC):
+        return f"not a PNG; first bytes are {raw[:12]!r}"
+    if len(raw) < 33:
+        return f"PNG stops after {len(raw)} bytes, before IHDR ends"
+    ihdr_size = int.from_bytes(raw[8:12], "big")
+    if raw[12:16] != b"IHDR" or ihdr_size != 13:
+        return f"PNG signature is not followed by a 13 byte IHDR; found {raw[12:16]!r}"
+    width = int.from_bytes(raw[16:20], "big")
+    height = int.from_bytes(raw[20:24], "big")
+    if not 0 < width <= PNG_MAX_DIMENSION or not 0 < height <= PNG_MAX_DIMENSION:
+        return f"IHDR declares implausible dimensions {width}x{height}"
+    if not raw.endswith(PNG_IEND):
+        return (
+            f"PNG does not end with IEND, so the image is truncated; last bytes are "
+            f"{raw[-8:]!r}"
+        )
+    return None
+
+
+def _assert_real_vector(body: str) -> None:
+    parsed = EmbeddingsResult.model_validate_json(body)
+    assert parsed.first_vector, f"/embeddings returned no vector: {body[:300]}"
+    assert any(component != 0.0 for component in parsed.first_vector), (
+        f"embedding vector is all zeros: {body[:300]}"
+    )
+
+
+def _assert_real_audio(result: StreamingResponse) -> None:
+    assert "audio" in (result.content_type or ""), (
+        f"/audio/speech content-type is not audio: {result.content_type!r}"
+    )
+    assert len(result.content) >= MIN_AUDIO_BYTES, (
+        f"/audio/speech returned only {len(result.content)} bytes, too short to be "
+        f"spoken audio"
+    )
+    defect = _wav_defect(result.content)
+    assert defect is None, (
+        f"/audio/speech body is not a coherent WAV: {defect}. Vertex synthesizes "
+        f"LINEAR16; a deployment returning another container needs that container's "
+        f"structural check added here"
+    )
+
+
+def _assert_real_image(body: str) -> None:
+    parsed = ImagesResult.model_validate_json(body)
+    assert parsed.data, f"/images/generations returned no data: {body[:300]}"
+    first = parsed.data[0]
+    assert first.b64_json, (
+        f"generated image carries no b64_json (url={first.url!r}), so its bytes "
+        f"cannot be checked"
+    )
+    raw = base64.b64decode(first.b64_json)
+    assert len(raw) >= MIN_IMAGE_BYTES, (
+        f"generated image decodes to only {len(raw)} bytes, too small to be a picture"
+    )
+    defect = _png_defect(raw)
+    assert defect is None, f"generated image is not a coherent PNG: {defect}"
+
+
+class TestCohereEmbeddings:
+    @pytest.mark.covers(
+        "llm.embeddings.cohere.basic.nonstream.works", exercised_on=["embeddings"]
+    )
+    def test_cohere_embeddings_returns_vector(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model = f"e2e-cohere-embeddings-{unique_marker()}"
+        model_id = endpoints_client.create_model(
+            model,
+            LiteLLMParamsBody(
+                model="cohere/embed-v4.0", api_key="os.environ/COHERE_API_KEY"
+            ),
+        )
+        resources.defer(lambda: endpoints_client.delete_model(model_id))
+        key = resources.key(models=[model])
+
+        result = endpoints_client.embeddings(key, model, "Say this is a test!")
+        require_successful_call(result)
+        _assert_real_vector(result.body)
+
+
+class TestVertexNonConversational:
+    def _register(
+        self,
+        endpoints_client: EndpointsClient,
+        resources: ResourceManager,
+        name: str,
+        backend: str,
+    ) -> tuple[str, str]:
+        model = f"e2e-{name}-{unique_marker()}"
+        model_id = endpoints_client.create_model(
+            model,
+            LiteLLMParamsBody(
+                model=backend,
+                vertex_project="os.environ/VERTEXAI_PROJECT",
+                vertex_location=VERTEX_LOCATION,
+            ),
+        )
+        resources.defer(lambda: endpoints_client.delete_model(model_id))
+        return model, resources.key(models=[model])
+
+    @pytest.mark.covers(
+        "llm.audio_speech.vertex.basic.nonstream.works", exercised_on=["audio_speech"]
+    )
+    def test_vertex_audio_speech_returns_audio(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model, key = self._register(
+            endpoints_client, resources, "vertex-speech", "vertex_ai/chirp"
+        )
+
+        result = endpoints_client.audio_speech(key, model, "Hello!")
+        require_successful_call(result)
+        _assert_real_audio(result)
+
+    @pytest.mark.covers(
+        "llm.images_generations.vertex.basic.nonstream.works",
+        exercised_on=["images_generations"],
+    )
+    def test_vertex_image_generation_returns_image(
+        self, endpoints_client: EndpointsClient, resources: ResourceManager
+    ) -> None:
+        model, key = self._register(
+            endpoints_client, resources, "vertex-image", "vertex_ai/gemini-2.5-flash-image"
+        )
+
+        result = endpoints_client.images(key, model, "Draw a cute cat")
+        require_successful_call(result)
+        _assert_real_image(result.body)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cohere embeddings had no live e2e coverage
- Vertex speech and image endpoints had none either
- Registry cells for those three sat uncovered

How it solves it:

- Adds one e2e file registering each deployment at runtime
- Asserts a real vector, and structurally coherent audio and image bytes
- Claims the three matching coverage-registry cells

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All three tests pass against a live proxy on port 4058 backed by real Cohere and real Vertex AI, at commit `5002134bff`. No mocks, no recorded responses; every call bills the provider

```
$ cd tests/e2e
$ set -a; source .env; set +a
$ PYTHONPATH=. LITELLM_PROXY_URL=http://localhost:4058 \
    python -m pytest llm_translation/test_nonconversational_provider_matrix_e2e.py -v

============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /.../tests/e2e
configfile: pytest.ini
collecting ... collected 3 items

llm_translation/test_nonconversational_provider_matrix_e2e.py::TestCohereEmbeddings::test_cohere_embeddings_returns_vector PASSED [ 33%]
llm_translation/test_nonconversational_provider_matrix_e2e.py::TestVertexNonConversational::test_vertex_audio_speech_returns_audio PASSED [ 66%]
llm_translation/test_nonconversational_provider_matrix_e2e.py::TestVertexNonConversational::test_vertex_image_generation_returns_image PASSED [100%]

============================== 3 passed in 8.43s ===============================
```

The Vertex speech call came back as a costed, real audio response; the harness recorded `status_code=200, response_cost=0.00018, content_type='audio/mpeg'`, a 30044 byte body opening `RIFF...WAVE` whose RIFF header declares exactly the 30036 bytes that followed it. The image call returned 1256189 decoded bytes opening with the PNG signature and closing with IEND

Every assertion was checked by mutation at the same commit, so none of them is decorative. Swapping each deployment for a wrong-modality model of the same provider (`cohere/command-r-08-2024` for embeddings, `vertex_ai/gemini-2.5-flash` for speech and for images) turns all three red: Cohere answers `invalid request: model 'command-r-08-2024' ...`, and Vertex answers `Multi-modal output is not supported`

The audio and image assertions were mutated separately, against payloads a broken gateway could plausibly emit. That includes the case a signature check alone cannot catch: a payload that is large and correctly signed while being internally incoherent. Every mutant fails, and a coherent payload still passes:

```
KILLED audio: 60KB JSON error page served as audio/mpeg: not a RIFF/WAVE container; first bytes are b'{"error":{"m'
KILLED audio: 60KB of noise behind a RIFF/WAVE signature: RIFF declares 286331153 bytes but 61428 arrived after the 8 byte header
KILLED audio: RIFF size field disagrees with the bytes that arrived: RIFF declares 999999 bytes but 20036 arrived after the 8 byte header
KILLED audio: truncated clip, RIFF header intact: RIFF declares 20036 bytes but 14992 arrived after the 8 byte header
KILLED audio: byte rate inconsistent with sample rate and block align: fmt chunk declares 12345 bytes per second, but 24000 Hz at 2 bytes per frame is 48000
KILLED audio: block align inconsistent with channels and bit depth: fmt chunk declares a 7 byte block for 1 channels of 16 bits, which needs 2
KILLED audio: fmt chunk declares a non-PCM format: fmt chunk declares audio format 0, which is not PCM
KILLED audio: nonsense sample rate: fmt chunk declares a 3 Hz sample rate
KILLED audio: nonsense bit depth: fmt chunk declares 7 bits per sample
KILLED audio: chunk list is padding, no fmt and no data: no fmt chunk in the chunk list (b'JUNK',)
KILLED audio: valid RIFF and fmt, no data chunk at all: no data chunk in the chunk list (b'fmt ', b'LIST'), so it carries no audio
KILLED audio: 20KB file whose data chunk header is truncated mid-field: no data chunk in the chunk list (b'LIST', b'fmt '), so it carries no audio
KILLED audio: data chunk declares zero samples: data chunk carries only 0 bytes of samples
KILLED audio: data chunk carries a trivial 512 bytes: data chunk carries only 512 bytes of samples
KILLED audio: valid fmt and data, trailing LIST chunk declaring more bytes than exist: b'LIST' chunk declares 999999 bytes with only 100 left in the response, so it overruns the end
KILLED audio: valid fmt and data, trailing chunk overruns by one byte: b'JUNK' chunk declares 101 bytes with only 100 left in the response, so it overruns the end
KILLED audio: leading LIST chunk declaring more bytes than exist: b'LIST' chunk declares 999999 bytes with only 22080 left in the response, so it overruns the end
KILLED audio: fmt chunk declaring more bytes than exist: b'fmt ' chunk declares 999999 bytes with only 20024 left in the response, so it overruns the end
KILLED audio: valid fmt and data, 3 trailing bytes that cannot start a chunk header: the response carries 3 more bytes than the chunk list (b'fmt ', b'data') accounts for, too few to form another chunk header, so it was cut off mid-chunk
KILLED audio: valid fmt and data, 7 trailing bytes, one short of a chunk header: the response carries 7 more bytes than the chunk list (b'fmt ', b'data') accounts for
KILLED audio: valid fmt and data, a single trailing byte: the response carries 1 more byte than the chunk list (b'fmt ', b'data') accounts for
KILLED audio: trailing chunk header cut off after its id: the response carries 4 more bytes than the chunk list (b'fmt ', b'data', b'LIST') accounts for
KILLED audio: empty body: /audio/speech returned only 0 bytes, too short to be spoken audio
KILLED image: 5KB of noise behind a PNG signature: PNG signature is not followed by a 13 byte IHDR; found b'\x11\x11\x11\x11'
KILLED image: IHDR declares zero width: IHDR declares implausible dimensions 0x64
KILLED image: IHDR chunk length is not 13: PNG signature is not followed by a 13 byte IHDR
KILLED image: truncated file, no IEND terminator: PNG does not end with IEND, so the image is truncated
KILLED image: b64 of plain text: not a PNG; first bytes are b'not an image'
KILLED image: url only, no bytes to check: generated image carries no b64_json (url='https://example.test/cat.png'), so its bytes cannot be checked
CONTROL canonical WAV passes
CONTROL valid WAV with a 2KB LIST chunk before fmt and data passes, so the walk does not assume an early data chunk
CONTROL valid WAV with an odd-length data chunk followed by its pad byte passes
CONTROL valid WAV whose final odd-length chunk omits its pad byte at EOF passes
CONTROL valid WAV with a well-formed trailing LIST chunk passes
CONTROL a coherent PNG passes
```

The controls matter as much as the mutants. A walker this strict must still accept the shapes a valid file legitimately takes, so it is exercised against metadata before the samples, an odd-length chunk followed by its pad byte, a final odd-length chunk whose pad byte is omitted at the end of the file, and a well-formed trailing chunk. A check that fails on real audio would be worse than the gap it closes, and the difference between a missing pad byte and a truncated response is exactly where that line runs

The sibling suites that share the touched harness model still pass on the same proxy: `test_audio_speech_e2e.py`, `test_audio_transcriptions_e2e.py`, `test_image_generation_e2e.py`, `test_embeddings_endpoint_e2e.py` and `test_moderations_e2e.py` give `8 passed`, with the two bedrock cases failing on an unrelated expired AWS token (`InvalidClientTokenId` from `AssumeRole`) in that environment

Environment prerequisites: the proxy process must hold `COHERE_API_KEY`, `VERTEXAI_PROJECT` and `VERTEXAI_CREDENTIALS`. The tests never send a secret; deployments carry `os.environ/NAME` references that the proxy resolves from its own environment at call time

## Type

✅ Test

## Changes

One new file, `tests/e2e/llm_translation/test_nonconversational_provider_matrix_e2e.py`. Each test registers its deployment through `/model/new`, scopes a virtual key to it, drives the endpoint, and deletes both on teardown, following `test_embeddings_endpoint_e2e.py` and `test_image_generation_e2e.py`

The audio and image assertions read the payload as bytes, since a content-type header states what the gateway believes it is serving while the bytes state what it actually served; an error page or a truncated stream would satisfy the header alone. A magic number carries the same weakness one level down, because a large malformed blob can start with the right four bytes, so both assertions check the container against itself

Speech asserts a coherent RIFF/WAVE. The size in the RIFF header must equal the bytes that actually arrived, which is what catches a truncated or padded response. The chunk list is then walked, following each chunk's declared length and its pad byte rather than probing fixed offsets, since a valid file may carry LIST or fact chunks before its samples. Every chunk in that walk must fit inside the payload, so a chunk declaring more bytes than the response holds fails wherever it sits, including after the samples. The chunk list must also consume the payload exactly: 1 to 7 bytes left over cannot begin another chunk, which means the response was cut off mid-header. A final odd-length chunk whose pad byte is missing at the end of the file is the one deviation allowed, since a pad byte carries no samples and its absence cannot hide lost audio. The walk must find a `fmt ` chunk describing a PCM stream with a sane channel count, sample rate and bit depth whose block align and byte rate multiply out, and a `data` chunk holding a non-trivial number of sample bytes. A WAVE without a data chunk carries no audio at all, so its absence fails. Image generation decodes `b64_json` and asserts a coherent PNG: the signature is followed by a 13 byte IHDR giving non-zero, plausible dimensions, and the file ends with the IEND marker, which is what catches a truncated image

Structural checks stop where a real decoder would begin. Proving every sample decodes would mean pulling a media library into the harness for a coverage test, and the value curve flattens well before that: the checks above already fail any payload that is truncated, padded, internally inconsistent, or not the container it claims. Vertex synthesizes LINEAR16 and this image model returns PNG, so those are the two containers validated; a deployment that starts returning another one fails loudly with a message asking for that container's check rather than silently falling back to a weaker assertion

### Shared harness change: raw bytes on StreamingResponse

This PR touches one shared module, `tests/e2e/e2e_http.py`, which deserves an explanation in a provider-coverage PR. It adds one field to `StreamingResponse`: `content`, the undecoded bytes of a non-streamed response body

The existing `body` field could not serve. It holds `resp.text`, the text decoding of the response, and a binary payload does not survive that decoding; a WAV or a PNG round-tripped through it is unrecoverable noise. `BinaryStream` reports chunk and byte counts without the bytes themselves, and only for a streamed call, so it cannot answer what container a non-streamed body carries. Since `e2e_http.py` is the only module permitted to touch `requests`, and that rule is enforced in CI, a test cannot reach the bytes on its own. Validating an audio or image payload was therefore impossible without widening the transport

It carries the whole body rather than a fixed-size prefix because a container's structure does not live at a fixed offset. A WAVE may place metadata before its samples, so locating the data chunk means following the chunk list wherever it runs; a prefix would have forced a choice between failing on valid files whose chunks start late and passing on malformed ones whose data chunk is missing, and the second is exactly the gap this round closes

The field is optional with a default of `b""` and is populated only on the non-streamed path. It holds the bytes object requests already materialized to produce `body`, so nothing extra is read from the wire and no copy of the payload is made. No signature changed and no existing consumer behaves differently; the streamed path, whose bytes are consumed as events, leaves it empty. The suites that share this model were run with and without the change and produce an identical set of failures, all of them provider credential errors on the test proxy rather than anything the change caused

Any future test that needs to prove a binary payload is what it claims to be can now read `content` instead of adding another one-off path

One product observation for whoever picks this up: Vertex synthesizes LINEAR16, so its speech responses carry a RIFF/WAVE body while the gateway labels every non-gemini speech response `audio/mpeg`. The test asserts the container the bytes really are, so it stays honest either way, but the label and the payload disagree today

It covers three coverage-registry cells: `llm.embeddings.cohere.basic.nonstream.works`, `llm.audio_speech.vertex.basic.nonstream.works` and `llm.images_generations.vertex.basic.nonstream.works`. Non-Core LLMs coverage moves from 39/51 to 42/51

Two provider notes for whoever maintains this next. Vertex image generation runs on `gemini-2.5-flash-image` because the Imagen family is not enabled on the project these credentials belong to; `imagen-4.0-fast-generate-001`, `imagen-4.0-generate-001`, `imagen-3.0-fast-generate-001`, `imagen-3.0-generate-002` and `imagegeneration@006` all answer `Publisher model ... was not found or your project does not have access`, as do the gemini-3 image variants. Separately, Gemini and Vertex chat models return empty content when `max_tokens` is small, since thinking tokens consume the budget first; anything added here that asserts on generated text should ask for at least 512 tokens. Neither of the tests in this PR sends `max_tokens`, so no assertion here depends on that

### Cells assigned but deliberately not covered

Four cells were in scope and are left uncovered, as an environment limit rather than an omission: `llm.embeddings.azure_openai.basic.nonstream.works`, `llm.audio_speech.azure_openai.basic.nonstream.works`, `llm.audio_transcriptions.azure_openai.basic.nonstream.works` and `llm.images_generations.azure_openai.basic.nonstream.works`

The Azure endpoint available to this test environment hosts chat and realtime deployments only. Enumerating it returns nine claude deployments plus `gpt-5.6-sol`, `gpt-5.6-sol-e2e`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.4-mini`, `gpt-5.4-mini-batch`, `gpt-4o`, `gpt-realtime`, `gpt-realtime-1.5` and `mistral-document-ai-2512`; the three Azure base URLs in the credential set all resolve to that same resource. There is no embeddings, text-to-speech, transcription or image deployment on it, and none of the region-specific Azure audio resources the older provider tests use is available either

Driving it anyway confirms the gap from the product side. Thirteen candidate deployment names return `DeploymentNotFound` through the proxy, covering `azure/text-embedding-3-small`, `azure/text-embedding-ada-002`, `azure/tts`, `azure/tts-1`, `azure/gpt-4o-mini-tts`, `azure/whisper`, `azure/whisper-1`, `azure/gpt-4o-mini-transcribe`, `azure/gpt-image-1`, `azure/gpt-image-1-mini` and `azure/dall-e-3`. Pointing the chat deployment at the wrong modality gets Azure's own refusal, `The embeddings operation does not work with the specified model, gpt-4o` and `The audioTranscriptions operation does not work with the specified model, gpt-4o`

Covering those four requires provisioning an embeddings deployment, a text-to-speech deployment, a transcription deployment and an image deployment on that Azure resource first. Until that happens, a test for them would either be written blind or would go red on every run, so they stay uncovered and the registry keeps showing the gap

## QA runbook

Prerequisites for every step below: a live proxy on port 4000 with `store_model_in_db` enabled, holding `COHERE_API_KEY`, `VERTEXAI_PROJECT` and `VERTEXAI_CREDENTIALS` in its own environment. `MASTER_KEY` below is that proxy's master key. Each step creates a deployment; delete it with `curl -X POST http://localhost:4000/model/delete -H "Authorization: Bearer $MASTER_KEY" -d '{"id": "<model_id>"}'` when you are done

- tests/e2e/llm_translation/test_nonconversational_provider_matrix_e2e.py::TestCohereEmbeddings::test_cohere_embeddings_returns_vector - a Cohere embed-v4.0 deployment added at runtime returns a real, non-zero embedding vector through /embeddings
  - [ ] Register the deployment: `curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"model_name": "qa-cohere-embed", "litellm_params": {"model": "cohere/embed-v4.0", "api_key": "os.environ/COHERE_API_KEY"}, "model_info": {}}'`
  - [ ] Mint a key scoped to it: `curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"models": ["qa-cohere-embed"]}'`
  - [ ] Call `POST /embeddings` with that key and `{"model": "qa-cohere-embed", "input": "Say this is a test!"}`
  - [ ] Expect 200 with `data[0].embedding` holding a long float array that is not all zeros
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_nonconversational_provider_matrix_e2e.py::TestVertexNonConversational::test_vertex_audio_speech_returns_audio - a Vertex text-to-speech deployment returns playable audio bytes through /v1/audio/speech rather than a JSON envelope
  - [ ] Register the deployment: `curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"model_name": "qa-vertex-speech", "litellm_params": {"model": "vertex_ai/chirp", "vertex_project": "os.environ/VERTEXAI_PROJECT", "vertex_location": "us-central1"}, "model_info": {}}'`
  - [ ] Mint a key scoped to it, the same way as above
  - [ ] Call `POST /v1/audio/speech` with that key and `{"model": "qa-vertex-speech", "input": "Hello!", "voice": "alloy"}`, saving the body with `curl -D - -o /tmp/qa-speech.audio`
  - [ ] Expect 200 and a `content-type` starting with `audio/`; the request reaches the Google synthesize endpoint, so no regional Vertex model needs to exist
  - [ ] Confirm the bytes match the claim: `file /tmp/qa-speech.audio` reports a WAV, and `xxd -l 12 /tmp/qa-speech.audio` shows `RIFF` then `WAVE`, over roughly 30 KB that plays. Note the gateway labels it audio/mpeg while Vertex actually synthesizes LINEAR16
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/llm_translation/test_nonconversational_provider_matrix_e2e.py::TestVertexNonConversational::test_vertex_image_generation_returns_image - a Vertex image deployment returns a generated image, not an empty data list, through /v1/images/generations
  - [ ] Register the deployment: `curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer $MASTER_KEY" -H "Content-Type: application/json" -d '{"model_name": "qa-vertex-image", "litellm_params": {"model": "vertex_ai/gemini-2.5-flash-image", "vertex_project": "os.environ/VERTEXAI_PROJECT", "vertex_location": "us-central1"}, "model_info": {}}'`
  - [ ] Mint a key scoped to it, the same way as above
  - [ ] Call `POST /v1/images/generations` with that key and `{"model": "qa-vertex-image", "prompt": "Draw a cute cat", "n": 1, "size": "1024x1024"}`
  - [ ] Expect 200 with a non-empty `data` array whose first item carries `b64_json`
  - [ ] Decode it and confirm real image bytes: `jq -r '.data[0].b64_json' response.json | base64 -d > /tmp/qa-image.png`, then `file /tmp/qa-image.png` reports PNG over roughly 1.2 MB and the picture opens
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
