### PR TITLE
fix(router): strip silent_model before generic Responses/Messages calls

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4475,6 +4475,11 @@ class Router:
             self._update_kwargs_with_deployment(deployment=deployment, kwargs=kwargs, function_name=function_name)
 
             data = deployment["litellm_params"].copy()
+            # `silent_model` is a router-level traffic-mirroring directive, not
+            # a provider parameter. It must not leak into the underlying API
+            # call (it breaks Responses / Anthropic Messages with
+            # "unexpected keyword argument 'silent_model'"). See #34890.
+            data.pop("silent_model", None)
             model_name = data["model"]
             self.total_calls[model_name] += 1
 

--- a/tests/test_litellm/test_router_silent_experiment.py
+++ b/tests/test_litellm/test_router_silent_experiment.py
@@ -281,3 +281,59 @@ def test_router_silent_experiment_completion():
         assert silent_call[1]["model"] == "openai/gpt-4"
         # Verify model_group is set to the silent model name for correct metric attribution
         assert silent_call[1]["metadata"]["model_group"] == "silent-model"
+
+
+async def test_silent_model_not_leaked_into_generic_api_call():
+    """
+    Regression test for #34890.
+
+    `aresponses` and `anthropic_messages` route through
+    `_ageneric_api_call_with_fallbacks_helper`, which spreads the deployment's
+    `litellm_params` into the call to the underlying provider function. The
+    router-level `silent_model` directive must be stripped there, otherwise the
+    primary Responses / Messages request fails with
+    "unexpected keyword argument 'silent_model'".
+    """
+    model_list = [
+        {
+            "model_name": "primary-model",
+            "litellm_params": {
+                "model": "openai/primary-model",
+                "api_key": "fake-key",
+                "silent_model": "silent-model",
+            },
+        },
+    ]
+    router = Router(model_list=model_list)
+
+    deployment = {
+        "model_name": "primary-model",
+        "litellm_params": {
+            "model": "openai/primary-model",
+            "api_key": "fake-key",
+            "silent_model": "silent-model",
+        },
+        "model_info": {"id": "test-deployment-id"},
+    }
+
+    captured = {}
+
+    async def fake_original_function(**kwargs):
+        captured.update(kwargs)
+        return litellm.ModelResponse(choices=[{"message": {"content": "ok"}}])
+
+    with patch.object(
+        router, "async_get_available_deployment", AsyncMock(return_value=deployment)
+    ), patch.object(
+        router, "async_routing_strategy_pre_call_checks", AsyncMock(return_value=None)
+    ), patch.object(
+        router, "_get_client", MagicMock(return_value=None)
+    ):
+        await router._ageneric_api_call_with_fallbacks_helper(
+            model="primary-model",
+            original_generic_function=fake_original_function,
+            input="Reply only OK",
+        )
+
+    # The router-level directive must not reach the provider call.
+    assert "silent_model" not in captured


### PR DESCRIPTION
## Summary

Fixes #34890

`aresponses` and `anthropic_messages` route through `_ageneric_api_call_with_fallbacks_helper`, which spreads the deployment's `litellm_params` into the underlying provider call. The router-level `silent_model` directive was **not** removed there, so any deployment configured with `silent_model` made the primary Responses / Anthropic Messages request fail with:

```
AsyncCompletions.create() got an unexpected keyword argument 'silent_model'
```

The Chat Completions path (`async_function_with_fallbacks` / `acompletion`) already pops `silent_model` before the call; this applies the same guard to the generic helper so Responses and Messages behave consistently.

## Fix

In `_ageneric_api_call_with_fallbacks_helper`, pop `silent_model` from the copied `litellm_params` before it is spread into the provider call:

```python
data = deployment["litellm_params"].copy()
data.pop("silent_model", None)
```

## Test

Added `test_silent_model_not_leaked_into_generic_api_call` to `tests/test_litellm/test_router_silent_experiment.py`, asserting `silent_model` never reaches the provider call.

```
$ pytest tests/test_litellm/test_router_silent_experiment.py -q
6 passed
```

Verified the test **fails** on the unfixed helper and **passes** with the fix.