### PR TITLE
fix(langtrace): use live app.langtrace.ai host and x-api-key header

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -3093,6 +3093,10 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         if signal_type == "traces" and "/v2/trace/otlp" in endpoint:
             return endpoint
 
+        # Langtrace ingests traces at /api/trace (a complete path, not an OTLP base). Do not rewrite.
+        if signal_type == "traces" and endpoint.endswith("/api/trace"):
+            return endpoint
+
         # Check if endpoint already ends with the correct signal path
         target_path = f"/v1/{signal_type}"
         if endpoint.endswith(target_path):

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3992,9 +3992,9 @@ def _init_custom_logger_compatible_class(
 
             otel_config = OpenTelemetryConfig(
                 exporter="otlp_http",
-                endpoint="https://langtrace.ai/api/trace",
+                endpoint="https://app.langtrace.ai/api/trace",
             )
-            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = f"api_key={os.getenv('LANGTRACE_API_KEY')}"
+            os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = f"x-api-key={os.getenv('LANGTRACE_API_KEY')}"
             for callback in _in_memory_loggers:
                 if isinstance(callback, OpenTelemetry) and callback.callback_name == "langtrace":
                     return callback  # type: ignore

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -1928,12 +1928,21 @@ class TestOpenTelemetryEndpointNormalization(unittest.TestCase):
                 "https://example.com/prefix/v2/trace/otlp",
                 "https://example.com/prefix/v2/trace/otlp",
             ),
+            (
+                "https://app.langtrace.ai/api/trace",
+                "https://app.langtrace.ai/api/trace",
+            ),
+            (
+                "https://app.langtrace.ai/api/trace/",
+                "https://app.langtrace.ai/api/trace",
+            ),
         ]
     )
     def test_normalize_traces_nonstandard_otlp_ingest_urls_unchanged(
         self, input_url: str, expected: str
     ) -> None:
-        """Splunk-style /v2/trace/otlp endpoints must not get /v1/traces appended."""
+        """Vendor full-path ingest URLs (Splunk /v2/trace/otlp, Langtrace /api/trace)
+        must not get /v1/traces appended — that 404s."""
         otel = OpenTelemetry()
         self.assertEqual(
             otel._normalize_otel_endpoint(input_url, "traces"),
@@ -5852,3 +5861,45 @@ class TestOpenTelemetryMetricAttributeFiltering(unittest.TestCase):
                         exporter="console", attributes=attributes
                     )
                 )
+
+
+class LangtraceV1ConfigTest(unittest.TestCase):
+    def test_langtrace_uses_live_host_and_x_api_key_header(self):
+        """Regression: litellm hardcoded the stale https://langtrace.ai/api/trace (now 404)
+        with header ``api_key=``. The live ingest is https://app.langtrace.ai/api/trace and
+        the auth header is ``x-api-key``. Pins both so the stale values can't return."""
+        import litellm
+        import litellm.litellm_core_utils.litellm_logging as ll
+        from litellm.integrations.opentelemetry import OpenTelemetry
+        from litellm.integrations.otel.model.config import is_otel_v2_enabled
+
+        saved = {
+            k: os.environ.get(k)
+            for k in (
+                "LANGTRACE_API_KEY",
+                "LITELLM_OTEL_V2",
+                "OTEL_EXPORTER_OTLP_TRACES_HEADERS",
+            )
+        }
+        try:
+            ll._in_memory_loggers.clear()  # force a fresh build, not a cached logger
+            os.environ["LANGTRACE_API_KEY"] = "lt-test"
+            os.environ.pop("LITELLM_OTEL_V2", None)
+            is_otel_v2_enabled.cache_clear()
+            litellm.credential_list = []
+            logger = ll._init_custom_logger_compatible_class("langtrace", None, None)
+            assert isinstance(logger, OpenTelemetry)
+            self.assertEqual(
+                logger.config.endpoint, "https://app.langtrace.ai/api/trace"
+            )
+            self.assertEqual(
+                os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"], "x-api-key=lt-test"
+            )
+        finally:
+            is_otel_v2_enabled.cache_clear()
+            ll._in_memory_loggers.clear()
+            for key, value in saved.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value


### PR DESCRIPTION
## TLDR

Problem this solves:

- The langtrace v1 exporter is hardcoded to `https://langtrace.ai/api/trace`, which now 404s
- It also sends the auth token as `api_key=...`, but langtrace's OTLP ingest expects `x-api-key`
- The shared OTEL endpoint normalizer appends `/v1/traces` to a full `/api/trace` ingest path, producing a broken URL

How it solves it:

- Point the exporter at the live host `https://app.langtrace.ai/api/trace`
- Send the token as `x-api-key`
- Teach the normalizer to treat a full `/api/trace` path as a complete ingest URL and leave it untouched, the same way it already handles Splunk `/v2/trace/otlp`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Resolving the langtrace logger on a clean env now yields the live host and header, and the normalizer leaves the full path intact:

```
$ LANGTRACE_API_KEY=lt-demo python - <<'PY'
import os; os.environ.pop("LITELLM_OTEL_V2", None)
import litellm; litellm.credential_list = []
import litellm.litellm_core_utils.litellm_logging as ll
lg = ll._init_custom_logger_compatible_class("langtrace", None, None)
print("endpoint:", lg.config.endpoint)
print("auth header:", os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"])
from litellm.integrations.opentelemetry import OpenTelemetry
print("normalized:", OpenTelemetry()._normalize_otel_endpoint("https://app.langtrace.ai/api/trace", "traces"))
PY
endpoint: https://app.langtrace.ai/api/trace
auth header: x-api-key=lt-demo
normalized: https://app.langtrace.ai/api/trace
```

Before this change the same run produced `endpoint: https://langtrace.ai/api/trace`, `auth header: api_key=lt-demo`, and `normalized: https://langtrace.ai/api/trace/v1/traces`

## Type

🐛 Bug Fix

## Changes

`litellm/litellm_core_utils/litellm_logging.py` sets the langtrace endpoint to `https://app.langtrace.ai/api/trace` and the OTLP traces header to `x-api-key`. `litellm/integrations/opentelemetry.py` short-circuits the traces normalizer for any endpoint ending in `/api/trace` so it is not rewritten to `/api/trace/v1/traces`. `tests/test_litellm/integrations/test_opentelemetry.py` pins both the exporter config and the normalizer behavior so the stale values cannot return.

## QA runbook

Set `LANGTRACE_API_KEY`, enable the `langtrace` callback, and send a chat completion; traces reach `https://app.langtrace.ai/api/trace` authenticated with `x-api-key`. The unit tests `LangtraceV1ConfigTest` and `test_normalize_traces_nonstandard_otlp_ingest_urls_unchanged` cover the config and normalizer respectively.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/34865" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->