### PR TITLE
fix(git-subdir): allow dot-prefixed path segments like .claude/ and .github/

### DIFF
--- a/litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py
+++ b/litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py
@@ -126,10 +126,12 @@ async def get_marketplace():
 
 
 # Allowlist for git-subdir paths: one or more segments separated by '/'.
-# Each segment must start with an alphanumeric character and contain only
-# alphanumeric characters, dots, hyphens, and underscores.
-# This implicitly blocks '..', leading '/', backslashes, and percent-encoded sequences.
-_VALID_GIT_SUBDIR_PATH_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*(/[a-zA-Z0-9][a-zA-Z0-9._-]*)*$")
+# Each segment may start with an optional leading dot (to support hidden directories
+# such as .claude/ or .github/) followed by a required alphanumeric character, then
+# any mix of alphanumeric characters, dots, hyphens, and underscores.
+# The required alphanumeric after the optional dot implicitly blocks '.' and '..',
+# leading '/', backslashes, and percent-encoded sequences.
+_VALID_GIT_SUBDIR_PATH_RE = re.compile(r"^\.?[a-zA-Z0-9][a-zA-Z0-9._-]*(/\.?[a-zA-Z0-9][a-zA-Z0-9._-]*)*$")
 
 
 def _validate_plugin_source(source: Dict[str, Any]) -> None:
@@ -164,7 +166,7 @@ def _validate_plugin_source(source: Dict[str, Any]) -> None:
             raise HTTPException(
                 status_code=400,
                 detail={
-                    "error": "git-subdir 'path' must be a relative path of the form 'segment/segment' (alphanumeric, dots, hyphens, underscores only)"
+                    "error": "git-subdir 'path' must be a relative path of the form 'segment/segment'; each segment may start with a dot (e.g. .claude/skills) followed by alphanumeric characters, dots, hyphens, or underscores"
                 },
             )
     else:

--- a/tests/test_litellm/proxy/anthropic_endpoints/test_claude_code_marketplace.py
+++ b/tests/test_litellm/proxy/anthropic_endpoints/test_claude_code_marketplace.py
@@ -199,6 +199,60 @@ async def test_register_plugin_git_subdir_path_traversal():
 
 
 @pytest.mark.asyncio
+async def test_register_plugin_git_subdir_dot_prefix_paths():
+    """git-subdir paths with dot-prefixed segments (e.g. .claude/skills) are accepted.
+
+    Regression test for #34778: the path validation regex previously required each
+    segment to start with an alphanumeric character, which incorrectly rejected
+    standard Unix hidden-directory names such as .claude/ and .github/.
+    """
+    for good_path in [
+        ".claude/skills",
+        ".github/actions/my-action",
+        ".claude",
+        "plugins/.claude/skills",
+        ".config/litellm",
+    ]:
+        request = RegisterPluginRequest(
+            name="dot-prefix-plugin",
+            source={
+                "source": "git-subdir",
+                "url": "https://github.com/org/monorepo.git",
+                "path": good_path,
+            },
+        )
+        response = await register_plugin(request=request, user_api_key_dict=_USER)
+        assert response["status"] == "success", f"expected success for path {good_path!r}"
+
+
+@pytest.mark.asyncio
+async def test_register_plugin_git_subdir_dot_only_segments_rejected():
+    """Bare dot and double-dot segments are still rejected after the regex fix.
+
+    Regression guard: allowing a leading dot must not re-open path-traversal via
+    '.' or '..' segments.
+    """
+    for bad_path in [
+        ".",
+        "..",
+        "plugins/../secrets",
+        "plugins/.",
+        "plugins/..",
+    ]:
+        request = RegisterPluginRequest(
+            name="bad-dot-plugin",
+            source={
+                "source": "git-subdir",
+                "url": "https://github.com/org/monorepo.git",
+                "path": bad_path,
+            },
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await register_plugin(request=request, user_api_key_dict=_USER)
+        assert exc_info.value.status_code == 400, f"expected 400 for path {bad_path!r}"
+
+
+@pytest.mark.asyncio
 async def test_register_plugin_unknown_source_type():
     """Unknown source type raises HTTP 400 listing all valid types."""
     request = RegisterPluginRequest(


### PR DESCRIPTION
## TLDR

Problem this solves:

The `_VALID_GIT_SUBDIR_PATH_RE` regex in `claude_code_marketplace.py` required every path segment to start with `[a-zA-Z0-9]`. This rejected hidden directories that follow standard Unix conventions - `.claude/`, `.github/`, `.config/`, etc. - with a generic validation error. Users who store skills or plugins under `.claude/skills/` in a monorepo could not register them.

How it solves it:

Changed the leading-character pattern for each segment from `[a-zA-Z0-9]` to `\.?[a-zA-Z0-9]` - an optional leading dot followed by a required alphanumeric. This allows `.claude/skills`, `.github/actions/my-action`, etc. while keeping bare `.` and `..` segments rejected (because after the optional dot the next character must be alphanumeric, not another dot), preserving all existing path-traversal protections.

Updated the error message to document that a dot-prefixed segment is now valid.

## Relevant issues

Fixes #34778

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Before the fix, registering a plugin with `"path": ".claude/skills"` returned HTTP 400:

```
{"error": "git-subdir 'path' must be a relative path of the form 'segment/segment' (alphanumeric, dots, hyphens, underscores only)"}
```

After the fix, the same request returns HTTP 200 with `"status": "success"`. Bare `..` and `../secrets` still return HTTP 400.

## Type

Bug Fix

## Changes

`litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py`
- Updated `_VALID_GIT_SUBDIR_PATH_RE` to accept an optional leading dot per segment
- Updated the comment and error message to document the new accepted format

`tests/test_litellm/proxy/anthropic_endpoints/test_claude_code_marketplace.py`
- Added `test_register_plugin_git_subdir_dot_prefix_paths`: verifies that `.claude/skills`, `.github/actions/my-action`, and similar paths succeed
- Added `test_register_plugin_git_subdir_dot_only_segments_rejected`: verifies that `.`, `..`, `plugins/..`, etc. are still rejected

## QA runbook

```bash
# Start proxy
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug

# Should succeed (dot-prefixed hidden dir)
curl -s -X POST http://localhost:4000/anthropic/claude-code/register-plugin \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"name":"test-plugin","source":{"source":"git-subdir","url":"https://github.com/org/repo.git","path":".claude/skills"}}'

# Should fail (path traversal - still blocked)
curl -s -X POST http://localhost:4000/anthropic/claude-code/register-plugin \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"name":"bad","source":{"source":"git-subdir","url":"https://github.com/org/repo.git","path":"../secrets"}}'
```

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR