### PR TITLE
fix(sap): normalize stream chunks to avoid MockValSer errors and clarify missing deployment error

### DIFF
--- a/litellm/llms/sap/chat/handler.py
+++ b/litellm/llms/sap/chat/handler.py
@@ -8,6 +8,7 @@ import httpx
 
 from litellm.llms.base_llm.chat.transformation import BaseConfig, BaseLLMException
 from litellm.types.llms.openai import OpenAIChatCompletionChunk
+from litellm.types.utils import Usage
 
 from ...custom_httpx.llm_http_handler import BaseLLMHTTPHandler
 
@@ -46,6 +47,25 @@ class _StreamParser:
     """Normalize orchestration streaming events into OpenAI-like chunks."""
 
     @staticmethod
+    def _validate_chunk(payload: dict) -> OpenAIChatCompletionChunk:
+        """
+        Validate an OpenAI-shaped dict into a chunk, normalizing fields that would
+        otherwise break downstream serialization:
+          - drop the empty `logprobs` ({}) the orchestration service sends on every choice
+          - replace the raw openai-SDK usage object (deferred-build pydantic model whose
+            serializer is still a MockValSer) with litellm's Usage, so nested
+            model_dump() calls in the streaming handler don't raise
+            "'MockValSer' object is not an instance of 'SchemaSerializer'"
+        """
+        for choice in payload.get("choices") or []:
+            if isinstance(choice, dict) and not choice.get("logprobs"):
+                choice.pop("logprobs", None)
+        chunk = OpenAIChatCompletionChunk.model_validate(payload)
+        if chunk.usage is not None:
+            chunk.usage = Usage(**chunk.usage.model_dump())
+        return chunk
+
+    @staticmethod
     def _from_orchestration_result(evt: dict) -> Optional[OpenAIChatCompletionChunk]:
         """
         Accepts orchestration_result shape and maps it to an OpenAI-like *chunk*.
@@ -54,7 +74,7 @@ class _StreamParser:
         if not orc:
             return None
 
-        return OpenAIChatCompletionChunk.model_validate(
+        return _StreamParser._validate_chunk(
             {
                 "id": orc.get("id") or evt.get("request_id") or "stream-chunk",
                 "object": orc.get("object") or "chat.completion.chunk",
@@ -92,7 +112,7 @@ class _StreamParser:
             # ensure it looks like an OpenAI chunk
             if "object" not in fr:
                 fr["object"] = "chat.completion.chunk"
-            return OpenAIChatCompletionChunk.model_validate(fr)
+            return _StreamParser._validate_chunk(fr)
 
         # Orchestration incremental delta
         if "orchestration_result" in event_obj:
@@ -100,7 +120,7 @@ class _StreamParser:
 
         # Already an OpenAI-like chunk
         if "choices" in event_obj and "object" in event_obj:
-            return OpenAIChatCompletionChunk.model_validate(event_obj)
+            return _StreamParser._validate_chunk(event_obj)
 
         # Unknown / heartbeat / metrics
         return None

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -191,6 +191,15 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
                 if cfg.get("executableId") == "orchestration":
                     valid.append((dep["deploymentUrl"], dep["createdAt"]))
             # newest first
+        if not valid:
+            raise GenAIHubOrchestrationError(
+                status_code=404,
+                message=(
+                    "No orchestration deployment found in SAP AI Core resource group "
+                    f"'{self.resource_group}'. Create/start an orchestration deployment "
+                    "in SAP AI Launchpad, then retry."
+                ),
+            )
         return sorted(valid, key=lambda x: x[1], reverse=True)[0][0]
 
     @classmethod

--- a/tests/test_litellm/llms/sap/chat/test_sap_stream_chunk_validation.py
+++ b/tests/test_litellm/llms/sap/chat/test_sap_stream_chunk_validation.py
@@ -1,0 +1,104 @@
+"""
+Tests for SAP orchestration stream chunk normalization (_StreamParser._validate_chunk)
+and the descriptive error raised when no orchestration deployment exists.
+
+Regression tests for:
+- TypeError: 'MockValSer' object is not an instance of 'SchemaSerializer'
+  raised from nested model_dump() when the raw openai-SDK usage object
+  (a deferred-build pydantic model) was attached to ModelResponseStream.
+- IndexError: list index out of range raised from deployment_url when the
+  configured resource group contains no orchestration deployment.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from litellm.llms.sap.chat.handler import GenAIHubOrchestrationError, _StreamParser
+from litellm.types.utils import ModelResponseStream, Usage
+
+
+def _final_chunk_payload() -> dict:
+    """OpenAI-shaped final chunk as sent by the SAP orchestration service:
+    every choice carries an empty `logprobs` ({}) and the last chunk carries usage."""
+    return {
+        "id": "chatcmpl-sap-final",
+        "object": "chat.completion.chunk",
+        "created": 1761319270,
+        "model": "anthropic--claude-4.7-opus",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {},
+                "logprobs": {},
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {
+            "completion_tokens": 206,
+            "prompt_tokens": 62322,
+            "total_tokens": 62528,
+        },
+    }
+
+
+def test_validate_chunk_drops_empty_logprobs():
+    chunk = _StreamParser._validate_chunk(_final_chunk_payload())
+    assert chunk.choices[0].logprobs is None
+
+
+def test_validate_chunk_preserves_real_logprobs():
+    payload = _final_chunk_payload()
+    payload["choices"][0]["logprobs"] = {
+        "content": [{"token": "Hello", "logprob": -0.1, "bytes": None, "top_logprobs": []}]
+    }
+    chunk = _StreamParser._validate_chunk(payload)
+    assert chunk.choices[0].logprobs is not None
+    assert chunk.choices[0].logprobs.content[0].token == "Hello"
+
+
+def test_validate_chunk_converts_usage_to_litellm_usage():
+    chunk = _StreamParser._validate_chunk(_final_chunk_payload())
+    assert isinstance(chunk.usage, Usage)
+    assert chunk.usage.completion_tokens == 206
+    assert chunk.usage.prompt_tokens == 62322
+    assert chunk.usage.total_tokens == 62528
+
+
+def test_validate_chunk_without_usage_keeps_none():
+    payload = _final_chunk_payload()
+    del payload["usage"]
+    chunk = _StreamParser._validate_chunk(payload)
+    assert chunk.usage is None
+
+
+def test_validated_usage_survives_nested_model_dump():
+    """The original crash: the raw openai-SDK usage object attached to a
+    ModelResponseStream made model_dump() raise
+    "TypeError: 'MockValSer' object is not an instance of 'SchemaSerializer'"."""
+    chunk = _StreamParser._validate_chunk(_final_chunk_payload())
+
+    model_response = ModelResponseStream()
+    setattr(model_response, "usage", chunk.usage)
+
+    dumped = model_response.model_dump()  # must not raise
+    assert dumped["usage"]["total_tokens"] == 62528
+
+
+def test_deployment_url_raises_404_when_no_orchestration_deployment():
+    from litellm.llms.sap.chat.transformation import GenAIHubOrchestrationConfig
+
+    config = GenAIHubOrchestrationConfig()
+    config.token_creator = lambda: "Bearer FAKE_TOKEN"
+    config._base_url = "https://api.ai.mock-sap.com/v2"
+    config._resource_group = "fake-group"
+
+    mock_client = MagicMock()
+    mock_client.get.return_value.json.return_value = {"resources": []}
+
+    with patch("litellm.module_level_client", mock_client):
+        with pytest.raises(GenAIHubOrchestrationError) as exc_info:
+            _ = config.deployment_url
+
+    assert exc_info.value.status_code == 404
+    assert "fake-group" in exc_info.value.message


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streaming tool calls crash with `'MockValSer' object is not an instance of 'SchemaSerializer'`
- Empty deployment list raises a bare `IndexError: list index out of range`

