### PR TITLE
test(e2e): realign Admin UI specs with the MCP dialog and keyless landing

### DIFF
--- a/tests/e2e/ui/tests/internal-user/internalUserNoTeam.spec.ts
+++ b/tests/e2e/ui/tests/internal-user/internalUserNoTeam.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from "@playwright/test";
-import { dismissFeedbackPopup } from "../../helpers/navigation";
+import { navigateToPage } from "../../helpers/navigation";
+import { Page } from "../../fixtures/pages";
 
 /**
  * Logs in fresh inside the test rather than reusing a stored session because
@@ -16,9 +17,12 @@ test.describe("Internal User with no team memberships", () => {
     await page.getByPlaceholder("Enter your username").fill("noteam@test.local");
     await page.getByPlaceholder("Enter your password").fill("test");
     await page.getByRole("button", { name: "Login", exact: true }).click();
+    // A non-admin with no keys lands on /ui/connect, so the keys dashboard has
+    // to be asked for explicitly once that redirect settles.
+    await page.waitForURL(/\/ui\/connect/, { timeout: 30_000 });
+    await navigateToPage(page, Page.ApiKeys);
     // Scope to the sidebar; the top-bar breadcrumb also shows "Virtual Keys".
     await expect(page.getByRole("complementary").getByText("Virtual Keys")).toBeVisible({ timeout: 15_000 });
-    await dismissFeedbackPopup(page);
 
     // Open the Create Key modal.
     await page.getByRole("button", { name: /Create New Key/i }).click();

--- a/tests/e2e/ui/tests/mcp/mcpServers.spec.ts
+++ b/tests/e2e/ui/tests/mcp/mcpServers.spec.ts
@@ -16,7 +16,7 @@ test.describe("MCP Servers", () => {
 
     // Open the discovery modal, then drop into the custom-server form
     await page.getByRole("button", { name: /Add New MCP Server/i }).click();
-    const discovery = page.locator(".ant-modal:visible").filter({ hasText: "Add MCP Server" });
+    const discovery = page.getByRole("dialog").filter({ hasText: "Add MCP Server" });
     await expect(discovery).toBeVisible({ timeout: 5_000 });
     await discovery.getByRole("button", { name: /Custom Server/i }).click();
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Two Admin UI e2e specs fail on stale selectors, not real bugs
- MCP discovery modal moved from antd to shadcn; `.ant-modal` no longer matches
- Keyless non-admins now land on /ui/connect, which has no sidebar

How it solves it:

- Locate the discovery modal by its dialog role
- Wait for the connect redirect, then ask for the keys page explicitly

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both specs were run against the real UI e2e stack (fresh Next.js build served by a live proxy, seeded Postgres, mock LLM upstream), which is what `tests/e2e/ui/run_e2e.sh` drives in CI. The only local deviation is ports, because other proxies already held 4000/5432 on this machine.

Before, at `f2cda740f7` (the tip this branch started from), both fail:

```
npx playwright test tests/internal-user/internalUserNoTeam.spec.ts tests/mcp/mcpServers.spec.ts --reporter=list
```

```
  ✘  1 [chromium] › tests/mcp/mcpServers.spec.ts:14:7 › MCP Servers › Add a custom MCP server via the discovery → custom form (6.0s)
  ✘  2 [chromium] › tests/internal-user/internalUserNoTeam.spec.ts:13:7 › Internal User with no team memberships › Create Key team dropdown is empty when the user belongs to no teams (15.3s)

  1) internalUserNoTeam.spec.ts
    Locator: getByRole('complementary').getByText('Virtual Keys')
    Expected: visible
    Error: element(s) not found

  2) mcpServers.spec.ts
    Locator: locator('.ant-modal:visible').filter({ hasText: 'Add MCP Server' })
    Expected: visible
    Error: element(s) not found

  2 failed
```

The Playwright page snapshot on that first failure shows why: the no-team user lands on the connect page, whose shell is the navbar only, with no `complementary` sidebar landmark to find "Virtual Keys" in.

```
- navigation:
  - link "LiteLLM Brand"
  - button "appstore AI Gateway"
  - button "Account menu — Internal User — signed in as noteam@test.local"
- heading "MCP Servers" [level=2]
- paragraph: Browse tools, authenticate once, use in chat
```

After, at `71ff0cf1ca`, both pass:

```
  ✓  2 [chromium] › tests/internal-user/internalUserNoTeam.spec.ts:14:7 › Internal User with no team memberships › Create Key team dropdown is empty when the user belongs to no teams (2.6s)
  ✓  1 [chromium] › tests/mcp/mcpServers.spec.ts:14:7 › MCP Servers › Add a custom MCP server via the discovery → custom form (12.2s)

  2 passed (15.6s)
```

Six-for-six across three repeats, to rule out a flaky pass:

```
npx playwright test tests/internal-user/internalUserNoTeam.spec.ts tests/mcp/mcpServers.spec.ts --reporter=list --repeat-each=3
```

```
  6 passed (17.2s)
```

The empty-dropdown assertion is still live rather than vacuous. Swapping the login to `internal@test.local`, who belongs to two seeded teams, turns the test red again, so it is genuinely reading the dropdown's contents and not passing by accident.

## Type

✅ Test

## Changes

`mcpServers.spec.ts` located the discovery modal with `.ant-modal:visible`. That modal became a shadcn/Base UI `Dialog` when `refactor(ui): migrate mcp-servers, tag-management and tool-policies to shadcn` landed, so the antd class is gone and the very first assertion fails. It is now found by its dialog role. The create form it opens is still an antd `Modal`, so that locator is untouched.

`internalUserNoTeam.spec.ts` logged in and expected the Virtual Keys sidebar right away. `feat(ui): land keyless users on the connect page after login` redirects a non-admin with an empty key list to `/ui/connect` when the landing URL carries `?login=success`, and the seeded no-team user has no keys, so it never reaches the dashboard. The test now waits for that redirect and then navigates to the keys page; a fresh navigation drops the `?login=success` marker, so the dashboard stays put. Waiting for the redirect to settle first matters: a `goto` issued while the app is still replacing the URL aborts the navigation.

Neither change touches product code, and the behavior each test covers is unchanged.

## QA runbook

- `tests/e2e/ui/tests/mcp/mcpServers.spec.ts` - an admin can add a custom Streamable HTTP MCP server with no auth from the discovery modal
  - [ ] Open http://localhost:4000/ui/?page=mcp-servers as a proxy admin
  - [ ] Click "+ Add New MCP Server" and expect the discovery dialog titled "Add MCP Server"
  - [ ] Click "+ Custom Server" in that dialog's header to reach the create form
  - [ ] Fill MCP Server Name with an underscore-only name, pick Transport Type "Streamable HTTP (Recommended)", set MCP Server URL to any URL, and pick Authentication "None"
  - [ ] Click "Add MCP Server" and expect the "MCP Server created successfully" toast plus a card for that name in the servers grid
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- `tests/e2e/ui/tests/internal-user/internalUserNoTeam.spec.ts` - the Create Key team dropdown offers nothing to a user who belongs to no teams
  - [ ] Log in at http://localhost:4000/ui/login as an internal user who has no team memberships and no keys
  - [ ] Expect to land on /ui/connect rather than the keys dashboard
  - [ ] Navigate to http://localhost:4000/ui/?page=api-keys and expect the sidebar to show "Virtual Keys"
  - [ ] Click "+ Create New Key", then open the Team dropdown in the Key Ownership section
  - [ ] Expect "No teams found" once the request settles, and no selectable options
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
