### PR TITLE
fix(proxy): serve aggregate MCP endpoint on bare /mcp instead of 307-redirecting

### DIFF
--- a/backend/routes/allowlist.py
+++ b/backend/routes/allowlist.py
@@ -142,11 +142,13 @@ BACKEND_EXACT_PATHS: frozenset[str] = frozenset(
         "/docs/oauth2-redirect",
         "/redoc",
         "/fallback/login",
+        "/mcp",  # bare spelling of the aggregate MCP endpoint; /mcp/ prefix covers the rest
     }
 )
 
 BACKEND_MOUNT_PATHS: frozenset[str] = frozenset(
     {
         "/swagger",  # API documentation static assets belong to the backend
+        "/mcp",  # lazily-mounted MCP sub-app serves on the backend component
     }
 )

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -16447,6 +16447,29 @@ async def _stream_mcp_asgi_response(handle_fn, scope: dict, receive) -> "Streami
 ########################################################
 
 
+@app.api_route(
+    BASE_MCP_ROUTE,
+    methods=["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"],
+)
+async def aggregate_mcp_route(request: Request):
+    """Serve the aggregate MCP endpoint on the bare ``/mcp`` spelling: the
+    ``/mcp`` mount cannot match its bare prefix, and the resulting 307 breaks
+    MCP clients behind TLS-terminating proxies."""
+    from litellm.proxy._experimental.mcp_server.utils import is_mcp_available
+
+    if not is_mcp_available():
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    from litellm.proxy._experimental.mcp_server.server import (
+        handle_streamable_http_mcp,
+    )
+
+    scope = dict(request.scope)
+    scope["_original_path"] = scope.get("path", "")
+    scope["path"] = BASE_MCP_ROUTE
+    return await _stream_mcp_asgi_response(handle_streamable_http_mcp, scope, request.receive)
+
+
 # Toolset-namespaced MCP routes - handle /toolset/{toolset_name}/mcp
 # Must be declared BEFORE /{mcp_server_name}/mcp to avoid being swallowed by the catchall.
 @app.api_route(

--- a/tests/test_litellm/proxy/test_dynamic_mcp_route.py
+++ b/tests/test_litellm/proxy/test_dynamic_mcp_route.py
@@ -540,3 +540,74 @@ async def test_toolset_mcp_route_unexpected_exception_returns_500_without_traceb
     assert exc_info.value.detail == "Internal server error"
     assert "db-host" not in str(exc_info.value.detail)
     assert "traceback" not in str(exc_info.value.detail).lower()
+
+
+# ---------------------------------------------------------------------------
+# 7. Aggregate /mcp without a trailing slash (bare mount prefix)
+# ---------------------------------------------------------------------------
+
+_IS_MCP_AVAILABLE = "litellm.proxy._experimental.mcp_server.utils.is_mcp_available"
+
+
+def _test_client():
+    from fastapi.testclient import TestClient
+
+    from litellm.proxy.proxy_server import app
+
+    return TestClient(app, follow_redirects=False)
+
+
+@pytest.mark.parametrize("method", ["GET", "POST", "DELETE"])
+def test_aggregate_mcp_route_bare_path_is_served_not_redirected(method):
+    """Bare /mcp must dispatch to the MCP handler with aggregate semantics,
+    never 307-redirect. Driven through the real app router so a lost route
+    registration (not just a broken handler body) fails this test."""
+    captured_scope: dict = {}
+
+    async def capturing_handle(scope, receive, send):
+        captured_scope.update(scope)
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"{}"})
+
+    with patch(_HANDLE_HTTP, new=capturing_handle):
+        response = _test_client().request(method, "/mcp")
+
+    assert response.status_code == 200
+    assert captured_scope.get("path") == "/mcp"
+    assert captured_scope.get("_original_path") == "/mcp"
+
+
+def test_aggregate_mcp_route_requires_exact_path():
+    """The bare-path route must match exactly /mcp; a sibling path like /mcpx
+    must not reach the MCP handler through it."""
+    calls = []
+
+    async def marking_handle(scope, receive, send):
+        calls.append(scope.get("path"))
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"{}"})
+
+    with patch(_HANDLE_HTTP, new=marking_handle):
+        response = _test_client().post("/mcpx")
+
+    assert calls == []
+    assert response.status_code != 200
+
+
+def test_aggregate_mcp_route_returns_404_when_mcp_unavailable():
+    """When the mcp package is unavailable the canonical /mcp/ sub-app is a
+    bare FastAPI that 404s, so the bare spelling must 404 identically instead
+    of erroring on the handler import."""
+    handler_calls = []
+
+    async def marking_handle(scope, receive, send):
+        handler_calls.append(scope.get("path"))
+
+    with (
+        patch(_IS_MCP_AVAILABLE, new=MagicMock(return_value=False)),
+        patch(_HANDLE_HTTP, new=marking_handle),
+    ):
+        response = _test_client().post("/mcp")
+
+    assert response.status_code == 404
+    assert handler_calls == []

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -7219,6 +7219,64 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/mcp": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Aggregate Mcp Route
+         * @description Serve the aggregate MCP endpoint on the bare ``/mcp`` spelling: the
+         *     ``/mcp`` mount cannot match its bare prefix, and the resulting 307 breaks
+         *     MCP clients behind TLS-terminating proxies.
+         */
+        get: operations["aggregate_mcp_route_mcp_get"];
+        /**
+         * Aggregate Mcp Route
+         * @description Serve the aggregate MCP endpoint on the bare ``/mcp`` spelling: the
+         *     ``/mcp`` mount cannot match its bare prefix, and the resulting 307 breaks
+         *     MCP clients behind TLS-terminating proxies.
+         */
+        put: operations["aggregate_mcp_route_mcp_put"];
+        /**
+         * Aggregate Mcp Route
+         * @description Serve the aggregate MCP endpoint on the bare ``/mcp`` spelling: the
+         *     ``/mcp`` mount cannot match its bare prefix, and the resulting 307 breaks
+         *     MCP clients behind TLS-terminating proxies.
+         */
+        post: operations["aggregate_mcp_route_mcp_post"];
+        /**
+         * Aggregate Mcp Route
+         * @description Serve the aggregate MCP endpoint on the bare ``/mcp`` spelling: the
+         *     ``/mcp`` mount cannot match its bare prefix, and the resulting 307 breaks
+         *     MCP clients behind TLS-terminating proxies.
+         */
+        delete: operations["aggregate_mcp_route_mcp_delete"];
+        /**
+         * Aggregate Mcp Route
+         * @description Serve the aggregate MCP endpoint on the bare ``/mcp`` spelling: the
+         *     ``/mcp`` mount cannot match its bare prefix, and the resulting 307 breaks
+         *     MCP clients behind TLS-terminating proxies.
+         */
+        options: operations["aggregate_mcp_route_mcp_options"];
+        /**
+         * Aggregate Mcp Route
+         * @description Serve the aggregate MCP endpoint on the bare ``/mcp`` spelling: the
+         *     ``/mcp`` mount cannot match its bare prefix, and the resulting 307 breaks
+         *     MCP clients behind TLS-terminating proxies.
+         */
+        head: operations["aggregate_mcp_route_mcp_head"];
+        /**
+         * Aggregate Mcp Route
+         * @description Serve the aggregate MCP endpoint on the bare ``/mcp`` spelling: the
+         *     ``/mcp`` mount cannot match its bare prefix, and the resulting 307 breaks
+         *     MCP clients behind TLS-terminating proxies.
+         */
+        patch: operations["aggregate_mcp_route_mcp_patch"];
+        trace?: never;
+    };
     "/mcp-rest/test/connection": {
         parameters: {
             query?: never;
@@ -43431,6 +43489,146 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    aggregate_mcp_route_mcp_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    aggregate_mcp_route_mcp_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    aggregate_mcp_route_mcp_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    aggregate_mcp_route_mcp_delete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    aggregate_mcp_route_mcp_options: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    aggregate_mcp_route_mcp_head: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    aggregate_mcp_route_mcp_patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
                 };
             };
         };