How it solves it:

- Normalize chunks at the SAP provider boundary before they reach core streaming
- Raise a clear 404 naming the resource group when no orchestration deployment exists

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- leave blank — not an internal contributor -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproduced and verified against a live SAP AI Core tenant (real orchestration deployment, no mocks).

**Before** (commit `0cd588ad10`): streaming tool-call request crashes in the streaming handler:

```
TypeError: 'MockValSer' object is not an instance of 'SchemaSerializer'
```

**After** (commit `f2c161e50b`): the same request streams to completion. Proxy log shows successful streaming with usage preserved:

```
'successful_requests': 2, 'failed_requests': 0
'prompt_tokens': 34601, 'completion_tokens': 366
```

Token usage values (`completion` / `prompt` / `total`) pass through unchanged, confirming the SDK usage object is correctly converted to litellm's `Usage`.

The empty-deployment path now returns a descriptive error instead of `IndexError`:

```
GenAIHubOrchestrationError: No orchestration deployment found in SAP AI Core
resource group 'default'. Create/start an orchestration deployment in SAP AI
Launchpad, then retry.
```

## Type

🐛 Bug Fix

## Changes

- `litellm/llms/sap/chat/handler.py`: add `_StreamParser._validate_chunk()` as the single choke point for all three `model_validate` call sites. It drops the empty `logprobs: {}` the orchestration service sends on every choice and converts the raw openai-SDK usage object (a deferred-build pydantic model whose serializer is still a `MockValSer`) into litellm's `Usage`. Calling `model_dump()` directly on the SDK instance is safe because it triggers the deferred serializer rebuild, which the nested call in the streaming handler never gets a chance to do.
- `litellm/llms/sap/chat/transformation.py`: `deployment_url` now raises a clear `GenAIHubOrchestrationError` (HTTP 404) naming the resource group being searched, instead of indexing an empty list and surfacing an opaque `IndexError`.

Both changes are fully contained in the SAP provider — no changes to core streaming logic and no impact on other providers.

## QA runbook

- Added unit tests: `tests/test_litellm/llms/sap/chat/test_sap_stream_chunk_validation.py` (6 tests); full SAP suite passes (107 passed).

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR