### PR TITLE
fix(helm): pin bundled postgres and redis to the bitnamilegacy images

### DIFF
--- a/helm/litellm-helm/Chart.lock
+++ b/helm/litellm-helm/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: redis
   repository: oci://registry-1.docker.io/bitnamicharts
   version: 18.19.1
-digest: sha256:8660fe6287f9941d08c0902f3f13731079b8cecd2a5da2fbc54e5b7aae4a6f62
-generated: "2024-03-10T02:28:52.275022+05:30"
+digest: sha256:38962e231f6596b93f82a8412bbe4cf5de696caecf5775dfbbd163383eb1c009
+generated: "2026-07-28T10:21:22.511401-07:00"

--- a/helm/litellm-helm/Chart.yaml
+++ b/helm/litellm-helm/Chart.yaml
@@ -18,7 +18,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -32,10 +32,10 @@ annotations:
 
 dependencies:
   - name: "postgresql"
-    version: ">=13.3.0"
+    version: "14.3.1"
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: db.deployStandalone
   - name: redis
-    version: ">=18.0.0"
+    version: "18.19.1"
     repository: oci://registry-1.docker.io/bitnamicharts
     condition: redis.enabled

--- a/helm/litellm-helm/README.md
+++ b/helm/litellm-helm/README.md
@@ -130,6 +130,16 @@ Set `billingMetrics.caSecretName` only when the collector is a private or test o
 | `db.deployStandalone`     | Deploy a standalone, single instance deployment of Postgres, using the Bitnami postgresql chart. This is useful for getting started but doesn't provide HA or (by default) data backups.                                                                                                  | `true`                                                                                     |
 | `postgresql.*`            | If `db.deployStandalone` is `true`, configuration passed to the Bitnami postgresql chart. See the [Bitnami Documentation](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) for full configuration details. See [values.yaml](./values.yaml) for the default configuration. | See [values.yaml](./values.yaml)                                                           |
 | `postgresql.auth.*`       | If `db.deployStandalone` is `true`, care should be taken to ensure the default `password` and `postgres-password` values are **NOT** used.                                                                                                                                                | `NoTaGrEaTpAsSwOrD`                                                                        |
+| `postgresql.image.*`      | If `db.deployStandalone` is `true`, the image for the bundled Postgres. Pinned to a `docker.io/bitnamilegacy` build because Bitnami retired the versioned tags under `docker.io/bitnami`.                                                                                                 | `bitnamilegacy/postgresql:16.2.0-debian-12-r6`                                             |
+| `redis.image.*`           | If `redis.enabled` is `true`, the image for the bundled Redis. Pinned to a `docker.io/bitnamilegacy` build for the same reason.                                                                                                                                                            | `bitnamilegacy/redis:7.2.4-debian-12-r9`                                                   |
+
+#### Bundled Postgres image
+
+Bitnami removed the versioned tags from `docker.io/bitnami` and republished the archived builds under `docker.io/bitnamilegacy`, so the image defaults that ship inside the `postgresql` and `redis` subcharts no longer pull. The chart pins both to the `bitnamilegacy` copies of the exact builds those subchart versions were released with, which keeps the on-disk data directory layout unchanged for existing installs.
+
+Keep `postgresql.image.tag` pinned. `docker.io/bitnami/postgresql` still publishes a floating `latest`, and pointing the bundled Postgres at a different major version starts the server against a data directory it cannot read (`database files are incompatible with server`). There is no in-place way back, so crossing a major version means dumping the database with the old image and restoring it into the new one. The chart refuses to render when the tag is empty or `latest`.
+
+Those images no longer receive updates. For anything beyond getting started, run Postgres outside the chart and point at it with `db.useExisting`.
 
 #### Example Postgres `db.useExisting` Secret
 