### PR DESCRIPTION
## TLDR

Problem this solves:

- Connecting an MCP client to the gateway with the aggregate URL spelled without a trailing slash (`https://<gateway>/mcp`) fails: the proxy 307-redirects `POST /mcp` to `/mcp/`, and behind a TLS-terminating ingress the redirect Location is scheme-downgraded to `http://` (uvicorn only trusts `X-Forwarded-Proto` from `forwarded-allow-ips`, default loopback), so clients strip the Authorization header on the cross-origin follow; the observable symptom in Claude Code is "Got new credentials, but reconnecting failed: ECONNRESET" right after a successful OAuth flow
- The redirect fires before auth, so the bare spelling also never returns the RFC 9728 `WWW-Authenticate` challenge OAuth clients need to start the flow

How it solves it:

- Registers an explicit route for the bare `/mcp` spelling beside the existing `/toolset/{name}/mcp` and `/{name}/mcp` routes, forwarding to `handle_streamable_http_mcp` with the same scope rewrite those routes already use, so `POST /mcp` is served with semantics identical to `/mcp/` and no redirect remains on the path

## Relevant issues

- `POST /mcp` (no trailing slash) was 307-redirected instead of served; the scheme-downgraded Location breaks MCP reconnect behind TLS-terminating ingresses
- The fix serves the bare spelling directly; `/mcp/`, `/mcp/{server}`, `/{server}/mcp` and `/toolset/{name}/mcp` are unchanged
- Regression tests drive the real app router, so a lost route registration (not just a broken handler body) fails the tests

## Linear ticket

Resolves LIT-4802

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Rig: config-only proxy (no DB) on `:4802` launched from this branch, one MCP server `demo_mcp` in `mcp_servers` pointing at a local FastMCP stub upstream on `:8933`, master key auth. Same commands before and after the fix

Before (unfixed code): the bare spelling is redirected, with or without auth, and the Location scheme comes from forwarded-proto trust (from a non-trusted peer it stays `http://`, which is the downgrade customers hit behind a TLS-terminating ingress)

```
$ curl -si -X POST http://127.0.0.1:4802/mcp -H 'x-litellm-api-key: Bearer sk-****' \
    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d "$INIT_BODY"
HTTP/1.1 307 Temporary Redirect
location: http://127.0.0.1:4802/mcp/

$ curl -si -X POST http://127.0.0.1:4802/mcp -d "$INIT_BODY"        # no auth: redirect fires before auth
HTTP/1.1 307 Temporary Redirect
location: http://127.0.0.1:4802/mcp/

$ curl -si -X POST http://127.0.0.1:4802/mcp -H 'X-Forwarded-Proto: https' -d '{}'
HTTP/1.1 307 Temporary Redirect
location: https://127.0.0.1:4802/mcp/    # scheme follows trusted X-Forwarded-Proto; untrusted peers get http://

$ curl -si -X POST http://127.0.0.1:4802/mcp/ -H 'x-litellm-api-key: Bearer sk-****' ... -d "$INIT_BODY"
HTTP/1.1 200 OK
mcp-session-id: df232db72eb24863b4549074f8cc4730
```

After (this branch): bare `/mcp` served identically to `/mcp/`, auth consulted, canonical spelling unchanged, exact-match boundary holds

```
$ curl -si -X POST http://127.0.0.1:4802/mcp -H 'x-litellm-api-key: Bearer sk-****' ... -d "$INIT_BODY"
HTTP/1.1 200 OK
content-type: text/event-stream
mcp-session-id: ecc602c1e9a84b9ab46f4526e3778b33

$ curl -si -X POST http://127.0.0.1:4802/mcp -d "$INIT_BODY"        # no auth: proper OAuth challenge now
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer resource_metadata="http://127.0.0.1:4802/.well-known/oauth-protected-resource/mcp"

$ curl -si -X POST http://127.0.0.1:4802/mcp/ -H 'x-litellm-api-key: Bearer sk-****' ... -d "$INIT_BODY"
HTTP/1.1 200 OK
mcp-session-id: 533bb79b227a48f893ec9288e1dd0b77

$ curl -s -X POST http://127.0.0.1:4802/mcp -H 'x-litellm-api-key: Bearer sk-****' ... \
    -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}' | grep -o '"name":"[^"]*"' | head -3
"name":"demo_mcp-echo"

$ curl -s -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:4802/mcpx -H 'x-litellm-api-key: Bearer sk-****' -d '{}'
404
```

## Type

🐛 Bug Fix

## Changes

- New `aggregate_mcp_route` in `proxy_server.py` registered on `BASE_MCP_ROUTE` (`/mcp`) with the same method set as the sibling MCP routes, forwarding via the existing `_stream_mcp_asgi_response(handle_streamable_http_mcp, ...)` idiom with `path=/mcp` and `_original_path` preserved for OAuth challenge URL selection
- Guarded with `is_mcp_available()` so the bare spelling 404s exactly like `/mcp/` does when the `mcp` package is absent
- Three regression tests in the mapped `tests/test_litellm/proxy/test_dynamic_mcp_route.py`, driven through the real app router with `TestClient(follow_redirects=False)`: bare-path served for GET/POST/DELETE with the exact forwarded scope, `/mcpx` never reaches the handler, unavailable-MCP 404 parity
- Regenerated `ui/litellm-dashboard/src/lib/http/schema.d.ts` for the new route's OpenAPI path entry (no hand edits)
- Assigned the bare `/mcp` route (exact path) and the lazily-mounted `/mcp` sub-app (mount path) to the backend component in `backend/routes/allowlist.py`; the existing `/mcp/` prefix cannot match the bare spelling, and without the exact entry the componentized backend's startup trim would drop the new route

The fix is deliberately not at the mount or via `redirect_slashes=False`: a Starlette mount structurally cannot match its bare prefix, and disabling slash redirects app-wide would change unrelated surfaces (an existing test pins the `/ui` static mount's 307). The exact-match route and the `/mcp` mount have disjoint match sets, so registration order cannot matter. Uvicorn's `forwarded-allow-ips` trust (the reason redirect Locations downgrade at all) is deployment configuration and is deliberately not changed here; deployments behind a TLS-terminating ingress can additionally set `FORWARDED_ALLOW_IPS` so any remaining redirects on other paths keep their scheme

## QA runbook

1. Start a proxy from this branch with any config that has at least one entry under `mcp_servers` and a `master_key`
2. `curl -si -X POST http://localhost:4000/mcp -H 'x-litellm-api-key: Bearer <master key>' -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'; expect `200` with an `mcp-session-id` header (on main you get `307` with a `location:` header)
3. Repeat against `/mcp/`; expect the same `200` (unchanged)
4. `curl -si -X POST http://localhost:4000/mcp` with no auth header; expect `401` with a `www-authenticate: Bearer resource_metadata=...` challenge, not a redirect
5. In Claude Code, add the gateway MCP server with the URL spelled WITHOUT the trailing slash (`https://<gateway>/mcp`), authenticate, and confirm tools list and calls work; before this fix the reconnect after OAuth fails with ECONNRESET behind a TLS-terminating ingress

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the MCP HTTP entry path and OAuth challenge routing for a widely used URL spelling; scope is narrow and covered by integration-style tests, but mis-routing could affect MCP auth and client connectivity.
> 
> **Overview**
> **Fixes MCP clients using `https://<gateway>/mcp` (no trailing slash)** by serving the aggregate endpoint directly instead of returning a **307** to `/mcp/`, which behind TLS-terminating ingresses can downgrade the redirect scheme and break reconnects (e.g. OAuth flows dropping `Authorization` on follow).
> 
> Adds **`aggregate_mcp_route`** on `BASE_MCP_ROUTE` (`/mcp`) in `proxy_server.py`, forwarding through the existing **`_stream_mcp_asgi_response` / `handle_streamable_http_mcp`** path with **`_original_path`** preserved (same pattern as toolset/dynamic MCP routes). Returns **404** when MCP is unavailable via **`is_mcp_available()`**.
> 
> Updates **`backend/routes/allowlist.py`** so the bare `/mcp` route and `/mcp` mount stay on the backend component when routes are trimmed. Adds router-level regression tests in **`test_dynamic_mcp_route.py`** and regenerates dashboard OpenAPI types for the new path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d4b50cd01b677cebd8ffc4b56ec44b253d9df5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->