### PR TITLE
fix(gateway): route /a2a through the gateway component

### DIFF
--- a/gateway/routes/allowlist.py
+++ b/gateway/routes/allowlist.py
@@ -54,6 +54,7 @@ GATEWAY_PATH_PREFIXES: tuple[str, ...] = (
     "/messages",
     "/v1/skills",
     "/v1/a2a/",
+    "/a2a/",
     # LiteLLM-native LLM surface
     "/v1/rerank",
     "/v2/rerank",

--- a/helm/litellm/templates/ingress.yaml
+++ b/helm/litellm/templates/ingress.yaml
@@ -19,7 +19,7 @@
     "/v1/fine-tuning" "/fine-tuning" "/v1/responses" "/responses" "/v1/threads" "/threads"
     "/v1/assistants" "/assistants" "/v1/vector_stores" "/vector_stores" "/v1/indexes"
     "/v1/models" "/models" "/openai" "/engines"
-    "/v1/messages" "/messages" "/v1/skills" "/v1/a2a"
+    "/v1/messages" "/messages" "/v1/skills" "/v1/a2a" "/a2a"
     "/v1/rerank" "/v2/rerank" "/rerank" "/v1/ocr" "/ocr" "/v1/rag" "/rag"
     "/v1/video" "/v1/videos" "/video" "/videos" "/v1/search" "/search"
     "/v1/containers" "/containers" "/v1/evals" "/v1/memory" "/queue/chat"

--- a/tests/test_litellm/proxy/test_component_allowlists.py
+++ b/tests/test_litellm/proxy/test_component_allowlists.py
@@ -24,7 +24,6 @@ RDS IAM token when ``IAM_TOKEN_DB_AUTH`` is set).
 """
 
 import os
-import re
 import sys
 
 # Importing ``litellm.proxy.proxy_server`` runs its module-level setup, which
@@ -220,54 +219,4 @@ def test_every_app_mount_is_assigned_to_a_component():
         f"{len(unassigned)} Mount(s) are not exposed on any component. "
         f"Add them to GATEWAY_MOUNT_PATHS, BACKEND_MOUNT_PATHS, or serve them "
         f"from the UI container:\n  " + "\n  ".join(sorted(unassigned))
-    )
-
-
-def _ingress_gateway_prefixes() -> frozenset[str]:
-    """The ``$gatewayPrefixes`` list from the helm ingress template — the path
-    prefixes the load balancer routes to the gateway service."""
-    template_path = os.path.join(_REPO_ROOT, "helm", "litellm", "templates", "ingress.yaml")
-    with open(template_path) as handle:
-        template = handle.read()
-    match = re.search(r"\$gatewayPrefixes := list(.*?)-\}\}", template, re.DOTALL)
-    assert match, "helm/litellm/templates/ingress.yaml no longer defines $gatewayPrefixes"
-    return frozenset(re.findall(r'"([^"]+)"', match.group(1)))
-
-
-def test_ingress_gateway_prefixes_are_served_by_the_gateway():
-    """Every prefix the ingress routes to the gateway service must survive the
-    gateway route trim. The template's header comment says the two lists must
-    mirror each other, but nothing enforced it: an ingress prefix absent from
-    GATEWAY_PATH_PREFIXES sends that surface to pods that trimmed it -> 404."""
-    allowlisted = frozenset(prefix.rstrip("/") for prefix in GATEWAY_PATH_PREFIXES)
-    unserved = frozenset(
-        prefix for prefix in _ingress_gateway_prefixes() if prefix.rstrip("/") not in allowlisted
-    )
-    assert not unserved, (
-        f"{len(unserved)} ingress gateway prefix(es) are trimmed from the gateway "
-        f"route table; add them to gateway/routes/allowlist.py or stop routing "
-        f"them to the gateway:\n  " + "\n  ".join(sorted(unserved))
-    )
-
-
-def test_a2a_routes_ride_the_gateway():
-    """A2A message-send runs the completion bridge (an outbound LLM call), so
-    /a2a/* must ride the gateway fleet, which holds the provider credentials;
-    on the backend fleet the bridge dies with a missing-provider-key auth error.
-    The routes register lazily via LazyFeatureMiddleware, so the gateway
-    allowlist must also keep them for the eager/force-load path."""
-    assert "/a2a" in _ingress_gateway_prefixes(), (
-        "the ingress no longer routes /a2a to the gateway service; A2A tool "
-        "invocation falls to the backend catch-all, which has no provider keys"
-    )
-    from litellm.proxy.agent_endpoints.a2a_endpoints import router as a2a_router
-
-    dropped = frozenset(
-        path
-        for route in a2a_router.routes
-        if (path := getattr(route, "path", None)) is not None and not _is_gateway_route(route)
-    )
-    assert not dropped, (
-        "a2a routes trimmed from the gateway route table (add their prefix to "
-        "gateway/routes/allowlist.py):\n  " + "\n  ".join(sorted(dropped))
     )

--- a/tests/test_litellm/proxy/test_component_allowlists.py
+++ b/tests/test_litellm/proxy/test_component_allowlists.py
@@ -24,6 +24,7 @@ RDS IAM token when ``IAM_TOKEN_DB_AUTH`` is set).
 """
 
 import os
+import re
 import sys
 
 # Importing ``litellm.proxy.proxy_server`` runs its module-level setup, which
@@ -219,4 +220,54 @@ def test_every_app_mount_is_assigned_to_a_component():
         f"{len(unassigned)} Mount(s) are not exposed on any component. "
         f"Add them to GATEWAY_MOUNT_PATHS, BACKEND_MOUNT_PATHS, or serve them "
         f"from the UI container:\n  " + "\n  ".join(sorted(unassigned))
+    )
+
+
+def _ingress_gateway_prefixes() -> frozenset[str]:
+    """The ``$gatewayPrefixes`` list from the helm ingress template — the path
+    prefixes the load balancer routes to the gateway service."""
+    template_path = os.path.join(_REPO_ROOT, "helm", "litellm", "templates", "ingress.yaml")
+    with open(template_path) as handle:
+        template = handle.read()
+    match = re.search(r"\$gatewayPrefixes := list(.*?)-\}\}", template, re.DOTALL)
+    assert match, "helm/litellm/templates/ingress.yaml no longer defines $gatewayPrefixes"
+    return frozenset(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def test_ingress_gateway_prefixes_are_served_by_the_gateway():
+    """Every prefix the ingress routes to the gateway service must survive the
+    gateway route trim. The template's header comment says the two lists must
+    mirror each other, but nothing enforced it: an ingress prefix absent from
+    GATEWAY_PATH_PREFIXES sends that surface to pods that trimmed it -> 404."""
+    allowlisted = frozenset(prefix.rstrip("/") for prefix in GATEWAY_PATH_PREFIXES)
+    unserved = frozenset(
+        prefix for prefix in _ingress_gateway_prefixes() if prefix.rstrip("/") not in allowlisted
+    )
+    assert not unserved, (
+        f"{len(unserved)} ingress gateway prefix(es) are trimmed from the gateway "
+        f"route table; add them to gateway/routes/allowlist.py or stop routing "
+        f"them to the gateway:\n  " + "\n  ".join(sorted(unserved))
+    )
+
+
+def test_a2a_routes_ride_the_gateway():
+    """A2A message-send runs the completion bridge (an outbound LLM call), so
+    /a2a/* must ride the gateway fleet, which holds the provider credentials;
+    on the backend fleet the bridge dies with a missing-provider-key auth error.
+    The routes register lazily via LazyFeatureMiddleware, so the gateway
+    allowlist must also keep them for the eager/force-load path."""
+    assert "/a2a" in _ingress_gateway_prefixes(), (
+        "the ingress no longer routes /a2a to the gateway service; A2A tool "
+        "invocation falls to the backend catch-all, which has no provider keys"
+    )
+    from litellm.proxy.agent_endpoints.a2a_endpoints import router as a2a_router
+
+    dropped = frozenset(
+        path
+        for route in a2a_router.routes
+        if (path := getattr(route, "path", None)) is not None and not _is_gateway_route(route)
+    )
+    assert not dropped, (
+        "a2a routes trimmed from the gateway route table (add their prefix to "
+        "gateway/routes/allowlist.py):\n  " + "\n  ".join(sorted(dropped))
     )


### PR DESCRIPTION
## TLDR

Problem this solves:

- A2A invocations 500 on stage: backend pods have no provider keys
- Ingress routed /a2a/{agent_id} to the backend catch-all

How it solves it:

- Adds /a2a to the ingress gateway prefixes
- Adds /a2a/ to the gateway route allowlist

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (stage e2e run of 2026-07-28 14:28 UTC, pre-fix chart): all four a2a e2e tests failed with the backend pod's own error, `500 {"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error: litellm.AuthenticationError: Missing Anthropic API Key - A call is being made to anthropic but no key is set either in the environment variables or via params..."}}`. The A2A message-send bridge executed on a litellm-backend pod because the ingress only routes the listed LLM prefixes to the gateway and `/a2a/{agent_id}` fell through to the backend catch-all; backend pods carry no provider credentials by design, the gateway pods do (verified in pod logs: 100% of /v1/messages traffic lands on gateway pods and every Anthropic-calling test on those routes passes in the same run)

After (this branch): `/a2a` is in the ingress `$gatewayPrefixes`, so A2A invocations ride the same fleet as /v1/messages, and `/a2a/` is in the gateway allowlist so the gateway route trim keeps the a2a routes. The four a2a e2e tests in the next scheduled stage run against a build containing this chart are the live proof; the failing 14:28 UTC run is the baseline

## Type

🐛 Bug Fix

## Changes

helm/litellm/templates/ingress.yaml adds `/a2a` to `$gatewayPrefixes` so `/a2a/{agent_id}`, `/a2a/{agent_id}/message/send`, and the `/.well-known/agent-card.json` discovery paths route to the gateway service instead of the backend catch-all. `/v1/a2a` was already listed, which is why only the unversioned serving paths were affected

gateway/routes/allowlist.py adds the matching `/a2a/` prefix. The a2a router registers lazily via LazyFeatureMiddleware, which happens after the startup route trim, so today the entry is belt-and-braces; it becomes load-bearing the moment the feature is force-loaded or made eager, and it keeps the allowlist an accurate statement of the gateway surface

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
