### PR TITLE
feat(minimax): add MiniMax-M3 video input capability to model cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27139,6 +27139,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_system_messages": true,
+        "supports_video_input": true,
         "supports_vision": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27214,6 +27214,7 @@
         "supports_prompt_caching": true,
         "supports_reasoning": true,
         "supports_system_messages": true,
+        "supports_video_input": true,
         "supports_vision": true,
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000

--- a/tests/test_litellm/llms/minimax/chat/test_transformation.py
+++ b/tests/test_litellm/llms/minimax/chat/test_transformation.py
@@ -14,6 +14,7 @@ sys.path.insert(
 
 import litellm
 from litellm import completion
+from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
 from litellm.llms.minimax.chat.transformation import MinimaxChatConfig
 
 
@@ -202,9 +203,37 @@ def test_minimax_chat_completion_streaming():
     assert len(chunks) > 0
 
 
+class TestMiniMaxM3InputCapabilities:
+    """Tests that minimax/MiniMax-M3 advertises the input modalities
+    documented by MiniMax, including the video-input capability that was
+    previously missing from the model cost map."""
+
+    @pytest.fixture(autouse=True)
+    def model_cost_map(self):
+        """Load directly from the bundled backup so tests don't depend on remote fetch."""
+        return GetModelCostMap.load_local_model_cost_map()
+
+    def test_minimax_m3_in_model_cost_map(self, model_cost_map):
+        """minimax/MiniMax-M3 should be present in the model cost map."""
+        assert "minimax/MiniMax-M3" in model_cost_map
+
+    def test_minimax_m3_supports_vision(self, model_cost_map):
+        """minimax/MiniMax-M3 should advertise image input via supports_vision."""
+        model_info = model_cost_map["minimax/MiniMax-M3"]
+        assert model_info.get("supports_vision") is True
+
+    def test_minimax_m3_supports_video_input(self, model_cost_map):
+        """minimax/MiniMax-M3 should advertise video input via supports_video_input."""
+        model_info = model_cost_map["minimax/MiniMax-M3"]
+        assert model_info.get("supports_video_input") is True
+
+    def test_minimax_m3_provider(self, model_cost_map):
+        """minimax/MiniMax-M3 should be assigned to the minimax provider."""
+        model_info = model_cost_map["minimax/MiniMax-M3"]
+        assert model_info["litellm_provider"] == "minimax"
+
+
 if __name__ == "__main__":
-    # Run basic tests that don't require API key
-    print("Testing MiniMax Chat Config...")
     test_minimax_chat_config()
     print("✓ Config test passed")
 


### PR DESCRIPTION
Reason: minimax/MiniMax-M3 is documented for text, image, and video input, but the model cost map only advertised image input via supports_vision and omitted the supports_video_input capability.

## Changes

- Set `supports_video_input: true` on the `minimax/MiniMax-M3` entry in `model_prices_and_context_window.json`.
- Set `supports_video_input: true` on the `minimax/MiniMax-M3` entry in `litellm/model_prices_and_context_window_backup.json` (the bundled backup cost map) so the shipped package advertises the same capability.

Both cost map files are kept in sync, matching the existing `supports_vision: true` flag that already advertised image input for this model.

## Tests

- Added `TestMiniMaxM3InputCapabilities` in `tests/test_litellm/llms/minimax/chat/test_transformation.py` covering: model presence in the cost map, `supports_vision`, `supports_video_input`, and provider assignment.

## Checks

- `python3 -m pytest tests/test_litellm/llms/minimax/chat/test_transformation.py -x -q` -> 8 passed, 4 skipped.
- `python3 -m pytest tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py -k minimax_m3 -x -q` -> 1 passed.
- `jq empty model_prices_and_context_window.json` and `jq empty litellm/model_prices_and_context_window_backup.json` -> valid JSON.
