### PR TITLE
fix(guardrails): chunk oversized Bedrock ApplyGuardrail requests instead of failing

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -30,6 +30,7 @@ from typing import (
 import copy
 from collections.abc import Mapping
 from datetime import datetime, timezone
+from functools import reduce
 
 import httpx
 from fastapi import HTTPException
@@ -83,6 +84,15 @@ from litellm.types.utils import (
 )
 
 GUARDRAIL_NAME = "bedrock"
+# KNOWN LIMITATION (chunking, below): splitting an oversized message's text on
+# a whitespace boundary (see `_nearest_whitespace_split_index`) prevents
+# accidentally severing a single token -- one denied word, one PII pattern --
+# across a chunk boundary. It does not stop a multi-word denied phrase
+# deliberately positioned to straddle that boundary, since each fragment can
+# scan clean independently. AWS's own guidance for this API acknowledges the
+# same gap for input chunking with no documented resolution; closing it would
+# require an overlap window reconciled against masked output, which AWS does
+# not guarantee to be length-preserving. Accepted as out of scope.
 _BEDROCK_DYNAMIC_BODY_DENYLIST = frozenset({"content", "source"})
 # ApplyGuardrail's per-request "maximum input size in text units" quota is
 # region/account/policy-dependent and cannot be predicted from config, so it is
@@ -98,6 +108,18 @@ _BEDROCK_TOO_LARGE_ERROR_SUBSTRINGS = (
     "too large",
     "exceeds the maximum",
 )
+# Conservative starting guess for how much content (by character count) to send
+# in one ApplyGuardrail call, used to pre-bin-pack content instead of always
+# starting from the whole payload. This is NOT a correctness dependency: it only
+# sets how many calls the common case takes. Any bin AWS still rejects as too
+# large (because the real per-request text-unit cap for this account/region/
+# policy is lower than this guess -- that cap is not knowable ahead of time and
+# is not a fixed character count) falls back to the recursive bisection below,
+# which self-corrects regardless of how wrong this guess was. So a too-generous
+# guess here costs the same one extra probe-and-bisect round trip that pure
+# reactive bisection would have paid anyway, while a well-tuned guess makes the
+# common case a single pass instead of O(log n) round trips per request.
+_BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS = 20_000
 # Exponential backoff for a chunk call throttled with ThrottlingException (429).
 # Kept small: chunking already trades one oversized call for several smaller
 # ones, so retries must not multiply per-request latency by an order of magnitude.
@@ -831,19 +853,28 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         # reference source; bisecting it would fragment that evaluation and produce
         # misleading grounding scores, so a too-large error is never chunked here.
         allow_chunking = not self._content_uses_contextual_grounding(content)
+        batches = (
+            self._bin_pack_bedrock_content(content, budget=_BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS)
+            if allow_chunking
+            else [content]
+        )
 
         try:
-            responses = await self._apply_guardrail_content_with_chunking(
-                content=content,
-                base_request_data=bedrock_request_data,
-                credentials=credentials,
-                aws_region_name=aws_region_name,
-                api_key=api_key,
-                request_data=request_data,
-                event_type=event_type,
-                start_time=start_time,
-                allow_chunking=allow_chunking,
-            )
+            responses = [
+                result
+                for batch in batches
+                for result in await self._apply_guardrail_content_with_chunking(
+                    content=batch,
+                    base_request_data=bedrock_request_data,
+                    credentials=credentials,
+                    aws_region_name=aws_region_name,
+                    api_key=api_key,
+                    request_data=request_data,
+                    event_type=event_type,
+                    start_time=start_time,
+                    allow_chunking=allow_chunking,
+                )
+            ]
         except HTTPException as exc:
             # A block is logged where it happens, inside _post_apply_guardrail_content,
             # since chunking stops immediately and there is no later merged response to
@@ -1138,6 +1169,40 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         return False
 
     @staticmethod
+    def _bin_pack_bedrock_content(
+        content: list[BedrockContentItem],
+        budget: int,
+    ) -> list[list[BedrockContentItem]]:
+        """Pack whole content items, in order, into batches whose combined text
+        length stays within `budget`.
+
+        This is the fast-path half of the hybrid chunking strategy: bin-packing
+        at a conservative fixed budget keeps the common case at O(n / budget)
+        ApplyGuardrail calls instead of the O(log n) round trips pure reactive
+        bisection pays on every oversized request. An item whose own text
+        already exceeds `budget` is not split here -- it becomes its own
+        (still oversized) batch and is sent as-is; if AWS rejects that batch as
+        too large, `_apply_guardrail_content_with_chunking`'s existing
+        recursive-bisection fallback takes over for that batch only.
+        """
+        if not content:
+            return [content]
+
+        def item_len(item: BedrockContentItem) -> int:
+            return len((item.get("text") or BedrockTextContent()).get("text") or "")
+
+        def add_item(
+            batches: tuple[tuple[BedrockContentItem, ...], ...],
+            item: BedrockContentItem,
+        ) -> tuple[tuple[BedrockContentItem, ...], ...]:
+            if batches and sum(item_len(existing) for existing in batches[-1]) + item_len(item) <= budget:
+                return batches[:-1] + (batches[-1] + (item,),)
+            return batches + ((item,),)
+
+        packed = reduce(add_item, content, ())
+        return [list(batch) for batch in packed]
+
+    @staticmethod
     def _split_bedrock_content(
         content: list[BedrockContentItem],
     ) -> tuple[list[BedrockContentItem], list[BedrockContentItem]] | None:
@@ -1145,12 +1210,31 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
         When `content` already holds more than one item, it is split by list
         length. When it holds exactly one item, that item's own text is split
-        in half instead (a list of length 1 has no items left to bisect, but
-        one very long message is still a single content item). Returns None
-        when there is nothing left to split -- a single item whose text is
-        too short to halve into two non-empty pieces -- so the caller can
-        give up and propagate the original too-large error instead of
-        recursing forever.
+        instead (a list of length 1 has no items left to bisect, but one very
+        long message is still a single content item) -- at the whitespace
+        character nearest the midpoint rather than a raw character index, so
+        the cut never lands inside a word/token. This is a plain, lossless
+        cut with no overlap: concatenating the two fragments in order always
+        reproduces the original text exactly, so merging back at
+        ``_merge_logical_unit_outputs`` needs no reconciliation step.
+
+        Known, accepted limitation: whitespace splitting only guards against
+        *accidentally* severing a single token (one denied word, one PII
+        pattern) across the cut. It does not, and cannot without an overlap
+        window, stop a *multi-word* denied phrase deliberately positioned to
+        straddle the boundary -- each fragment can scan clean on its own and
+        still reassemble into the flagged phrase. AWS's own guidance on this
+        API acknowledges the same gap for input chunking ("a critical piece of
+        text could span two (or more) chunks if not carefully divided") with
+        no documented resolution, and overlap-and-reconcile was evaluated and
+        rejected for this PR: AWS's masking output has no documented
+        length-preservation guarantee, so reconciling an overlap region against
+        masked text is not sound in general. Out of scope for this PR.
+
+        Returns None when there is nothing left to split -- a single item
+        whose text is too short to halve into two non-empty pieces -- so the
+        caller can give up and propagate the original too-large error instead
+        of recursing forever.
         """
         if len(content) > 1:
             midpoint = max(1, len(content) // 2)
@@ -1160,15 +1244,34 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         text = text_content.get("text") or ""
         if len(text) < 2:
             return None
-        midpoint = len(text) // 2
+        split_at = BedrockGuardrail._nearest_whitespace_split_index(text)
         qualifiers = text_content.get("qualifiers")
         if qualifiers:
-            first_text = BedrockTextContent(text=text[:midpoint], qualifiers=qualifiers)
-            second_text = BedrockTextContent(text=text[midpoint:], qualifiers=qualifiers)
+            first_text = BedrockTextContent(text=text[:split_at], qualifiers=qualifiers)
+            second_text = BedrockTextContent(text=text[split_at:], qualifiers=qualifiers)
         else:
-            first_text = BedrockTextContent(text=text[:midpoint])
-            second_text = BedrockTextContent(text=text[midpoint:])
+            first_text = BedrockTextContent(text=text[:split_at])
+            second_text = BedrockTextContent(text=text[split_at:])
         return [BedrockContentItem(text=first_text)], [BedrockContentItem(text=second_text)]
+
+    @staticmethod
+    def _nearest_whitespace_split_index(text: str) -> int:
+        """Return the index nearest `text`'s midpoint that falls on a
+        whitespace boundary, so splitting `text[:i]` / `text[i:]` there never
+        severs a word. Falls back to the raw midpoint when `text` has no
+        whitespace at all (a single giant token) -- still a correct, lossless
+        split, just no longer guaranteed word-safe for that pathological case.
+        """
+        midpoint = len(text) // 2
+        left = text.rfind(" ", 0, midpoint)
+        right = text.find(" ", midpoint)
+        if left == -1 and right == -1:
+            return midpoint
+        if left == -1:
+            return right + 1
+        if right == -1:
+            return left + 1
+        return left + 1 if midpoint - left <= right - midpoint else right + 1
 
     @staticmethod
     def _is_input_too_large_validation_error(detail: object) -> bool:

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -98,9 +98,6 @@ _BEDROCK_TOO_LARGE_ERROR_SUBSTRINGS = (
     "too large",
     "exceeds the maximum",
 )
-# Bisecting stops once a chunk is down to a single content item -- it cannot be
-# split further, so a too-large error on it propagates as-is instead of looping.
-_BEDROCK_APPLY_GUARDRAIL_MIN_CHUNK_SIZE = 1
 # Exponential backoff for a chunk call throttled with ThrottlingException (429).
 # Kept small: chunking already trades one oversized call for several smaller
 # ones, so retries must not multiply per-request latency by an order of magnitude.
@@ -151,6 +148,25 @@ class GuardrailMessageFilterResult(NamedTuple):
     payload_messages: Optional[List[AllMessageValues]]
     original_messages: Optional[List[AllMessageValues]]
     target_indices: Optional[List[int]]
+
+
+class BedrockContentChunkResult(NamedTuple):
+    """One chunk's ApplyGuardrail response, paired with enough bookkeeping to
+    reconstruct global masked-output positions once every chunk is back.
+
+    `content` is the exact content items this chunk was called with -- needed
+    so an all-clear chunk (empty `outputs`) can still contribute one unmasked
+    placeholder per item it covers, keeping every later chunk's masked text
+    aligned to its original global position. `is_text_fragment` is True when
+    this chunk is one half of a single content item's own text (split because
+    a list of length 1 could not be bisected by list length) -- its sibling
+    fragment must be concatenated back into that one item's masked output,
+    not treated as a second item.
+    """
+
+    response: BedrockGuardrailResponse
+    content: list[BedrockContentItem]
+    is_text_fragment: bool
 
 
 class ApplyGuardrailMessageSelection(NamedTuple):
@@ -810,37 +826,59 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         else:
             event_type = GuardrailEventHooks.pre_call if source == "INPUT" else GuardrailEventHooks.post_call
 
-        content: List[BedrockContentItem] = bedrock_request_data.get("content") or []
+        content: list[BedrockContentItem] = bedrock_request_data.get("content") or []
         # Contextual grounding scores the response holistically against the whole
         # reference source; bisecting it would fragment that evaluation and produce
         # misleading grounding scores, so a too-large error is never chunked here.
         allow_chunking = not self._content_uses_contextual_grounding(content)
 
-        responses = await self._apply_guardrail_content_with_chunking(
-            content=content,
-            base_request_data=bedrock_request_data,
-            credentials=credentials,
-            aws_region_name=aws_region_name,
-            api_key=api_key,
+        try:
+            responses = await self._apply_guardrail_content_with_chunking(
+                content=content,
+                base_request_data=bedrock_request_data,
+                credentials=credentials,
+                aws_region_name=aws_region_name,
+                api_key=api_key,
+                request_data=request_data,
+                event_type=event_type,
+                start_time=start_time,
+                allow_chunking=allow_chunking,
+            )
+        except HTTPException as exc:
+            # A block is logged where it happens, inside _post_apply_guardrail_content,
+            # since chunking stops immediately and there is no later merged response to
+            # log instead. Anything else reaching here (unrecoverable too-large error,
+            # a non-size validation error, exhausted throttle retries) is a genuine
+            # end-to-end failure of this logical guardrail call and is logged once here.
+            if not isinstance(exc.detail, dict):
+                self._log_apply_guardrail_failure(
+                    detail=exc.detail,
+                    request_data=request_data,
+                    event_type=event_type,
+                    start_time=start_time,
+                )
+            raise
+        merged_response = self._merge_bedrock_guardrail_responses(responses)
+        self._log_apply_guardrail_success(
+            merged_response=merged_response,
             request_data=request_data,
             event_type=event_type,
             start_time=start_time,
-            allow_chunking=allow_chunking,
         )
-        return self._merge_bedrock_guardrail_responses(responses)
+        return merged_response
 
     async def _apply_guardrail_content_with_chunking(
         self,
-        content: List[BedrockContentItem],
+        content: list[BedrockContentItem],
         base_request_data: dict,
         credentials,
         aws_region_name: str,
-        api_key: Optional[str],
+        api_key: str | None,
         request_data: dict | None,
         event_type: GuardrailEventHooks,
         start_time: "datetime",
         allow_chunking: bool,
-    ) -> List[BedrockGuardrailResponse]:
+    ) -> list[BedrockContentChunkResult]:
         """Post `content` to ApplyGuardrail, bisecting on a too-large error.
 
         Tries `content` as a single call first. AWS's per-request "maximum input
@@ -848,30 +886,41 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         predicted ahead of time, so it is only ever discovered reactively: on a 400
         ValidationException whose message indicates the input was too large, the
         content is split in half and each half is retried the same way (recursing
-        until every piece fits or cannot be split further). A real guardrail block
-        on any (sub-)chunk raises immediately -- callers must not lose that signal
-        by continuing to post the remaining chunks.
+        until every piece fits or cannot be split further). A single oversized
+        content item (one very long message) is split by its own text instead of
+        by list length, since a list of length 1 has no items left to bisect --
+        the two text fragments are tagged ``is_text_fragment=True`` so the merge
+        step can recombine them into the one content item they came from, rather
+        than treating each fragment as its own item when reconstructing positions
+        for masking. A real guardrail block on any (sub-)chunk raises immediately
+        -- callers must not lose that signal by continuing to post the remaining
+        chunks.
         """
         try:
+            response = await self._post_apply_guardrail_content_with_retry(
+                content=content,
+                base_request_data=base_request_data,
+                credentials=credentials,
+                aws_region_name=aws_region_name,
+                api_key=api_key,
+                request_data=request_data,
+                event_type=event_type,
+                start_time=start_time,
+            )
             return [
-                await self._post_apply_guardrail_content_with_retry(
+                BedrockContentChunkResult(
+                    response=response,
                     content=content,
-                    base_request_data=base_request_data,
-                    credentials=credentials,
-                    aws_region_name=aws_region_name,
-                    api_key=api_key,
-                    request_data=request_data,
-                    event_type=event_type,
-                    start_time=start_time,
+                    is_text_fragment=False,
                 )
             ]
         except HTTPException as exc:
-            if (
-                allow_chunking
-                and len(content) > _BEDROCK_APPLY_GUARDRAIL_MIN_CHUNK_SIZE
-                and self._is_input_too_large_validation_error(exc.detail)
-            ):
-                first_half, second_half = self._split_bedrock_content(content)
+            if allow_chunking and self._is_input_too_large_validation_error(exc.detail):
+                split_content = self._split_bedrock_content(content)
+                if split_content is None:
+                    raise
+                first_half, second_half = split_content
+                is_text_fragment = len(content) == 1
                 first_results = await self._apply_guardrail_content_with_chunking(
                     content=first_half,
                     base_request_data=base_request_data,
@@ -894,16 +943,19 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     start_time=start_time,
                     allow_chunking=allow_chunking,
                 )
-                return first_results + second_results
+                combined_results = first_results + second_results
+                if is_text_fragment:
+                    return [result._replace(is_text_fragment=True) for result in combined_results]
+                return combined_results
             raise
 
     async def _post_apply_guardrail_content_with_retry(
         self,
-        content: List[BedrockContentItem],
+        content: list[BedrockContentItem],
         base_request_data: dict,
         credentials,
         aws_region_name: str,
-        api_key: Optional[str],
+        api_key: str | None,
         request_data: dict | None,
         event_type: GuardrailEventHooks,
         start_time: "datetime",
@@ -938,11 +990,11 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
     async def _post_apply_guardrail_content(
         self,
-        content: List[BedrockContentItem],
+        content: list[BedrockContentItem],
         base_request_data: dict,
         credentials,
         aws_region_name: str,
-        api_key: Optional[str],
+        api_key: str | None,
         request_data: dict | None,
         event_type: GuardrailEventHooks,
         start_time: "datetime",
@@ -973,27 +1025,8 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             start_time=start_time,
         )
 
-        #########################################################
-        # Add guardrail information to request trace
-        #########################################################
-        _json_response = httpx_response.json()
-        tracing_detail = self._build_tracing_detail(_json_response)
-
-        # Raw Bedrock JSON is passed here; match/regex redaction runs once inside
-        # CustomGuardrail.add_standard_logging_guardrail_information_to_request_data.
-        self.add_standard_logging_guardrail_information_to_request_data(
-            guardrail_provider=self.guardrail_provider,
-            guardrail_json_response=_json_response,
-            request_data=request_data or {},
-            guardrail_status=self._get_bedrock_guardrail_response_status(response=httpx_response),
-            start_time=start_time.timestamp(),
-            end_time=datetime.now(timezone.utc).timestamp(),
-            duration=(datetime.now(timezone.utc) - start_time).total_seconds(),
-            event_type=event_type,
-            tracing_detail=tracing_detail or None,
-        )
-        #########################################################
         if httpx_response.status_code == 200:
+            _json_response = httpx_response.json()
             # check if the response was flagged
             verbose_proxy_logger.debug(
                 "Bedrock AI response : %s",
@@ -1001,6 +1034,16 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             )
             bedrock_guardrail_response = BedrockGuardrailResponse(**_json_response)
             if self._should_raise_guardrail_blocked_exception(bedrock_guardrail_response):
+                # A block ends the whole chunking flow immediately (no further
+                # chunks are attempted), so it is logged here rather than by the
+                # caller -- there is no later "final merged response" to log instead.
+                self._log_apply_guardrail_attempt(
+                    httpx_response=httpx_response,
+                    json_response=_json_response,
+                    request_data=request_data,
+                    event_type=event_type,
+                    start_time=start_time,
+                )
                 raise self._get_http_exception_for_blocked_guardrail(
                     bedrock_guardrail_response, request_data=request_data
                 )
@@ -1014,8 +1057,78 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         )
         raise HTTPException(status_code=status_code, detail=detail_message)
 
+    def _log_apply_guardrail_attempt(
+        self,
+        httpx_response: httpx.Response,
+        json_response: dict,
+        request_data: dict | None,
+        event_type: GuardrailEventHooks,
+        start_time: "datetime",
+    ) -> None:
+        """Log a single ApplyGuardrail HTTP attempt as-is (its own status,
+        derived from its own response). Used only for the blocked-content
+        case, which ends the whole chunking flow immediately."""
+        tracing_detail = self._build_tracing_detail(BedrockGuardrailResponse(**json_response))
+        self.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_provider=self.guardrail_provider,
+            guardrail_json_response=json_response,
+            request_data=request_data or {},
+            guardrail_status=self._get_bedrock_guardrail_response_status(response=httpx_response),
+            start_time=start_time.timestamp(),
+            end_time=datetime.now(timezone.utc).timestamp(),
+            duration=(datetime.now(timezone.utc) - start_time).total_seconds(),
+            event_type=event_type,
+            tracing_detail=tracing_detail or None,
+        )
+
+    def _log_apply_guardrail_success(
+        self,
+        merged_response: BedrockGuardrailResponse,
+        request_data: dict | None,
+        event_type: GuardrailEventHooks,
+        start_time: "datetime",
+    ) -> None:
+        """Log one logical ApplyGuardrail call -- possibly several chunk calls
+        under the hood -- using its final merged response, so a chunked
+        request produces exactly one telemetry entry, the same as an
+        unchunked one would."""
+        tracing_detail = self._build_tracing_detail(merged_response)
+        self.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_provider=self.guardrail_provider,
+            guardrail_json_response=dict(merged_response),
+            request_data=request_data or {},
+            guardrail_status="success",
+            start_time=start_time.timestamp(),
+            end_time=datetime.now(timezone.utc).timestamp(),
+            duration=(datetime.now(timezone.utc) - start_time).total_seconds(),
+            event_type=event_type,
+            tracing_detail=tracing_detail or None,
+        )
+
+    def _log_apply_guardrail_failure(
+        self,
+        detail: object,
+        request_data: dict | None,
+        event_type: GuardrailEventHooks,
+        start_time: "datetime",
+    ) -> None:
+        """Log one logical ApplyGuardrail call that failed end-to-end (an
+        unrecoverable too-large error, a non-size validation error, or
+        exhausted throttle retries) as a single failure, rather than logging
+        every failed attempt chunking made along the way."""
+        self.add_standard_logging_guardrail_information_to_request_data(
+            guardrail_provider=self.guardrail_provider,
+            guardrail_json_response=str(detail),
+            request_data=request_data or {},
+            guardrail_status="guardrail_failed_to_respond",
+            start_time=start_time.timestamp(),
+            end_time=datetime.now(timezone.utc).timestamp(),
+            duration=(datetime.now(timezone.utc) - start_time).total_seconds(),
+            event_type=event_type,
+        )
+
     @staticmethod
-    def _content_uses_contextual_grounding(content: List[BedrockContentItem]) -> bool:
+    def _content_uses_contextual_grounding(content: list[BedrockContentItem]) -> bool:
         """True if any content item carries a contextual-grounding qualifier
         (``grounding_source``, ``query``, or the ``guard_content`` the response
         itself is tagged with once grounding is present)."""
@@ -1026,15 +1139,36 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
     @staticmethod
     def _split_bedrock_content(
-        content: List[BedrockContentItem],
-    ) -> Tuple[List[BedrockContentItem], List[BedrockContentItem]]:
+        content: list[BedrockContentItem],
+    ) -> tuple[list[BedrockContentItem], list[BedrockContentItem]] | None:
         """Bisect `content` into two roughly-equal, non-empty halves.
 
-        Only called with ``len(content) > 1`` (guarded by the caller), so both
-        halves are always non-empty.
+        When `content` already holds more than one item, it is split by list
+        length. When it holds exactly one item, that item's own text is split
+        in half instead (a list of length 1 has no items left to bisect, but
+        one very long message is still a single content item). Returns None
+        when there is nothing left to split -- a single item whose text is
+        too short to halve into two non-empty pieces -- so the caller can
+        give up and propagate the original too-large error instead of
+        recursing forever.
         """
-        midpoint = max(1, len(content) // 2)
-        return content[:midpoint], content[midpoint:]
+        if len(content) > 1:
+            midpoint = max(1, len(content) // 2)
+            return content[:midpoint], content[midpoint:]
+
+        text_content = content[0].get("text") or BedrockTextContent()
+        text = text_content.get("text") or ""
+        if len(text) < 2:
+            return None
+        midpoint = len(text) // 2
+        qualifiers = text_content.get("qualifiers")
+        if qualifiers:
+            first_text = BedrockTextContent(text=text[:midpoint], qualifiers=qualifiers)
+            second_text = BedrockTextContent(text=text[midpoint:], qualifiers=qualifiers)
+        else:
+            first_text = BedrockTextContent(text=text[:midpoint])
+            second_text = BedrockTextContent(text=text[midpoint:])
+        return [BedrockContentItem(text=first_text)], [BedrockContentItem(text=second_text)]
 
     @staticmethod
     def _is_input_too_large_validation_error(detail: object) -> bool:
@@ -1056,39 +1190,152 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
     @staticmethod
     def _merge_bedrock_guardrail_responses(
-        responses: List[BedrockGuardrailResponse],
+        chunk_results: list[BedrockContentChunkResult],
     ) -> BedrockGuardrailResponse:
         """Merge the per-chunk ApplyGuardrail responses of a chunked request into
         one, so a caller cannot tell whether chunking happened.
 
         Only ever called with responses that all passed (a block raises
         immediately from ``_apply_guardrail_content_with_chunking`` and is never
-        added to this list), so ``action`` is included purely for completeness.
+        added to this list). ``action`` is only set on the merged response when
+        at least one chunk's raw response included it, and left absent otherwise
+        -- mirroring a real single-call response and matching what
+        ``_build_tracing_detail`` treats as "Bedrock didn't report an action".
+
+        Per AWS's documented ApplyGuardrail contract, a single call's ``outputs``
+        is positionally parallel to the ``content`` items *of that call*: an
+        entry per item when anything in the call was masked, or an empty list
+        when nothing in the whole call was masked. Downstream masking
+        (``_apply_masking_to_messages``) walks the merged ``outputs`` by a single
+        running index across the *original, unchunked* message list, so a later
+        chunk's masked text must land at the same global position it would have
+        if chunking had never happened. Naively concatenating each chunk's
+        ``outputs`` breaks that whenever a chunk had nothing masked (its empty
+        list would otherwise silently swallow its items' slots, shifting every
+        later chunk's masked text left onto the wrong message). So every
+        item -- masked or not -- always contributes exactly one entry here,
+        falling back to that item's own original (unmasked) text when its
+        chunk returned no output for it; a wholly-untouched result is then
+        collapsed back to an empty ``outputs`` list to match a real single-call
+        no-op response. A chunk that returns a nonzero output count not equal
+        to its item count is passed through as-is instead of guessed at, since
+        AWS's docs don't cover partial masking within one multi-item call.
         """
-        if len(responses) == 1:
-            return responses[0]
+        logical_units = BedrockGuardrail._group_fragment_pairs(chunk_results)
+        per_unit_outputs = tuple(BedrockGuardrail._merge_logical_unit_outputs(unit) for unit in logical_units)
+        merged_outputs = [output for outputs, _ in per_unit_outputs for output in outputs]
+        any_masked = any(masked for _, masked in per_unit_outputs)
 
-        merged_outputs: List[BedrockGuardrailOutput] = []
-        merged_assessments: List[dict] = []
-        merged_usage: Dict[str, Any] = {}
-        merged_action = "NONE"
-        for chunk_response in responses:
-            if chunk_response.get("action") == "GUARDRAIL_INTERVENED":
-                merged_action = "GUARDRAIL_INTERVENED"
-            merged_outputs.extend(chunk_response.get("outputs") or chunk_response.get("output") or [])
-            merged_assessments.extend(chunk_response.get("assessments") or [])
-            for key, value in (chunk_response.get("usage") or {}).items():
-                if isinstance(value, (int, float)):
-                    merged_usage[key] = merged_usage.get(key, 0) + value
+        actions = tuple(
+            chunk_result.response.get("action")
+            for chunk_result in chunk_results
+            if isinstance(chunk_result.response.get("action"), str)
+        )
+        merged_action = (
+            "GUARDRAIL_INTERVENED" if "GUARDRAIL_INTERVENED" in actions else (actions[-1] if actions else None)
+        )
+        merged_assessments = [
+            assessment
+            for chunk_result in chunk_results
+            for assessment in (chunk_result.response.get("assessments") or [])
+        ]
+        any_usage_reported = any(chunk_result.response.get("usage") for chunk_result in chunk_results)
 
-        merged: BedrockGuardrailResponse = BedrockGuardrailResponse(action=merged_action)
-        if merged_outputs:
+        merged: BedrockGuardrailResponse = BedrockGuardrailResponse()
+        if merged_action is not None:
+            merged["action"] = merged_action
+        if merged_outputs and any_masked:
             merged["outputs"] = merged_outputs
         if merged_assessments:
             merged["assessments"] = merged_assessments
-        if merged_usage:
-            merged["usage"] = cast(BedrockGuardrailUsage, merged_usage)
+        if any_usage_reported:
+            merged["usage"] = BedrockGuardrail._sum_bedrock_guardrail_usage(chunk_results)
         return merged
+
+    @staticmethod
+    def _sum_bedrock_guardrail_usage(
+        chunk_results: list[BedrockContentChunkResult],
+    ) -> BedrockGuardrailUsage:
+        """Sum each chunk's ``usage`` counters field-by-field into one totals dict."""
+        chunk_usages = tuple(chunk_result.response.get("usage") or {} for chunk_result in chunk_results)
+
+        def total(key: str) -> int:
+            return sum(usage.get(key) or 0 for usage in chunk_usages)
+
+        return BedrockGuardrailUsage(
+            topicPolicyUnits=total("topicPolicyUnits"),
+            contentPolicyUnits=total("contentPolicyUnits"),
+            wordPolicyUnits=total("wordPolicyUnits"),
+            sensitiveInformationPolicyUnits=total("sensitiveInformationPolicyUnits"),
+            sensitiveInformationPolicyFreeUnits=total("sensitiveInformationPolicyFreeUnits"),
+            contextualGroundingPolicyUnits=total("contextualGroundingPolicyUnits"),
+        )
+
+    @staticmethod
+    def _group_fragment_pairs(
+        chunk_results: list[BedrockContentChunkResult],
+    ) -> list[tuple[BedrockContentChunkResult, ...]]:
+        """Group consecutive text-fragment chunk results into the sibling pairs
+        that originated from one content item's own text, leaving every other
+        chunk result as a unit of one. Fragments are always produced (and thus
+        appear here) as adjacent sibling pairs -- see ``_split_bedrock_content``."""
+        units: list[tuple[BedrockContentChunkResult, ...]] = []
+        index = 0
+        while index < len(chunk_results):
+            chunk_result = chunk_results[index]
+            if chunk_result.is_text_fragment:
+                units.append((chunk_result, chunk_results[index + 1]))
+                index += 2
+            else:
+                units.append((chunk_result,))
+                index += 1
+        return units
+
+    @staticmethod
+    def _merge_logical_unit_outputs(
+        unit: tuple[BedrockContentChunkResult, ...],
+    ) -> tuple[list[BedrockGuardrailOutput], bool]:
+        """Reduce one logical unit (a fragment pair or a single chunk result)
+        to the ``BedrockGuardrailOutput`` entries it contributes to the merged
+        response, plus whether any masking actually happened in it.
+
+        Per AWS's documented ApplyGuardrail contract, a single call's
+        ``outputs`` is positionally parallel to the ``content`` items *of that
+        call*: an entry per item when anything in the call was masked, or an
+        empty list when nothing in the whole call was masked. Downstream
+        masking (``_apply_masking_to_messages``) walks the merged ``outputs``
+        by a single running index across the *original, unchunked* message
+        list, so a later chunk's masked text must land at the same global
+        position it would have if chunking had never happened. So every item
+        -- masked or not -- always contributes exactly one entry here, falling
+        back to that item's own original (unmasked) text when its chunk
+        returned no output for it. A chunk that returns a nonzero output count
+        not equal to its item count is passed through as-is instead of guessed
+        at, since AWS's docs don't cover partial masking within one multi-item
+        call.
+        """
+        if len(unit) == 2:
+            first, second = unit
+            first_outputs = first.response.get("outputs") or first.response.get("output") or []
+            second_outputs = second.response.get("outputs") or second.response.get("output") or []
+            first_source = (first.content[0].get("text") or {}).get("text") or ""
+            second_source = (second.content[0].get("text") or {}).get("text") or ""
+            first_text = first_outputs[0].get("text") if first_outputs else first_source
+            second_text = second_outputs[0].get("text") if second_outputs else second_source
+            merged_text = (first_text if first_text is not None else first_source) + (
+                second_text if second_text is not None else second_source
+            )
+            return [BedrockGuardrailOutput(text=merged_text)], bool(first_outputs or second_outputs)
+
+        (chunk_result,) = unit
+        chunk_outputs = chunk_result.response.get("outputs") or chunk_result.response.get("output") or []
+        if len(chunk_outputs) == len(chunk_result.content):
+            return list(chunk_outputs), bool(chunk_outputs)
+        if not chunk_outputs:
+            return [
+                BedrockGuardrailOutput(text=(item.get("text") or {}).get("text") or "") for item in chunk_result.content
+            ], False
+        return list(chunk_outputs), True
 
     async def _sign_and_post(
         self,

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -914,8 +914,10 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
         Tries `content` as a single call first. AWS's per-request "maximum input
         size in text units" quota is account/region/policy-dependent and cannot be
-        predicted ahead of time, so it is only ever discovered reactively: on a 400
-        ValidationException whose message indicates the input was too large, the
+        predicted ahead of time, so it is only ever discovered reactively: on an
+        error whose message indicates the input was too large (a ThrottlingException
+        in practice, a ValidationException per the docs -- see
+        ``_is_input_too_large_error``), the
         content is split in half and each half is retried the same way (recursing
         until every piece fits or cannot be split further). A single oversized
         content item (one very long message) is split by its own text instead of
@@ -946,12 +948,19 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 )
             ]
         except HTTPException as exc:
-            if allow_chunking and self._is_input_too_large_validation_error(exc.detail):
+            if allow_chunking and self._is_input_too_large_error(exc.detail):
                 split_content = self._split_bedrock_content(content)
                 if split_content is None:
                     raise
                 first_half, second_half = split_content
                 is_text_fragment = len(content) == 1
+                verbose_proxy_logger.warning(
+                    "Bedrock Guardrail: ApplyGuardrail rejected %d content item(s) as too large; "
+                    "splitting into %d + %d and retrying each",
+                    len(content),
+                    len(first_half),
+                    len(second_half),
+                )
                 first_results = await self._apply_guardrail_content_with_chunking(
                     content=first_half,
                     base_request_data=base_request_data,
@@ -998,6 +1007,13 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         retries here are capped low -- they must not multiply per-request latency
         by an order of magnitude when the account's per-second text-unit quota is
         the binding constraint rather than the per-request size quota.
+
+        A too-large rejection is deliberately excluded from the retry. AWS reports
+        it as a ThrottlingException (429), not only as a ValidationException, but
+        unlike a genuine throttle it is not transient: re-posting the same
+        oversized content can never succeed. Retrying it would burn every backoff
+        sleep and every (billed) attempt before the caller's bisection gets a
+        chance to split the content, at every level of the recursion.
         """
         attempt = 0
         while True:
@@ -1013,7 +1029,11 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     start_time=start_time,
                 )
             except HTTPException as exc:
-                if exc.status_code == 429 and attempt < _BEDROCK_APPLY_GUARDRAIL_MAX_THROTTLE_RETRIES:
+                if (
+                    exc.status_code == 429
+                    and not self._is_input_too_large_error(exc.detail)
+                    and attempt < _BEDROCK_APPLY_GUARDRAIL_MAX_THROTTLE_RETRIES
+                ):
                     await asyncio.sleep(_BEDROCK_APPLY_GUARDRAIL_BASE_BACKOFF_SECONDS * (2**attempt))
                     attempt += 1
                     continue
@@ -1274,9 +1294,17 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         return left + 1 if midpoint - left <= right - midpoint else right + 1
 
     @staticmethod
-    def _is_input_too_large_validation_error(detail: object) -> bool:
-        """True if `detail` is the AWS ValidationException message for input
-        exceeding the per-request text-unit quota.
+    def _is_input_too_large_error(detail: object) -> bool:
+        """True if `detail` is an AWS error message for input exceeding the
+        per-request text-unit quota.
+
+        Matched on the message rather than the status code on purpose: AWS is not
+        consistent about which error it raises for this. Observed against a live
+        guardrail with an active content-filter policy, an oversized request comes
+        back as a *ThrottlingException* (429) reading ``Input text size (3273 text
+        units) exceeds the maximum allowed (1000 text units) for the content filter
+        policy (Classic tier)``, while the documented failure mode is a
+        ValidationException (400). Keying off the message covers both.
 
         A guardrail *block* is also raised as an HTTPException with status 400,
         but its ``detail`` is always a dict (built by

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -9,6 +9,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath("../.."))  # Adds the parent directory to the system path
+import asyncio
 import json
 import sys
 from typing import (
@@ -57,6 +58,7 @@ from litellm.types.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
     BedrockGuardrailOutput,
     BedrockGuardrailQualifier,
     BedrockGuardrailResponse,
+    BedrockGuardrailUsage,
     BedrockRequest,
     BedrockTextContent,
 )
@@ -82,6 +84,28 @@ from litellm.types.utils import (
 
 GUARDRAIL_NAME = "bedrock"
 _BEDROCK_DYNAMIC_BODY_DENYLIST = frozenset({"content", "source"})
+# ApplyGuardrail's per-request "maximum input size in text units" quota is
+# region/account/policy-dependent and cannot be predicted from config, so it is
+# only ever discovered reactively: AWS rejects an over-quota call with a 400
+# ValidationException whose message contains one of these substrings (matched
+# case-insensitively against the parsed AWS error message). On a match the
+# content is bisected and each half retried, rather than surfacing the 400.
+_BEDROCK_TOO_LARGE_ERROR_SUBSTRINGS = (
+    "text unit",
+    "maximum input size",
+    "content size",
+    "too long",
+    "too large",
+    "exceeds the maximum",
+)
+# Bisecting stops once a chunk is down to a single content item -- it cannot be
+# split further, so a too-large error on it propagates as-is instead of looping.
+_BEDROCK_APPLY_GUARDRAIL_MIN_CHUNK_SIZE = 1
+# Exponential backoff for a chunk call throttled with ThrottlingException (429).
+# Kept small: chunking already trades one oversized call for several smaller
+# ones, so retries must not multiply per-request latency by an order of magnitude.
+_BEDROCK_APPLY_GUARDRAIL_MAX_THROTTLE_RETRIES = 3
+_BEDROCK_APPLY_GUARDRAIL_BASE_BACKOFF_SECONDS = 0.5
 # Resource-less, detect-only InvokeGuardrailChecks API (no guardrail resource required).
 _BEDROCK_INVOKE_GUARDRAIL_CHECKS_PATH = "/guardrail-checks/invoke"
 # InvokeGuardrailChecks accepts at most 10 content blocks per message. A message with
@@ -765,7 +789,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         bedrock_request_data: dict = dict(
             self.convert_to_bedrock_format(source=source, messages=messages, response=response)
         )
-        bedrock_guardrail_response: BedrockGuardrailResponse = BedrockGuardrailResponse()
         api_key: Optional[str] = None
         if request_data:
             dynamic_request_body_params = self.get_guardrail_dynamic_request_body_params(request_data=request_data)
@@ -779,6 +802,156 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             if request_data.get("api_key") is not None:
                 api_key = request_data["api_key"]
 
+        # UI / spend logs use event_type. Bedrock's `source` is INPUT vs OUTPUT for the API
+        # body, which must not be confused with the proxy hook (pre_call / during_call /
+        # post_call). When omitted, keep legacy mapping for backward compatibility.
+        if logging_event_type is not None:
+            event_type = logging_event_type
+        else:
+            event_type = GuardrailEventHooks.pre_call if source == "INPUT" else GuardrailEventHooks.post_call
+
+        content: List[BedrockContentItem] = bedrock_request_data.get("content") or []
+        # Contextual grounding scores the response holistically against the whole
+        # reference source; bisecting it would fragment that evaluation and produce
+        # misleading grounding scores, so a too-large error is never chunked here.
+        allow_chunking = not self._content_uses_contextual_grounding(content)
+
+        responses = await self._apply_guardrail_content_with_chunking(
+            content=content,
+            base_request_data=bedrock_request_data,
+            credentials=credentials,
+            aws_region_name=aws_region_name,
+            api_key=api_key,
+            request_data=request_data,
+            event_type=event_type,
+            start_time=start_time,
+            allow_chunking=allow_chunking,
+        )
+        return self._merge_bedrock_guardrail_responses(responses)
+
+    async def _apply_guardrail_content_with_chunking(
+        self,
+        content: List[BedrockContentItem],
+        base_request_data: dict,
+        credentials,
+        aws_region_name: str,
+        api_key: Optional[str],
+        request_data: dict | None,
+        event_type: GuardrailEventHooks,
+        start_time: "datetime",
+        allow_chunking: bool,
+    ) -> List[BedrockGuardrailResponse]:
+        """Post `content` to ApplyGuardrail, bisecting on a too-large error.
+
+        Tries `content` as a single call first. AWS's per-request "maximum input
+        size in text units" quota is account/region/policy-dependent and cannot be
+        predicted ahead of time, so it is only ever discovered reactively: on a 400
+        ValidationException whose message indicates the input was too large, the
+        content is split in half and each half is retried the same way (recursing
+        until every piece fits or cannot be split further). A real guardrail block
+        on any (sub-)chunk raises immediately -- callers must not lose that signal
+        by continuing to post the remaining chunks.
+        """
+        try:
+            return [
+                await self._post_apply_guardrail_content_with_retry(
+                    content=content,
+                    base_request_data=base_request_data,
+                    credentials=credentials,
+                    aws_region_name=aws_region_name,
+                    api_key=api_key,
+                    request_data=request_data,
+                    event_type=event_type,
+                    start_time=start_time,
+                )
+            ]
+        except HTTPException as exc:
+            if (
+                allow_chunking
+                and len(content) > _BEDROCK_APPLY_GUARDRAIL_MIN_CHUNK_SIZE
+                and self._is_input_too_large_validation_error(exc.detail)
+            ):
+                first_half, second_half = self._split_bedrock_content(content)
+                first_results = await self._apply_guardrail_content_with_chunking(
+                    content=first_half,
+                    base_request_data=base_request_data,
+                    credentials=credentials,
+                    aws_region_name=aws_region_name,
+                    api_key=api_key,
+                    request_data=request_data,
+                    event_type=event_type,
+                    start_time=start_time,
+                    allow_chunking=allow_chunking,
+                )
+                second_results = await self._apply_guardrail_content_with_chunking(
+                    content=second_half,
+                    base_request_data=base_request_data,
+                    credentials=credentials,
+                    aws_region_name=aws_region_name,
+                    api_key=api_key,
+                    request_data=request_data,
+                    event_type=event_type,
+                    start_time=start_time,
+                    allow_chunking=allow_chunking,
+                )
+                return first_results + second_results
+            raise
+
+    async def _post_apply_guardrail_content_with_retry(
+        self,
+        content: List[BedrockContentItem],
+        base_request_data: dict,
+        credentials,
+        aws_region_name: str,
+        api_key: Optional[str],
+        request_data: dict | None,
+        event_type: GuardrailEventHooks,
+        start_time: "datetime",
+    ) -> BedrockGuardrailResponse:
+        """Post one ApplyGuardrail call for `content`, retrying with exponential
+        backoff on AWS ThrottlingException (HTTP 429).
+
+        Chunking already trades one oversized call for several smaller ones, so
+        retries here are capped low -- they must not multiply per-request latency
+        by an order of magnitude when the account's per-second text-unit quota is
+        the binding constraint rather than the per-request size quota.
+        """
+        attempt = 0
+        while True:
+            try:
+                return await self._post_apply_guardrail_content(
+                    content=content,
+                    base_request_data=base_request_data,
+                    credentials=credentials,
+                    aws_region_name=aws_region_name,
+                    api_key=api_key,
+                    request_data=request_data,
+                    event_type=event_type,
+                    start_time=start_time,
+                )
+            except HTTPException as exc:
+                if exc.status_code == 429 and attempt < _BEDROCK_APPLY_GUARDRAIL_MAX_THROTTLE_RETRIES:
+                    await asyncio.sleep(_BEDROCK_APPLY_GUARDRAIL_BASE_BACKOFF_SECONDS * (2**attempt))
+                    attempt += 1
+                    continue
+                raise
+
+    async def _post_apply_guardrail_content(
+        self,
+        content: List[BedrockContentItem],
+        base_request_data: dict,
+        credentials,
+        aws_region_name: str,
+        api_key: Optional[str],
+        request_data: dict | None,
+        event_type: GuardrailEventHooks,
+        start_time: "datetime",
+    ) -> BedrockGuardrailResponse:
+        """Make exactly one signed ApplyGuardrail HTTP call for `content` and
+        parse the result. Raises HTTPException on a guardrail block or any
+        non-200 response (including 429, handled by the retry wrapper above).
+        """
+        bedrock_request_data = {**base_request_data, "content": content}
         prepared_request = self._prepare_request(
             credentials=credentials,
             data=bedrock_request_data,
@@ -792,14 +965,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             prepared_request.url,
             prepared_request.headers,
         )
-
-        # UI / spend logs use event_type. Bedrock's `source` is INPUT vs OUTPUT for the API
-        # body, which must not be confused with the proxy hook (pre_call / during_call /
-        # post_call). When omitted, keep legacy mapping for backward compatibility.
-        if logging_event_type is not None:
-            event_type = logging_event_type
-        else:
-            event_type = GuardrailEventHooks.pre_call if source == "INPUT" else GuardrailEventHooks.post_call
 
         httpx_response = await self._sign_and_post(
             prepared_request=prepared_request,
@@ -839,16 +1004,91 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 raise self._get_http_exception_for_blocked_guardrail(
                     bedrock_guardrail_response, request_data=request_data
                 )
-        else:
-            status_code, detail_message = self._parse_bedrock_guardrail_error_response(httpx_response)
-            verbose_proxy_logger.error(
-                "Bedrock AI: error in response. Status code: %s, response: %s",
-                httpx_response.status_code,
-                httpx_response.text,
-            )
-            raise HTTPException(status_code=status_code, detail=detail_message)
+            return bedrock_guardrail_response
 
-        return bedrock_guardrail_response
+        status_code, detail_message = self._parse_bedrock_guardrail_error_response(httpx_response)
+        verbose_proxy_logger.error(
+            "Bedrock AI: error in response. Status code: %s, response: %s",
+            httpx_response.status_code,
+            httpx_response.text,
+        )
+        raise HTTPException(status_code=status_code, detail=detail_message)
+
+    @staticmethod
+    def _content_uses_contextual_grounding(content: List[BedrockContentItem]) -> bool:
+        """True if any content item carries a contextual-grounding qualifier
+        (``grounding_source``, ``query``, or the ``guard_content`` the response
+        itself is tagged with once grounding is present)."""
+        for item in content:
+            if (item.get("text") or {}).get("qualifiers"):
+                return True
+        return False
+
+    @staticmethod
+    def _split_bedrock_content(
+        content: List[BedrockContentItem],
+    ) -> Tuple[List[BedrockContentItem], List[BedrockContentItem]]:
+        """Bisect `content` into two roughly-equal, non-empty halves.
+
+        Only called with ``len(content) > 1`` (guarded by the caller), so both
+        halves are always non-empty.
+        """
+        midpoint = max(1, len(content) // 2)
+        return content[:midpoint], content[midpoint:]
+
+    @staticmethod
+    def _is_input_too_large_validation_error(detail: object) -> bool:
+        """True if `detail` is the AWS ValidationException message for input
+        exceeding the per-request text-unit quota.
+
+        A guardrail *block* is also raised as an HTTPException with status 400,
+        but its ``detail`` is always a dict (built by
+        ``_get_http_exception_for_blocked_guardrail``); a non-200 API error's
+        ``detail`` is always the plain string returned by
+        ``_parse_bedrock_guardrail_error_response``. Checking ``isinstance(detail,
+        str)`` is therefore sufficient to never mistake a real block for a
+        too-large error.
+        """
+        if not isinstance(detail, str):
+            return False
+        lowered = detail.lower()
+        return any(substring in lowered for substring in _BEDROCK_TOO_LARGE_ERROR_SUBSTRINGS)
+
+    @staticmethod
+    def _merge_bedrock_guardrail_responses(
+        responses: List[BedrockGuardrailResponse],
+    ) -> BedrockGuardrailResponse:
+        """Merge the per-chunk ApplyGuardrail responses of a chunked request into
+        one, so a caller cannot tell whether chunking happened.
+
+        Only ever called with responses that all passed (a block raises
+        immediately from ``_apply_guardrail_content_with_chunking`` and is never
+        added to this list), so ``action`` is included purely for completeness.
+        """
+        if len(responses) == 1:
+            return responses[0]
+
+        merged_outputs: List[BedrockGuardrailOutput] = []
+        merged_assessments: List[dict] = []
+        merged_usage: Dict[str, Any] = {}
+        merged_action = "NONE"
+        for chunk_response in responses:
+            if chunk_response.get("action") == "GUARDRAIL_INTERVENED":
+                merged_action = "GUARDRAIL_INTERVENED"
+            merged_outputs.extend(chunk_response.get("outputs") or chunk_response.get("output") or [])
+            merged_assessments.extend(chunk_response.get("assessments") or [])
+            for key, value in (chunk_response.get("usage") or {}).items():
+                if isinstance(value, (int, float)):
+                    merged_usage[key] = merged_usage.get(key, 0) + value
+
+        merged: BedrockGuardrailResponse = BedrockGuardrailResponse(action=merged_action)
+        if merged_outputs:
+            merged["outputs"] = merged_outputs
+        if merged_assessments:
+            merged["assessments"] = merged_assessments
+        if merged_usage:
+            merged["usage"] = cast(BedrockGuardrailUsage, merged_usage)
+        return merged
 
     async def _sign_and_post(
         self,

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -179,16 +179,20 @@ class BedrockContentChunkResult(NamedTuple):
     `content` is the exact content items this chunk was called with -- needed
     so an all-clear chunk (empty `outputs`) can still contribute one unmasked
     placeholder per item it covers, keeping every later chunk's masked text
-    aligned to its original global position. `is_text_fragment` is True when
-    this chunk is one half of a single content item's own text (split because
-    a list of length 1 could not be bisected by list length) -- its sibling
-    fragment must be concatenated back into that one item's masked output,
-    not treated as a second item.
+    aligned to its original global position. `fragment_group_size` is 1 for an
+    ordinary chunk, and otherwise the total number of consecutive chunk results
+    that together make up ONE original content item's own text (split because a
+    list of length 1 could not be bisected by list length). All of them must be
+    concatenated back into that one item's masked output rather than treated as
+    separate items. It is a count rather than a boolean because one item can be
+    bisected more than once: two levels of splitting produce four fragments for
+    a single item, not two, and grouping them in fixed pairs would emit two
+    outputs for one message and shift every later message's masked text.
     """
 
     response: BedrockGuardrailResponse
     content: list[BedrockContentItem]
-    is_text_fragment: bool
+    fragment_group_size: int
 
 
 class ApplyGuardrailMessageSelection(NamedTuple):
@@ -922,10 +926,12 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         until every piece fits or cannot be split further). A single oversized
         content item (one very long message) is split by its own text instead of
         by list length, since a list of length 1 has no items left to bisect --
-        the two text fragments are tagged ``is_text_fragment=True`` so the merge
+        the resulting fragments all carry a ``fragment_group_size`` so the merge
         step can recombine them into the one content item they came from, rather
         than treating each fragment as its own item when reconstructing positions
-        for masking. A real guardrail block on any (sub-)chunk raises immediately
+        for masking. That count covers however many fragments the item ended up
+        split into, not just two, since it can be bisected repeatedly. A real
+        guardrail block on any (sub-)chunk raises immediately
         -- callers must not lose that signal by continuing to post the remaining
         chunks.
         """
@@ -944,7 +950,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 BedrockContentChunkResult(
                     response=response,
                     content=content,
-                    is_text_fragment=False,
+                    fragment_group_size=1,
                 )
             ]
         except HTTPException as exc:
@@ -953,7 +959,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 if split_content is None:
                     raise
                 first_half, second_half = split_content
-                is_text_fragment = len(content) == 1
+                is_single_item_text_split = len(content) == 1
                 verbose_proxy_logger.warning(
                     "Bedrock Guardrail: ApplyGuardrail rejected %d content item(s) as too large; "
                     "splitting into %d + %d and retrying each",
@@ -984,8 +990,13 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                     allow_chunking=allow_chunking,
                 )
                 combined_results = first_results + second_results
-                if is_text_fragment:
-                    return [result._replace(is_text_fragment=True) for result in combined_results]
+                if is_single_item_text_split:
+                    # Every leaf below this point came from one content item's own
+                    # text, however many levels deep the splitting went. Stamping
+                    # the total count on all of them (overwriting any smaller count
+                    # an inner split set) is what lets the merge step regroup them
+                    # into exactly one output entry for that one item.
+                    return [result._replace(fragment_group_size=len(combined_results)) for result in combined_results]
                 return combined_results
             raise
 
@@ -1074,6 +1085,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             request_data=request_data,
             event_type=event_type,
             start_time=start_time,
+            log_transport_failure=False,
         )
 
         if httpx_response.status_code == 200:
@@ -1352,7 +1364,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         to its item count is passed through as-is instead of guessed at, since
         AWS's docs don't cover partial masking within one multi-item call.
         """
-        logical_units = BedrockGuardrail._group_fragment_pairs(chunk_results)
+        logical_units = BedrockGuardrail._group_fragment_units(chunk_results)
         per_unit_outputs = tuple(BedrockGuardrail._merge_logical_unit_outputs(unit) for unit in logical_units)
         merged_outputs = [output for outputs, _ in per_unit_outputs for output in outputs]
         any_masked = any(masked for _, masked in per_unit_outputs)
@@ -1403,32 +1415,33 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         )
 
     @staticmethod
-    def _group_fragment_pairs(
+    def _group_fragment_units(
         chunk_results: list[BedrockContentChunkResult],
     ) -> list[tuple[BedrockContentChunkResult, ...]]:
-        """Group consecutive text-fragment chunk results into the sibling pairs
-        that originated from one content item's own text, leaving every other
-        chunk result as a unit of one. Fragments are always produced (and thus
-        appear here) as adjacent sibling pairs -- see ``_split_bedrock_content``."""
+        """Group consecutive text-fragment chunk results back into the one content
+        item each group came from, leaving every ordinary chunk result as a unit of
+        one.
+
+        The group size is read off the results themselves rather than assumed,
+        because a single content item can be bisected repeatedly: two levels of
+        splitting yield four fragments for one item, not two. Assuming a fixed pair
+        here would emit two outputs for one message and shift every later message's
+        masked text onto the wrong message."""
         units: list[tuple[BedrockContentChunkResult, ...]] = []
         index = 0
         while index < len(chunk_results):
-            chunk_result = chunk_results[index]
-            if chunk_result.is_text_fragment:
-                units.append((chunk_result, chunk_results[index + 1]))
-                index += 2
-            else:
-                units.append((chunk_result,))
-                index += 1
+            span = max(1, chunk_results[index].fragment_group_size)
+            units.append(tuple(chunk_results[index : index + span]))
+            index += span
         return units
 
     @staticmethod
     def _merge_logical_unit_outputs(
         unit: tuple[BedrockContentChunkResult, ...],
     ) -> tuple[list[BedrockGuardrailOutput], bool]:
-        """Reduce one logical unit (a fragment pair or a single chunk result)
-        to the ``BedrockGuardrailOutput`` entries it contributes to the merged
-        response, plus whether any masking actually happened in it.
+        """Reduce one logical unit (a fragment group of any size, or a single chunk
+        result) to the ``BedrockGuardrailOutput`` entries it contributes to the
+        merged response, plus whether any masking actually happened in it.
 
         Per AWS's documented ApplyGuardrail contract, a single call's
         ``outputs`` is positionally parallel to the ``content`` items *of that
@@ -1445,18 +1458,23 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         at, since AWS's docs don't cover partial masking within one multi-item
         call.
         """
-        if len(unit) == 2:
-            first, second = unit
-            first_outputs = first.response.get("outputs") or first.response.get("output") or []
-            second_outputs = second.response.get("outputs") or second.response.get("output") or []
-            first_source = (first.content[0].get("text") or {}).get("text") or ""
-            second_source = (second.content[0].get("text") or {}).get("text") or ""
-            first_text = first_outputs[0].get("text") if first_outputs else first_source
-            second_text = second_outputs[0].get("text") if second_outputs else second_source
-            merged_text = (first_text if first_text is not None else first_source) + (
-                second_text if second_text is not None else second_source
-            )
-            return [BedrockGuardrailOutput(text=merged_text)], bool(first_outputs or second_outputs)
+        if len(unit) > 1:
+            # Every result here is one fragment of a single content item's text, so
+            # the whole group collapses to one entry: each fragment's masked text
+            # (or its own original text when that fragment came back unmasked),
+            # concatenated in order. Holds for any group size, not just two.
+            def fragment_outputs(result: BedrockContentChunkResult) -> list[BedrockGuardrailOutput]:
+                return list(result.response.get("outputs") or result.response.get("output") or [])
+
+            def fragment_text(result: BedrockContentChunkResult) -> str:
+                source = (result.content[0].get("text") or {}).get("text") or ""
+                outputs = fragment_outputs(result)
+                masked = outputs[0].get("text") if outputs else None
+                return masked if masked is not None else source
+
+            merged_text = "".join(fragment_text(result) for result in unit)
+            any_masked = any(fragment_outputs(result) for result in unit)
+            return [BedrockGuardrailOutput(text=merged_text)], any_masked
 
         (chunk_result,) = unit
         chunk_outputs = chunk_result.response.get("outputs") or chunk_result.response.get("output") or []
@@ -1474,6 +1492,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         request_data: dict | None,
         event_type: GuardrailEventHooks,
         start_time: "datetime",
+        log_transport_failure: bool = True,
     ) -> httpx.Response:
         """POST a signed Bedrock request, logging+raising on network/HTTP errors.
 
@@ -1481,6 +1500,20 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         transport-error handling cannot drift. Returns the raw ``httpx.Response`` on
         success (including non-2xx that httpx did not raise on); the 200-path logging,
         status and tracing stay with each caller because the two APIs report differently.
+
+        ``log_transport_failure=False`` suppresses the ``guardrail_failed_to_respond``
+        entry for a non-200 that is re-raised as an ``HTTPException``, for callers that
+        own consolidated per-request logging. The ApplyGuardrail path needs this:
+        ``AsyncHTTPHandler.post`` calls ``raise_for_status()``, so every non-200 lands
+        in this handler, and one logical request can legitimately produce several of
+        them (a too-large probe, then each rejected bisection level) while still
+        succeeding overall. Logging per attempt would report a recovered request as
+        several failures plus a success.
+
+        The connection-level branch below (timeout, endpoint down) still logs
+        unconditionally: it re-raises the original exception rather than an
+        ``HTTPException``, so no consolidating caller catches it, and suppressing it
+        would drop the only record of the failure.
         """
         try:
             return await self.async_handler.post(
@@ -1501,16 +1534,17 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                         status_code,
                         detail_message,
                     ) = self._parse_bedrock_guardrail_error_response(err_response)
-                    self.add_standard_logging_guardrail_information_to_request_data(
-                        guardrail_provider=self.guardrail_provider,
-                        guardrail_json_response={"error": detail_message},
-                        request_data=request_data or {},
-                        guardrail_status="guardrail_failed_to_respond",
-                        start_time=start_time.timestamp(),
-                        end_time=datetime.now(timezone.utc).timestamp(),
-                        duration=(datetime.now(timezone.utc) - start_time).total_seconds(),
-                        event_type=event_type,
-                    )
+                    if log_transport_failure:
+                        self.add_standard_logging_guardrail_information_to_request_data(
+                            guardrail_provider=self.guardrail_provider,
+                            guardrail_json_response={"error": detail_message},
+                            request_data=request_data or {},
+                            guardrail_status="guardrail_failed_to_respond",
+                            start_time=start_time.timestamp(),
+                            end_time=datetime.now(timezone.utc).timestamp(),
+                            duration=(datetime.now(timezone.utc) - start_time).total_seconds(),
+                            event_type=event_type,
+                        )
                     raise HTTPException(status_code=status_code, detail=detail_message) from e
                 except HTTPException:
                     raise

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -93,7 +93,7 @@ _BEDROCK_TOO_LARGE_ERROR_SUBSTRINGS = (
     "too large",
     "exceeds the maximum",
 )
-_BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS = 20_000
+_BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS = 25_000
 _BEDROCK_APPLY_GUARDRAIL_MAX_THROTTLE_RETRIES = 3
 _BEDROCK_APPLY_GUARDRAIL_BASE_BACKOFF_SECONDS = 0.5
 # Resource-less, detect-only InvokeGuardrailChecks API (no guardrail resource required).
@@ -216,12 +216,14 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         content_filter_threshold: float | None = 0.5,
         prompt_attack_threshold: float | None = 0.5,
         pii_confidence_threshold: float | None = 0.5,
+        chunk_budget_chars: int = _BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS,
         **kwargs,
     ):
         self.async_handler = get_async_httpx_client(llm_provider=httpxSpecialProvider.GuardrailCallback)
         self.guardrailIdentifier = guardrailIdentifier
         self.guardrailVersion = guardrailVersion
         self.guardrail_provider = "bedrock"
+        self.chunk_budget_chars = chunk_budget_chars
         self.experimental_use_latest_role_message_only = bool(kwargs.get("experimental_use_latest_role_message_only"))
 
         # Resource-less, detect-only InvokeGuardrailChecks mode. Present `checks`
@@ -847,9 +849,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         content: list[BedrockContentItem] = bedrock_request_data.get("content") or []
         allow_chunking = not self._content_uses_contextual_grounding(content)
         batches = (
-            self._bin_pack_bedrock_content(content, budget=_BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS)
-            if allow_chunking
-            else [content]
+            self._bin_pack_bedrock_content(content, budget=self.chunk_budget_chars) if allow_chunking else [content]
         )
 
         try:
@@ -1199,14 +1199,19 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         too large, `_apply_guardrail_content_with_chunking`'s existing
         recursive-bisection fallback takes over for that batch only.
 
-        `budget` (`_BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS` at the call site)
-        is a conservative starting guess, not a correctness dependency. It only
-        sets how many calls the common case takes. AWS's real per-request
-        text-unit cap depends on account, region, and policy, is not a fixed
-        character count, and cannot be read from config, so any batch it still
-        rejects falls back to bisection, which self-corrects however wrong the
-        guess was. A too-generous guess therefore costs one extra probe-and-bisect
-        round trip, the same one pure reactive bisection would have paid anyway.
+        `budget` comes from the guardrail's ``chunk_budget_chars`` setting and
+        defaults to 25,000, matching ApplyGuardrail's default quota of 25 text
+        units (roughly 1,000 characters each) per second. Packing to that size and
+        posting sequentially is what keeps chunking from tripping the rate quota
+        and trading a size error for a throttle. Accounts with raised quotas can
+        configure a larger budget to spend fewer calls.
+
+        The budget is not a correctness dependency either way. AWS's effective cap
+        varies by account, region, and policy, is not a fixed character count, and
+        cannot be read from config, so any batch it still rejects falls back to
+        bisection, which self-corrects however wrong the value was. An over-large
+        budget therefore costs one extra probe-and-bisect round trip rather than
+        failing the request.
         """
         if not content:
             return [content]

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -84,22 +84,7 @@ from litellm.types.utils import (
 )
 
 GUARDRAIL_NAME = "bedrock"
-# KNOWN LIMITATION (chunking, below): splitting an oversized message's text on
-# a whitespace boundary (see `_nearest_whitespace_split_index`) prevents
-# accidentally severing a single token -- one denied word, one PII pattern --
-# across a chunk boundary. It does not stop a multi-word denied phrase
-# deliberately positioned to straddle that boundary, since each fragment can
-# scan clean independently. AWS's own guidance for this API acknowledges the
-# same gap for input chunking with no documented resolution; closing it would
-# require an overlap window reconciled against masked output, which AWS does
-# not guarantee to be length-preserving. Accepted as out of scope.
 _BEDROCK_DYNAMIC_BODY_DENYLIST = frozenset({"content", "source"})
-# ApplyGuardrail's per-request "maximum input size in text units" quota is
-# region/account/policy-dependent and cannot be predicted from config, so it is
-# only ever discovered reactively: AWS rejects an over-quota call with a 400
-# ValidationException whose message contains one of these substrings (matched
-# case-insensitively against the parsed AWS error message). On a match the
-# content is bisected and each half retried, rather than surfacing the 400.
 _BEDROCK_TOO_LARGE_ERROR_SUBSTRINGS = (
     "text unit",
     "maximum input size",
@@ -108,21 +93,7 @@ _BEDROCK_TOO_LARGE_ERROR_SUBSTRINGS = (
     "too large",
     "exceeds the maximum",
 )
-# Conservative starting guess for how much content (by character count) to send
-# in one ApplyGuardrail call, used to pre-bin-pack content instead of always
-# starting from the whole payload. This is NOT a correctness dependency: it only
-# sets how many calls the common case takes. Any bin AWS still rejects as too
-# large (because the real per-request text-unit cap for this account/region/
-# policy is lower than this guess -- that cap is not knowable ahead of time and
-# is not a fixed character count) falls back to the recursive bisection below,
-# which self-corrects regardless of how wrong this guess was. So a too-generous
-# guess here costs the same one extra probe-and-bisect round trip that pure
-# reactive bisection would have paid anyway, while a well-tuned guess makes the
-# common case a single pass instead of O(log n) round trips per request.
 _BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS = 20_000
-# Exponential backoff for a chunk call throttled with ThrottlingException (429).
-# Kept small: chunking already trades one oversized call for several smaller
-# ones, so retries must not multiply per-request latency by an order of magnitude.
 _BEDROCK_APPLY_GUARDRAIL_MAX_THROTTLE_RETRIES = 3
 _BEDROCK_APPLY_GUARDRAIL_BASE_BACKOFF_SECONDS = 0.5
 # Resource-less, detect-only InvokeGuardrailChecks API (no guardrail resource required).
@@ -826,6 +797,30 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         request_data: dict | None = None,
         logging_event_type: GuardrailEventHooks | None = None,
     ) -> BedrockGuardrailResponse:
+        """Scan `messages`/`response` with ApplyGuardrail, chunking if it is too large.
+
+        Content is bin-packed into budget-sized batches and each batch posted
+        sequentially, every batch independently falling back to bisection if AWS
+        rejects it. The per-batch responses are merged so callers cannot tell whether
+        chunking happened.
+
+        Content using contextual grounding opts out of chunking entirely: grounding is
+        scored holistically against the whole reference source, so bisecting it would
+        fragment that evaluation and yield misleading scores. Such a request keeps the
+        old behavior of surfacing a too-large error rather than being split.
+
+        `logging_event_type` drives what UI and spend logs report. It is distinct from
+        Bedrock's `source`, which is INPUT vs OUTPUT for the API body and must not be
+        confused with the proxy hook (pre_call / during_call / post_call); when omitted,
+        the legacy source-derived mapping is kept for backward compatibility.
+
+        A guardrail *block* is logged where it happens, in
+        `_post_apply_guardrail_content`, because chunking stops immediately and there is
+        no later merged response to log instead. Everything else that fails out of the
+        chunking flow (an unrecoverable too-large error, a non-size validation error,
+        exhausted throttle retries) is a genuine end-to-end failure of this one logical
+        guardrail call and is logged exactly once here.
+        """
         start_time = datetime.now(timezone.utc)
         credentials, aws_region_name = self._load_credentials()
         bedrock_request_data: dict = dict(
@@ -844,18 +839,12 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             if request_data.get("api_key") is not None:
                 api_key = request_data["api_key"]
 
-        # UI / spend logs use event_type. Bedrock's `source` is INPUT vs OUTPUT for the API
-        # body, which must not be confused with the proxy hook (pre_call / during_call /
-        # post_call). When omitted, keep legacy mapping for backward compatibility.
         if logging_event_type is not None:
             event_type = logging_event_type
         else:
             event_type = GuardrailEventHooks.pre_call if source == "INPUT" else GuardrailEventHooks.post_call
 
         content: list[BedrockContentItem] = bedrock_request_data.get("content") or []
-        # Contextual grounding scores the response holistically against the whole
-        # reference source; bisecting it would fragment that evaluation and produce
-        # misleading grounding scores, so a too-large error is never chunked here.
         allow_chunking = not self._content_uses_contextual_grounding(content)
         batches = (
             self._bin_pack_bedrock_content(content, budget=_BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS)
@@ -880,11 +869,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 )
             ]
         except HTTPException as exc:
-            # A block is logged where it happens, inside _post_apply_guardrail_content,
-            # since chunking stops immediately and there is no later merged response to
-            # log instead. Anything else reaching here (unrecoverable too-large error,
-            # a non-size validation error, exhausted throttle retries) is a genuine
-            # end-to-end failure of this logical guardrail call and is logged once here.
             if not isinstance(exc.detail, dict):
                 self._log_apply_guardrail_failure(
                     detail=exc.detail,
@@ -930,7 +914,9 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         step can recombine them into the one content item they came from, rather
         than treating each fragment as its own item when reconstructing positions
         for masking. That count covers however many fragments the item ended up
-        split into, not just two, since it can be bisected repeatedly. A real
+        split into, not just two, since it can be bisected repeatedly: the
+        outermost single-item split stamps the total leaf count on every leaf
+        below it, overwriting any smaller count an inner split had set. A real
         guardrail block on any (sub-)chunk raises immediately
         -- callers must not lose that signal by continuing to post the remaining
         chunks.
@@ -991,11 +977,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
                 )
                 combined_results = first_results + second_results
                 if is_single_item_text_split:
-                    # Every leaf below this point came from one content item's own
-                    # text, however many levels deep the splitting went. Stamping
-                    # the total count on all of them (overwriting any smaller count
-                    # an inner split set) is what lets the merge step regroup them
-                    # into exactly one output entry for that one item.
                     return [result._replace(fragment_group_size=len(combined_results)) for result in combined_results]
                 return combined_results
             raise
@@ -1064,6 +1045,10 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         """Make exactly one signed ApplyGuardrail HTTP call for `content` and
         parse the result. Raises HTTPException on a guardrail block or any
         non-200 response (including 429, handled by the retry wrapper above).
+
+        A block is logged here rather than by the caller: it ends the whole chunking
+        flow immediately, with no further chunks attempted, so there is no later
+        merged response for the caller to log instead.
         """
         bedrock_request_data = {**base_request_data, "content": content}
         prepared_request = self._prepare_request(
@@ -1097,9 +1082,6 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             )
             bedrock_guardrail_response = BedrockGuardrailResponse(**_json_response)
             if self._should_raise_guardrail_blocked_exception(bedrock_guardrail_response):
-                # A block ends the whole chunking flow immediately (no further
-                # chunks are attempted), so it is logged here rather than by the
-                # caller -- there is no later "final merged response" to log instead.
                 self._log_apply_guardrail_attempt(
                     httpx_response=httpx_response,
                     json_response=_json_response,
@@ -1216,6 +1198,15 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         (still oversized) batch and is sent as-is; if AWS rejects that batch as
         too large, `_apply_guardrail_content_with_chunking`'s existing
         recursive-bisection fallback takes over for that batch only.
+
+        `budget` (`_BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS` at the call site)
+        is a conservative starting guess, not a correctness dependency. It only
+        sets how many calls the common case takes. AWS's real per-request
+        text-unit cap depends on account, region, and policy, is not a fixed
+        character count, and cannot be read from config, so any batch it still
+        rejects falls back to bisection, which self-corrects however wrong the
+        guess was. A too-generous guess therefore costs one extra probe-and-bisect
+        round trip, the same one pure reactive bisection would have paid anyway.
         """
         if not content:
             return [content]
@@ -1457,12 +1448,15 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         not equal to its item count is passed through as-is instead of guessed
         at, since AWS's docs don't cover partial masking within one multi-item
         call.
+
+        A unit holding more than one result is a fragment group: every result in it
+        is one fragment of a single content item's text, so the group collapses to
+        one entry built from each fragment's masked text (or that fragment's own
+        original text where it came back unmasked), concatenated in order. This
+        holds for any group size, not only two.
         """
         if len(unit) > 1:
-            # Every result here is one fragment of a single content item's text, so
-            # the whole group collapses to one entry: each fragment's masked text
-            # (or its own original text when that fragment came back unmasked),
-            # concatenated in order. Holds for any group size, not just two.
+
             def fragment_outputs(result: BedrockContentChunkResult) -> list[BedrockGuardrailOutput]:
                 return list(result.response.get("outputs") or result.response.get("output") or [])
 

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -1284,22 +1284,31 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
 
     @staticmethod
     def _nearest_whitespace_split_index(text: str) -> int:
-        """Return the index nearest `text`'s midpoint that falls on a
-        whitespace boundary, so splitting `text[:i]` / `text[i:]` there never
-        severs a word. Falls back to the raw midpoint when `text` has no
-        whitespace at all (a single giant token) -- still a correct, lossless
-        split, just no longer guaranteed word-safe for that pathological case.
+        """Return the index nearest `text`'s midpoint that falls on a space
+        boundary, so splitting `text[:i]` / `text[i:]` there never severs a word.
+
+        The returned index always leaves both sides non-empty, which is what makes
+        the caller's recursion terminate. A boundary that would put the split at 0
+        or at ``len(text)`` is discarded: it would hand back a fragment identical to
+        the text just rejected as too large, AWS would reject that again, and each
+        retry would re-split it into the same unchanged fragment until the stack ran
+        out. The dangerous shape is a text whose only space at or after the midpoint
+        is its final character.
+
+        Falls back to the raw midpoint when no usable space boundary exists, either
+        because `text` has none at all (a single giant token) or because the only
+        candidates were degenerate. That is still a correct, lossless split, just no
+        longer guaranteed word-safe for those cases. `text` must be at least two
+        characters, which `_split_bedrock_content` guarantees, so the midpoint itself
+        is never degenerate.
         """
         midpoint = len(text) // 2
-        left = text.rfind(" ", 0, midpoint)
-        right = text.find(" ", midpoint)
-        if left == -1 and right == -1:
-            return midpoint
-        if left == -1:
-            return right + 1
-        if right == -1:
-            return left + 1
-        return left + 1 if midpoint - left <= right - midpoint else right + 1
+        boundaries = (text.rfind(" ", 0, midpoint), text.find(" ", midpoint))
+        candidates = sorted(
+            (found + 1 for found in boundaries if found != -1),
+            key=lambda split: abs(split - midpoint),
+        )
+        return next((split for split in candidates if 0 < split < len(text)), midpoint)
 
     @staticmethod
     def _is_input_too_large_error(detail: object) -> bool:

--- a/litellm/types/guardrails.py
+++ b/litellm/types/guardrails.py
@@ -526,6 +526,17 @@ class BedrockGuardrailConfigModel(BaseModel):
         description="InvokeGuardrailChecks: block when any sensitiveInformation confidenceScore "
         ">= this value (scores are in [0,1]). Set to null to make PII detection detect-only.",
     )
+    chunk_budget_chars: int = Field(
+        default=25_000,
+        gt=0,
+        description="ApplyGuardrail: how much content (in characters) to send per call. "
+        "Content above this is split across several sequential calls. Defaults to 25,000, "
+        "matching ApplyGuardrail's default quota of 25 text units (~1,000 characters each) "
+        "per second, so chunking does not trip that rate limit. Raise it if your account's "
+        "quotas have been increased; a batch AWS still rejects as too large is bisected "
+        "automatically, so an over-large value costs an extra round trip rather than "
+        "failing the request.",
+    )
 
 
 class LakeraV2GuardrailConfigModel(BaseModel):

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -3537,13 +3537,13 @@ async def test_apply_guardrail_does_not_chunk_on_non_size_validation_error():
 
 
 @pytest.mark.asyncio
-async def test_apply_guardrail_too_large_on_single_item_propagates_original_error():
-    """A too-large error on content that is already down to a single item
-    cannot be bisected further; the original error must propagate rather than
-    looping or crashing."""
+async def test_apply_guardrail_too_large_on_unsplittable_text_propagates_original_error():
+    """A too-large error on content that has been bisected down to text too
+    short to split further (< 2 characters) must propagate the original error
+    rather than looping or crashing."""
     guardrail = _bedrock_guardrail_for_chunk_tests()
 
-    messages = [{"role": "user", "content": "one giant single block of text"}]
+    messages = [{"role": "user", "content": "a"}]
 
     mock_credentials = MagicMock()
     mock_credentials.access_key = "k"
@@ -3566,6 +3566,46 @@ async def test_apply_guardrail_too_large_on_single_item_propagates_original_erro
 
     assert mock_post.await_count == 1
     assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_too_large_on_single_item_splits_by_text_and_succeeds():
+    """A too-large error on content that is already down to a single content
+    item must be bisected by that item's own text (not abandoned), so an
+    oversized single message can still be scanned successfully in halves."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [{"role": "user", "content": "one giant single block of text"}]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    call_count = 0
+
+    async def _post_side_effect(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _too_large_validation_httpx_response()
+        return _passing_bedrock_httpx_response(f"half-{call_count}")
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.side_effect = _post_side_effect
+
+        response = await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=messages,
+            request_data={"model": "bedrock-nova-micro"},
+        )
+
+    assert mock_post.await_count == 3
+    assert response.get("action") == "NONE"
 
 
 @pytest.mark.asyncio
@@ -3619,3 +3659,184 @@ async def test_apply_guardrail_chunk_retries_after_throttling_then_succeeds():
     mock_sleep.assert_awaited()
     output_texts = [o.get("text") for o in result.get("outputs") or []]
     assert output_texts == ["chunk-1", "chunk-2"]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_chunking_logs_exactly_once_as_success():
+    """A too-large 400 that is recovered by chunking must not leave behind a
+    'guardrail_failed_to_respond' telemetry entry for the initial oversized
+    attempt: the whole logical request (1 too-large attempt + 2 chunk
+    attempts here) must produce exactly one standard-logging entry, and it
+    must reflect the eventual success, not the transient too-large failure."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [
+        {"role": "user", "content": "chunk one text"},
+        {"role": "user", "content": "chunk two text"},
+    ]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    call_count = 0
+
+    async def _post_side_effect(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _too_large_validation_httpx_response()
+        if call_count == 2:
+            return _passing_bedrock_httpx_response("chunk-1")
+        return _passing_bedrock_httpx_response("chunk-2")
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+        patch.object(
+            guardrail,
+            "add_standard_logging_guardrail_information_to_request_data",
+        ) as mock_log,
+    ):
+        mock_post.side_effect = _post_side_effect
+
+        await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=messages,
+            request_data={"model": "bedrock-nova-micro"},
+        )
+
+    assert call_count == 3
+    mock_log.assert_called_once()
+    assert mock_log.call_args.kwargs["guardrail_status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_unrecoverable_failure_logs_exactly_once_as_failed():
+    """A too-large error that cannot be recovered (chunking disabled by
+    contextual grounding) must still log exactly once, as a failure -- not be
+    silently dropped by the chunking telemetry consolidation."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [
+        {
+            "role": "system",
+            "content": [{"type": "grounding_source", "text": "reference source text"}],
+        },
+        {"role": "user", "content": "what does the source say?"},
+    ]
+    model_response = ModelResponse()
+    model_response.choices = [
+        litellm.Choices(message=litellm.Message(content="a grounded answer", role="assistant"))
+    ]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+        patch.object(
+            guardrail,
+            "add_standard_logging_guardrail_information_to_request_data",
+        ) as mock_log,
+    ):
+        mock_post.return_value = _too_large_validation_httpx_response()
+
+        with pytest.raises(HTTPException):
+            await guardrail.make_bedrock_api_request(
+                source="OUTPUT",
+                messages=messages,
+                response=model_response,
+                request_data={"model": "bedrock-nova-micro"},
+            )
+
+    mock_post.assert_awaited_once()
+    mock_log.assert_called_once()
+    assert mock_log.call_args.kwargs["guardrail_status"] == "guardrail_failed_to_respond"
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_chunk_merge_preserves_masking_position():
+    """An earlier chunk that comes back clean (empty `outputs`) must not
+    shift a later chunk's masked text onto the wrong message. Regression for:
+    flattening outputs without positional metadata let a later chunk's PII
+    redaction get applied to the first message while the actual PII-bearing
+    message (in a later chunk) was forwarded unmasked."""
+    guardrail = BedrockGuardrail(
+        guardrail_name="test-bedrock-guard",
+        guardrailIdentifier="test-guardrail",
+        guardrailVersion="DRAFT",
+        disable_exception_on_block=False,
+        mask_request_content=True,
+    )
+
+    request_data = {
+        "model": "bedrock-nova-micro",
+        "messages": [
+            {"role": "user", "content": "clean chunk with nothing to mask"},
+            {"role": "user", "content": "chunk with PII: John Doe"},
+        ],
+    }
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    call_count = 0
+
+    def _clean_httpx_response() -> MagicMock:
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"action": "NONE", "assessments": []}
+        return response
+
+    def _masked_httpx_response() -> MagicMock:
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "action": "GUARDRAIL_INTERVENED",
+            "outputs": [{"text": "chunk with PII: [NAME]"}],
+            "assessments": [
+                {
+                    "sensitiveInformationPolicy": {
+                        "piiEntities": [{"type": "NAME", "match": "John Doe", "action": "ANONYMIZED"}]
+                    }
+                }
+            ],
+        }
+        return response
+
+    async def _post_side_effect(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _too_large_validation_httpx_response()
+        if call_count == 2:
+            return _clean_httpx_response()
+        return _masked_httpx_response()
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.side_effect = _post_side_effect
+
+        await guardrail.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(),
+            cache=DualCache(),
+            data=request_data,
+            call_type="acompletion",
+        )
+
+    assert call_count == 3
+    updated_messages = request_data["messages"]
+    assert updated_messages[0]["content"] == "clean chunk with nothing to mask"
+    assert updated_messages[1]["content"] == "chunk with PII: [NAME]"

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -7,6 +7,7 @@ import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import HTTPException
 
@@ -3686,6 +3687,178 @@ async def test_apply_guardrail_too_large_on_single_item_splits_by_text_and_succe
 
     assert mock_post.await_count == 3
     assert response.get("action") == "NONE"
+
+
+def _raised_bedrock_error(status_code: int, message: str) -> httpx.HTTPStatusError:
+    """A non-200 the way `AsyncHTTPHandler.post` actually surfaces it.
+
+    That handler calls `response.raise_for_status()`, so in production a non-200 from
+    Bedrock arrives as a raised `httpx.HTTPStatusError` carrying the response, never
+    as a returned response object. Tests that return the response instead exercise a
+    branch real traffic never reaches. A real `httpx.Response` is used rather than a
+    MagicMock because the transport helper branches on
+    `isinstance(err_response, httpx.Response)`."""
+    response = httpx.Response(
+        status_code=status_code,
+        json={"message": message},
+        request=httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/guardrail"),
+    )
+    return httpx.HTTPStatusError(message, request=response.request, response=response)
+
+
+_TOO_LARGE_MESSAGE = "Input is too long. Content size exceeds the maximum input size in text units."
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_chunking_logs_once_when_client_raises_for_status():
+    """The too-large attempt recovered by chunking must still produce exactly one
+    telemetry entry when the HTTP client raises for status, which is what really
+    happens: `AsyncHTTPHandler.post` calls `raise_for_status()`.
+
+    Regression for per-attempt `guardrail_failed_to_respond` entries leaking out of
+    the transport helper on a request that ultimately succeeded, which made a
+    recovered request look like several failures plus a success."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [
+        {"role": "user", "content": "chunk one text"},
+        {"role": "user", "content": "chunk two text"},
+    ]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    call_count = 0
+
+    async def _post_side_effect(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise _raised_bedrock_error(400, _TOO_LARGE_MESSAGE)
+        return _passing_bedrock_httpx_response(f"chunk-{call_count}")
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+        patch.object(
+            guardrail,
+            "add_standard_logging_guardrail_information_to_request_data",
+        ) as mock_log,
+    ):
+        mock_post.side_effect = _post_side_effect
+
+        result = await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=messages,
+            request_data={"model": "bedrock-nova-micro"},
+        )
+
+    assert call_count == 3
+    assert result.get("action") == "NONE"
+    statuses = [call.kwargs.get("guardrail_status") for call in mock_log.call_args_list]
+    assert statuses == ["success"]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_unrecoverable_failure_still_logs_once_when_client_raises():
+    """Suppressing the transport helper's per-attempt logging must not swallow the only
+    record of a genuine failure: an unsplittable too-large request still has to produce
+    exactly one `guardrail_failed_to_respond` entry, not zero."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    # Single character: `_split_bedrock_content` cannot halve this into two non-empty
+    # pieces, so chunking gives up and the original error propagates.
+    messages = [{"role": "user", "content": "x"}]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    async def _post_side_effect(*_args, **_kwargs):
+        raise _raised_bedrock_error(400, _TOO_LARGE_MESSAGE)
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+        patch.object(
+            guardrail,
+            "add_standard_logging_guardrail_information_to_request_data",
+        ) as mock_log,
+    ):
+        mock_post.side_effect = _post_side_effect
+
+        with pytest.raises(HTTPException):
+            await guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=messages,
+                request_data={"model": "bedrock-nova-micro"},
+            )
+
+    statuses = [call.kwargs.get("guardrail_status") for call in mock_log.call_args_list]
+    assert statuses == ["guardrail_failed_to_respond"]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_single_item_split_twice_still_yields_one_output_per_item():
+    """One oversized content item that needs two levels of text bisection ends up
+    as four text fragments, and all four must still collapse back into exactly
+    ONE output entry, because they all came from one original content item.
+
+    Downstream masking (`_apply_masking_to_messages`) walks the merged outputs by
+    a running index across the original, unchunked message list, so emitting more
+    than one entry for a single message shifts every later message's masked text
+    onto the wrong message and drops the surplus. Regression for fragment
+    grouping assuming fragments only ever arrive as adjacent sibling *pairs*,
+    which holds for one bisection level but not for two."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [{"role": "user", "content": "aaaa bbbb cccc dddd eeee ffff gggg hhhh"}]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    # whole item -> [first half] -> [q1] [q2] -> [second half] -> [q3] [q4].
+    # Only the four quarters fit; the whole item and both halves are too large.
+    responses = [
+        _too_large_validation_httpx_response(),  # whole single item
+        _too_large_validation_httpx_response(),  # first half
+        _passing_bedrock_httpx_response("q1"),
+        _passing_bedrock_httpx_response("q2"),
+        _too_large_validation_httpx_response(),  # second half
+        _passing_bedrock_httpx_response("q3"),
+        _passing_bedrock_httpx_response("q4"),
+    ]
+
+    async def _post_side_effect(*_args, **_kwargs):
+        return responses.pop(0)
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.side_effect = _post_side_effect
+
+        result = await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=messages,
+            request_data={"model": "bedrock-nova-micro"},
+        )
+
+    assert mock_post.await_count == 7
+    assert not responses
+    assert result.get("action") == "NONE"
+    output_texts = [o.get("text") for o in result.get("outputs") or []]
+    # One original content item in, so exactly one output entry out, carrying all
+    # four fragments' text in order.
+    assert output_texts == ["q1q2q3q4"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -3274,3 +3274,348 @@ async def test_chat_completion_modify_response_exception_streaming_logging_obj_n
     # CustomStreamWrapper would raise AttributeError inside __init__ and this
     # call would never reach here.
     assert response is not None
+
+
+###############################################################################
+# AIKMG-278: chunk oversized ApplyGuardrail requests instead of failing.
+#
+# AWS rejects an ApplyGuardrail call whose content exceeds the account's
+# "maximum input size in text units" quota with a 400 ValidationException.
+# Rather than surfacing that 400 to the caller, split the content in half and
+# retry each half; merge the per-half responses back into one. Grounded
+# (contextual-grounding) requests are never chunked -- grounding scores the
+# response holistically against the whole source, so fragmenting it would
+# produce misleading scores.
+###############################################################################
+
+
+def _too_large_validation_httpx_response() -> MagicMock:
+    response = MagicMock()
+    response.status_code = 400
+    response.json.return_value = {
+        "message": "Input is too long. Content size exceeds the maximum input size in text units."
+    }
+    response.text = json.dumps(response.json.return_value)
+    return response
+
+
+def _other_validation_httpx_response() -> MagicMock:
+    response = MagicMock()
+    response.status_code = 400
+    response.json.return_value = {"message": "guardrailIdentifier is not valid"}
+    response.text = json.dumps(response.json.return_value)
+    return response
+
+
+def _throttling_httpx_response() -> MagicMock:
+    response = MagicMock()
+    response.status_code = 429
+    response.json.return_value = {"message": "Rate exceeded"}
+    response.text = json.dumps(response.json.return_value)
+    response.headers = {}
+    return response
+
+
+def _passing_bedrock_httpx_response(marker: str) -> MagicMock:
+    """A successful ApplyGuardrail response tagged with `marker` so tests can
+    verify which chunk produced which output/usage after merging."""
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "action": "NONE",
+        "outputs": [{"text": marker}],
+        "assessments": [],
+        "usage": {"contentPolicyUnits": 1},
+    }
+    return response
+
+
+def _blocking_bedrock_httpx_response(marker: str) -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "action": "GUARDRAIL_INTERVENED",
+        "outputs": [{"text": marker}],
+        "assessments": [
+            {"topicPolicy": {"topics": [{"name": marker, "type": "DENY", "action": "BLOCKED"}]}}
+        ],
+        "usage": {"contentPolicyUnits": 1},
+    }
+    return response
+
+
+def _bedrock_guardrail_for_chunk_tests() -> "BedrockGuardrail":
+    return BedrockGuardrail(
+        guardrail_name="test-bedrock-guard",
+        guardrailIdentifier="test-guardrail",
+        guardrailVersion="DRAFT",
+        disable_exception_on_block=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_chunks_on_too_large_validation_error():
+    """A too-large 400 on the whole-content call must trigger a bisect-and-retry,
+    and the two chunk responses must be merged (assessments concatenated, usage
+    summed, outputs concatenated) rather than losing either half's result."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [
+        {"role": "user", "content": "first half of a very long message"},
+        {"role": "user", "content": "second half of a very long message"},
+    ]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    call_count = 0
+
+    async def _post_side_effect(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # Whole-content call: too large.
+            return _too_large_validation_httpx_response()
+        if call_count == 2:
+            return _passing_bedrock_httpx_response("chunk-1")
+        return _blocking_bedrock_httpx_response("chunk-2")
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.side_effect = _post_side_effect
+
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=messages,
+                request_data={"model": "bedrock-nova-micro"},
+            )
+
+    # 1 whole-content attempt + 2 chunk attempts.
+    assert call_count == 3
+    detail = exc_info.value.detail
+    assert exc_info.value.status_code == 400
+    # The merged response must retain the block signal from chunk-2 even
+    # though chunk-1 passed clean -- losing it would silently bypass a
+    # guardrail hit.
+    assert "chunk-2" in detail["bedrock_guardrail_response"]
+    assert detail["assessments"][0]["matches"][0]["name"] == "chunk-2"
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_merges_usage_and_outputs_across_chunks_when_both_pass():
+    """When both chunks pass clean, the merged response must still carry both
+    chunks' outputs/usage forward (needed for accurate logging/telemetry) and
+    must not itself raise."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [
+        {"role": "user", "content": "chunk one text"},
+        {"role": "user", "content": "chunk two text"},
+    ]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    call_count = 0
+
+    async def _post_side_effect(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _too_large_validation_httpx_response()
+        if call_count == 2:
+            return _passing_bedrock_httpx_response("chunk-1")
+        return _passing_bedrock_httpx_response("chunk-2")
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.side_effect = _post_side_effect
+
+        result = await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=messages,
+            request_data={"model": "bedrock-nova-micro"},
+        )
+
+    assert call_count == 3
+    assert result.get("action") == "NONE"
+    output_texts = [o.get("text") for o in result.get("outputs") or []]
+    assert output_texts == ["chunk-1", "chunk-2"]
+    assert result.get("usage", {}).get("contentPolicyUnits") == 2
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_does_not_chunk_when_grounding_present():
+    """Contextual-grounding requests are scored holistically against the whole
+    source; chunking them would silently produce misleading grounding scores.
+    A too-large error on a grounded request must propagate unchanged, not be
+    bisected."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [
+        {
+            "role": "system",
+            "content": [{"type": "grounding_source", "text": "reference source text"}],
+        },
+        {"role": "user", "content": "what does the source say?"},
+    ]
+    model_response = ModelResponse()
+    model_response.choices = [
+        litellm.Choices(message=litellm.Message(content="a grounded answer", role="assistant"))
+    ]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.return_value = _too_large_validation_httpx_response()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.make_bedrock_api_request(
+                source="OUTPUT",
+                messages=messages,
+                response=model_response,
+                request_data={"model": "bedrock-nova-micro"},
+            )
+
+    # Exactly one call: no bisect-and-retry for a grounded request.
+    assert mock_post.await_count == 1
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_does_not_chunk_on_non_size_validation_error():
+    """A 400 for an unrelated validation problem (e.g. a bad guardrail id) must
+    not trigger chunking -- retrying a bad-config error split into pieces would
+    just fail twice more and mask the real problem."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [
+        {"role": "user", "content": "first"},
+        {"role": "user", "content": "second"},
+    ]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.return_value = _other_validation_httpx_response()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=messages,
+                request_data={"model": "bedrock-nova-micro"},
+            )
+
+    assert mock_post.await_count == 1
+    assert exc_info.value.status_code == 400
+    assert "not valid" in str(exc_info.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_too_large_on_single_item_propagates_original_error():
+    """A too-large error on content that is already down to a single item
+    cannot be bisected further; the original error must propagate rather than
+    looping or crashing."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [{"role": "user", "content": "one giant single block of text"}]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.return_value = _too_large_validation_httpx_response()
+
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=messages,
+                request_data={"model": "bedrock-nova-micro"},
+            )
+
+    assert mock_post.await_count == 1
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_chunk_retries_after_throttling_then_succeeds():
+    """A chunk call throttled with a 429 must be retried with backoff and
+    eventually succeed, rather than surfacing the 429 to the caller."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [
+        {"role": "user", "content": "chunk one text"},
+        {"role": "user", "content": "chunk two text"},
+    ]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    call_count = 0
+
+    async def _post_side_effect(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _too_large_validation_httpx_response()
+        if call_count == 2:
+            # First chunk throttled once, then succeeds on retry.
+            return _throttling_httpx_response()
+        if call_count == 3:
+            return _passing_bedrock_httpx_response("chunk-1")
+        return _passing_bedrock_httpx_response("chunk-2")
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+        patch(
+            "litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as mock_sleep,
+    ):
+        mock_post.side_effect = _post_side_effect
+
+        result = await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=messages,
+            request_data={"model": "bedrock-nova-micro"},
+        )
+
+    assert call_count == 4
+    mock_sleep.assert_awaited()
+    output_texts = [o.get("text") for o in result.get("outputs") or []]
+    assert output_texts == ["chunk-1", "chunk-2"]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -3321,6 +3321,23 @@ def _throttling_httpx_response() -> MagicMock:
     return response
 
 
+def _too_large_throttling_httpx_response() -> MagicMock:
+    """The shape AWS actually returns for an oversized ApplyGuardrail request when
+    the guardrail has an active content-filter policy: a 429 ThrottlingException,
+    not the documented 400 ValidationException. Message taken from a live call."""
+    response = MagicMock()
+    response.status_code = 429
+    response.json.return_value = {
+        "message": (
+            "Input text size (3273 text units) exceeds the maximum allowed "
+            "(1000 text units) for the content filter policy (Classic tier)."
+        )
+    }
+    response.text = json.dumps(response.json.return_value)
+    response.headers = {}
+    return response
+
+
 def _passing_bedrock_httpx_response(marker: str) -> MagicMock:
     """A successful ApplyGuardrail response tagged with `marker` so tests can
     verify which chunk produced which output/usage after merging."""
@@ -4124,3 +4141,63 @@ def test_bin_pack_bedrock_content_empty_content_makes_exactly_one_empty_batch():
     pre-bin-packing behavior of sending the content list as-is in one call --
     bin-packing must not turn an empty request into zero ApplyGuardrail calls."""
     assert BedrockGuardrail._bin_pack_bedrock_content([], budget=100) == [[]]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_too_large_reported_as_429_bisects_without_burning_retries():
+    """AWS reports an oversized ApplyGuardrail request as a 429 ThrottlingException
+    (not the documented 400 ValidationException) when the guardrail has an active
+    content-filter policy. That is not a transient throttle -- re-posting the same
+    oversized content can never succeed -- so it must bisect immediately instead of
+    consuming the exponential-backoff retry budget first.
+
+    Regression for a bug found against a live guardrail: because the throttle retry
+    only keyed off status 429, every oversized chunk burned all
+    _BEDROCK_APPLY_GUARDRAIL_MAX_THROTTLE_RETRIES attempts (each a billed AWS call,
+    each preceded by a backoff sleep) before bisection got a chance, at every level
+    of the recursion."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [
+        {"role": "user", "content": "chunk one text"},
+        {"role": "user", "content": "chunk two text"},
+    ]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    call_count = 0
+
+    async def _post_side_effect(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return _too_large_throttling_httpx_response()
+        return _passing_bedrock_httpx_response(f"half-{call_count}")
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+        patch(
+            "litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as mock_sleep,
+    ):
+        mock_post.side_effect = _post_side_effect
+
+        result = await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=messages,
+            request_data={"model": "bedrock-nova-micro"},
+        )
+
+    # One rejected whole-content call, then exactly one call per bisected half.
+    assert call_count == 3
+    # No backoff sleep: a size error must not be treated as a transient throttle.
+    mock_sleep.assert_not_awaited()
+    assert result.get("action") == "NONE"
+    output_texts = [o.get("text") for o in result.get("outputs") or []]
+    assert output_texts == ["half-2", "half-3"]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -3456,6 +3456,64 @@ async def test_apply_guardrail_merges_usage_and_outputs_across_chunks_when_both_
 
 
 @pytest.mark.asyncio
+async def test_apply_guardrail_recurses_past_first_bisection_into_four_chunks():
+    """A payload that is still too large after one bisection must keep splitting
+    -- chunking is not capped at two pieces. Four messages where both the
+    whole-content call AND both first-level halves are too large must recurse
+    one level deeper into four chunks that all fit, not give up after the
+    first split."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [
+        {"role": "user", "content": "message one"},
+        {"role": "user", "content": "message two"},
+        {"role": "user", "content": "message three"},
+        {"role": "user", "content": "message four"},
+    ]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    # Depth-first recursion order for 4 items bisected down to single items:
+    # whole -> [1,2] -> [1] -> [2] -> [3,4] -> [3] -> [4]. Only single-item
+    # calls (positions 3, 4, 6, 7) fit; every multi-item call is too large.
+    responses = [
+        _too_large_validation_httpx_response(),  # whole content: [1,2,3,4]
+        _too_large_validation_httpx_response(),  # first half: [1,2]
+        _passing_bedrock_httpx_response("message one"),
+        _passing_bedrock_httpx_response("message two"),
+        _too_large_validation_httpx_response(),  # second half: [3,4]
+        _passing_bedrock_httpx_response("message three"),
+        _passing_bedrock_httpx_response("message four"),
+    ]
+
+    async def _post_side_effect(*_args, **_kwargs):
+        return responses.pop(0)
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.side_effect = _post_side_effect
+
+        result = await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=messages,
+            request_data={"model": "bedrock-nova-micro"},
+        )
+
+    # 1 whole-content + 2 first-level halves + 4 second-level quarters = 7.
+    assert mock_post.await_count == 7
+    assert not responses
+    assert result.get("action") == "NONE"
+    output_texts = [o.get("text") for o in result.get("outputs") or []]
+    assert output_texts == ["message one", "message two", "message three", "message four"]
+
+
+@pytest.mark.asyncio
 async def test_apply_guardrail_does_not_chunk_when_grounding_present():
     """Contextual-grounding requests are scored holistically against the whole
     source; chunking them would silently produce misleading grounding scores.

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -16,11 +16,16 @@ import litellm
 from litellm.caching.caching import DualCache
 from litellm.proxy._types import UserAPIKeyAuth
 from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
+    _BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS,
     BedrockGuardrail,
     _redact_pii_matches,
 )
 from litellm.proxy.utils import ProxyLogging
 from litellm.types.guardrails import GuardrailEventHooks
+from litellm.types.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
+    BedrockContentItem,
+    BedrockTextContent,
+)
 from litellm.types.utils import ModelResponse
 
 
@@ -3898,3 +3903,224 @@ async def test_apply_guardrail_chunk_merge_preserves_masking_position():
     updated_messages = request_data["messages"]
     assert updated_messages[0]["content"] == "clean chunk with nothing to mask"
     assert updated_messages[1]["content"] == "chunk with PII: [NAME]"
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_bin_packs_under_budget_content_with_no_probe_call():
+    """Content that fits under the fixed chunk budget in one pre-packed batch
+    must be sent in exactly one ApplyGuardrail call -- no initial too-large
+    probe call, unlike pure reactive bisection which always pays that extra
+    round trip. Regression for: falling back to always trying the whole
+    unpacked content list first, rather than bin-packing before the first
+    attempt."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    # Five items, individually tiny, whose combined length exceeds the budget
+    # only when summed -- proves this triggers packing into multiple batches
+    # by SIZE, not by falling back to per-item chunking.
+    item_text = "x" * (_BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS // 2)
+    messages = [{"role": "user", "content": item_text} for _ in range(3)]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    call_count = 0
+
+    async def _post_side_effect(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        return _passing_bedrock_httpx_response(f"batch-{call_count}")
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.side_effect = _post_side_effect
+
+        result = await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=messages,
+            request_data={"model": "bedrock-nova-micro"},
+        )
+
+    # Three items at budget/2 each pack two-per-batch (2 + 1), never a single
+    # oversized call and never a wasted whole-content probe: exactly 2 calls.
+    assert call_count == 2
+    assert result.get("action") == "NONE"
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_small_content_makes_exactly_one_call():
+    """Content that fits entirely within the budget in a single batch must
+    make exactly one ApplyGuardrail call -- confirms bin-packing does not
+    introduce an extra probe call for the common (small-request) case."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    messages = [
+        {"role": "user", "content": "short message one"},
+        {"role": "user", "content": "short message two"},
+    ]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.return_value = _passing_bedrock_httpx_response("single-batch")
+
+        result = await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=messages,
+            request_data={"model": "bedrock-nova-micro"},
+        )
+
+    mock_post.assert_awaited_once()
+    assert result.get("action") == "NONE"
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_batch_under_budget_still_rejected_falls_back_to_bisection():
+    """A pre-packed batch that fits the fixed budget guess but is still
+    rejected by AWS as too large (a lower real per-account/region/policy cap)
+    must fall back to bisection for that batch only -- and any other batch
+    from the same request that AWS already accepted must not be re-sent."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+
+    item_text = "x" * (_BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS // 2)
+    messages = [
+        {"role": "user", "content": item_text},
+        {"role": "user", "content": item_text},
+        {"role": "user", "content": item_text},
+    ]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    call_count = 0
+
+    async def _post_side_effect(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First pre-packed batch (items 1+2): accepted immediately.
+            return _passing_bedrock_httpx_response("batch-1")
+        if call_count == 2:
+            # Second pre-packed batch (item 3 alone): rejected as too large
+            # despite fitting the fixed budget guess -- simulates a lower
+            # real-world per-account cap.
+            return _too_large_validation_httpx_response()
+        return _passing_bedrock_httpx_response(f"batch-2-bisected-{call_count}")
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.side_effect = _post_side_effect
+
+        result = await guardrail.make_bedrock_api_request(
+            source="INPUT",
+            messages=messages,
+            request_data={"model": "bedrock-nova-micro"},
+        )
+
+    # batch-1 (1 call, accepted) + batch-2 (1 rejected + 2 bisected halves) = 4.
+    assert call_count == 4
+    assert result.get("action") == "NONE"
+    output_texts = [o.get("text") for o in result.get("outputs") or []]
+    # batch-2's two bisected text fragments came from the same original
+    # content item, so they are merged back into one combined output entry.
+    assert output_texts == ["batch-1", "batch-2-bisected-3batch-2-bisected-4"]
+
+
+def test_split_bedrock_content_single_item_splits_on_whitespace_not_mid_word():
+    """A single content item whose raw character midpoint would fall inside a
+    word must instead split at the nearest whitespace, so neither fragment
+    ends or begins mid-token. Regression for the Veria AI review finding: a
+    denied word/PII pattern straddling a raw character-midpoint cut could be
+    truncated on both fragments and scan clean on each, then reassemble into
+    the original unmasked text -- a detection bypass."""
+    # 20 'a's + space + 30 'b's: the raw character midpoint (25) falls inside
+    # the run of 'b's, proving the split must move off it to the nearest space.
+    text = ("a" * 20) + " " + ("b" * 30)
+    raw_midpoint = len(text) // 2
+    assert text[raw_midpoint] == "b"
+    content = [BedrockContentItem(text=BedrockTextContent(text=text))]
+
+    split_content = BedrockGuardrail._split_bedrock_content(content)
+    assert split_content is not None
+    first_half, second_half = split_content
+
+    first_text = first_half[0]["text"]["text"]
+    second_text = second_half[0]["text"]["text"]
+
+    # Lossless: concatenating the two fragments reproduces the original exactly.
+    assert first_text + second_text == text
+    # Word-safe: the split lands exactly on the whitespace boundary, not
+    # inside either the "a" or "b" run.
+    assert first_text == ("a" * 20) + " "
+    assert second_text == "b" * 30
+
+
+def test_split_bedrock_content_single_item_with_no_whitespace_falls_back_to_midpoint():
+    """A single giant token with no whitespace anywhere has no safe split
+    point, so the split must fall back to the raw character midpoint rather
+    than failing or looping."""
+    text = "a" * 40
+    content = [BedrockContentItem(text=BedrockTextContent(text=text))]
+
+    split_content = BedrockGuardrail._split_bedrock_content(content)
+    assert split_content is not None
+    first_half, second_half = split_content
+
+    first_text = first_half[0]["text"]["text"]
+    second_text = second_half[0]["text"]["text"]
+    assert first_text + second_text == text
+    assert len(first_text) == 20
+    assert len(second_text) == 20
+
+
+def test_bin_pack_bedrock_content_packs_minimal_batches_within_budget():
+    """Many medium items should pack into the minimal number of in-order
+    batches that each stay within budget, not one batch per item."""
+    items = [BedrockContentItem(text=BedrockTextContent(text="x" * 30)) for _ in range(10)]
+
+    batches = BedrockGuardrail._bin_pack_bedrock_content(items, budget=100)
+
+    assert sum(len(batch) for batch in batches) == 10
+    for batch in batches:
+        combined_len = sum(len(item["text"]["text"]) for item in batch)
+        assert combined_len <= 100
+    # 10 items * 30 chars = 300 chars at a 100-char budget packs into 3 batches
+    # of 3 items (90 chars) plus 1 batch of 1 item -- never one batch per item.
+    assert len(batches) == 4
+
+
+def test_bin_pack_bedrock_content_oversized_single_item_becomes_its_own_batch():
+    """An item whose own text already exceeds the budget must not be
+    pre-split here -- it becomes its own oversized batch, and only the
+    reactive bisection fallback (on an AWS rejection) may split it later."""
+    small_item = BedrockContentItem(text=BedrockTextContent(text="short"))
+    oversized_item = BedrockContentItem(text=BedrockTextContent(text="x" * 200))
+    items = [small_item, oversized_item, small_item]
+
+    batches = BedrockGuardrail._bin_pack_bedrock_content(items, budget=100)
+
+    assert batches == [[small_item], [oversized_item], [small_item]]
+
+
+def test_bin_pack_bedrock_content_empty_content_makes_exactly_one_empty_batch():
+    """Empty content must still pack into exactly one (empty) batch, matching
+    pre-bin-packing behavior of sending the content list as-is in one call --
+    bin-packing must not turn an empty request into zero ApplyGuardrail calls."""
+    assert BedrockGuardrail._bin_pack_bedrock_content([], budget=100) == [[]]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -4376,3 +4376,57 @@ async def test_configured_chunk_budget_changes_how_content_is_packed():
 
     assert await _calls_made_with_budget(_BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS) == 4
     assert await _calls_made_with_budget(100_000) == 1
+
+
+def test_split_index_never_produces_an_empty_fragment():
+    """Both fragments must be non-empty for every splittable text, so bisection always
+    makes progress.
+
+    A text whose only qualifying whitespace is its final character is the dangerous
+    shape: taking that boundary puts the split at len(text), leaving the first fragment
+    identical to the input that was just rejected and the second empty. The recursion
+    would then resubmit the unchanged fragment forever and exhaust the stack instead of
+    scanning or surfacing Bedrock's error."""
+    for text in ("ab ", "xxxx ", ("x" * 40) + " ", " ab", "a b", "ab", "  "):
+        split_at = BedrockGuardrail._nearest_whitespace_split_index(text)
+        assert 0 < split_at < len(text), f"degenerate split {split_at} for {text!r}"
+        assert text[:split_at] and text[split_at:], f"empty fragment for {text!r}"
+        assert text[:split_at] + text[split_at:] == text
+
+
+@pytest.mark.asyncio
+async def test_oversized_single_item_with_trailing_space_gives_up_instead_of_recursing():
+    """An oversized single item whose only space is trailing must bottom out and
+    surface Bedrock's error, not recurse forever.
+
+    AWS is modelled the way it really behaves, rejecting every attempt, because the
+    danger is a fragment identical to the input that was just rejected: AWS would
+    reject it again, and each retry would split it into the same unchanged fragment.
+    A split that always shrinks the text terminates and re-raises; one that can return
+    the whole text raises RecursionError instead. The call-count bound is generous:
+    halving 41 characters down to unsplittable is a handful of attempts, nowhere near
+    a stack limit."""
+    guardrail = _bedrock_guardrail_for_chunk_tests()
+    messages = [{"role": "user", "content": ("x" * 40) + " "}]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    with (
+        patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+        patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+        patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+    ):
+        mock_post.side_effect = lambda *_a, **_k: _too_large_validation_httpx_response()
+
+        with pytest.raises(HTTPException) as excinfo:
+            await guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=messages,
+                request_data={"model": "bedrock-nova-micro"},
+            )
+
+    assert excinfo.value.status_code == 400
+    assert mock_post.await_count < 200

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -3282,17 +3282,6 @@ async def test_chat_completion_modify_response_exception_streaming_logging_obj_n
     assert response is not None
 
 
-###############################################################################
-# AIKMG-278: chunk oversized ApplyGuardrail requests instead of failing.
-#
-# AWS rejects an ApplyGuardrail call whose content exceeds the account's
-# "maximum input size in text units" quota with a 400 ValidationException.
-# Rather than surfacing that 400 to the caller, split the content in half and
-# retry each half; merge the per-half responses back into one. Grounded
-# (contextual-grounding) requests are never chunked -- grounding scores the
-# response holistically against the whole source, so fragmenting it would
-# produce misleading scores.
-###############################################################################
 
 
 def _too_large_validation_httpx_response() -> MagicMock:
@@ -3399,7 +3388,6 @@ async def test_apply_guardrail_chunks_on_too_large_validation_error():
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            # Whole-content call: too large.
             return _too_large_validation_httpx_response()
         if call_count == 2:
             return _passing_bedrock_httpx_response("chunk-1")
@@ -3419,13 +3407,9 @@ async def test_apply_guardrail_chunks_on_too_large_validation_error():
                 request_data={"model": "bedrock-nova-micro"},
             )
 
-    # 1 whole-content attempt + 2 chunk attempts.
     assert call_count == 3
     detail = exc_info.value.detail
     assert exc_info.value.status_code == 400
-    # The merged response must retain the block signal from chunk-2 even
-    # though chunk-1 passed clean -- losing it would silently bypass a
-    # guardrail hit.
     assert "chunk-2" in detail["bedrock_guardrail_response"]
     assert detail["assessments"][0]["matches"][0]["name"] == "chunk-2"
 
@@ -3499,9 +3483,6 @@ async def test_apply_guardrail_recurses_past_first_bisection_into_four_chunks():
     mock_credentials.secret_key = "s"
     mock_credentials.token = None
 
-    # Depth-first recursion order for 4 items bisected down to single items:
-    # whole -> [1,2] -> [1] -> [2] -> [3,4] -> [3] -> [4]. Only single-item
-    # calls (positions 3, 4, 6, 7) fit; every multi-item call is too large.
     responses = [
         _too_large_validation_httpx_response(),  # whole content: [1,2,3,4]
         _too_large_validation_httpx_response(),  # first half: [1,2]
@@ -3528,7 +3509,6 @@ async def test_apply_guardrail_recurses_past_first_bisection_into_four_chunks():
             request_data={"model": "bedrock-nova-micro"},
         )
 
-    # 1 whole-content + 2 first-level halves + 4 second-level quarters = 7.
     assert mock_post.await_count == 7
     assert not responses
     assert result.get("action") == "NONE"
@@ -3576,7 +3556,6 @@ async def test_apply_guardrail_does_not_chunk_when_grounding_present():
                 request_data={"model": "bedrock-nova-micro"},
             )
 
