### PR TITLE
fix(ui): backport cache leakage card layout fix to rc/1.94.0

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.tsx
@@ -102,8 +102,8 @@ const CacheLeakageCard: React.FC<CacheLeakageCardProps> = ({ activity }) => {
     <TooltipProvider delay={300}>
       <Card>
         <CardHeader>
-          <div className="flex flex-wrap items-start justify-between gap-4">
-            <div>
+          <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0">
               <CardTitle>Cache leakage by {dimension === "model" ? "model" : "virtual key"}</CardTitle>
               <p className="mt-1 text-sm text-muted-foreground">
                 {subject} sending large volumes of uncached input with a low cache hit rate are likely missing prompt
@@ -111,7 +111,9 @@ const CacheLeakageCard: React.FC<CacheLeakageCardProps> = ({ activity }) => {
                 {dimension === "model" ? " Limited to Anthropic (Claude) models, which support prompt caching." : ""}
               </p>
             </div>
-            <AdvancedDatePicker value={dateValue} onValueChange={onDateChange} />
+            <div className="shrink-0">
+              <AdvancedDatePicker value={dateValue} onValueChange={onDateChange} />
+            </div>
           </div>
           <Tabs
             value={dimension}

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.tsx
@@ -105,10 +105,9 @@ const CacheLeakageCard: React.FC<CacheLeakageCardProps> = ({ activity }) => {
           <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
             <div className="min-w-0">
               <CardTitle>Cache leakage by {dimension === "model" ? "model" : "virtual key"}</CardTitle>
-              <p className="mt-1 text-sm text-muted-foreground">
+              <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
                 {subject} sending large volumes of uncached input with a low cache hit rate are likely missing prompt
                 caching. Potential savings is approximate: uncached input priced at the realized cache-read discount.
-                {dimension === "model" ? " Limited to Anthropic (Claude) models, which support prompt caching." : ""}
               </p>
             </div>
             <div className="shrink-0">
@@ -118,7 +117,6 @@ const CacheLeakageCard: React.FC<CacheLeakageCardProps> = ({ activity }) => {
           <Tabs
             value={dimension}
             onValueChange={(value) => setDimension(value === "model" ? "model" : "key")}
-            className="mt-3"
           >
             <TabsList>
               <TabsTrigger value="key">By virtual key</TabsTrigger>

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CacheLeakageCard.tsx
@@ -114,10 +114,7 @@ const CacheLeakageCard: React.FC<CacheLeakageCardProps> = ({ activity }) => {
               <AdvancedDatePicker value={dateValue} onValueChange={onDateChange} />
             </div>
           </div>
-          <Tabs
-            value={dimension}
-            onValueChange={(value) => setDimension(value === "model" ? "model" : "key")}
-          >
+          <Tabs value={dimension} onValueChange={(value) => setDimension(value === "model" ? "model" : "key")}>
             <TabsList>
               <TabsTrigger value="key">By virtual key</TabsTrigger>
               <TabsTrigger value="model">By model</TabsTrigger>

--- a/ui/litellm-dashboard/src/components/ui/card.tsx
+++ b/ui/litellm-dashboard/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<"di
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-xs ring-1 ring-foreground/10 [--card-spacing:--spacing(6)] has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(4)] *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "group/card flex flex-col gap-(--card-spacing) rounded-xl bg-card py-(--card-spacing) text-sm text-card-foreground shadow-xs ring-1 ring-foreground/10 [--card-spacing:--spacing(6)] has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(4)] *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
         className,
       )}
       {...props}


### PR DESCRIPTION
Backports the cache leakage card layout fix onto `rc/1.94.0`

#34885 alone is dead on arrival on this branch. Its headline claim, keeping the date picker pinned to the right, is delivered by `shrink-0` on the picker plus `min-w-0` on the title/description block plus `md:flex-row` stacking, and all of that lives in #34439, which never landed on `rc/1.94.0`. Picking #34885 by itself applies without conflict but leaves the old `flex flex-wrap` header and a bare `AdvancedDatePicker`, so the picker still drops onto its own line under the description at higher browser zoom. Only the two secondary parts would have landed: the `overflow-hidden` removal that stops popovers being clipped, and `line-clamp-2` that keeps both card variants the same height

So this picks #34439 first and #34885 on top. Both apply cleanly, and the two resulting files are byte-identical to `litellm_internal_staging` apart from the formatting commit described below

#34885 merged into staging with `frontend-lint` red: dropping `className="mt-3"` from `<Tabs>` shortened the line enough that prettier wants the props back on a single line. A verbatim pick inherits that failure, so the third commit here is a formatting-only fixup that gets `frontend-lint` green on this branch

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Tests are inherited, not new: `CacheLeakageCard.test.tsx` and `PromptCachingTab.test.tsx` already exist on this branch and pass, but they assert on rendered rows rather than layout classes, so they pass with or without the fix and give no signal on it. This is a pure Tailwind class change with no logic, and the verification that matters is visual, which is why the runbook below is manual

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Pending; captured against a live proxy on `localhost:4000` with the dashboard dev server on `localhost:3000`, populated with real Anthropic (Claude) cache-read and uncached traffic

## Type

🐛 Bug Fix

## Changes

`CacheLeakageCard.tsx` gets the responsive header from #34439, so the title and description block shrinks (`min-w-0`) while the picker holds its width (`shrink-0`), and the header stacks below `md` rather than wrapping the picker onto its own line. On top of that, #34885 clamps the description to two lines and drops the Anthropic-only sentence so the "by model" and "by virtual key" variants keep the same height, and removes the now-redundant `mt-3` from the tabs

`card.tsx` loses `overflow-hidden` so popovers and dropdowns can escape the card boundary instead of being clipped. This is the shared Card primitive, and the blast radius on this branch is smaller than on staging: 10 files import it here against 34 on staging

## Verification

The 2 failures in `src/components/page_utils.test.ts` are pre-existing on this branch and unrelated to this change; they reproduce identically on pristine `rc/1.94.0`, and they are about `cost-optimization` missing an entry in `page_metadata.ts`. Worth a separate fix on this line. Everything else in the suite is green: 484 of 485 files, 4885 of 4887 tests

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
