### PR TITLE
fix(proxy): allow /key/update to identify the key by key_alias

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1169,7 +1169,6 @@ class GenerateKeyResponse(KeyRequestBase):
 class UpdateKeyRequest(KeyRequestBase):
     # Note: the defaults of all Params here MUST BE NONE
     # else they will get overwritten
-    key: str  # type: ignore
     duration: Optional[str] = None
     spend: Optional[float] = None
     metadata: Optional[dict] = None
@@ -1184,6 +1183,12 @@ class UpdateKeyRequest(KeyRequestBase):
         if self.temp_budget_increase is not None or self.temp_budget_expiry is not None:
             if self.temp_budget_increase is None or self.temp_budget_expiry is None:
                 raise ValueError("temp_budget_increase and temp_budget_expiry must be set together")
+        return self
+
+    @model_validator(mode="after")
+    def validate_key_identifier(self) -> "UpdateKeyRequest":
+        if self.key is None and self.key_alias is None:
+            raise ValueError("either key or key_alias must be provided")
         return self
 
 

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2023,7 +2023,7 @@ def _validate_max_budget(max_budget: Optional[float]) -> None:
 
 
 async def _get_and_validate_existing_key(
-    token: str, prisma_client: Optional[PrismaClient]
+    token: str | None, prisma_client: Optional[PrismaClient], key_alias: str | None = None
 ) -> LiteLLM_VerificationToken:
     """
     Get existing key from database and validate it exists.
@@ -2031,12 +2031,13 @@ async def _get_and_validate_existing_key(
     Args:
         token: The key token to look up
         prisma_client: Prisma client instance
+        key_alias: Alias to look the key up by when token is not provided
 
     Returns:
         LiteLLM_VerificationToken: The existing key row
 
     Raises:
-        ProxyException: 404 if key is not found
+        ProxyException: 404 if key is not found, 400 if the alias matches multiple keys
     """
     if prisma_client is None:
         raise HTTPException(
@@ -2044,19 +2045,65 @@ async def _get_and_validate_existing_key(
             detail={"error": "Database not connected"},
         )
 
-    hashed_token = _hash_token_if_needed(token=token)
+    if token is not None:
+        hashed_token = _hash_token_if_needed(token=token)
 
-    existing_key_row = await VerificationTokenRepository(prisma_client).table.find_unique(where={"token": hashed_token})
+        existing_key_row: LiteLLM_VerificationToken | None = await VerificationTokenRepository(
+            prisma_client
+        ).table.find_unique(where={"token": hashed_token})
 
-    if existing_key_row is None:
+        if existing_key_row is None:
+            raise ProxyException(
+                message="Key not found.",
+                type=ProxyErrorTypes.not_found_error,
+                param="key",
+                code=status.HTTP_404_NOT_FOUND,
+            )
+
+        return existing_key_row
+
+    if key_alias is None:
+        raise ProxyException(
+            message="either key or key_alias must be provided",
+            type=ProxyErrorTypes.bad_request_error,
+            param="key",
+            code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    rows: list[LiteLLM_VerificationToken] = await VerificationTokenRepository(prisma_client).table.find_many(
+        where={"key_alias": key_alias}, take=2
+    )
+
+    if len(rows) == 0:
+        raise ProxyException(
+            message=f"Key not found. No key with key_alias='{key_alias}'.",
+            type=ProxyErrorTypes.not_found_error,
+            param="key_alias",
+            code=status.HTTP_404_NOT_FOUND,
+        )
+
+    if len(rows) > 1:
+        raise ProxyException(
+            message=f"Multiple keys share key_alias='{key_alias}', so it cannot be used as an identifier.",
+            type=ProxyErrorTypes.bad_request_error,
+            param="key_alias",
+            code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    return rows[0]
+
+
+def _resolve_token_to_update(data: UpdateKeyRequest, existing_key_row: LiteLLM_VerificationToken) -> str:
+    if data.key is not None:
+        return data.key
+    if existing_key_row.token is None:
         raise ProxyException(
             message="Key not found.",
             type=ProxyErrorTypes.not_found_error,
             param="key",
             code=status.HTTP_404_NOT_FOUND,
         )
-
-    return existing_key_row
+    return existing_key_row.token
 
 
 async def _process_single_key_update(
@@ -2508,8 +2555,8 @@ async def update_key_fn(
     Update an existing API key's parameters.
 
     Parameters:
-    - key: str - The key to update
-    - key_alias: Optional[str] - User-friendly key alias
+    - key: Optional[str] - The key to update. Either key or key_alias must be provided.
+    - key_alias: Optional[str] - User-friendly key alias. If key is omitted, also identifies the key to update (must match exactly one key, same as /key/delete's key_aliases)
     - user_id: Optional[str] - User ID associated with key
     - team_id: Optional[str] - Team ID associated with key
     - agent_id: Optional[str] - The agent id associated with the key.
@@ -2592,14 +2639,14 @@ async def update_key_fn(
                 detail={"error": f"max_budget must be a non-negative finite number. Received: {data.max_budget}"},
             )
 
-        data_json: dict = data.model_dump(exclude_unset=True)
-        key = data_json.pop("key")
-
         # get the row from db
         existing_key_row = await _get_and_validate_existing_key(
             token=data.key,
             prisma_client=prisma_client,
+            key_alias=data.key_alias,
         )
+        key = _resolve_token_to_update(data=data, existing_key_row=existing_key_row)
+        data.key = key
 
         await _validate_update_key_data(
             data=data,

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -2507,6 +2507,195 @@ async def test_update_key_nonexistent_key_returns_404(monkeypatch):
     assert "Authentication Error" not in str(exc_info.value.message)
 
 
+def _setup_update_key_mocks(monkeypatch, mock_prisma_client):
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    monkeypatch.setattr("litellm.proxy.proxy_server.user_api_key_cache", AsyncMock())
+    monkeypatch.setattr("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock())
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
+    monkeypatch.setattr("litellm.store_audit_logs", False)
+
+
+@pytest.mark.asyncio
+async def test_update_key_by_alias_only(monkeypatch):
+    """
+    /key/update identified by key_alias alone resolves the key row via
+    find_many on the alias and updates using the resolved token.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        update_key_fn,
+    )
+
+    hashed_token = "0d62f396c1317066f55a96086517047c737087c61eb2bf016b72e6298927b15b"
+    key_in_db = LiteLLM_VerificationToken(
+        token=hashed_token,
+        key_alias="prod-alias",
+        user_id="test-user",
+        max_budget=200.0,
+    )
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_many = AsyncMock(
+        return_value=[key_in_db]
+    )
+    mock_prisma_client.db.litellm_verificationtoken.find_first = AsyncMock(
+        return_value=None
+    )
+    mock_prisma_client.update_data = AsyncMock(
+        return_value={"data": {"max_budget": 50.0}}
+    )
+    _setup_update_key_mocks(monkeypatch, mock_prisma_client)
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-admin", user_id="admin-user"
+    )
+
+    request_data = UpdateKeyRequest(key_alias="prod-alias", max_budget=50.0)
+
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object"
+    ) as mock_delete_cache:
+        mock_delete_cache.return_value = None
+        result = await update_key_fn(
+            request=MagicMock(),
+            data=request_data,
+            user_api_key_dict=user_api_key_dict,
+            litellm_changed_by=None,
+        )
+
+    mock_prisma_client.db.litellm_verificationtoken.find_many.assert_called_once_with(
+        where={"key_alias": "prod-alias"}, take=2
+    )
+    assert request_data.key == hashed_token
+    mock_prisma_client.db.litellm_verificationtoken.find_unique.assert_not_called()
+    mock_prisma_client.update_data.assert_awaited_once()
+    assert mock_prisma_client.update_data.call_args.kwargs["token"] == hashed_token
+    assert (
+        mock_prisma_client.update_data.call_args.kwargs["data"]["token"] == hashed_token
+    )
+    assert result["key"] == hashed_token
+
+
+@pytest.mark.asyncio
+async def test_update_key_by_alias_not_found_returns_404(monkeypatch):
+    """
+    /key/update with a key_alias matching no key returns 404.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        update_key_fn,
+    )
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_many = AsyncMock(
+        return_value=[]
+    )
+    _setup_update_key_mocks(monkeypatch, mock_prisma_client)
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-admin", user_id="admin-user"
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await update_key_fn(
+            request=MagicMock(),
+            data=UpdateKeyRequest(key_alias="no-such-alias", max_budget=50.0),
+            user_api_key_dict=user_api_key_dict,
+            litellm_changed_by=None,
+        )
+
+    assert str(exc_info.value.code) == "404"
+    assert "not found" in str(exc_info.value.message).lower()
+    mock_prisma_client.update_data.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_key_by_duplicate_alias_returns_400(monkeypatch):
+    """
+    /key/update with a key_alias shared by multiple keys returns 400
+    instead of silently updating one of them.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        update_key_fn,
+    )
+
+    rows = [
+        LiteLLM_VerificationToken(token="hashed-token-1", key_alias="dup-alias"),
+        LiteLLM_VerificationToken(token="hashed-token-2", key_alias="dup-alias"),
+    ]
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_many = AsyncMock(
+        return_value=rows
+    )
+    _setup_update_key_mocks(monkeypatch, mock_prisma_client)
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-admin", user_id="admin-user"
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await update_key_fn(
+            request=MagicMock(),
+            data=UpdateKeyRequest(key_alias="dup-alias", max_budget=50.0),
+            user_api_key_dict=user_api_key_dict,
+            litellm_changed_by=None,
+        )
+
+    assert str(exc_info.value.code) == "400"
+    assert "multiple keys" in str(exc_info.value.message).lower()
+    mock_prisma_client.update_data.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_key_with_key_and_alias_selects_by_key(monkeypatch):
+    """
+    Regression: passing both key and key_alias keeps today's behavior. The key
+    identifies the row (find_unique, never find_many) and key_alias is the new
+    alias to set; the response echoes the caller-passed key.
+    """
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        update_key_fn,
+    )
+
+    hashed_token = "0d62f396c1317066f55a96086517047c737087c61eb2bf016b72e6298927b15b"
+    key_in_db = LiteLLM_VerificationToken(
+        token=hashed_token,
+        key_alias="old-name",
+        user_id="test-user",
+    )
+
+    mock_prisma_client = AsyncMock()
+    mock_prisma_client.db.litellm_verificationtoken.find_unique = AsyncMock(
+        return_value=key_in_db
+    )
+    mock_prisma_client.db.litellm_verificationtoken.find_first = AsyncMock(
+        return_value=None
+    )
+    mock_prisma_client.update_data = AsyncMock(
+        return_value={"data": {"key_alias": "new-name"}}
+    )
+    _setup_update_key_mocks(monkeypatch, mock_prisma_client)
+
+    user_api_key_dict = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, api_key="sk-admin", user_id="admin-user"
+    )
+
+    with patch(
+        "litellm.proxy.management_endpoints.key_management_endpoints._delete_cache_key_object"
+    ) as mock_delete_cache:
+        mock_delete_cache.return_value = None
+        result = await update_key_fn(
+            request=MagicMock(),
+            data=UpdateKeyRequest(key="sk-test-key", key_alias="new-name"),
+            user_api_key_dict=user_api_key_dict,
+            litellm_changed_by=None,
+        )
+
+    mock_prisma_client.db.litellm_verificationtoken.find_many.assert_not_called()
+    mock_prisma_client.db.litellm_verificationtoken.find_unique.assert_called_once()
+    assert mock_prisma_client.update_data.call_args.kwargs["token"] == "sk-test-key"
+    assert result["key"] == "sk-test-key"
+
+
 @pytest.mark.asyncio
 async def test_block_key_existing_key_succeeds(monkeypatch):
     """

--- a/tests/test_litellm/proxy/test_proxy_types.py
+++ b/tests/test_litellm/proxy/test_proxy_types.py
@@ -139,3 +139,23 @@ def test_key_request_router_settings_keeps_enable_tag_filtering():
     dumped = req.router_settings.model_dump(exclude_none=True)
     assert dumped["enable_tag_filtering"] is True
     assert dumped["num_retries"] == 2
+
+
+def test_update_key_request_requires_key_or_key_alias():
+    """``/key/update`` can be addressed by ``key`` or by ``key_alias``;
+    a request with neither has no way to identify the target key and must
+    fail validation before hitting the endpoint."""
+    import pydantic
+
+    from litellm.proxy._types import UpdateKeyRequest
+
+    with pytest.raises(pydantic.ValidationError, match="either key or key_alias must be provided"):
+        UpdateKeyRequest(max_budget=10.0)
+
+    by_key = UpdateKeyRequest(key="sk-1234")
+    assert by_key.key == "sk-1234"
+    assert by_key.key_alias is None
+
+    by_alias = UpdateKeyRequest(key_alias="my-alias")
+    assert by_alias.key is None
+    assert by_alias.key_alias == "my-alias"

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -6935,8 +6935,8 @@ export interface paths {
          * @description Update an existing API key's parameters.
          *
          *     Parameters:
-         *     - key: str - The key to update
-         *     - key_alias: Optional[str] - User-friendly key alias
+         *     - key: Optional[str] - The key to update. Either key or key_alias must be provided.
+         *     - key_alias: Optional[str] - User-friendly key alias. If key is omitted, also identifies the key to update (must match exactly one key, same as /key/delete's key_aliases)
          *     - user_id: Optional[str] - User ID associated with key
          *     - team_id: Optional[str] - Team ID associated with key
          *     - agent_id: Optional[str] - The agent id associated with the key.
@@ -23478,7 +23478,7 @@ export interface components {
              * @description Default role assigned to new users created
              * @default internal_user_viewer
              */
-            user_role: ("internal_user" | "internal_user_viewer" | "proxy_admin" | "proxy_admin_viewer") | null;
+            user_role: ("proxy_admin" | "proxy_admin_viewer" | "internal_user" | "internal_user_viewer") | null;
         };
         /**
          * DefaultTeamSSOParams
@@ -26019,7 +26019,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */
@@ -32442,7 +32442,7 @@ export interface components {
             /** Guardrails */
             guardrails?: string[] | null;
             /** Key */
-            key: string;
+            key?: string | null;
             /** Key Alias */
             key_alias?: string | null;
             /** Max Budget */
@@ -34115,7 +34115,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23478,7 +23478,7 @@ export interface components {
              * @description Default role assigned to new users created
              * @default internal_user_viewer
              */
-            user_role: ("proxy_admin" | "proxy_admin_viewer" | "internal_user" | "internal_user_viewer") | null;
+            user_role: ("internal_user" | "internal_user_viewer" | "proxy_admin" | "proxy_admin_viewer") | null;
         };
         /**
          * DefaultTeamSSOParams
@@ -26019,7 +26019,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: string | number | null;
+            stream_timeout?: number | string | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */
@@ -34115,7 +34115,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: string | number | null;
+            stream_timeout?: number | string | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */


### PR DESCRIPTION
## TLDR

Problem this solves:

- /key/update required the raw key value, which is a secret
- /key/delete already accepts key_alias; /key/update did not
- Automation like key rotation had to store key material just to update settings

How it solves it:

- UpdateKeyRequest.key is now optional; key_alias identifies the key when key is omitted
- Alias lookup 404s when no key matches and 400s when several keys share the alias
- Passing key behaves exactly as before, including key plus key_alias renames

## Relevant issues

## Linear ticket

Resolves LIT-2820

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All captured at commit 22922c78a8 against a live proxy run from this branch (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --port 4820 --detailed_debug --use_v2_migration_resolver`), hitting the real Groq API for the inference step

Create a key with an alias:

```bash
curl -s http://localhost:4820/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key_alias": "lit-2820-qa-alias2", "metadata": {"purpose": "LIT-2820 QA"}}'
```
```json
{"key_alias":"lit-2820-qa-alias2","max_budget":null,"metadata":{"purpose":"LIT-2820 QA"},"key":"sk-UNoAp7IsiN60Aemng_TIYA","key_name":"sk-...TIYA","token":"23b0f6b0b829...","created_at":"2026-07-27T23:47:14.228000Z"}
```

Update by alias only, no `key` field (the bug: this previously failed validation because `key` was required):

```bash
curl -s -w '\nHTTP %{http_code}\n' http://localhost:4820/key/update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key_alias": "lit-2820-qa-alias2", "max_budget": 42.5}'
```
```json
{"key":"23b0f6b0b829...","key_name":"sk-...TIYA","key_alias":"lit-2820-qa-alias2","max_budget":42.5}
HTTP 200
```

Confirm the right key was updated, without the key value ever being sent to /key/update:

```bash
curl -s "http://localhost:4820/key/info?key=sk-UNoAp7IsiN60Aemng_TIYA" -H 'Authorization: Bearer sk-1234'
```
```json
{"key_name": "sk-...TIYA", "key_alias": "lit-2820-qa-alias2", "max_budget": 42.5, "metadata": {"purpose": "LIT-2820 QA"}}
```

Unknown alias returns 404:

```bash
curl -s -w '\nHTTP %{http_code}\n' http://localhost:4820/key/update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key_alias": "does-not-exist-xyz", "max_budget": 1}'
```
```json
{"error":{"message":"Key not found. No key with key_alias='does-not-exist-xyz'.","type":"not_found_error","param":"key_alias","code":"404"}}
HTTP 404
```

Neither key nor key_alias fails validation with a 422:

```bash
curl -s -w '\nHTTP %{http_code}\n' http://localhost:4820/key/update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{}'
```
```json
{"detail":[{"type":"value_error","loc":["body"],"msg":"Value error, either key or key_alias must be provided","input":{},"ctx":{"error":{}}}]}
HTTP 422
```

Regression check: passing both `key` and `key_alias` still selects by key and renames the alias, exactly as before:

```bash
curl -s -w '\nHTTP %{http_code}\n' http://localhost:4820/key/update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key": "sk-UNoAp7IsiN60Aemng_TIYA", "key_alias": "lit-2820-qa-alias2-renamed", "max_budget": 10}'
```
```json
{"key_alias": "lit-2820-qa-alias2-renamed", "max_budget": 10.0, "token": "23b0f6b0b8294ea2..."}
HTTP 200
```

The updated key still works for real inference (live Groq call through the proxy):

```bash
curl -s http://localhost:4820/v1/chat/completions -H 'Authorization: Bearer sk-UNoAp7IsiN60Aemng_TIYA' -H 'Content-Type: application/json' \
  -d '{"model": "lit-2820-qa-groq-oss", "messages": [{"role": "user", "content": "Reply with exactly: LIT-2820 key works"}]}'
```
```json
{"id":"chatcmpl-3c728cda-a3cf-467b-ad14-630d0d0039c9","model":"lit-2820-qa-groq-oss","choices":[{"finish_reason":"stop","message":{"content":"LIT-2820 key works","role":"assistant"}}],"usage":{"total_tokens":138},"x_groq":{"id":"req_01kyjzmbvffe1tt1614t3c07en"}}
HTTP 200
```

Cleanup, deleting by alias (the pre-existing /key/delete alias support this PR mirrors):

```bash
curl -s -w '\nHTTP %{http_code}\n' http://localhost:4820/key/delete -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key_aliases": ["lit-2820-qa-alias2-renamed"]}'
```
```json
{"deleted_keys":["lit-2820-qa-alias2-renamed"]}
HTTP 200
```

## Type

🐛 Bug Fix

## Changes

`UpdateKeyRequest.key` drops its required override, so the field is optional like the base class, and a model validator rejects requests carrying neither `key` nor `key_alias`. `_get_and_validate_existing_key` gains an alias lookup path: when `key` is absent it resolves the row via `find_many` on `key_alias` (capped at 2), returning 404 when nothing matches and 400 when several keys share the alias, since alias uniqueness is only enforced at the application layer and legacy duplicates may exist. `update_key_fn` backfills `data.key` with the resolved token so downstream consumers (audit log hook, guaranteed throughput exclusion, spend counter cache) behave exactly as if the caller had passed the key. Bulk update endpoints always pass `key` and are unchanged. `schema.d.ts` is the regenerated dashboard API type for the loosened field

Unit tests cover the alias happy path (asserting the update runs against the resolved token), alias not found, duplicate aliases, the neither-field validator, and a regression test that key plus key_alias still selects by key and renames

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

