### PR TITLE
fix(bedrock): stop tool_choice leaking on toolless converse requests

### DIFF
--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1290,7 +1290,12 @@ class AmazonConverseConfig(BaseConfig):
 
         # Handle parallel_tool_calls configuration
         parallel_tool_use_config = additional_request_params.pop("_parallel_tool_use_config", None)
-        if parallel_tool_use_config is not None and bedrock_converse_supports_parallel_tool_use_config(model):
+        request_has_tools: bool = bool(cast("dict[str, object]", inference_params).get("tools"))
+        if (
+            parallel_tool_use_config is not None
+            and request_has_tools
+            and bedrock_converse_supports_parallel_tool_use_config(model)
+        ):
             additional_request_params = self._merge_parallel_tool_use_config(
                 additional_request_params, parallel_tool_use_config
             )
@@ -1573,9 +1578,9 @@ class AmazonConverseConfig(BaseConfig):
                     bedrock_tools.append(ToolBlock(cachePoint=cache_point))
                     break
 
+        tool_choice_values: Optional[ToolChoiceValuesBlock] = inference_params.pop("tool_choice", None)
         bedrock_tool_config: Optional[ToolConfigBlock] = None
         if len(bedrock_tools) > 0:
-            tool_choice_values: ToolChoiceValuesBlock = inference_params.pop("tool_choice", None)
             bedrock_tool_config = ToolConfigBlock(
                 tools=bedrock_tools,
             )

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1578,7 +1578,7 @@ class AmazonConverseConfig(BaseConfig):
                     bedrock_tools.append(ToolBlock(cachePoint=cache_point))
                     break
 
-        tool_choice_values: Optional[ToolChoiceValuesBlock] = inference_params.pop("tool_choice", None)
+        tool_choice_values: ToolChoiceValuesBlock | None = inference_params.pop("tool_choice", None)
         bedrock_tool_config: Optional[ToolConfigBlock] = None
         if len(bedrock_tools) > 0:
             bedrock_tool_config = ToolConfigBlock(

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -1290,7 +1290,7 @@ class AmazonConverseConfig(BaseConfig):
 
         # Handle parallel_tool_calls configuration
         parallel_tool_use_config = additional_request_params.pop("_parallel_tool_use_config", None)
-        request_has_tools: bool = bool(cast("dict[str, object]", inference_params).get("tools"))
+        request_has_tools: bool = bool(inference_params.get("tools"))
         if (
             parallel_tool_use_config is not None
             and request_has_tools

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -620,7 +620,7 @@ def test_parallel_tool_calls_config_kept_for_sonnet_5():
         config = AmazonConverseConfig()
         optional_params = config.map_openai_params(
             model="anthropic.claude-sonnet-5",
-            non_default_params={"parallel_tool_calls": False},
+            non_default_params={"parallel_tool_calls": False, "tools": _TOOL_PARAM},
             optional_params={},
             drop_params=False,
         )
@@ -656,7 +656,7 @@ def test_parallel_tool_calls_config_dropped_for_ttl_only_model(
     config = AmazonConverseConfig()
     optional_params = config.map_openai_params(
         model=model,
-        non_default_params={"parallel_tool_calls": False},
+        non_default_params={"parallel_tool_calls": False, "tools": _TOOL_PARAM},
         optional_params={},
         drop_params=False,
     )
@@ -669,6 +669,146 @@ def test_parallel_tool_calls_config_dropped_for_ttl_only_model(
     )
 
     assert "tool_choice" not in data.get("additionalModelRequestFields", {})
+
+
+def test_toolless_tool_choice_does_not_leak_into_inference_config():
+    """Regression for #34420: tool_choice on a toolless request must not reach inferenceConfig.
+
+    Bedrock rejects a tool_choice that is not accompanied by a toolConfig, so a
+    plain chat completion that carries tool_choice (e.g. from an agent framework)
+    used to 400.
+    """
+    config = AmazonConverseConfig()
+    optional_params = config.map_openai_params(
+        model="anthropic.claude-sonnet-5",
+        non_default_params={"tool_choice": "auto"},
+        optional_params={},
+        drop_params=True,
+    )
+
+    data = config._transform_request_helper(
+        model="anthropic.claude-sonnet-5",
+        system_content_blocks=[],
+        optional_params=optional_params,
+        messages=None,
+    )
+
+    assert "tool_choice" not in data["inferenceConfig"]
+    assert "toolConfig" not in data
+
+
+def test_toolless_parallel_tool_calls_config_not_emitted():
+    """Regression for #34420: parallel_tool_calls on a toolless request must not emit a tool_choice block.
+
+    disable_parallel_tool_use is a tool_choice directive; emitting it with no
+    toolConfig (as agent frameworks trigger by defaulting parallel_tool_calls on
+    every turn) made Bedrock 400.
+    """
+    old_env = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    old_cost = litellm.model_cost
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    try:
+        config = AmazonConverseConfig()
+        optional_params = config.map_openai_params(
+            model="anthropic.claude-sonnet-5",
+            non_default_params={"parallel_tool_calls": False},
+            optional_params={},
+            drop_params=False,
+        )
+
+        data = config._transform_request_helper(
+            model="anthropic.claude-sonnet-5",
+            system_content_blocks=[],
+            optional_params=optional_params,
+            messages=None,
+        )
+
+        assert "tool_choice" not in data.get("additionalModelRequestFields", {})
+        assert "toolConfig" not in data
+    finally:
+        litellm.model_cost = old_cost
+        if old_env is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = old_env
+
+
+def test_empty_tools_list_parallel_tool_calls_config_not_emitted():
+    """Regression for #34420: an empty tools list must be treated as no tools.
+
+    An empty list produces no toolConfig, so the disable_parallel_tool_use block
+    would leak into additionalModelRequestFields with no tools to govern; the gate
+    must test tool presence by truthiness, not mere key membership.
+    """
+    old_env = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    old_cost = litellm.model_cost
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    try:
+        config = AmazonConverseConfig()
+        optional_params = config.map_openai_params(
+            model="anthropic.claude-sonnet-5",
+            non_default_params={"parallel_tool_calls": False, "tools": []},
+            optional_params={},
+            drop_params=False,
+        )
+
+        data = config._transform_request_helper(
+            model="anthropic.claude-sonnet-5",
+            system_content_blocks=[],
+            optional_params=optional_params,
+            messages=None,
+        )
+
+        assert "tool_choice" not in data.get("additionalModelRequestFields", {})
+        assert "toolConfig" not in data
+    finally:
+        litellm.model_cost = old_cost
+        if old_env is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = old_env
+
+
+def test_with_tools_parallel_and_tool_choice_both_emitted():
+    """With tools present, both toolConfig.toolChoice and the parallel-tool-use block are emitted."""
+    old_env = os.environ.get("LITELLM_LOCAL_MODEL_COST_MAP")
+    old_cost = litellm.model_cost
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    try:
+        config = AmazonConverseConfig()
+        optional_params = config.map_openai_params(
+            model="anthropic.claude-sonnet-5",
+            non_default_params={
+                "parallel_tool_calls": False,
+                "tool_choice": "auto",
+                "tools": _TOOL_PARAM,
+            },
+            optional_params={},
+            drop_params=False,
+        )
+
+        data = config._transform_request_helper(
+            model="anthropic.claude-sonnet-5",
+            system_content_blocks=[],
+            optional_params=optional_params,
+            messages=None,
+        )
+
+        assert data["toolConfig"]["toolChoice"] == {"auto": {}}
+        assert data["additionalModelRequestFields"]["tool_choice"] == {
+            "type": "auto",
+            "disable_parallel_tool_use": True,
+        }
+        assert "tool_choice" not in data["inferenceConfig"]
+    finally:
+        litellm.model_cost = old_cost
+        if old_env is None:
+            os.environ.pop("LITELLM_LOCAL_MODEL_COST_MAP", None)
+        else:
+            os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = old_env
 
 
 def test_transform_response_with_computer_use_tool():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Converse 400s on toolless requests
- parallel_tool_calls or tool_choice with no tools breaks chat
- Agent frameworks default parallel_tool_calls every turn

How it solves it:

- Pop tool_choice for every request, not just tool ones
- Attach it to toolConfig only when tools exist
- Gate the parallel-tool-use block on tool presence

## Relevant issues

Fixes #34420

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Bedrock Converse rejects a tool_choice directive that arrives without a toolConfig, so a toolless request that carries either tool_choice or parallel_tool_calls used to 400. The transform below drives the exact code paths a live `litellm.completion` call would hit; I did not have Bedrock credentials wired up in this environment to capture a live 400, so a maintainer with Bedrock access can confirm the end to end behavior with the curl in the runbook

Before, on buggy baseline `daf22ec871`

```
[1] toolless request with tool_choice='auto'
    inferenceConfig     = {'tool_choice': {'auto': {}}}
    toolConfig present  = False
[2] toolless request with parallel_tool_calls=False
    additionalModelRequestFields = {'tool_choice': {'type': 'auto', 'disable_parallel_tool_use': True}}
    toolConfig present           = False
```

Both cases send a tool_choice with no toolConfig, which is what Bedrock 400s on

After, with the fix at `f8dcfd2fbf`

```
[1] toolless request with tool_choice='auto'
    inferenceConfig     = {}
    toolConfig present  = False
[2] toolless request with parallel_tool_calls=False
    additionalModelRequestFields = None
    toolConfig present           = False
```

No stray tool_choice in inferenceConfig and no leaked parallel-tool-use block, so nothing invalid reaches Bedrock

The repro that produced both blocks

```python
import os
os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
import litellm
litellm.model_cost = litellm.get_model_cost_map(url="")
from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig

cfg = AmazonConverseConfig()
M = "anthropic.claude-sonnet-5"

def transform(non_default):
    op = cfg.map_openai_params(model=M, non_default_params=non_default, optional_params={}, drop_params=True)
    return cfg._transform_request_helper(model=M, system_content_blocks=[], optional_params=op, messages=None)

print("[1] toolless request with tool_choice='auto'")
d = transform({"tool_choice": "auto"})
print("    inferenceConfig     =", d["inferenceConfig"])
print("    toolConfig present  =", "toolConfig" in d)

print("[2] toolless request with parallel_tool_calls=False")
d = transform({"parallel_tool_calls": False})
print("    additionalModelRequestFields =", d.get("additionalModelRequestFields"))
print("    toolConfig present           =", "toolConfig" in d)
```

For a maintainer with Bedrock access, the live check against a proxy on localhost:4000

```bash
curl -sS http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
    "messages": [{"role": "user", "content": "hi"}],
    "parallel_tool_calls": false
  }'
```

On the buggy baseline this returns a Bedrock 400 about tool_choice/toolConfig; with the fix it returns a normal 200 completion

## Type

🐛 Bug Fix

## Changes

`tool_choice` was popped from the working params only inside the `len(bedrock_tools) > 0` branch of `_transform_request_helper`, so a toolless request left it behind and it surfaced under `inferenceConfig`. It is now popped unconditionally and only copied onto `toolConfig` when tools are present

`parallel_tool_calls` maps to a `disable_parallel_tool_use` tool_choice block that `_prepare_request_params` emitted into `additionalModelRequestFields` gated only on model capability. That gate now also requires the request to actually carry tools, checked by truthiness so an empty tools list is treated as no tools

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
