### PR TITLE
fix(azure/gpt-5): honour per-deployment reasoning_effort capability overrides

### DIFF
--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -1,6 +1,6 @@
 """Support for Azure OpenAI gpt-5 model family."""
 
-from typing import List, Optional
+from typing import List
 
 import litellm
 from litellm.exceptions import UnsupportedParamsError
@@ -32,7 +32,7 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         return model
 
     @classmethod
-    def _supports_reasoning_effort_level(cls, model: str, level: str, deployment_model: Optional[str] = None) -> bool:
+    def _supports_reasoning_effort_level(cls, model: str, level: str, deployment_model: str | None = None) -> bool:
         """Override to handle gpt5_series/ prefix used for Azure routing.
 
         The parent class calls ``_supports_factory(model, custom_llm_provider=None)``
@@ -48,7 +48,7 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
 
     @classmethod
     def _is_reasoning_effort_level_explicitly_disabled(
-        cls, model: str, level: str, deployment_model: Optional[str] = None
+        cls, model: str, level: str, deployment_model: str | None = None
     ) -> bool:
         """Override to handle gpt5_series/ prefix and Azure cost-map key resolution."""
         return super()._is_reasoning_effort_level_explicitly_disabled(
@@ -80,7 +80,7 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         _normalized = model.split("/")[-1]  # strip provider prefix, e.g. "azure/"
         return ("gpt-5" in model and not _normalized.startswith("gpt-5-chat")) or "gpt5_series" in model
 
-    def get_supported_openai_params(self, model: str, deployment_model: Optional[str] = None) -> List[str]:
+    def get_supported_openai_params(self, model: str, deployment_model: str | None = None) -> list[str]:
         """Get supported parameters for Azure OpenAI GPT-5 models.
 
         Azure OpenAI GPT-5.2/5.4 models support logprobs, unlike OpenAI's GPT-5.
@@ -119,7 +119,7 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         drop_params: bool,
         api_version: str = "",
         *,
-        deployment_model: Optional[str] = None,
+        deployment_model: str | None = None,
     ) -> dict:
         reasoning_effort_value = non_default_params.get("reasoning_effort") or optional_params.get("reasoning_effort")
         effective_effort = _get_effort_level(reasoning_effort_value)

--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -1,6 +1,6 @@
 """Support for Azure OpenAI gpt-5 model family."""
 
-from typing import List
+from typing import List, Optional
 
 import litellm
 from litellm.exceptions import UnsupportedParamsError
@@ -19,7 +19,20 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
     GPT5_SERIES_ROUTE = "gpt5_series/"
 
     @classmethod
-    def _supports_reasoning_effort_level(cls, model: str, level: str) -> bool:
+    def _normalize_azure_model_name(cls, model: str) -> str:
+        """Resolve an Azure model or deployment name to its cost-map key.
+
+        Strips the ``gpt5_series/`` routing prefix and prepends ``azure/`` so the
+        lookup finds e.g. ``azure/gpt-5.1`` in model_prices_and_context_window.json.
+        """
+        if model.startswith(cls.GPT5_SERIES_ROUTE):
+            return "azure/" + model[len(cls.GPT5_SERIES_ROUTE) :]
+        if not model.startswith("azure/"):
+            return "azure/" + model
+        return model
+
+    @classmethod
+    def _supports_reasoning_effort_level(cls, model: str, level: str, deployment_model: Optional[str] = None) -> bool:
         """Override to handle gpt5_series/ prefix used for Azure routing.
 
         The parent class calls ``_supports_factory(model, custom_llm_provider=None)``
@@ -27,11 +40,22 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         entry. Strip the prefix and prepend ``azure/`` so the lookup finds
         ``azure/gpt-5.1`` in model_prices_and_context_window.json.
         """
-        if model.startswith(cls.GPT5_SERIES_ROUTE):
-            model = "azure/" + model[len(cls.GPT5_SERIES_ROUTE) :]
-        elif not model.startswith("azure/"):
-            model = "azure/" + model
-        return super()._supports_reasoning_effort_level(model, level)
+        return super()._supports_reasoning_effort_level(
+            cls._normalize_azure_model_name(model),
+            level,
+            cls._normalize_azure_model_name(deployment_model) if deployment_model is not None else None,
+        )
+
+    @classmethod
+    def _is_reasoning_effort_level_explicitly_disabled(
+        cls, model: str, level: str, deployment_model: Optional[str] = None
+    ) -> bool:
+        """Override to handle gpt5_series/ prefix and Azure cost-map key resolution."""
+        return super()._is_reasoning_effort_level_explicitly_disabled(
+            cls._normalize_azure_model_name(model),
+            level,
+            cls._normalize_azure_model_name(deployment_model) if deployment_model is not None else None,
+        )
 
     @classmethod
     def is_model_gpt_5_model(cls, model: str) -> bool:
@@ -92,13 +116,15 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         model: str,
         drop_params: bool,
         api_version: str = "",
+        *,
+        deployment_model: Optional[str] = None,
     ) -> dict:
         reasoning_effort_value = non_default_params.get("reasoning_effort") or optional_params.get("reasoning_effort")
         effective_effort = _get_effort_level(reasoning_effort_value)
 
         # gpt-5.1/5.2/5.4 support reasoning_effort='none', but other gpt-5 models don't
         # See: https://learn.microsoft.com/en-us/azure/ai-foundry/openai/how-to/reasoning
-        supports_none = self._supports_reasoning_effort_level(model, "none")
+        supports_none = self._supports_reasoning_effort_level(model, "none", deployment_model)
 
         if effective_effort == "none" and not supports_none:
             if litellm.drop_params is True or (drop_params is not None and drop_params is True):
@@ -126,6 +152,7 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
             optional_params=optional_params,
             model=model,
             drop_params=drop_params,
+            deployment_model=deployment_model,
         )
 
         # Only drop reasoning_effort='none' for models that don't support it

--- a/litellm/llms/azure/chat/gpt_5_transformation.py
+++ b/litellm/llms/azure/chat/gpt_5_transformation.py
@@ -80,7 +80,7 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         _normalized = model.split("/")[-1]  # strip provider prefix, e.g. "azure/"
         return ("gpt-5" in model and not _normalized.startswith("gpt-5-chat")) or "gpt5_series" in model
 
-    def get_supported_openai_params(self, model: str) -> List[str]:
+    def get_supported_openai_params(self, model: str, deployment_model: Optional[str] = None) -> List[str]:
         """Get supported parameters for Azure OpenAI GPT-5 models.
 
         Azure OpenAI GPT-5.2/5.4 models support logprobs, unlike OpenAI's GPT-5.
@@ -91,7 +91,7 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         - Azure returns logprobs successfully despite Microsoft's general
           documentation stating reasoning models don't support it.
         """
-        params = OpenAIGPT5Config.get_supported_openai_params(self, model=model)
+        params = OpenAIGPT5Config.get_supported_openai_params(self, model=model, deployment_model=deployment_model)
 
         # Azure supports tool_choice for GPT-5 deployments, but the base GPT-5 config
         # can drop it when the deployment name isn't in the OpenAI model registry.
@@ -101,7 +101,9 @@ class AzureOpenAIGPT5Config(AzureOpenAIConfig, OpenAIGPT5Config):
         # Only gpt-5.2+ has been verified to support logprobs on Azure.
         # The base OpenAI class includes logprobs for gpt-5.1+, but Azure
         # hasn't verified support for gpt-5.1, so remove them unless gpt-5.2/5.4+.
-        if self._supports_reasoning_effort_level(model, "none") and not self.is_model_gpt_5_2_model(model):
+        if self._supports_reasoning_effort_level(model, "none", deployment_model) and not self.is_model_gpt_5_2_model(
+            model
+        ):
             params = [p for p in params if p not in ["logprobs", "top_logprobs"]]
         elif self.is_model_gpt_5_2_model(model):
             azure_supported_params = ["logprobs", "top_logprobs"]

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -115,21 +115,48 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             return False
 
     @classmethod
-    def _supports_reasoning_effort_level(cls, model: str, level: str) -> bool:
+    def _deployment_capability_override(cls, deployment_model: str, key: str) -> Optional[bool]:
+        """Resolve an explicitly configured capability for a deployment name.
+
+        Per-deployment ``model_info`` overrides are registered in the cost map under
+        the backend deployment name, while capability lookups for Azure resolve
+        against ``base_model``.  This returns the explicitly configured value for
+        ``key`` (``True`` or ``False``), or ``None`` when the deployment carries no
+        explicit setting and the ``base_model`` entry should be used instead.
+        """
+        if _supports_factory(model=deployment_model, custom_llm_provider=None, key=key):
+            return True
+        if _is_explicitly_disabled_factory(model=deployment_model, custom_llm_provider=None, key=key):
+            return False
+        return None
+
+    @classmethod
+    def _supports_reasoning_effort_level(cls, model: str, level: str, deployment_model: Optional[str] = None) -> bool:
         """Check if the model supports a specific reasoning_effort level.
 
         Looks up ``supports_{level}_reasoning_effort`` in the model map via
         the shared ``_supports_factory`` helper.
         Returns False for unknown models (safe fallback).
+
+        When ``deployment_model`` is given and carries an explicit setting for the
+        capability, that per-deployment override wins over ``model`` (which is the
+        ``base_model`` for Azure deployments).
         """
+        key = f"supports_{level}_reasoning_effort"
+        if deployment_model is not None and deployment_model != model:
+            override = cls._deployment_capability_override(deployment_model, key)
+            if override is not None:
+                return override
         return _supports_factory(
             model=model,
             custom_llm_provider=None,
-            key=f"supports_{level}_reasoning_effort",
+            key=key,
         )
 
     @classmethod
-    def _is_reasoning_effort_level_explicitly_disabled(cls, model: str, level: str) -> bool:
+    def _is_reasoning_effort_level_explicitly_disabled(
+        cls, model: str, level: str, deployment_model: Optional[str] = None
+    ) -> bool:
         """Return True only when the model map explicitly sets the capability to False.
 
         Unlike ``_supports_reasoning_effort_level`` (which requires an explicit True),
@@ -138,11 +165,19 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         supported (i.e. this method returns False = not disabled).
 
         Use this for opt-out checks where unknown models should be allowed through.
+
+        When ``deployment_model`` is given and carries an explicit setting for the
+        capability, that per-deployment override wins over ``model``.
         """
+        key = f"supports_{level}_reasoning_effort"
+        if deployment_model is not None and deployment_model != model:
+            override = cls._deployment_capability_override(deployment_model, key)
+            if override is not None:
+                return override is False
         return _is_explicitly_disabled_factory(
             model=model,
             custom_llm_provider=None,
-            key=f"supports_{level}_reasoning_effort",
+            key=key,
         )
 
     def get_supported_openai_params(self, model: str) -> list:
@@ -194,6 +229,8 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         optional_params: dict,
         model: str,
         drop_params: bool,
+        *,
+        deployment_model: Optional[str] = None,
     ) -> dict:
         if self.is_model_gpt_5_search_model(model):
             if "max_tokens" in non_default_params:
@@ -224,7 +261,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
 
         if effective_effort == "xhigh":
             # xhigh is an opt-in capability: only allow if model explicitly supports it.
-            if not self._supports_reasoning_effort_level(model, effective_effort):
+            if not self._supports_reasoning_effort_level(model, effective_effort, deployment_model):
                 if litellm.drop_params or drop_params:
                     non_default_params.pop("reasoning_effort", None)
                     optional_params.pop("reasoning_effort", None)
@@ -238,7 +275,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             # the model map explicitly sets supports_{level}_reasoning_effort=false.
             # Example: gpt-5.5-pro only accepts {medium, high, xhigh}, so it sets
             # supports_low_reasoning_effort=false (and supports_minimal=false).
-            if self._is_reasoning_effort_level_explicitly_disabled(model, effective_effort):
+            if self._is_reasoning_effort_level_explicitly_disabled(model, effective_effort, deployment_model):
                 if litellm.drop_params or drop_params:
                     non_default_params.pop("reasoning_effort", None)
                     optional_params.pop("reasoning_effort", None)
@@ -256,7 +293,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             optional_params["max_completion_tokens"] = non_default_params.pop("max_tokens")
 
         # gpt-5.1/5.2 support logprobs, top_p, top_logprobs only when reasoning_effort="none"
-        supports_none = self._supports_reasoning_effort_level(model, "none")
+        supports_none = self._supports_reasoning_effort_level(model, "none", deployment_model)
         if supports_none:
             sampling_params = ["logprobs", "top_logprobs", "top_p"]
             has_sampling = any(p in non_default_params for p in sampling_params)

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -1,6 +1,6 @@
 """Support for OpenAI gpt-5 model family."""
 
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import litellm
 from litellm.utils import (
@@ -115,7 +115,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             return False
 
     @classmethod
-    def _deployment_capability_override(cls, deployment_model: str, key: str) -> Optional[bool]:
+    def _deployment_capability_override(cls, deployment_model: str, key: str) -> bool | None:
         """Resolve an explicitly configured capability for a deployment name.
 
         Per-deployment ``model_info`` overrides are registered in the cost map under
@@ -131,7 +131,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         return None
 
     @classmethod
-    def _supports_reasoning_effort_level(cls, model: str, level: str, deployment_model: Optional[str] = None) -> bool:
+    def _supports_reasoning_effort_level(cls, model: str, level: str, deployment_model: str | None = None) -> bool:
         """Check if the model supports a specific reasoning_effort level.
 
         Looks up ``supports_{level}_reasoning_effort`` in the model map via
@@ -155,7 +155,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
 
     @classmethod
     def _is_reasoning_effort_level_explicitly_disabled(
-        cls, model: str, level: str, deployment_model: Optional[str] = None
+        cls, model: str, level: str, deployment_model: str | None = None
     ) -> bool:
         """Return True only when the model map explicitly sets the capability to False.
 
@@ -180,7 +180,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             key=key,
         )
 
-    def get_supported_openai_params(self, model: str, deployment_model: Optional[str] = None) -> List[str]:
+    def get_supported_openai_params(self, model: str, deployment_model: str | None = None) -> list[str]:
         if self.is_model_gpt_5_search_model(model):
             return [
                 "max_tokens",
@@ -230,7 +230,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         model: str,
         drop_params: bool,
         *,
-        deployment_model: Optional[str] = None,
+        deployment_model: str | None = None,
     ) -> dict:
         if self.is_model_gpt_5_search_model(model):
             if "max_tokens" in non_default_params:

--- a/litellm/llms/openai/chat/gpt_5_transformation.py
+++ b/litellm/llms/openai/chat/gpt_5_transformation.py
@@ -1,6 +1,6 @@
 """Support for OpenAI gpt-5 model family."""
 
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import litellm
 from litellm.utils import (
@@ -180,7 +180,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
             key=key,
         )
 
-    def get_supported_openai_params(self, model: str) -> list:
+    def get_supported_openai_params(self, model: str, deployment_model: Optional[str] = None) -> List[str]:
         if self.is_model_gpt_5_search_model(model):
             return [
                 "max_tokens",
@@ -218,7 +218,7 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
         ]
 
         # gpt-5.1/5.2 support logprobs, top_p, top_logprobs when reasoning_effort="none"
-        if not self._supports_reasoning_effort_level(model, "none"):
+        if not self._supports_reasoning_effort_level(model, "none", deployment_model):
             non_supported_params.extend(["logprobs", "top_p", "top_logprobs"])
 
         return [param for param in base_gpt_series_params if param not in non_supported_params]
@@ -331,9 +331,8 @@ class OpenAIGPT5Config(OpenAIGPTConfig):
                         ).format(temperature_value),
                         status_code=400,
                     )
-        return super()._map_openai_params(
-            non_default_params=non_default_params,
-            optional_params=optional_params,
-            model=model,
-            drop_params=drop_params,
-        )
+        supported_openai_params = self.get_supported_openai_params(model=model, deployment_model=deployment_model)
+        return {
+            **optional_params,
+            **{k: v for k, v in non_default_params.items() if k in supported_openai_params},
+        }

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4298,6 +4298,7 @@ def get_optional_params(
                 optional_params=optional_params,
                 model=_azure_detection_model,
                 drop_params=(drop_params if drop_params is not None and isinstance(drop_params, bool) else False),
+                deployment_model=model,
             )
         else:
             verbose_logger.debug(

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -438,3 +438,74 @@ def test_get_optional_params_without_override_keeps_temperature(
         drop_params=True,
     )
     assert params["temperature"] == 0.2
+
+
+@pytest.fixture()
+def sampling_capability_override() -> Iterator[None]:
+    """Register a deployment that enables reasoning_effort='none' over a base model without it."""
+    original_model_cost = litellm.model_cost.copy()
+    litellm.register_model(model_cost={"azure/gpt-5-sampling-dz": {"supports_none_reasoning_effort": True}})
+    yield
+    litellm.model_cost = original_model_cost
+
+
+def test_azure_gpt5_deployment_override_allows_top_p(config: AzureOpenAIGPT5Config, sampling_capability_override: None):
+    """A deployment enabling none-effort must have top_p honoured, not stripped.
+
+    top_p is only supported when reasoning_effort='none' is available.  The base
+    model (azure/gpt-5) does not support it, so the parameter survives only when the
+    supported-parameter list is resolved with the deployment override applied.
+    """
+    assert not litellm.model_cost["azure/gpt-5"].get("supports_none_reasoning_effort")
+
+    params = config.map_openai_params(
+        non_default_params={"top_p": 0.5},
+        optional_params={},
+        model="azure/gpt-5",
+        drop_params=True,
+        api_version="2025-01-01-preview",
+        deployment_model="gpt-5-sampling-dz",
+    )
+    assert params["top_p"] == 0.5
+
+
+def test_azure_gpt5_supported_params_reflect_deployment_override(
+    config: AzureOpenAIGPT5Config, sampling_capability_override: None
+):
+    """get_supported_openai_params must reflect the deployment override.
+
+    Guards the pre-mapping validation path, which filters parameters before the
+    request-mapping gates run.
+    """
+    assert "top_p" not in config.get_supported_openai_params(model="azure/gpt-5")
+    assert "top_p" in config.get_supported_openai_params(model="azure/gpt-5", deployment_model="gpt-5-sampling-dz")
+
+
+def test_get_optional_params_honours_deployment_override_for_top_p(
+    sampling_capability_override: None,
+):
+    """End-to-end: top_p survives for an overriding deployment through get_optional_params."""
+    params = litellm.utils.get_optional_params(
+        model="gpt-5-sampling-dz",
+        custom_llm_provider="azure",
+        base_model="azure/gpt-5",
+        top_p=0.5,
+        drop_params=True,
+    )
+    assert params["top_p"] == 0.5
+
+
+def test_azure_gpt5_logprobs_still_gated_by_model_version(
+    config: AzureOpenAIGPT5Config, sampling_capability_override: None
+):
+    """logprobs stays gated on gpt-5.2+ regardless of the capability override.
+
+    Azure has only verified logprobs for gpt-5.2 and newer, and that rule keys off the
+    model version rather than the reasoning-effort capability.  A registry gpt-5.1
+    entry behaves identically, so the override must not widen logprobs support.
+    """
+    assert "logprobs" not in config.get_supported_openai_params(model="azure/gpt-5.1")
+    assert "logprobs" not in config.get_supported_openai_params(
+        model="azure/gpt-5", deployment_model="gpt-5-sampling-dz"
+    )
+    assert "logprobs" in config.get_supported_openai_params(model="azure/gpt-5.2")

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -1,3 +1,5 @@
+from typing import Iterator
+
 import pytest
 
 import litellm
@@ -11,15 +13,11 @@ def config() -> AzureOpenAIGPT5Config:
 
 def test_azure_gpt5_supports_reasoning_effort(config: AzureOpenAIGPT5Config):
     assert "reasoning_effort" in config.get_supported_openai_params(model="gpt-5")
-    assert "reasoning_effort" in config.get_supported_openai_params(
-        model="gpt5_series/my-deployment"
-    )
+    assert "reasoning_effort" in config.get_supported_openai_params(model="gpt5_series/my-deployment")
 
 
 def test_azure_gpt5_allows_tool_choice_for_deployment_names():
-    supported_params = litellm.get_supported_openai_params(
-        model="gpt-5-chat-2025-08-07", custom_llm_provider="azure"
-    )
+    supported_params = litellm.get_supported_openai_params(model="gpt-5-chat-2025-08-07", custom_llm_provider="azure")
     assert supported_params is not None
     assert "tool_choice" in supported_params
     # gpt-5-chat* should not be treated as a GPT-5 reasoning model
@@ -71,9 +69,7 @@ def test_azure_gpt5_codex_model_detection(config: AzureOpenAIGPT5Config):
 def test_azure_gpt5_codex_supports_reasoning_effort(config: AzureOpenAIGPT5Config):
     """Test that Azure GPT-5-Codex supports reasoning_effort parameter."""
     assert "reasoning_effort" in config.get_supported_openai_params(model="gpt-5-codex")
-    assert "reasoning_effort" in config.get_supported_openai_params(
-        model="gpt5_series/gpt-5-codex"
-    )
+    assert "reasoning_effort" in config.get_supported_openai_params(model="gpt5_series/gpt-5-codex")
 
 
 def test_azure_gpt5_codex_maps_max_tokens(config: AzureOpenAIGPT5Config):
@@ -299,3 +295,146 @@ def test_azure_gpt5_1_does_not_support_logprobs(config: AzureOpenAIGPT5Config):
     supported_params = config.get_supported_openai_params(model="gpt-5.1")
     assert "logprobs" not in supported_params
     assert "top_logprobs" not in supported_params
+
+
+@pytest.fixture()
+def deployment_capability_override() -> Iterator[None]:
+    """Register a deployment-name-keyed capability override, as the router does.
+
+    Router._create_deployment registers per-deployment ``model_info`` under the
+    backend model name (``azure/<deployment>``), while Azure capability lookups
+    resolve against ``base_model``.  This fixture reproduces that registration so
+    tests can assert the override is honoured.
+    """
+    original_model_cost = litellm.model_cost.copy()
+    litellm.register_model(
+        model_cost={
+            "azure/gpt-5.6-luna-dz": {"supports_none_reasoning_effort": False},
+            "azure/gpt-5-none-enabled-dz": {"supports_none_reasoning_effort": True},
+        }
+    )
+    yield
+    litellm.model_cost = original_model_cost
+
+
+def test_azure_gpt5_deployment_override_disables_flexible_temperature(
+    config: AzureOpenAIGPT5Config, deployment_capability_override: None
+):
+    """A per-deployment supports_none_reasoning_effort=false must drop temperature.
+
+    The registry entry for the base_model (azure/gpt-5.6-luna) sets the capability
+    to true, so without honouring the deployment override the temperature is
+    forwarded and Azure rejects the request with a 400.
+    """
+    assert litellm.model_cost["azure/gpt-5.6-luna"]["supports_none_reasoning_effort"] is True
+
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.2},
+        optional_params={},
+        model="azure/gpt-5.6-luna",
+        drop_params=True,
+        api_version="2025-01-01-preview",
+        deployment_model="gpt-5.6-luna-dz",
+    )
+    assert "temperature" not in params
+
+
+def test_azure_gpt5_deployment_override_raises_without_drop_params(
+    config: AzureOpenAIGPT5Config, deployment_capability_override: None
+):
+    """With drop_params disabled the override must surface as an UnsupportedParamsError."""
+    with pytest.raises(litellm.utils.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"temperature": 0.2},
+            optional_params={},
+            model="azure/gpt-5.6-luna",
+            drop_params=False,
+            api_version="2025-01-01-preview",
+            deployment_model="gpt-5.6-luna-dz",
+        )
+
+
+def test_azure_gpt5_deployment_override_enables_flexible_temperature(
+    config: AzureOpenAIGPT5Config, deployment_capability_override: None
+):
+    """A per-deployment supports_none_reasoning_effort=true must allow temperature.
+
+    The base_model here (azure/gpt-5) does not support reasoning_effort='none', so
+    the temperature is only preserved when the deployment override is honoured.
+    """
+    assert not litellm.model_cost["azure/gpt-5"].get("supports_none_reasoning_effort")
+
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.3},
+        optional_params={},
+        model="azure/gpt-5",
+        drop_params=True,
+        api_version="2025-01-01-preview",
+        deployment_model="gpt-5-none-enabled-dz",
+    )
+    assert params["temperature"] == 0.3
+
+
+def test_azure_gpt5_without_deployment_override_uses_base_model(
+    config: AzureOpenAIGPT5Config, deployment_capability_override: None
+):
+    """A deployment without an explicit override must keep using base_model capabilities.
+
+    Guards the base_model resolution added in #31243 against regression.
+    """
+    params = config.map_openai_params(
+        non_default_params={"temperature": 0.2},
+        optional_params={},
+        model="azure/gpt-5.6-luna",
+        drop_params=True,
+        api_version="2025-01-01-preview",
+        deployment_model="gpt-5.6-luna-no-override-dz",
+    )
+    assert params["temperature"] == 0.2
+
+
+def test_azure_gpt5_temperature_one_survives_deployment_override(
+    config: AzureOpenAIGPT5Config, deployment_capability_override: None
+):
+    """temperature=1 is the Azure default and must never be dropped."""
+    params = config.map_openai_params(
+        non_default_params={"temperature": 1},
+        optional_params={},
+        model="azure/gpt-5.6-luna",
+        drop_params=True,
+        api_version="2025-01-01-preview",
+        deployment_model="gpt-5.6-luna-dz",
+    )
+    assert params["temperature"] == 1
+
+
+def test_get_optional_params_honours_deployment_override(
+    deployment_capability_override: None,
+):
+    """End-to-end through get_optional_params, which is what the proxy calls.
+
+    Covers the deployment identity being threaded through the azure branch rather
+    than collapsed into ``base_model or model``.
+    """
+    params = litellm.utils.get_optional_params(
+        model="gpt-5.6-luna-dz",
+        custom_llm_provider="azure",
+        base_model="azure/gpt-5.6-luna",
+        temperature=0.2,
+        drop_params=True,
+    )
+    assert "temperature" not in params
+
+
+def test_get_optional_params_without_override_keeps_temperature(
+    deployment_capability_override: None,
+):
+    """Sibling control: an unoverridden deployment still resolves via base_model."""
+    params = litellm.utils.get_optional_params(
+        model="gpt-5.6-terra-dz",
+        custom_llm_provider="azure",
+        base_model="azure/gpt-5.6-terra",
+        temperature=0.2,
+        drop_params=True,
+    )
+    assert params["temperature"] == 0.2

--- a/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
+++ b/tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py
@@ -509,3 +509,74 @@ def test_azure_gpt5_logprobs_still_gated_by_model_version(
         model="azure/gpt-5", deployment_model="gpt-5-sampling-dz"
     )
     assert "logprobs" in config.get_supported_openai_params(model="azure/gpt-5.2")
+
+
+@pytest.fixture()
+def minimal_effort_overrides() -> Iterator[None]:
+    """Register deployments overriding the minimal reasoning-effort capability both ways."""
+    original_model_cost = litellm.model_cost.copy()
+    litellm.register_model(
+        model_cost={
+            "azure/gpt-55-minimal-allowed-dz": {"supports_minimal_reasoning_effort": True},
+            "azure/gpt-54-minimal-blocked-dz": {"supports_minimal_reasoning_effort": False},
+        }
+    )
+    yield
+    litellm.model_cost = original_model_cost
+
+
+def test_azure_gpt5_deployment_override_re_enables_minimal_effort(
+    config: AzureOpenAIGPT5Config, minimal_effort_overrides: None
+):
+    """A deployment may re-enable a minimal effort level its base model disables.
+
+    azure/gpt-5.5-pro sets supports_minimal_reasoning_effort=false, so without the
+    override reasoning_effort='minimal' is dropped.
+    """
+    assert litellm.model_cost["azure/gpt-5.5-pro"]["supports_minimal_reasoning_effort"] is False
+
+    params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "minimal"},
+        optional_params={},
+        model="azure/gpt-5.5-pro",
+        drop_params=True,
+        api_version="2025-01-01-preview",
+        deployment_model="gpt-55-minimal-allowed-dz",
+    )
+    assert params["reasoning_effort"] == "minimal"
+
+
+def test_azure_gpt5_deployment_override_blocks_minimal_effort(
+    config: AzureOpenAIGPT5Config, minimal_effort_overrides: None
+):
+    """A deployment may disable a minimal effort level its base model allows.
+
+    azure/gpt-5.4 carries no explicit setting, so minimal passes through unless the
+    deployment override marks it unsupported.
+    """
+    assert litellm.model_cost["azure/gpt-5.4"].get("supports_minimal_reasoning_effort") is None
+
+    params = config.map_openai_params(
+        non_default_params={"reasoning_effort": "minimal"},
+        optional_params={},
+        model="azure/gpt-5.4",
+        drop_params=True,
+        api_version="2025-01-01-preview",
+        deployment_model="gpt-54-minimal-blocked-dz",
+    )
+    assert "reasoning_effort" not in params
+
+
+def test_azure_gpt5_deployment_override_blocks_minimal_effort_strict(
+    config: AzureOpenAIGPT5Config, minimal_effort_overrides: None
+):
+    """The blocking override must raise rather than forward when drop_params is off."""
+    with pytest.raises(litellm.utils.UnsupportedParamsError):
+        config.map_openai_params(
+            non_default_params={"reasoning_effort": "minimal"},
+            optional_params={},
+            model="azure/gpt-5.4",
+            drop_params=False,
+            api_version="2025-01-01-preview",
+            deployment_model="gpt-54-minimal-blocked-dz",
+        )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Per-deployment `model_info` capability overrides are ignored when `base_model` is set
- Azure gpt-5.6 deployments 400 on any temperature other than 1, with no workaround
- Affects the temperature, logprobs/top_p, xhigh, and minimal/low effort gates

How it solves it:

- Threads the deployment name into the gpt-5 capability gates
- An explicitly configured per-deployment capability wins over the `base_model` entry
- Routing and version detection still use `base_model`, so #31243 is unchanged

## Relevant issues

Fixes #34932

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

The proof here is production traffic across the version boundary rather than a local curl. The defect only reproduces against an Azure deployment whose service-side default has reasoning on, which is a property of the deployment rather than of the model name, so a fresh Azure resource does not exhibit it and I cannot hand a reviewer credentials for the one that does. What follows is the observed behaviour of a real deployment serving real traffic, plus a credential-free local reproduction anyone can run

**Before, on v1.89.1 and then v1.93.0, same config and same callers**

Occurrences of the Azure temperature 400 in the gateway logs, from the production deployment:

| Window | Occurrences |
|---|---|
| 6 days before upgrading, on v1.89.1 | 0 |
| after upgrading to v1.93.0 | 332 |

The error as the end user saw it:

```
litellm.BadRequestError: AzureException BadRequestError - Unsupported value: 'temperature'
does not support 0.0 with this model. Only the default (1) value is supported.
Received Model Group=gpt-5.6-luna
Available Model Group Fallbacks=None
```

Nothing changed in the gpt-5 transformation code between those versions; the gpt-5 transformation files differ only in formatting. What changed is the registry: v1.89.1 shipped no `azure/gpt-5.6-*` entries, so `supports_none` resolved false and the `drop_params` branch removed the temperature, while v1.93.0 added 12 entries carrying `supports_none_reasoning_effort: true`, which flips the gate to forward the temperature to Azure

**Attempting the documented workaround, which is what this PR fixes**

Setting `supports_none_reasoning_effort: false` in `model_info` on all 24 affected deployments changed nothing. `/model/info` on the running pod reported the flag as `False` while `temperature=0.0` still returned the Azure 400, because the override registers under the deployment name while the gate resolves against `base_model`

**After, with a per-deployment temperature drop applied as a stopgap**

Same deployment, same callers, after rolling out a workaround that drops the parameter before the gate:

| Metric | Before | After |
|---|---|---|
| Azure temperature 400s, 09:00Z | 62/h | 0 |
| Azure temperature 400s, 10:00Z | 44/h | 0 |

Zero is not merely absence of traffic; 33 gpt-5.6 requests were served in the window after the change with no errors. Reasoning also stayed on, 27 and 25 reasoning tokens on a thinking prompt, so the models were still doing real work

That stopgap is a per-deployment parameter drop, which is a blunt instrument; this PR makes the intended `model_info` override actually work, which is the mechanism a deployment should be able to use

**Credential-free reproduction, before and after**

Captured on `daf22ec871`, the parent of this branch, in a clean worktree:

```
$ git log --oneline -1
daf22ec871 test(e2e): make MCP and prometheus e2e tests robust to data-plane sync lag (#34854)

$ python -c '
import litellm
litellm.register_model(model_cost={"azure/gpt-5.6-luna-dz": {"supports_none_reasoning_effort": False}})
print(litellm.model_cost["azure/gpt-5.6-luna-dz"]["supports_none_reasoning_effort"])
print(litellm.model_cost["azure/gpt-5.6-luna"]["supports_none_reasoning_effort"])
print(litellm.utils.get_optional_params(model="gpt-5.6-luna-dz", custom_llm_provider="azure",
      base_model="azure/gpt-5.6-luna", temperature=0.2, drop_params=True))'
False
True
{'temperature': 0.2, 'stream': False, 'extra_body': {}}
```

`temperature` survives despite the deployment override saying it must not, and is then sent to Azure

Same commands on this branch, `8140818c6b`:

```
$ git log --oneline -1
8140818c6b fix(azure/gpt-5): apply deployment capability overrides to supported params

$ python -c '... identical to above ...'
False
True
{'stream': False, 'extra_body': {}}
```

`temperature` is now dropped. The sibling control, a deployment with no override, still resolves through `base_model` and keeps `temperature=0.2`, so the `base_model` behaviour from #31243 is intact

**Sampling parameters, after the Greptile finding**

Greptile flagged that a deployment enabling `supports_none_reasoning_effort` over a base model without it would still lose `top_p`. Confirmed and fixed in `8140818c6b`:

```
$ python -c '
import litellm
litellm.register_model(model_cost={"azure/my-gpt5-dep": {"supports_none_reasoning_effort": True}})
print(litellm.utils.get_optional_params(model="my-gpt5-dep", custom_llm_provider="azure",
      base_model="azure/gpt-5", top_p=0.5, drop_params=True))'
{'top_p': 0.5, 'stream': False, 'extra_body': {}}
```

Before that commit the same call returned `{'stream': False, 'extra_body': {}}` with `top_p` gone

The cause was one step later than the review suggested. Pre-mapping validation in `get_optional_params` does list `top_p` as supported and does not raise; the parameter was lost in the final filter inside the mapper, which resolved the supported-parameter list from `base_model` without the override. `get_supported_openai_params` now takes the deployment name and that filter uses it

`logprobs` and `top_logprobs` deliberately stay excluded. Azure only verified those for gpt-5.2 and newer, and that check keys off the model version rather than the reasoning-effort capability; a registry `azure/gpt-5.1` entry with `supports_none_reasoning_effort: true` behaves identically, so widening them through an override would be a behaviour change rather than a fix. There is a test pinning that

## Type

🐛 Bug Fix

## Changes

`get_optional_params` collapsed Azure model identity into `_azure_detection_model = base_model or model` and passed only that into `AzureOpenAIGPT5Config.map_openai_params`, so the deployment name was unavailable to the capability gates. The deployment name is now passed alongside it as a keyword-only `deployment_model`

`_supports_reasoning_effort_level` and `_is_reasoning_effort_level_explicitly_disabled` accept that deployment name and prefer an explicitly configured capability on it, whether `true` or `false`, over the entry resolved from `base_model`. A deployment with no explicit setting falls through to the previous behaviour, so `base_model` resolution is unchanged unless someone has deliberately overridden a capability. Both helpers are shared by the temperature, sampling, xhigh, and minimal/low gates, so all four honour overrides now

`deployment_model` is keyword-only because `AzureOpenAIGPT5Config` inherits from both `AzureOpenAIConfig` and `OpenAIGPT5Config`, whose sixth positional parameter differs; a positional addition would have been an incompatible override of one parent or the other

Fourteen tests in `tests/test_litellm/llms/azure/chat/test_azure_gpt5_transformation.py` cover an override of `false` beating a registry `true`, an override of `true` beating a registry that lacks it, `temperature=1` never being dropped, the strict path raising instead of forwarding, a deployment without an override still resolving through `base_model`, the same behaviour end to end through `get_optional_params`, `top_p` surviving an enabling override, the `logprobs` version boundary, and both directions of the minimal effort gate. Thirteen of the fourteen fail against the base commit `daf22ec871`; the fourteenth is a no-override control asserting that `base_model` resolution is untouched, so it passes either way by design

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
