### PR TITLE
feat(modelsell): add OpenAI-compatible provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -728,6 +728,7 @@ openai_compatible_endpoints: List = [
     "https://api.libertai.io/v1",
     "https://pinstripes.io/v1",
     "https://api.meta.ai/v1",
+    "https://modelsell.com/v1",
 ]
 
 
@@ -795,6 +796,7 @@ openai_compatible_providers: List = [
     "pinstripes",  # Pinstripes - JSON-configured provider
     "darkbloom",
     "meta",  # Meta Model API (Muse Spark) - JSON-configured provider
+    "modelsell",
 ]
 openai_text_completion_compatible_providers: List = [  # providers that support `/v1/completions`
     "together_ai",

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -349,6 +349,9 @@ def get_llm_provider(
                     elif endpoint == "https://api.meta.ai/v1":
                         custom_llm_provider = "meta"
                         dynamic_api_key = get_secret_str("META_API_KEY")
+                    elif endpoint == "https://modelsell.com/v1":
+                        custom_llm_provider = "modelsell"
+                        dynamic_api_key = get_secret_str("MODELSELL_API_KEY")
 
                     if api_base is not None and not isinstance(api_base, str):
                         raise Exception("api base needs to be a string. api_base={}".format(api_base))

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -183,5 +183,15 @@
       "max_completion_tokens": "max_tokens"
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+  },
+  "modelsell": {
+    "base_url": "https://modelsell.com/v1",
+    "api_key_env": "MODELSELL_API_KEY",
+    "api_base_env": "MODELSELL_API_BASE",
+    "base_class": "openai_gpt",
+    "param_mappings": {
+      "max_completion_tokens": "max_tokens"
+    },
+    "supported_endpoints": ["/v1/chat/completions"]
   }
 }

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3510,6 +3510,7 @@ class LlmProviders(str, Enum):
     PINSTRIPES = "pinstripes"
     DARKBLOOM = "darkbloom"
     META = "meta"
+    MODELSELL = "modelsell"
     LITELLM_AGENT = "litellm_agent"
     CURSOR = "cursor"
     BEDROCK_MANTLE = "bedrock_mantle"

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -1547,6 +1547,24 @@
         "interactions": false
       }
     },
+    "modelsell": {
+      "display_name": "Modelsell (`modelsell`)",
+      "url": "https://modelsell.com/docs/api-reference",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false,
+        "interactions": false
+      }
+    },
     "moonshot": {
       "display_name": "Moonshot (`moonshot`)",
       "url": "https://docs.litellm.ai/docs/providers/moonshot",

--- a/tests/test_litellm/llms/openai_like/test_modelsell_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_modelsell_provider.py
@@ -1,0 +1,95 @@
+import litellm
+
+
+def test_modelsell_registered_as_openai_compatible_provider():
+    from litellm import LlmProviders
+    from litellm.constants import openai_compatible_providers
+
+    assert LlmProviders.MODELSELL.value == "modelsell"
+    assert "modelsell" in litellm.provider_list
+    assert "modelsell" in openai_compatible_providers
+
+
+def test_modelsell_json_config_supports_only_chat_completions():
+    from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+    provider = JSONProviderRegistry.get("modelsell")
+
+    assert provider is not None
+    assert provider.base_url == "https://modelsell.com/v1"
+    assert provider.api_key_env == "MODELSELL_API_KEY"
+    assert provider.api_base_env == "MODELSELL_API_BASE"
+    assert provider.param_mappings == {"max_completion_tokens": "max_tokens"}
+    assert provider.supported_endpoints == ["/v1/chat/completions"]
+    assert JSONProviderRegistry.supports_responses_api("modelsell") is False
+
+
+def test_modelsell_prefixed_model_uses_default_configuration():
+    from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+    model, provider, api_key, api_base = get_llm_provider(
+        model="modelsell/test-model",
+        custom_llm_provider=None,
+        api_base=None,
+        api_key="sk-test",
+    )
+
+    assert model == "test-model"
+    assert provider == "modelsell"
+    assert api_key == "sk-test"
+    assert api_base == "https://modelsell.com/v1"
+
+
+def test_modelsell_configuration_can_be_overridden_from_env(monkeypatch):
+    from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+    monkeypatch.setenv("MODELSELL_API_KEY", "sk-env-test")
+    monkeypatch.setenv("MODELSELL_API_BASE", "https://proxy.example.com/v1")
+
+    _, provider, api_key, api_base = get_llm_provider(
+        model="modelsell/test-model",
+        custom_llm_provider=None,
+        api_base=None,
+        api_key=None,
+    )
+
+    assert provider == "modelsell"
+    assert api_key == "sk-env-test"
+    assert api_base == "https://proxy.example.com/v1"
+
+
+def test_modelsell_url_autodetection_uses_environment_api_key(monkeypatch):
+    from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+    monkeypatch.setenv("MODELSELL_API_KEY", "sk-env-test")
+
+    model, provider, api_key, api_base = get_llm_provider(
+        model="test-model",
+        custom_llm_provider=None,
+        api_base="https://modelsell.com/v1",
+        api_key=None,
+    )
+
+    assert model == "test-model"
+    assert provider == "modelsell"
+    assert api_key == "sk-env-test"
+    assert api_base == "https://modelsell.com/v1"
+
+
+def test_modelsell_chat_completions_url():
+    config = litellm.ProviderConfigManager.get_provider_chat_config(
+        model="test-model",
+        provider=litellm.LlmProviders.MODELSELL,
+    )
+
+    assert config is not None
+    assert (
+        config.get_complete_url(
+            api_base=None,
+            api_key="sk-test",
+            model="test-model",
+            optional_params={},
+            litellm_params={},
+        )
+        == "https://modelsell.com/v1/chat/completions"
+    )

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23479,7 +23479,7 @@ export interface components {
              * @description Default role assigned to new users created
              * @default internal_user_viewer
              */
-            user_role: ("proxy_admin" | "proxy_admin_viewer" | "internal_user" | "internal_user_viewer") | null;
+            user_role: ("internal_user" | "internal_user_viewer" | "proxy_admin" | "proxy_admin_viewer") | null;
         };
         /**
          * DefaultTeamSSOParams
@@ -26020,7 +26020,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: string | number | null;
+            stream_timeout?: number | string | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */
@@ -34110,7 +34110,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: string | number | null;
+            stream_timeout?: number | string | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23479,7 +23479,7 @@ export interface components {
              * @description Default role assigned to new users created
              * @default internal_user_viewer
              */
-            user_role: ("internal_user" | "internal_user_viewer" | "proxy_admin" | "proxy_admin_viewer") | null;
+            user_role: ("proxy_admin" | "proxy_admin_viewer" | "internal_user" | "internal_user_viewer") | null;
         };
         /**
          * DefaultTeamSSOParams
@@ -26020,7 +26020,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */
@@ -34110,7 +34110,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */


### PR DESCRIPTION
## TLDR

Problem this solves:

- Modelsell requires repeated custom OpenAI configuration
- Modelsell has no named LiteLLM provider

How it solves it:

- Registers Modelsell through the JSON provider system
- Adds routing, endpoint metadata, and focused tests

## Relevant issues

Closes #34858

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Not included because no Modelsell API key was used for a live end-to-end request

## Type

New Feature

## Changes

This registers `modelsell` with the default `https://modelsell.com/v1` base URL, `MODELSELL_API_KEY`, and optional `MODELSELL_API_BASE` override

The initial capability scope is Chat Completions only, while the model catalog remains dynamic through Modelsell's `/v1/models` endpoint instead of adding static model or price entries

Provider resolution supports the `modelsell/<model>` prefix and automatic detection from the default API base

The focused tests cover registration, JSON configuration, environment overrides, URL detection, and the generated Chat Completions URL

Local validation passed with `24 passed, 4 skipped` across the Modelsell and generic JSON provider tests, plus `make pre-commit`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
