### PR TITLE
feat(ui): shareable log links via log_id query param on the logs page

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3308,8 +3308,36 @@ async def ui_view_session_spend_logs(
                 detail="Database not connected",
             )
 
-        # Build query conditions
-        where_conditions = {"session_id": session_id}
+        if _is_admin_view_safe(user_api_key_dict=user_api_key_dict):
+            scope_sql = ""
+            scope_params = ()
+            where_conditions = {"session_id": session_id}
+        else:
+            try:
+                permitted_team_ids = (
+                    await _get_permitted_team_ids_for_spend_logs(
+                        prisma_client=prisma_client,
+                        user_api_key_dict=user_api_key_dict,
+                    )
+                    if _can_user_view_spend_log(user_api_key_dict=user_api_key_dict)
+                    else []
+                )
+            except Exception:  # noqa: BLE001  # mirror /spend/logs/ui: failed team lookup falls back to own-logs-only scope
+                permitted_team_ids = []
+            if permitted_team_ids:
+                scope_sql = ' AND ("user" = $4 OR team_id = ANY($5::text[]))'
+                scope_params = (user_api_key_dict.user_id, permitted_team_ids)
+                where_conditions = {
+                    "session_id": session_id,
+                    "OR": [
+                        {"user": user_api_key_dict.user_id},
+                        {"team_id": {"in": permitted_team_ids}},
+                    ],
+                }
+            else:
+                scope_sql = ' AND "user" = $4'
+                scope_params = (user_api_key_dict.user_id,)
+                where_conditions = {"session_id": session_id, "user": user_api_key_dict.user_id}
 
         # Calculate pagination offsets
         skip = (page - 1) * page_size
