### PR TITLE
fix(aiohttp): keep keep-alive connector config when a session is rebuilt

### DIFF
--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -143,13 +143,26 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
         client: Union[ClientSession, Callable[[], ClientSession]],
         ssl_verify: Optional[Union[bool, ssl.SSLContext]] = None,
         owns_session: bool = True,
+        session_factory: Callable[[], ClientSession] | None = None,
     ):
         self.client = client
         self._ssl_verify = ssl_verify  # Store for per-request SSL override
         super().__init__(client=client, owns_session=owns_session)
         # Store the client factory for recreating sessions when needed
-        if callable(client):
-            self._client_factory = client
+        default_factory: Callable[[], ClientSession] = client if callable(client) else ClientSession
+        self._client_factory: Callable[[], ClientSession] = session_factory or default_factory
+
+    def _rebuild_session(self) -> ClientSession:
+        """
+        Build a replacement session from the configured factory.
+
+        The replacement is reachable only from this transport, so the transport
+        owns it from here on even when it was originally handed a session it did
+        not own (the proxy's shared session).
+        """
+        session = self._client_factory()
+        self._owns_session = True
+        return session
 
     def _get_valid_client_session(self) -> ClientSession:
         """
@@ -158,24 +171,16 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
         This handles the case where the session was created in a different
         event loop that may have been closed (common in CI/CD environments).
         """
-        from aiohttp.client import ClientSession
-
         # If we don't have a client or it's not a ClientSession, create one
         if not isinstance(self.client, ClientSession):
-            if hasattr(self, "_client_factory") and callable(self._client_factory):
-                self.client = self._client_factory()
-            else:
-                self.client = ClientSession()
+            self.client = self._rebuild_session()
             # Don't return yet - check if the newly created session is valid
 
         # Check if the session itself is closed
         if self.client.closed:
             verbose_logger.debug("Session is closed, creating new session")
             # Create a new session
-            if hasattr(self, "_client_factory") and callable(self._client_factory):
-                self.client = self._client_factory()
-            else:
-                self.client = ClientSession()
+            self.client = self._rebuild_session()
             return self.client
 
         # Check if the existing session is still valid for the current event loop
@@ -188,7 +193,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
                 # Close old session to prevent leaks
                 old_session = self.client
                 try:
-                    if not old_session.closed:
+                    if self._owns_session and not old_session.closed:
                         try:
                             asyncio.create_task(old_session.close())
                         except RuntimeError:
@@ -198,17 +203,11 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
                     verbose_logger.debug(f"Error closing old session: {e}")
 
                 # Create a new session in the current event loop
-                if hasattr(self, "_client_factory") and callable(self._client_factory):
-                    self.client = self._client_factory()
-                else:
-                    self.client = ClientSession()
+                self.client = self._rebuild_session()
 
         except (RuntimeError, AttributeError):
             # If we can't check the loop or session is invalid, recreate it
-            if hasattr(self, "_client_factory") and callable(self._client_factory):
-                self.client = self._client_factory()
-            else:
-                self.client = ClientSession()
+            self.client = self._rebuild_session()
 
         return self.client
 
@@ -303,10 +302,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
             if "Session is closed" in str(e):
                 verbose_logger.debug(f"Session closed during request, retrying with new session: {e}")
                 # Force creation of a new session
-                if hasattr(self, "_client_factory") and callable(self._client_factory):
-                    self.client = self._client_factory()
-                else:
-                    self.client = ClientSession()
+                self.client = self._rebuild_session()
                 client_session = self.client
 
                 # Retry the request with the new session

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -1013,17 +1013,6 @@ class AsyncHTTPHandler:
 
         verbose_logger.debug("Creating AiohttpTransport...")
 