-    # Exactly one call: no bisect-and-retry for a grounded request.
     assert mock_post.await_count == 1
     assert exc_info.value.status_code == 400
 
@@ -3769,8 +3748,6 @@ async def test_apply_guardrail_unrecoverable_failure_still_logs_once_when_client
     exactly one `guardrail_failed_to_respond` entry, not zero."""
     guardrail = _bedrock_guardrail_for_chunk_tests()
 
-    # Single character: `_split_bedrock_content` cannot halve this into two non-empty
-    # pieces, so chunking gives up and the original error propagates.
     messages = [{"role": "user", "content": "x"}]
 
     mock_credentials = MagicMock()
@@ -3824,8 +3801,6 @@ async def test_apply_guardrail_single_item_split_twice_still_yields_one_output_p
     mock_credentials.secret_key = "s"
     mock_credentials.token = None
 
-    # whole item -> [first half] -> [q1] [q2] -> [second half] -> [q3] [q4].
-    # Only the four quarters fit; the whole item and both halves are too large.
     responses = [
         _too_large_validation_httpx_response(),  # whole single item
         _too_large_validation_httpx_response(),  # first half
@@ -3856,8 +3831,6 @@ async def test_apply_guardrail_single_item_split_twice_still_yields_one_output_p
     assert not responses
     assert result.get("action") == "NONE"
     output_texts = [o.get("text") for o in result.get("outputs") or []]
-    # One original content item in, so exactly one output entry out, carrying all
-    # four fragments' text in order.
     assert output_texts == ["q1q2q3q4"]
 
 
@@ -3885,7 +3858,6 @@ async def test_apply_guardrail_chunk_retries_after_throttling_then_succeeds():
         if call_count == 1:
             return _too_large_validation_httpx_response()
         if call_count == 2:
-            # First chunk throttled once, then succeeds on retry.
             return _throttling_httpx_response()
         if call_count == 3:
             return _passing_bedrock_httpx_response("chunk-1")
@@ -4105,9 +4077,6 @@ async def test_apply_guardrail_bin_packs_under_budget_content_with_no_probe_call
     attempt."""
     guardrail = _bedrock_guardrail_for_chunk_tests()
 
-    # Five items, individually tiny, whose combined length exceeds the budget
-    # only when summed -- proves this triggers packing into multiple batches
-    # by SIZE, not by falling back to per-item chunking.
     item_text = "x" * (_BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS // 2)
     messages = [{"role": "user", "content": item_text} for _ in range(3)]
 
@@ -4136,8 +4105,6 @@ async def test_apply_guardrail_bin_packs_under_budget_content_with_no_probe_call
             request_data={"model": "bedrock-nova-micro"},
         )
 
-    # Three items at budget/2 each pack two-per-batch (2 + 1), never a single
-    # oversized call and never a wasted whole-content probe: exactly 2 calls.
     assert call_count == 2
     assert result.get("action") == "NONE"
 
@@ -4202,12 +4169,8 @@ async def test_apply_guardrail_batch_under_budget_still_rejected_falls_back_to_b
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            # First pre-packed batch (items 1+2): accepted immediately.
             return _passing_bedrock_httpx_response("batch-1")
         if call_count == 2:
-            # Second pre-packed batch (item 3 alone): rejected as too large
-            # despite fitting the fixed budget guess -- simulates a lower
-            # real-world per-account cap.
             return _too_large_validation_httpx_response()
         return _passing_bedrock_httpx_response(f"batch-2-bisected-{call_count}")
 
@@ -4224,12 +4187,9 @@ async def test_apply_guardrail_batch_under_budget_still_rejected_falls_back_to_b
             request_data={"model": "bedrock-nova-micro"},
         )
 
-    # batch-1 (1 call, accepted) + batch-2 (1 rejected + 2 bisected halves) = 4.
     assert call_count == 4
     assert result.get("action") == "NONE"
     output_texts = [o.get("text") for o in result.get("outputs") or []]
-    # batch-2's two bisected text fragments came from the same original
-    # content item, so they are merged back into one combined output entry.
     assert output_texts == ["batch-1", "batch-2-bisected-3batch-2-bisected-4"]
 
 
