### PR TITLE
fix(proxy): honour `allow_requests_on_db_unavailable` in readiness probe

### DIFF
--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import logging
+import math
 import os
 import secrets
 import time
@@ -1314,7 +1315,8 @@ async def _db_health_readiness_check():
         return db_health_cache
 
 
-_DEFAULT_READINESS_DB_PROBE_TIMEOUT_SECONDS = "2.0"
+_DEFAULT_READINESS_DB_PROBE_TIMEOUT_SECONDS = 2.0
+_MIN_READINESS_DB_PROBE_TIMEOUT_SECONDS = 0.1
 
 
 def _readiness_ignores_db_outage() -> bool:
@@ -1338,16 +1340,36 @@ def _readiness_db_probe_timeout_seconds() -> float:
     ``query_raw`` has no timeout of its own, so an unreachable DB can block
     past the kubelet's ``timeoutSeconds`` and fail the probe on time no matter
     what status code we would have returned.
+
+    A misconfigured override falls back to the default instead of propagating:
+    this runs per probe on an unauthenticated endpoint, so letting a typo raise
+    would 500 the probe and evict the pod, which is the very outage the
+    ``allow_requests_on_db_unavailable`` path exists to prevent. Non-finite
+    values are rejected for the same reason, since ``inf`` silently restores
+    the unbounded wait.
     """
-    return max(
-        0.1,
-        float(
-            os.getenv(
-                "LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS",
-                _DEFAULT_READINESS_DB_PROBE_TIMEOUT_SECONDS,
-            )
-        ),
-    )
+    raw = os.getenv("LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS")
+    if raw is None:
+        return _DEFAULT_READINESS_DB_PROBE_TIMEOUT_SECONDS
+
+    parsed = _parse_finite_float(raw)
+    if parsed is None:
+        verbose_proxy_logger.warning(
+            "LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS=%r is not a finite number, using %ss",
+            raw,
+            _DEFAULT_READINESS_DB_PROBE_TIMEOUT_SECONDS,
+        )
+        return _DEFAULT_READINESS_DB_PROBE_TIMEOUT_SECONDS
+
+    return max(_MIN_READINESS_DB_PROBE_TIMEOUT_SECONDS, parsed)
+
+
+def _parse_finite_float(raw: str) -> float | None:
+    try:
+        parsed = float(raw)
+    except ValueError:
+        return None
+    return parsed if math.isfinite(parsed) else None
 
 
 async def _readiness_db_status() -> str:

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1314,6 +1314,79 @@ async def _db_health_readiness_check():
         return db_health_cache
 
 
+_DEFAULT_READINESS_DB_PROBE_TIMEOUT_SECONDS = "2.0"
+
+
+def _readiness_ignores_db_outage() -> bool:
+    """
+    True when ``general_settings.allow_requests_on_db_unavailable`` is set.
+
+    That flag declares the worker serves traffic without the DB, and the
+    request layer honours it via ``PrismaDBExceptionHandler``. Failing the
+    readiness probe on DB loss removes every replica from the Service at the
+    same time, so the fallback the flag enables never gets a request to run on.
+    """
+    return PrismaDBExceptionHandler.should_allow_request_on_db_unavailable()
+
+
+def _readiness_db_probe_timeout_seconds() -> float:
+    """
+    Upper bound on the time the readiness probe may spend on the DB when the
+    worker is allowed to serve without it.
+
+    ``PrismaClient.health_check`` retries under ``backoff`` and its underlying
+    ``query_raw`` has no timeout of its own, so an unreachable DB can block
+    past the kubelet's ``timeoutSeconds`` and fail the probe on time no matter
+    what status code we would have returned.
+    """
+    return max(
+        0.1,
+        float(
+            os.getenv(
+                "LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS",
+                _DEFAULT_READINESS_DB_PROBE_TIMEOUT_SECONDS,
+            )
+        ),
+    )
+
+
+async def _readiness_db_status() -> str:
+    """
+    DB status string for the readiness payload, for callers that already know a
+    Prisma client is configured.
+
+    When the worker may serve without the DB the lookup is bounded, because a
+    probe that answers late is indistinguishable from a probe that answers 503.
+    Reconnection is not lost by giving up early: ``_db_health_watchdog_loop``
+    owns it and runs on its own schedule.
+    """
+    if not _readiness_ignores_db_outage():
+        return (await _db_health_readiness_check())["status"]
+
+    timeout_seconds = _readiness_db_probe_timeout_seconds()
+    try:
+        db_health_status = await asyncio.wait_for(_db_health_readiness_check(), timeout=timeout_seconds)
+    except asyncio.TimeoutError:
+        verbose_proxy_logger.warning(
+            "_readiness_db_status: DB probe exceeded %ss, reporting disconnected while staying ready",
+            timeout_seconds,
+        )
+        return "disconnected"
+    return db_health_status["status"]
+
+
+def _apply_db_readiness_status(db_status: str, response: Response | None) -> None:
+    """
+    Flip the probe to 503 when a configured DB is unreachable, unless the
+    operator opted into serving without one.
+    """
+    if response is None or db_status == "connected":
+        return
+    if _readiness_ignores_db_outage():
+        return
+    response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+
+
 @router.get(
     "/settings",
     tags=["health"],
@@ -1449,16 +1522,17 @@ async def _get_health_readiness_details(
 
         # check DB
         if prisma_client is not None:  # if db passed in, check if it's connected
-            db_health_status = await _db_health_readiness_check()
+            db_status = await _readiness_db_status()
             # A configured DB that is not reachable means the worker cannot
             # serve requests that depend on persisted state (keys, budgets,
             # spend logs). Return 503 so orchestrators take this pod out of
-            # rotation; "Not connected" (no DB configured at all) stays 200.
-            if response is not None and db_health_status["status"] != "connected":
-                response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+            # rotation; "Not connected" (no DB configured at all) stays 200,
+            # and so does an unreachable DB once the operator has set
+            # allow_requests_on_db_unavailable.
+            _apply_db_readiness_status(db_status, response)
             return {
                 "status": "healthy",
-                "db": db_health_status["status"],
+                "db": db_status,
                 "cache": cache_type,
                 "litellm_version": version,
                 "success_callbacks": success_callback_names,
@@ -1536,16 +1610,18 @@ async def _resolve_public_readiness_db(response: Response) -> str:
     Return the db status string for the public probe and flip the response to
     503 when a configured DB is unreachable. Mirrors the legacy values:
     "Not connected" (no DB configured), "connected", "disconnected".
+
+    ``allow_requests_on_db_unavailable`` keeps the 200 so the pod stays in
+    rotation; the body still reports the real db status either way.
     """
     from litellm.proxy.proxy_server import prisma_client
 
     if prisma_client is None:
         return "Not connected"
 
