### PR TITLE
test(e2e): cover router strategy selection and context-window fallback

### DIFF
--- a/tests/e2e/router/test_reliability_context_window_fallback_e2e.py
+++ b/tests/e2e/router/test_reliability_context_window_fallback_e2e.py
@@ -1,0 +1,107 @@
+"""Live e2e: a prompt too large for a deployment's context window is rerouted to
+the configured context-window fallback.
+
+The primary is a real `openai/gpt-4` deployment, chosen for the smallest context
+window OpenAI still serves (8k), so a prompt can overflow it for a few cents;
+`gpt-5.5`, the model the rest of this suite runs on, has a million-token window
+that no affordable prompt reaches. The overflow is therefore real: OpenAI itself
+rejects the call with a context-length error, which is the trigger
+`context_window_fallbacks` exists for.
+
+The same oversized prompt is sent twice. The first call carries no fallback and
+must come back as a context-window rejection, which is what proves the prompt
+genuinely overflows the primary instead of the deployment being broken some other
+way. The second names `gpt-5.5` as the context-window fallback and must come back
+200, served by a different deployment than the primary, with the proxy reporting
+the attempted fallback.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from complexity_router_client import ComplexityRouterClient
+from e2e_config import unique_marker
+from e2e_http import StreamingResponse
+from lifecycle import ResourceManager
+from models import ChatMessage, LiteLLMParamsBody, ReliabilityChatBody, RouterSettingsOverride
+from proxy_client import ProxyClient
+from reliability_support import REAL_KEY, REAL_MODEL
+
+pytestmark = pytest.mark.e2e
+
+SMALL_CONTEXT_MODEL = "openai/gpt-4"
+LARGE_CONTEXT_GROUP = "gpt-5.5"
+FILLER_SENTENCE = "The quick brown fox jumps over the lazy dog. "
+FILLER_REPEATS = 900
+ANSWER_TOKENS = 256
+
+
+def _oversized_prompt() -> str:
+    """Roughly ten thousand tokens of filler: past gpt-4's 8k window, and unique per
+    call so the proxy's response cache never answers it from an earlier run."""
+    return f"{FILLER_SENTENCE * FILLER_REPEATS} summarize the text above [{unique_marker()}]"
+
+
+def _summarize(
+    proxy: ProxyClient, key: str, group: str, override: RouterSettingsOverride | None = None
+) -> StreamingResponse:
+    """Ask `group` to summarize an oversized prompt, optionally with a fallback wired
+    for this one request. The answer budget is generous on purpose: gpt-5.5 spends
+    tokens on reasoning before it writes anything, and a budget it cannot finish in
+    is its own error, which would muddy the context-window one under test."""
+    return proxy.transport.send(
+        "/chat/completions",
+        headers=proxy.transport.bearer(key),
+        json=ReliabilityChatBody(
+            model=group,
+            messages=[ChatMessage(role="user", content=_oversized_prompt())],
+            max_tokens=ANSWER_TOKENS,
+            router_settings_override=override,
+        ),
+    )
+
+
+class TestReliabilityContextWindowFallback:
+    @pytest.mark.covers("reliability.fallback.context_window.routes_to_fallback")
+    def test_context_window_overflow_routes_to_fallback(
+        self, client: ComplexityRouterClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        primary = f"reliability-ctx-{unique_marker()}"
+        model_id = client.proxy.create_model(
+            primary, LiteLLMParamsBody(model=SMALL_CONTEXT_MODEL, api_key=REAL_KEY)
+        )
+        resources.defer(lambda: client.proxy.delete_model(model_id))
+
+        rejected = _summarize(client.proxy, scoped_key, primary)
+        assert rejected.status_code == 400, (
+            f"the oversized prompt should be rejected by {SMALL_CONTEXT_MODEL} with a 400, got "
+            f"{rejected.status_code}: {rejected.body[:300]}"
+        )
+        assert "context length" in rejected.body.lower(), (
+            f"the rejection should name the context length, got: {rejected.body[:300]}"
+        )
+
+        rerouted = _summarize(
+            client.proxy,
+            scoped_key,
+            primary,
+            RouterSettingsOverride(context_window_fallbacks=[{primary: [LARGE_CONTEXT_GROUP]}]),
+        )
+        assert rerouted.status_code == 200, (
+            f"the same prompt should be served by the context-window fallback, got "
+            f"{rerouted.status_code}: {rerouted.body[:300]}"
+        )
+        served = rerouted.headers.get("x-litellm-model-id")
+        assert served is not None and served != model_id, (
+            f"the fallback answer came from the deployment that could not fit the prompt "
+            f"({model_id}); x-litellm-model-id={served!r}"
+        )
+        assert rerouted.headers.get("x-litellm-model-name") == REAL_MODEL, (
+            f"the fallback should have been served by a {REAL_MODEL} deployment, but "
+            f"x-litellm-model-name is {rerouted.headers.get('x-litellm-model-name')!r}"
+        )
+        attempted = rerouted.headers.get("x-litellm-attempted-fallbacks")
+        assert attempted is not None and int(attempted) >= 1, (
+            f"the proxy should report at least one attempted fallback, got {attempted!r}"
+        )

--- a/tests/e2e/router/test_reliability_routing_e2e.py
+++ b/tests/e2e/router/test_reliability_routing_e2e.py
@@ -1,0 +1,302 @@
+"""Live e2e: each routing strategy picks the deployment that strategy implies.
+
+Every test builds its own model group of real `openai/gpt-5.5` deployments that
+differ in exactly one dimension the strategy under test reads - configured price,
+tpm ceiling, shuffle weight, or recorded latency - so only one
+deployment can win and the pick is a statement about the strategy rather than
+about luck. The strategy is selected per request through a
+`router_settings_override` on the /chat/completions body, so one long-lived proxy
+serves every strategy, and the deployment that actually served a call is read
+back from the x-litellm-model-id response header.
+
+Every prompt carries a unique marker: the proxy under test has its response cache
+on, and a repeated prompt would be answered from cache before the router ever
+routed it.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from complexity_router_client import ComplexityRouterClient
+from e2e_config import unique_marker
+from e2e_http import StreamingResponse, unwrap
+from lifecycle import ResourceManager
+from models import ChatBody, ChatMessage, LiteLLMParamsBody, ModelInfoBody, ModelNewResponse
+from proxy_client import ProxyClient
+from reliability_support import REAL_KEY, REAL_MODEL
+
+pytestmark = pytest.mark.e2e
+
+StrategyName = Literal[
+    "simple-shuffle",
+    "usage-based-routing-v2",
+    "latency-based-routing",
+    "cost-based-routing",
+]
+
+PRICEY_PER_TOKEN = 1e-3
+CHEAP_PER_TOKEN = 1e-9
+EXHAUSTED_TPM = 1
+UNREACHABLE_BASE = "http://127.0.0.1:9/v1"
+UNMEETABLE_DEADLINE_SECONDS = 0.001
+
+ANSWER_TOKENS = 256
+SHUFFLE_CALLS = 4
+
+GROUP_READY_TIMEOUT_SECONDS = 30.0
+GROUP_READY_POLL_SECONDS = 0.5
+
+SHORT_PROMPT = "answer in one word: what colour is a clear midday sky?"
+
+
+class RoutingParams(LiteLLMParamsBody):
+    """/model/new litellm_params plus the two per-deployment routing knobs the
+    shared body does not model: the tpm ceiling usage-based routing reads, and the
+    pick weight simple-shuffle reads."""
+
+    tpm: int | None = None
+    weight: int | None = None
+
+
+class RoutingModelNewBody(BaseModel):
+    """POST /model/new carrying RoutingParams.
+
+    The shared ModelNewBody types `litellm_params` as LiteLLMParamsBody, and pydantic
+    serializes a field by its declared type, so handing it a RoutingParams would drop
+    tpm and weight from the request body without a word - every routing strategy
+    would then see two identical deployments."""
+
+    model_config = ConfigDict(protected_namespaces=())
+    model_name: str
+    litellm_params: RoutingParams
+    model_info: ModelInfoBody = ModelInfoBody()
+
+
+class StrategyOverride(BaseModel):
+    """The `router_settings_override` that picks a routing strategy for one call,
+    and optionally the deadline that call is held to."""
+
+    routing_strategy: StrategyName
+    timeout: float | None = None
+
+
+class StrategyChatBody(ChatBody):
+    """A /chat/completions body routed by one strategy. Composes ChatBody."""
+
+    router_settings_override: StrategyOverride
+
+
+def _group_size(client: ComplexityRouterClient, group: str) -> int:
+    return sum(1 for entry in client.proxy.model_info() if entry.model_name == group)
+
+
+def _await_group_size(client: ComplexityRouterClient, group: str, size: int) -> None:
+    """Block until the proxy serves `size` deployments under `group`.
+
+    /model/new answers before the new deployment is necessarily on the router that
+    serves the next call, and a group name shows up on /v1/models as soon as its
+    first deployment lands, so routing without this gate can credit a strategy for a
+    pick it never had a choice in."""
+    deadline = time.monotonic() + GROUP_READY_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        if _group_size(client, group) >= size:
+            return
+        time.sleep(GROUP_READY_POLL_SECONDS)
+    raise AssertionError(
+        f"the proxy never reported {size} deployments under {group!r} within "
+        f"{GROUP_READY_TIMEOUT_SECONDS}s of registering them"
+    )
+
+
+def _deploy(
+    client: ComplexityRouterClient,
+    resources: ResourceManager,
+    group: str,
+    *,
+    tpm: int | None = None,
+    weight: int | None = None,
+    input_cost_per_token: float | None = None,
+    output_cost_per_token: float | None = None,
+    api_base: str | None = None,
+) -> str:
+    """Register one real gpt-5.5 deployment under `group`, wait for the proxy to
+    serve it alongside the group's existing deployments, delete it on teardown, and
+    return the model_id the router reports as the server of a call."""
+    expected = _group_size(client, group) + 1
+    model_id = unwrap(
+        client.proxy.transport.post(
+            "/model/new",
+            headers=client.proxy.transport.master,
+            json=RoutingModelNewBody(
+                model_name=group,
+                litellm_params=RoutingParams(
+                    model=REAL_MODEL,
+                    api_key=REAL_KEY,
+                    tpm=tpm,
+                    weight=weight,
+                    input_cost_per_token=input_cost_per_token,
+                    output_cost_per_token=output_cost_per_token,
+                    api_base=api_base,
+                ),
+            ),
+            response_type=ModelNewResponse,
+        )
+    ).model_id
+    resources.defer(lambda: client.proxy.delete_model(model_id))
+    _await_group_size(client, group, expected)
+    return model_id
+
+
+def _route(
+    proxy: ProxyClient,
+    key: str,
+    group: str,
+    strategy: StrategyName,
+    *,
+    prompt: str = SHORT_PROMPT,
+    max_tokens: int = ANSWER_TOKENS,
+    timeout: float | None = None,
+) -> StreamingResponse:
+    """Drive one real completion through `group` under `strategy`, returning the raw
+    outcome so the caller can read the deployment header off it."""
+    return proxy.transport.send(
+        "/chat/completions",
+        headers=proxy.transport.bearer(key),
+        json=StrategyChatBody(
+            model=group,
+            messages=[ChatMessage(role="user", content=f"{prompt} [{unique_marker()}]")],
+            max_tokens=max_tokens,
+            router_settings_override=StrategyOverride(routing_strategy=strategy, timeout=timeout),
+        ),
+    )
+
+
+def _served_by(resp: StreamingResponse) -> str:
+    """The model_id of the deployment that served a successful call."""
+    assert resp.status_code == 200, f"routed call failed with {resp.status_code}: {resp.body[:300]}"
+    model_id = resp.headers.get("x-litellm-model-id")
+    assert model_id, (
+        f"response carries no x-litellm-model-id, so the served deployment is unknowable; "
+        f"headers={sorted(resp.headers)}"
+    )
+    return model_id
+
+
+class TestReliabilityRoutingStrategies:
+    @pytest.mark.covers("reliability.routing.cost_based.picks_lowest_cost")
+    def test_cost_based_picks_lowest_cost(
+        self, client: ComplexityRouterClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        """Two deployments of the same model priced a million-fold apart: cost-based
+        routing must spend the request on the cheap one."""
+        group = f"routing-cost-{unique_marker()}"
+        pricey = _deploy(
+            client,
+            resources,
+            group,
+            input_cost_per_token=PRICEY_PER_TOKEN,
+            output_cost_per_token=PRICEY_PER_TOKEN,
+        )
+        cheap = _deploy(
+            client,
+            resources,
+            group,
+            input_cost_per_token=CHEAP_PER_TOKEN,
+            output_cost_per_token=CHEAP_PER_TOKEN,
+        )
+
+        served = _served_by(_route(client.proxy, scoped_key, group, "cost-based-routing"))
+        assert served == cheap, (
+            f"cost-based routing served {served}, but the cheap deployment is {cheap} "
+            f"(the other, {pricey}, costs {PRICEY_PER_TOKEN / CHEAP_PER_TOKEN:.0e}x more per token)"
+        )
+
+    @pytest.mark.covers("reliability.routing.usage_based.picks_under_tpm")
+    def test_usage_based_picks_deployment_under_tpm(
+        self, client: ComplexityRouterClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        """One deployment's tpm ceiling is a single token, so no real prompt fits under
+        it; usage-based routing must place the request on the deployment that has
+        token budget left rather than over-allocating the capped one."""
+        group = f"routing-tpm-{unique_marker()}"
+        capped = _deploy(client, resources, group, tpm=EXHAUSTED_TPM)
+        uncapped = _deploy(client, resources, group)
+
+        served = _served_by(_route(client.proxy, scoped_key, group, "usage-based-routing-v2"))
+        assert served == uncapped, (
+            f"usage-based routing served {served}, but only {uncapped} had tpm budget for the "
+            f"request; {capped} is capped at {EXHAUSTED_TPM} tpm and cannot fit any prompt"
+        )
+
+    @pytest.mark.covers("reliability.routing.simple_shuffle.picks_healthy_deployment")
+    def test_simple_shuffle_picks_healthy_deployment(
+        self, client: ComplexityRouterClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        """A zero-weight deployment pointed at an unreachable base sits next to the
+        healthy one: simple-shuffle's weighted pick must land every call on the
+        healthy deployment, so every call is answered instead of dying on a dead
+        connection."""
+        group = f"routing-shuffle-{unique_marker()}"
+        unreachable = _deploy(client, resources, group, weight=0, api_base=UNREACHABLE_BASE)
+        healthy = _deploy(client, resources, group, weight=1)
+
+        served = tuple(
+            _served_by(_route(client.proxy, scoped_key, group, "simple-shuffle"))
+            for _ in range(SHUFFLE_CALLS)
+        )
+        assert set(served) == {healthy}, (
+            f"simple-shuffle served {served}, but every call had to land on the healthy "
+            f"deployment {healthy}; {unreachable} carries weight 0 and an unreachable base"
+        )
+
+    @pytest.mark.covers("reliability.routing.latency_based.picks_lowest_latency")
+    def test_latency_based_picks_lowest_latency(
+        self, client: ComplexityRouterClient, resources: ResourceManager, scoped_key: str
+    ) -> None:
+        """The first deployment answers a request held to a deadline it cannot meet,
+        which is the router's worst latency observation; the second then joins the
+        group and answers normally. Both deployments are configured identically and
+        stay healthy - the deadline lived on the request, not on the deployment - so
+        the only thing separating them is the latency the router measured, and the
+        assertion call has to go to the deployment that was quick.
+
+        The simple-shuffle control in the middle is there to rule out the other reason
+        a router skips a deployment: it forces the pick onto the timed-out deployment
+        by weight and gets an answer, which no cooled-down deployment would give."""
+        group = f"routing-latency-{unique_marker()}"
+        timed_out = _deploy(client, resources, group, weight=1)
+
+        missed_deadline = _route(
+            client.proxy,
+            scoped_key,
+            group,
+            "latency-based-routing",
+            timeout=UNMEETABLE_DEADLINE_SECONDS,
+        )
+        assert missed_deadline.status_code == 408, (
+            f"the seeding call was meant to exceed its {UNMEETABLE_DEADLINE_SECONDS}s deadline on "
+            f"{timed_out}, got {missed_deadline.status_code}: {missed_deadline.body[:300]}"
+        )
+
+        quick = _deploy(client, resources, group, weight=0)
+        assert _served_by(_route(client.proxy, scoped_key, group, "latency-based-routing")) == quick, (
+            f"a deployment with no latency history is the router's lowest known latency, so this "
+            f"call should have gone to {quick}"
+        )
+
+        control = _route(client.proxy, scoped_key, group, "simple-shuffle")
+        assert _served_by(control) == timed_out, (
+            f"the weighted control call should have been served by {timed_out}, proving it is "
+            f"still healthy and selectable after its timeout"
+        )
+
+        served = _served_by(_route(client.proxy, scoped_key, group, "latency-based-routing"))
+        assert served == quick, (
+            f"latency-based routing served {served}, but {quick} answered in the time {timed_out} "
+            f"blew a deadline in, so it is the lower-latency deployment"
+        )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Router strategy selection had no e2e coverage
- Context-window fallback rerouting was untested end to end
- Five reliability registry cells sat uncovered

How it solves it:

- One model group per strategy, one deciding difference
- Asserts which deployment served, from response headers
- Real oversized prompt proves context-window reroute

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at commit `53a2138d0523a9060e8a2b71d619c70fabdc66e5`, against a live proxy on port 4057 backed by postgres and redis with `store_model_in_db` on, driving real `openai/gpt-5.5` and `openai/gpt-4` traffic that costs real money (roughly five cents a run, almost all of it the ten thousand token prompt the context-window test sends)

```
$ cd tests/e2e
$ set -a; source .env; set +a
$ PYTHONPATH=. LITELLM_PROXY_URL=http://localhost:4057 python -m pytest \
    router/test_reliability_routing_e2e.py \
    router/test_reliability_context_window_fallback_e2e.py -v

============================= test session starts ==============================
platform darwin -- Python 3.12.13, pytest-9.1.1, pluggy-1.6.0
rootdir: /.../tests/e2e
configfile: pytest.ini
plugins: anyio-4.14.2
collecting ... collected 5 items

router/test_reliability_routing_e2e.py::TestReliabilityRoutingStrategies::test_cost_based_picks_lowest_cost PASSED [ 20%]
router/test_reliability_routing_e2e.py::TestReliabilityRoutingStrategies::test_usage_based_picks_deployment_under_tpm PASSED [ 40%]
router/test_reliability_routing_e2e.py::TestReliabilityRoutingStrategies::test_simple_shuffle_picks_healthy_deployment PASSED [ 60%]
router/test_reliability_routing_e2e.py::TestReliabilityRoutingStrategies::test_latency_based_picks_lowest_latency PASSED [ 80%]
router/test_reliability_context_window_fallback_e2e.py::TestReliabilityContextWindowFallback::test_context_window_overflow_routes_to_fallback PASSED [100%]

============================== 5 passed in 20.22s ==============================
```

Every assertion these tests make was also checked in reverse. For each test the deciding setup was flipped, the flip was verified to have actually reached the file, and the test was confirmed to go red before the file was restored from a saved copy and byte-compared. Swapping the two price constants made cost-based routing serve the expensive deployment and failed on the served model id; moving the `tpm=1` ceiling onto the other deployment failed the same way; moving the shuffle weight onto the unreachable deployment failed immediately with a 500 connection error from the dead base, which is the outcome the weighted pick exists to prevent; widening the seeding deadline from one millisecond to sixty seconds meant no latency penalty was ever recorded and failed on the 408 seeding assertion; and pointing the context-window primary at `openai/gpt-5.5` failed on the rejection assertion because a million token window cannot be overflowed by the prompt

## Type

✅ Test

## Changes

Two new files under `tests/e2e/router/`, no shared harness module touched. `test_reliability_routing_e2e.py` covers four of the router's routing strategies, and `test_reliability_context_window_fallback_e2e.py` covers context-window fallback rerouting. Together they add five rows to `tests/e2e/coverage_registry/reliability.yaml`, taking Reliability and Performance from 8 of 26 to 13 of 26

Each routing test builds its own model group of real `openai/gpt-5.5` deployments that differ in exactly one dimension the strategy under test reads, so only one deployment can win and the pick is a statement about the strategy rather than about luck. The strategy is chosen per request through `router_settings_override.routing_strategy` on the `/chat/completions` body, so one long-lived proxy serves every strategy with no config change and no restart. The deployment that actually served each call is read back from the `x-litellm-model-id` response header and compared against the `model_id` that `/model/new` returned, so a 200 on its own never passes anything

How each test makes the correct choice unambiguous:

- Cost: two deployments of the same model priced a million-fold apart, `1e-3` against `1e-9` per input and output token, and the cheap `model_id` has to serve
- Usage: one deployment's tpm ceiling is a single token, so no real prompt fits under it, and the deployment that still has token budget has to serve
- Simple shuffle: a zero-weight deployment pointed at an unreachable base sits beside a weight-one healthy one, so four consecutive calls all have to come back from the healthy `model_id`; picking the other one fails the connection rather than merely picking differently
- Latency: the first deployment answers a request held to a one millisecond deadline, which is the worst latency observation the router can record, then a second deployment joins and answers normally; a simple-shuffle control call in the middle forces a pick onto the timed-out deployment by weight and gets a real answer, which proves it is still healthy and selectable and rules out cooldown as the reason it is later skipped

The context-window test registers a real `openai/gpt-4` deployment, chosen because 8k is the smallest context window OpenAI still serves and therefore the only one a prompt can overflow for a few cents. The same oversized prompt is sent twice. The first call carries no fallback and has to come back as a real context-length rejection from OpenAI, which is what proves the prompt genuinely overflows the primary instead of the deployment being broken some other way. The second names `gpt-5.5` as the context-window fallback and has to come back 200, served by a different `model_id` than the primary, with `x-litellm-attempted-fallbacks` at one or more

Every prompt carries a unique marker because the proxy under test has its response cache on; a repeated prompt would be answered from cache before the router ever routed it

Three of the eight cells this work was scoped to are deliberately not covered here, so their absence does not read as an oversight. `reliability.routing.least_busy.picks_lowest_traffic` would have to prove that the router had counted an in-flight request against a specific deployment at the moment of the pick, and nothing the proxy exposes says that: the least-busy tally never appears in the router's in-memory cache dump, `/metrics` is not served, and a spend row only lands once a call finishes, which is exactly when the request stops being in flight. Barriers built on what is observable, a fixed wait or a virtual-key concurrency cap, both sit at an earlier layer than routing, so the pick could still be made while both deployments looked idle; that is a probability bet dressed as a barrier and it does not belong in the suite. `reliability.fallback.content_policy.routes_to_fallback` needs a `ContentPolicyViolationError`, which litellm raises only for an OpenAI-shaped `invalid_request_error` carrying `content_policy_violation`, an "Invalid prompt ... violating our usage policy" message, or "request was rejected as a result of the safety system"; OpenAI chat completions returns none of those, it answers 200 with a refusal, so `content_policy_fallbacks` never fires. That error surface belongs to the Azure content filter, Bedrock guardrails, and the image endpoints, and this environment has credentials for none of them. `reliability.cache.prompt_caching_model_select.returns_cached` needs the router constructed with `optional_pre_call_checks: ["prompt_caching"]`; the default list is empty and `Router.update_settings` does not accept that key, so covering it requires a `router_settings` addition to the e2e gateway config and a proxy restart rather than a test-only change

On timing: none of these tests waits on the clock for a state it then asserts against. The latency test's one millisecond deadline cannot be met by any real provider round trip, and every other test is a sequence of completed calls whose outcome is read from response headers. The one behaviour that would need a wall-clock or concurrency setup, least-busy, is left uncovered for the reason given above rather than shipped as a timing bet

## QA runbook

Prerequisites for every item below: a live proxy on `http://localhost:4000` with `store_model_in_db` on and `OPENAI_API_KEY` in its environment, the master key `sk-1234`, and `curl -i` so the `x-litellm-*` response headers are visible. Every `/model/new` call returns a `model_id`; note it, because each check compares it against the `x-litellm-model-id` of the served response. Delete the deployments with `POST /model/delete` when done

- tests/e2e/router/test_reliability_routing_e2e.py::TestReliabilityRoutingStrategies::test_cost_based_picks_lowest_cost - cost-based routing spends the request on the cheaper of two identically capable deployments
  - [ ] Register the expensive deployment: `curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"model_name":"routing-cost-demo","litellm_params":{"model":"openai/gpt-5.5","api_key":"os.environ/OPENAI_API_KEY","input_cost_per_token":0.001,"output_cost_per_token":0.001},"model_info":{}}'`
  - [ ] Register the cheap one under the same `model_name` with `input_cost_per_token` and `output_cost_per_token` of `1e-9`
  - [ ] Send one completion pinned to the strategy: `curl -i -X POST http://localhost:4000/chat/completions -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"model":"routing-cost-demo","messages":[{"role":"user","content":"answer in one word: what colour is a clear midday sky?"}],"max_tokens":256,"router_settings_override":{"routing_strategy":"cost-based-routing"}}'`
  - [ ] Expect 200 and `x-litellm-model-id` equal to the cheap deployment's `model_id`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/router/test_reliability_routing_e2e.py::TestReliabilityRoutingStrategies::test_usage_based_picks_deployment_under_tpm - usage-based routing skips a deployment whose tpm ceiling cannot fit the request
  - [ ] Register a capped deployment: same `/model/new` body as above under `model_name` `routing-tpm-demo`, with `"tpm": 1` in `litellm_params` and no cost overrides
  - [ ] Register a second deployment under the same name with no `tpm` at all
  - [ ] Send one completion with `"router_settings_override":{"routing_strategy":"usage-based-routing-v2"}`
  - [ ] Expect 200 and `x-litellm-model-id` equal to the uncapped deployment's `model_id`, since a single token of budget fits no real prompt
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/router/test_reliability_routing_e2e.py::TestReliabilityRoutingStrategies::test_simple_shuffle_picks_healthy_deployment - simple shuffle's weighted pick keeps every call off a zero-weight deployment that cannot answer
  - [ ] Register the unreachable deployment under `model_name` `routing-shuffle-demo` with `"weight": 0` and `"api_base": "http://127.0.0.1:9/v1"`
  - [ ] Register the healthy one under the same name with `"weight": 1` and no `api_base`
  - [ ] Send four completions with `"router_settings_override":{"routing_strategy":"simple-shuffle"}`
  - [ ] Expect all four to return 200 with `x-litellm-model-id` equal to the healthy deployment's `model_id`; a pick of the zero-weight deployment surfaces as a 500 naming a connection error
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/router/test_reliability_routing_e2e.py::TestReliabilityRoutingStrategies::test_latency_based_picks_lowest_latency - latency-based routing avoids the deployment it measured as slow, and does so on latency rather than on cooldown
  - [ ] Register one deployment under `model_name` `routing-latency-demo` with `"weight": 1`
  - [ ] Send a completion with `"router_settings_override":{"routing_strategy":"latency-based-routing","timeout":0.001}` and expect a 408 naming the timeout; this is the observation that gives that deployment the router's worst recorded latency
  - [ ] Register a second deployment under the same name with `"weight": 0`
  - [ ] Send a completion with `"router_settings_override":{"routing_strategy":"latency-based-routing"}` and expect the second deployment's `model_id`, since a deployment with no history reads as the lowest known latency
  - [ ] Send a control completion with `"router_settings_override":{"routing_strategy":"simple-shuffle"}` and expect 200 from the first deployment, which proves it is still healthy and selectable rather than in cooldown
  - [ ] Send one more latency-based completion and expect the second deployment's `model_id` again, now that both have history
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/router/test_reliability_context_window_fallback_e2e.py::TestReliabilityContextWindowFallback::test_context_window_overflow_routes_to_fallback - a prompt that overflows a deployment's context window is rerouted to the configured context-window fallback and answered
  - [ ] Register a small-context deployment: `curl -X POST http://localhost:4000/model/new -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' -d '{"model_name":"reliability-ctx-demo","litellm_params":{"model":"openai/gpt-4","api_key":"os.environ/OPENAI_API_KEY"},"model_info":{}}'`
  - [ ] Build a prompt of roughly ten thousand tokens, for example the sentence "The quick brown fox jumps over the lazy dog. " repeated nine hundred times followed by "summarize the text above"
  - [ ] Send it to `reliability-ctx-demo` with `"max_tokens":256` and no fallback, and expect a 400 whose body names the model's maximum context length
  - [ ] Send the same prompt again with `"router_settings_override":{"context_window_fallbacks":[{"reliability-ctx-demo":["gpt-5.5"]}]}` and expect 200, `x-litellm-model-name` of `openai/gpt-5.5`, an `x-litellm-model-id` different from the primary's, and `x-litellm-attempted-fallbacks` of at least 1
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
