### PR TITLE
fix(noma): honor streaming_end_of_stream_only and streaming_sampling_rate in Noma v2

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/noma/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from litellm.types.guardrails import SupportedGuardrailIntegrations
 
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from litellm.types.guardrails import Guardrail, LitellmParams
 
 
-def _get_config_value(litellm_params: Any, optional_params: Any, attribute_name: str) -> Optional[Any]:
+def _get_config_value(litellm_params: object, optional_params: object, attribute_name: str) -> Optional[object]:
     if optional_params is not None:
         value = (
             optional_params.get(attribute_name)

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 from litellm.types.guardrails import SupportedGuardrailIntegrations
 
@@ -7,6 +7,18 @@ from .noma_v2 import NomaV2Guardrail
 
 if TYPE_CHECKING:
     from litellm.types.guardrails import Guardrail, LitellmParams
+
+
+def _get_config_value(litellm_params: Any, optional_params: Any, attribute_name: str) -> Optional[Any]:
+    if optional_params is not None:
+        value = (
+            optional_params.get(attribute_name)
+            if isinstance(optional_params, dict)
+            else getattr(optional_params, attribute_name, None)
+        )
+        if value is not None:
+            return value
+    return getattr(litellm_params, attribute_name, None)
 
 
 def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"):
@@ -37,6 +49,8 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
 def initialize_guardrail_v2(litellm_params: "LitellmParams", guardrail: "Guardrail"):
     import litellm
 
+    optional_params = getattr(litellm_params, "optional_params", None)
+
     _noma_v2_callback = NomaV2Guardrail(
         guardrail_name=guardrail.get("guardrail_name", ""),
         api_key=litellm_params.api_key,
@@ -46,6 +60,8 @@ def initialize_guardrail_v2(litellm_params: "LitellmParams", guardrail: "Guardra
         block_failures=litellm_params.block_failures,
         event_hook=litellm_params.mode,
         default_on=litellm_params.default_on,
+        streaming_end_of_stream_only=_get_config_value(litellm_params, optional_params, "streaming_end_of_stream_only"),
+        streaming_sampling_rate=_get_config_value(litellm_params, optional_params, "streaming_sampling_rate"),
     )
     litellm.logging_callback_manager.add_litellm_callback(_noma_v2_callback)
 

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/__init__.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from litellm.types.guardrails import SupportedGuardrailIntegrations
 
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from litellm.types.guardrails import Guardrail, LitellmParams
 
 
-def _get_config_value(litellm_params: object, optional_params: object, attribute_name: str) -> Optional[object]:
+def _get_config_value(litellm_params: object, optional_params: object, attribute_name: str) -> object | None:
     if optional_params is not None:
         value = (
             optional_params.get(attribute_name)

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
@@ -43,7 +43,7 @@ class _Action(str, enum.Enum):
     GUARDRAIL_INTERVENED = "GUARDRAIL_INTERVENED"
 
 
-def _coerce_end_of_stream_only(value: Any) -> bool:
+def _coerce_end_of_stream_only(value: object) -> bool:
     if value is None:
         return False
     if isinstance(value, str):
@@ -51,14 +51,14 @@ def _coerce_end_of_stream_only(value: Any) -> bool:
     return bool(value)
 
 
-def _coerce_sampling_rate(value: Any) -> int:
+def _coerce_sampling_rate(value: object) -> int:
     if value is None or value == "":
         return 5
-    if isinstance(value, bool):
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
         raise ValueError(f"streaming_sampling_rate must be an integer >= 1, got {value!r}")
     try:
-        rate = int(value)
-    except (TypeError, ValueError) as e:
+        rate = int(float(value))
+    except ValueError as e:
         raise ValueError(f"streaming_sampling_rate must be an integer >= 1, got {value!r}") from e
     if rate != float(value) or rate < 1:
         raise ValueError(f"streaming_sampling_rate must be an integer >= 1, got {value!r}")
@@ -73,8 +73,8 @@ class NomaV2Guardrail(CustomGuardrail):
         application_id: Optional[str] = None,
         monitor_mode: Optional[bool] = None,
         block_failures: Optional[bool] = None,
-        streaming_end_of_stream_only: Optional[bool] = None,
-        streaming_sampling_rate: Optional[int] = None,
+        streaming_end_of_stream_only: bool | None = None,
+        streaming_sampling_rate: int | None = None,
         **kwargs: Any,
     ) -> None:
         self.async_handler = get_async_httpx_client(llm_provider=httpxSpecialProvider.GuardrailCallback)

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
@@ -43,6 +43,28 @@ class _Action(str, enum.Enum):
     GUARDRAIL_INTERVENED = "GUARDRAIL_INTERVENED"
 
 
+def _coerce_end_of_stream_only(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return value.strip().lower() == "true"
+    return bool(value)
+
+
+def _coerce_sampling_rate(value: Any) -> int:
+    if value is None or value == "":
+        return 5
+    if isinstance(value, bool):
+        raise ValueError(f"streaming_sampling_rate must be an integer >= 1, got {value!r}")
+    try:
+        rate = int(value)
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"streaming_sampling_rate must be an integer >= 1, got {value!r}") from e
+    if rate != float(value) or rate < 1:
+        raise ValueError(f"streaming_sampling_rate must be an integer >= 1, got {value!r}")
+    return rate
+
+
 class NomaV2Guardrail(CustomGuardrail):
     def __init__(
         self,
@@ -51,6 +73,8 @@ class NomaV2Guardrail(CustomGuardrail):
         application_id: Optional[str] = None,
         monitor_mode: Optional[bool] = None,
         block_failures: Optional[bool] = None,
+        streaming_end_of_stream_only: Optional[bool] = None,
+        streaming_sampling_rate: Optional[int] = None,
         **kwargs: Any,
     ) -> None:
         self.async_handler = get_async_httpx_client(llm_provider=httpxSpecialProvider.GuardrailCallback)
@@ -70,6 +94,9 @@ class NomaV2Guardrail(CustomGuardrail):
 
         if self._requires_api_key(api_base=self.api_base) and not self.api_key:
             raise ValueError("Noma v2 guardrail requires api_key when using Noma SaaS endpoint")
+
+        self.streaming_end_of_stream_only: bool = _coerce_end_of_stream_only(streaming_end_of_stream_only)
+        self.streaming_sampling_rate: int = _coerce_sampling_rate(streaming_sampling_rate)
 
         kwargs.setdefault("supported_event_hooks", list(self.get_supported_event_hooks()))
 

--- a/litellm/types/proxy/guardrails/guardrail_hooks/noma.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/noma.py
@@ -49,11 +49,11 @@ class NomaV2GuardrailConfigModel(GuardrailConfigModel):
         default=None,
         description="When true, fail closed on Noma API errors.",
     )
-    streaming_end_of_stream_only: Optional[bool] = Field(
+    streaming_end_of_stream_only: bool | None = Field(
         default=None,
         description="When true, scan the assembled response once at end of stream instead of scanning sampled chunks during the stream.",
     )
-    streaming_sampling_rate: Optional[int] = Field(
+    streaming_sampling_rate: int | None = Field(
         default=None,
         ge=1,
         description=(

--- a/litellm/types/proxy/guardrails/guardrail_hooks/noma.py
+++ b/litellm/types/proxy/guardrails/guardrail_hooks/noma.py
@@ -49,6 +49,18 @@ class NomaV2GuardrailConfigModel(GuardrailConfigModel):
         default=None,
         description="When true, fail closed on Noma API errors.",
     )
+    streaming_end_of_stream_only: Optional[bool] = Field(
+        default=None,
+        description="When true, scan the assembled response once at end of stream instead of scanning sampled chunks during the stream.",
+    )
+    streaming_sampling_rate: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description=(
+            "When streaming_end_of_stream_only is False, scan every Nth streamed chunk. "
+            "Ignored when streaming_end_of_stream_only is True. Must be an integer >= 1."
+        ),
+    )
 
     @staticmethod
     def ui_friendly_name() -> str:

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_noma_v2.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_noma_v2.py
@@ -3,10 +3,27 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from litellm.proxy.guardrails.guardrail_hooks.noma import NomaV2Guardrail
+from litellm.proxy._types import UserAPIKeyAuth
+from litellm.proxy.guardrails.guardrail_hooks.noma import (
+    NomaV2Guardrail,
+    initialize_guardrail,
+    initialize_guardrail_v2,
+)
 from litellm.proxy.guardrails.guardrail_hooks.noma.noma import NomaBlockedMessage
+from litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail import (
+    UnifiedLLMGuardrails,
+)
+from litellm.types.guardrails import LitellmParams
 from litellm.types.proxy.guardrails.guardrail_hooks.noma import (
     NomaV2GuardrailConfigModel,
+)
+from litellm.types.utils import (
+    Choices,
+    Delta,
+    Message,
+    ModelResponse,
+    ModelResponseStream,
+    StreamingChoices,
 )
 
 
@@ -41,6 +58,8 @@ class TestNomaV2Configuration:
         assert "application_id" in noma_v2_params
         assert "monitor_mode" in noma_v2_params
         assert "block_failures" in noma_v2_params
+        assert "streaming_end_of_stream_only" in noma_v2_params
+        assert "streaming_sampling_rate" in noma_v2_params
 
     def test_init_requires_auth_for_saas_endpoint(self):
         with patch.dict(os.environ, {}, clear=True):
@@ -655,3 +674,229 @@ class TestNomaV2ApplicationIdResolution:
 
         payload = call_mock.call_args.kwargs["payload"]
         assert "application_id" not in payload
+
+
+def _streaming_guardrail(**streaming_kwargs):
+    return NomaV2Guardrail(
+        api_base="https://self-managed.noma.local",
+        application_id="test-app",
+        guardrail_name="test-noma-v2-streaming",
+        event_hook="post_call",
+        default_on=True,
+        **streaming_kwargs,
+    )
+
+
+def _text_stream(chunk_count):
+    async def _stream():
+        for index in range(chunk_count):
+            yield ModelResponseStream(
+                model="gpt-4o",
+                choices=[
+                    StreamingChoices(
+                        index=0,
+                        delta=Delta(content=f"chunk-{index}"),
+                        finish_reason="stop" if index == chunk_count - 1 else None,
+                    )
+                ],
+            )
+
+    return _stream()
+
+
+async def _drain_through_unified_guardrail(guardrail, chunk_count, scanned_texts=None):
+    assembled = ModelResponse(
+        choices=[Choices(index=0, message=Message(role="assistant", content="assembled"))]
+    )
+    scan_mock = AsyncMock(return_value={"action": "NONE"})
+    if scanned_texts is not None:
+        original_apply = guardrail.apply_guardrail
+
+        async def _record(**kwargs):
+            scanned_texts.append("".join(kwargs["inputs"].get("texts") or []))
+            return await original_apply(**kwargs)
+
+        guardrail.apply_guardrail = _record
+    with (
+        patch.object(guardrail, "_call_noma_scan", scan_mock),
+        patch(
+            "litellm.llms.openai.chat.guardrail_translation.handler.stream_chunk_builder",
+            return_value=assembled,
+        ),
+    ):
+        request_data = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "guardrail_to_apply": guardrail,
+            "metadata": {"guardrails": ["test-noma-v2-streaming"]},
+        }
+        async for _ in UnifiedLLMGuardrails().async_post_call_streaming_iterator_hook(
+            user_api_key_dict=UserAPIKeyAuth(api_key="test", request_route="/chat/completions"),
+            response=_text_stream(chunk_count),
+            request_data=request_data,
+        ):
+            pass
+    return scan_mock
+
+
+class TestNomaV2StreamingKnobs:
+    def test_streaming_knobs_default_to_framework_defaults(self):
+        guardrail = _streaming_guardrail()
+
+        assert guardrail.streaming_end_of_stream_only is False
+        assert guardrail.streaming_sampling_rate == 5
+
+    def test_streaming_knobs_accept_explicit_values(self):
+        guardrail = _streaming_guardrail(
+            streaming_end_of_stream_only=True,
+            streaming_sampling_rate=2,
+        )
+
+        assert guardrail.streaming_end_of_stream_only is True
+        assert guardrail.streaming_sampling_rate == 2
+
+    @pytest.mark.parametrize("invalid_rate", [0, -1, "0", "abc", 1.5, True, False])
+    def test_streaming_sampling_rate_rejects_invalid_values(self, invalid_rate):
+        with pytest.raises(ValueError, match="streaming_sampling_rate must be an integer >= 1"):
+            _streaming_guardrail(streaming_sampling_rate=invalid_rate)
+
+    @pytest.mark.parametrize("raw_rate, expected", [("3", 3), (3, 3), ("", 5), (None, 5)])
+    def test_streaming_sampling_rate_coerces_config_values(self, raw_rate, expected):
+        guardrail = _streaming_guardrail(streaming_sampling_rate=raw_rate)
+
+        assert guardrail.streaming_sampling_rate == expected
+
+    @pytest.mark.parametrize(
+        "raw_flag, expected",
+        [("true", True), ("True", True), ("false", False), ("no", False), (True, True), (False, False)],
+    )
+    def test_streaming_end_of_stream_only_coerces_config_values(self, raw_flag, expected):
+        guardrail = _streaming_guardrail(streaming_end_of_stream_only=raw_flag)
+
+        assert guardrail.streaming_end_of_stream_only is expected
+
+    def test_initialize_guardrail_v2_forwards_streaming_knobs(self):
+        litellm_params = LitellmParams(
+            guardrail="noma_v2",
+            mode="post_call",
+            api_base="https://self-managed.noma.local",
+            streaming_end_of_stream_only=True,
+            streaming_sampling_rate=3,
+        )
+
+        with patch("litellm.logging_callback_manager.add_litellm_callback") as mock_add:
+            guardrail = initialize_guardrail_v2(
+                litellm_params=litellm_params,
+                guardrail={"guardrail_name": "test-noma-v2-streaming"},
+            )
+
+        assert guardrail.streaming_end_of_stream_only is True
+        assert guardrail.streaming_sampling_rate == 3
+        mock_add.assert_called_once_with(guardrail)
+
+    def test_initialize_guardrail_v2_reads_knobs_from_optional_params_model(self):
+        litellm_params = LitellmParams(
+            guardrail="noma_v2",
+            mode="post_call",
+            api_base="https://self-managed.noma.local",
+            streaming_end_of_stream_only=False,
+            streaming_sampling_rate=9,
+            optional_params={
+                "streaming_end_of_stream_only": True,
+                "streaming_sampling_rate": 1,
+            },
+        )
+
+        with patch("litellm.logging_callback_manager.add_litellm_callback"):
+            guardrail = initialize_guardrail_v2(
+                litellm_params=litellm_params,
+                guardrail={"guardrail_name": "test-noma-v2-streaming"},
+            )
+
+        assert guardrail.streaming_end_of_stream_only is True
+        assert guardrail.streaming_sampling_rate == 1
+
+    def test_initialize_guardrail_v2_falls_back_to_top_level_when_optional_params_omits_knob(self):
+        litellm_params = LitellmParams(
+            guardrail="noma_v2",
+            mode="post_call",
+            api_base="https://self-managed.noma.local",
+            streaming_sampling_rate=7,
+        )
+        litellm_params.optional_params = {"streaming_end_of_stream_only": True}
+
+        with patch("litellm.logging_callback_manager.add_litellm_callback"):
+            guardrail = initialize_guardrail_v2(
+                litellm_params=litellm_params,
+                guardrail={"guardrail_name": "test-noma-v2-streaming"},
+            )
+
+        assert guardrail.streaming_end_of_stream_only is True
+        assert guardrail.streaming_sampling_rate == 7
+
+    def test_use_v2_true_routes_through_v2_streaming_wiring(self):
+        litellm_params = LitellmParams(
+            guardrail="noma",
+            mode="post_call",
+            api_base="https://self-managed.noma.local",
+            use_v2=True,
+            streaming_sampling_rate=4,
+        )
+
+        with patch("litellm.logging_callback_manager.add_litellm_callback") as mock_add:
+            guardrail = initialize_guardrail(
+                litellm_params=litellm_params,
+                guardrail={"guardrail_name": "test-noma-v2-streaming"},
+            )
+
+        assert isinstance(guardrail, NomaV2Guardrail)
+        assert guardrail.streaming_sampling_rate == 4
+        mock_add.assert_called_once_with(guardrail)
+
+    @pytest.mark.asyncio
+    async def test_end_of_stream_only_scans_assembled_response_without_partials(self):
+        guardrail = _streaming_guardrail(streaming_end_of_stream_only=True)
+        scanned_texts = []
+
+        scan_mock = await _drain_through_unified_guardrail(
+            guardrail, chunk_count=6, scanned_texts=scanned_texts
+        )
+
+        assert scan_mock.call_count == 1
+        assert scanned_texts == ["assembled"]
+
+    @pytest.mark.asyncio
+    async def test_default_config_scans_a_mid_stream_partial(self):
+        guardrail = _streaming_guardrail()
+        scanned_texts = []
+
+        await _drain_through_unified_guardrail(guardrail, chunk_count=6, scanned_texts=scanned_texts)
+
+        assert scanned_texts == ["chunk-0chunk-1chunk-2chunk-3chunk-4", "assembled"]
+
+    @pytest.mark.asyncio
+    async def test_sampling_rate_controls_which_partials_are_scanned(self):
+        guardrail = _streaming_guardrail(streaming_sampling_rate=2)
+        scanned_texts = []
+
+        scan_mock = await _drain_through_unified_guardrail(
+            guardrail, chunk_count=5, scanned_texts=scanned_texts
+        )
+
+        assert scan_mock.call_count == 3
+        assert scanned_texts == [
+            "chunk-0chunk-1",
+            "chunk-0chunk-1chunk-2chunk-3",
+            "assembled",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_end_of_stream_only_makes_sampling_rate_irrelevant(self):
+        guardrail = _streaming_guardrail(
+            streaming_end_of_stream_only=True,
+            streaming_sampling_rate=2,
+        )
+        scanned_texts = []
+
+        await _drain_through_unified_guardrail(guardrail, chunk_count=4, scanned_texts=scanned_texts)
+
+        assert scanned_texts == ["assembled"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Noma v2 silently ignores both shared streaming knobs
- Config sets them, guardrail always scans per chunk at rate 5
- No error and no warning, so misconfiguration is invisible
- Streaming Noma API cost and latency cannot be reduced

How it solves it:

- Accept both knobs in the constructor and assign them
- Forward them from litellm_params in the initializer
- Declare both fields on the v2 config model for the UI
- Coerce string values, reject sampling rates below 1

## Relevant issues

Fixes #34922

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

### Why the knobs never took effect

`NomaV2Guardrail` implements `apply_guardrail` and does not define its own `async_post_call_streaming_iterator_hook`. `_callback_capabilities` in `litellm/proxy/utils.py` therefore classifies it as `apply_guardrail`, and the streaming post-call is routed through `UnifiedLLMGuardrails.async_post_call_streaming_iterator_hook`, which reads the knobs off the guardrail instance:

```python
value = getattr(guardrail_to_apply, name, value)
...
sampling_rate = _streaming_flag("streaming_sampling_rate", 5)
end_of_stream_only = _streaming_flag("streaming_end_of_stream_only", False)
```

The constructor never accepted the knobs and the initializer never forwarded them, so the attributes were absent and the `getattr` defaults always won. The other two resolution branches cannot be used as a workaround: nothing in `litellm/` ever assigns a `guardrail_config` attribute, and `UnifiedLLMGuardrails` is constructed with no arguments at both production call sites, so its `optional_params` is always empty.

### Before / after, driving the real dispatcher

Captured against the real `UnifiedLLMGuardrails.async_post_call_streaming_iterator_hook` with only the outbound Noma HTTP call counted. Each scan is shown with the text the guardrail actually received, which is what makes the difference observable rather than just a call tally.

Before, at parent commit `daf22ec871`:

```
--- commit daf22ec871 ---
eos=True n=6   : attr='<never set>' scans=2 texts=['chunk-0chunk-1chunk-2chunk-3chunk-4', 'assembled']
rate=2  n=5    : scans=2 texts=['assembled', 'assembled']
```

With `streaming_end_of_stream_only=True` the attribute is absent and the stream is still scanned twice, one of those a mid-stream partial. With `streaming_sampling_rate=2` the requested cadence is ignored: no mid-stream partial is sampled at all, because the default rate of 5 never divides into a 5-chunk stream ahead of the terminal chunk.

After, at `d4a343893d`:

```
--- commit d4a343893d ---
eos=True n=6   : attr=True scans=1 texts=['assembled']
rate=2  n=5    : scans=3 texts=['chunk-0chunk-1', 'chunk-0chunk-1chunk-2chunk-3', 'assembled']
```

End-of-stream-only now scans exactly once, over the assembled response, with no partials. Sampling rate 2 now produces the two expected mid-stream partials at chunks 2 and 4 plus the end-of-stream scan.

Note on the arithmetic for reviewers: a sampled round that lands on the terminal chunk is not a partial scan. `_process_streaming_block_only` sees a non-null `finish_reason` and takes the `stream_chunk_builder` path, so it scans the assembled response and the end-of-stream round then scans it again. The 5-chunk example above avoids that overlap, which is why it is used as the proof rather than a 4-chunk stream.

### Config-value coercion

Neither knob is a declared field on `LitellmParams` (both are accepted via `extra="allow"`), so values arrive uncoerced from quoted YAML, from the Admin UI number input, and from stored guardrail rows. Without coercion `"2"` reaches an `int` comparison as a string, and `"false"` is truthy, which would silently enable the mode a user was trying to disable. Coercion at the guardrail boundary:

```
'2'      -> 2
'3'      -> 3
''       -> 5    (unset)
'true'   -> True
'false'  -> False
'abc'    -> ValueError: streaming_sampling_rate must be an integer >= 1, got 'abc'
0        -> ValueError: streaming_sampling_rate must be an integer >= 1, got 0
-1       -> ValueError: streaming_sampling_rate must be an integer >= 1, got -1
1.5      -> ValueError: streaming_sampling_rate must be an integer >= 1, got 1.5
```

Rejecting values below 1 at init is deliberate: `unified_guardrail` computes `chunk_counter % sampling_rate`, so `0` would raise `ZeroDivisionError` mid-response, after content had already streamed to the client. Failing at startup is the safer of the two, and no working configuration can depend on the old behavior because the value was ignored entirely. `generic_guardrail_api` validates the same field the same way.

### Test suite

```
56 passed
```

Proof-of-fix was validated by mutation rather than by a green run alone. Reverting only the two attribute assignments, and separately reverting only the initializer forwarding, each makes the relevant tests fail; a coordinated mutation that drops the end-of-stream knob and simultaneously shifts the default sampling rate is caught by `test_default_config_scans_a_mid_stream_partial`, which asserts the scanned text rather than the scan count.

`streaming_transform_mode` and `streaming_buffer_until_moderated` are two further knobs `_streaming_flag` resolves that `noma_v2` also ignores. They are left out to keep this PR to one problem. A very large `streaming_sampling_rate` is behaviorally close to end-of-stream-only; an upper bound would affect all four guardrails sharing these knobs, so it is not introduced here.

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py` - accept `streaming_end_of_stream_only` and `streaming_sampling_rate`, assign them to the instance so the unified streaming hook can resolve them, and coerce config-supplied values through two module-level helpers.
- `litellm/proxy/guardrails/guardrail_hooks/noma/__init__.py` - forward both knobs in `initialize_guardrail_v2`, consulting `optional_params` before the top-level params, matching `generic_guardrail_api`.
- `litellm/types/proxy/guardrails/guardrail_hooks/noma.py` - declare both fields on `NomaV2GuardrailConfigModel` so they are discoverable in the Admin UI.
- `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_noma_v2.py` - 13 tests appended to the existing mapped file (27 cases with parametrization), covering the streaming behavior through the real dispatcher, the initializer wiring, and value coercion. Two assertions were added to the existing config-surface test rather than creating a new one.

Noma v1 is deliberately untouched: `NomaGuardrail` defines its own `async_post_call_streaming_iterator_hook`, so it is classified as an iterator override and never routes through `UnifiedLLMGuardrails`. Its hook buffers the whole stream unconditionally, so neither knob has meaning there.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