-    db_health_status = await _db_health_readiness_check()
-    if db_health_status["status"] != "connected":
-        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
-    return db_health_status["status"]
+    db_status = await _readiness_db_status()
+    _apply_db_readiness_status(db_status, response)
+    return db_status
 
 
 @router.get(

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1,13 +1,22 @@
 import asyncio
 import copy
 import logging
-import math
 import os
 import secrets
 import time
 import traceback
 from datetime import datetime, timedelta
-from typing import Any, Dict, Iterable, Literal, Optional, TypedDict, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    Literal,
+    Optional,
+    TypedDict,
+    Union,
+    cast,
+)
 
 import fastapi
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
@@ -43,6 +52,9 @@ from litellm.proxy.middleware.in_flight_requests_middleware import (
     get_in_flight_requests,
 )
 from litellm.proxy.shutdown.graceful_shutdown_manager import GracefulShutdownManager
+
+if TYPE_CHECKING:
+    from litellm.proxy.utils import PrismaClient
 
 #### Health ENDPOINTS ####
 
@@ -1315,10 +1327,6 @@ async def _db_health_readiness_check():
         return db_health_cache
 
 
-_DEFAULT_READINESS_DB_PROBE_TIMEOUT_SECONDS = 2.0
-_MIN_READINESS_DB_PROBE_TIMEOUT_SECONDS = 0.1
-
-
 def _readiness_ignores_db_outage() -> bool:
     """
     True when ``general_settings.allow_requests_on_db_unavailable`` is set.
@@ -1331,61 +1339,27 @@ def _readiness_ignores_db_outage() -> bool:
     return PrismaDBExceptionHandler.should_allow_request_on_db_unavailable()
 
 
-def _readiness_db_probe_timeout_seconds() -> float:
-    """
-    Upper bound on the time the readiness probe may spend on the DB when the
-    worker is allowed to serve without it.
-
-    ``PrismaClient.health_check`` retries under ``backoff`` and its underlying
-    ``query_raw`` has no timeout of its own, so an unreachable DB can block
-    past the kubelet's ``timeoutSeconds`` and fail the probe on time no matter
-    what status code we would have returned.
-
-    A misconfigured override falls back to the default instead of propagating:
-    this runs per probe on an unauthenticated endpoint, so letting a typo raise
-    would 500 the probe and evict the pod, which is the very outage the
-    ``allow_requests_on_db_unavailable`` path exists to prevent. Non-finite
-    values are rejected for the same reason, since ``inf`` silently restores
-    the unbounded wait.
-    """
-    raw = os.getenv("LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS")
-    if raw is None:
-        return _DEFAULT_READINESS_DB_PROBE_TIMEOUT_SECONDS
-
-    parsed = _parse_finite_float(raw)
-    if parsed is None:
-        verbose_proxy_logger.warning(
-            "LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS=%r is not a finite number, using %ss",
-            raw,
-            _DEFAULT_READINESS_DB_PROBE_TIMEOUT_SECONDS,
-        )
-        return _DEFAULT_READINESS_DB_PROBE_TIMEOUT_SECONDS
-
-    return max(_MIN_READINESS_DB_PROBE_TIMEOUT_SECONDS, parsed)
-
-
-def _parse_finite_float(raw: str) -> float | None:
-    try:
-        parsed = float(raw)
-    except ValueError:
-        return None
-    return parsed if math.isfinite(parsed) else None
-
-
-async def _readiness_db_status() -> str:
+async def _readiness_db_status(prisma_client: "PrismaClient") -> str:
     """
     DB status string for the readiness payload, for callers that already know a
     Prisma client is configured.
 
     When the worker may serve without the DB the lookup is bounded, because a
-    probe that answers late is indistinguishable from a probe that answers 503.
-    Reconnection is not lost by giving up early: ``_db_health_watchdog_loop``
-    owns it and runs on its own schedule.
+    probe that answers late is indistinguishable from a probe that answers 503:
+    ``PrismaClient.health_check`` retries under ``backoff`` over a ``query_raw``
+    that has no timeout of its own, so an unreachable DB can outlast the
+    kubelet's ``timeoutSeconds`` whatever status code we would have returned.
+
+    The bound reuses the watchdog's probe timeout because both answer the same
+    question, how long to wait on a DB liveness check, and an operator who
+    tightens one wants the other tightened too. Giving up early costs no
+    recovery either: ``_db_health_watchdog_loop`` owns reconnection and runs on
+    its own schedule.
     """
     if not _readiness_ignores_db_outage():
         return (await _db_health_readiness_check())["status"]
 
-    timeout_seconds = _readiness_db_probe_timeout_seconds()
+    timeout_seconds = prisma_client.db_health_probe_timeout_seconds
     try:
         db_health_status = await asyncio.wait_for(_db_health_readiness_check(), timeout=timeout_seconds)
     except asyncio.TimeoutError:
@@ -1544,7 +1518,7 @@ async def _get_health_readiness_details(
 
         # check DB
         if prisma_client is not None:  # if db passed in, check if it's connected
-            db_status = await _readiness_db_status()
+            db_status = await _readiness_db_status(prisma_client)
             # A configured DB that is not reachable means the worker cannot
             # serve requests that depend on persisted state (keys, budgets,
             # spend logs). Return 503 so orchestrators take this pod out of
@@ -1641,7 +1615,7 @@ async def _resolve_public_readiness_db(response: Response) -> str:
     if prisma_client is None:
         return "Not connected"
 
-    db_status = await _readiness_db_status()
+    db_status = await _readiness_db_status(prisma_client)
     _apply_db_readiness_status(db_status, response)
     return db_status
 

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4866,6 +4866,18 @@ class PrismaClient:
         finally:
             self._db_reconnect_lock.release()
 
+    @property
+    def db_health_probe_timeout_seconds(self) -> float:
+        """
+        How long a DB liveness probe may run before the caller gives up.
+
+        Set by ``PRISMA_HEALTH_WATCHDOG_PROBE_TIMEOUT_SECONDS``. Exposed because
+        the readiness endpoint bounds its own ``SELECT 1`` with the same budget:
+        both are asking how long to wait on a liveness check, so an operator who
+        tightens one wants the other tightened too.
+        """
+        return self._db_health_watchdog_probe_timeout_seconds
+
     async def start_db_health_watchdog_task(self) -> None:
         """Start background tasks that monitor DB health:
         - A periodic SELECT 1 probe that triggers reconnect on network/connection failure.

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 import sys
 import time
