### PR TITLE
fix(mcp): annotate connected-app reachability on the gateway connect page

### DIFF
--- a/litellm/models/mcp_server.py
+++ b/litellm/models/mcp_server.py
@@ -102,6 +102,7 @@ class LiteLLM_MCPServerTable(LiteLLMPydanticObjectBase):
     byok_description: List[str] = Field(default_factory=list)
     byok_api_key_help_url: Optional[str] = None
     has_user_credential: Optional[bool] = None
+    connected_app_reachable: bool | None = None
     source_url: Optional[str] = None
     timeout: Optional[float] = None
     max_concurrent_requests: Optional[int] = None

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -21,6 +21,7 @@ from litellm.proxy._experimental.mcp_server.faults.list_outcomes import (
     list_fault_http_status,
 )
 from litellm.proxy._experimental.mcp_server.ui_session_utils import (
+    acting_user_auth,
     build_effective_auth_contexts,
 )
 from litellm.proxy._experimental.mcp_server.utils import (
@@ -706,6 +707,7 @@ if MCP_AVAILABLE:
         )
 
         try:
+            user_api_key_dict = await acting_user_auth(user_api_key_dict)
             mcp_server_name = _as_query_str(mcp_server_name)
             toolset_name = _as_query_str(toolset_name)
 
@@ -905,6 +907,7 @@ if MCP_AVAILABLE:
         )
 
         try:
+            user_api_key_dict = await acting_user_auth(user_api_key_dict)
             data = await request.json()
 
             tool_name = data.get("name")

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -645,13 +645,19 @@ if MCP_AVAILABLE:
         """Coerce an Optional[str] Query param to str|None, dropping unresolved FastAPI defaults."""
         return value if isinstance(value, str) else None
 
-    async def _resolve_toolset_scope(
+    async def _resolve_acting_auth(
         toolset_name: str | None,
         user_api_key_dict: UserAPIKeyAuth,
     ) -> UserAPIKeyAuth:
-        """Resolve ``toolset_name`` to its scoped ``UserAPIKeyAuth``, or return unchanged."""
+        """The one credential this tools request acts as.
+
+        A toolset name narrows the caller's own credential to that toolset; otherwise a dashboard
+        session is swapped for its admitted subject. The two are mutually exclusive by construction,
+        which is why they share an owner: the admitted subject resolves per grant source and a team
+        source deliberately carries none of the caller's ``object_permission``, so a toolset
+        narrowing layered on top would evaporate on every team-granted server."""
         if not toolset_name:
-            return user_api_key_dict
+            return await acting_user_auth(user_api_key_dict)
 
         from litellm.proxy.utils import get_prisma_client_or_throw
 
@@ -707,17 +713,15 @@ if MCP_AVAILABLE:
         )
 
         try:
-            user_api_key_dict = await acting_user_auth(user_api_key_dict)
             mcp_server_name = _as_query_str(mcp_server_name)
             toolset_name = _as_query_str(toolset_name)
+            user_api_key_dict = await _resolve_acting_auth(toolset_name, user_api_key_dict)
 
             # The full catalog (allowlist filter skipped) is admin-only so the
             # REST endpoint can't be used to enumerate deliberately-disabled tools.
             apply_tool_filters = not (
                 include_disabled_tools and user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
             )
-
-            user_api_key_dict = await _resolve_toolset_scope(toolset_name, user_api_key_dict)
 
             if server_id is None:
                 server_id = mcp_server_name

