### PR TITLE
fix(proxy): preserve Router model_group in SpendLogs when guardrails add litellm_metadata

### DIFF
--- a/litellm/litellm_core_utils/core_helpers.py
+++ b/litellm/litellm_core_utils/core_helpers.py
@@ -170,10 +170,17 @@ def add_missing_spend_metadata_to_litellm_metadata(litellm_metadata: dict, metad
 
     PATCH for issue where both `litellm_metadata` and `metadata` are present in the kwargs
     and user_api_key values are in 'metadata'.
+
+    Also copies Router-set keys (model_group, model_id, deployment) that the
+    spend log needs for aggregation but that live in `metadata` rather than
+    `litellm_metadata` (#34905).
     """
     potential_spend_tracking_metadata_substring = "user_api_key"
+    router_spend_keys = ("model_group", "model_id", "deployment")
     for key, value in metadata.items():
         if potential_spend_tracking_metadata_substring in key:
+            litellm_metadata[key] = value
+        elif key in router_spend_keys and key not in litellm_metadata:
             litellm_metadata[key] = value
     return litellm_metadata
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -2902,3 +2902,53 @@ async def test_compression_savings_survive_to_spend_log_payload_metadata(monkeyp
         "tokens_saved": 7000,
         "source": "compression_interception",
     }
+
+
+def test_add_missing_spend_metadata_preserves_model_group():
+    """Regression test for #34905.
+
+    When both litellm_metadata and metadata are present (e.g. a unified
+    pre_call guardrail creates litellm_metadata), the Router-set model_group
+    in metadata must be copied into litellm_metadata so SpendLogsPayload
+    does not lose it.
+    """
+    from litellm.litellm_core_utils.core_helpers import (
+        add_missing_spend_metadata_to_litellm_metadata,
+        get_litellm_metadata_from_kwargs,
+    )
+
+    litellm_metadata = {"user_api_key_user_id": "test-user"}
+    metadata = {
+        "model_group": "router-model-group",
+        "model_id": "deployment-123",
+        "deployment": "openai/gpt-4o",
+        "user_api_key": "sk-test",
+    }
+
+    result = add_missing_spend_metadata_to_litellm_metadata(
+        litellm_metadata.copy(), metadata
+    )
+
+    assert result["model_group"] == "router-model-group"
+    assert result["model_id"] == "deployment-123"
+    assert result["deployment"] == "openai/gpt-4o"
+    assert result["user_api_key"] == "sk-test"
+    assert result["user_api_key_user_id"] == "test-user"
+
+
+def test_get_litellm_metadata_from_kwargs_preserves_model_group():
+    """End-to-end: get_litellm_metadata_from_kwargs must surface model_group
+    when both metadata dicts are present (#34905)."""
+    from litellm.litellm_core_utils.core_helpers import (
+        get_litellm_metadata_from_kwargs,
+    )
+
+    kwargs = {
+        "litellm_params": {
+            "metadata": {"model_group": "router-model-group"},
+            "litellm_metadata": {"user_api_key_user_id": "test-user"},
+        }
+    }
+
+    metadata = get_litellm_metadata_from_kwargs(kwargs)
+    assert metadata.get("model_group") == "router-model-group"


### PR DESCRIPTION
## Summary

Fixes #34905

When a unified `pre_call` guardrail creates `litellm_metadata` alongside the Router's `metadata` dict, `add_missing_spend_metadata_to_litellm_metadata` only copied keys containing `user_api_key`. Router-set keys like `model_group`, `model_id`, and `deployment` were dropped, leaving `SpendLogsPayload.model_group` empty and breaking spend aggregation by model group.

## Fix

Copy the Router spend keys (`model_group`, `model_id`, `deployment`) from `metadata` into `litellm_metadata` when they are not already present:

```python
router_spend_keys = ("model_group", "model_id", "deployment")
for key, value in metadata.items():
    if "user_api_key" in key:
        litellm_metadata[key] = value
    elif key in router_spend_keys and key not in litellm_metadata:
        litellm_metadata[key] = value
```

## Test

Added two regression tests in `test_spend_tracking_utils.py`:

- `test_add_missing_spend_metadata_preserves_model_group` — direct unit test of the merge helper
- `test_get_litellm_metadata_from_kwargs_preserves_model_group` — end-to-end via the public helper

```
$ pytest tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py -q
111 passed
```

Verified both new tests **fail** on the unfixed code and **pass** with the fix.