### PR TITLE
fix: vertex_ai - route service_tier via headers for actual tier enforcement

### DIFF
--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -1175,14 +1175,13 @@ def _transform_request_body(
         if cached_content is not None:
             data["cachedContent"] = cached_content
 
+        # Vertex AI: skip serviceTier in body — tier routing is via headers
+        # set in validate_environment(). See: https://github.com/BerriAI/litellm/issues/34914
         if service_tier := optional_params.pop("service_tier", None):
-            if isinstance(service_tier, str):
-                if service_tier.lower() == "default":
-                    data["serviceTier"] = "standard"
-                else:
-                    data["serviceTier"] = service_tier.lower()
-            else:
-                data["serviceTier"] = service_tier
+            if custom_llm_provider == LlmProviders.GEMINI and isinstance(service_tier, str):
+                normalized = service_tier.lower().removeprefix("service_tier_")
+                if normalized in ("priority", "flex", "standard"):
+                    data["serviceTier"] = normalized
 
         # Only add labels for Vertex AI endpoints (not Google GenAI/AI Studio) and only if non-empty
         if labels and custom_llm_provider != LlmProviders.GEMINI:

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -424,15 +424,10 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         ]
 
     def _map_service_tier_param(self, value: str, optional_params: dict) -> None:
-        """
-        Map OpenAI service_tier (string) to Gemini serviceTier.
-        'auto' maps to 'priority'.
-        Other values are passed lowercased.
-        """
-        if value.lower() == "auto":
-            optional_params["service_tier"] = "priority"
-        else:
-            optional_params["service_tier"] = value.lower()
+        normalized = value.lower().removeprefix("service_tier_")
+        if normalized in ("auto", "default", "scale", "unspecified"):
+            return
+        optional_params["service_tier"] = normalized
 
     def _transform_computer_use_config(self, computer_use_config: dict) -> dict:
         """
@@ -2581,6 +2576,19 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             default_headers.update(api_key)
         elif api_key is not None:
             default_headers["Authorization"] = f"Bearer {api_key}"
+
+        # Vertex AI: route service_tier via headers for actual tier enforcement.
+        # See: https://github.com/BerriAI/litellm/issues/34914
+        service_tier = optional_params.get("service_tier")
+        provider = litellm_params.get("custom_llm_provider")
+        if (
+            isinstance(service_tier, str)
+            and service_tier in ("priority", "flex")
+            and provider != "gemini"
+        ):
+            default_headers["X-Vertex-AI-LLM-Request-Type"] = "shared"
+            default_headers["X-Vertex-AI-LLM-Shared-Request-Type"] = service_tier
+
         if headers is not None:
             default_headers.update(headers)
 

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -2581,11 +2581,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         # See: https://github.com/BerriAI/litellm/issues/34914
         service_tier = optional_params.get("service_tier")
         provider = litellm_params.get("custom_llm_provider")
-        if (
-            isinstance(service_tier, str)
-            and service_tier in ("priority", "flex")
-            and provider != "gemini"
-        ):
+        if isinstance(service_tier, str) and service_tier in ("priority", "flex") and provider != "gemini":
             default_headers["X-Vertex-AI-LLM-Request-Type"] = "shared"
             default_headers["X-Vertex-AI-LLM-Shared-Request-Type"] = service_tier
 

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -1,3 +1,5 @@
+import pytest
+
 from litellm.litellm_core_utils.prompt_templates.factory import (
     convert_to_gemini_tool_call_result,
 )

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_ai_gemini_transformation.py
@@ -197,23 +197,64 @@ def test_vertex_ai_includes_labels():
     assert result["labels"] == {"project": "test", "team": "ai"}
 
 
-def test_service_tier_forwarded_to_vertex_ai():
-    """Test that service_tier in optional_params is mapped to serviceTier in request body."""
-    messages = [{"role": "user", "content": "test"}]
-    optional_params = {"service_tier": "flex"}
-    litellm_params = {}
-
+@pytest.mark.parametrize(
+    "service_tier",
+    ["flex", "FLEX", "priority", "standard", "default", "SERVICE_TIER_FLEX"],
+)
+def test_service_tier_not_in_vertex_ai_request_body(service_tier):
+    """
+    Vertex AI: service_tier should NOT be in the request body.
+    Tier routing is handled via X-Vertex-AI-LLM-Shared-Request-Type headers
+    set in validate_environment(), not the serviceTier body field.
+    See: https://github.com/BerriAI/litellm/issues/34914
+    """
     result = _transform_request_body(
-        messages=messages,
+        messages=[{"role": "user", "content": "test"}],
         model="gemini-2.5-pro",
-        optional_params=optional_params,
+        optional_params={"service_tier": service_tier},
         custom_llm_provider="vertex_ai",
-        litellm_params=litellm_params,
+        litellm_params={},
         cached_content=None,
     )
 
-    assert "serviceTier" in result
-    assert result["serviceTier"] == "flex"
+    assert "serviceTier" not in result
+
+
+@pytest.mark.parametrize(
+    "service_tier, expected",
+    [
+        ("flex", "flex"),
+        ("PRIORITY", "priority"),
+        ("SERVICE_TIER_FLEX", "flex"),
+    ],
+)
+def test_service_tier_forwarded_to_google_ai_studio_as_lowercase(service_tier, expected):
+    """Google AI Studio's generativelanguage API only accepts the lowercase enum names"""
+    result = _transform_request_body(
+        messages=[{"role": "user", "content": "test"}],
+        model="gemini-2.5-pro",
+        optional_params={"service_tier": service_tier},
+        custom_llm_provider="gemini",
+        litellm_params={},
+        cached_content=None,
+    )
+
+    assert result["serviceTier"] == expected
+
+
+@pytest.mark.parametrize("service_tier", ["auto", "default", "scale"])
+def test_service_tier_omitted_from_gemini_body_for_non_routing_tiers(service_tier):
+    """Non-routing tiers (auto, default, scale) should be omitted, not sent to the body."""
+    result = _transform_request_body(
+        messages=[{"role": "user", "content": "test"}],
+        model="gemini-2.5-pro",
+        optional_params={"service_tier": service_tier},
+        custom_llm_provider="gemini",
+        litellm_params={},
+        cached_content=None,
+    )
+
+    assert "serviceTier" not in result
 
 
 def test_extra_body_cache_not_forwarded_to_vertex_ai():

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -4402,7 +4402,7 @@ def test_vertex_ai_service_tier_in_map_openai_params():
 
     v = VertexGeminiConfig()
 
-    # Test pass-through
+    # Test pass-through with normalization (FLEX -> flex)
     optional_params = {}
     non_default_params = {"service_tier": "FLEX"}
 
@@ -4415,7 +4415,20 @@ def test_vertex_ai_service_tier_in_map_openai_params():
 
     assert result["service_tier"] == "flex"
 
-    # Test auto -> priority
+    # Test prefixed enum normalization (SERVICE_TIER_PRIORITY -> priority)
+    optional_params_prefixed = {}
+    non_default_params_prefixed = {"service_tier": "SERVICE_TIER_PRIORITY"}
+
+    result_prefixed = v.map_openai_params(
+        non_default_params=non_default_params_prefixed,
+        optional_params=optional_params_prefixed,
+        model="gemini-3-pro-preview",
+        drop_params=True,
+    )
+
+    assert result_prefixed["service_tier"] == "priority"
+
+    # Test auto -> omitted (lets provider decide)
     optional_params_auto = {}
     non_default_params_auto = {"service_tier": "auto"}
 
@@ -4426,9 +4439,9 @@ def test_vertex_ai_service_tier_in_map_openai_params():
         drop_params=True,
     )
 
-    assert result_auto["service_tier"] == "priority"
+    assert "service_tier" not in result_auto
 
-    # Test AUTO (uppercase) -> priority
+    # Test AUTO (uppercase) -> omitted
     optional_params_auto_upper = {}
     non_default_params_auto_upper = {"service_tier": "AUTO"}
 
@@ -4439,7 +4452,46 @@ def test_vertex_ai_service_tier_in_map_openai_params():
         drop_params=True,
     )
 
-    assert result_auto_upper["service_tier"] == "priority"
+    assert "service_tier" not in result_auto_upper
+
+
+@pytest.mark.parametrize(
+    "service_tier, provider, expect_headers",
+    [
+        ("priority", "vertex_ai", True),
+        ("flex", "vertex_ai", True),
+        ("priority", "vertex_ai_beta", True),
+        ("priority", "gemini", False),
+        ("flex", "gemini", False),
+        ("auto", "vertex_ai", False),
+        ("standard", "vertex_ai", False),
+    ],
+)
+def test_vertex_ai_validate_environment_service_tier_headers(
+    service_tier, provider, expect_headers
+):
+    """validate_environment should inject Vertex AI tier headers for priority/flex
+    on Vertex AI only, not Google AI Studio."""
+    from litellm.llms.vertex_ai.gemini.vertex_and_google_ai_studio_gemini import (
+        VertexGeminiConfig,
+    )
+
+    v = VertexGeminiConfig()
+    headers = v.validate_environment(
+        headers=None,
+        model="gemini-3.5-flash-lite",
+        messages=[],
+        optional_params={"service_tier": service_tier},
+        litellm_params={"custom_llm_provider": provider},
+        api_key="test-key",
+    )
+
+    if expect_headers:
+        assert headers["X-Vertex-AI-LLM-Request-Type"] == "shared"
+        assert headers["X-Vertex-AI-LLM-Shared-Request-Type"] == service_tier
+    else:
+        assert "X-Vertex-AI-LLM-Request-Type" not in headers
+        assert "X-Vertex-AI-LLM-Shared-Request-Type" not in headers
 
 
 def test_vertex_ai_usage_metadata_with_video_tokens_in_prompt():


### PR DESCRIPTION
The `serviceTier` body field is accepted by Vertex AI (no 400) but does not activate tier routing. The `X-Vertex-AI-LLM-Shared-Request-Type` header is what actually routes to shared rate-limit pools with priority/flex enforcement.

Changes:
- `validate_environment()`: inject `X-Vertex-AI-LLM-Request-Type` and `X-Vertex-AI-LLM-Shared-Request-Type` headers when `service_tier` is `priority` or `flex` (Vertex AI only, not Google AI Studio)
- `_transform_request_body()`: skip `serviceTier` in body for Vertex AI (keep for Google AI Studio `gemini/` where body field works)
- `_map_service_tier_param()`: normalize prefixed values (`SERVICE_TIER_FLEX` -> `flex`), skip non-routing tiers (`auto`, `default`, `scale`, `unspecified`)

See: https://github.com/BerriAI/litellm/issues/34914

## TLDR

Problem this solves:

- `service_tier` param sent as `serviceTier` in request body — Vertex AI accepts it but ignores it for tier routing
- `auto` was mapped to `priority`, forcing priority on every `auto` request
- Prefixed enum values (`SERVICE_TIER_FLEX`) not normalized, silently failing header matching

How it solves it:

- Route `service_tier` via `X-Vertex-AI-LLM-Shared-Request-Type` headers for Vertex AI (actual tier enforcement)
- Skip `serviceTier` in body for Vertex AI, keep for Google AI Studio
- Normalize and skip non-routing tiers (`auto`, `default`, `scale`, `unspecified`)

## Relevant issues

Fixes #34914

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All tests run against a live LiteLLM proxy connected to Vertex AI (`vertex_ai/gemini-3.5-flash-lite`, project `engineering-vertex-ai`, location `global`).

### Before fix: `service_tier=flex` returns 200 but tier is NOT applied (latency matches standard)

```bash
# Standard (no tier) — baseline
curl -sS -w "\n%{time_total}s" http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" -H "Authorization: Bearer fake" \
  -d '{"model": "gemini-3.5-flash-lite", "messages": [{"role": "user", "content": "Classify this job title: Senior VP of Engineering"}], "max_tokens": 200, "extra_body": {"reasoning_effort": "low"}}'
# Latency: ~1.2s

# Flex via serviceTier body (BEFORE fix — tier ignored, same speed as standard)
curl -sS -w "\n%{time_total}s" http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" -H "Authorization: Bearer fake" \
  -d '{"model": "gemini-3.5-flash-lite", "messages": [{"role": "user", "content": "Classify this job title: Senior VP of Engineering"}], "max_tokens": 200, "service_tier": "flex"}'
# Latency: ~1.4s  ← should be ~7-10s if flex were actually applied
```

### After fix: `service_tier=flex` routes via headers, tier IS applied (latency matches headers approach)

```bash
# Standard (no tier) — baseline
curl -sS -w "\n%{time_total}s" http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" -H "Authorization: Bearer fake" \
  -d '{"model": "gemini-3.5-flash-lite", "messages": [{"role": "user", "content": "Classify this job title: Senior VP of Engineering"}], "max_tokens": 200, "extra_body": {"reasoning_effort": "low"}}'
# Latency: ~1.6s

# Flex via service_tier body (AFTER fix — headers injected, tier applied)
curl -sS -w "\n%{time_total}s" http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" -H "Authorization: Bearer fake" \
  -d '{"model": "gemini-3.5-flash-lite", "messages": [{"role": "user", "content": "Classify this job title: Senior VP of Engineering"}], "max_tokens": 200, "service_tier": "flex"}'
# Latency: ~7.1s  ← flex deprioritization confirmed

# Priority via service_tier body (AFTER fix — headers injected, tier applied)
curl -sS -w "\n%{time_total}s" http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" -H "Authorization: Bearer fake" \
  -d '{"model": "gemini-3.5-flash-lite", "messages": [{"role": "user", "content": "Classify this job title: Senior VP of Engineering"}], "max_tokens": 200, "service_tier": "priority"}'
# Latency: ~1.0s  ← priority speed confirmed
```

### Summary

| Approach | Before fix | After fix |
|---|---|---|
| Standard (no tier) | ~1.2s | ~1.6s |
| Flex (`service_tier` body) | ~1.4s (tier NOT applied) | ~7.1s (tier applied) |
| Priority (`service_tier` body) | ~1.4s (tier NOT applied) | ~1.0s (tier applied) |

## Type

🐛 Bug Fix

## Changes

- **`vertex_and_google_ai_studio_gemini.py` — `validate_environment()`**: Inject `X-Vertex-AI-LLM-Request-Type: shared` and `X-Vertex-AI-LLM-Shared-Request-Type: <tier>` headers when `service_tier` is `priority` or `flex`, gated on `provider != "gemini"` (Vertex AI only)
- **`vertex_and_google_ai_studio_gemini.py` — `_map_service_tier_param()`**: Normalize prefixed values (`SERVICE_TIER_FLEX` → `flex`), skip non-routing tiers (`auto`, `default`, `scale`, `unspecified`) instead of mapping `auto` → `priority`
- **`transformation.py` — `_transform_request_body()`**: Skip `serviceTier` in body for Vertex AI (keep for Google AI Studio `gemini/` where the body field works)
- **Tests**: Updated existing tests and added parametrized tests for both Vertex AI (body skipped) and Google AI Studio (body kept, normalized)

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