--- a/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
@@ -23,12 +23,19 @@ def clone_user_api_key_auth_with_team(
     return cloned_auth
 
 
+def is_ui_session_credential(user_api_key_auth: UserAPIKeyAuth) -> bool:
+    """Whether the caller is the dashboard's SSO-minted session token acting as its user,
+    the only credential shape allowed to widen a request to the owning user's identity."""
+
+    return user_api_key_auth.team_id == UI_SESSION_TOKEN_TEAM_ID and bool(user_api_key_auth.user_id)
+
+
 async def resolve_ui_session_team_ids(
     user_api_key_auth: UserAPIKeyAuth,
 ) -> List[str]:
     """Resolve the real team ids backing a UI session token."""
 
-    if user_api_key_auth.team_id != UI_SESSION_TOKEN_TEAM_ID or not user_api_key_auth.user_id:
+    if not is_ui_session_credential(user_api_key_auth):
         return []
 
     from litellm.proxy.auth.auth_checks import get_user_object

--- a/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
@@ -95,6 +95,23 @@ async def _admitted_user_context(user_api_key_auth: UserAPIKeyAuth) -> UserAPIKe
         return None
 
 
+async def acting_user_auth(user_api_key_auth: UserAPIKeyAuth) -> UserAPIKeyAuth:
+    """The principal acting-as-user MCP routes resolve permissions with. A non-admin dashboard
+    session acts as the admitted subject, the same identity a gateway session resolves with, so
+    server reachability, per-source tool ceilings, rate limits, and billing bind identically on
+    both surfaces. An admin session keeps its operator view and any caller-passed credential is
+    returned unchanged, never widened."""
+
+    if not is_ui_session_credential(user_api_key_auth):
+        return user_api_key_auth
+    from litellm.proxy.management_endpoints.common_utils import _user_has_admin_view
+
+    if _user_has_admin_view(user_api_key_auth):
+        return user_api_key_auth
+    admitted = await _admitted_user_context(user_api_key_auth)
+    return admitted if admitted is not None else user_api_key_auth
+
+
 async def build_effective_auth_contexts(
     user_api_key_auth: UserAPIKeyAuth,
 ) -> List[UserAPIKeyAuth]:

--- a/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import List
 
+from fastapi import HTTPException
+
 from litellm._logging import verbose_logger
 from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
 from litellm.proxy._types import UserAPIKeyAuth
@@ -75,12 +77,36 @@ async def resolve_ui_session_team_ids(
     return resolved_team_ids
 
 
+async def _admitted_user_context(user_api_key_auth: UserAPIKeyAuth) -> UserAPIKeyAuth | None:
+    """The user-identity context for a dashboard session: the same admitted-subject auth a
+    gateway OAuth session for this user resolves with, carrying the user row's own object
+    permission. None for any other credential (a caller-passed key is never widened) and on
+    reload failure (falls back to team contexts only)."""
+
+    if not is_ui_session_credential(user_api_key_auth) or user_api_key_auth.user_id is None:
+        return None
+    from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+        MCPRequestHandler,
+    )
+
+    try:
+        return await MCPRequestHandler._reload_admitted_user(user_api_key_auth.user_id)
+    except HTTPException:
+        return None
+
+
 async def build_effective_auth_contexts(
     user_api_key_auth: UserAPIKeyAuth,
 ) -> List[UserAPIKeyAuth]:
     """Return auth contexts that reflect the actual teams for UI session tokens."""
 
     resolved_team_ids = await resolve_ui_session_team_ids(user_api_key_auth)
-    if resolved_team_ids:
-        return [clone_user_api_key_auth_with_team(user_api_key_auth, team_id) for team_id in resolved_team_ids]
-    return [user_api_key_auth]
+    team_contexts = (
+        [clone_user_api_key_auth_with_team(user_api_key_auth, team_id) for team_id in resolved_team_ids]
+        if resolved_team_ids
+        else [user_api_key_auth]
+    )
+    admitted_context = await _admitted_user_context(user_api_key_auth)
+    if admitted_context is None:
+        return team_contexts
+    return [*team_contexts, admitted_context]

--- a/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
@@ -1,4 +1,4 @@
-"""Helpers to resolve real team contexts for UI session tokens."""
+"""Helpers to resolve the identity a dashboard UI session token acts as."""
 
 from __future__ import annotations
 
@@ -77,22 +77,25 @@ async def resolve_ui_session_team_ids(
     return resolved_team_ids
 
 
-async def _admitted_user_context(user_api_key_auth: UserAPIKeyAuth) -> UserAPIKeyAuth | None:
-    """The user-identity context for a dashboard session: the same admitted-subject auth a
-    gateway OAuth session for this user resolves with, carrying the user row's own object
-    permission. None for any other credential (a caller-passed key is never widened) and on
-    reload failure (falls back to team contexts only)."""
+async def admitted_user_context(user_api_key_auth: UserAPIKeyAuth) -> UserAPIKeyAuth | None:
+    """THE owner of "resolve this dashboard session's user identity": the same admitted-subject auth a
+    gateway OAuth session for this user resolves with, carrying the user row's own object permission,
+    on this request's tracing span. None for any other credential (a caller-passed key is never
+    widened) and on reload failure, which every caller reads as "no user-level identity available"."""
 
-    if not is_ui_session_credential(user_api_key_auth) or user_api_key_auth.user_id is None:
+    user_id = user_api_key_auth.user_id
+    if not is_ui_session_credential(user_api_key_auth) or user_id is None:
         return None
     from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
         MCPRequestHandler,
     )
 
     try:
-        return await MCPRequestHandler._reload_admitted_user(user_api_key_auth.user_id)
-    except HTTPException:
+        admitted = await MCPRequestHandler._reload_admitted_user(user_id)
+    except HTTPException as e:
+        verbose_logger.warning(f"MCP dashboard session: admitted-subject reload failed for {user_id}: {e.detail}")
         return None
+    return admitted.model_copy(update={"parent_otel_span": user_api_key_auth.parent_otel_span})
 
 
 async def acting_user_auth(user_api_key_auth: UserAPIKeyAuth) -> UserAPIKeyAuth:
@@ -100,7 +103,12 @@ async def acting_user_auth(user_api_key_auth: UserAPIKeyAuth) -> UserAPIKeyAuth:
     session acts as the admitted subject, the same identity a gateway session resolves with, so
     server reachability, per-source tool ceilings, rate limits, and billing bind identically on
     both surfaces. An admin session keeps its operator view and any caller-passed credential is
-    returned unchanged, never widened."""
+    returned unchanged, never widened.
+
+    Do not combine this with a narrowing that rewrites a single credential's ``object_permission``
+    (toolset scope): the admitted subject resolves per grant source and a team source deliberately
+    carries none of the caller's own grants, so the narrowing would silently evaporate on every
+    team-granted server. A request carrying such a scope keeps the caller's own credential."""
 
     if not is_ui_session_credential(user_api_key_auth):
         return user_api_key_auth
@@ -108,14 +116,16 @@ async def acting_user_auth(user_api_key_auth: UserAPIKeyAuth) -> UserAPIKeyAuth:
 
     if _user_has_admin_view(user_api_key_auth):
         return user_api_key_auth
-    admitted = await _admitted_user_context(user_api_key_auth)
+    admitted = await admitted_user_context(user_api_key_auth)
     return admitted if admitted is not None else user_api_key_auth
 
 
 async def build_effective_auth_contexts(
     user_api_key_auth: UserAPIKeyAuth,
 ) -> List[UserAPIKeyAuth]:
-    """Return auth contexts that reflect the actual teams for UI session tokens."""
+    """Every auth context a management or listing surface must resolve a UI session token through:
+    one per real team backing the session, plus the session user's own admitted identity, so a grant
+    made directly to the user row is as visible to the dashboard as it is to a gateway session."""
 
     resolved_team_ids = await resolve_ui_session_team_ids(user_api_key_auth)
     team_contexts = (
@@ -123,7 +133,7 @@ async def build_effective_auth_contexts(
         if resolved_team_ids
         else [user_api_key_auth]
     )
-    admitted_context = await _admitted_user_context(user_api_key_auth)
+    admitted_context = await admitted_user_context(user_api_key_auth)
     if admitted_context is None:
         return team_contexts
     return [*team_contexts, admitted_context]

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -1033,6 +1033,13 @@ if MCP_AVAILABLE:
 
         if connected_app_view is True:
             reachable_ids = await _connected_app_reachable_server_ids(user_api_key_dict.user_id)
+            listed_ids = {server.server_id for server in redacted_mcp_servers}
+            missing_tables = [
+                global_mcp_server_manager._build_mcp_server_table(registry_server)
+                for missing_id in sorted(reachable_ids - listed_ids)
+                if (registry_server := global_mcp_server_manager.get_mcp_server_by_id(missing_id)) is not None
+            ]
+            redacted_mcp_servers.extend(_redact_mcp_credentials_list(missing_tables))
             for server in redacted_mcp_servers:
                 server.connected_app_reachable = server.server_id in reachable_ids
 

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -149,6 +149,7 @@ if MCP_AVAILABLE:
     )
     from litellm.proxy._experimental.mcp_server.ui_session_utils import (
         build_effective_auth_contexts,
+        is_ui_session_credential,
     )
     from litellm.proxy._types import (
         LiteLLM_MCPServerTable,
@@ -1031,7 +1032,7 @@ if MCP_AVAILABLE:
             servers = await _resolve_accessible_mcp_servers(user_api_key_dict)
             redacted_mcp_servers = _redact_mcp_credentials_list(servers)
 
-        if connected_app_view is True:
+        if connected_app_view is True and is_ui_session_credential(user_api_key_dict):
             reachable_ids = await _connected_app_reachable_server_ids(user_api_key_dict.user_id)
             listed_ids = {server.server_id for server in redacted_mcp_servers}
             missing_tables = [

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -1034,13 +1034,6 @@ if MCP_AVAILABLE:
 
         if connected_app_view is True and is_ui_session_credential(user_api_key_dict):
             reachable_ids = await _connected_app_reachable_server_ids(user_api_key_dict.user_id)
-            listed_ids = {server.server_id for server in redacted_mcp_servers}
-            missing_tables = [
-                global_mcp_server_manager._build_mcp_server_table(registry_server)
-                for missing_id in sorted(reachable_ids - listed_ids)
-                if (registry_server := global_mcp_server_manager.get_mcp_server_by_id(missing_id)) is not None
-            ]
-            redacted_mcp_servers.extend(_redact_mcp_credentials_list(missing_tables))
             for server in redacted_mcp_servers:
                 server.connected_app_reachable = server.server_id in reachable_ids
 

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -939,6 +939,22 @@ if MCP_AVAILABLE:
                 aggregated.setdefault(server.server_id, server)
         return list(aggregated.values())
 
+    async def _connected_app_reachable_server_ids(user_id: str | None) -> frozenset[str]:
+        if not user_id:
+            return frozenset()
+        from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+            MCPRequestHandler,
+        )
+
+        try:
+            admitted = await MCPRequestHandler._reload_admitted_user(user_id)
+            return frozenset(await global_mcp_server_manager.get_allowed_mcp_servers(admitted))
+        except HTTPException as e:
+            verbose_proxy_logger.warning(
+                f"connected_app_view: marking every MCP server unreachable; admitted-subject reload failed: {e.detail}"
+            )
+            return frozenset()
+
     @router.get(
         "/server",
         description="Returns the mcp server list with associated teams",
@@ -952,6 +968,12 @@ if MCP_AVAILABLE:
             description="Filter MCP servers by team scope. When provided, returns only "
             "servers the team has access to plus globally available (allow_all_keys) servers. "
             "Used by the Create Key UI to show team-scoped MCP servers.",
+        ),
+        connected_app_view: bool = Query(
+            False,
+            description="Annotate each returned server with connected_app_reachable: whether a "
+            "connected app authorized by the calling user (a gateway OAuth session) is served "
+            "this server on the aggregate MCP endpoint.",
         ),
     ):
         """
@@ -1008,6 +1030,11 @@ if MCP_AVAILABLE:
         else:
             servers = await _resolve_accessible_mcp_servers(user_api_key_dict)
             redacted_mcp_servers = _redact_mcp_credentials_list(servers)
+
+        if connected_app_view is True:
+            reachable_ids = await _connected_app_reachable_server_ids(user_api_key_dict.user_id)
+            for server in redacted_mcp_servers:
+                server.connected_app_reachable = server.server_id in reachable_ids
 
         # augment the mcp servers with public status
         if litellm.public_mcp_servers is not None:

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -148,6 +148,7 @@ if MCP_AVAILABLE:
         global_mcp_server_manager,
     )
     from litellm.proxy._experimental.mcp_server.ui_session_utils import (
+        admitted_user_context,
         build_effective_auth_contexts,
         is_ui_session_credential,
     )
@@ -940,21 +941,15 @@ if MCP_AVAILABLE:
                 aggregated.setdefault(server.server_id, server)
         return list(aggregated.values())
 
-    async def _connected_app_reachable_server_ids(user_id: str | None) -> frozenset[str]:
-        if not user_id:
+    async def _connected_app_reachable_server_ids(user_api_key_dict: UserAPIKeyAuth) -> frozenset[str]:
+        """Server ids a connected app authorized by this dashboard user is served on the aggregate
+        MCP endpoint, resolved through the one owner of the admitted subject so the page and the
+        session cannot drift. Empty when that identity cannot be built, which is the true answer:
+        the same user cannot open a gateway session either."""
+        admitted = await admitted_user_context(user_api_key_dict)
+        if admitted is None:
             return frozenset()
-        from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
-            MCPRequestHandler,
-        )
-
-        try:
-            admitted = await MCPRequestHandler._reload_admitted_user(user_id)
-            return frozenset(await global_mcp_server_manager.get_allowed_mcp_servers(admitted))
-        except HTTPException as e:
-            verbose_proxy_logger.warning(
-                f"connected_app_view: marking every MCP server unreachable; admitted-subject reload failed: {e.detail}"
-            )
-            return frozenset()
+        return frozenset(await global_mcp_server_manager.get_allowed_mcp_servers(admitted))
 
     @router.get(
         "/server",
@@ -1033,7 +1028,7 @@ if MCP_AVAILABLE:
             redacted_mcp_servers = _redact_mcp_credentials_list(servers)
 
         if connected_app_view is True and is_ui_session_credential(user_api_key_dict):
-            reachable_ids = await _connected_app_reachable_server_ids(user_api_key_dict.user_id)
+            reachable_ids = await _connected_app_reachable_server_ids(user_api_key_dict)
             for server in redacted_mcp_servers:
                 server.connected_app_reachable = server.server_id in reachable_ids
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -769,6 +769,84 @@ class TestListToolsRestAPI:
         assert captured["server"] is stub_server
         assert result["tools"] == ["tool-1"]
         assert result["error"] is None
+
+    async def test_non_admin_ui_session_resolves_as_admitted_subject(self, monkeypatch):
+        """LIT-4861: a non-admin dashboard session must act as the admitted subject on this
+        route, so server reachability AND tool ceilings bind to the user's grants exactly as
+        they do for a gateway session, never to the bare session key."""
+        from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+
+        session_auth = UserAPIKeyAuth(
+            team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="grant-user", user_role="internal_user"
+        )
+        admitted_auth = UserAPIKeyAuth(user_id="grant-user")
+
+        async def fake_reload(user_id):
+            assert user_id == "grant-user"
+            return admitted_auth
+
+        monkeypatch.setattr(
+            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+            fake_reload,
+        )
+
+        seen_server_resolution_auths = []
+
+        async def fake_get_allowed_mcp_servers(user_api_key_auth=None, **kwargs):
+            seen_server_resolution_auths.append(user_api_key_auth)
+            return ["server-1"]
+
+        class StubServer:
+            alias = "server-1"
+            server_name = "server-1"
+            name = "stub"
+            allowed_tools = None
+            mcp_info = {"server_name": "stub"}
+            available_on_public_internet = True
+
+        stub_server = StubServer()
+        captured = {}
+
+        async def fake_get_tools(
+            server,
+            server_auth_header,
+            raw_headers=None,
+            user_api_key_auth=None,
+            extra_headers=None,
+            apply_tool_filters=True,
+        ):
+            captured["user_api_key_auth"] = user_api_key_auth
+            return ["tool-1"]
+
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            fake_get_allowed_mcp_servers,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_id",
+            lambda server_id: stub_server if server_id == "server-1" else None,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints,
+            "_get_tools_for_single_server",
+            fake_get_tools,
+            raising=False,
+        )
+
+        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+        result = await rest_endpoints.list_tool_rest_api(
+            request,
+            server_id="server-1",
+            user_api_key_dict=session_auth,
+        )
+
+        assert result["tools"] == ["tool-1"]
+        assert seen_server_resolution_auths and all(a is admitted_auth for a in seen_server_resolution_auths)
+        assert captured["user_api_key_auth"] is admitted_auth
         assert result["message"] == "Successfully retrieved tools"
 
     async def test_include_disabled_tools_is_admin_only(self, monkeypatch):

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_rest_endpoints.py
@@ -779,7 +779,7 @@ class TestListToolsRestAPI:
         session_auth = UserAPIKeyAuth(
             team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="grant-user", user_role="internal_user"
         )
-        admitted_auth = UserAPIKeyAuth(user_id="grant-user")
+        admitted_auth = UserAPIKeyAuth(user_id="grant-user", org_id="admitted-org")
 
         async def fake_reload(user_id):
             assert user_id == "grant-user"
@@ -844,10 +844,103 @@ class TestListToolsRestAPI:
             user_api_key_dict=session_auth,
         )
 
+        resolved = [*seen_server_resolution_auths, captured["user_api_key_auth"]]
+        assert seen_server_resolution_auths
+        assert all(a.org_id == "admitted-org" and a.team_id is None for a in resolved)
         assert result["tools"] == ["tool-1"]
-        assert seen_server_resolution_auths and all(a is admitted_auth for a in seen_server_resolution_auths)
-        assert captured["user_api_key_auth"] is admitted_auth
         assert result["message"] == "Successfully retrieved tools"
+
+    async def test_toolset_scoped_request_keeps_the_caller_credential(self, monkeypatch):
+        """LIT-4861: the admitted subject resolves per grant source and a team source deliberately
+        carries none of the caller's own object_permission, so a toolset narrowing layered on top
+        would evaporate on every team-granted server. A toolset-scoped request therefore stays on
+        the caller's own credential, exactly as it did before the acting-as-user swap."""
+        from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+        from litellm.proxy._types import LiteLLM_ObjectPermissionTable
+
+        session_auth = UserAPIKeyAuth(
+            team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="grant-user", user_role="internal_user"
+        )
+        scoped_auth = UserAPIKeyAuth(
+            object_permission=LiteLLM_ObjectPermissionTable(
+                object_permission_id="toolset-scope",
+                mcp_servers=["toolset-server-1"],
+            )
+        )
+        reload_calls: list[str] = []
+        scope_inputs: list[UserAPIKeyAuth] = []
+
+        async def record_reload(user_id):
+            reload_calls.append(user_id)
+            return UserAPIKeyAuth(user_id=user_id)
+
+        class StubToolset:
+            toolset_id = "toolset-1"
+
+        class StubServer:
+            alias = "toolset-server-1"
+            server_name = "toolset-server-1"
+            name = "toolset-server-1"
+            allowed_tools = None
+            mcp_info = {"server_name": "toolset-server-1"}
+            available_on_public_internet = True
+
+        stub_server = StubServer()
+
+        async def fake_get_toolset_by_name_cached(prisma_client, toolset_name):
+            return StubToolset()
+
+        async def fake_apply_toolset_scope(user_api_key_auth, toolset_id):
+            scope_inputs.append(user_api_key_auth)
+            return scoped_auth
+
+        async def fake_get_allowed_mcp_servers(user_api_key_auth=None, **kwargs):
+            assert user_api_key_auth is scoped_auth
+            return ["toolset-server-1"]
+
+        async def fake_get_tools(server, server_auth_header, *args, **kwargs):
+            return ["toolset-tool-1"]
+
+        monkeypatch.setattr(
+            "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+            record_reload,
+        )
+        monkeypatch.setattr(
+            "litellm.proxy.utils.get_prisma_client_or_throw",
+            lambda *args, **kwargs: MagicMock(),
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_toolset_by_name_cached",
+            fake_get_toolset_by_name_cached,
+            raising=False,
+        )
+        monkeypatch.setattr(rest_endpoints, "_apply_toolset_scope", fake_apply_toolset_scope, raising=False)
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_allowed_mcp_servers",
+            fake_get_allowed_mcp_servers,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            rest_endpoints.global_mcp_server_manager,
+            "get_mcp_server_by_id",
+            lambda server_id: stub_server if server_id == "toolset-server-1" else None,
+            raising=False,
+        )
+        monkeypatch.setattr(rest_endpoints, "_get_tools_for_single_server", fake_get_tools, raising=False)
+
+        request = _build_request(path="/mcp-rest/tools/list", method="GET")
+        result = await rest_endpoints.list_tool_rest_api(
+            request,
+            server_id=None,
+            toolset_name="research_tools",
+            user_api_key_dict=session_auth,
+        )
+
+        assert result["tools"] == ["toolset-tool-1"]
+        assert scope_inputs == [session_auth]
+        assert reload_calls == []
 
     async def test_include_disabled_tools_is_admin_only(self, monkeypatch):
         """include_disabled_tools skips the allowlist filter only for PROXY_ADMIN;

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
@@ -179,3 +179,55 @@ async def test_build_effective_auth_contexts_survives_admitted_reload_failure(mo
     contexts = await build_effective_auth_contexts(user_auth)
 
     assert [ctx.team_id for ctx in contexts] == ["team-a"]
+
+
+@pytest.mark.asyncio
+async def test_acting_user_auth_returns_admitted_subject_for_non_admin_sessions(monkeypatch):
+    """LIT-4861: acting-as-user MCP routes must resolve a non-admin dashboard session as the
+    admitted subject so tool ceilings, reachability, and limits bind exactly as on /mcp."""
+    from litellm.proxy._experimental.mcp_server.ui_session_utils import acting_user_auth
+
+    user_auth = UserAPIKeyAuth(team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="user-42", user_role="internal_user")
+    admitted_auth = UserAPIKeyAuth(user_id="user-42")
+    reload_mock = AsyncMock(return_value=admitted_auth)
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        reload_mock,
+    )
+
+    result = await acting_user_auth(user_auth)
+
+    assert result is admitted_auth
+    reload_mock.assert_awaited_once_with("user-42")
+
+
+@pytest.mark.asyncio
+async def test_acting_user_auth_keeps_admin_sessions_and_passed_keys_unchanged(monkeypatch):
+    from litellm.proxy._experimental.mcp_server.ui_session_utils import acting_user_auth
+
+    reload_mock = AsyncMock()
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        reload_mock,
+    )
+
+    admin_session = UserAPIKeyAuth(team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="admin-1", user_role="proxy_admin")
+    assert await acting_user_auth(admin_session) is admin_session
+
+    passed_key = UserAPIKeyAuth(team_id="regular-team", user_id="user-1", user_role="internal_user")
+    assert await acting_user_auth(passed_key) is passed_key
+
+    reload_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_acting_user_auth_falls_back_to_session_auth_on_reload_failure(monkeypatch):
+    from litellm.proxy._experimental.mcp_server.ui_session_utils import acting_user_auth
+
+    user_auth = UserAPIKeyAuth(team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="user-9", user_role="internal_user")
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        AsyncMock(side_effect=HTTPException(status_code=503, detail="db down")),
+    )
+
+    assert await acting_user_auth(user_auth) is user_auth

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import HTTPException
 
 from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
 from litellm.proxy._types import UserAPIKeyAuth
@@ -120,3 +121,61 @@ async def test_build_effective_auth_contexts_handles_unpicklable_parent_span(
 
     assert contexts[0].team_id == "team-span"
     assert contexts[0].parent_otel_span is parent_span
+
+
+@pytest.mark.asyncio
+async def test_build_effective_auth_contexts_appends_admitted_user_context(monkeypatch):
+    """LIT-4861: the dashboard session must resolve with the user's admitted identity so the
+    page list and every per-server action endpoint see user-level grants the same way the
+    gateway session does."""
+    user_auth = UserAPIKeyAuth(team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="user-42")
+    admitted_auth = UserAPIKeyAuth(user_id="user-42")
+
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.ui_session_utils.resolve_ui_session_team_ids",
+        AsyncMock(return_value=["team-one"]),
+    )
+    reload_mock = AsyncMock(return_value=admitted_auth)
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        reload_mock,
+    )
+
+    contexts = await build_effective_auth_contexts(user_auth)
+
+    assert contexts[-1] is admitted_auth
+    assert [ctx.team_id for ctx in contexts[:-1]] == ["team-one"]
+    reload_mock.assert_awaited_once_with("user-42")
+
+
+@pytest.mark.asyncio
+async def test_build_effective_auth_contexts_never_widens_caller_passed_keys(monkeypatch):
+    normal_user = UserAPIKeyAuth(team_id="regular-team", user_id="user-1")
+    reload_mock = AsyncMock()
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        reload_mock,
+    )
+
+    contexts = await build_effective_auth_contexts(normal_user)
+
+    assert contexts == [normal_user]
+    reload_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_build_effective_auth_contexts_survives_admitted_reload_failure(monkeypatch):
+    user_auth = UserAPIKeyAuth(team_id=UI_SESSION_TOKEN_TEAM_ID, user_id="user-9")
+
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.ui_session_utils.resolve_ui_session_team_ids",
+        AsyncMock(return_value=["team-a"]),
+    )
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        AsyncMock(side_effect=HTTPException(status_code=503, detail="db down")),
+    )
+
+    contexts = await build_effective_auth_contexts(user_auth)
+
+    assert [ctx.team_id for ctx in contexts] == ["team-a"]

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_ui_session_utils.py
@@ -143,7 +143,7 @@ async def test_build_effective_auth_contexts_appends_admitted_user_context(monke
 
     contexts = await build_effective_auth_contexts(user_auth)
 
-    assert contexts[-1] is admitted_auth
+    assert contexts[-1].user_id == "user-42" and contexts[-1].team_id is None
     assert [ctx.team_id for ctx in contexts[:-1]] == ["team-one"]
     reload_mock.assert_awaited_once_with("user-42")
 
@@ -197,7 +197,7 @@ async def test_acting_user_auth_returns_admitted_subject_for_non_admin_sessions(
 
     result = await acting_user_auth(user_auth)
 
-    assert result is admitted_auth
+    assert result.user_id == "user-42" and result.team_id is None
     reload_mock.assert_awaited_once_with("user-42")
 
 
@@ -231,3 +231,30 @@ async def test_acting_user_auth_falls_back_to_session_auth_on_reload_failure(mon
     )
 
     assert await acting_user_auth(user_auth) is user_auth
+
+
+@pytest.mark.asyncio
+async def test_admitted_user_context_carries_the_request_span(monkeypatch):
+    """Swapping the principal must not drop the request: the admitted subject is rebuilt from the
+    user row and carries no span of its own, so every consumer would otherwise lose trace linkage
+    for the resolution and logging it drives."""
+    from litellm.proxy._experimental.mcp_server.ui_session_utils import acting_user_auth
+
+    class DummySpan:
+        def __init__(self) -> None:
+            self._lock = threading.RLock()
+
+    parent_span = DummySpan()
+    user_auth = UserAPIKeyAuth(
+        team_id=UI_SESSION_TOKEN_TEAM_ID,
+        user_id="user-42",
+        user_role="internal_user",
+        parent_otel_span=parent_span,
+    )
+    monkeypatch.setattr(
+        "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+        AsyncMock(return_value=UserAPIKeyAuth(user_id="user-42")),
+    )
+
+    assert (await acting_user_auth(user_auth)).parent_otel_span is parent_span
+    assert (await build_effective_auth_contexts(user_auth))[-1].parent_otel_span is parent_span

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -6142,7 +6142,14 @@ def test_bundled_openapi_registry_parses_and_entries_are_well_formed():
 
 class TestConnectedAppViewAnnotation:
     """LIT-4861: GET /v1/mcp/server?connected_app_view=true must annotate each server with
-    whether the caller's gateway OAuth sessions (connected apps) are served it on /mcp."""
+    whether the caller's gateway OAuth sessions (connected apps) are served it on /mcp.
+    The view is honored only for the dashboard's UI session credential; a caller-passed
+    virtual key must never be widened to its owning user's identity."""
+
+    def _ui_session_auth(self, user_role: LitellmUserRoles = LitellmUserRoles.PROXY_ADMIN) -> UserAPIKeyAuth:
+        from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+
+        return generate_mock_user_api_key_auth(user_role=user_role, team_id=UI_SESSION_TOKEN_TEAM_ID)
 
     def _mock_manager(self, servers, reachable_ids):
         mock_manager = MagicMock()
@@ -6159,7 +6166,7 @@ class TestConnectedAppViewAnnotation:
 
     @pytest.mark.asyncio
     async def test_connected_app_view_annotates_reachability_via_admitted_resolver(self):
-        caller_auth = generate_mock_user_api_key_auth()
+        caller_auth = self._ui_session_auth()
         admitted_auth = UserAPIKeyAuth(user_id="test_user_id")
         admitted_auth.mcp_admitted_user_subject = True
         mock_manager = self._mock_manager(self._servers(), ["server-1"])
@@ -6194,7 +6201,7 @@ class TestConnectedAppViewAnnotation:
     async def test_connected_app_view_stamps_view_all_list_and_survives_non_admin_sanitizer(self):
         """view_all preempts the manager's admin shortcut with a second whole-registry
         shortcut; the annotation must still land, and must survive the non-admin sanitizer."""
-        caller_auth = generate_mock_user_api_key_auth(user_role=LitellmUserRoles.INTERNAL_USER)
+        caller_auth = self._ui_session_auth(user_role=LitellmUserRoles.INTERNAL_USER)
         mock_manager = self._mock_manager(self._servers(), ["server-2"])
 
         with (
@@ -6225,7 +6232,7 @@ class TestConnectedAppViewAnnotation:
     async def test_connected_app_view_appends_session_reachable_servers_missing_from_page_list(self):
         """A server the session is served must appear on the connect view even when the
         dashboard resolver did not list it (internal-user path, non-admin sanitizer)."""
-        caller_auth = generate_mock_user_api_key_auth(user_role=LitellmUserRoles.INTERNAL_USER)
+        caller_auth = self._ui_session_auth(user_role=LitellmUserRoles.INTERNAL_USER)
         admitted_auth = UserAPIKeyAuth(user_id="test_user_id")
         mock_manager = MagicMock()
         mock_manager.get_all_allowed_mcp_servers = AsyncMock(
@@ -6265,7 +6272,7 @@ class TestConnectedAppViewAnnotation:
 
     @pytest.mark.asyncio
     async def test_connected_app_view_fails_closed_when_admitted_reload_fails(self):
-        caller_auth = generate_mock_user_api_key_auth()
+        caller_auth = self._ui_session_auth()
         mock_manager = self._mock_manager(self._servers(), ["server-1"])
 
         with (
@@ -6320,8 +6327,12 @@ class TestConnectedAppViewAnnotation:
         reload_mock.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_connected_app_view_userless_caller_marks_all_unreachable(self):
-        caller_auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, api_key="test_api_key")
+    async def test_connected_app_view_userless_ui_credential_leaves_field_unset(self):
+        from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+
+        caller_auth = UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN, api_key="test_api_key", team_id=UI_SESSION_TOKEN_TEAM_ID
+        )
         caller_auth.user_id = None
         mock_manager = self._mock_manager(self._servers(), ["server-1"])
         reload_mock = AsyncMock(return_value=UserAPIKeyAuth(user_id="test_user_id"))
@@ -6346,5 +6357,36 @@ class TestConnectedAppViewAnnotation:
 
             result = await fetch_all_mcp_servers(user_api_key_dict=caller_auth, connected_app_view=True)
 
-        assert all(server.connected_app_reachable is False for server in result)
+        assert all(server.connected_app_reachable is None for server in result)
+        reload_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_connected_app_view_ignored_for_caller_passed_virtual_keys(self):
+        """A virtual key the user passes themselves is never widened to the owning user's
+        identity: the view param is a no-op and the admitted resolver is never consulted."""
+        caller_auth = generate_mock_user_api_key_auth(team_id="some-real-team")
+        mock_manager = self._mock_manager(self._servers(), ["server-1"])
+        reload_mock = AsyncMock(return_value=UserAPIKeyAuth(user_id="test_user_id"))
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
+                AsyncMock(return_value=[caller_auth]),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                reload_mock,
+            ),
+        ):
+            from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+                fetch_all_mcp_servers,
+            )
+
+            result = await fetch_all_mcp_servers(user_api_key_dict=caller_auth, connected_app_view=True)
+
+        assert all(server.connected_app_reachable is None for server in result)
         reload_mock.assert_not_awaited()

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -6229,22 +6229,23 @@ class TestConnectedAppViewAnnotation:
         assert flags == {"server-1": False, "server-2": True}
 
     @pytest.mark.asyncio
-    async def test_connected_app_view_appends_session_reachable_servers_missing_from_page_list(self):
-        """A server the session is served must appear on the connect view even when the
-        dashboard resolver did not list it (internal-user path, non-admin sanitizer)."""
+    async def test_connected_app_view_lists_user_granted_servers_via_admitted_context(self):
+        """A server granted only through the user's own object permission must be listed and
+        flagged reachable: the REAL build_effective_auth_contexts appends the admitted-user
+        context, so the page and every action endpoint resolve it identically."""
         caller_auth = self._ui_session_auth(user_role=LitellmUserRoles.INTERNAL_USER)
         admitted_auth = UserAPIKeyAuth(user_id="test_user_id")
+        listed_row = generate_mock_mcp_server_db_record(server_id="server-1", alias="TeamGranted")
+        user_granted_row = generate_mock_mcp_server_db_record(server_id="server-2", alias="UserGranted")
+
+        async def per_context_servers(user_api_key_auth=None):
+            if user_api_key_auth is admitted_auth:
+                return [listed_row, user_granted_row]
+            return [listed_row]
+
         mock_manager = MagicMock()
-        mock_manager.get_all_allowed_mcp_servers = AsyncMock(
-            return_value=[generate_mock_mcp_server_db_record(server_id="server-1", alias="Listed")]
-        )
+        mock_manager.get_all_allowed_mcp_servers = AsyncMock(side_effect=per_context_servers)
         mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server-1", "server-2"])
-        mock_manager.get_mcp_server_by_id = MagicMock(
-            return_value=generate_mock_mcp_server_config_record(server_id="server-2", name="SessionOnly")
-        )
-        mock_manager._build_mcp_server_table = MagicMock(
-            return_value=generate_mock_mcp_server_db_record(server_id="server-2", alias="SessionOnly")
-        )
 
         with (
             patch(
@@ -6252,8 +6253,8 @@ class TestConnectedAppViewAnnotation:
                 mock_manager,
             ),
             patch(
-                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
-                AsyncMock(return_value=[caller_auth]),
+                "litellm.proxy._experimental.mcp_server.ui_session_utils.resolve_ui_session_team_ids",
+                AsyncMock(return_value=[]),
             ),
             patch(
                 "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
@@ -6268,7 +6269,6 @@ class TestConnectedAppViewAnnotation:
 
         flags = {server.server_id: server.connected_app_reachable for server in result}
         assert flags == {"server-1": True, "server-2": True}
-        mock_manager.get_mcp_server_by_id.assert_called_once_with("server-2")
 
     @pytest.mark.asyncio
     async def test_connected_app_view_fails_closed_when_admitted_reload_fails(self):

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -6138,3 +6138,171 @@ def test_bundled_openapi_registry_parses_and_entries_are_well_formed():
                 )
         for tool in entry.get("key_tools", []):
             assert tool.get("name") and tool.get("description"), f"{entry['name']}: malformed key_tool"
+
+
+class TestConnectedAppViewAnnotation:
+    """LIT-4861: GET /v1/mcp/server?connected_app_view=true must annotate each server with
+    whether the caller's gateway OAuth sessions (connected apps) are served it on /mcp."""
+
+    def _mock_manager(self, servers, reachable_ids):
+        mock_manager = MagicMock()
+        mock_manager.get_all_allowed_mcp_servers = AsyncMock(return_value=servers)
+        mock_manager.get_all_mcp_servers_unfiltered = AsyncMock(return_value=servers)
+        mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=reachable_ids)
+        return mock_manager
+
+    def _servers(self):
+        return [
+            generate_mock_mcp_server_db_record(server_id="server-1", alias="Granted"),
+            generate_mock_mcp_server_db_record(server_id="server-2", alias="Ungranted"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_connected_app_view_annotates_reachability_via_admitted_resolver(self):
+        caller_auth = generate_mock_user_api_key_auth()
+        admitted_auth = UserAPIKeyAuth(user_id="test_user_id")
+        admitted_auth.mcp_admitted_user_subject = True
+        mock_manager = self._mock_manager(self._servers(), ["server-1"])
+        reload_mock = AsyncMock(return_value=admitted_auth)
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
+                AsyncMock(return_value=[caller_auth]),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                reload_mock,
+            ),
+        ):
+            from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+                fetch_all_mcp_servers,
+            )
+
+            result = await fetch_all_mcp_servers(user_api_key_dict=caller_auth, connected_app_view=True)
+
+        flags = {server.server_id: server.connected_app_reachable for server in result}
+        assert flags == {"server-1": True, "server-2": False}
+        reload_mock.assert_awaited_once_with("test_user_id")
+        mock_manager.get_allowed_mcp_servers.assert_awaited_once_with(admitted_auth)
+
+    @pytest.mark.asyncio
+    async def test_connected_app_view_stamps_view_all_list_and_survives_non_admin_sanitizer(self):
+        """view_all preempts the manager's admin shortcut with a second whole-registry
+        shortcut; the annotation must still land, and must survive the non-admin sanitizer."""
+        caller_auth = generate_mock_user_api_key_auth(user_role=LitellmUserRoles.INTERNAL_USER)
+        mock_manager = self._mock_manager(self._servers(), ["server-2"])
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints._get_user_mcp_management_mode",
+                return_value="view_all",
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                AsyncMock(return_value=UserAPIKeyAuth(user_id="test_user_id")),
+            ),
+        ):
+            from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+                fetch_all_mcp_servers,
+            )
+
+            result = await fetch_all_mcp_servers(user_api_key_dict=caller_auth, connected_app_view=True)
+
+        mock_manager.get_all_mcp_servers_unfiltered.assert_awaited_once()
+        flags = {server.server_id: server.connected_app_reachable for server in result}
+        assert flags == {"server-1": False, "server-2": True}
+
+    @pytest.mark.asyncio
+    async def test_connected_app_view_fails_closed_when_admitted_reload_fails(self):
+        caller_auth = generate_mock_user_api_key_auth()
+        mock_manager = self._mock_manager(self._servers(), ["server-1"])
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
+                AsyncMock(return_value=[caller_auth]),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                AsyncMock(side_effect=HTTPException(status_code=401, detail="expired")),
+            ),
+        ):
+            from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+                fetch_all_mcp_servers,
+            )
+
+            result = await fetch_all_mcp_servers(user_api_key_dict=caller_auth, connected_app_view=True)
+
+        assert all(server.connected_app_reachable is False for server in result)
+
+    @pytest.mark.asyncio
+    async def test_connected_app_view_off_leaves_field_unset(self):
+        caller_auth = generate_mock_user_api_key_auth()
+        mock_manager = self._mock_manager(self._servers(), ["server-1"])
+        reload_mock = AsyncMock(return_value=UserAPIKeyAuth(user_id="test_user_id"))
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
+                AsyncMock(return_value=[caller_auth]),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                reload_mock,
+            ),
+        ):
+            from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+                fetch_all_mcp_servers,
+            )
+
+            result = await fetch_all_mcp_servers(user_api_key_dict=caller_auth)
+
+        assert all(server.connected_app_reachable is None for server in result)
+        reload_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_connected_app_view_userless_caller_marks_all_unreachable(self):
+        caller_auth = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, api_key="test_api_key")
+        caller_auth.user_id = None
+        mock_manager = self._mock_manager(self._servers(), ["server-1"])
+        reload_mock = AsyncMock(return_value=UserAPIKeyAuth(user_id="test_user_id"))
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
+                AsyncMock(return_value=[caller_auth]),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                reload_mock,
+            ),
+        ):
+            from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+                fetch_all_mcp_servers,
+            )
+
+            result = await fetch_all_mcp_servers(user_api_key_dict=caller_auth, connected_app_view=True)
+
+        assert all(server.connected_app_reachable is False for server in result)
+        reload_mock.assert_not_awaited()

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -6222,6 +6222,48 @@ class TestConnectedAppViewAnnotation:
         assert flags == {"server-1": False, "server-2": True}
 
     @pytest.mark.asyncio
