### PR TITLE
fix(proxy): accept dot-prefixed segments in git-subdir plugin paths

### DIFF
--- a/litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py
+++ b/litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py
@@ -126,10 +126,12 @@ async def get_marketplace():
 
 
 # Allowlist for git-subdir paths: one or more segments separated by '/'.
-# Each segment must start with an alphanumeric character and contain only
-# alphanumeric characters, dots, hyphens, and underscores.
-# This implicitly blocks '..', leading '/', backslashes, and percent-encoded sequences.
-_VALID_GIT_SUBDIR_PATH_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*(/[a-zA-Z0-9][a-zA-Z0-9._-]*)*$")
+# Each segment may start with a single leading dot (so conventional dirs like
+# '.claude/' and '.github/' are accepted), then requires an alphanumeric character
+# and contains only alphanumeric characters, dots, hyphens, and underscores.
+# Requiring an alphanumeric after the optional dot keeps '.' and '..' segments
+# unmatchable, so this still blocks '..', leading '/', backslashes, and percent-encoded sequences.
+_VALID_GIT_SUBDIR_PATH_RE = re.compile(r"^\.?[a-zA-Z0-9][a-zA-Z0-9._-]*(/\.?[a-zA-Z0-9][a-zA-Z0-9._-]*)*$")
 
 
 def _validate_plugin_source(source: Dict[str, Any]) -> None:

--- a/tests/test_litellm/proxy/anthropic_endpoints/test_claude_code_marketplace.py
+++ b/tests/test_litellm/proxy/anthropic_endpoints/test_claude_code_marketplace.py
@@ -107,6 +107,32 @@ async def test_register_plugin_git_subdir_update():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        ".claude/skills/my-skill",
+        ".github/plugins/my-plugin",
+        "plugins/.hidden/my-plugin",
+    ],
+)
+async def test_register_plugin_git_subdir_dot_prefixed_path(path):
+    """git-subdir paths with dot-prefixed segments (e.g. .claude/) register successfully."""
+    request = RegisterPluginRequest(
+        name="dot-prefixed-plugin",
+        source={
+            "source": "git-subdir",
+            "url": "https://github.com/org/monorepo.git",
+            "path": path,
+        },
+    )
+
+    response = await register_plugin(request=request, user_api_key_dict=_USER)
+
+    assert response["status"] == "success"
+    assert response["plugin"]["source"]["path"] == path
+
+
+@pytest.mark.asyncio
 async def test_register_plugin_git_subdir_missing_url():
     """git-subdir without url field raises HTTP 400."""
     request = RegisterPluginRequest(
@@ -181,6 +207,10 @@ async def test_register_plugin_git_subdir_path_traversal():
         "plugins/%2e%2e/secrets",  # percent-encoded traversal
         "plugins/%2E%2E/secrets",  # uppercase percent-encoded traversal
         "plugins/%252e%252e/secrets",  # double-encoded traversal
+        ".claude/../secrets",  # dot-prefixed segment must not open a traversal bypass
+        ".",  # bare current-dir segment
+        "..",  # bare parent-dir segment
+        "plugins/./my-plugin",  # embedded current-dir segment
     ]:
         request = RegisterPluginRequest(
             name="bad-plugin",


### PR DESCRIPTION
## TLDR

Problem this solves:

- `POST /claude-code/plugins` returns a 400 for any git-subdir path whose segment starts with a dot (e.g. `.claude/skills/my-skill`), even though the error message advertises dots as valid characters
- Conventional directories like `.claude/` and `.github/` are a reasonable place to host plugins/skills and callers expect them to work

How it solves it:

- Relaxes `_VALID_GIT_SUBDIR_PATH_RE` so each segment may begin with a single leading dot, then still requires an alphanumeric character
- Keeps bare `.` and `..` segments unmatchable, so path traversal, leading `/`, backslashes, and percent-encoded sequences remain blocked

## Relevant issues

Fixes #34778

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

I could not stand up a live proxy in my environment (the plugin-registration endpoint requires a provisioned Postgres/prisma DB and local bootstrap of the prisma engine failed), so the proof below exercises the shipped regex directly against the accept/reject matrix rather than curling a running proxy. A reviewer with a live proxy can reproduce the end-user behavior with the curls in the QA runbook.

```
$ uv run python - <<'PY'
from litellm.proxy.anthropic_endpoints.claude_code_endpoints.claude_code_marketplace import _VALID_GIT_SUBDIR_PATH_RE as R
accept = [".claude/skills/my-skill", ".github/plugins/my-plugin", "plugins/.hidden/my-plugin", "plugins/my-plugin"]
reject = ["../../etc/passwd", "/absolute/path", ".claude/../secrets", ".", "..", "plugins/./my-plugin", "..foo", ""]
for p in accept: print(f"accept {p!r:40} -> match={bool(R.match(p))}")
for p in reject: print(f"reject {p!r:40} -> match={bool(R.match(p))}")
PY
accept '.claude/skills/my-skill'                -> match=True
accept '.github/plugins/my-plugin'              -> match=True
accept 'plugins/.hidden/my-plugin'              -> match=True
accept 'plugins/my-plugin'                      -> match=True
reject '../../etc/passwd'                       -> match=False
reject '/absolute/path'                         -> match=False
reject '.claude/../secrets'                     -> match=False
reject '.'                                      -> match=False
reject '..'                                     -> match=False
reject 'plugins/./my-plugin'                    -> match=False
reject '..foo'                                  -> match=False
reject ''                                       -> match=False
```

The dot-prefixed paths now match while traversal, absolute, and bare `.`/`..` inputs stay rejected.

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py`: the segment pattern changes from `[a-zA-Z0-9][a-zA-Z0-9._-]*` to `\.?[a-zA-Z0-9][a-zA-Z0-9._-]*`, applied to both the first segment and each subsequent `/`-separated segment. Requiring an alphanumeric after the optional dot is what keeps `.` and `..` unmatchable

Added a parametrized regression test for dot-prefixed paths (`.claude/skills/...`, `.github/...`, `plugins/.hidden/...`) and extended the traversal test to cover `.claude/../secrets`, bare `.`, bare `..`, and an embedded `./` segment so a leading dot can never open a traversal bypass

## QA runbook

Run the proxy locally, then register a plugin whose path starts with a dot and confirm a traversal attempt is still rejected

```
# dot-prefixed path is accepted
curl -s -X POST http://localhost:4000/claude-code/plugins \
  -H "x-litellm-api-key: $LITELLM_MASTER_KEY" -H "content-type: application/json" \
  -d '{"name":"my-skill","source":{"source":"git-subdir","url":"https://github.com/org/repo.git","path":".claude/skills/my-skill"}}'

# traversal via a dot-prefixed segment is still rejected with a 400
curl -s -X POST http://localhost:4000/claude-code/plugins \
  -H "x-litellm-api-key: $LITELLM_MASTER_KEY" -H "content-type: application/json" \
  -d '{"name":"bad","source":{"source":"git-subdir","url":"https://github.com/org/repo.git","path":".claude/../secrets"}}'
```

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