@@ -2292,7 +2293,13 @@ async def test_health_readiness_returns_503_when_db_disconnected():
     }
 
     response = Response()
-    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"allow_requests_on_db_unavailable": False},
+        ),
+    ):
         result = await health_readiness(response=response)
 
     assert response.status_code == 503
@@ -2339,6 +2346,157 @@ async def test_health_readiness_returns_200_when_no_db_configured():
 
     assert response.status_code == 200
     assert result == {"status": "healthy", "db": "Not connected"}
+
+
+def _unreachable_prisma_client():
+    mock_prisma = MagicMock()
+    mock_prisma.health_check = AsyncMock(side_effect=PrismaError("Can't reach database server"))
+    mock_prisma.attempt_db_reconnect = AsyncMock(return_value=False)
+    return mock_prisma
+
+
+def _expire_db_health_cache():
+    _health_endpoints_module.db_health_cache = {
+        "status": "unknown",
+        "last_updated": datetime.now() - timedelta(seconds=60),
+    }
+
+
+@pytest.mark.asyncio
+async def test_health_readiness_stays_ready_when_db_unreachable_and_fallback_enabled():
+    """
+    allow_requests_on_db_unavailable declares that this worker serves traffic
+    without the DB, and the request layer honours it. A readiness 503 pulls
+    every replica out of the Service at once, so the fallback never gets a
+    request to run on and a recoverable DB blip becomes a total outage.
+
+    Regression test for the flag being ignored by the readiness probe.
+    """
+    from fastapi import Response
+
+    from litellm.proxy.health_endpoints._health_endpoints import health_readiness
+
+    _expire_db_health_cache()
+
+    response = Response()
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", _unreachable_prisma_client()),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"allow_requests_on_db_unavailable": True},
+        ),
+    ):
+        result = await health_readiness(response=response)
+
+    assert response.status_code == 200
+    assert result == {"status": "healthy", "db": "disconnected"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "allow_requests_on_db_unavailable, expected_status_code",
+    [(True, 200), (False, 503)],
+)
+async def test_health_readiness_details_honours_db_fallback_flag(
+    allow_requests_on_db_unavailable, expected_status_code
+):
+    """
+    The detailed payload is reachable unauthenticated via
+    allow_public_health_readiness_details, so it must make the same
+    in-rotation decision as the low-detail probe. Either way the body keeps
+    reporting the real db status.
+    """
+    from fastapi import Response
+
+    from litellm.proxy.health_endpoints._health_endpoints import health_readiness
+
+    _expire_db_health_cache()
+
+    response = Response()
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", _unreachable_prisma_client()),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {
+                "allow_public_health_readiness_details": True,
+                "allow_requests_on_db_unavailable": allow_requests_on_db_unavailable,
+            },
+        ),
+    ):
+        result = await health_readiness(response=response)
+
+    assert response.status_code == expected_status_code
+    assert result["db"] == "disconnected"
+
+
+@pytest.mark.asyncio
+async def test_health_readiness_bounds_db_probe_when_fallback_enabled():
+    """
+    Returning 200 is not enough on its own. health_check retries under backoff
+    and its query_raw has no timeout, so an unreachable DB can outlast the
+    kubelet's timeoutSeconds and fail the probe on time whatever status code we
+    would have produced. With the fallback enabled the lookup must give up and
+    report 'disconnected' rather than wait for the DB to answer.
+    """
+    from fastapi import Response
+
+    from litellm.proxy.health_endpoints._health_endpoints import health_readiness
+
+    async def _slow_health_check(*args, **kwargs):
+        await asyncio.sleep(0.3)
+
+    mock_prisma = MagicMock()
+    mock_prisma.health_check = AsyncMock(side_effect=_slow_health_check)
+
+    _expire_db_health_cache()
+
+    response = Response()
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"allow_requests_on_db_unavailable": True},
+        ),
+        patch.dict(os.environ, {"LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS": "0.05"}),
+    ):
+        result = await health_readiness(response=response)
+
+    assert response.status_code == 200
+    assert result == {"status": "healthy", "db": "disconnected"}
+
+
+@pytest.mark.asyncio
+async def test_health_readiness_does_not_bound_db_probe_when_fallback_disabled():
+    """
+    The bound only exists because the fallback makes the DB answer optional.
+    Without the flag a slow but reachable DB must still be reported connected,
+    so the default path keeps waiting for health_check exactly as before.
+    """
+    from fastapi import Response
+
+    from litellm.proxy.health_endpoints._health_endpoints import health_readiness
+
+    async def _slow_health_check(*args, **kwargs):
+        await asyncio.sleep(0.3)
+
+    mock_prisma = MagicMock()
+    mock_prisma.health_check = AsyncMock(side_effect=_slow_health_check)
+
+    _expire_db_health_cache()
+
+    response = Response()
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"allow_requests_on_db_unavailable": False},
+        ),
+        patch.dict(os.environ, {"LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS": "0.05"}),
+    ):
+        result = await health_readiness(response=response)
+
+    assert response.status_code == 200
+    assert result == {"status": "healthy", "db": "connected"}
 
 
 def test_clean_endpoint_data_strips_credentials_keeps_routing_fields():

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -2348,10 +2348,21 @@ async def test_health_readiness_returns_200_when_no_db_configured():
     assert result == {"status": "healthy", "db": "Not connected"}
 
 
-def _unreachable_prisma_client():
+def _unreachable_prisma_client(probe_timeout_seconds=5.0):
     mock_prisma = MagicMock()
     mock_prisma.health_check = AsyncMock(side_effect=PrismaError("Can't reach database server"))
     mock_prisma.attempt_db_reconnect = AsyncMock(return_value=False)
+    mock_prisma.db_health_probe_timeout_seconds = probe_timeout_seconds
+    return mock_prisma
+
+
+def _slow_prisma_client(delay_seconds, probe_timeout_seconds):
+    async def _slow_health_check(*args, **kwargs):
+        await asyncio.sleep(delay_seconds)
+
+    mock_prisma = MagicMock()
+    mock_prisma.health_check = AsyncMock(side_effect=_slow_health_check)
+    mock_prisma.db_health_probe_timeout_seconds = probe_timeout_seconds
     return mock_prisma
 
 
@@ -2437,66 +2448,9 @@ async def test_health_readiness_bounds_db_probe_when_fallback_enabled():
     kubelet's timeoutSeconds and fail the probe on time whatever status code we
     would have produced. With the fallback enabled the lookup must give up and
     report 'disconnected' rather than wait for the DB to answer.
-    """
-    from fastapi import Response
 
-    from litellm.proxy.health_endpoints._health_endpoints import health_readiness
-
-    async def _slow_health_check(*args, **kwargs):
-        await asyncio.sleep(0.3)
-
-    mock_prisma = MagicMock()
-    mock_prisma.health_check = AsyncMock(side_effect=_slow_health_check)
-
-    _expire_db_health_cache()
-
-    response = Response()
-    with (
-        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
-        patch(
-            "litellm.proxy.proxy_server.general_settings",
-            {"allow_requests_on_db_unavailable": True},
-        ),
-        patch.dict(os.environ, {"LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS": "0.05"}),
-    ):
-        result = await health_readiness(response=response)
-
-    assert response.status_code == 200
-    assert result == {"status": "healthy", "db": "disconnected"}
-
-
-@pytest.mark.parametrize(
-    "raw_timeout, expected",
-    [
-        ("0.5", 0.5),
-        ("0.01", 0.1),
-        ("abc", 2.0),
-        ("", 2.0),
-        ("inf", 2.0),
-        ("-inf", 2.0),
-        ("nan", 2.0),
-    ],
-)
-def test_readiness_db_probe_timeout_rejects_unusable_overrides(raw_timeout, expected):
-    """
-    The override is read per probe on an unauthenticated endpoint, so a typo
-    must not propagate: an unhandled ValueError would 500 the probe and evict
-    the pod, which is the outage this whole path exists to prevent. 'inf' is
-    rejected too because it silently restores the unbounded wait.
-    """
-    from litellm.proxy.health_endpoints._health_endpoints import (
-        _readiness_db_probe_timeout_seconds,
-    )
-
-    with patch.dict(os.environ, {"LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS": raw_timeout}):
-        assert _readiness_db_probe_timeout_seconds() == expected
-
-
-@pytest.mark.asyncio
-async def test_health_readiness_survives_malformed_probe_timeout_override():
-    """
-    End to end version of the above: a malformed override must still leave the
-    pod in rotation rather than turning the probe into a 500.
+    The budget comes from PrismaClient.db_health_probe_timeout_seconds, the same
+    knob the health watchdog uses, so tightening one tightens both.
     """
     from fastapi import Response
 
@@ -2506,12 +2460,14 @@ async def test_health_readiness_survives_malformed_probe_timeout_override():
 
     response = Response()
     with (
-        patch("litellm.proxy.proxy_server.prisma_client", _unreachable_prisma_client()),
+        patch(
+            "litellm.proxy.proxy_server.prisma_client",
+            _slow_prisma_client(delay_seconds=0.3, probe_timeout_seconds=0.05),
+        ),
         patch(
             "litellm.proxy.proxy_server.general_settings",
             {"allow_requests_on_db_unavailable": True},
         ),
-        patch.dict(os.environ, {"LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS": "not-a-number"}),
     ):
         result = await health_readiness(response=response)
 
@@ -2530,22 +2486,18 @@ async def test_health_readiness_does_not_bound_db_probe_when_fallback_disabled()
 
     from litellm.proxy.health_endpoints._health_endpoints import health_readiness
 
-    async def _slow_health_check(*args, **kwargs):
-        await asyncio.sleep(0.3)
-
-    mock_prisma = MagicMock()
-    mock_prisma.health_check = AsyncMock(side_effect=_slow_health_check)
-
     _expire_db_health_cache()
 
     response = Response()
     with (
-        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch(
+            "litellm.proxy.proxy_server.prisma_client",
+            _slow_prisma_client(delay_seconds=0.3, probe_timeout_seconds=0.05),
+        ),
         patch(
             "litellm.proxy.proxy_server.general_settings",
             {"allow_requests_on_db_unavailable": False},
         ),
-        patch.dict(os.environ, {"LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS": "0.05"}),
     ):
         result = await health_readiness(response=response)
 

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -2465,6 +2465,60 @@ async def test_health_readiness_bounds_db_probe_when_fallback_enabled():
     assert result == {"status": "healthy", "db": "disconnected"}
 
 
+@pytest.mark.parametrize(
+    "raw_timeout, expected",
+    [
+        ("0.5", 0.5),
+        ("0.01", 0.1),
+        ("abc", 2.0),
+        ("", 2.0),
+        ("inf", 2.0),
+        ("-inf", 2.0),
+        ("nan", 2.0),
+    ],
+)
+def test_readiness_db_probe_timeout_rejects_unusable_overrides(raw_timeout, expected):
+    """
+    The override is read per probe on an unauthenticated endpoint, so a typo
+    must not propagate: an unhandled ValueError would 500 the probe and evict
+    the pod, which is the outage this whole path exists to prevent. 'inf' is
+    rejected too because it silently restores the unbounded wait.
+    """
+    from litellm.proxy.health_endpoints._health_endpoints import (
+        _readiness_db_probe_timeout_seconds,
+    )
+
+    with patch.dict(os.environ, {"LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS": raw_timeout}):
+        assert _readiness_db_probe_timeout_seconds() == expected
+
+
+@pytest.mark.asyncio
+async def test_health_readiness_survives_malformed_probe_timeout_override():
+    """
+    End to end version of the above: a malformed override must still leave the
+    pod in rotation rather than turning the probe into a 500.
+    """
+    from fastapi import Response
+
+    from litellm.proxy.health_endpoints._health_endpoints import health_readiness
+
+    _expire_db_health_cache()
+
+    response = Response()
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", _unreachable_prisma_client()),
+        patch(
+            "litellm.proxy.proxy_server.general_settings",
+            {"allow_requests_on_db_unavailable": True},
+        ),
+        patch.dict(os.environ, {"LITELLM_READINESS_DB_PROBE_TIMEOUT_SECONDS": "not-a-number"}),
+    ):
+        result = await health_readiness(response=response)
+
+    assert response.status_code == 200
+    assert result == {"status": "healthy", "db": "disconnected"}
+
+
 @pytest.mark.asyncio
 async def test_health_readiness_does_not_bound_db_probe_when_fallback_disabled():
     """


### PR DESCRIPTION
## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves: 

- `allow_requests_on_db_unavailable` had no effect on readiness
- A DB outage marked every replica NotReady in ~30s
- Kubernetes emptied the Service, so the fail-open never ran
- The probe could also blow its timeout on a hung DB

How it solves it:

- Readiness keeps its 200 when the flag is set
- Body still reports the real db status
- The DB lookup is bounded when serving without a DB
- Behaviour with the flag unset is unchanged

## Relevant issues

<!-- e.g., "Fixes #000" -->
Fixes #34934

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [X] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->


Before is captured at `daf22ec8712e406f502da4268efcb1743d5564ff` (the branch point), after at `771c09f6c04b48f0168abf17d9899e70eed974a0`. Every call below hits a real OpenAI model and costs real money; nothing is mocked

1. Start a Postgres the proxy can lose on demand:

```bash
docker run -d --name litellm-db -e POSTGRES_PASSWORD=pw -p 5432:5432 postgres:16
```

2. Write `proof_config.yaml`:

```yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-1234
  allow_requests_on_db_unavailable: true
```

3. Check out the branch point and start the proxy:

```bash
git checkout daf22ec8712e406f502da4268efcb1743d5564ff
DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres \
  python litellm/proxy/proxy_cli.py --config proof_config.yaml --detailed_debug \
  --use_v2_migration_resolver 2>&1 | tee before.log
```

4. Confirm the baseline in another shell:

```bash
curl -s -w '\nhttp=%{http_code} time=%{time_total}\n' http://localhost:4000/health/readiness
```

5. Take the database down:

```bash
docker stop litellm-db
```

6. Call readiness again. Before the fix this answers `503` even though the flag is on:

```bash
curl -s -w '\nhttp=%{http_code} time=%{time_total}\n' http://localhost:4000/health/readiness
```

7. Show the request layer is still perfectly willing to serve, which is what makes the 503 a self-inflicted outage:

```bash
curl -s -w '\nhttp=%{http_code}\n' -X POST http://localhost:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"reply with exactly: proof of fix"}]}'
```

8. Simulate the failover case where connections hang instead of being refused, then call readiness once more. Before the fix this outlasts a `timeoutSeconds: 5` probe:

```bash
docker start litellm-db && sleep 5 && docker pause litellm-db
curl -s -w '\nhttp=%{http_code} time=%{time_total}\n' http://localhost:4000/health/readiness
```

9. Stop the proxy, move to this branch, and start it again with the database still paused:

```bash
docker unpause litellm-db && docker stop litellm-db
git checkout litellm_readiness_honor_db_unavailable_flag
DATABASE_URL=postgresql://postgres:pw@localhost:5432/postgres \
  python litellm/proxy/proxy_cli.py --config proof_config.yaml --detailed_debug \
  --use_v2_migration_resolver 2>&1 | tee after.log
```

10. Readiness now answers `200` with the real db status in the body, so the pod stays in the Service:

```bash
curl -s -w '\nhttp=%{http_code} time=%{time_total}\n' http://localhost:4000/health/readiness
```

11. Repeat the hung-connection case and confirm the probe returns inside the bound rather than waiting on the DB:

```bash
docker start litellm-db && sleep 5 && docker pause litellm-db
curl -s -w '\nhttp=%{http_code} time=%{time_total}\n' http://localhost:4000/health/readiness
```

12. Bring the database back and confirm readiness reports `connected` again:

```bash
docker unpause litellm-db
sleep 20 && curl -s -w '\nhttp=%{http_code}\n' http://localhost:4000/health/readiness
```

13. Confirm the default is untouched. Set `allow_requests_on_db_unavailable: false` in `proof_config.yaml`, restart the proxy, stop the database, and check that readiness goes back to `503`:

```bash
docker stop litellm-db
curl -s -w '\nhttp=%{http_code}\n' http://localhost:4000/health/readiness
```

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🐛 Bug Fix

## Changes

`/health/readiness` returned `503` whenever a configured Prisma DB was unreachable and never looked at `general_settings.allow_requests_on_db_unavailable`. Under the probe defaults the Helm chart ships (`readinessProbe.path: /health/readiness`, `periodSeconds: 10`, `failureThreshold: 3`) a database outage marks every replica NotReady inside about thirty seconds, Kubernetes drops all of them from the Service endpoints, and the request-layer fallback that the flag exists to provide never gets a request to run on. A recoverable blip becomes a total outage

The flag used to gate this. `_db_health_readiness_check` called `PrismaDBExceptionHandler.handle_db_exception`, which re-raised only when the flag was off, and `health_readiness` turned that into an `HTTPException(503)`. #26134 dropped the call to fix a 503 loop, then #27003 re-added an unconditional 503, which left the flag with no say over readiness

`_apply_db_readiness_status` now makes that call in one place and both readiness paths share it, so the low-detail probe and the detailed payload reachable through `allow_public_health_readiness_details` cannot disagree. With the flag set an unreachable DB keeps the 200; the `db` field still carries the truth either way

Status code alone is not enough. `PrismaClient.health_check` retries under `backoff` over a `query_raw` that has no timeout of its own, so an unreachable DB can outlast the kubelet's `timeoutSeconds` and fail the probe on time whatever we would have returned. `_readiness_db_status` therefore bounds the lookup with `asyncio.wait_for` when the flag is set. Giving up early costs no recovery, since `_db_health_watchdog_loop` already owns reconnection and runs on its own schedule. The bound deliberately does not apply when the flag is unset, so a slow but reachable DB on the default path behaves exactly as it does today

The budget for that bound is the watchdog's own `PRISMA_HEALTH_WATCHDOG_PROBE_TIMEOUT_SECONDS`, surfaced as a `PrismaClient.db_health_probe_timeout_seconds` property rather than a new setting. Both are answering the same question, how long to wait on a DB liveness check, and an operator who tightens one wants the other tightened too. Note that the 5 second default is longer than some probe configurations allow, so a deployment running `readinessProbe.timeoutSeconds` below that should lower this knob

Four tests cover this. Three fail if the source change is reverted, and the fourth fails if the bound is applied unconditionally, so the "unchanged by default" half of the contract is pinned too. They assert on the returned status and body rather than on elapsed time, so there is nothing timing-sensitive to flake in CI

One thing is deliberately left out of scope. #26237 asks that a worker which never successfully loaded its router fail readiness, and it should keep failing even with this flag set, since "router state was never populated" is a different condition from "the DB is momentarily unreachable". That needs first-successful-load tracking in the startup path, so it belongs in its own PR

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