+    async def test_connected_app_view_appends_session_reachable_servers_missing_from_page_list(self):
+        """A server the session is served must appear on the connect view even when the
+        dashboard resolver did not list it (internal-user path, non-admin sanitizer)."""
+        caller_auth = generate_mock_user_api_key_auth(user_role=LitellmUserRoles.INTERNAL_USER)
+        admitted_auth = UserAPIKeyAuth(user_id="test_user_id")
+        mock_manager = MagicMock()
+        mock_manager.get_all_allowed_mcp_servers = AsyncMock(
+            return_value=[generate_mock_mcp_server_db_record(server_id="server-1", alias="Listed")]
+        )
+        mock_manager.get_allowed_mcp_servers = AsyncMock(return_value=["server-1", "server-2"])
+        mock_manager.get_mcp_server_by_id = MagicMock(
+            return_value=generate_mock_mcp_server_config_record(server_id="server-2", name="SessionOnly")
+        )
+        mock_manager._build_mcp_server_table = MagicMock(
+            return_value=generate_mock_mcp_server_db_record(server_id="server-2", alias="SessionOnly")
+        )
+
+        with (
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.global_mcp_server_manager",
+                mock_manager,
+            ),
+            patch(
+                "litellm.proxy.management_endpoints.mcp_management_endpoints.build_effective_auth_contexts",
+                AsyncMock(return_value=[caller_auth]),
+            ),
+            patch(
+                "litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp.MCPRequestHandler._reload_admitted_user",
+                AsyncMock(return_value=admitted_auth),
+            ),
+        ):
+            from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+                fetch_all_mcp_servers,
+            )
+
+            result = await fetch_all_mcp_servers(user_api_key_dict=caller_auth, connected_app_view=True)
+
+        flags = {server.server_id: server.connected_app_reachable for server in result}
+        assert flags == {"server-1": True, "server-2": True}
+        mock_manager.get_mcp_server_by_id.assert_called_once_with("server-2")
+
+    @pytest.mark.asyncio
     async def test_connected_app_view_fails_closed_when_admitted_reload_fails(self):
         caller_auth = generate_mock_user_api_key_auth()
         mock_manager = self._mock_manager(self._servers(), ["server-1"])

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -6234,12 +6234,12 @@ class TestConnectedAppViewAnnotation:
         flagged reachable: the REAL build_effective_auth_contexts appends the admitted-user
         context, so the page and every action endpoint resolve it identically."""
         caller_auth = self._ui_session_auth(user_role=LitellmUserRoles.INTERNAL_USER)
-        admitted_auth = UserAPIKeyAuth(user_id="test_user_id")
+        admitted_auth = UserAPIKeyAuth(user_id="test_user_id", org_id="admitted-org")
         listed_row = generate_mock_mcp_server_db_record(server_id="server-1", alias="TeamGranted")
         user_granted_row = generate_mock_mcp_server_db_record(server_id="server-2", alias="UserGranted")
 
         async def per_context_servers(user_api_key_auth=None):
-            if user_api_key_auth is admitted_auth:
+            if user_api_key_auth is not None and user_api_key_auth.org_id == "admitted-org":
                 return [listed_row, user_granted_row]
             return [listed_row]
 

--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -2755,7 +2755,7 @@
       "count": 1
     },
     "no-nested-ternary": {
-      "count": 6
+      "count": 5
     }
   },
   "src/components/chat/MCPConnectPicker.tsx": {

--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -2755,7 +2755,7 @@
       "count": 1
     },
     "no-nested-ternary": {
-      "count": 5
+      "count": 4
     }
   },
   "src/components/chat/MCPConnectPicker.tsx": {

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
@@ -114,22 +114,22 @@ describe("MCPAppsPanel connected-app reachability (LIT-4861)", () => {
     vi.clearAllMocks();
   });
 
-  it("requests the connected-app view and labels unreachable servers in connect mode", async () => {
+  it("requests the connected-app view and hides unreachable servers in connect mode", async () => {
     vi.mocked(fetchMCPServers).mockResolvedValue(connectServers);
     vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });
 
     renderConnectPanel(true, ["reachable_srv", "unreachable_srv"]);
 
-    expect(await screen.findByText("unreachable_srv")).toBeInTheDocument();
+    expect(await screen.findByText("reachable_srv")).toBeInTheDocument();
     expect(vi.mocked(fetchMCPServers)).toHaveBeenCalledWith("tok", undefined, true);
-    expect(screen.getByText("Not available to connected apps")).toBeInTheDocument();
+    expect(screen.queryByText("unreachable_srv")).not.toBeInTheDocument();
     expect(screen.getByText("Connected (1)")).toBeInTheDocument();
     const toolCountFetchedIds = vi.mocked(listMCPTools).mock.calls.map((call) => call[1]);
     expect(toolCountFetchedIds).toContain("s-reach");
     expect(toolCountFetchedIds).not.toContain("s-unreach");
   });
 
-  it("blocks connecting an unavailable server from the detail view in connect mode", async () => {
+  it("blocks connecting an unsupported server from the detail view in connect mode", async () => {
     const detailServers = [
       ...connectServers,
       {
@@ -144,12 +144,6 @@ describe("MCPAppsPanel connected-app reachability (LIT-4861)", () => {
 
     renderConnectPanel(true);
 
-    fireEvent.click(await screen.findByText("unreachable_srv"));
-    expect(await screen.findByRole("heading", { name: "unreachable_srv" })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Connect" })).not.toBeInTheDocument();
-    expect(screen.getByText("Not available to connected apps")).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole("button", { name: /Back/ }));
     fireEvent.click(await screen.findByText("unsupported_srv"));
     expect(await screen.findByRole("heading", { name: "unsupported_srv" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Connect" })).not.toBeInTheDocument();

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
@@ -129,6 +129,44 @@ describe("MCPAppsPanel connected-app reachability (LIT-4861)", () => {
     expect(toolCountFetchedIds).not.toContain("s-unreach");
   });
 
+  it("blocks connecting an unavailable server from the detail view in connect mode", async () => {
+    const detailServers = [
+      ...connectServers,
+      {
+        server_id: "s-unsup",
+        server_name: "unsupported_srv",
+        auth_type: "oauth2_token_exchange",
+        connected_app_reachable: true,
+      },
+    ] as MCPServer[];
+    vi.mocked(fetchMCPServers).mockResolvedValue(detailServers);
+    vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });
+
+    renderConnectPanel(true);
+
+    fireEvent.click(await screen.findByText("unreachable_srv"));
+    expect(await screen.findByRole("heading", { name: "unreachable_srv" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Connect" })).not.toBeInTheDocument();
+    expect(screen.getByText("Not available to connected apps")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Back/ }));
+    fireEvent.click(await screen.findByText("unsupported_srv"));
+    expect(await screen.findByRole("heading", { name: "unsupported_srv" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Connect" })).not.toBeInTheDocument();
+    expect(screen.getByText("Not supported on this connection")).toBeInTheDocument();
+  });
+
+  it("keeps the detail-view Connect action outside connect mode", async () => {
+    vi.mocked(fetchMCPServers).mockResolvedValue(connectServers);
+    vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });
+
+    renderConnectPanel(false);
+
+    fireEvent.click(await screen.findByText("unreachable_srv"));
+    expect(await screen.findByRole("heading", { name: "unreachable_srv" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument();
+  });
+
   it("ignores the flag and skips no server outside connect mode", async () => {
     vi.mocked(fetchMCPServers).mockResolvedValue(connectServers);
     vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import MCPAppsPanel from "./MCPAppsPanel";
 import { fetchMCPServers, listMCPTools } from "../networking";
@@ -84,5 +84,62 @@ describe("MCPAppsPanel logos", () => {
 
     expect(await screen.findByRole("heading", { name: "local_logo" })).toBeInTheDocument();
     expect(screen.getByAltText("local_logo logo").getAttribute("src")).toBe("/litellm/ui/assets/logos/github.svg");
+  });
+});
+
+const connectServers = [
+  {
+    server_id: "s-reach",
+    server_name: "reachable_srv",
+    auth_type: "none",
+    connected_app_reachable: true,
+  },
+  {
+    server_id: "s-unreach",
+    server_name: "unreachable_srv",
+    auth_type: "none",
+    connected_app_reachable: false,
+  },
+] as MCPServer[];
+
+const renderConnectPanel = (connectMode: boolean, selectedServers: string[] = []) =>
+  render(
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <MCPAppsPanel accessToken="tok" selectedServers={selectedServers} onChange={vi.fn()} connectMode={connectMode} />
+    </QueryClientProvider>,
+  );
+
+describe("MCPAppsPanel connected-app reachability (LIT-4861)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("requests the connected-app view and labels unreachable servers in connect mode", async () => {
+    vi.mocked(fetchMCPServers).mockResolvedValue(connectServers);
+    vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });
+
+    renderConnectPanel(true, ["reachable_srv", "unreachable_srv"]);
+
+    expect(await screen.findByText("unreachable_srv")).toBeInTheDocument();
+    expect(vi.mocked(fetchMCPServers)).toHaveBeenCalledWith("tok", undefined, true);
+    expect(screen.getByText("Not available to connected apps")).toBeInTheDocument();
+    expect(screen.getByText("Connected (1)")).toBeInTheDocument();
+    const toolCountFetchedIds = vi.mocked(listMCPTools).mock.calls.map((call) => call[1]);
+    expect(toolCountFetchedIds).toContain("s-reach");
+    expect(toolCountFetchedIds).not.toContain("s-unreach");
+  });
+
+  it("ignores the flag and skips no server outside connect mode", async () => {
+    vi.mocked(fetchMCPServers).mockResolvedValue(connectServers);
+    vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });
+
+    renderConnectPanel(false, ["reachable_srv", "unreachable_srv"]);
+
+    expect(await screen.findByText("unreachable_srv")).toBeInTheDocument();
+    expect(vi.mocked(fetchMCPServers)).toHaveBeenCalledWith("tok", undefined, false);
+    expect(screen.queryByText("Not available to connected apps")).not.toBeInTheDocument();
+    expect(screen.getByText("Connected (2)")).toBeInTheDocument();
+    const toolCountFetchedIds = vi.mocked(listMCPTools).mock.calls.map((call) => call[1]);
+    expect(toolCountFetchedIds).toContain("s-unreach");
   });
 });

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import MCPAppsPanel from "./MCPAppsPanel";
@@ -175,36 +175,90 @@ describe("MCPAppsPanel connected-app reachability (LIT-4861)", () => {
     expect(toolCountFetchedIds).toContain("s-unreach");
   });
 
+  const revocable = (reachable: boolean) =>
+    [
+      { server_id: "s-reach", server_name: "reachable_srv", auth_type: "none", connected_app_reachable: true },
+      { server_id: "s-drop", server_name: "revoked_srv", auth_type: "none", connected_app_reachable: reachable },
+    ] as MCPServer[];
+
+  const ConnectPanel = ({
+    token,
+    onChange,
+    client,
+  }: {
+    token: string;
+    onChange: (servers: string[]) => void;
+    client: QueryClient;
+  }) => (
+    <QueryClientProvider client={client}>
+      <MCPAppsPanel accessToken={token} selectedServers={[]} onChange={onChange} connectMode />
+    </QueryClientProvider>
+  );
+
+  const newClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
   it("drops an open detail view when a refetch removes that server from the reachable set", async () => {
-    const revocable = (reachable: boolean) =>
-      [
-        { server_id: "s-reach", server_name: "reachable_srv", auth_type: "none", connected_app_reachable: true },
-        {
-          server_id: "s-drop",
-          server_name: "revoked_srv",
-          auth_type: "none",
-          connected_app_reachable: reachable,
-        },
-      ] as MCPServer[];
     vi.mocked(fetchMCPServers).mockResolvedValueOnce(revocable(true)).mockResolvedValueOnce(revocable(false));
     vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });
 
-    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-    const panel = (token: string) => (
-      <QueryClientProvider client={client}>
-        <MCPAppsPanel accessToken={token} selectedServers={[]} onChange={vi.fn()} connectMode />
-      </QueryClientProvider>
-    );
-    const { rerender } = render(panel("tok"));
+    const client = newClient();
+    const { rerender } = render(<ConnectPanel token="tok" onChange={vi.fn()} client={client} />);
 
     fireEvent.click(await screen.findByText("revoked_srv"));
     expect(await screen.findByRole("heading", { name: "revoked_srv" })).toBeInTheDocument();
 
-    rerender(panel("tok-refreshed"));
+    rerender(<ConnectPanel token="tok-refreshed" onChange={vi.fn()} client={client} />);
 
     await waitFor(() => expect(screen.queryByRole("heading", { name: "revoked_srv" })).not.toBeInTheDocument());
     expect(screen.queryByRole("button", { name: "Connect" })).not.toBeInTheDocument();
     expect(screen.queryByText("revoked_srv")).not.toBeInTheDocument();
     expect(screen.getByText("reachable_srv")).toBeInTheDocument();
+  });
+
+  it("does not select a server whose Connect finishes after a refetch removed it", async () => {
+    vi.mocked(fetchMCPServers).mockResolvedValueOnce(revocable(true)).mockResolvedValueOnce(revocable(false));
+    vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });
+
+    const onChange = vi.fn();
+    const client = newClient();
+    const { rerender } = render(<ConnectPanel token="tok" onChange={onChange} client={client} />);
+
+    fireEvent.click(await screen.findByText("revoked_srv"));
+    expect(await screen.findByRole("heading", { name: "revoked_srv" })).toBeInTheDocument();
+
+    let finishConnect: (result: { tools: never[] }) => void = () => {};
+    vi.mocked(listMCPTools).mockImplementationOnce(() => new Promise((resolve) => (finishConnect = resolve)));
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    rerender(<ConnectPanel token="tok-refreshed" onChange={onChange} client={client} />);
+    await waitFor(() => expect(screen.queryByRole("heading", { name: "revoked_srv" })).not.toBeInTheDocument());
+
+    await act(async () => {
+      finishConnect({ tools: [] });
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.queryByText("revoked_srv")).not.toBeInTheDocument();
+    expect(screen.getByText("Connected", { exact: false }).textContent).toBe("Connected");
+  });
+
+  it("does not let a superseded list load overwrite the current reachable set", async () => {
+    let finishStaleLoad: (servers: MCPServer[]) => void = () => {};
+    vi.mocked(fetchMCPServers)
+      .mockImplementationOnce(() => new Promise((resolve) => (finishStaleLoad = resolve)))
+      .mockResolvedValueOnce(revocable(false));
+    vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });
+
+    const client = newClient();
+    const { rerender } = render(<ConnectPanel token="tok" onChange={vi.fn()} client={client} />);
+    rerender(<ConnectPanel token="tok-refreshed" onChange={vi.fn()} client={client} />);
+
+    expect(await screen.findByText("reachable_srv")).toBeInTheDocument();
+
+    await act(async () => {
+      finishStaleLoad(revocable(true));
+    });
+
+    expect(screen.queryByText("revoked_srv")).not.toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
@@ -242,6 +242,35 @@ describe("MCPAppsPanel connected-app reachability (LIT-4861)", () => {
     expect(screen.getByText("Connected", { exact: false }).textContent).toBe("Connected");
   });
 
+  it("does not select a server when Connect resolves in the same tick the refetch drops it", async () => {
+    let finishRefetch: (servers: MCPServer[]) => void = () => {};
+    vi.mocked(fetchMCPServers)
+      .mockResolvedValueOnce(revocable(true))
+      .mockImplementationOnce(() => new Promise((resolve) => (finishRefetch = resolve)));
+    vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });
+
+    const onChange = vi.fn();
+    const client = newClient();
+    const { rerender } = render(<ConnectPanel token="tok" onChange={onChange} client={client} />);
+
+    fireEvent.click(await screen.findByText("revoked_srv"));
+    expect(await screen.findByRole("heading", { name: "revoked_srv" })).toBeInTheDocument();
+
+    let finishConnect: (result: { tools: never[] }) => void = () => {};
+    vi.mocked(listMCPTools).mockImplementationOnce(() => new Promise((resolve) => (finishConnect = resolve)));
+    fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+
+    rerender(<ConnectPanel token="tok-refreshed" onChange={onChange} client={client} />);
+
+    await act(async () => {
+      finishRefetch(revocable(false));
+      finishConnect({ tools: [] });
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.queryByText("revoked_srv")).not.toBeInTheDocument();
+  });
+
   it("does not let a superseded list load overwrite the current reachable set", async () => {
     let finishStaleLoad: (servers: MCPServer[]) => void = () => {};
     vi.mocked(fetchMCPServers)

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import MCPAppsPanel from "./MCPAppsPanel";
@@ -173,5 +173,38 @@ describe("MCPAppsPanel connected-app reachability (LIT-4861)", () => {
     expect(screen.getByText("Connected (2)")).toBeInTheDocument();
     const toolCountFetchedIds = vi.mocked(listMCPTools).mock.calls.map((call) => call[1]);
     expect(toolCountFetchedIds).toContain("s-unreach");
+  });
+
+  it("drops an open detail view when a refetch removes that server from the reachable set", async () => {
+    const revocable = (reachable: boolean) =>
+      [
+        { server_id: "s-reach", server_name: "reachable_srv", auth_type: "none", connected_app_reachable: true },
+        {
+          server_id: "s-drop",
+          server_name: "revoked_srv",
+          auth_type: "none",
+          connected_app_reachable: reachable,
+        },
+      ] as MCPServer[];
+    vi.mocked(fetchMCPServers).mockResolvedValueOnce(revocable(true)).mockResolvedValueOnce(revocable(false));
+    vi.mocked(listMCPTools).mockResolvedValue({ tools: [] });
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const panel = (token: string) => (
+      <QueryClientProvider client={client}>
+        <MCPAppsPanel accessToken={token} selectedServers={[]} onChange={vi.fn()} connectMode />
+      </QueryClientProvider>
+    );
+    const { rerender } = render(panel("tok"));
+
+    fireEvent.click(await screen.findByText("revoked_srv"));
+    expect(await screen.findByRole("heading", { name: "revoked_srv" })).toBeInTheDocument();
+
+    rerender(panel("tok-refreshed"));
+
+    await waitFor(() => expect(screen.queryByRole("heading", { name: "revoked_srv" })).not.toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: "Connect" })).not.toBeInTheDocument();
+    expect(screen.queryByText("revoked_srv")).not.toBeInTheDocument();
+    expect(screen.getByText("reachable_srv")).toBeInTheDocument();
   });
 });

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -124,6 +124,8 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
 
   const nameOf = (s: MCPServer) => s.server_name ?? s.alias ?? s.server_id;
 
+  const unreachableOnConnect = (s: MCPServer) => !!connectMode && s.connected_app_reachable === false;
+
   const fetchLoadCancelledRef = useRef(false);
 
   const fetchToolCount = useCallback(
@@ -166,11 +168,12 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
   useEffect(() => {
     fetchLoadCancelledRef.current = false;
 
-    fetchMCPServers(accessToken)
+    fetchMCPServers(accessToken, undefined, connectMode)
       .then(async (serverData) => {
         if (fetchLoadCancelledRef.current) return;
         const list: MCPServer[] = Array.isArray(serverData) ? serverData : serverData?.data ?? [];
-        const oauthServers = list.filter((s) => s.auth_type === AUTH_TYPE.OAUTH2);
+        const reachable = connectMode ? list.filter((s) => s.connected_app_reachable !== false) : list;
+        const oauthServers = reachable.filter((s) => s.auth_type === AUTH_TYPE.OAUTH2);
         setServers(list);
         setOauthChecking(new Set(oauthServers.map((s) => s.server_id)));
         setLoading(false);
@@ -178,8 +181,8 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
         oauthServers.forEach((s) => checkOauthCredential(s));
 
         setLoadingCounts(true);
-        const chunks = Array.from({ length: Math.ceil(list.length / TOOLS_FETCH_CONCURRENCY) }, (_, i) =>
-          list.slice(i * TOOLS_FETCH_CONCURRENCY, (i + 1) * TOOLS_FETCH_CONCURRENCY),
+        const chunks = Array.from({ length: Math.ceil(reachable.length / TOOLS_FETCH_CONCURRENCY) }, (_, i) =>
+          reachable.slice(i * TOOLS_FETCH_CONCURRENCY, (i + 1) * TOOLS_FETCH_CONCURRENCY),
         );
         for (const chunk of chunks) {
           if (fetchLoadCancelledRef.current) return;
@@ -196,7 +199,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
     return () => {
       fetchLoadCancelledRef.current = true;
     };
-  }, [accessToken, fetchToolCount, checkOauthCredential]);
+  }, [accessToken, connectMode, fetchToolCount, checkOauthCredential]);
 
   useEffect(() => {
     if (oauthConnected.size === 0) return;
@@ -250,6 +253,13 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
         </span>
       );
     }
+    if (unreachableOnConnect(server)) {
+      return (
+        <span className="text-[11px] text-muted-foreground shrink-0 whitespace-nowrap">
+          Not available to connected apps
+        </span>
+      );
+    }
     if (server.auth_type === AUTH_TYPE.OAUTH2) {
       if (oauthConnected.has(server.server_id)) {
         return <CheckCircle className="h-3.5 w-3.5 text-emerald-600 shrink-0" />;
@@ -285,11 +295,11 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
       !query.trim() ||
       name.toLowerCase().includes(query.toLowerCase()) ||
       (s.description ?? "").toLowerCase().includes(query.toLowerCase());
-    const matchesTab = activeTab === "all" || selectedServers.includes(name);
+    const matchesTab = activeTab === "all" || (selectedServers.includes(name) && !unreachableOnConnect(s));
     return matchesQuery && matchesTab;
   });
 
-  const connectedCount = servers.filter((s) => selectedServers.includes(nameOf(s))).length;
+  const connectedCount = servers.filter((s) => selectedServers.includes(nameOf(s)) && !unreachableOnConnect(s)).length;
   const totalTools = Object.values(toolCounts).reduce((sum, n) => sum + n, 0);
 
   if (detailServer) {
@@ -508,7 +518,8 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
             const color = getAvatarColor(name);
             const isLeftCol = idx % 2 === 0;
             const count = toolCounts[name];
-            const unsupported = !!connectMode && isUnsupportedOnGatewayConnect(server.auth_type);
+            const unavailable =
+              (!!connectMode && isUnsupportedOnGatewayConnect(server.auth_type)) || unreachableOnConnect(server);
 
             return (
               <div
@@ -517,7 +528,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
                 className={`flex items-center gap-3 p-4 bg-card cursor-pointer transition-colors hover:bg-accent/30 min-w-0 ${
                   isLeftCol ? "border-r" : ""
                 } ${Math.floor(idx / 2) < Math.floor((filtered.length - 1) / 2) ? "border-b" : ""} ${
-                  unsupported ? "opacity-50" : ""
+                  unavailable ? "opacity-50" : ""
                 }`}
               >
                 {server.mcp_info?.logo_url ? (

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -124,7 +124,15 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
 
   const nameOf = (s: MCPServer) => s.server_name ?? s.alias ?? s.server_id;
 
-  const unreachableOnConnect = (s: MCPServer) => !!connectMode && s.connected_app_reachable === false;
+  const connectUnavailabilityLabel = useCallback(
+    (s: MCPServer): string | null => {
+      if (!connectMode) return null;
+      if (isUnsupportedOnGatewayConnect(s.auth_type)) return "Not supported on this connection";
+      if (s.connected_app_reachable === false) return "Not available to connected apps";
+      return null;
+    },
+    [connectMode],
+  );
 
   const fetchLoadCancelledRef = useRef(false);
 
@@ -204,12 +212,17 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
   useEffect(() => {
     if (oauthConnected.size === 0) return;
     const namesToAdd = serversRef.current
-      .filter((s) => oauthConnected.has(s.server_id) && !selectedServersRef.current.includes(nameOf(s)))
+      .filter(
+        (s) =>
+          oauthConnected.has(s.server_id) &&
+          !selectedServersRef.current.includes(nameOf(s)) &&
+          connectUnavailabilityLabel(s) === null,
+      )
       .map(nameOf);
     if (namesToAdd.length > 0) {
       onChangeRef.current([...selectedServersRef.current, ...namesToAdd]);
     }
-  }, [oauthConnected]);
+  }, [oauthConnected, connectUnavailabilityLabel]);
 
   const handleToggle = async (serverName: string, checked: boolean, serverId?: string) => {
     if (!checked) {
@@ -223,6 +236,8 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
       }
       return;
     }
+    const target = serversRef.current.find((s) => s.server_id === serverId || nameOf(s) === serverName);
+    if (target && connectUnavailabilityLabel(target) !== null) return;
     setTogglingOn((prev) => new Set(prev).add(serverName));
     try {
       const idToFetch = serverId ?? serverName;
@@ -246,18 +261,10 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
   };
 
   const renderConnectionIndicator = (server: MCPServer) => {
-    if (connectMode && isUnsupportedOnGatewayConnect(server.auth_type)) {
+    const unavailabilityLabel = connectUnavailabilityLabel(server);
+    if (unavailabilityLabel !== null) {
       return (
-        <span className="text-[11px] text-muted-foreground shrink-0 whitespace-nowrap">
-          Not supported on this connection
-        </span>
-      );
-    }
-    if (unreachableOnConnect(server)) {
-      return (
-        <span className="text-[11px] text-muted-foreground shrink-0 whitespace-nowrap">
-          Not available to connected apps
-        </span>
+        <span className="text-[11px] text-muted-foreground shrink-0 whitespace-nowrap">{unavailabilityLabel}</span>
       );
     }
     if (server.auth_type === AUTH_TYPE.OAUTH2) {
@@ -295,11 +302,14 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
       !query.trim() ||
       name.toLowerCase().includes(query.toLowerCase()) ||
       (s.description ?? "").toLowerCase().includes(query.toLowerCase());
-    const matchesTab = activeTab === "all" || (selectedServers.includes(name) && !unreachableOnConnect(s));
+    const matchesTab =
+      activeTab === "all" || (selectedServers.includes(name) && connectUnavailabilityLabel(s) === null);
     return matchesQuery && matchesTab;
   });
 
-  const connectedCount = servers.filter((s) => selectedServers.includes(nameOf(s)) && !unreachableOnConnect(s)).length;
+  const connectedCount = servers.filter(
+    (s) => selectedServers.includes(nameOf(s)) && connectUnavailabilityLabel(s) === null,
+  ).length;
   const totalTools = Object.values(toolCounts).reduce((sum, n) => sum + n, 0);
 
   if (detailServer) {
@@ -307,6 +317,59 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
     const isConnected = selectedServers.includes(name);
     const isTogglingOn = togglingOn.has(name);
     const color = getAvatarColor(name);
+
+    const renderDetailAction = () => {
+      const unavailabilityLabel = connectUnavailabilityLabel(detailServer);
+      if (unavailabilityLabel !== null) {
+        return <span className="text-[13px] text-muted-foreground py-2.5 shrink-0">{unavailabilityLabel}</span>;
+      }
+      if (detailServer.auth_type !== AUTH_TYPE.OAUTH2) {
+        return (
+          <Button
+            variant={isConnected ? "outline" : "default"}
+            disabled={isTogglingOn}
+            onClick={() => handleToggle(name, !isConnected, detailServer.server_id)}
+            className="font-semibold h-[38px] min-w-[110px]"
+          >
+            {isTogglingOn && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
+            {isConnected ? "Disconnect" : "Connect"}
+          </Button>
+        );
+      }
+      if (oauthConnected.has(detailServer.server_id)) {
+        return (
+          <Button
+            variant="destructive"
+            onClick={async () => {
+              try {
+                await deleteMCPOAuthUserCredential(accessToken, detailServer.server_id);
+              } catch (_) {
+                // Ignore
+              }
+              setOauthConnected((prev) => {
+                const n = new Set(prev);
+                n.delete(detailServer.server_id);
+                return n;
+              });
+              onChangeRef.current(selectedServersRef.current.filter((s) => s !== name));
+            }}
+            className="font-semibold h-[38px] min-w-[110px]"
+          >
+            Disconnect
+          </Button>
+        );
+      }
+      return (
+        <OAuth2ConnectButton
+          server={detailServer}
+          accessToken={accessToken}
+          onConnect={(id) => {
+            setOauthConnected((prev) => new Set(prev).add(id));
+          }}
+          variant="button"
+        />
+      );
+    };
 
     return (
       <div className="w-full">
@@ -339,48 +402,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
             <h2 className="m-0 mb-1 text-[22px] font-bold text-foreground">{name}</h2>
             <p className="m-0 text-sm text-muted-foreground">{detailServer.description ?? "MCP server"}</p>
           </div>
-          {detailServer.auth_type === AUTH_TYPE.OAUTH2 ? (
-            oauthConnected.has(detailServer.server_id) ? (
-              <Button
-                variant="destructive"
-                onClick={async () => {
-                  try {
-                    await deleteMCPOAuthUserCredential(accessToken, detailServer.server_id);
-                  } catch (_) {
-                    // Ignore
-                  }
-                  setOauthConnected((prev) => {
-                    const n = new Set(prev);
-                    n.delete(detailServer.server_id);
-                    return n;
-                  });
-                  onChangeRef.current(selectedServersRef.current.filter((s) => s !== name));
-                }}
-                className="font-semibold h-[38px] min-w-[110px]"
-              >
-                Disconnect
-              </Button>
-            ) : (
-              <OAuth2ConnectButton
-                server={detailServer}
-                accessToken={accessToken}
-                onConnect={(id) => {
-                  setOauthConnected((prev) => new Set(prev).add(id));
-                }}
-                variant="button"
-              />
-            )
-          ) : (
-            <Button
-              variant={isConnected ? "outline" : "default"}
-              disabled={isTogglingOn}
-              onClick={() => handleToggle(name, !isConnected, detailServer.server_id)}
-              className="font-semibold h-[38px] min-w-[110px]"
-            >
-              {isTogglingOn && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
-              {isConnected ? "Disconnect" : "Connect"}
-            </Button>
-          )}
+          {renderDetailAction()}
         </div>
 
         <h3 className="m-0 mb-3 text-[15px] font-semibold text-foreground">Information</h3>
@@ -518,8 +540,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
             const color = getAvatarColor(name);
             const isLeftCol = idx % 2 === 0;
             const count = toolCounts[name];
-            const unavailable =
-              (!!connectMode && isUnsupportedOnGatewayConnect(server.auth_type)) || unreachableOnConnect(server);
+            const unavailable = connectUnavailabilityLabel(server) !== null;
 
             return (
               <div

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -128,7 +128,6 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
     (s: MCPServer): string | null => {
       if (!connectMode) return null;
       if (isUnsupportedOnGatewayConnect(s.auth_type)) return "Not supported on this connection";
-      if (s.connected_app_reachable === false) return "Not available to connected apps";
       return null;
     },
     [connectMode],
@@ -182,7 +181,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
         const list: MCPServer[] = Array.isArray(serverData) ? serverData : serverData?.data ?? [];
         const reachable = connectMode ? list.filter((s) => s.connected_app_reachable !== false) : list;
         const oauthServers = reachable.filter((s) => s.auth_type === AUTH_TYPE.OAUTH2);
-        setServers(list);
+        setServers(reachable);
         setOauthChecking(new Set(oauthServers.map((s) => s.server_id)));
         setLoading(false);
 
@@ -310,6 +309,15 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
   const connectedCount = servers.filter(
     (s) => selectedServers.includes(nameOf(s)) && connectUnavailabilityLabel(s) === null,
   ).length;
+
+  const emptyStateText = () => {
+    if (servers.length === 0) {
+      return connectMode
+        ? "No MCP servers are available to this connection yet. Ask an admin to grant your user or team access."
+        : "No MCP servers configured. Add servers in Tools -> MCP Servers.";
+    }
+    return activeTab === "connected" ? "No servers connected yet." : "No servers match your search.";
+  };
   const totalTools = Object.values(toolCounts).reduce((sum, n) => sum + n, 0);
 
   if (detailServer) {
@@ -526,13 +534,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
           ))}
         </div>
       ) : filtered.length === 0 ? (
-        <div className="text-center text-muted-foreground text-[13px] py-12 px-3">
-          {servers.length === 0
-            ? "No MCP servers configured. Add servers in Tools -> MCP Servers."
-            : activeTab === "connected"
-              ? "No servers connected yet."
-              : "No servers match your search."}
-        </div>
+        <div className="text-center text-muted-foreground text-[13px] py-12 px-3">{emptyStateText()}</div>
       ) : (
         <div className="grid grid-cols-2 border rounded-lg overflow-hidden">
           {filtered.map((server, idx) => {

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -110,9 +110,10 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
   const [oauthChecking, setOauthChecking] = useState<Set<string>>(new Set());
 
   const serversRef = useRef<MCPServer[]>([]);
-  useEffect(() => {
-    serversRef.current = servers;
-  }, [servers]);
+  const commitServers = useCallback((next: MCPServer[]) => {
+    serversRef.current = next;
+    setServers(next);
+  }, []);
   const selectedServersRef = useRef<string[]>(selectedServers);
   useEffect(() => {
     selectedServersRef.current = selectedServers;
@@ -190,7 +191,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
         const list: MCPServer[] = Array.isArray(serverData) ? serverData : serverData?.data ?? [];
         const reachable = connectMode ? list.filter((s) => s.connected_app_reachable !== false) : list;
         const oauthServers = reachable.filter((s) => s.auth_type === AUTH_TYPE.OAUTH2);
-        setServers(reachable);
+        commitServers(reachable);
         setOauthChecking(new Set(oauthServers.map((s) => s.server_id)));
         setLoading(false);
 
@@ -208,14 +209,14 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
       })
       .catch(() => {
         if (isCurrentLoad()) {
-          setServers([]);
+          commitServers([]);
           setLoading(false);
         }
       });
     return () => {
       current = false;
     };
-  }, [accessToken, connectMode, fetchToolCount, checkOauthCredential]);
+  }, [accessToken, connectMode, commitServers, fetchToolCount, checkOauthCredential]);
 
   useEffect(() => {
     if (oauthConnected.size === 0) return;

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -135,13 +135,19 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
     [connectMode],
   );
 
-  const fetchLoadCancelledRef = useRef(false);
+  const connectableNow = useCallback(
+    (serverId: string): MCPServer | undefined => {
+      const current = serversRef.current.find((s) => s.server_id === serverId);
+      return current !== undefined && connectUnavailabilityLabel(current) === null ? current : undefined;
+    },
+    [connectUnavailabilityLabel],
+  );
 
   const fetchToolCount = useCallback(
-    async (server: MCPServer) => {
+    async (server: MCPServer, isCurrentLoad: () => boolean) => {
       try {
         const toolsData = await listMCPTools(accessToken, server.server_id);
-        if (fetchLoadCancelledRef.current) return;
+        if (!isCurrentLoad()) return;
         const tools: MCPTool[] = Array.isArray(toolsData?.tools) ? toolsData.tools : [];
         setToolCounts((prev) => ({ ...prev, [nameOf(server)]: tools.length }));
       } catch {
@@ -152,17 +158,17 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
   );
 
   const checkOauthCredential = useCallback(
-    async (server: MCPServer) => {
+    async (server: MCPServer, isCurrentLoad: () => boolean) => {
       try {
         const status = await getMCPOAuthUserCredentialStatus(accessToken, server.server_id);
-        if (fetchLoadCancelledRef.current) return;
+        if (!isCurrentLoad()) return;
         if (status.has_credential && !status.is_expired) {
           setOauthConnected((prev) => new Set(prev).add(server.server_id));
         }
       } catch {
         // ignore
       } finally {
-        if (!fetchLoadCancelledRef.current) {
+        if (isCurrentLoad()) {
           setOauthChecking((prev) => {
             const next = new Set(prev);
             next.delete(server.server_id);
@@ -175,11 +181,12 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
   );
 
   useEffect(() => {
-    fetchLoadCancelledRef.current = false;
+    let current = true;
+    const isCurrentLoad = () => current;
 
     fetchMCPServers(accessToken, undefined, connectMode)
       .then(async (serverData) => {
-        if (fetchLoadCancelledRef.current) return;
+        if (!isCurrentLoad()) return;
         const list: MCPServer[] = Array.isArray(serverData) ? serverData : serverData?.data ?? [];
         const reachable = connectMode ? list.filter((s) => s.connected_app_reachable !== false) : list;
         const oauthServers = reachable.filter((s) => s.auth_type === AUTH_TYPE.OAUTH2);
@@ -187,26 +194,26 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
         setOauthChecking(new Set(oauthServers.map((s) => s.server_id)));
         setLoading(false);
 
-        oauthServers.forEach((s) => checkOauthCredential(s));
+        oauthServers.forEach((s) => checkOauthCredential(s, isCurrentLoad));
 
         setLoadingCounts(true);
         const chunks = Array.from({ length: Math.ceil(reachable.length / TOOLS_FETCH_CONCURRENCY) }, (_, i) =>
           reachable.slice(i * TOOLS_FETCH_CONCURRENCY, (i + 1) * TOOLS_FETCH_CONCURRENCY),
         );
         for (const chunk of chunks) {
-          if (fetchLoadCancelledRef.current) return;
-          await Promise.allSettled(chunk.map((s) => fetchToolCount(s)));
+          if (!isCurrentLoad()) return;
+          await Promise.allSettled(chunk.map((s) => fetchToolCount(s, isCurrentLoad)));
         }
-        if (!fetchLoadCancelledRef.current) setLoadingCounts(false);
+        if (isCurrentLoad()) setLoadingCounts(false);
       })
       .catch(() => {
-        if (!fetchLoadCancelledRef.current) {
+        if (isCurrentLoad()) {
           setServers([]);
           setLoading(false);
         }
       });
     return () => {
-      fetchLoadCancelledRef.current = true;
+      current = false;
     };
   }, [accessToken, connectMode, fetchToolCount, checkOauthCredential]);
 
@@ -236,7 +243,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
       });
       return;
     }
-    if (connectUnavailabilityLabel(server) !== null) return;
+    if (connectableNow(server.server_id) === undefined) return;
     setTogglingOn((prev) => new Set(prev).add(serverName));
     try {
       const result = await listMCPTools(accessToken, server.server_id);
@@ -244,6 +251,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
         MessageManager.warning(`Could not load tools for ${serverName}`);
         return;
       }
+      if (connectableNow(server.server_id) === undefined) return;
       if (!selectedServersRef.current.includes(serverName)) {
         onChange([...selectedServersRef.current, serverName]);
       }

--- a/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/chat/MCPAppsPanel.tsx
@@ -103,7 +103,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
   const [query, setQuery] = useState("");
   const [activeTab, setActiveTab] = useState<TabKey>("all");
   const [togglingOn, setTogglingOn] = useState<Set<string>>(new Set());
-  const [detailServer, setDetailServer] = useState<MCPServer | null>(null);
+  const [detailServerId, setDetailServerId] = useState<string | null>(null);
   const [toolCounts, setToolCounts] = useState<Record<string, number>>({});
   const [loadingCounts, setLoadingCounts] = useState(false);
   const [oauthConnected, setOauthConnected] = useState<Set<string>>(new Set());
@@ -123,6 +123,8 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
   }, [onChange]);
 
   const nameOf = (s: MCPServer) => s.server_name ?? s.alias ?? s.server_id;
+
+  const detailServer = servers.find((s) => s.server_id === detailServerId);
 
   const connectUnavailabilityLabel = useCallback(
     (s: MCPServer): string | null => {
@@ -223,24 +225,21 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
     }
   }, [oauthConnected, connectUnavailabilityLabel]);
 
-  const handleToggle = async (serverName: string, checked: boolean, serverId?: string) => {
+  const handleToggle = async (server: MCPServer, checked: boolean) => {
+    const serverName = nameOf(server);
     if (!checked) {
       onChange(selectedServers.filter((s) => s !== serverName));
-      if (serverId) {
-        setOauthConnected((prev) => {
-          const next = new Set(prev);
-          next.delete(serverId);
-          return next;
-        });
-      }
+      setOauthConnected((prev) => {
+        const next = new Set(prev);
+        next.delete(server.server_id);
+        return next;
+      });
       return;
     }
-    const target = serversRef.current.find((s) => s.server_id === serverId || nameOf(s) === serverName);
-    if (target && connectUnavailabilityLabel(target) !== null) return;
+    if (connectUnavailabilityLabel(server) !== null) return;
     setTogglingOn((prev) => new Set(prev).add(serverName));
     try {
-      const idToFetch = serverId ?? serverName;
-      const result = await listMCPTools(accessToken, idToFetch);
+      const result = await listMCPTools(accessToken, server.server_id);
       if (result?.error) {
         MessageManager.warning(`Could not load tools for ${serverName}`);
         return;
@@ -336,7 +335,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
           <Button
             variant={isConnected ? "outline" : "default"}
             disabled={isTogglingOn}
-            onClick={() => handleToggle(name, !isConnected, detailServer.server_id)}
+            onClick={() => handleToggle(detailServer, !isConnected)}
             className="font-semibold h-[38px] min-w-[110px]"
           >
             {isTogglingOn && <Loader2 className="h-4 w-4 animate-spin mr-1.5" />}
@@ -384,7 +383,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
         <Button
           variant="ghost"
           size="sm"
-          onClick={() => setDetailServer(null)}
+          onClick={() => setDetailServerId(null)}
           className="-ml-3 mb-5 gap-1.5 text-muted-foreground hover:text-foreground"
         >
           <ArrowLeft className="h-3 w-3" />
@@ -547,7 +546,7 @@ const MCPAppsPanel: React.FC<Props> = ({ accessToken, selectedServers, onChange,
             return (
               <div
                 key={server.server_id}
-                onClick={() => setDetailServer(server)}
+                onClick={() => setDetailServerId(server.server_id)}
                 className={`flex items-center gap-3 p-4 bg-card cursor-pointer transition-colors hover:bg-accent/30 min-w-0 ${
                   isLeftCol ? "border-r" : ""
                 } ${Math.floor(idx / 2) < Math.floor((filtered.length - 1) / 2) ? "border-b" : ""} ${

--- a/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
+++ b/ui/litellm-dashboard/src/components/mcp_tools/types.tsx
@@ -436,6 +436,7 @@ export interface MCPServer {
   byok_description?: string[] | null;
   byok_api_key_help_url?: string | null;
   has_user_credential?: boolean | null;
+  connected_app_reachable?: boolean | null;
 
   /** GitHub / source repository URL */
   source_url?: string | null;

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -4782,9 +4782,12 @@ export const fetchDiscoverableMCPServers = async (accessToken: string) => {
   }
 };
 
-export const fetchMCPServers = async (accessToken: string, teamId?: string | null) => {
+export const fetchMCPServers = async (accessToken: string, teamId?: string | null, connectedAppView?: boolean) => {
   try {
-    return await apiClient.get(`/v1/mcp/server`, { accessToken, query: { team_id: teamId || undefined } });
+    return await apiClient.get(`/v1/mcp/server`, {
+      accessToken,
+      query: { team_id: teamId || undefined, connected_app_view: connectedAppView || undefined },
+    });
   } catch (error) {
     console.error("Failed to fetch MCP servers:", error);
     throw error;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Connect page shows servers a gateway session is never served
- Real report: page shows 7 servers / 253 tools, client gets 171
- Nothing on the page marks which servers actually count

How it solves it:

- GET /v1/mcp/server?connected_app_view=true stamps per-server reachability
- Computed by the exact resolver pair the live session uses
- Connect page shows only servers the session will be served

## Relevant issues

- The MCP connect page resolves its grid through the dashboard identity, so an admin sees the whole registry, while the gateway DCR session minted by that page resolves servers as an admitted subject through grant sources only
- This PR adds an opt-in annotation to the server list endpoint plus connect-mode rendering that hides servers the session will not be served, so the page and the session can no longer disagree
- Existing consumers of GET /v1/mcp/server are unchanged; the field stays null unless the new param is passed

## Linear ticket

Resolves LIT-4861

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Rig: proxy on localhost:4861 backed by real Postgres, four streamable HTTP MCP upstreams serving three tools each, and four servers registered through the API to exercise every grant channel: u1srv granted through the signed-in user's own object permission, t1srv granted through a roster team, a1srv flagged allow_all_keys, x1srv with no grant. The signed-in user is a proxy admin, matching the reported setup. The client leg is the full gateway DCR flow over the wire: /register, /authorize (303 to /ui/chat/integrations?connect_flow=...), POST /authorize/complete with the session cookie, /token with PKCE, then MCP initialize and tools/list with the minted session bearer

Before, at base bdf8f8c309:

```
$ curl -s "http://localhost:4861/v1/mcp/server" -H "Authorization: Bearer $UI_SESSION_KEY"
servers listed: 4        # a1srv, t1srv, u1srv, x1srv; no reachability field exists

$ curl -s "http://localhost:4861/v1/mcp/server?connected_app_view=true" -H "Authorization: Bearer $UI_SESSION_KEY"
servers listed: 4 | any connected_app_reachable field: False        # unknown param silently dropped

$ ./dcr_flow.sh          # register -> authorize -> complete -> token -> MCP tools/list
served tool count: 9
served server prefixes: ['a1srv', 't1srv', 'u1srv']        # x1srv absent, no error anywhere
```

The page lists 4 connectable servers while the session it just created is served 3. This is the reported 253 vs 171 mismatch reduced to a rig

After, at e2444030e8, same commands against the same database:

```
$ curl -s "http://localhost:4861/v1/mcp/server?connected_app_view=true" -H "Authorization: Bearer $UI_SESSION_KEY"
  a1srv | connected_app_reachable: True
  t1srv | connected_app_reachable: True
  u1srv | connected_app_reachable: True
  x1srv | connected_app_reachable: False

$ curl -s "http://localhost:4861/v1/mcp/server" -H "Authorization: Bearer $UI_SESSION_KEY"
servers listed: 4 | flags: ['None']        # default unchanged without the param

$ ./dcr_flow.sh
served tool count: 9
served server prefixes: ['a1srv', 't1srv', 'u1srv']        # equals the flagged-true set exactly
```

UI verification steps: run the dashboard dev server, start a gateway connect flow from any MCP client so the browser lands on /ui/chat/integrations?connect_flow=..., and observe that servers without a grant do not appear at all, while the plain Integrations page without connect_flow renders exactly as before

## Type

🐛 Bug Fix

## Changes

- GET /v1/mcp/server gains an opt-in connected_app_view query param; response rows gain connected_app_reachable, default null
- A new helper builds the admitted-subject auth with MCPRequestHandler._reload_admitted_user and resolves the server set with MCPServerManager.get_allowed_mcp_servers, the same two owners the live /mcp session uses, so the page and the session cannot drift
- Any failure to build the admitted set marks every server unreachable; a user whose reload fails cannot open a gateway session either, so this is the true answer rather than a fallback
- The stamp lands after both list branches, so view_all deployments (whose management-endpoint shortcut preempts the server manager's admin shortcut) and team_id queries are annotated uniformly, and it lands before the sanitizers, which preserve it
- MCPAppsPanel in connect mode requests the flag and hides unreachable servers entirely; the filtered list is the single source for counts, tabs, auto-select, detail view, and tool-count fetches. Client-forwarded auth types keep their existing "Not supported on this connection" label (a server property, unlike reachability, which is caller-relative), and a user with zero reachable servers gets an explanatory empty state

Two things a reviewer may ask. The API annotates rather than filters so the reachability field stays caller-relative and every other consumer of GET /v1/mcp/server is untouched; the connect page hides the annotated-unreachable rows client side, so the page never advertises a server the session cannot use, and the annotation still lands uniformly on the view_all and team_id branches. build_effective_auth_contexts now appends the admitted-user context for UI session credentials, so the page list, tool counts, Connect actions, and credential endpoints all resolve every server the user is granted through any channel identically; the page's membership equals the admitted set by construction and no row can render whose follow-up actions would be denied. On the REST tool routes a non-admin dashboard session is swapped for the admitted-subject principal at the route boundary (acting_user_auth), so tool permission ceilings, reachability, rate limits, and billing bind exactly as they do for a gateway session; admin sessions keep their operator view and caller-passed keys are never widened. The view is honored only for the dashboard's UI session credential, via is_ui_session_credential factored out of resolve_ui_session_team_ids so both user-identity widening sites share one trust boundary; a caller-passed virtual key gets the param as a no-op, so a scoped key can never enumerate its owning user's wider grants The keyless /ui/connect page (which renders the same panel without connect mode) and the enable_chat_ui gating of /ui/chat/integrations are pre-existing gaps tracked on the Linear ticket, kept out of this PR's scope

Three things changed after the last review round, all at the class rather than at the reported call

The connect page's detail view no longer keeps its own copy of the server object. It stores the selected server's id and derives the row from the list, so a server a refetch drops as unreachable cannot be the detail view's subject at all; the stale render, the stale tools query and the Connect action that fell through a missing-target lookup stop being reachable states instead of being blocked one at a time. handleToggle takes the server it is toggling, which deletes the lookup that could miss. Pinned by a test that opens the detail view, refetches a list without that server, and asserts the view falls back to the grid with no connect action anywhere; storing the object again fails it

admitted_user_context is now the single owner of "what user identity does this dashboard session act as". The management endpoint's private copy of the reload, the HTTPException swallow and the logging is gone, along with its dead empty-user_id branch, so the page annotation, build_effective_auth_contexts and the tool routes cannot answer that question differently. The owner also carries the request's tracing span onto the admitted principal, because _reload_admitted_user builds a fresh auth from the user row and has none of its own, so the previous round's swap had silently detached every downstream lookup and the tool-call logging from the request's trace

Toolset scoping and the acting-as-user swap are mutually exclusive, and they now share one owner on the tools list route. The admitted subject resolves per grant source and a team source deliberately carries none of the caller's object_permission, so a toolset narrowing layered on top would evaporate on every team-granted server: a non-admin dashboard user whose own object permission grants a toolset would be admitted through that grant and then served tools from servers the toolset never named. A request carrying a toolset name keeps the caller's own credential, exactly as it did before the swap. The equivalent composition on /toolset/{name}/mcp for a gateway session predates this PR, is untouched by it, and is tracked separately

A fourth followed from reading the rest of the panel's async surface. Three continuations decided against state captured before their await and committed after it, so a reachability refetch landing in between could not be seen. handleToggle validated the server at click time and then wrote its name into the selection whatever the list had since become, so a server the refresh had dropped was selected anyway; it now re-asks connectableNow at the commit, and that predicate resolves the id against the current list, so absence fails closed rather than reading as nothing to block. The load pipeline was the worse of the two because its cancel flag was shared across runs: the successor's effect body reset it to false before the predecessor's fetch resolved, so a superseded load could still run setServers and put the dropped server back on the page outright. That flag is now a per-effect local only its own cleanup can clear, which is also what makes unmount stop the chunked tool-count loop again, and the load passes its own liveness check down to the tool-count and oauth-status writes instead of having them consult a flag every other run shares. Both are pinned by tests that hold the in-flight request open across the refetch, and each mutation kills exactly its own test

## QA runbook

Against the same rig, with the dashboard dev server on :3000 and the proxy on :4861

1. Sign in as the non-admin user and start a gateway connect flow so the browser lands on /ui/chat/integrations?connect_flow=..., then open any server's detail view and leave it open. In another tab revoke that user's grant for that server, then force the panel to reload its list (sign the dashboard session out and back in, which changes the access token the panel keys its fetch on). The detail view should fall back to the grid with the revoked server gone, and no Connect control for it anywhere
2. `curl -s "http://localhost:4861/mcp-rest/tools/list?toolset_name=<a toolset the user's own object permission does not grant>" -H "Authorization: Bearer $UI_SESSION_KEY"` should still be refused, the same as before this PR; the toolset request must not be admitted through the user's grant union
3. `curl -s "http://localhost:4861/v1/mcp/server?connected_app_view=true" -H "Authorization: Bearer $UI_SESSION_KEY"` should return the same connected_app_reachable flags as before, and the served tool count over the real DCR flow should still equal the flagged-true set exactly

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP authorization identity resolution (dashboard vs admitted subject) and server listing semantics; behavior is gated to UI session credentials and connect mode, with broad test coverage, but mistakes could affect tool access or visibility for dashboard users.
> 
> **Overview**
> Fixes the gateway **connect** flow showing MCP servers and tool counts that the minted OAuth session never receives.
> 
> **Backend:** `GET /v1/mcp/server` accepts optional `connected_app_view` and sets `connected_app_reachable` on each row using the same admitted-subject resolver as live `/mcp` sessions (UI session credentials only; virtual keys are not widened). `build_effective_auth_contexts` now also includes the admitted user context so listings match user-level grants. MCP REST tool list/call routes resolve non-admin dashboard sessions via `acting_user_auth` (renamed from toolset-only scope), while **toolset-scoped** requests keep the caller credential so narrowing is not lost on team grants.
> 
> **Dashboard:** In connect mode, `MCPAppsPanel` requests the new view, filters out unreachable servers, and hardens async behavior (detail view by server id, per-load cancellation, re-check after Connect) so refetches cannot leave stale UI or selections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6d3b1763ca23471e00bef85c0cebccfbd54835d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->