-        # Use shared session if provided and valid
-        if shared_session is not None and not shared_session.closed:
-            verbose_logger.debug(f"SHARED SESSION: Reusing existing ClientSession (ID: {id(shared_session)})")
-            return LiteLLMAiohttpTransport(
-                client=shared_session,
-                ssl_verify=ssl_for_transport,
-                owns_session=False,
-            )
-
-        # Create new session only if none provided or existing one is invalid
-        verbose_logger.debug("NEW SESSION: Creating new ClientSession (no shared session provided)")
         transport_connector_kwargs = {
             "keepalive_timeout": AIOHTTP_KEEPALIVE_TIMEOUT,
             "ttl_dns_cache": AIOHTTP_TTL_DNS_CACHE,
@@ -1041,11 +1030,26 @@ class AsyncHTTPHandler:
         if socket_factory is not None:
             transport_connector_kwargs["socket_factory"] = socket_factory
 
-        return LiteLLMAiohttpTransport(
-            client=lambda: ClientSession(
+        def session_factory() -> ClientSession:
+            return ClientSession(
                 connector=TCPConnector(**transport_connector_kwargs),
                 trust_env=trust_env,
-            ),
+            )
+
+        # Use shared session if provided and valid
+        if shared_session is not None and not shared_session.closed:
+            verbose_logger.debug(f"SHARED SESSION: Reusing existing ClientSession (ID: {id(shared_session)})")
+            return LiteLLMAiohttpTransport(
+                client=shared_session,
+                ssl_verify=ssl_for_transport,
+                owns_session=False,
+                session_factory=session_factory,
+            )
+
+        # Create new session only if none provided or existing one is invalid
+        verbose_logger.debug("NEW SESSION: Creating new ClientSession (no shared session provided)")
+        return LiteLLMAiohttpTransport(
+            client=session_factory,
             ssl_verify=ssl_for_transport,
         )
 

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_so_keepalive.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_so_keepalive.py
@@ -1,6 +1,9 @@
 import socket
 from unittest.mock import MagicMock, patch
 
+import aiohttp
+import pytest
+
 
 def _invoke_connector_factory(http_handler_module):
     """
@@ -159,3 +162,32 @@ def test_socket_factory_uses_tcp_keepalive_when_keepidle_unavailable(monkeypatch
         setsockopt_calls[(socket.IPPROTO_TCP, fake_socket_module.TCP_KEEPALIVE)] == 60
     )
     assert (socket.IPPROTO_TCP, getattr(socket, "TCP_KEEPIDLE", -1)) not in setsockopt_calls
+
+
+@pytest.mark.asyncio
+async def test_shared_session_transport_rebuilds_with_socket_factory(monkeypatch):
+    """
+    The proxy hands _create_aiohttp_transport an already-built shared session.
+    When that session is rebuilt (closed session, or a session from another
+    event loop) the replacement must still carry the keep-alive socket factory
+    and the configured keepalive timeout, otherwise AIOHTTP_SO_KEEPALIVE stops
+    protecting every later request served by that transport.
+    """
+    from litellm.llms.custom_httpx import http_handler as http_handler_module
+
+    monkeypatch.setattr(http_handler_module, "AIOHTTP_SO_KEEPALIVE", True)
+    monkeypatch.setattr(http_handler_module, "_AIOHTTP_SUPPORTS_SOCKET_FACTORY", True)
+
+    shared_session = aiohttp.ClientSession()
+    transport = http_handler_module.AsyncHTTPHandler._create_aiohttp_transport(shared_session=shared_session)
+    await shared_session.close()
+
+    rebuilt_session = MagicMock(name="rebuilt_session")
+
+    with patch.object(http_handler_module, "TCPConnector", return_value=MagicMock(name="connector")) as mock_tcp_connector:
+        with patch.object(http_handler_module, "ClientSession", return_value=rebuilt_session):
+            assert transport._get_valid_client_session() is rebuilt_session
+
+    assert mock_tcp_connector.call_count == 1
+    assert callable(mock_tcp_connector.call_args.kwargs.get("socket_factory"))
+    assert mock_tcp_connector.call_args.kwargs["keepalive_timeout"] == http_handler_module.AIOHTTP_KEEPALIVE_TIMEOUT

--- a/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
+++ b/tests/test_litellm/llms/custom_httpx/test_aiohttp_transport.py
@@ -727,3 +727,103 @@ async def test_response_stream_closes_response_on_generator_exit():
     await iterator.aclose()
 
     assert mock_response.closed is True
+
+
+@pytest.mark.asyncio
+async def test_closed_shared_session_rebuild_uses_injected_session_factory():
+    """
+    A transport handed an already-built session (the proxy's shared session)
+    must rebuild through the injected factory. Rebuilding with a bare
+    ClientSession drops the connector's keep-alive socket options, pool limits
+    and DNS cache for every later request on that transport.
+    """
+    shared_session = aiohttp.ClientSession()
+    await shared_session.close()
+
+    rebuilt = []
+
+    def session_factory():
+        session = _make_mock_session()
+        rebuilt.append(session)
+        return session
+
+    transport = LiteLLMAiohttpTransport(
+        client=shared_session,
+        owns_session=False,
+        session_factory=session_factory,  # type: ignore
+    )
+
+    assert transport._get_valid_client_session() in rebuilt
+
+
+def test_rebuild_without_running_loop_uses_injected_session_factory():
+    """
+    The loop-validity fallback must also go through the injected factory, so a
+    transport recovering outside a running event loop does not silently swap in
+    an unconfigured session.
+    """
+    rebuilt = []
+
+    def session_factory():
+        session = _make_mock_session()
+        rebuilt.append(session)
+        return session
+
+    transport = LiteLLMAiohttpTransport(
+        client=object(),  # type: ignore
+        session_factory=session_factory,  # type: ignore
+    )
+
+    assert transport._get_valid_client_session() in rebuilt
+
+
+@pytest.mark.asyncio
+async def test_rebuilt_session_becomes_transport_owned():
+    """
+    A rebuilt session is reachable only from the transport, so aclose() must
+    close it even when the transport was handed a session it did not own.
+    """
+    shared_session = aiohttp.ClientSession()
+    await shared_session.close()
+
+    replacement = aiohttp.ClientSession()
+    transport = LiteLLMAiohttpTransport(
+        client=shared_session,
+        owns_session=False,
+        session_factory=lambda: replacement,
+    )
+
+    assert transport._get_valid_client_session() is replacement
+
+    await transport.aclose()
+
+    assert replacement.closed
+
+
+@pytest.mark.asyncio
+async def test_stale_loop_rebuild_does_not_close_unowned_session():
+    """
+    A session the transport does not own (the proxy's shared session) is used by
+    other transports too, so a rebuild must leave it open for them.
+    """
+    shared_session = aiohttp.ClientSession()
+    running_loop = asyncio.get_running_loop()
+    other_loop = asyncio.new_event_loop()
+
+    replacement = _make_mock_session()
+    transport = LiteLLMAiohttpTransport(
+        client=shared_session,
+        owns_session=False,
+        session_factory=lambda: replacement,  # type: ignore
+    )
+
+    try:
+        shared_session._loop = other_loop
+        assert transport._get_valid_client_session() is replacement
+        shared_session._loop = running_loop
+        await asyncio.sleep(0.05)
+        assert not shared_session.closed
+    finally:
+        shared_session._loop = running_loop
+        other_loop.close()
+        await shared_session.close()


### PR DESCRIPTION
## TLDR

Problem this solves:

- `AIOHTTP_SO_KEEPALIVE` stopped applying after an aiohttp session rebuild
- Rebuilt sessions used aiohttp defaults, not the configured connector
- Keepalive timeout silently dropped from 120s to 15s

How it solves it:

- Build the configured session factory once and inject it into the transport
- Every session rebuild goes through that factory

## Relevant issues

Fixes #33567

## Linear ticket

Resolves LIT-4674

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The observable is a kernel socket option on the connection litellm actually holds open to the provider, so the proof reads it off the pooled socket after a real, paid OpenAI call rather than off a mock. The script drives the production functions directly (`_initialize_shared_aiohttp_session` -> `_create_aiohttp_transport` -> `httpx.AsyncClient`), because a session rebuild has no HTTP surface a curl could show

```python
# socket_proof.py
import asyncio, os, socket
os.environ["AIOHTTP_SO_KEEPALIVE"] = "true"
os.environ["AIOHTTP_TCP_KEEPIDLE"] = "45"

import httpx, litellm
from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
from litellm.proxy.proxy_server import _initialize_shared_aiohttp_session

print("litellm loaded from:", os.path.dirname(litellm.__file__))
KEEPIDLE_OPT = getattr(socket, "TCP_KEEPIDLE", None) or getattr(socket, "TCP_KEEPALIVE", None)

async def main():
    shared = await _initialize_shared_aiohttp_session()
    transport = AsyncHTTPHandler._create_aiohttp_transport(shared_session=shared)
    await shared.close()   # force the rebuild path

    client = httpx.AsyncClient(transport=transport)
    r = await client.post(
        "https://api.openai.com/v1/chat/completions",
        headers={"Authorization": "Bearer " + os.environ["OPENAI_API_KEY"]},
        json={"model": "gpt-5.1", "messages": [{"role": "user", "content": "say ok"}]},
        timeout=60,
    )
    print("HTTP", r.status_code, (await r.aread())[:60].decode())

    for key, deq in transport.client.connector._conns.items():
        for proto, _ in deq:
            sock = proto.transport.get_extra_info("socket")
            print("pooled socket ->", key.host)
            print("  SO_KEEPALIVE  =", sock.getsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE))
            print("  TCP keepidle  =", sock.getsockopt(socket.IPPROTO_TCP, KEEPIDLE_OPT))
    await client.aclose()

asyncio.run(main())
```

Before, at `d91fd084f7` (current `litellm_internal_staging`), with `AIOHTTP_SO_KEEPALIVE=true` and `AIOHTTP_TCP_KEEPIDLE=45` exported:

```
$ PYTHONPATH="$PWD" python socket_proof.py
litellm loaded from: /Users/.../litellm
HTTP 200 {
  "id": "chatcmpl-E6fmRIC2vcERnXFE17I578zib4vb8",
pooled socket -> api.openai.com
  SO_KEEPALIVE  = 0
  TCP keepidle  = 7200
```

The socket carrying real traffic has keepalive off and the kernel's 2-hour idle default, so the env var bought nothing

After, at `d2b7341137` (this PR), same command and same env:

```
$ PYTHONPATH="$PWD" python socket_proof.py
litellm loaded from: /Users/.../litellm
HTTP 200 {
  "id": "chatcmpl-E6g0ooaKvmifaeqVKxkrR7TPKiMeH",
pooled socket -> api.openai.com
  SO_KEEPALIVE  = 8
  TCP keepidle  = 45
```

Keepalive is on and the idle-before-first-probe is the configured 45s, which is what makes the kernel reset a middlebox idle timer before the flow is reaped

The same build serving normal traffic end to end, live proxy at `d2b7341137` on port 4674 with `AIOHTTP_SO_KEEPALIVE=true`:

```
$ curl -s http://127.0.0.1:4674/v1/chat/completions \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model":"gpt-5.1","messages":[{"role":"user","content":"reply with the single word: keepalive"}]}'
{
  "id": "chatcmpl-E6g1I2b9Y7nSFDYVIupu54nTgdSaB",
  "model": "gpt-5.1",
  "content": "keepalive",
  "usage": {"completion_tokens": 11, "prompt_tokens": 14, "total_tokens": 25}
}
```

## Type

🐛 Bug Fix

## Changes

`LiteLLMAiohttpTransport` only remembered a session factory when it was constructed with a callable. `_create_aiohttp_transport` passes a concrete `ClientSession` on the shared-session path, so that transport had no factory, and each of the five session-rebuild sites in `aiohttp_transport.py` fell back to a bare `aiohttp.ClientSession()` carrying aiohttp's default connector. That dropped the keepalive socket factory behind `AIOHTTP_SO_KEEPALIVE`/`AIOHTTP_TCP_KEEPIDLE`, along with `keepalive_timeout` (120s -> aiohttp's 15s), `ttl_dns_cache`, `limit`/`limit_per_host`, `enable_cleanup_closed` and `trust_env`. A rebuild fires whenever the session is closed or belongs to a different or closed event loop, and the replacement is cached on the transport, so a single rebuild disabled stale-socket protection for every later request that transport served

The fix builds the session factory once in `_create_aiohttp_transport` and injects it into both the shared-session and new-session transports through a new `session_factory` argument, then routes every rebuild through `self._client_factory`. The factory now always exists, which also removes the repeated `hasattr(self, "_client_factory") and callable(...)` branching and a redundant in-function `ClientSession` import. Behavior is unchanged for a transport built with no factory at all: it still falls back to `ClientSession`

The rebuild also fixes an ownership hole that Greptile caught. A replacement session is reachable only from the transport, yet `owns_session` stayed `False` on the shared-session path, so `aclose()` left the replacement and its connector open. Rebuilding now transfers ownership to the transport, and the reverse case is handled too: a rebuild no longer closes a session the transport does not own, so one transport hitting a stale event loop cannot close the proxy-wide shared session out from under every other transport holding it

Worth noting for the linked issue: the reporter's reading that the factory is never wired into the Azure/OpenAI path is not quite right, the first session on every path does get it (`http_handler.py`); what was broken is that every rebuild threw it away. The reporter's second ask, an env-tunable keepalive timeout, already exists as `AIOHTTP_KEEPALIVE_TIMEOUT` and is left at its 120s default here since lowering it changes pooling for everyone

`litellm/proxy/proxy_server.py::_initialize_shared_aiohttp_session` still rebuilds the same connector kwargs independently, and it has already drifted: it never passes `trust_env`, so the proxy's shared session ignores `litellm.aiohttp_trust_env` / `AIOHTTP_TRUST_ENV`, and it never calls `_get_ssl_connector_kwargs`, so `litellm.force_ipv4`'s `local_addr` never reaches that connector either. Both are silent. Collapsing the two builders into one helper is the right fix for that, but it is a separate change and is not needed here, since the transport now rebuilds from its own configured factory

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
