### PR TITLE
test: unstale the reasoning-effort grid count and the responses bridge test

### DIFF
--- a/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
+++ b/tests/llm_translation/reasoning_effort_grid/test_reasoning_effort_grid.py
@@ -201,8 +201,8 @@ async def test_reasoning_effort_grid(
 
 
 def test_grid_cell_count() -> None:
-    assert len(_PARAMS) == 30 * 11, (
-        f"expected 330 cells (30 provider x model combos x 11 efforts), "
+    assert len(_PARAMS) == 31 * 11, (
+        f"expected 341 cells (31 provider x model combos x 11 efforts), "
         f"got {len(_PARAMS)}"
     )
 

--- a/tests/llm_translation/test_openai.py
+++ b/tests/llm_translation/test_openai.py
@@ -613,13 +613,13 @@ async def test_openai_via_gemini_streaming_bridge():
     assert len(printed_chunks) > 0
 
 
-def test_openai_deepresearch_model_bridge():
+def test_openai_responses_only_model_bridge():
     """
-    Test that the deepresearch model bridge works correctly
+    Test that the responses-only model bridge works correctly
     """
     litellm._turn_on_debug()
     response = litellm.completion(
-        model="o3-deep-research-2025-06-26",
+        model="gpt-5.5-pro",
         messages=[{"role": "user", "content": "Hey, how's it going?"}],
         tools=[
             {"type": "web_search_preview"},


### PR DESCRIPTION
## TLDR

Problem this solves:

- Grid cell-count tripwire never bumped for claude-opus-5
- OpenAI shut down o3-deep-research on 2026-07-23

How it solves it:

- Bumps the expected cell count from 330 to 341
- Points the bridge test at gpt-5.5-pro, a live responses-only model

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs were captured at `ea3b9ba23e` against a live proxy on `localhost:4002` backed by real OpenAI calls. The code path is identical in both; only the model differs, since the test change is a model swap. Proxy config used:

```yaml
model_list:
  - model_name: o3-deep-research
    litellm_params:
      model: openai/o3-deep-research-2025-06-26
      api_key: os.environ/OPENAI_API_KEY
  - model_name: gpt-5.5-pro
    litellm_params:
      model: openai/gpt-5.5-pro
      api_key: os.environ/OPENAI_API_KEY
```

Before, the model the test used until this PR:

```bash
curl -sS -w '\nHTTP %{http_code}\n' -X POST http://localhost:4002/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{"model": "o3-deep-research", "messages": [{"role": "user", "content": "Hey, how is it going?"}], "tools": [{"type": "web_search_preview"}, {"type": "code_interpreter", "container": {"type": "auto"}}]}'
```

```
{"error":{"message":"litellm.BadRequestError: OpenAIException - {\n  \"error\": {\n    \"message\": \"Model not found o3-deep-research-2025-06-26\",\n    \"type\": \"invalid_request_error\",\n    \"param\": \"model\",\n    \"code\": null\n  }\n}...","type":null,"param":null,"code":"404"}}
HTTP 404
```

After, the model the test uses now:

```bash
curl -sS -w '\nHTTP %{http_code}\n' -X POST http://localhost:4002/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' \
  -H 'Content-Type: application/json' \
  -d '{"model": "gpt-5.5-pro", "messages": [{"role": "user", "content": "Hey, how is it going?"}], "tools": [{"type": "web_search_preview"}, {"type": "code_interpreter", "container": {"type": "auto"}}]}'
```

```
{"id":"chatcmpl-6db3aa54-7e97-424d-aaae-08692b6242b4","created":1785199736,"model":"gpt-5.5-pro","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hey! I’m doing well—thanks for asking. How can I help you today?","role":"assistant"}}],"usage":{"completion_tokens":22,"prompt_tokens":5023,"total_tokens":5045,"completion_tokens_details":{"reasoning_tokens":0},"prompt_tokens_details":{"cached_tokens":0,"cache_write_tokens":0,"cache_creation_tokens":0}}}
HTTP 200
```

Both requests go through `litellm/completion_extras/litellm_responses_transformation/handler.py`, so the bridge is still what is under test; the 5023 prompt tokens on the 200 are the two built-in tool definitions being sent to `/v1/responses`

Model availability was checked with an authenticated read before picking the replacement, rather than guessed from docs:

```bash
for M in o3-deep-research o3-deep-research-2025-06-26 o4-mini-deep-research gpt-5.5-pro; do
  printf '%-32s ' "$M"
  curl -s "https://api.openai.com/v1/models/$M" -H "Authorization: Bearer $OPENAI_API_KEY" | jq -r '.id // ("ERR: " + .error.message)'
done
```

```
o3-deep-research                 ERR: The model 'o3-deep-research' does not exist
o3-deep-research-2025-06-26      ERR: The model 'o3-deep-research-2025-06-26' does not exist
o4-mini-deep-research            ERR: The model 'o4-mini-deep-research' does not exist
gpt-5.5-pro                      gpt-5.5-pro
```

## Type

✅ Test

## Changes

Two unrelated-looking test failures with the same shape: the suite drifted behind reality, and neither is a behavior regression.

`test_grid_cell_count` is a deliberate tripwire that pins the size of the reasoning-effort grid so a model cannot be added to `grid_spec.py` without someone noticing. `ae81625ee6` added the `claude-opus-5` entry and left the assertion at 30 combos, so the tripwire did its job and nobody bumped it. This raises it to 31 combos / 341 cells, the same maintenance `d6f09c4f24` did for `claude-sonnet-5`

`test_openai_deepresearch_model_bridge` made a live call to `o3-deep-research-2025-06-26`. OpenAI announced the retirement of `o3-deep-research` and `o4-mini-deep-research` on 2026-04-22 and shut both down on 2026-07-23, so the call now comes back as a 400 with `Model not found`. Nothing on our side changed

The bridge under test was never specific to deep research: `responses_api_bridge_check` in `litellm/main.py` fires on any model whose cost-map `mode` is `responses`, and deep research just happened to be one. The test now uses `gpt-5.5-pro`, the newest OpenAI model that is still responses-only, and is renamed to `test_openai_responses_only_model_bridge` to say what it actually covers. OpenAI's own recommended replacement, `gpt-5.6-sol`, is deliberately not used here: it serves `/v1/chat/completions`, so the bridge would never fire and the test would pass while covering nothing

The other `o3-deep-research` and `o4-mini-deep-research` references in the suite are config strings in mocked router and polling tests, never live calls, so they still pass and are left alone

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