--- a/helm/litellm-helm/templates/_helpers.tpl
+++ b/helm/litellm-helm/templates/_helpers.tpl
@@ -146,3 +146,18 @@ Get redis service port
 {{ .Values.redis.master.service.ports.redis }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Reject an unpinned image tag for the bundled PostgreSQL.
+A floating tag lets a chart upgrade start a newer PostgreSQL major against the
+existing PersistentVolumeClaim. The server then refuses to start on a data
+directory written by another major version, and the only way back is a dump
+taken before the change, which by that point no longer exists.
+*/}}
+{{- define "litellm.validateBundledPostgresImageTag" -}}
+{{- $tag := .Values.postgresql.image.tag | default "" | toString -}}
+{{- $digest := .Values.postgresql.image.digest | default "" | toString -}}
+{{- if and (eq $digest "") (or (eq $tag "") (eq $tag "latest")) -}}
+{{- fail (printf "postgresql.image.tag must be pinned to an explicit version when db.deployStandalone is true (got %q). An unpinned tag can start a different PostgreSQL major against the existing data directory, which makes the database unreadable and is not recoverable in place. Crossing a major version requires a dump and restore." $tag) -}}
+{{- end -}}
+{{- end -}}

--- a/helm/litellm-helm/templates/secret-dbcredentials.yaml
+++ b/helm/litellm-helm/templates/secret-dbcredentials.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.db.deployStandalone -}}
+{{- include "litellm.validateBundledPostgresImageTag" . -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/litellm-helm/templates/tests/test-servicemonitor.yaml
+++ b/helm/litellm-helm/templates/tests/test-servicemonitor.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   containers:
     - name: test
-      image: bitnami/kubectl:latest
+      image: docker.io/bitnamilegacy/kubectl:1.29.2-debian-12-r3
       command: ['sh', '-c']
       args:
         - |

--- a/helm/litellm-helm/tests/bundled_db_images_tests.yaml
+++ b/helm/litellm-helm/tests/bundled_db_images_tests.yaml
@@ -1,0 +1,94 @@
+suite: test bundled database images
+templates:
+  - charts/postgresql/templates/primary/statefulset.yaml
+  - charts/redis/templates/master/application.yaml
+  - charts/redis/templates/configmap.yaml
+  - charts/redis/templates/health-configmap.yaml
+  - charts/redis/templates/scripts-configmap.yaml
+  - charts/redis/templates/secret.yaml
+  - secret-dbcredentials.yaml
+  - templates/tests/test-servicemonitor.yaml
+tests:
+  - it: should pull the bundled postgres from a repository that still publishes the pinned tag
+    template: charts/postgresql/templates/primary/statefulset.yaml
+    set:
+      db.deployStandalone: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/bitnamilegacy/postgresql:16.2.0-debian-12-r6
+
+  - it: should pull the bundled postgres metrics exporter from the same repository
+    template: charts/postgresql/templates/primary/statefulset.yaml
+    set:
+      db.deployStandalone: true
+      postgresql.metrics.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: docker.io/bitnamilegacy/postgres-exporter:0.15.0-debian-12-r14
+
+  - it: should run the bundled postgres init container from the same repository
+    template: charts/postgresql/templates/primary/statefulset.yaml
+    set:
+      db.deployStandalone: true
+      postgresql.volumePermissions.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: docker.io/bitnamilegacy/os-shell:12-debian-12-r16
+
+  - it: should pull the bundled redis from a repository that still publishes the pinned tag
+    template: charts/redis/templates/master/application.yaml
+    set:
+      redis.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/bitnamilegacy/redis:7.2.4-debian-12-r9
+
+  - it: should reject a floating postgres tag that could cross a major version on an existing volume
+    template: secret-dbcredentials.yaml
+    set:
+      db.deployStandalone: true
+      postgresql.image.tag: latest
+    asserts:
+      - failedTemplate:
+          errorMessage: 'postgresql.image.tag must be pinned to an explicit version when db.deployStandalone is true (got "latest"). An unpinned tag can start a different PostgreSQL major against the existing data directory, which makes the database unreadable and is not recoverable in place. Crossing a major version requires a dump and restore.'
+
+  - it: should reject an empty postgres tag
+    template: secret-dbcredentials.yaml
+    set:
+      db.deployStandalone: true
+      postgresql.image.tag: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: 'postgresql.image.tag must be pinned to an explicit version when db.deployStandalone is true (got ""). An unpinned tag can start a different PostgreSQL major against the existing data directory, which makes the database unreadable and is not recoverable in place. Crossing a major version requires a dump and restore.'
+
+  - it: should accept an empty postgres tag when the image is pinned by digest
+    template: secret-dbcredentials.yaml
+    set:
+      db.deployStandalone: true
+      postgresql.image.tag: ""
+      postgresql.image.digest: sha256:0d0e2f1a5b3c4d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: should run the servicemonitor test pod from a pinned image
+    template: templates/tests/test-servicemonitor.yaml
+    set:
+      serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.containers[0].image
+          value: docker.io/bitnamilegacy/kubectl:1.29.2-debian-12-r3
+
+  - it: should not constrain the postgres tag when the bundled database is not deployed
+    template: secret-dbcredentials.yaml
+    set:
+      db.deployStandalone: false
+      postgresql.image.tag: latest
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/helm/litellm-helm/values.yaml
+++ b/helm/litellm-helm/values.yaml
@@ -328,8 +328,32 @@ lifecycle: {}
 
 # Settings for Bitnami postgresql chart (if db.deployStandalone is true, ignored
 #  otherwise)
+#
+# Bitnami retired the versioned tags under docker.io/bitnami and republished the
+# archived builds under docker.io/bitnamilegacy, so the subchart's own image
+# defaults no longer resolve. The repository below points at the same build the
+# subchart was released with, which keeps the on-disk data directory layout
+# identical for existing installs.
+#
+# Keep the tag pinned. docker.io/bitnami still publishes a floating `latest`,
+# and starting a newer PostgreSQL major against an existing data directory
+# leaves the server refusing to boot ("database files are incompatible with
+# server") with no way back other than a dump taken beforehand. Crossing a major
+# version is a dump-and-restore, not an image bump. The chart refuses to render
+# an unpinned tag for this reason
 postgresql:
   architecture: standalone
+  image:
+    repository: bitnamilegacy/postgresql
+    tag: 16.2.0-debian-12-r6
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+      tag: 12-debian-12-r16
+  metrics:
+    image:
+      repository: bitnamilegacy/postgres-exporter
+      tag: 0.15.0-debian-12-r14
   auth:
     username: litellm
     database: litellm
@@ -359,9 +383,36 @@ postgresql:
 # When `redis.sentinel.enabled` is set, the coordination block is rendered with
 # `sentinel_nodes` and `service_name` (from `redis.sentinel.masterSet`) instead
 # of host/port, because a plain Redis client cannot talk to the sentinel port
+#
+# The image repositories carry the same bitnamilegacy repoint as postgresql
+# above; the versioned tags the subchart ships with are gone from
+# docker.io/bitnami
 redis:
   enabled: false
   architecture: standalone
+  image:
+    repository: bitnamilegacy/redis
+    tag: 7.2.4-debian-12-r9
+  sentinel:
+    image:
+      repository: bitnamilegacy/redis-sentinel
+      tag: 7.2.4-debian-12-r7
+  metrics:
+    image:
+      repository: bitnamilegacy/redis-exporter
+      tag: 1.58.0-debian-12-r4
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+      tag: 12-debian-12-r16
+  sysctl:
+    image:
+      repository: bitnamilegacy/os-shell
+      tag: 12-debian-12-r16
+  kubectl:
+    image:
+      repository: bitnamilegacy/kubectl
+      tag: 1.29.2-debian-12-r3
   coordination:
     # Set to false to keep the bundled Redis for response caching only and leave
     # `general_settings.coordination_redis` out of the rendered config. A


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every install and upgrade of `litellm-helm` with the bundled database fails to pull its Postgres image. Bitnami retired the versioned tags under `docker.io/bitnami` and republished the archived builds under `docker.io/bitnamilegacy`, so the tag the vendored `postgresql` 14.3.1 subchart defaults to (`docker.io/bitnami/postgresql:16.2.0-debian-12-r6`) returns `not found`. The bundled `redis` 18.19.1 subchart is broken the same way
- Working around it by overriding only the image repository lands on the floating `latest` tag, which is PostgreSQL 18 today. v18 initializes the (empty) PVC with a v18 data directory, and going back to the pinned 16.2 then crashloops with `database files are incompatible with server`. There is no in-place way back, and one deployment lost its keys, teams, users and spend logs this way
- The `postgresql` dependency range is `>=13.3.0`, so a `helm dependency update` resolves to the current bitnami chart, whose own default is `tag: latest`. The chart's protection against a major-version jump is entirely accidental today: it comes from `Chart.lock` and the vendored tarball, not from anything the chart states

How it solves it:

- Point the subchart images at the `bitnamilegacy` copies of the exact builds those subchart versions were released with. Same image content, so the on-disk data directory layout is unchanged and an existing install keeps its data across the upgrade. Every image the two subcharts can render is covered, including the ones behind `volumePermissions`, `metrics`, `sentinel` and `sysctl`
- Pin both subchart dependency ranges to the versions already in `Chart.lock`, so refreshing dependencies reproduces what is vendored instead of jumping a Postgres major. The re-resolved tarballs are byte-identical to the vendored ones
- Fail the render when `postgresql.image.tag` is empty or `latest` while `db.deployStandalone` is true, with a message that says why. That is the one remaining path to the data loss above
- Pin the chart's own `helm test` pod, which ran `bitnami/kubectl:latest`. That tag still resolves today, but it is a floating tag on the same catalog that just got pulled out from under the subcharts, and CircleCI's `helm test litellm` depends on it
- Document the pin and the dump-and-restore requirement for crossing a major version in the chart README, along with the note that these images no longer receive updates and anything past getting started belongs on `db.useExisting`

## Relevant issues

## Linear ticket

Resolves LIT-4708

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All of this runs against a real `kind` cluster pulling from the real Docker Hub. Values used throughout (`repro-values.yaml`), which deploys only the bundled database so the evidence is about the Postgres image and nothing else:

```yaml
replicaCount: 0
migrationJob:
  enabled: false
db:
  deployStandalone: true
masterkey: sk-lit4708
```

### Before: the reported install failure, on the current chart

```console
$ helm template lit4708 helm/litellm-helm -f repro-values.yaml | grep -A1 "image: docker.io/bitnami"
          image: docker.io/bitnami/postgresql:16.2.0-debian-12-r6
          imagePullPolicy: "IfNotPresent"

$ helm install lit4708 helm/litellm-helm -f repro-values.yaml
NAME: lit4708
STATUS: deployed

$ kubectl get pods
NAME                   READY   STATUS         RESTARTS   AGE
lit4708-postgresql-0   0/1     ErrImagePull   0          8s

$ kubectl get events --field-selector involvedObject.name=lit4708-postgresql-0 --sort-by=.lastTimestamp | tail -6
4s    Normal    Scheduled   pod/lit4708-postgresql-0   Successfully assigned default/lit4708-postgresql-0 to lit4708-control-plane
4s    Normal    Pulling     pod/lit4708-postgresql-0   Pulling image "docker.io/bitnami/postgresql:16.2.0-debian-12-r6"
3s    Warning   Failed      pod/lit4708-postgresql-0   Failed to pull image "docker.io/bitnami/postgresql:16.2.0-debian-12-r6": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/bitnami/postgresql:16.2.0-debian-12-r6": failed to resolve reference "docker.io/bitnami/postgresql:16.2.0-debian-12-r6": docker.io/bitnami/postgresql:16.2.0-debian-12-r6: not found
3s    Warning   Failed      pod/lit4708-postgresql-0   Error: ErrImagePull
3s    Normal    BackOff     pod/lit4708-postgresql-0   Back-off pulling image "docker.io/bitnami/postgresql:16.2.0-debian-12-r6"
3s    Warning   Failed      pod/lit4708-postgresql-0   Error: ImagePullBackOff
```

### Before: the data loss, on the current chart

Overriding the repository without pinning the tag, which is what the pull failure pushes people toward:

```console
$ helm install lit4708 helm/litellm-helm -f repro-values.yaml \
    --set postgresql.image.repository=bitnami/postgresql --set postgresql.image.tag=latest
NAME: lit4708

$ kubectl get pod lit4708-postgresql-0 -o jsonpath='{.spec.containers[0].image}'
docker.io/bitnami/postgresql:latest

$ kubectl exec lit4708-postgresql-0 -- cat /bitnami/postgresql/data/PG_VERSION
18
```

Going back to the version the chart pins, on the same volume:

```console
$ helm upgrade lit4708 helm/litellm-helm -f repro-values.yaml --set postgresql.image.repository=bitnamilegacy/postgresql
Release "lit4708" has been upgraded. Happy Helming!

$ kubectl logs lit4708-postgresql-0 | grep -A2 -i incompatible
2026-07-28 17:17:28.738 GMT [1] FATAL:  database files are incompatible with server
2026-07-28 17:17:28.738 GMT [1] DETAIL:  The data directory was initialized by PostgreSQL version 18, which is not compatible with this version 16.2.
```

### After: fresh install works with no overrides

```console
$ helm template lit4708 helm/litellm-helm --set db.deployStandalone=true --set redis.enabled=true | grep "image: docker.io" | sort -u
          image: docker.io/bitnamilegacy/postgresql:16.2.0-debian-12-r6
          image: docker.io/bitnamilegacy/redis:7.2.4-debian-12-r9

$ helm install lit4708 helm/litellm-helm -f repro-values.yaml
NAME: lit4708

$ kubectl get pods
NAME                   READY   STATUS    RESTARTS   AGE
lit4708-postgresql-0   1/1     Running   0          16s

$ kubectl exec lit4708-postgresql-0 -- env PGPASSWORD=... psql -U litellm -d litellm -tc "select version()"
 PostgreSQL 16.2 on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
```

With `redis.enabled=true` as well:

```console
$ kubectl get pods
NAME                     READY   STATUS    RESTARTS   AGE
lit4708-postgresql-0     1/1     Running   0          3m14s
lit4708-redis-master-0   1/1     Running   0          34s

$ kubectl get pod lit4708-redis-master-0 -o jsonpath='{.spec.containers[0].image}'
docker.io/bitnamilegacy/redis:7.2.4-debian-12-r9

$ kubectl exec lit4708-redis-master-0 -- redis-cli -a ... ping
PONG
```

### After: upgrading an existing install keeps its data

Installed from the current chart with the `bitnamilegacy` workaround people are being given today, with a row written to it, then upgraded to this branch with no image overrides at all:

```console
$ helm install lit4708 <current-chart> -f repro-values.yaml --set postgresql.image.repository=bitnamilegacy/postgresql
$ kubectl exec lit4708-postgresql-0 -- env PGPASSWORD=... psql -U litellm -d litellm \
    -c "create table lit4708(v text)" -c "insert into lit4708 values ('customer-data')"
CREATE TABLE
INSERT 0 1

$ helm upgrade lit4708 helm/litellm-helm -f repro-values.yaml
Release "lit4708" has been upgraded. Happy Helming!

$ kubectl get pod lit4708-postgresql-0 -o jsonpath='{.spec.containers[0].image}'
docker.io/bitnamilegacy/postgresql:16.2.0-debian-12-r6

$ kubectl exec lit4708-postgresql-0 -- env PGPASSWORD=... psql -U litellm -d litellm -c "select * from lit4708"
       v
---------------
 customer-data
(1 row)
```

### After: the unpinned tag is rejected before anything is created

```console
$ helm template lit4708 helm/litellm-helm -f repro-values.yaml --set postgresql.image.tag=latest
Error: execution error at (litellm-helm/templates/secret-dbcredentials.yaml:2:4): postgresql.image.tag must be pinned to an explicit version when db.deployStandalone is true (got "latest"). An unpinned tag can start a different PostgreSQL major against the existing data directory, which makes the database unreadable and is not recoverable in place. Crossing a major version requires a dump and restore.

$ helm template lit4708 helm/litellm-helm --set db.deployStandalone=false --set postgresql.image.tag=latest >/dev/null && echo "not constrained when the bundled db is off"
not constrained when the bundled db is off
```

### Dependency pin re-resolves to the vendored tarballs, byte for byte

```console
$ helm dependency update .
Pulled: registry-1.docker.io/bitnamicharts/postgresql:14.3.1
Pulled: registry-1.docker.io/bitnamicharts/redis:18.19.1

$ shasum -a256 <vendored>/*.tgz <re-resolved>/*.tgz
3c8125526b06833df32e2f626db34aeaedb29d38f03d15349db6604027d4a167  vendored/postgresql-14.3.1.tgz
b2fa1835f673a18002ca864c54fadac3c33789b26f6c5e58e2851b0b14a8f984  vendored/redis-18.19.1.tgz
3c8125526b06833df32e2f626db34aeaedb29d38f03d15349db6604027d4a167  re-resolved/postgresql-14.3.1.tgz
b2fa1835f673a18002ca864c54fadac3c33789b26f6c5e58e2851b0b14a8f984  re-resolved/redis-18.19.1.tgz
```

## Type

🐛 Bug Fix

## Changes

`helm/litellm-helm/values.yaml` repoints every image the `postgresql` and `redis` subcharts can render to its `bitnamilegacy` build, at the tag that subchart version shipped with. `helm/litellm-helm/Chart.yaml` pins the two dependency ranges to the vendored versions and bumps the chart to 1.1.1; `Chart.lock` carries the matching digest. `templates/_helpers.tpl` adds `litellm.validateBundledPostgresImageTag`, included from `templates/secret-dbcredentials.yaml`, which renders only when the bundled database is deployed. The guard exempts an image pinned by `postgresql.image.digest`, which the subchart honors over the tag and which is at least as specific as a pinned tag. `templates/tests/test-servicemonitor.yaml` pins the kubectl image its test pod runs. `tests/bundled_db_images_tests.yaml` covers the rendered images (including the metrics, volume-permissions and test-pod paths), both rejection cases, and the digest exemption; every one of its assertions fails against the current chart or against the guard without the digest exemption.

Worth flagging for whoever picks this up: `bitnamilegacy` is an archive that receives no updates, so this restores installs rather than putting the bundled database on a maintained image. The durable answer is either `db.useExisting` against a real managed Postgres, which the README now points at, or replacing the bundled subchart with something that is still published. Also, CI never caught this because `helm/litellm-helm/ci/test-values.yaml` sets `db.deployStandalone: false`, so the CircleCI `helm_chart_testing` job installs the chart without ever pulling a Bitnami image; the new helm-unittest suite pins the rendered image coordinates, but nothing in CI pulls them.

## QA runbook

Install the chart with the bundled database on any cluster, `helm install litellm ./helm/litellm-helm --set db.deployStandalone=true`, and confirm `<release>-postgresql-0` reaches Running instead of ImagePullBackOff. Then confirm `helm template ./helm/litellm-helm --set db.deployStandalone=true --set postgresql.image.tag=latest` is refused. For an existing release, `helm upgrade` and confirm the Postgres pod restarts on `docker.io/bitnamilegacy/postgresql:16.2.0-debian-12-r6` with its data intact.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