@@ -3318,7 +3346,7 @@ async def ui_view_session_spend_logs(
         total_records = await SpendLogsRepository(prisma_client).table.count(where=where_conditions)
 
         # Query with raw SQL to exclude heavy columns (messages, response, proxy_server_request)
-        sql_query = """
+        sql_query = f"""
             SELECT
                 request_id, call_type, api_key, spend, total_tokens,
                 prompt_tokens, completion_tokens, "startTime", "endTime",
@@ -3328,11 +3356,11 @@ async def ui_view_session_spend_logs(
                 organization_id, end_user, requester_ip_address,
                 session_id, status, mcp_namespaced_tool_name, agent_id
             FROM "LiteLLM_SpendLogs"
-            WHERE session_id = $1
+            WHERE session_id = $1{scope_sql}
             ORDER BY "startTime" DESC
             LIMIT $2 OFFSET $3
         """
-        result = await prisma_client.db.query_raw(sql_query, session_id, page_size, skip)
+        result = await prisma_client.db.query_raw(sql_query, session_id, page_size, skip, *scope_params)
 
         total_pages = (total_records + page_size - 1) // page_size
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1548,6 +1548,7 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
             assert page_size == 1
             assert skip == 1  # page=2, page_size=1
             assert 'ORDER BY "startTime" DESC' in sql_query
+            assert '"user" = $4' not in sql_query
             return [mock_spend_logs[0]]
 
     class MockPrismaClient:
@@ -1558,20 +1559,144 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
     mock_prisma_client = MockPrismaClient()
     monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
 
-    response = client.get(
-        "/spend/logs/session/ui",
-        params={"session_id": "session-123", "page": 2, "page_size": 1},
-        headers={"Authorization": "Bearer sk-test"},
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
     )
 
-    assert response.status_code == 200
-    data = response.json()
-    assert data["total"] == 2
-    assert data["page"] == 2
-    assert data["page_size"] == 1
-    assert data["total_pages"] == 2
-    assert len(data["data"]) == 1
-    assert data["data"][0]["request_id"] == "req1"
+    try:
+        response = client.get(
+            "/spend/logs/session/ui",
+            params={"session_id": "session-123", "page": 2, "page_size": 1},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        assert data["page"] == 2
+        assert data["page_size"] == 1
+        assert data["total_pages"] == 2
+        assert len(data["data"]) == 1
+        assert data["data"][0]["request_id"] == "req1"
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_ui_view_session_spend_logs_scopes_non_admin_to_own_logs(client, monkeypatch):
+    own_log = {
+        "id": "log1",
+        "request_id": "req1",
+        "session_id": "session-123",
+        "user": "user-1",
+        "startTime": "2024-01-01T00:00:00Z",
+    }
+
+    class MockDB:
+        async def count(self, *args, **kwargs):
+            assert kwargs.get("where") == {"session_id": "session-123", "user": "user-1"}
+            return 1
+
+        async def query_raw(self, sql_query, session_id, page_size, skip, scoped_user):
+            assert session_id == "session-123"
+            assert scoped_user == "user-1"
+            assert '"user" = $4' in sql_query
+            return [own_log]
+
+    class MockPrismaClient:
+        def __init__(self):
+            self.db = MockDB()
+            self.db.litellm_spendlogs = self.db
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MockPrismaClient())
+
+    async def no_permitted_teams(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(
+        "litellm.proxy.spend_tracking.spend_management_endpoints._get_permitted_team_ids_for_spend_logs",
+        no_permitted_teams,
+    )
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER, user_id="user-1"
+    )
+
+    try:
+        response = client.get(
+            "/spend/logs/session/ui",
+            params={"session_id": "session-123", "page": 1, "page_size": 50},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert [row["request_id"] for row in data["data"]] == ["req1"]
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
+async def test_ui_view_session_spend_logs_includes_permitted_team_logs(client, monkeypatch):
+    class MockDB:
+        async def count(self, *args, **kwargs):
+            assert kwargs.get("where") == {
+                "session_id": "session-123",
+                "OR": [
+                    {"user": "user-1"},
+                    {"team_id": {"in": ["team-9"]}},
+                ],
+            }
+            return 1
+
+        async def query_raw(self, sql_query, session_id, page_size, skip, scoped_user, team_ids):
+            assert session_id == "session-123"
+            assert scoped_user == "user-1"
+            assert team_ids == ["team-9"]
+            assert '("user" = $4 OR team_id = ANY($5::text[]))' in sql_query
+            return [
+                {
+                    "id": "log2",
+                    "request_id": "req2",
+                    "session_id": "session-123",
+                    "team_id": "team-9",
+                    "startTime": "2024-01-02T00:00:00Z",
+                }
+            ]
+
+    class MockPrismaClient:
+        def __init__(self):
+            self.db = MockDB()
+            self.db.litellm_spendlogs = self.db
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MockPrismaClient())
+
+    async def permitted_teams(*args, **kwargs):
+        return ["team-9"]
+
+    monkeypatch.setattr(
+        "litellm.proxy.spend_tracking.spend_management_endpoints._get_permitted_team_ids_for_spend_logs",
+        permitted_teams,
+    )
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER, user_id="user-1"
+    )
+
+    try:
+        response = client.get(
+            "/spend/logs/session/ui",
+            params={"session_id": "session-123", "page": 1, "page_size": 50},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 1
+        assert [row["request_id"] for row in data["data"]] == ["req2"]
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
 
 
 @pytest.mark.asyncio

--- a/ui/litellm-dashboard/src/app/(dashboard)/navigateWithParams.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/navigateWithParams.ts
@@ -1,7 +1,11 @@
-export function navigateWithParams(mutate: (params: URLSearchParams) => void): void {
+export function navigateWithParams(mutate: (params: URLSearchParams) => void, mode: "push" | "replace" = "push"): void {
   const params = new URLSearchParams(window.location.search);
   mutate(params);
   const qs = params.toString();
   const url = qs ? `${window.location.pathname}?${qs}` : window.location.pathname;
-  window.history.pushState(null, "", url);
+  if (mode === "replace") {
+    window.history.replaceState(null, "", url);
+  } else {
+    window.history.pushState(null, "", url);
+  }
 }

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
@@ -352,6 +352,29 @@ describe("RequestLogsPanel", () => {
       });
     });
 
+    it("clicking a log row clears a lingering ?session_id= so the drawer shows the clicked log", async () => {
+      const user = userEvent.setup();
+      respondWith([
+        logEntry({ request_id: "req-a", session_id: "sess-a", session_total_count: 1 }),
+        logEntry({ request_id: "req-b" }),
+      ]);
+      renderWithProviders(<RequestLogsPanel {...defaultProps} />);
+
+      await waitFor(() => expect(row("req-a")).not.toBeNull());
+      await user.click(within(row("req-a") as HTMLElement).getByText("sess-a"));
+      await waitFor(() => expect(new URLSearchParams(window.location.search).get("session_id")).toBe("sess-a"));
+
+      await user.click(row("req-b") as HTMLElement);
+
+      const params = new URLSearchParams(window.location.search);
+      expect(params.get("log_id")).toBe("req-b");
+      expect(params.get("session_id")).toBeNull();
+      await waitFor(() => {
+        expect(drawer()).toHaveAttribute("data-log-id", "req-b");
+        expect(drawer()).toHaveAttribute("data-session-id", "");
+      });
+    });
+
     it("browser back after opening via a session id closes the drawer", async () => {
       const user = userEvent.setup();
       respondWith([logEntry({ request_id: "req-solo", session_id: "sess-solo", session_total_count: 1 })]);

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
@@ -27,17 +27,25 @@ vi.mock("./LogDetailsDrawer", () => ({
     logEntry,
     sessionId,
     onClose,
+    allLogs = [],
+    onSelectLog,
   }: {
     open: boolean;
     logEntry?: { request_id: string } | null;
     sessionId?: string | null;
     onClose: () => void;
+    allLogs?: { request_id: string }[];
+    onSelectLog?: (log: { request_id: string }) => void;
   }) {
+    const nextLog = allLogs.find((log) => log.request_id !== logEntry?.request_id);
     return (
       <div data-testid="log-details-drawer" data-log-id={logEntry?.request_id ?? ""} data-session-id={sessionId ?? ""}>
         {open ? "open" : "closed"}
         <button type="button" onClick={onClose}>
           close-drawer
+        </button>
+        <button type="button" onClick={() => nextLog && onSelectLog?.(nextLog)}>
+          select-next-log
         </button>
       </div>
     );
@@ -53,7 +61,11 @@ vi.mock("next/navigation", async (importOriginal) => {
       const search = useSyncExternalStore(
         (onChange: () => void) => {
           window.addEventListener("test-locationchange", onChange);
-          return () => window.removeEventListener("test-locationchange", onChange);
+          window.addEventListener("popstate", onChange);
+          return () => {
+            window.removeEventListener("test-locationchange", onChange);
+            window.removeEventListener("popstate", onChange);
+          };
         },
         () => window.location.search,
       );
@@ -63,14 +75,20 @@ vi.mock("next/navigation", async (importOriginal) => {
 });
 
 const originalPushState = window.history.pushState.bind(window.history);
+const originalReplaceState = window.history.replaceState.bind(window.history);
 beforeAll(() => {
   window.history.pushState = (data, unused, url) => {
     originalPushState(data, unused, url);
     window.dispatchEvent(new Event("test-locationchange"));
   };
+  window.history.replaceState = (data, unused, url) => {
+    originalReplaceState(data, unused, url);
+    window.dispatchEvent(new Event("test-locationchange"));
+  };
 });
 afterAll(() => {
   window.history.pushState = originalPushState;
+  window.history.replaceState = originalReplaceState;
 });
 
 import { uiSpendLogsCall } from "../networking";
@@ -296,6 +314,57 @@ describe("RequestLogsPanel", () => {
 
       expect(new URLSearchParams(window.location.search).get("log_id")).toBeNull();
       await waitFor(() => expect(drawer()).toHaveTextContent("closed"));
+    });
+
+    it("switching logs inside the drawer replaces the URL, so back closes the drawer in one step", async () => {
+      const user = userEvent.setup();
+      respondWith([logEntry({ request_id: "req-1" }), logEntry({ request_id: "req-2" })]);
+      renderWithProviders(<RequestLogsPanel {...defaultProps} />);
+
+      await waitFor(() => expect(row("req-1")).not.toBeNull());
+      await user.click(row("req-1") as HTMLElement);
+      await waitFor(() => expect(drawer()).toHaveAttribute("data-log-id", "req-1"));
+
+      await user.click(screen.getByRole("button", { name: "select-next-log" }));
+      await waitFor(() => expect(drawer()).toHaveAttribute("data-log-id", "req-2"));
+      expect(new URLSearchParams(window.location.search).get("log_id")).toBe("req-2");
+
+      window.history.back();
+
+      await waitFor(() => expect(drawer()).toHaveTextContent("closed"));
+      expect(new URLSearchParams(window.location.search).get("log_id")).toBeNull();
+    });
+
+    it("clicking a session id writes ?session_id= and ?log_id= and opens the session drawer", async () => {
+      const user = userEvent.setup();
+      respondWith([logEntry({ request_id: "req-solo", session_id: "sess-solo", session_total_count: 1 })]);
+      renderWithProviders(<RequestLogsPanel {...defaultProps} />);
+
+      await waitFor(() => expect(row("req-solo")).not.toBeNull());
+      await user.click(within(row("req-solo") as HTMLElement).getByText("sess-solo"));
+
+      const params = new URLSearchParams(window.location.search);
+      expect(params.get("session_id")).toBe("sess-solo");
+      expect(params.get("log_id")).toBe("req-solo");
+      await waitFor(() => {
+        expect(drawer()).toHaveTextContent("open");
+        expect(drawer()).toHaveAttribute("data-session-id", "sess-solo");
+      });
+    });
+
+    it("browser back after opening via a session id closes the drawer", async () => {
+      const user = userEvent.setup();
+      respondWith([logEntry({ request_id: "req-solo", session_id: "sess-solo", session_total_count: 1 })]);
+      renderWithProviders(<RequestLogsPanel {...defaultProps} />);
+
+      await waitFor(() => expect(row("req-solo")).not.toBeNull());
+      await user.click(within(row("req-solo") as HTMLElement).getByText("sess-solo"));
+      await waitFor(() => expect(drawer()).toHaveTextContent("open"));
+
+      window.history.back();
+
+      await waitFor(() => expect(drawer()).toHaveTextContent("closed"));
+      expect(new URLSearchParams(window.location.search).get("session_id")).toBeNull();
     });
 
     it("opens a deep-linked multi-call session log in session mode", async () => {

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import moment from "moment";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { renderWithProviders, testQueryClient } from "../../../tests/test-utils";
 import type { LogEntry } from "./columns";
@@ -22,10 +22,56 @@ vi.mock("@/components/key_team_helpers/filter_helpers", () => ({
 }));
 
 vi.mock("./LogDetailsDrawer", () => ({
-  LogDetailsDrawer: function LogDetailsDrawerMock({ open }: { open: boolean }) {
-    return <div data-testid="log-details-drawer">{open ? "open" : "closed"}</div>;
+  LogDetailsDrawer: function LogDetailsDrawerMock({
+    open,
+    logEntry,
+    sessionId,
+    onClose,
+  }: {
+    open: boolean;
+    logEntry?: { request_id: string } | null;
+    sessionId?: string | null;
+    onClose: () => void;
+  }) {
+    return (
+      <div data-testid="log-details-drawer" data-log-id={logEntry?.request_id ?? ""} data-session-id={sessionId ?? ""}>
+        {open ? "open" : "closed"}
+        <button type="button" onClick={onClose}>
+          close-drawer
+        </button>
+      </div>
+    );
   },
 }));
+
+vi.mock("next/navigation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("next/navigation")>();
+  const { useSyncExternalStore } = await import("react");
+  return {
+    ...actual,
+    useSearchParams: () => {
+      const search = useSyncExternalStore(
+        (onChange: () => void) => {
+          window.addEventListener("test-locationchange", onChange);
+          return () => window.removeEventListener("test-locationchange", onChange);
+        },
+        () => window.location.search,
+      );
+      return new URLSearchParams(search);
+    },
+  };
+});
+
+const originalPushState = window.history.pushState.bind(window.history);
+beforeAll(() => {
+  window.history.pushState = (data, unused, url) => {
+    originalPushState(data, unused, url);
+    window.dispatchEvent(new Event("test-locationchange"));
+  };
+});
+afterAll(() => {
+  window.history.pushState = originalPushState;
+});
 
 import { uiSpendLogsCall } from "../networking";
 
@@ -73,6 +119,7 @@ describe("RequestLogsPanel", () => {
     vi.clearAllMocks();
     sessionStorage.clear();
     testQueryClient.clear();
+    window.history.replaceState(null, "", "/logs/");
     respondWith([]);
   });
 
@@ -181,6 +228,87 @@ describe("RequestLogsPanel", () => {
           .utc(call.end_date, "YYYY-MM-DD HH:mm:ss")
           .diff(moment.utc(call.start_date, "YYYY-MM-DD HH:mm:ss"), "seconds");
         expect(diff).toBeGreaterThanOrEqual(24 * 60 * 60);
+      });
+    });
+  });
+
+  describe("shareable log links (?log_id=)", () => {
+    const drawer = () => screen.getByTestId("log-details-drawer");
+
+    it("clicking a row writes ?log_id=<request_id> to the URL and opens the drawer", async () => {
+      const user = userEvent.setup();
+      respondWith([logEntry({ request_id: "req-1" })]);
+      renderWithProviders(<RequestLogsPanel {...defaultProps} />);
+
+      await waitFor(() => expect(row("req-1")).not.toBeNull());
+      await user.click(row("req-1") as HTMLElement);
+
+      expect(new URLSearchParams(window.location.search).get("log_id")).toBe("req-1");
+      await waitFor(() => {
+        expect(drawer()).toHaveTextContent("open");
+        expect(drawer()).toHaveAttribute("data-log-id", "req-1");
+      });
+    });
+
+    it("opens the drawer on load when ?log_id= matches a log in the loaded page", async () => {
+      window.history.replaceState(null, "", "/logs/?log_id=req-2");
+      respondWith([logEntry({ request_id: "req-1" }), logEntry({ request_id: "req-2" })]);
+      renderWithProviders(<RequestLogsPanel {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(drawer()).toHaveTextContent("open");
+        expect(drawer()).toHaveAttribute("data-log-id", "req-2");
+      });
+    });
+
+    it("fetches the log by request_id and opens the drawer when it is not in the loaded page", async () => {
+      window.history.replaceState(null, "", "/logs/?log_id=req-old");
+      vi.mocked(uiSpendLogsCall).mockImplementation(async ({ params }) =>
+        params?.request_id === "req-old"
+          ? { data: [logEntry({ request_id: "req-old" })], total: 1, page: 1, page_size: 1, total_pages: 1 }
+          : { data: [], total: 0, page: 1, page_size: 50, total_pages: 0 },
+      );
+      renderWithProviders(<RequestLogsPanel {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(drawer()).toHaveTextContent("open");
+        expect(drawer()).toHaveAttribute("data-log-id", "req-old");
+      });
+
+      const byIdCall = vi
+        .mocked(uiSpendLogsCall)
+        .mock.calls.find(([options]) => options.params?.request_id === "req-old")?.[0];
+      if (!byIdCall) throw new Error("expected a by-id uiSpendLogsCall");
+      expect(byIdCall.page).toBe(1);
+      expect(byIdCall.page_size).toBe(1);
+    });
+
+    it("closing the drawer removes ?log_id= from the URL and closes the drawer", async () => {
+      const user = userEvent.setup();
+      respondWith([logEntry({ request_id: "req-1" })]);
+      renderWithProviders(<RequestLogsPanel {...defaultProps} />);
+
+      await waitFor(() => expect(row("req-1")).not.toBeNull());
+      await user.click(row("req-1") as HTMLElement);
+      await waitFor(() => expect(drawer()).toHaveTextContent("open"));
+
+      await user.click(screen.getByRole("button", { name: "close-drawer" }));
+
+      expect(new URLSearchParams(window.location.search).get("log_id")).toBeNull();
+      await waitFor(() => expect(drawer()).toHaveTextContent("closed"));
+    });
+
+    it("opens a deep-linked multi-call session log in session mode", async () => {
+      window.history.replaceState(null, "", "/logs/?log_id=req-llm");
+      respondWith([
+        logEntry({ request_id: "req-llm", call_type: "acompletion", session_id: "sess-1", session_total_count: 3 }),
+      ]);
+      renderWithProviders(<RequestLogsPanel {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(drawer()).toHaveTextContent("open");
+        expect(drawer()).toHaveAttribute("data-log-id", "req-llm");
+        expect(drawer()).toHaveAttribute("data-session-id", "sess-1");
       });
     });
   });

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
@@ -54,9 +54,15 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
 
   const [selectedKeyIdInfoView, setSelectedKeyIdInfoView] = useState<string | null>(null);
   const [selectedLog, setSelectedLog] = useState<LogEntry | null>(null);
-  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
 
-  const { logId: urlLogId, openLog, close: closeUrlLog } = useLogDetailRouting();
+  const {
+    logId: urlLogId,
+    sessionId: urlSessionId,
+    openLog,
+    openSession,
+    selectLog,
+    close: closeUrlLog,
+  } = useLogDetailRouting();
 
   const [isLiveTail, setIsLiveTail] = useState<boolean>(() => {
     const storedValue = sessionStorage.getItem("isLiveTail");
@@ -131,20 +137,18 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
   const { data: urlLog } = useQuery(urlLogQueryOptions);
 
   const displayLog = useMemo<LogEntry | null>(() => {
-    if (urlLogId !== null) {
-      if (selectedLog?.request_id === urlLogId) return selectedLog;
-      return filteredLogs.data.find((log) => log.request_id === urlLogId) ?? urlLog ?? null;
-    }
-    return selectedSessionId !== null ? selectedLog : null;
-  }, [urlLogId, selectedLog, filteredLogs.data, urlLog, selectedSessionId]);
+    if (urlLogId === null) return null;
+    if (selectedLog?.request_id === urlLogId) return selectedLog;
+    return filteredLogs.data.find((log) => log.request_id === urlLogId) ?? urlLog ?? null;
+  }, [urlLogId, selectedLog, filteredLogs.data, urlLog]);
 
   const displaySessionId = useMemo<string | null>(() => {
-    if (selectedSessionId !== null) return selectedSessionId;
+    if (urlSessionId !== null) return urlSessionId;
     if (displayLog?.session_id !== undefined && (displayLog.session_total_count || 1) > 1) {
       return displayLog.session_id;
     }
     return null;
-  }, [selectedSessionId, displayLog]);
+  }, [urlSessionId, displayLog]);
 
   const isDrawerOpen = displayLog !== null || displaySessionId !== null;
 
@@ -230,7 +234,6 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
 
   const handleRowClick = useCallback(
     (log: LogEntry) => {
-      setSelectedSessionId(null);
       setSelectedLog(log);
       openLog(log.request_id);
     },
@@ -241,25 +244,19 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
     (sessionId: string) => {
       if (!sessionId) return;
       const log = rows.find((candidate) => candidate.session_id === sessionId) ?? null;
-      setSelectedSessionId(sessionId);
       setSelectedLog(log);
-      if (log) openLog(log.request_id);
+      openSession(sessionId, log?.request_id ?? null);
     },
-    [rows, openLog],
+    [rows, openSession],
   );
 
   const handleSelectLog = useCallback(
     (log: LogEntry) => {
       setSelectedLog(log);
-      openLog(log.request_id);
+      selectLog(log.request_id);
     },
-    [openLog],
+    [selectLog],
   );
-
-  const handleDrawerClose = useCallback(() => {
-    setSelectedSessionId(null);
-    closeUrlLog();
-  }, [closeUrlLog]);
 
   const handleKeyHashClick = useCallback((keyHash: string) => {
     setSelectedKeyIdInfoView(keyHash);
@@ -324,7 +321,7 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
 
       <LogDetailsDrawer
         open={isDrawerOpen}
-        onClose={handleDrawerClose}
+        onClose={closeUrlLog}
         logEntry={displayLog}
         sessionId={displaySessionId}
         accessToken={accessToken}

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
@@ -8,7 +8,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { AutoRouterModelGroupsProvider } from "@/components/shared/table_cells";
 import { internalUserRoles } from "../../utils/roles";
 import type { KeyResponse } from "../key_team_helpers/key_list";
-import { keyInfoV1Call } from "../networking";
+import { keyInfoV1Call, uiSpendLogsCall } from "../networking";
 import KeyInfoView from "../templates/key_info_view";
 import type { LogEntry } from "./columns";
 import { AGENT_CALL_TYPES, MCP_CALL_TYPES } from "./constants";
@@ -17,8 +17,10 @@ import {
   formatLogsWindow,
   getLogsWindowEndBound,
   LOG_FILTER_IDS,
+  type PaginatedResponse,
   useLogFilterLogic,
 } from "./log_filter_logic";
+import { useLogDetailRouting } from "./logDetailRouting";
 import { LogDetailsDrawer } from "./LogDetailsDrawer";
 import { LiveTailBanner, LogsTableToolbar } from "./LogsTableToolbar";
 import { RequestLogsTable } from "./RequestLogsTable";
@@ -52,8 +54,9 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
 
   const [selectedKeyIdInfoView, setSelectedKeyIdInfoView] = useState<string | null>(null);
   const [selectedLog, setSelectedLog] = useState<LogEntry | null>(null);
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+
+  const { logId: urlLogId, openLog, close: closeUrlLog } = useLogDetailRouting();
 
   const [isLiveTail, setIsLiveTail] = useState<boolean>(() => {
     const storedValue = sessionStorage.getItem("isLiveTail");
@@ -105,6 +108,45 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
   };
 
   const { data: selectedKeyInfo } = useQuery(keyInfoQueryOptions);
+
+  const urlLogQueryOptions: UseQueryOptions<LogEntry | null> = {
+    queryKey: ["logs", "byId", urlLogId, accessToken],
+    queryFn: async () => {
+      if (urlLogId === null) return null;
+      const window = formatLogsWindow(startTime, endTime, isCustomDate);
+      const response: PaginatedResponse = await uiSpendLogsCall({
+        accessToken,
+        start_date: window.start_date,
+        end_date: window.end_date,
+        page: 1,
+        page_size: 1,
+        params: { request_id: urlLogId },
+      });
+      return response.data.find((log) => log.request_id === urlLogId) ?? null;
+    },
+    enabled: urlLogId !== null && selectedLog?.request_id !== urlLogId,
+    staleTime: Infinity,
+  };
+
+  const { data: urlLog } = useQuery(urlLogQueryOptions);
+
+  const displayLog = useMemo<LogEntry | null>(() => {
+    if (urlLogId !== null) {
+      if (selectedLog?.request_id === urlLogId) return selectedLog;
+      return filteredLogs.data.find((log) => log.request_id === urlLogId) ?? urlLog ?? null;
+    }
+    return selectedSessionId !== null ? selectedLog : null;
+  }, [urlLogId, selectedLog, filteredLogs.data, urlLog, selectedSessionId]);
+
+  const displaySessionId = useMemo<string | null>(() => {
+    if (selectedSessionId !== null) return selectedSessionId;
+    if (displayLog?.session_id !== undefined && (displayLog.session_total_count || 1) > 1) {
+      return displayLog.session_id;
+    }
+    return null;
+  }, [selectedSessionId, displayLog]);
+
+  const isDrawerOpen = displayLog !== null || displaySessionId !== null;
 
   const rows = useMemo<LogEntry[]>(() => {
     const searchedLogs = filteredLogs.data;
@@ -186,12 +228,14 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
     resetToFirstPage();
   }, [resetToFirstPage]);
 
-  const handleRowClick = useCallback((log: LogEntry) => {
-    const isMultiCallSession = log.session_id !== undefined && (log.session_total_count || 1) > 1;
-    setSelectedSessionId(isMultiCallSession ? log.session_id ?? null : null);
-    setSelectedLog(log);
-    setIsDrawerOpen(true);
-  }, []);
+  const handleRowClick = useCallback(
+    (log: LogEntry) => {
+      setSelectedSessionId(null);
+      setSelectedLog(log);
+      openLog(log.request_id);
+    },
+    [openLog],
+  );
 
   const handleSessionClick = useCallback(
     (sessionId: string) => {
@@ -199,10 +243,23 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
       const log = rows.find((candidate) => candidate.session_id === sessionId) ?? null;
       setSelectedSessionId(sessionId);
       setSelectedLog(log);
-      setIsDrawerOpen(true);
+      if (log) openLog(log.request_id);
     },
-    [rows],
+    [rows, openLog],
   );
+
+  const handleSelectLog = useCallback(
+    (log: LogEntry) => {
+      setSelectedLog(log);
+      openLog(log.request_id);
+    },
+    [openLog],
+  );
+
+  const handleDrawerClose = useCallback(() => {
+    setSelectedSessionId(null);
+    closeUrlLog();
+  }, [closeUrlLog]);
 
   const handleKeyHashClick = useCallback((keyHash: string) => {
     setSelectedKeyIdInfoView(keyHash);
@@ -267,15 +324,12 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
 
       <LogDetailsDrawer
         open={isDrawerOpen}
-        onClose={() => {
-          setIsDrawerOpen(false);
-          setSelectedSessionId(null);
-        }}
-        logEntry={selectedLog}
-        sessionId={selectedSessionId}
+        onClose={handleDrawerClose}
+        logEntry={displayLog}
+        sessionId={displaySessionId}
         accessToken={accessToken}
         allLogs={rows}
-        onSelectLog={setSelectedLog}
+        onSelectLog={handleSelectLog}
         startTime={moment(startTime).utc().format("YYYY-MM-DD HH:mm:ss")}
       />
     </AutoRouterModelGroupsProvider>

--- a/ui/litellm-dashboard/src/components/view_logs/logDetailRouting.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/logDetailRouting.ts
@@ -1,0 +1,34 @@
+import { useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+import { navigateWithParams } from "@/app/(dashboard)/navigateWithParams";
+
+export const LOG_ID_QUERY_PARAM = "log_id";
+
+export interface LogDetailRouting {
+  logId: string | null;
+  openLog: (requestId: string) => void;
+  close: () => void;
+}
+
+export function useLogDetailRouting(): LogDetailRouting {
+  const searchParams = useSearchParams();
+
+  const openLog = useCallback((requestId: string) => {
+    navigateWithParams((params) => {
+      params.set(LOG_ID_QUERY_PARAM, requestId);
+    });
+  }, []);
+
+  const close = useCallback(() => {
+    navigateWithParams((params) => {
+      params.delete(LOG_ID_QUERY_PARAM);
+    });
+  }, []);
+
+  return {
+    logId: searchParams?.get(LOG_ID_QUERY_PARAM) ?? null,
+    openLog,
+    close,
+  };
+}

--- a/ui/litellm-dashboard/src/components/view_logs/logDetailRouting.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/logDetailRouting.ts
@@ -4,10 +4,14 @@ import { useCallback } from "react";
 import { navigateWithParams } from "@/app/(dashboard)/navigateWithParams";
 
 export const LOG_ID_QUERY_PARAM = "log_id";
+export const SESSION_ID_QUERY_PARAM = "session_id";
 
 export interface LogDetailRouting {
   logId: string | null;
+  sessionId: string | null;
   openLog: (requestId: string) => void;
+  openSession: (sessionId: string, requestId: string | null) => void;
+  selectLog: (requestId: string) => void;
   close: () => void;
 }
 
@@ -20,15 +24,36 @@ export function useLogDetailRouting(): LogDetailRouting {
     });
   }, []);
 
+  const openSession = useCallback((sessionId: string, requestId: string | null) => {
+    navigateWithParams((params) => {
+      params.set(SESSION_ID_QUERY_PARAM, sessionId);
+      if (requestId === null) {
+        params.delete(LOG_ID_QUERY_PARAM);
+      } else {
+        params.set(LOG_ID_QUERY_PARAM, requestId);
+      }
+    });
+  }, []);
+
+  const selectLog = useCallback((requestId: string) => {
+    navigateWithParams((params) => {
+      params.set(LOG_ID_QUERY_PARAM, requestId);
+    }, "replace");
+  }, []);
+
   const close = useCallback(() => {
     navigateWithParams((params) => {
       params.delete(LOG_ID_QUERY_PARAM);
+      params.delete(SESSION_ID_QUERY_PARAM);
     });
   }, []);
 
   return {
     logId: searchParams?.get(LOG_ID_QUERY_PARAM) ?? null,
+    sessionId: searchParams?.get(SESSION_ID_QUERY_PARAM) ?? null,
     openLog,
+    openSession,
+    selectLog,
     close,
   };
 }

--- a/ui/litellm-dashboard/src/components/view_logs/logDetailRouting.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/logDetailRouting.ts
@@ -21,6 +21,7 @@ export function useLogDetailRouting(): LogDetailRouting {
   const openLog = useCallback((requestId: string) => {
     navigateWithParams((params) => {
       params.set(LOG_ID_QUERY_PARAM, requestId);
+      params.delete(SESSION_ID_QUERY_PARAM);
     });
   }, []);
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Logs cannot be shared; the drawer is click-only local state
- A pasted request id link had no way to open its log

How it solves it:

- Row click writes `?log_id=<request_id>` to the URL
- Session click writes `?session_id=...`, so sessions are shareable too
- Loading `/ui/logs?log_id=...` opens the drawer for that log
- Logs outside the loaded page are fetched by request id
- Session endpoint now scopes non-admins to logs they may view

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verified live at commit e95fb2af97 against a worktree proxy with the built dashboard, using a real Groq completion (cost $0.00003675). Steps to reproduce, screenshots to follow:

1. Make a real call and note the returned id: `curl -s http://localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"model":"groq-gpt-oss-120b","messages":[{"role":"user","content":"Say the word: shareable"}]}'` (returned `chatcmpl-03ac1257-cad2-4fbe-be40-07107d0c0e4b`)
2. Open http://localhost:4000/ui/logs/?log_id=chatcmpl-03ac1257-cad2-4fbe-be40-07107d0c0e4b (substituting the id from step 1); the detail drawer opens directly on that log showing the model, Success status, tokens, and cost
3. Close the drawer (X or Escape); `log_id` disappears from the URL
4. Click any row in the table; the URL updates to `?log_id=<that row's request id>` and can be copied and shared
5. Press the browser back button; the drawer closes. Press forward; it reopens

The id lookup ignores the 24h date window (the backend drops the window for request id lookups since LIT-3981), so a shared link keeps working after the log ages out of the default view

## Type

🆕 New Feature

## Changes

New `useLogDetailRouting` hook mirrors the models page `?model=` pattern (`useSearchParams` for reads, `navigateWithParams` for writes) with `log_id` and `session_id` params. `RequestLogsPanel` now derives the drawer's open state and displayed log entirely from the URL instead of separate `isDrawerOpen`/`selectedSessionId` booleans, which removes the two-sources-of-truth class of sync bugs and makes back/forward work for both log and session opens. When the deep-linked log is not among the loaded rows, a one-row `/spend/logs/ui?request_id=` query fetches it. Deep links to a multi-call session's log restore the session drawer, derived from the log itself

History granularity follows the standard overlay pattern: opening and closing the drawer push a history entry, while switching logs inside the open drawer (J/K keys, sidebar clicks) replaces the entry, so back always closes the drawer in one step instead of replaying every viewed log. `navigateWithParams` gained an optional `"replace"` mode for this. A row click clears any lingering `session_id` param so the drawer shows the clicked log rather than a stale session

Because session ids become pasteable input with this PR, `/spend/logs/session/ui` now applies the same non-admin scoping as `/spend/logs/ui`: callers receive only their own logs plus logs of teams where they hold the spend-logs permission (the gap predates this PR; the endpoint previously returned any session's rows to any authenticated user). Admin views are unchanged. Verified live: an unrelated internal user requesting an admin session's id gets `total: 0` while the admin still sees the full session

Tests cover the behaviors end to end at the panel level: row click writes the param, deep link opens a loaded log, deep link fetches an out-of-page log by id (asserting the one-row query shape), close removes the params and closes the drawer, session click writes both params, browser back after a session open closes the drawer, in-drawer switching replaces rather than pushes history, and a multi-call session deep link restores session mode. The `next/navigation` mock syncs `useSearchParams` with `history.pushState`/`replaceState` and `popstate` via `useSyncExternalStore`, matching the app router behavior these flows depend on

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
