### PR TITLE
fix(gemini): use collection endpoint for custom context cache

### DIFF
--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -75,6 +75,9 @@ class ContextCachingEndpoints(VertexBase):
             base_url = get_vertex_base_url(vertex_location)
             url = f"{base_url}/v1beta1/projects/{vertex_project}/locations/{vertex_location}/{endpoint}"
 
+        if custom_llm_provider == "gemini" and api_base:
+            return auth_header, f"{api_base.rstrip('/')}/{endpoint}"
+
         return self._check_custom_proxy(
             api_base=api_base,
             custom_llm_provider=custom_llm_provider,

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -1881,9 +1881,7 @@ class TestVertexAIGlobalLocation:
                 "global-aiplatform" not in url
             ), "URL should not contain 'global-aiplatform' prefix"
 
-    def test_gemini_context_caching_with_custom_api_base_uses_collection_endpoint(
-        self,
-    ):
+    def test_gemini_custom_cache_uses_collection_endpoint_without_model(self):
         caching = ContextCachingEndpoints()
 
         auth_header, url = caching._get_token_and_url_context_caching(
@@ -1893,7 +1891,6 @@ class TestVertexAIGlobalLocation:
             vertex_project=None,
             vertex_location=None,
             vertex_auth_header=None,
-            model="gemini-1.5-pro",
         )
 
         assert auth_header == {"x-goog-api-key": "test-key"}

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -1881,12 +1881,9 @@ class TestVertexAIGlobalLocation:
                 "global-aiplatform" not in url
             ), "URL should not contain 'global-aiplatform' prefix"
 
-    def test_gemini_context_caching_with_custom_api_base_passes_model(self):
-        """Gemini context caching with custom api_base must pass model to _check_custom_proxy.
-
-        Regression test for https://github.com/BerriAI/litellm/issues/23846
-        Previously model was hardcoded to None, causing ValueError when api_base was set.
-        """
+    def test_gemini_context_caching_with_custom_api_base_uses_collection_endpoint(
+        self,
+    ):
         caching = ContextCachingEndpoints()
 
         auth_header, url = caching._get_token_and_url_context_caching(
@@ -1899,8 +1896,8 @@ class TestVertexAIGlobalLocation:
             model="gemini-1.5-pro",
         )
 
-        assert "models/gemini-1.5-pro" in url
-        assert url.startswith("https://my-proxy.example.com/")
+        assert auth_header == {"x-goog-api-key": "test-key"}
+        assert url == "https://my-proxy.example.com/cachedContents"
 
     def test_gemini_context_caching_without_api_base_ignores_model(self):
         """Without custom api_base, model param is not needed (default URL is used)."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Custom Gemini context caching calls an invalid model action URL

How it solves it:

- Sends cache list and create calls to the collection endpoint
- Preserves Gemini API key and caller-provided authentication headers

## Relevant issues

Fixes #34872

Related #23846

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Live SDK calls used the same cache-controlled prompt and a Gemini-compatible custom `api_base`

Before, at `3c0b1db633`:

```text
BadRequestError ... INVALID_ARGUMENT: GetModelRequest.name: unexpected model name format
```

After, at `2ef0d360d4`:

```text
1 success cached_tokens 5602
2 success cached_tokens 5602
```

The first successful request creates the named cache and the second reuses it

## Type

Bug Fix

## Changes

The Gemini context-caching URL builder now treats `cachedContents` as a collection when `api_base` is set instead of delegating to the model-action URL builder

The regression test verifies custom cache URL construction succeeds without a model, asserts the exact collection URL, and confirms the Gemini API key header remains intact

Validation:

```text
108 passed in 0.54s
make pre-commit: passed
```

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