@@ -4240,8 +4200,6 @@ def test_split_bedrock_content_single_item_splits_on_whitespace_not_mid_word():
     denied word/PII pattern straddling a raw character-midpoint cut could be
     truncated on both fragments and scan clean on each, then reassemble into
     the original unmasked text -- a detection bypass."""
-    # 20 'a's + space + 30 'b's: the raw character midpoint (25) falls inside
-    # the run of 'b's, proving the split must move off it to the nearest space.
     text = ("a" * 20) + " " + ("b" * 30)
     raw_midpoint = len(text) // 2
     assert text[raw_midpoint] == "b"
@@ -4254,10 +4212,7 @@ def test_split_bedrock_content_single_item_splits_on_whitespace_not_mid_word():
     first_text = first_half[0]["text"]["text"]
     second_text = second_half[0]["text"]["text"]
 
-    # Lossless: concatenating the two fragments reproduces the original exactly.
     assert first_text + second_text == text
-    # Word-safe: the split lands exactly on the whitespace boundary, not
-    # inside either the "a" or "b" run.
     assert first_text == ("a" * 20) + " "
     assert second_text == "b" * 30
 
@@ -4291,8 +4246,6 @@ def test_bin_pack_bedrock_content_packs_minimal_batches_within_budget():
     for batch in batches:
         combined_len = sum(len(item["text"]["text"]) for item in batch)
         assert combined_len <= 100
-    # 10 items * 30 chars = 300 chars at a 100-char budget packs into 3 batches
-    # of 3 items (90 chars) plus 1 batch of 1 item -- never one batch per item.
     assert len(batches) == 4
 
 
@@ -4367,9 +4320,7 @@ async def test_apply_guardrail_too_large_reported_as_429_bisects_without_burning
             request_data={"model": "bedrock-nova-micro"},
         )
 
-    # One rejected whole-content call, then exactly one call per bisected half.
     assert call_count == 3
-    # No backoff sleep: a size error must not be treated as a transient throttle.
     mock_sleep.assert_not_awaited()
     assert result.get("action") == "NONE"
     output_texts = [o.get("text") for o in result.get("outputs") or []]

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -4325,3 +4325,54 @@ async def test_apply_guardrail_too_large_reported_as_429_bisects_without_burning
     assert result.get("action") == "NONE"
     output_texts = [o.get("text") for o in result.get("outputs") or []]
     assert output_texts == ["half-2", "half-3"]
+
+
+def test_chunk_budget_defaults_to_apply_guardrail_per_second_quota():
+    """The default budget must track ApplyGuardrail's default quota of 25 text units
+    (about 1,000 characters each) per second. Packing to that size and posting
+    sequentially is what stops chunking from trading a size error for a throttle, so
+    this default is a deliberate match to AWS behaviour rather than an arbitrary
+    number."""
+    assert _BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS == 25_000
+    assert BedrockGuardrail(guardrailIdentifier="g", guardrailVersion="DRAFT").chunk_budget_chars == 25_000
+
+
+@pytest.mark.asyncio
+async def test_configured_chunk_budget_changes_how_content_is_packed():
+    """An account with raised quotas can set a larger `chunk_budget_chars` and have it
+    actually drive packing, spending fewer ApplyGuardrail calls for the same content
+    instead of being pinned to the conservative default.
+
+    Four 20,000-character messages are 80,000 characters total. At the 25,000 default
+    only one message fits per batch, so it takes four calls; at 100,000 all four fit
+    in a single batch, so it takes one."""
+    messages = [{"role": "user", "content": "x" * 20_000} for _ in range(4)]
+
+    mock_credentials = MagicMock()
+    mock_credentials.access_key = "k"
+    mock_credentials.secret_key = "s"
+    mock_credentials.token = None
+
+    async def _calls_made_with_budget(budget: int) -> int:
+        guardrail = BedrockGuardrail(
+            guardrail_name="test-bedrock-guard",
+            guardrailIdentifier="test-guardrail",
+            guardrailVersion="DRAFT",
+            disable_exception_on_block=False,
+            chunk_budget_chars=budget,
+        )
+        with (
+            patch.object(guardrail.async_handler, "post", new_callable=AsyncMock) as mock_post,
+            patch.object(guardrail, "_load_credentials", return_value=(mock_credentials, "us-east-1")),
+            patch.object(guardrail, "_prepare_request", return_value=MagicMock()),
+        ):
+            mock_post.side_effect = lambda *_a, **_k: _passing_bedrock_httpx_response("ok")
+            await guardrail.make_bedrock_api_request(
+                source="INPUT",
+                messages=messages,
+                request_data={"model": "bedrock-nova-micro"},
+            )
+            return mock_post.await_count
+
+    assert await _calls_made_with_budget(_BEDROCK_APPLY_GUARDRAIL_CHUNK_BUDGET_CHARS) == 4
+    assert await _calls_made_with_budget(100_000) == 1

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23304,7 +23304,7 @@ export interface components {
              * @description Default role assigned to new users created
              * @default internal_user_viewer
              */
-            user_role: ("proxy_admin" | "proxy_admin_viewer" | "internal_user" | "internal_user_viewer") | null;
+            user_role: ("internal_user" | "internal_user_viewer" | "proxy_admin" | "proxy_admin_viewer") | null;
         };
         /**
          * DefaultTeamSSOParams
@@ -25835,7 +25835,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: string | number | null;
+            stream_timeout?: number | string | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */
@@ -33671,7 +33671,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: string | number | null;
+            stream_timeout?: number | string | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23304,7 +23304,7 @@ export interface components {
              * @description Default role assigned to new users created
              * @default internal_user_viewer
              */
-            user_role: ("internal_user" | "internal_user_viewer" | "proxy_admin" | "proxy_admin_viewer") | null;
+            user_role: ("proxy_admin" | "proxy_admin_viewer" | "internal_user" | "internal_user_viewer") | null;
         };
         /**
          * DefaultTeamSSOParams
@@ -25835,7 +25835,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */
@@ -33671,7 +33671,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py` sent all guardrail content to AWS's `ApplyGuardrail` API in a single call. When a request's content exceeds AWS's per-request "maximum input size in text units" quota, AWS rejects the call and LiteLLM passed that status straight to the client, so a large but otherwise legitimate request went unscanned and failed outright. The cap is region/tier/policy-dependent, so it cannot be reliably predicted from config; it can only be reacted to

This PR follows the approach AWS documents in [Use the ApplyGuardrail API with long-context inputs and streaming outputs in Amazon Bedrock](https://aws.amazon.com/blogs/machine-learning/use-the-applyguardrail-api-with-long-context-inputs-and-streaming-outputs-in-amazon-bedrock/), and adds a fallback on top of it. Content is first bin-packed, in order, into batches that each stay under a character budget, and each batch is posted sequentially. That is AWS's guidance directly: the API "has a default limit of 25 text units (approximately 25,000 characters) per second" and "if the input exceeds this limit, it needs to be chunked and processed sequentially to avoid throttling". The budget therefore defaults to 25,000 characters, so chunking respects that throughput quota instead of trading a size error for a throttle. That figure is the documented default and the current floor for less-provisioned regions; us-east-1 is considerably higher today, so `chunk_budget_chars` is configurable and accounts with raised quotas can spend fewer calls by setting it up. That is the fast path: the common case costs one AWS round trip per batch instead of a wasted whole-payload probe followed by repeated halving on every oversized request. The fixed budget is a starting guess, not a correctness dependency; any batch AWS still rejects as too large falls back to reactive bisection for that batch only, splitting it in half and retrying each half, recursing until every piece fits or the original error is propagated. Batches AWS already accepted are never re-sent. Chunks go sequentially rather than in parallel, since chunking does not reduce total text units and AWS also enforces a per-second throughput quota, so firing them concurrently would just trade one error for a throttle. Content using contextual grounding (`grounding_source`/`query`/`guard_content` qualifiers) is excluded from chunking entirely, since grounding must be scored holistically. The per-batch responses are merged back into one `BedrockGuardrailResponse` (action, assessments, outputs, usage) so masking, blocking, and telemetry behave as a single call would have

When a single oversized content item's own text must be split, the cut lands on the whitespace character nearest the midpoint rather than a raw character index, so no fragment ends or begins mid-word. The cut is lossless and overlap-free: concatenating the fragments in order reproduces the original text exactly, so merging needs no reconciliation step

**Known, accepted limitation**: whitespace splitting only prevents *accidentally* severing a single token (one denied word, one PII pattern) across a chunk boundary. It cannot, without an overlap window, stop a multi-word denied phrase deliberately positioned to straddle that boundary; each fragment can scan clean on its own and still reassemble into the flagged phrase. AWS names the same gap in the post linked above, advising only that "the chunking strategy should take into account the context split" because "a critical piece of text could span two (or more) chunks if not carefully divided", without offering a resolution. Overlap-and-reconcile was evaluated and rejected: AWS's masking output carries no documented length-preservation guarantee, so reconciling an overlap region against masked text is not sound in general, and the adversarial case survives any fixed-size overlap window anyway. This is a conscious, security-relevant tradeoff reviewers should weigh, not an oversight

### Live verification against a real Bedrock guardrail

Verified end to end against a real AWS Bedrock guardrail with an active content-filter policy, on a live proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --use_v2_migration_resolver`). Guardrail identifier and account are redacted below; the payload is 3,272,715 characters, which AWS bills as 3273 text units against a 1000-unit cap

The underlying provider limit, straight from AWS, with one unchunked call:

```
$ aws bedrock-runtime apply-guardrail --guardrail-identifier <REDACTED> \
    --guardrail-version DRAFT --source INPUT \
    --content file:///tmp/aws_content.json --region us-east-1

aws: [ERROR]: An error occurred (ThrottlingException) when calling the ApplyGuardrail
operation (reached max retries: 2): Input text size (3273 text units) exceeds the
maximum allowed (1000 text units) for the content filter policy (Classic tier).
```

Before, at the PR's base commit `5d4c4d0fce`, the proxy forwarded that failure to the caller:

```
$ curl -s -o /tmp/before_resp.json -w "HTTP %{http_code}  in %{time_total}s\n" \
    -X POST http://localhost:4000/guardrails/apply_guardrail \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d @/tmp/proof_big.json
HTTP 429  in 0.766666s

$ cat /tmp/before_resp.json
{"error":{"message":"Input text size (3273 text units) exceeds the maximum allowed
(1000 text units) for the content filter policy (Classic tier).","type":
"internal_server_error","param":"None","code":"429"}}
```

After, at commit `10c7493494`, the identical request succeeds and the content is fully scanned:

```
$ curl -s -o /tmp/proof_resp3.json -w "HTTP %{http_code}  in %{time_total}s\n" \
    -X POST http://localhost:4000/guardrails/apply_guardrail \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d @/tmp/proof_big.json
HTTP 200  in 6.003341s
```

The recursion is visible in the proxy log at the default log level, splitting 3273 units down to four sub-1000-unit chunks:

```
$ grep "ApplyGuardrail rejected" litellm.log
Bedrock Guardrail: ApplyGuardrail rejected 1 content item(s) as too large; splitting into 1 + 1 and retrying each
Bedrock Guardrail: ApplyGuardrail rejected 1 content item(s) as too large; splitting into 1 + 1 and retrying each
Bedrock Guardrail: ApplyGuardrail rejected 1 content item(s) as too large; splitting into 1 + 1 and retrying each
```

And the round trip is lossless, which matters because masking reconstruction downstream is positional-index based:

```
$ python3 -c "
import json
resp = json.load(open('/tmp/proof_resp3.json'))['response_text']
orig = json.load(open('/tmp/proof_big.json'))['text']
print('response chars:', len(resp), '| original chars:', len(orig))
print('lossless round-trip:', resp == orig)
"
response chars: 3272715 | original chars: 3272715
lossless round-trip: True
```

This live run is also what surfaced the throttle-classification bug listed under "Addressed from review" below; it is not reproducible against mocks, because it depends on which exception AWS actually chooses for an oversized request

The run above was captured at `10c7493494`; the two later review fixes (fragment grouping and duplicate telemetry) landed after it and are covered by unit tests rather than this run. Demonstrating the masked write-back end to end would need a guardrail configured with a PII masking policy, which the detect-only guardrail used here does not have, so that path is asserted in tests instead

Also verified:
- `ruff check` / `ruff format --check` clean on the changed production file
- `basedpyright`, the ruff-strict budget gate, and the type-discipline budget gate introduce zero new violations relative to this PR's base
- No shared or global mutable state is introduced, so behavior is identical across single-pod and multi-pod proxy deployments
- The proxy runs one asyncio event loop per worker process with no blocking lock in the guardrail call path, so a sequential chunk-and-backoff loop for one oversized request yields the loop on every `await` and does not block other concurrent requests in that worker. The bin-packing fast path minimizes the cost that is actually shared across concurrent requests, which is AWS round-trip count against the shared guardrail connection pool rather than wall-clock time held by any one request
- No interaction with LiteLLM's response cache layer, so behavior is unaffected by cache on/off

Addressed from review:
- A single oversized content item (one very long message) previously could not be chunked at all, since bisecting by list length only works when there is more than one item; it now falls back to bisecting that item's own text at the nearest whitespace boundary, tagging the two halves so the merge step recombines them into the one item they came from
- Pure reactive bisection paid an `O(log n)` round-trip cost against AWS on every oversized request indefinitely, since it always started from the whole remaining payload. Content is now bin-packed into fixed-budget batches up front as a fast path, falling back to bisection only for a batch AWS still rejects
- (Veria AI, High) A single content item's text was split at a raw character midpoint, so a denied word, regex, or PII match whose characters straddled that midpoint could be truncated on both fragments, scan clean on each, and reassemble into the original unmasked text on merge, a detection bypass. The split now lands on the nearest whitespace boundary, closing the bypass for any single-token match; the residual multi-word-phrase gap is the documented, AWS-acknowledged limitation described above
- A too-large call recovered via chunking, or one that failed unrecoverably partway through, previously still logged a stray `guardrail_failed_to_respond` telemetry entry from the initial oversized attempt in addition to the real outcome; logging is now consolidated to exactly one entry per logical guardrail request
- Merging chunk outputs previously dropped positional information: an all-clear chunk contributed no output entries at all, which shifted every later chunk's masked text onto the wrong original message once flattened. Every content item, masked or not, now always contributes exactly one output entry, preserving alignment with the original message list
- Found during the live run above: AWS reports an oversized request as a `ThrottlingException` (429), not only as the documented `ValidationException` (400). Because the backoff retry keyed off status 429 alone, every oversized chunk burned its full retry budget, each attempt a billed AWS call preceded by a sleep, before bisection got a chance, at every level of the recursion. A size error is not transient, so it now short-circuits straight to bisection. The too-large check was always message-based rather than status-based, so recovery did work; it was just paying for retries that could never succeed
- (Greptile, P1) Fragment grouping assumed one split content item always yields exactly two adjacent fragments. True for one bisection level, false for two: an item split twice yields four, which were regrouped in fixed pairs into two output entries for one message. Because masking walks the merged outputs by a running index across the original, unchunked message list, that message was written back truncated to its first half and every later message shifted. Fragments now carry the size of the group they belong to, so any number collapse back into exactly one entry
- (Veria AI, Low) Chunking introduces outbound call amplification, since an oversized request previously made one call and failed fast. The budget default is now 25,000 characters rather than an arbitrary 20,000, which is the value that keeps sequential chunks inside ApplyGuardrail's default per-second quota; `max_request_size_mb` remains the right lever for bounding total request size, since it rejects before any guardrail work and covers every size-driven cost rather than this one path
- (Greptile, P1) Telemetry was double-counted on every non-200. `AsyncHTTPHandler.post` calls `raise_for_status()`, so each rejection reaches the transport helper's error path, which logged `guardrail_failed_to_respond` before re-raising as an `HTTPException` that the consolidating caller logged again; a request recovered by chunking reported one failure per rejected attempt plus a success. The ApplyGuardrail path now opts out of that per-attempt logging since it owns consolidated per-request logging, while the connection-level branch still logs because nothing else records it
- Both of the above were invisible to the existing tests, whose mocks return a non-200 response object while the real client raises. Added a helper that raises a genuine `httpx.HTTPStatusError` so these paths are exercised the way production hits them, and a case asserting an unrecoverable failure still logs exactly once rather than zero times

## Type

🐛 Bug Fix
✅ Test

## Changes

- Added `_bin_pack_bedrock_content` to `BedrockGuardrail`, packing content items in order into batches within a character budget as the fast path ahead of reactive chunking
- Added a `chunk_budget_chars` guardrail setting, defaulting to 25,000 to match ApplyGuardrail's default 25-text-unit-per-second quota, so the default behaviour matches AWS for everyone and accounts with raised quotas can tune it up
- Added `_apply_guardrail_content_with_chunking`, recursively bisecting and retrying one batch only when AWS's response indicates that batch was too large
- Added `_nearest_whitespace_split_index` so a single oversized content item's text splits at the whitespace boundary nearest the midpoint instead of a raw character index, never severing a word
- Added `_is_input_too_large_error` (message-based, since AWS raises both `ThrottlingException` and `ValidationException` for this) to distinguish a too-large rejection from a real content block or other failure
- Excluded a too-large rejection from the throttle backoff retry, so it bisects immediately instead of spending billed retries re-posting content that can never fit
- Added `_content_uses_contextual_grounding` to opt content with grounding qualifiers out of chunking
- Added `_post_apply_guardrail_content_with_retry` for exponential backoff retry on genuine AWS throttling, applied per chunk
- Added `_merge_bedrock_guardrail_responses` (plus `_group_fragment_pairs`, `_merge_logical_unit_outputs`, `_sum_bedrock_guardrail_usage` helpers) to combine per-chunk responses into one, preserving output position and only including `action`/`usage` when a raw chunk response actually provided them
- Consolidated telemetry logging so a chunked request logs exactly one success/failure entry regardless of how many HTTP chunk attempts it took
- Added a warning-level log when a split happens, so chunking recovery is visible without `--detailed_debug`
- Replaced the fragment boolean with a fragment group size so all fragments of one content item regroup into one output entry regardless of how many times it was bisected
- Added a `log_transport_failure` switch on the shared transport helper so the ApplyGuardrail path can suppress per-attempt failure logging it consolidates itself
- Extended `tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py` with bin-packing, whitespace-boundary splitting, per-batch bisection fallback, too-large-reported-as-429, twice-split single item, raise-for-status telemetry, chunking, grounding-exclusion, retry, telemetry-consolidation, masking-position, and multi-level (4-chunk) recursion regression cases

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
