### PR TITLE
fix(proxy): fix AttributeError in model_info_v2 when using --model CLI flag

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12149,13 +12149,9 @@ async def model_info_v2(
                 user_model_info = dict(litellm.get_model_info(model=user_model))
             except Exception:
                 user_model_info = {}
-            user_model_litellm_params = LiteLLM_Params(model=user_model)
-            user_model_deployment = Deployment(
-                model_name="*",
-                litellm_params=user_model_litellm_params,
-                model_info=user_model_info,
-            )
-            all_models += [user_model_deployment.model_dump()]
+            user_model_params = LiteLLM_Params(model=user_model)
+            deployment = Deployment(model_name="*", litellm_params=user_model_params, model_info=user_model_info)
+            all_models += [deployment.model_dump()]
 
         if model is not None:
             all_models = [m for m in all_models if m["model_name"] == model]

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12146,7 +12146,7 @@ async def model_info_v2(
         if user_model is not None:
             # if user does not use a config.yaml, https://github.com/BerriAI/litellm/issues/2061
             try:
-                user_model_info = cast(dict[str, object], litellm.get_model_info(model=user_model))
+                user_model_info = dict(litellm.get_model_info(model=user_model))
             except Exception:
                 user_model_info = {}
             user_model_deployment = Deployment(

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12149,9 +12149,10 @@ async def model_info_v2(
                 user_model_info = dict(litellm.get_model_info(model=user_model))
             except Exception:
                 user_model_info = {}
+            user_model_litellm_params = LiteLLM_Params(model=user_model)
             user_model_deployment = Deployment(
                 model_name="*",
-                litellm_params=LiteLLM_Params(model=user_model),
+                litellm_params=user_model_litellm_params,
                 model_info=user_model_info,
             )
             all_models += [user_model_deployment.model_dump()]

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12147,7 +12147,7 @@ async def model_info_v2(
             # if user does not use a config.yaml, https://github.com/BerriAI/litellm/issues/2061
             try:
                 user_model_info = dict(litellm.get_model_info(model=user_model))
-            except Exception:
+            except Exception:  # noqa: BLE001  # unmapped CLI model name must not block model listing
                 user_model_info = {}
             user_model_params = LiteLLM_Params(model=user_model)
             deployment = Deployment(model_name="*", litellm_params=user_model_params, model_info=user_model_info)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12145,7 +12145,16 @@ async def model_info_v2(
 
         if user_model is not None:
             # if user does not use a config.yaml, https://github.com/BerriAI/litellm/issues/2061
-            all_models += [user_model]
+            try:
+                user_model_info: Dict = cast(Dict, litellm.get_model_info(model=user_model))
+            except Exception:
+                user_model_info = {}
+            user_model_deployment = Deployment(
+                model_name="*",
+                litellm_params=LiteLLM_Params(model=user_model),
+                model_info=user_model_info,
+            )
+            all_models += [user_model_deployment.model_dump()]
 
         if model is not None:
             all_models = [m for m in all_models if m["model_name"] == model]

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12146,7 +12146,7 @@ async def model_info_v2(
         if user_model is not None:
             # if user does not use a config.yaml, https://github.com/BerriAI/litellm/issues/2061
             try:
-                user_model_info: Dict = cast(Dict, litellm.get_model_info(model=user_model))
+                user_model_info = cast(dict[str, object], litellm.get_model_info(model=user_model))
             except Exception:
                 user_model_info = {}
             user_model_deployment = Deployment(

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1673,7 +1673,14 @@ async def test_get_all_team_models():
 
 
 @pytest.mark.asyncio
-async def test_model_info_v2_with_cli_model_and_team_models_does_not_crash(monkeypatch):
+@pytest.mark.parametrize(
+    "cli_model",
+    [
+        "deepseek/deepseek-v4-pro",  # litellm.get_model_info succeeds
+        "totally-unrecognized-cli-model-xyz",  # litellm.get_model_info raises, falls back to {}
+    ],
+)
+async def test_model_info_v2_with_cli_model_and_team_models_does_not_crash(monkeypatch, cli_model):
     """
     Regression test: a proxy started with `--model <name>` (no config.yaml)
     crashed GET /v2/model/info?include_team_models=true.
@@ -1687,6 +1694,10 @@ async def test_model_info_v2_with_cli_model_and_team_models_does_not_crash(monke
     that calls `_model.get("model_info", {})` (e.g.
     `_populate_team_access_on_models`, reached via `include_team_models=true`)
     raised `AttributeError: 'str' object has no attribute 'get'`.
+
+    Parametrized over a model litellm recognizes (get_model_info succeeds)
+    and one it doesn't (get_model_info raises, falling back to `{}`), since
+    both paths build the CLI-model deployment differently.
     """
     import litellm.proxy.proxy_server as proxy_server_module
     from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
@@ -1704,7 +1715,7 @@ async def test_model_info_v2_with_cli_model_and_team_models_does_not_crash(monke
     )
 
     monkeypatch.setattr(proxy_server_module, "llm_router", llm_router)
-    monkeypatch.setattr(proxy_server_module, "user_model", "deepseek/deepseek-v4-pro")
+    monkeypatch.setattr(proxy_server_module, "user_model", cli_model)
     monkeypatch.setattr(proxy_server_module, "prisma_client", MagicMock())
     monkeypatch.setattr(
         proxy_server_module.proxy_config, "get_config", AsyncMock(return_value={})

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1672,6 +1672,69 @@ async def test_get_all_team_models():
         assert result == {"gpt-4-model-1": ["team1"], "gpt-4-model-2": ["team1"]}
 
 
+@pytest.mark.asyncio
+async def test_model_info_v2_with_cli_model_and_team_models_does_not_crash(monkeypatch):
+    """
+    Regression test: a proxy started with `--model <name>` (no config.yaml)
+    crashed GET /v2/model/info?include_team_models=true.
+
+    `user_model` (set from the CLI `--model` flag) used to be appended to
+    `all_models` as a bare string:
+
+        all_models += [user_model]
+
+    every other entry in that list is a deployment dict, so downstream code
+    that calls `_model.get("model_info", {})` (e.g.
+    `_populate_team_access_on_models`, reached via `include_team_models=true`)
+    raised `AttributeError: 'str' object has no attribute 'get'`.
+    """
+    import litellm.proxy.proxy_server as proxy_server_module
+    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+    from litellm.proxy.proxy_server import model_info_v2
+    from litellm.router import Router
+
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": "gpt-4",
+                "litellm_params": {"model": "openai/gpt-4.1"},
+                "model_info": {"id": "configured-model-1"},
+            }
+        ]
+    )
+
+    monkeypatch.setattr(proxy_server_module, "llm_router", llm_router)
+    monkeypatch.setattr(proxy_server_module, "user_model", "deepseek/deepseek-v4-pro")
+    monkeypatch.setattr(proxy_server_module, "prisma_client", MagicMock())
+    monkeypatch.setattr(
+        proxy_server_module.proxy_config, "get_config", AsyncMock(return_value={})
+    )
+    monkeypatch.setattr(
+        proxy_server_module, "get_all_team_models", AsyncMock(return_value={})
+    )
+
+    user_api_key_dict = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN)
+
+    # Before the fix, this raised AttributeError: 'str' object has no attribute 'get'
+    response = await model_info_v2(
+        user_api_key_dict=user_api_key_dict,
+        model=None,
+        user_models_only=False,
+        include_team_models=True,
+        debug=False,
+        page=1,
+        size=50,
+        search=None,
+        modelId=None,
+        teamId=None,
+        sortBy=None,
+        sortOrder="asc",
+    )
+
+    model_names = {m["model_name"] for m in response["data"]}
+    assert "gpt-4" in model_names
+
+
 def test_add_team_models_to_all_models():
     """
     Test add_team_models_to_all_models function


### PR DESCRIPTION
## TLDR

Problem this solves:

- Starting the proxy with `--model <name>` (no config.yaml) crashes GET /v2/model/info?include_team_models=true with a 500 error
- The crash happens because a raw model name string gets appended into a list that every other entry represents as a deployment dict

How it solves it:

- Builds a proper `Deployment` dict for the CLI-supplied model, matching the pattern already used by the `/model/info` endpoint, instead of appending the bare string

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on Slack (#pr-review).

## Screenshots / Proof of Fix

Started the proxy at commit df3b42a795 (this fix applied) with `litellm --model deepseek/deepseek-v4-pro` against a Postgres-backed DB, added a model through the Admin UI flow (`POST /model/new`), then hit the endpoint that used to crash:

```bash
curl -s -X POST "http://localhost:4000/model/new" \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model_name": "deepseek-test",
    "litellm_params": {
      "model": "deepseek/deepseek-v4-pro",
      "api_key": "os.environ/DEEPSEEK_API_KEY"
    }
  }'

curl -s -w "\nHTTP_STATUS:%{http_code}\n" "http://localhost:4000/v2/model/info?include_team_models=true&page=1&size=50" -H "Authorization: Bearer sk-1234"
```

Output (truncated to the status line, full model list returned successfully):

```
HTTP_STATUS:200
```

Before the fix, the same request against a proxy started with `--model <name>` returned:

```
HTTP_STATUS:500
{"error":{"message":"AttributeError: 'str' object has no attribute 'get'", ...}}
```

with this server-side traceback:

```
File "litellm/proxy/proxy_server.py", line 12140, in model_info_v2
  all_models = await get_all_team_and_direct_access_models(...)
File "litellm/proxy/proxy_server.py", line 11305, in get_all_team_and_direct_access_models
  all_models = await _populate_team_access_on_models(...)
File "litellm/proxy/proxy_server.py", line 11274, in _populate_team_access_on_models
  model_id = _model.get("model_info", {}).get("id", None)
AttributeError: 'str' object has no attribute 'get'
```

## Type

🐛 Bug Fix
✅ Test

## Changes

- `litellm/proxy/proxy_server.py`: in `model_info_v2`, build a `Deployment` dict (with `model_info` populated via `litellm.get_model_info`) for the CLI-supplied `user_model` instead of appending the raw string to `all_models`
- `tests/test_litellm/proxy/test_proxy_server.py`: add `test_model_info_v2_with_cli_model_and_team_models_does_not_crash`, a regression test that calls `model_info_v2` with `user_model` set and `include_team_models=True`, reproducing the exact request that used to crash. Confirmed it fails with the original `AttributeError` when the fix is reverted, and passes with the fix applied

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR