### PR TITLE
feat(ui): make the Headroom compression card editable

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -220,11 +220,6 @@
       "count": 1
     }
   },
-  "src/app/(dashboard)/cost-optimization/_components/PromptCompressionTab.tsx": {
-    "no-restricted-imports": {
-      "count": 1
-    }
-  },
   "src/app/(dashboard)/cost-tracking/_components/add_margin_form.tsx": {
     "local/filename-pascal-case": {
       "count": 1

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx
@@ -28,7 +28,7 @@ const CostOptimizationView: React.FC<CostOptimizationViewProps> = ({ accessToken
     {
       key: "compression",
       label: "Prompt Compression",
-      children: <PromptCompressionTab accessToken={accessToken} />,
+      children: <PromptCompressionTab accessToken={accessToken} userRole={userRole} />,
     },
     {
       key: "autorouter",

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/PromptCompressionTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/PromptCompressionTab.test.tsx
@@ -1,0 +1,185 @@
+/* @vitest-environment jsdom */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetGuardrailsList = vi.fn();
+const mockCreateGuardrailCall = vi.fn();
+const mockUpdateGuardrailCall = vi.fn();
+const mockPush = vi.fn();
+
+vi.mock("@/components/networking", () => ({
+  serverRootPath: "/",
+  getGuardrailsList: (...args: unknown[]) => mockGetGuardrailsList(...args),
+  createGuardrailCall: (...args: unknown[]) => mockCreateGuardrailCall(...args),
+  updateGuardrailCall: (...args: unknown[]) => mockUpdateGuardrailCall(...args),
+}));
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: mockPush }) }));
+
+vi.mock("@/components/molecules/notifications_manager", () => ({
+  __esModule: true,
+  default: { success: vi.fn(), fromBackend: vi.fn() },
+}));
+
+import PromptCompressionTab from "./PromptCompressionTab";
+
+const compressionGuardrail = (overrides: Record<string, unknown> = {}) => ({
+  guardrail_id: "fee65a60",
+  guardrail_name: "headroom-compression",
+  litellm_params: { guardrail: "headroom", api_base: "https://headroom.example.com", default_on: true },
+  guardrail_definition_location: "db",
+  ...overrides,
+});
+
+describe("PromptCompressionTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetGuardrailsList.mockResolvedValue({ guardrails: [compressionGuardrail()] });
+  });
+
+  it("switches an always-on endpoint to opt-in without clobbering its other params", async () => {
+    mockUpdateGuardrailCall.mockResolvedValue({});
+    mockGetGuardrailsList.mockResolvedValueOnce({ guardrails: [compressionGuardrail()] }).mockResolvedValueOnce({
+      guardrails: [
+        compressionGuardrail({
+          litellm_params: { guardrail: "headroom", api_base: "https://headroom.example.com", default_on: false },
+        }),
+      ],
+    });
+
+    const user = userEvent.setup();
+    render(<PromptCompressionTab accessToken="sk-test" userRole="Admin" />);
+
+    await user.click(await screen.findByLabelText("Compression mode for headroom-compression"));
+    await user.click(await screen.findByRole("option", { name: "Opt-in" }));
+
+    await waitFor(() =>
+      expect(mockUpdateGuardrailCall).toHaveBeenCalledWith("sk-test", "fee65a60", {
+        litellm_params: { default_on: false },
+      }),
+    );
+    expect(await screen.findByText(/only runs when a request asks for it/)).toBeInTheDocument();
+  });
+
+  it("sends default_on true when switching back to always on", async () => {
+    mockUpdateGuardrailCall.mockResolvedValue({});
+    mockGetGuardrailsList.mockResolvedValue({
+      guardrails: [
+        compressionGuardrail({
+          litellm_params: { guardrail: "headroom", api_base: "https://headroom.example.com", default_on: false },
+        }),
+      ],
+    });
+
+    const user = userEvent.setup();
+    render(<PromptCompressionTab accessToken="sk-test" userRole="Admin" />);
+
+    await user.click(await screen.findByLabelText("Compression mode for headroom-compression"));
+    await user.click(await screen.findByRole("option", { name: "Always on" }));
+
+    await waitFor(() =>
+      expect(mockUpdateGuardrailCall).toHaveBeenCalledWith("sk-test", "fee65a60", {
+        litellm_params: { default_on: true },
+      }),
+    );
+  });
+
+  it("deep-links Edit settings to the guardrail's settings tab", async () => {
+    render(<PromptCompressionTab accessToken="sk-test" userRole="Admin" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: /Edit settings/ }));
+
+    expect(mockPush).toHaveBeenCalledWith("/ui/guardrails?guardrail=fee65a60&guardrail_tab=settings");
+  });
+
+  it("shows a read-only badge instead of edit controls for non-admins", async () => {
+    render(<PromptCompressionTab accessToken="sk-test" userRole="Internal User" />);
+
+    expect(await screen.findByText("Always on")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Compression mode for headroom-compression")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Edit settings/ })).not.toBeInTheDocument();
+  });
+
+  it("keeps a config-file guardrail read-only even for an admin", async () => {
+    mockGetGuardrailsList.mockResolvedValue({
+      guardrails: [compressionGuardrail({ guardrail_definition_location: "config" })],
+    });
+
+    render(<PromptCompressionTab accessToken="sk-test" userRole="Admin" />);
+
+    expect(await screen.findByText(/Defined in the proxy config file/)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Compression mode for headroom-compression")).not.toBeInTheDocument();
+  });
+
+  it("creates a guardrail from the empty state and refreshes the list", async () => {
+    mockGetGuardrailsList.mockResolvedValueOnce({ guardrails: [] }).mockResolvedValueOnce({
+      guardrails: [compressionGuardrail()],
+    });
+    mockCreateGuardrailCall.mockResolvedValue({});
+
+    render(<PromptCompressionTab accessToken="sk-test" userRole="Admin" />);
+
+    fireEvent.change(await screen.findByLabelText("Name"), { target: { value: "headroom-compression" } });
+    fireEvent.change(screen.getByLabelText("Headroom API base"), {
+      target: { value: "https://headroom.example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add guardrail" }));
+
+    await waitFor(() =>
+      expect(mockCreateGuardrailCall).toHaveBeenCalledWith("sk-test", {
+        guardrail_name: "headroom-compression",
+        litellm_params: {
+          guardrail: "headroom",
+          mode: "pre_call",
+          api_base: "https://headroom.example.com",
+          default_on: true,
+        },
+      }),
+    );
+    expect(await screen.findByText("headroom-compression")).toBeInTheDocument();
+  });
+
+  it("blocks submission and flags the empty fields instead of creating a blank guardrail", async () => {
+    mockGetGuardrailsList.mockResolvedValue({ guardrails: [] });
+
+    render(<PromptCompressionTab accessToken="sk-test" userRole="Admin" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Add guardrail" }));
+
+    expect(await screen.findByText("Name is required")).toBeInTheDocument();
+    expect(screen.getByText("API base is required")).toBeInTheDocument();
+    expect(mockCreateGuardrailCall).not.toHaveBeenCalled();
+  });
+
+  it("hides the add form behind an explicit action once an endpoint exists", async () => {
+    render(<PromptCompressionTab accessToken="sk-test" userRole="Admin" />);
+
+    expect(await screen.findByText("headroom-compression")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Headroom API base")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /Add another endpoint/ }));
+
+    expect(await screen.findByLabelText("Headroom API base")).toBeInTheDocument();
+  });
+
+  it("ignores guardrails from other providers", async () => {
+    mockGetGuardrailsList.mockResolvedValue({
+      guardrails: [
+        compressionGuardrail(),
+        {
+          guardrail_id: "other",
+          guardrail_name: "presidio-pii",
+          litellm_params: { guardrail: "presidio", default_on: true },
+          guardrail_definition_location: "db",
+        },
+      ],
+    });
+
+    render(<PromptCompressionTab accessToken="sk-test" userRole="Admin" />);
+
+    const list = await screen.findByRole("list");
+    expect(within(list).getAllByRole("listitem")).toHaveLength(1);
+    expect(screen.queryByText("presidio-pii")).not.toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/PromptCompressionTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/PromptCompressionTab.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockGetGuardrailsList = vi.fn();
 const mockCreateGuardrailCall = vi.fn();
 const mockUpdateGuardrailCall = vi.fn();
+const mockDeleteGuardrailCall = vi.fn();
 const mockPush = vi.fn();
 
 vi.mock("@/components/networking", () => ({
@@ -13,6 +14,7 @@ vi.mock("@/components/networking", () => ({
   getGuardrailsList: (...args: unknown[]) => mockGetGuardrailsList(...args),
   createGuardrailCall: (...args: unknown[]) => mockCreateGuardrailCall(...args),
   updateGuardrailCall: (...args: unknown[]) => mockUpdateGuardrailCall(...args),
+  deleteGuardrailCall: (...args: unknown[]) => mockDeleteGuardrailCall(...args),
 }));
 
 vi.mock("next/navigation", () => ({ useRouter: () => ({ push: mockPush }) }));
@@ -99,6 +101,56 @@ describe("PromptCompressionTab", () => {
     expect(await screen.findByText("Always on")).toBeInTheDocument();
     expect(screen.queryByLabelText("Compression mode for headroom-compression")).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Edit settings/ })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Delete headroom-compression")).not.toBeInTheDocument();
+  });
+
+  it("deletes an endpoint after the confirmation modal and drops it from the card", async () => {
+    mockDeleteGuardrailCall.mockResolvedValue({});
+    mockGetGuardrailsList
+      .mockResolvedValueOnce({ guardrails: [compressionGuardrail()] })
+      .mockResolvedValueOnce({ guardrails: [] });
+
+    render(<PromptCompressionTab accessToken="sk-test" userRole="Admin" />);
+
+    fireEvent.click(await screen.findByLabelText("Delete headroom-compression"));
+
+    const modal = within(await screen.findByRole("dialog"));
+    expect(modal.getByText(/Every request is compressed by this guardrail today/)).toBeInTheDocument();
+    expect(modal.getByText("https://headroom.example.com")).toBeInTheDocument();
+
+    fireEvent.click(modal.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(mockDeleteGuardrailCall).toHaveBeenCalledWith("sk-test", "fee65a60"));
+    expect(await screen.findByLabelText("Headroom API base")).toBeInTheDocument();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+
+  it("does not delete anything when the confirmation is cancelled", async () => {
+    render(<PromptCompressionTab accessToken="sk-test" userRole="Admin" />);
+
+    fireEvent.click(await screen.findByLabelText("Delete headroom-compression"));
+    const modal = within(await screen.findByRole("dialog"));
+    fireEvent.click(modal.getByRole("button", { name: "Cancel" }));
+
+    expect(mockDeleteGuardrailCall).not.toHaveBeenCalled();
+    expect(within(screen.getByRole("list")).getByText("headroom-compression")).toBeInTheDocument();
+  });
+
+  it("warns about failing opt-in callers instead of lost savings when deleting an opt-in endpoint", async () => {
+    mockGetGuardrailsList.mockResolvedValue({
+      guardrails: [
+        compressionGuardrail({
+          litellm_params: { guardrail: "headroom", api_base: "https://headroom.example.com", default_on: false },
+        }),
+      ],
+    });
+
+    render(<PromptCompressionTab accessToken="sk-test" userRole="Admin" />);
+
+    fireEvent.click(await screen.findByLabelText("Delete headroom-compression"));
+
+    const modal = within(await screen.findByRole("dialog"));
+    expect(modal.getByText(/Requests that ask for this guardrail by name will fail/)).toBeInTheDocument();
   });
 
   it("keeps a config-file guardrail read-only even for an admin", async () => {
@@ -110,6 +162,7 @@ describe("PromptCompressionTab", () => {
 
     expect(await screen.findByText(/Defined in the proxy config file/)).toBeInTheDocument();
     expect(screen.queryByLabelText("Compression mode for headroom-compression")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Delete headroom-compression")).not.toBeInTheDocument();
   });
 
   it("creates a guardrail from the empty state and refreshes the list", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/PromptCompressionTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/PromptCompressionTab.tsx
@@ -1,39 +1,139 @@
 "use client";
 
 import React, { useCallback, useEffect, useState } from "react";
-import { Button, Form, Input, Switch } from "antd";
+import { useRouter } from "next/navigation";
+import { Plus, Settings2 } from "lucide-react";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { createGuardrailCall, getGuardrailsList } from "@/components/networking";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { createGuardrailCall, getGuardrailsList, updateGuardrailCall } from "@/components/networking";
 import NotificationsManager from "@/components/molecules/notifications_manager";
+import { guardrailDetailHref } from "@/app/(dashboard)/guardrails/detailNavigation";
+import { isAdminRole } from "@/utils/roles";
 import {
   buildCompressionGuardrailPayload,
   compressionGuardrailsOf,
   GuardrailListItem,
   GuardrailListResponse,
+  isConfigDefinedGuardrail,
 } from "./helpers";
 
 interface PromptCompressionTabProps {
   accessToken: string | null;
+  userRole?: string;
 }
 
-interface CompressionFormValues {
-  name: string;
-  apiBase: string;
-  defaultOn: boolean;
+type CompressionMode = "always" | "opt_in";
+
+const MODE_LABELS: Readonly<Record<CompressionMode, string>> = {
+  always: "Always on",
+  opt_in: "Opt-in",
+};
+
+const modeOf = (guardrail: GuardrailListItem): CompressionMode =>
+  guardrail.litellm_params?.default_on ? "always" : "opt_in";
+
+interface CompressionEndpointRowProps {
+  guardrail: GuardrailListItem;
+  canEdit: boolean;
+  isPending: boolean;
+  onModeChange: (guardrail: GuardrailListItem, mode: CompressionMode) => void;
+  onEditSettings: (guardrail: GuardrailListItem) => void;
 }
 
-const PromptCompressionTab: React.FC<PromptCompressionTabProps> = ({ accessToken }) => {
-  const [form] = Form.useForm<CompressionFormValues>();
+const CompressionEndpointRow: React.FC<CompressionEndpointRowProps> = ({
+  guardrail,
+  canEdit,
+  isPending,
+  onModeChange,
+  onEditSettings,
+}) => {
+  const mode = modeOf(guardrail);
+  const name = guardrail.guardrail_name ?? guardrail.guardrail_id;
+  const isFromConfig = isConfigDefinedGuardrail(guardrail);
+  const isEditable = canEdit && !isFromConfig;
+
+  const handleSelect = (value: unknown) => {
+    if (value !== "always" && value !== "opt_in") {
+      return;
+    }
+    onModeChange(guardrail, value);
+  };
+
+  return (
+    <li className="flex flex-wrap items-center justify-between gap-4 p-4">
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium text-foreground">{name}</p>
+        <p className="truncate text-xs text-muted-foreground">{guardrail.litellm_params?.api_base ?? ""}</p>
+        {isFromConfig && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            Defined in the proxy config file, so it is read-only here
+          </p>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        {isEditable ? (
+          <Select value={mode} onValueChange={handleSelect} disabled={isPending}>
+            <SelectTrigger size="sm" className="w-[124px]" aria-label={`Compression mode for ${name}`}>
+              <SelectValue>{MODE_LABELS[mode]}</SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              {Object.entries(MODE_LABELS).map(([value, label]) => (
+                <SelectItem key={value} value={value}>
+                  {label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <Badge variant={mode === "always" ? "secondary" : "outline"}>{MODE_LABELS[mode]}</Badge>
+        )}
+
+        {canEdit && (
+          <Button variant="outline" size="sm" onClick={() => onEditSettings(guardrail)}>
+            <Settings2 />
+            Edit settings
+          </Button>
+        )}
+      </div>
+
+      {mode === "opt_in" && (
+        <p className="w-full rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
+          Compression only runs when a request asks for it:{" "}
+          <code className="font-mono text-foreground">&quot;guardrails&quot;: [&quot;{name}&quot;]</code> in the request
+          body. Turning it on for a specific key or team instead is a LiteLLM Enterprise feature
+        </p>
+      )}
+    </li>
+  );
+};
+
+const PromptCompressionTab: React.FC<PromptCompressionTabProps> = ({ accessToken, userRole }) => {
+  const router = useRouter();
+  const isAdmin = userRole ? isAdminRole(userRole) : false;
+
   const [guardrails, setGuardrails] = useState<GuardrailListItem[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isSaving, setIsSaving] = useState<boolean>(false);
+  const [pendingModeId, setPendingModeId] = useState<string | null>(null);
+  const [isAddFormOpen, setIsAddFormOpen] = useState<boolean>(false);
+  const [name, setName] = useState<string>("");
+  const [apiBase, setApiBase] = useState<string>("");
+  const [defaultOn, setDefaultOn] = useState<boolean>(true);
+  const [showFieldErrors, setShowFieldErrors] = useState<boolean>(false);
 
   const loadGuardrails = useCallback(() => {
     if (!accessToken) {
-      return;
+      return Promise.resolve();
     }
-    getGuardrailsList(accessToken)
+    return getGuardrailsList(accessToken)
       .then((response) => setGuardrails(compressionGuardrailsOf(response as GuardrailListResponse)))
       .catch((error) => {
         console.error("Failed to load compression guardrails:", error);
@@ -46,22 +146,50 @@ const PromptCompressionTab: React.FC<PromptCompressionTabProps> = ({ accessToken
     loadGuardrails();
   }, [loadGuardrails]);
 
-  const handleAdd = async (values: CompressionFormValues) => {
+  const handleModeChange = async (guardrail: GuardrailListItem, mode: CompressionMode) => {
     if (!accessToken) {
+      return;
+    }
+    const nextDefaultOn = mode === "always";
+    setPendingModeId(guardrail.guardrail_id);
+    try {
+      await updateGuardrailCall(accessToken, guardrail.guardrail_id, {
+        litellm_params: { default_on: nextDefaultOn },
+      });
+      NotificationsManager.success(
+        nextDefaultOn ? "Compression now runs on every request" : "Compression is now opt-in per request",
+      );
+      await loadGuardrails();
+    } catch (error) {
+      console.error("Failed to update compression guardrail:", error);
+      NotificationsManager.fromBackend("Failed to update compression guardrail");
+    } finally {
+      setPendingModeId(null);
+    }
+  };
+
+  const handleEditSettings = (guardrail: GuardrailListItem) => {
+    router.push(guardrailDetailHref(guardrail.guardrail_id, "settings"));
+  };
+
+  const handleAdd = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!accessToken) {
+      return;
+    }
+    if (!name.trim() || !apiBase.trim()) {
+      setShowFieldErrors(true);
       return;
     }
     setIsSaving(true);
     try {
-      await createGuardrailCall(
-        accessToken,
-        buildCompressionGuardrailPayload({
-          name: values.name,
-          apiBase: values.apiBase,
-          defaultOn: values.defaultOn ?? true,
-        }),
-      );
+      await createGuardrailCall(accessToken, buildCompressionGuardrailPayload({ name, apiBase, defaultOn }));
       NotificationsManager.success("Compression guardrail created");
-      form.resetFields();
+      setName("");
+      setApiBase("");
+      setDefaultOn(true);
+      setShowFieldErrors(false);
+      setIsAddFormOpen(false);
       await loadGuardrails();
     } catch (error) {
       console.error("Failed to create compression guardrail:", error);
@@ -71,105 +199,124 @@ const PromptCompressionTab: React.FC<PromptCompressionTabProps> = ({ accessToken
     }
   };
 
-  return (
-    <div className="w-full space-y-6">
-      <Card>
-        <CardHeader>
-          <CardTitle>Headroom prompt compression</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="mb-4 text-sm text-muted-foreground">
-            Headroom is a native LiteLLM guardrail that compresses your prompts before they reach the model, so you pay
-            for fewer input tokens. The tokens it removes are priced and shown on the Usage tab as compression savings.{" "}
-            <a
-              href="https://docs.litellm.ai/docs/proxy/headroom"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 underline"
-            >
-              Headroom setup docs
-            </a>
-          </p>
-          {isLoading && <p className="text-sm text-muted-foreground">Loading...</p>}
-          {!isLoading && guardrails.length === 0 && (
-            <p className="text-sm text-muted-foreground">
-              No prompt compression guardrails configured yet. Add one below to start saving on input tokens
-            </p>
-          )}
-          {!isLoading && guardrails.length > 0 && (
-            <ul className="divide-y divide-gray-200">
-              {guardrails.map((guardrail) => (
-                <li key={guardrail.guardrail_id} className="flex items-center justify-between py-3">
-                  <div>
-                    <p className="text-sm font-medium text-foreground">{guardrail.guardrail_name}</p>
-                    <p className="text-xs text-muted-foreground">{guardrail.litellm_params?.api_base ?? ""}</p>
-                  </div>
-                  <span
-                    className={`rounded-full px-2 py-0.5 text-xs font-medium ${
-                      guardrail.litellm_params?.default_on
-                        ? "bg-emerald-100 text-emerald-800"
-                        : "bg-gray-100 text-gray-600"
-                    }`}
-                  >
-                    {guardrail.litellm_params?.default_on ? "Always on" : "Opt-in"}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          )}
-        </CardContent>
-      </Card>
+  const hasGuardrails = guardrails.length > 0;
+  const isFormVisible = isAdmin && !isLoading && (!hasGuardrails || isAddFormOpen);
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Add Headroom compression guardrail</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <Form
-            form={form}
-            layout="vertical"
-            requiredMark={false}
-            onFinish={handleAdd}
-            initialValues={{ defaultOn: true }}
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Headroom prompt compression</CardTitle>
+        <CardDescription>
+          Headroom is a native LiteLLM guardrail that compresses your prompts before they reach the model, so you pay
+          for fewer input tokens. The tokens it removes are priced and shown on the Usage tab as compression savings.{" "}
+          <a
+            href="https://docs.litellm.ai/docs/proxy/headroom"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-primary underline underline-offset-4"
           >
-            <Form.Item name="name" label="Name" rules={[{ required: true, message: "Name is required" }]}>
-              <Input placeholder="headroom-compression" />
-            </Form.Item>
-            <Form.Item
-              name="apiBase"
-              label="Headroom API base"
-              tooltip="Base URL of your Headroom compression service (LiteLLM calls its /v1/compress endpoint)"
-              extra="The URL where your Headroom compression service is hosted"
-              rules={[{ required: true, message: "API base is required" }]}
-            >
-              <Input placeholder="https://your-headroom-endpoint" />
-            </Form.Item>
-            <Form.Item name="defaultOn" label="Apply to all requests" valuePropName="checked">
-              <Switch />
-            </Form.Item>
-            <div className="mb-4 rounded-lg border border-yellow-200 bg-yellow-50 p-3">
-              <p className="text-sm text-yellow-800">
-                Applying compression to all requests is available to all users. Enabling it selectively per key or team
-                is a LiteLLM Enterprise feature. Get a trial key{" "}
+            Headroom setup docs
+          </a>
+        </CardDescription>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {isLoading && <Skeleton className="h-14 w-full" />}
+
+        {!isLoading && hasGuardrails && (
+          <ul className="divide-y divide-border rounded-lg border border-border">
+            {guardrails.map((guardrail) => (
+              <CompressionEndpointRow
+                key={guardrail.guardrail_id}
+                guardrail={guardrail}
+                canEdit={isAdmin}
+                isPending={pendingModeId === guardrail.guardrail_id}
+                onModeChange={handleModeChange}
+                onEditSettings={handleEditSettings}
+              />
+            ))}
+          </ul>
+        )}
+
+        {!isLoading && !hasGuardrails && !isFormVisible && (
+          <p className="text-sm text-muted-foreground">
+            No prompt compression endpoint is configured. An admin can add one to start saving on input tokens
+          </p>
+        )}
+
+        {!isLoading && hasGuardrails && isAdmin && !isAddFormOpen && (
+          <Button variant="ghost" size="sm" onClick={() => setIsAddFormOpen(true)}>
+            <Plus />
+            Add another endpoint
+          </Button>
+        )}
+
+        {isFormVisible && (
+          <form onSubmit={handleAdd} className="space-y-4 rounded-lg border border-border p-4">
+            <div className="space-y-2">
+              <Label htmlFor="compression-name">Name</Label>
+              <Input
+                id="compression-name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="headroom-compression"
+                aria-invalid={showFieldErrors && !name.trim()}
+              />
+              {showFieldErrors && !name.trim() && <p className="text-xs text-destructive">Name is required</p>}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="compression-api-base">Headroom API base</Label>
+              <Input
+                id="compression-api-base"
+                value={apiBase}
+                onChange={(event) => setApiBase(event.target.value)}
+                placeholder="https://your-headroom-endpoint"
+                aria-invalid={showFieldErrors && !apiBase.trim()}
+              />
+              <p className="text-xs text-muted-foreground">
+                Where your Headroom compression service is hosted; LiteLLM calls its /v1/compress endpoint
+              </p>
+              {showFieldErrors && !apiBase.trim() && <p className="text-xs text-destructive">API base is required</p>}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="compression-default-on">
+                <Switch
+                  id="compression-default-on"
+                  checked={defaultOn}
+                  onCheckedChange={(checked) => setDefaultOn(checked)}
+                />
+                Apply to all requests
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Off means callers opt in per request. Applying compression to all requests is available to all users;
+                enabling it selectively per key or team is a LiteLLM Enterprise feature.{" "}
                 <a
                   href="https://www.litellm.ai/#pricing"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="underline"
+                  className="font-medium text-primary underline underline-offset-4"
                 >
-                  here
+                  Get a trial key
                 </a>
               </p>
             </div>
-            <div className="flex justify-end">
-              <Button type="primary" htmlType="submit" loading={isSaving}>
-                Add guardrail
+
+            <div className="flex justify-end gap-2">
+              {hasGuardrails && (
+                <Button type="button" variant="ghost" onClick={() => setIsAddFormOpen(false)}>
+                  Cancel
+                </Button>
+              )}
+              <Button type="submit" disabled={isSaving}>
+                {isSaving ? "Adding..." : "Add guardrail"}
               </Button>
             </div>
-          </Form>
-        </CardContent>
-      </Card>
-    </div>
+          </form>
+        )}
+      </CardContent>
+    </Card>
   );
 };
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/PromptCompressionTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/PromptCompressionTab.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, Settings2 } from "lucide-react";
+import { Plus, Settings2, Trash2 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -12,12 +12,19 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
-import { createGuardrailCall, getGuardrailsList, updateGuardrailCall } from "@/components/networking";
+import {
+  createGuardrailCall,
+  deleteGuardrailCall,
+  getGuardrailsList,
+  updateGuardrailCall,
+} from "@/components/networking";
 import NotificationsManager from "@/components/molecules/notifications_manager";
+import DeleteResourceModal from "@/components/common_components/DeleteResourceModal";
 import { guardrailDetailHref } from "@/app/(dashboard)/guardrails/detailNavigation";
 import { isAdminRole } from "@/utils/roles";
 import {
   buildCompressionGuardrailPayload,
+  CompressionGuardrailInput,
   compressionGuardrailsOf,
   GuardrailListItem,
   GuardrailListResponse,
@@ -45,6 +52,7 @@ interface CompressionEndpointRowProps {
   isPending: boolean;
   onModeChange: (guardrail: GuardrailListItem, mode: CompressionMode) => void;
   onEditSettings: (guardrail: GuardrailListItem) => void;
+  onDelete: (guardrail: GuardrailListItem) => void;
 }
 
 const CompressionEndpointRow: React.FC<CompressionEndpointRowProps> = ({
@@ -53,6 +61,7 @@ const CompressionEndpointRow: React.FC<CompressionEndpointRowProps> = ({
   isPending,
   onModeChange,
   onEditSettings,
+  onDelete,
 }) => {
   const mode = modeOf(guardrail);
   const name = guardrail.guardrail_name ?? guardrail.guardrail_id;
@@ -102,6 +111,18 @@ const CompressionEndpointRow: React.FC<CompressionEndpointRowProps> = ({
             Edit settings
           </Button>
         )}
+
+        {isEditable && (
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={`Delete ${name}`}
+            className="text-muted-foreground hover:text-destructive"
+            onClick={() => onDelete(guardrail)}
+          >
+            <Trash2 />
+          </Button>
+        )}
       </div>
 
       {mode === "opt_in" && (
@@ -115,6 +136,127 @@ const CompressionEndpointRow: React.FC<CompressionEndpointRowProps> = ({
   );
 };
 
+interface AddEndpointFormProps {
+  isSaving: boolean;
+  canCancel: boolean;
+  onCancel: () => void;
+  onSubmit: (input: CompressionGuardrailInput) => void;
+}
+
+const AddEndpointForm: React.FC<AddEndpointFormProps> = ({ isSaving, canCancel, onCancel, onSubmit }) => {
+  const [name, setName] = useState<string>("");
+  const [apiBase, setApiBase] = useState<string>("");
+  const [defaultOn, setDefaultOn] = useState<boolean>(true);
+  const [showFieldErrors, setShowFieldErrors] = useState<boolean>(false);
+
+  const isNameMissing = !name.trim();
+  const isApiBaseMissing = !apiBase.trim();
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isNameMissing || isApiBaseMissing) {
+      setShowFieldErrors(true);
+      return;
+    }
+    onSubmit({ name, apiBase, defaultOn });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 rounded-lg border border-border p-4">
+      <div className="space-y-2">
+        <Label htmlFor="compression-name">Name</Label>
+        <Input
+          id="compression-name"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="headroom-compression"
+          aria-invalid={showFieldErrors && isNameMissing}
+        />
+        {showFieldErrors && isNameMissing && <p className="text-xs text-destructive">Name is required</p>}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="compression-api-base">Headroom API base</Label>
+        <Input
+          id="compression-api-base"
+          value={apiBase}
+          onChange={(event) => setApiBase(event.target.value)}
+          placeholder="https://your-headroom-endpoint"
+          aria-invalid={showFieldErrors && isApiBaseMissing}
+        />
+        <p className="text-xs text-muted-foreground">
+          Where your Headroom compression service is hosted; LiteLLM calls its /v1/compress endpoint
+        </p>
+        {showFieldErrors && isApiBaseMissing && <p className="text-xs text-destructive">API base is required</p>}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="compression-default-on">
+          <Switch id="compression-default-on" checked={defaultOn} onCheckedChange={setDefaultOn} />
+          Apply to all requests
+        </Label>
+        <p className="text-xs text-muted-foreground">
+          Off means callers opt in per request. Applying compression to all requests is available to all users; enabling
+          it selectively per key or team is a LiteLLM Enterprise feature.{" "}
+          <a
+            href="https://www.litellm.ai/#pricing"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-primary underline underline-offset-4"
+          >
+            Get a trial key
+          </a>
+        </p>
+      </div>
+
+      <div className="flex justify-end gap-2">
+        {canCancel && (
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+        )}
+        <Button type="submit" disabled={isSaving}>
+          {isSaving ? "Adding..." : "Add guardrail"}
+        </Button>
+      </div>
+    </form>
+  );
+};
+
+interface DeleteEndpointModalProps {
+  guardrail: GuardrailListItem | null;
+  isDeleting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+const DeleteEndpointModal: React.FC<DeleteEndpointModalProps> = ({ guardrail, isDeleting, onCancel, onConfirm }) => {
+  const isAlwaysOn = guardrail !== null && modeOf(guardrail) === "always";
+
+  return (
+    <DeleteResourceModal
+      isOpen={guardrail !== null}
+      title="Delete compression guardrail"
+      alertMessage={
+        isAlwaysOn
+          ? "Every request is compressed by this guardrail today. Deleting it stops compression immediately and input token costs go back up"
+          : "Requests that ask for this guardrail by name will fail once it is deleted"
+      }
+      message={`Are you sure you want to delete guardrail: ${guardrail?.guardrail_name ?? ""}? This action cannot be undone.`}
+      resourceInformationTitle="Guardrail Information"
+      resourceInformation={[
+        { label: "Name", value: guardrail?.guardrail_name },
+        { label: "ID", value: guardrail?.guardrail_id, code: true },
+        { label: "API base", value: guardrail?.litellm_params?.api_base },
+        { label: "Applies to", value: isAlwaysOn ? MODE_LABELS.always : MODE_LABELS.opt_in },
+      ]}
+      onCancel={onCancel}
+      onOk={onConfirm}
+      confirmLoading={isDeleting}
+    />
+  );
+};
+
 const PromptCompressionTab: React.FC<PromptCompressionTabProps> = ({ accessToken, userRole }) => {
   const router = useRouter();
   const isAdmin = userRole ? isAdminRole(userRole) : false;
@@ -123,11 +265,9 @@ const PromptCompressionTab: React.FC<PromptCompressionTabProps> = ({ accessToken
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [isSaving, setIsSaving] = useState<boolean>(false);
   const [pendingModeId, setPendingModeId] = useState<string | null>(null);
+  const [guardrailToDelete, setGuardrailToDelete] = useState<GuardrailListItem | null>(null);
+  const [isDeleting, setIsDeleting] = useState<boolean>(false);
   const [isAddFormOpen, setIsAddFormOpen] = useState<boolean>(false);
-  const [name, setName] = useState<string>("");
-  const [apiBase, setApiBase] = useState<string>("");
-  const [defaultOn, setDefaultOn] = useState<boolean>(true);
-  const [showFieldErrors, setShowFieldErrors] = useState<boolean>(false);
 
   const loadGuardrails = useCallback(() => {
     if (!accessToken) {
@@ -172,23 +312,32 @@ const PromptCompressionTab: React.FC<PromptCompressionTabProps> = ({ accessToken
     router.push(guardrailDetailHref(guardrail.guardrail_id, "settings"));
   };
 
-  const handleAdd = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!accessToken) {
+  const handleDeleteConfirm = async () => {
+    if (!accessToken || !guardrailToDelete) {
       return;
     }
-    if (!name.trim() || !apiBase.trim()) {
-      setShowFieldErrors(true);
+    setIsDeleting(true);
+    try {
+      await deleteGuardrailCall(accessToken, guardrailToDelete.guardrail_id);
+      NotificationsManager.success("Compression guardrail deleted");
+      setGuardrailToDelete(null);
+      await loadGuardrails();
+    } catch (error) {
+      console.error("Failed to delete compression guardrail:", error);
+      NotificationsManager.fromBackend("Failed to delete compression guardrail");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleAdd = async (input: CompressionGuardrailInput) => {
+    if (!accessToken) {
       return;
     }
     setIsSaving(true);
     try {
-      await createGuardrailCall(accessToken, buildCompressionGuardrailPayload({ name, apiBase, defaultOn }));
+      await createGuardrailCall(accessToken, buildCompressionGuardrailPayload(input));
       NotificationsManager.success("Compression guardrail created");
-      setName("");
-      setApiBase("");
-      setDefaultOn(true);
-      setShowFieldErrors(false);
       setIsAddFormOpen(false);
       await loadGuardrails();
     } catch (error) {
@@ -200,7 +349,12 @@ const PromptCompressionTab: React.FC<PromptCompressionTabProps> = ({ accessToken
   };
 
   const hasGuardrails = guardrails.length > 0;
-  const isFormVisible = isAdmin && !isLoading && (!hasGuardrails || isAddFormOpen);
+  const isSettled = !isLoading;
+  const wantsAddForm = !hasGuardrails || isAddFormOpen;
+  const isFormVisible = isAdmin && isSettled && wantsAddForm;
+  const isListVisible = isSettled && hasGuardrails;
+  const isEmptyStateVisible = isSettled && !hasGuardrails && !isFormVisible;
+  const isAddAnotherVisible = isListVisible && isAdmin && !isAddFormOpen;
 
   return (
     <Card>
@@ -221,9 +375,9 @@ const PromptCompressionTab: React.FC<PromptCompressionTabProps> = ({ accessToken
       </CardHeader>
 
       <CardContent className="space-y-4">
-        {isLoading && <Skeleton className="h-14 w-full" />}
+        {!isSettled && <Skeleton className="h-14 w-full" />}
 
-        {!isLoading && hasGuardrails && (
+        {isListVisible && (
           <ul className="divide-y divide-border rounded-lg border border-border">
             {guardrails.map((guardrail) => (
               <CompressionEndpointRow
@@ -233,18 +387,19 @@ const PromptCompressionTab: React.FC<PromptCompressionTabProps> = ({ accessToken
                 isPending={pendingModeId === guardrail.guardrail_id}
                 onModeChange={handleModeChange}
                 onEditSettings={handleEditSettings}
+                onDelete={setGuardrailToDelete}
               />
             ))}
           </ul>
         )}
 
-        {!isLoading && !hasGuardrails && !isFormVisible && (
+        {isEmptyStateVisible && (
           <p className="text-sm text-muted-foreground">
             No prompt compression endpoint is configured. An admin can add one to start saving on input tokens
           </p>
         )}
 
-        {!isLoading && hasGuardrails && isAdmin && !isAddFormOpen && (
+        {isAddAnotherVisible && (
           <Button variant="ghost" size="sm" onClick={() => setIsAddFormOpen(true)}>
             <Plus />
             Add another endpoint
@@ -252,69 +407,20 @@ const PromptCompressionTab: React.FC<PromptCompressionTabProps> = ({ accessToken
         )}
 
         {isFormVisible && (
-          <form onSubmit={handleAdd} className="space-y-4 rounded-lg border border-border p-4">
-            <div className="space-y-2">
-              <Label htmlFor="compression-name">Name</Label>
-              <Input
-                id="compression-name"
-                value={name}
-                onChange={(event) => setName(event.target.value)}
-                placeholder="headroom-compression"
-                aria-invalid={showFieldErrors && !name.trim()}
-              />
-              {showFieldErrors && !name.trim() && <p className="text-xs text-destructive">Name is required</p>}
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="compression-api-base">Headroom API base</Label>
-              <Input
-                id="compression-api-base"
-                value={apiBase}
-                onChange={(event) => setApiBase(event.target.value)}
-                placeholder="https://your-headroom-endpoint"
-                aria-invalid={showFieldErrors && !apiBase.trim()}
-              />
-              <p className="text-xs text-muted-foreground">
-                Where your Headroom compression service is hosted; LiteLLM calls its /v1/compress endpoint
-              </p>
-              {showFieldErrors && !apiBase.trim() && <p className="text-xs text-destructive">API base is required</p>}
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="compression-default-on">
-                <Switch
-                  id="compression-default-on"
-                  checked={defaultOn}
-                  onCheckedChange={(checked) => setDefaultOn(checked)}
-                />
-                Apply to all requests
-              </Label>
-              <p className="text-xs text-muted-foreground">
-                Off means callers opt in per request. Applying compression to all requests is available to all users;
-                enabling it selectively per key or team is a LiteLLM Enterprise feature.{" "}
-                <a
-                  href="https://www.litellm.ai/#pricing"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="font-medium text-primary underline underline-offset-4"
-                >
-                  Get a trial key
-                </a>
-              </p>
-            </div>
-
-            <div className="flex justify-end gap-2">
-              {hasGuardrails && (
-                <Button type="button" variant="ghost" onClick={() => setIsAddFormOpen(false)}>
-                  Cancel
-                </Button>
-              )}
-              <Button type="submit" disabled={isSaving}>
-                {isSaving ? "Adding..." : "Add guardrail"}
-              </Button>
-            </div>
-          </form>
+          <AddEndpointForm
+            isSaving={isSaving}
+            canCancel={hasGuardrails}
+            onCancel={() => setIsAddFormOpen(false)}
+            onSubmit={handleAdd}
+          />
         )}
+
+        <DeleteEndpointModal
+          guardrail={guardrailToDelete}
+          isDeleting={isDeleting}
+          onCancel={() => setGuardrailToDelete(null)}
+          onConfirm={handleDeleteConfirm}
+        />
       </CardContent>
     </Card>
   );

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/helpers.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/helpers.ts
@@ -1,3 +1,5 @@
+import { GuardrailDefinitionLocation } from "@/components/guardrails/types";
+
 export interface GuardrailLitellmParams {
   guardrail?: string | null;
   api_base?: string | null;
@@ -8,6 +10,7 @@ export interface GuardrailListItem {
   guardrail_id: string;
   guardrail_name: string | null;
   litellm_params?: GuardrailLitellmParams | null;
+  guardrail_definition_location?: GuardrailDefinitionLocation | null;
 }
 
 export interface GuardrailListResponse {
@@ -21,6 +24,10 @@ export const isCompressionGuardrail = (guardrail: GuardrailListItem): boolean =>
 
 export const compressionGuardrailsOf = (response: GuardrailListResponse): GuardrailListItem[] =>
   (response.guardrails ?? []).filter(isCompressionGuardrail);
+
+/** Guardrails declared in the proxy config file are owned by that file; the API cannot rewrite them. */
+export const isConfigDefinedGuardrail = (guardrail: GuardrailListItem): boolean =>
+  guardrail.guardrail_definition_location === GuardrailDefinitionLocation.CONFIG;
 
 export interface CompressionGuardrailInput {
   name: string;

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailsPanel.test.tsx
@@ -30,9 +30,18 @@ vi.mock("./guardrail_table", () => ({
   ),
 }));
 
+const mockGuardrailInfoProps = vi.fn();
+
 vi.mock("./guardrail_info", () => ({
   __esModule: true,
-  default: () => <div>Mock Guardrail Info View</div>,
+  default: (props: any) => {
+    mockGuardrailInfoProps(props);
+    return <div>Mock Guardrail Info View</div>;
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(window.location.search),
 }));
 
 vi.mock("./GuardrailTestPlayground", () => ({
@@ -83,6 +92,7 @@ describe("GuardrailsPanel", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    window.history.pushState(null, "", "/guardrails");
     mockGetGuardrailsList.mockResolvedValue({
       guardrails: [
         {
@@ -127,6 +137,27 @@ describe("GuardrailsPanel", () => {
       expect(mockDeleteGuardrailCall).toHaveBeenCalledWith("test-token", "test-guardrail-1");
     });
     expect(mockGetGuardrailsList).toHaveBeenCalledTimes(2);
+  });
+
+  it("should open the detail view on the settings tab from a deep link", async () => {
+    window.history.pushState(null, "", "/guardrails?guardrail=test-guardrail-1&guardrail_tab=settings");
+
+    render(<GuardrailsPanel {...defaultProps} />);
+    fireEvent.click(screen.getByText("Guardrails"));
+
+    expect(await screen.findByText("Mock Guardrail Info View")).toBeInTheDocument();
+    expect(screen.queryByText("Mock Guardrail Table")).not.toBeInTheDocument();
+    expect(mockGuardrailInfoProps).toHaveBeenCalledWith(
+      expect.objectContaining({ guardrailId: "test-guardrail-1", initialTab: "settings" }),
+    );
+  });
+
+  it("should show the table when no guardrail is deep-linked", async () => {
+    render(<GuardrailsPanel {...defaultProps} />);
+    fireEvent.click(screen.getByText("Guardrails"));
+
+    expect(await screen.findByText("Mock Guardrail Table")).toBeInTheDocument();
+    expect(screen.queryByText("Mock Guardrail Info View")).not.toBeInTheDocument();
   });
 
   it("should not delete anything when the modal is cancelled", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailsPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/GuardrailsPanel.tsx
@@ -22,6 +22,7 @@ import { getGuardrailLogoAndName } from "./guardrail_info_helpers";
 import { CustomCodeModal } from "./custom_code";
 import GuardrailGarden from "./guardrail_garden";
 import { TeamGuardrailsTab } from "./TeamGuardrailsTab";
+import { useGuardrailDetailRouting } from "../detailNavigation";
 
 interface GuardrailsPanelProps {
   accessToken: string | null;
@@ -40,7 +41,12 @@ const GuardrailsPanel: React.FC<GuardrailsPanelProps> = ({ accessToken, userRole
   const [isDeleting, setIsDeleting] = useState(false);
   const [guardrailToDelete, setGuardrailToDelete] = useState<Guardrail | null>(null);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [selectedGuardrailId, setSelectedGuardrailId] = useState<string | null>(null);
+  const {
+    guardrailId: selectedGuardrailId,
+    tab: guardrailDetailTab,
+    openGuardrail,
+    close,
+  } = useGuardrailDetailRouting();
   const isAdmin = userRole ? isAdminRole(userRole) : false;
 
   const fetchGuardrails = async () => {
@@ -65,14 +71,14 @@ const GuardrailsPanel: React.FC<GuardrailsPanelProps> = ({ accessToken, userRole
 
   const handleAddGuardrail = () => {
     if (selectedGuardrailId) {
-      setSelectedGuardrailId(null);
+      close();
     }
     setIsAddModalVisible(true);
   };
 
   const handleAddCustomCodeGuardrail = () => {
     if (selectedGuardrailId) {
-      setSelectedGuardrailId(null);
+      close();
     }
     setIsCustomCodeModalVisible(true);
   };
@@ -166,16 +172,17 @@ const GuardrailsPanel: React.FC<GuardrailsPanelProps> = ({ accessToken, userRole
                       {selectedGuardrailId ? (
                         <GuardrailInfoView
                           guardrailId={selectedGuardrailId}
-                          onClose={() => setSelectedGuardrailId(null)}
+                          onClose={close}
                           accessToken={accessToken}
                           isAdmin={isAdmin}
+                          initialTab={guardrailDetailTab}
                         />
                       ) : (
                         <GuardrailTable
                           guardrailsList={guardrailsList}
                           isLoading={isLoading}
                           onDeleteClick={handleDeleteClick}
-                          onGuardrailClick={(id) => setSelectedGuardrailId(id)}
+                          onGuardrailClick={openGuardrail}
                         />
                       )}
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.test.tsx
@@ -166,6 +166,74 @@ describe("Guardrail Info", () => {
     }
   });
 
+  it("should open on the settings tab when linked to it, without a second click", async () => {
+    vi.mocked(networking.getGuardrailInfo).mockResolvedValue({
+      guardrail_id: "123",
+      guardrail_name: "Test Guardrail",
+      litellm_params: {
+        guardrail: "headroom",
+        mode: "pre_call",
+        default_on: true,
+      },
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+      guardrail_definition_location: "database",
+    });
+
+    vi.mocked(networking.getGuardrailUISettings).mockResolvedValue({
+      supported_entities: [],
+      supported_actions: [],
+      pii_entity_categories: [],
+      supported_modes: ["pre_call"],
+    });
+
+    vi.mocked(networking.getGuardrailProviderSpecificParams).mockResolvedValue({});
+
+    const { findByText, getByRole } = render(
+      <GuardrailInfoView guardrailId="123" onClose={() => {}} accessToken="123" isAdmin={true} initialTab="settings" />,
+    );
+
+    expect(await findByText("Guardrail Settings")).toBeInTheDocument();
+    expect(getByRole("button", { name: "Edit Settings" })).toBeInTheDocument();
+  });
+
+  it("should stay on the overview tab for a non-admin linked to the settings tab", async () => {
+    vi.mocked(networking.getGuardrailInfo).mockResolvedValue({
+      guardrail_id: "123",
+      guardrail_name: "Test Guardrail",
+      litellm_params: {
+        guardrail: "headroom",
+        mode: "pre_call",
+        default_on: true,
+      },
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+      guardrail_definition_location: "database",
+    });
+
+    vi.mocked(networking.getGuardrailUISettings).mockResolvedValue({
+      supported_entities: [],
+      supported_actions: [],
+      pii_entity_categories: [],
+      supported_modes: ["pre_call"],
+    });
+
+    vi.mocked(networking.getGuardrailProviderSpecificParams).mockResolvedValue({});
+
+    const { findAllByText, queryByText } = render(
+      <GuardrailInfoView
+        guardrailId="123"
+        onClose={() => {}}
+        accessToken="123"
+        isAdmin={false}
+        initialTab="settings"
+      />,
+    );
+
+    await findAllByText("Test Guardrail");
+    expect(queryByText("Guardrail Settings")).not.toBeInTheDocument();
+  });
+
   it("should render the guardrail info", async () => {
     // Mock the network responses
     vi.mocked(networking.getGuardrailInfo).mockResolvedValue({

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.tsx
@@ -27,12 +27,14 @@ import GuardrailOptionalParams from "./guardrail_optional_params";
 import GuardrailProviderFields from "./guardrail_provider_fields";
 import PiiConfiguration from "./pii_configuration";
 import ToolPermissionRulesEditor, { ToolPermissionConfig } from "./tool_permission/ToolPermissionRulesEditor";
+import type { GuardrailDetailTab } from "../detailNavigation";
 
 export interface GuardrailInfoProps {
   guardrailId: string;
   onClose: () => void;
   accessToken: string | null;
   isAdmin: boolean;
+  initialTab?: GuardrailDetailTab;
 }
 
 interface ProviderParam {
@@ -51,7 +53,13 @@ interface ProviderParamsResponse {
   [provider: string]: { [key: string]: ProviderParam };
 }
 
-const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose, accessToken, isAdmin }) => {
+const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({
+  guardrailId,
+  onClose,
+  accessToken,
+  isAdmin,
+  initialTab = "overview",
+}) => {
   const [guardrailData, setGuardrailData] = useState<any>(null);
   const [guardrailProviderSpecificParams, setGuardrailProviderSpecificParams] = useState<any>(null);
   const [loading, setLoading] = useState(true);
@@ -512,7 +520,7 @@ const GuardrailInfoView: React.FC<GuardrailInfoProps> = ({ guardrailId, onClose,
         </div>
       </div>
 
-      <TabGroup>
+      <TabGroup defaultIndex={isAdmin && initialTab === "settings" ? 1 : 0}>
         <TabList className="mb-4">
           <Tab key="overview">Overview</Tab>
           {isAdmin ? <Tab key="settings">Settings</Tab> : <></>}

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/detailNavigation.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/detailNavigation.test.ts
@@ -1,0 +1,74 @@
+/* @vitest-environment jsdom */
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { guardrailDetailHref, useGuardrailDetailRouting } from "./detailNavigation";
+
+vi.mock("next/navigation", () => ({ useSearchParams: () => new URLSearchParams(window.location.search) }));
+vi.mock("@/components/networking", () => ({ serverRootPath: "/" }));
+
+describe("guardrailDetailHref", () => {
+  it("links straight to the settings tab when asked for it", () => {
+    expect(guardrailDetailHref("fee65a60", "settings")).toBe(
+      "/ui/guardrails?guardrail=fee65a60&guardrail_tab=settings",
+    );
+  });
+
+  it("omits the tab param for the default overview tab", () => {
+    expect(guardrailDetailHref("fee65a60")).toBe("/ui/guardrails?guardrail=fee65a60");
+  });
+});
+
+describe("useGuardrailDetailRouting", () => {
+  beforeEach(() => {
+    window.history.pushState(null, "", "/guardrails");
+  });
+
+  it("openGuardrail sets ?guardrail= via history.pushState (no full navigation)", () => {
+    const spy = vi.spyOn(window.history, "pushState");
+    const { result } = renderHook(() => useGuardrailDetailRouting());
+    act(() => result.current.openGuardrail("fee65a60"));
+    expect(spy).toHaveBeenCalledWith(null, "", expect.stringContaining("guardrail=fee65a60"));
+    spy.mockRestore();
+  });
+
+  it("openGuardrail drops a stale tab param so the detail view opens on overview", () => {
+    window.history.pushState(null, "", "/guardrails?guardrail=old&guardrail_tab=settings");
+    const spy = vi.spyOn(window.history, "pushState");
+    const { result } = renderHook(() => useGuardrailDetailRouting());
+    act(() => result.current.openGuardrail("fee65a60"));
+    const url = spy.mock.calls.at(-1)?.[2] as string;
+    expect(url).toContain("guardrail=fee65a60");
+    expect(url).not.toContain("guardrail_tab");
+    spy.mockRestore();
+  });
+
+  it("close removes both guardrail params and keeps unrelated ones", () => {
+    window.history.pushState(null, "", "/guardrails?tab=garden&guardrail=fee65a60&guardrail_tab=settings");
+    const spy = vi.spyOn(window.history, "pushState");
+    const { result } = renderHook(() => useGuardrailDetailRouting());
+    act(() => result.current.close());
+    const url = spy.mock.calls.at(-1)?.[2] as string;
+    expect(url).toContain("tab=garden");
+    expect(url).not.toContain("guardrail=");
+    expect(url).not.toContain("guardrail_tab");
+    spy.mockRestore();
+  });
+
+  it("reads the guardrail id and settings tab from the query string", () => {
+    window.history.pushState(null, "", "/guardrails?guardrail=fee65a60&guardrail_tab=settings");
+    const { result } = renderHook(() => useGuardrailDetailRouting());
+    expect(result.current.guardrailId).toBe("fee65a60");
+    expect(result.current.tab).toBe("settings");
+  });
+
+  it("falls back to the overview tab for an unknown tab value", () => {
+    window.history.pushState(null, "", "/guardrails?guardrail=fee65a60&guardrail_tab=bogus");
+    const { result } = renderHook(() => useGuardrailDetailRouting());
+    expect(result.current.tab).toBe("overview");
+  });
+
+  it("guardrailId is null when no guardrail param is present", () => {
+    const { result } = renderHook(() => useGuardrailDetailRouting());
+    expect(result.current.guardrailId).toBeNull();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/detailNavigation.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/detailNavigation.ts
@@ -1,0 +1,52 @@
+import { useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+import { migratedHref } from "@/utils/migratedPages";
+import { navigateWithParams } from "../navigateWithParams";
+
+export const GUARDRAIL_PARAM = "guardrail";
+export const GUARDRAIL_TAB_PARAM = "guardrail_tab";
+
+export type GuardrailDetailTab = "overview" | "settings";
+
+export interface GuardrailDetailRouting {
+  guardrailId: string | null;
+  tab: GuardrailDetailTab;
+  openGuardrail: (id: string) => void;
+  close: () => void;
+}
+
+/** Same-origin href that opens a guardrail's detail view, e.g. "/ui/guardrails?guardrail=abc&guardrail_tab=settings". */
+export function guardrailDetailHref(guardrailId: string, tab: GuardrailDetailTab = "overview"): string {
+  const params = new URLSearchParams(
+    tab === "settings"
+      ? { [GUARDRAIL_PARAM]: guardrailId, [GUARDRAIL_TAB_PARAM]: tab }
+      : { [GUARDRAIL_PARAM]: guardrailId },
+  );
+  return `${migratedHref("guardrails")}?${params.toString()}`;
+}
+
+export function useGuardrailDetailRouting(): GuardrailDetailRouting {
+  const searchParams = useSearchParams();
+
+  const openGuardrail = useCallback((id: string) => {
+    navigateWithParams((params) => {
+      params.set(GUARDRAIL_PARAM, id);
+      params.delete(GUARDRAIL_TAB_PARAM);
+    });
+  }, []);
+
+  const close = useCallback(() => {
+    navigateWithParams((params) => {
+      params.delete(GUARDRAIL_PARAM);
+      params.delete(GUARDRAIL_TAB_PARAM);
+    });
+  }, []);
+
+  return {
+    guardrailId: searchParams?.get(GUARDRAIL_PARAM) ?? null,
+    tab: searchParams?.get(GUARDRAIL_TAB_PARAM) === "settings" ? "settings" : "overview",
+    openGuardrail,
+    close,
+  };
+}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Compression config was read-only on the cost page
- No way to switch a Headroom endpoint to opt-in
- Deleting one meant leaving for the Guardrails page
- Guardrail detail view had no shareable URL

How it solves it:

- Always on / Opt-in select PATCHes only default_on
- Row delete reuses the shared DeleteResourceModal
- Edit settings deep-links to the guardrail settings tab
- Guardrail selection moved into ?guardrail= query params

## Relevant issues

- Adds Always on / Opt-in switching and delete to the Prompt Compression tab, so a Headroom endpoint can be reconfigured or removed without leaving the cost page
- Makes the guardrail detail view addressable by URL, so the compression card can link straight to that guardrail's settings tab for the rest of its config and for delete
- Rebuilds the compression card on shadcn/ui primitives and gates its editing affordances on admin, matching what the guardrail routes actually allow

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Backend proof, captured at 49c65cead8 against a live proxy on :4194, that the one-field PATCH the select sends flips the mode and leaves the rest of `litellm_params` intact (this is the merge the card depends on; the old UI never sent it)

```bash
# create the guardrail exactly like the tab's form does
curl -s -X POST http://localhost:4194/guardrails -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"guardrail":{"guardrail_name":"headroom-compression","litellm_params":{"guardrail":"headroom","mode":"pre_call","api_base":"https://headroom-guardrail.onrender.com","default_on":true}}}'

GID=91771430-4775-47a5-8984-715f87841423

# what the card sends when you pick Opt-in
curl -s -X PATCH http://localhost:4194/guardrails/$GID -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"litellm_params": {"default_on": false}}'

curl -s http://localhost:4194/guardrails/$GID/info -H "Authorization: Bearer sk-1234"
```

```
== 1. after create (Always on) ==
{
  "guardrail_name": "headroom-compression",
  "guardrail": "headroom",
  "mode": "pre_call",
  "api_base": "https://headroom-guardrail.onrender.com",
  "default_on": true
}
== 2. PATCH {"litellm_params": {"default_on": false}} ==
http_status=200
{
  "guardrail_name": "headroom-compression",
  "guardrail": "headroom",
  "mode": "pre_call",
  "api_base": "https://headroom-guardrail.onrender.com",
  "default_on": false
}
== 3. PATCH back to Always on ==
http_status=200
{
  "guardrail_name": "headroom-compression",
  "guardrail": "headroom",
  "mode": "pre_call",
  "api_base": "https://headroom-guardrail.onrender.com",
  "default_on": true
}
```

Delete goes through `DELETE /guardrails/{id}`, same call the Guardrails table makes, verified on the same rig at the end of the run above

```bash
curl -s -X DELETE http://localhost:4194/guardrails/$GID -H "Authorization: Bearer sk-1234"
# {"message":"Guardrail 91771430-4775-47a5-8984-715f87841423 deleted successfully"}
curl -s http://localhost:4194/v2/guardrails/list -H "Authorization: Bearer sk-1234"
# {"guardrails":[]}
```

UI screenshots to follow: before/after of the Prompt Compression card, the Opt-in state with its per-request hint, the delete confirmation, and the guardrail Settings tab reached from Edit settings

## Type

🆕 New Feature

## Changes

`PromptCompressionTab.tsx` is one card again instead of a read-only list plus a permanent add form. Each configured endpoint is a row with its name, api base, an Always on / Opt-in select, an Edit settings button, and a delete action; picking Opt-in sends `PATCH /guardrails/{id}` with nothing but `{"litellm_params": {"default_on": false}}`, which the patch handler merges into the stored params, and the row then spells out that callers have to pass `"guardrails": ["<name>"]` for compression to run at all. The add form only shows up when there is no endpoint yet, or behind an explicit "Add another endpoint" action, and it validates in place rather than through antd's Form

Delete opens the shared `DeleteResourceModal`, the same confirmation the Guardrails table uses, listing the endpoint name, id, api base, and current mode. Its warning depends on that mode because the two fail differently: removing an always-on endpoint quietly stops compressing and input costs go back up, while removing an opt-in one breaks the callers that name it. The card body was getting long, so the add form and that modal are their own components now, and the form owns its fields, which means a failed create keeps what was typed

Edit settings needs somewhere to go, so guardrail selection moved out of `GuardrailsPanel` component state into `?guardrail=` and `?guardrail_tab=` query params via a new `detailNavigation.ts`, mirroring `useKeyDetailRouting` on the api-keys page. `GuardrailInfoView` takes an `initialTab` prop so the link lands on Settings, where name, Default On, and the provider fields generated from `HeadroomGuardrailConfigModel` (api_base, api_key, model, unreachable_fallback) are already editable, and where delete already lives. The Guardrails page gets working back navigation and shareable per-guardrail links out of the same change

Editing and delete are admin-only now, which is what the backend already enforces: `internal_user_routes` includes `/guardrails/list` and `/v2/guardrails/list` but not create or patch, so the previously always-visible form handed non-admins a guaranteed 403. Config-file guardrails stay read-only on this card for the same reason `guardrail_info` refuses to edit them

The card no longer imports antd, which `no-restricted-imports` bans for new dashboard UI, so its entry in `eslint-suppressions.json` is pruned. It is built from Card, Select, Badge, Button, Input, Label, Switch, and Skeleton

## QA runbook

Run the proxy with the dashboard dev server (`npm run dev` in `ui/litellm-dashboard`, proxy on :4000) and sign in as a proxy admin

- Switching modes from the cost page
  - [ ] Go to http://localhost:4000/ui/cost-optimization and open the Prompt Compression tab
  - [ ] With no Headroom guardrail configured, expect the card to show the add form directly; fill Name and Headroom API base, leave "Apply to all requests" on, and submit
  - [ ] Expect a row for the new endpoint with its api base and an "Always on" select
  - [ ] Set the select to Opt-in and expect a success toast plus a line under the row telling you to pass `"guardrails": ["<name>"]` per request
  - [ ] Confirm it persisted: `curl -s http://localhost:4000/guardrails/<id>/info -H "Authorization: Bearer sk-1234"` shows `default_on: false` with `api_base` and `mode` unchanged
  - [ ] Set it back to Always on and confirm `default_on: true` the same way
- Deep link into the guardrail
  - [ ] Click Edit settings on the row and expect to land on /ui/guardrails?guardrail=<id>&guardrail_tab=settings with the Settings tab already open
  - [ ] Click Edit Settings there, change the Headroom api base, save, then go back to the compression tab and expect the new api base on the row
  - [ ] Press the browser back button from the detail view and expect the guardrail table, not a jump out of the page
  - [ ] Press the browser back button again and expect the cost page you came from
- Deleting from the cost page
  - [ ] Click the trash action on the row and expect a confirmation naming the endpoint, its id, its api base, and Applies to: Always on
  - [ ] Cancel and confirm nothing was deleted (`curl -s http://localhost:4000/v2/guardrails/list -H "Authorization: Bearer sk-1234"` still lists it)
  - [ ] Set the row to Opt-in, open the delete confirmation again, and expect the warning to change to the one about callers that name the guardrail failing
  - [ ] Confirm the delete and expect the row to disappear, the card to fall back to its add form, and the guardrail to be gone from `/v2/guardrails/list`
- Non-admin and config-file cases
  - [ ] Sign in as an internal user and expect the compression row to show a plain Always on / Opt-in badge with no select, no Edit settings, no delete, and no add form
  - [ ] Define a headroom guardrail in the proxy config file instead of the DB and expect its row to say it is read-only, with no select and no delete

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
