### PR TITLE
feat(prometheus): add service_tier label to latency and spend metrics

### DIFF
--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -69,6 +69,15 @@ else:
 
 _DEFAULT_BUDGET_METRICS_PER_REQUEST_TIMEOUT = 5.0
 
+# Tiers a caller may name in a request, across the providers that accept the
+# parameter: OpenAI ("auto", "default", "flex", "priority", "scale"), Bedrock and
+# Groq (subsets of those), Anthropic ("auto", "standard_only") and Vertex, which
+# maps "default" to "standard". Used to bound the caller-controlled fallback in
+# ``get_service_tier_from_standard_logging_payload``.
+KNOWN_REQUEST_SERVICE_TIERS = frozenset(
+    {"auto", "batch", "default", "flex", "priority", "scale", "standard", "standard_only"}
+)
+
 
 def _get_budget_metrics_per_request_timeout() -> float:
     raw = os.getenv("PROMETHEUS_BUDGET_METRICS_PER_REQUEST_TIMEOUT")
@@ -4109,19 +4118,32 @@ def get_service_tier_from_standard_logging_payload(
     so latency and spend stay segmentable when the request said ``auto`` and the
     provider picked the concrete tier. Providers report the served tier either at
     the top level of the response (OpenAI, Bedrock, Groq) or on the usage object
-    (Anthropic); the requested value from the request params is the last resort,
-    which is what covers streaming responses that carry no served tier.
+    (Anthropic).
+
+    Streaming responses carry no served tier, so the requested tier is the
+    fallback. That value is caller-controlled and survives param mapping even
+    where the provider then ignores it (Bedrock and Groq accept the request and
+    drop an unrecognized tier), so it is only labelled when it names a known
+    tier; otherwise one caller could mint a Prometheus series per string. Values
+    the provider itself reports are not caller-controlled and stay unrestricted,
+    so a tier a provider adds later is still labelled correctly.
     """
     response = standard_logging_payload.get("response")
     usage_object = standard_logging_payload.get("metadata", {}).get("usage_object")
-    model_parameters = standard_logging_payload.get("model_parameters")
 
-    candidates: tuple[object, ...] = (
+    served_candidates: tuple[object, ...] = (
         response.get("service_tier") if isinstance(response, dict) else None,
         usage_object.get("service_tier") if isinstance(usage_object, dict) else None,
-        model_parameters.get("service_tier") if isinstance(model_parameters, dict) else None,
     )
-    return next((tier for tier in candidates if isinstance(tier, str) and tier), None)
+    served_tier = next((tier for tier in served_candidates if isinstance(tier, str) and tier), None)
+    if served_tier is not None:
+        return served_tier
+
+    model_parameters = standard_logging_payload.get("model_parameters")
+    requested_tier = model_parameters.get("service_tier") if isinstance(model_parameters, dict) else None
+    if isinstance(requested_tier, str) and requested_tier in KNOWN_REQUEST_SERVICE_TIERS:
+        return requested_tier
+    return None
 
 
 def _get_combined_custom_metadata_from_standard_logging_payload(

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1245,6 +1245,7 @@ class PrometheusLogger(CustomLogger):
             client_ip=standard_logging_payload["metadata"].get("requester_ip_address"),
             user_agent=standard_logging_payload["metadata"].get("user_agent"),
             stream=(str(standard_logging_payload.get("stream")) if litellm.prometheus_emit_stream_label else None),
+            service_tier=get_service_tier_from_standard_logging_payload(standard_logging_payload),
         )
 
         if user_api_key is not None and isinstance(user_api_key, str) and user_api_key.startswith("sk-"):
@@ -4096,6 +4097,31 @@ def get_custom_labels_from_metadata(metadata: dict) -> Dict[str, str]:
             result[original_key.replace(".", "_")] = value
 
     return result
+
+
+def get_service_tier_from_standard_logging_payload(
+    standard_logging_payload: StandardLoggingPayload,
+) -> str | None:
+    """
+    Resolve the service tier a request ran on, for the ``service_tier`` label.
+
+    The tier the provider actually served wins over the tier the caller asked for,
+    so latency and spend stay segmentable when the request said ``auto`` and the
+    provider picked the concrete tier. Providers report the served tier either at
+    the top level of the response (OpenAI, Bedrock, Groq) or on the usage object
+    (Anthropic); the requested value from the request params is the last resort,
+    which is what covers streaming responses that carry no served tier.
+    """
+    response = standard_logging_payload.get("response")
+    usage_object = standard_logging_payload.get("metadata", {}).get("usage_object")
+    model_parameters = standard_logging_payload.get("model_parameters")
+
+    candidates: tuple[object, ...] = (
+        response.get("service_tier") if isinstance(response, dict) else None,
+        usage_object.get("service_tier") if isinstance(usage_object, dict) else None,
+        model_parameters.get("service_tier") if isinstance(model_parameters, dict) else None,
+    )
+    return next((tier for tier in candidates if isinstance(tier, str) and tier), None)
 
 
 def _get_combined_custom_metadata_from_standard_logging_payload(

--- a/litellm/types/integrations/prometheus.py
+++ b/litellm/types/integrations/prometheus.py
@@ -190,6 +190,7 @@ class UserAPIKeyLabelNames(Enum):
     ORG_ALIAS = "org_alias"
     MCP_TOOL_NAME = "mcp_tool_name"
     MCP_SERVER_NAME = "mcp_server_name"
+    SERVICE_TIER = "service_tier"
 
 
 DEFINED_PROMETHEUS_METRICS = Literal[
@@ -286,6 +287,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.SERVICE_TIER.value,
     ]
 
     litellm_llm_api_time_to_first_token_metric = [
@@ -299,6 +301,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.USER.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.SERVICE_TIER.value,
     ]
 
     litellm_request_total_latency_metric = [
@@ -312,6 +315,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.v1_LITELLM_MODEL_NAME.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.SERVICE_TIER.value,
     ]
 
     litellm_request_queue_time_seconds = [
@@ -453,6 +457,7 @@ class PrometheusMetricLabels:
         UserAPIKeyLabelNames.REQUESTED_MODEL.value,
         UserAPIKeyLabelNames.MODEL_ID.value,
         UserAPIKeyLabelNames.API_PROVIDER.value,
+        UserAPIKeyLabelNames.SERVICE_TIER.value,
     ]
 
     litellm_input_tokens_metric = [
@@ -878,6 +883,7 @@ class UserAPIKeyLabelValues:
     org_alias: Optional[str] = None
     mcp_tool_name: Optional[str] = None
     mcp_server_name: Optional[str] = None
+    service_tier: Optional[str] = None
 
     # Added for test compatibility.
     def __init__(self, **kwargs: Any) -> None:

--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
@@ -428,6 +428,7 @@ def test_set_latency_metrics(prometheus_logger):
         model="gpt-5-mini",
         model_id="model-123",
         api_provider="openai",
+        service_tier=None,
     )
     prometheus_logger.litellm_llm_api_time_to_first_token_metric.labels().observe.assert_called_once_with(
         0.5
@@ -447,6 +448,7 @@ def test_set_latency_metrics(prometheus_logger):
         model="gpt-5-mini",
         model_id="model-123",
         api_provider="openai",
+        service_tier=None,
     )
     prometheus_logger.litellm_llm_api_latency_metric.labels().observe.assert_called_once_with(
         1.5
@@ -466,6 +468,7 @@ def test_set_latency_metrics(prometheus_logger):
         model="gpt-5-mini",
         model_id="model-123",
         api_provider="openai",
+        service_tier=None,
     )
     prometheus_logger.litellm_request_total_latency_metric.labels().observe.assert_called_once_with(
         2.0
@@ -634,6 +637,7 @@ def test_increment_top_level_request_and_spend_metrics(prometheus_logger):
         client_ip=None,
         user_agent=None,
         requested_model=None,
+        service_tier=None,
     )
     prometheus_logger.litellm_spend_metric.labels().inc.assert_called_once_with(0.1)
 

--- a/tests/test_litellm/integrations/test_prometheus_service_tier_label.py
+++ b/tests/test_litellm/integrations/test_prometheus_service_tier_label.py
@@ -1,0 +1,200 @@
+"""
+Unit tests for the service_tier Prometheus label on latency and spend metrics.
+
+Covers the label being declared on the metrics that carry it, the precedence
+between the tier a provider served and the tier a caller requested, and the
+end-to-end emit wiring through async_log_success_event.
+
+Run with:
+    uv run pytest tests/test_litellm/integrations/test_prometheus_service_tier_label.py -v
+"""
+
+import datetime
+
+import pytest
+
+from litellm.integrations.prometheus import (
+    PrometheusLogger,
+    get_service_tier_from_standard_logging_payload,
+)
+from litellm.types.integrations.prometheus import (
+    PrometheusMetricLabels,
+    UserAPIKeyLabelNames,
+    UserAPIKeyLabelValues,
+)
+
+SERVICE_TIER_METRICS = [
+    "litellm_llm_api_latency_metric",
+    "litellm_llm_api_time_to_first_token_metric",
+    "litellm_request_total_latency_metric",
+    "litellm_spend_metric",
+]
+
+
+def _clear_prometheus_registry() -> None:
+    from prometheus_client import REGISTRY
+
+    for collector in list(REGISTRY._collector_to_names.keys()):
+        try:
+            REGISTRY.unregister(collector)
+        except Exception:
+            pass
+
+
+def _collected_samples(metric_name: str):
+    from prometheus_client import REGISTRY
+
+    return [sample for metric in REGISTRY.collect() for sample in metric.samples if sample.name == metric_name]
+
+
+def _standard_logging_payload(
+    response: object = None,
+    usage_object: object = None,
+    model_parameters: object = None,
+) -> dict:
+    return {
+        "id": "t",
+        "call_type": "completion",
+        "response_cost": 0.001,
+        "status": "success",
+        "total_tokens": 30,
+        "prompt_tokens": 20,
+        "completion_tokens": 10,
+        "startTime": 1.0,
+        "endTime": 2.0,
+        "completionStartTime": 1.5,
+        "model": "gpt-4o-mini",
+        "model_id": "model-123",
+        "model_group": "gpt-4o-mini",
+        "api_base": "https://api.openai.com",
+        "custom_llm_provider": "openai",
+        "request_tags": [],
+        "end_user": None,
+        "cache_hit": False,
+        "stream": True,
+        "response": response,
+        "model_parameters": model_parameters,
+        "metadata": {
+            "user_api_key_hash": "h",
+            "user_api_key_alias": "a",
+            "user_api_key_team_id": "t",
+            "user_api_key_team_alias": "ta",
+            "user_api_key_user_id": "u",
+            "user_api_key_user_email": "e@x.com",
+            "user_api_key_org_id": None,
+            "user_api_key_org_alias": None,
+            "requester_metadata": None,
+            "user_api_key_end_user_id": None,
+            "usage_object": usage_object,
+        },
+        "hidden_params": {"litellm_overhead_time_ms": None, "additional_headers": None},
+    }
+
+
+def test_service_tier_label_declared_on_latency_and_spend_metrics():
+    for metric_name in SERVICE_TIER_METRICS:
+        labels = PrometheusMetricLabels.get_labels(metric_name)
+        assert UserAPIKeyLabelNames.SERVICE_TIER.value in labels, f"{metric_name} should carry the service_tier label"
+
+
+def test_user_api_key_label_values_carries_service_tier():
+    values = UserAPIKeyLabelValues(service_tier="flex")
+
+    assert values.service_tier == "flex"
+    assert values.model_dump()["service_tier"] == "flex"
+    assert UserAPIKeyLabelValues().service_tier is None
+
+
+def test_served_tier_wins_over_requested_tier():
+    payload = _standard_logging_payload(
+        response={"service_tier": "default"},
+        model_parameters={"service_tier": "auto"},
+    )
+
+    assert get_service_tier_from_standard_logging_payload(payload) == "default"
+
+
+def test_usage_object_tier_used_when_response_has_none():
+    payload = _standard_logging_payload(
+        response={"id": "chatcmpl-1"},
+        usage_object={"prompt_tokens": 1, "service_tier": "standard"},
+        model_parameters={"service_tier": "auto"},
+    )
+
+    assert get_service_tier_from_standard_logging_payload(payload) == "standard"
+
+
+def test_requested_tier_used_when_no_served_tier():
+    payload = _standard_logging_payload(
+        response={"id": "chatcmpl-1"},
+        usage_object={"prompt_tokens": 1},
+        model_parameters={"service_tier": "flex"},
+    )
+
+    assert get_service_tier_from_standard_logging_payload(payload) == "flex"
+
+
+@pytest.mark.parametrize(
+    "response, usage_object, model_parameters",
+    [
+        (None, None, None),
+        ({"service_tier": None}, {"service_tier": ""}, {"service_tier": None}),
+        ("redacted-by-litellm", None, {}),
+        ({"service_tier": 1}, None, None),
+    ],
+)
+def test_no_tier_resolves_to_none(response, usage_object, model_parameters):
+    payload = _standard_logging_payload(
+        response=response,
+        usage_object=usage_object,
+        model_parameters=model_parameters,
+    )
+
+    assert get_service_tier_from_standard_logging_payload(payload) is None
+
+
+@pytest.mark.asyncio
+async def test_success_event_emits_service_tier_on_latency_and_spend_metrics():
+    """
+    End-to-end emit wiring.
+
+    Drives the real logger with a payload whose response was served on the flex
+    tier and asserts every latency histogram and the spend counter carries
+    service_tier="flex". Fails if the label is dropped from a metric's label list
+    or if the value is not populated on the success path.
+    """
+    payload = _standard_logging_payload(
+        response={"service_tier": "flex"},
+        model_parameters={"service_tier": "auto"},
+    )
+    now = datetime.datetime.now()
+    kwargs = {
+        "model": "gpt-4o-mini",
+        "litellm_params": {"metadata": {}},
+        "standard_logging_object": payload,
+        "stream": True,
+        "start_time": now - datetime.timedelta(seconds=3),
+        "api_call_start_time": now - datetime.timedelta(seconds=2),
+        "completion_start_time": now - datetime.timedelta(seconds=1),
+        "end_time": now,
+    }
+
+    _clear_prometheus_registry()
+    try:
+        logger = PrometheusLogger()
+        await logger.async_log_success_event(kwargs, None, now, now)
+
+        for metric_name in (
+            "litellm_request_total_latency_metric_bucket",
+            "litellm_llm_api_latency_metric_bucket",
+            "litellm_llm_api_time_to_first_token_metric_bucket",
+            "litellm_spend_metric_total",
+        ):
+            samples = _collected_samples(metric_name)
+            assert samples, f"expected {metric_name} to be emitted"
+            assert all(sample.labels.get("service_tier") == "flex" for sample in samples), (
+                f"{metric_name} must carry service_tier=flex, got "
+                f"{sorted({sample.labels.get('service_tier') for sample in samples})}"
+            )
+    finally:
+        _clear_prometheus_registry()

--- a/tests/test_litellm/integrations/test_prometheus_service_tier_label.py
+++ b/tests/test_litellm/integrations/test_prometheus_service_tier_label.py
@@ -14,6 +14,7 @@ import datetime
 import pytest
 
 from litellm.integrations.prometheus import (
+    KNOWN_REQUEST_SERVICE_TIERS,
     PrometheusLogger,
     get_service_tier_from_standard_logging_payload,
 )
@@ -132,6 +133,37 @@ def test_requested_tier_used_when_no_served_tier():
     )
 
     assert get_service_tier_from_standard_logging_payload(payload) == "flex"
+
+
+def test_unrecognized_requested_tier_is_not_labelled():
+    """
+    A caller-supplied tier survives param mapping even where the provider then
+    ignores it (Bedrock and Groq drop an unrecognized tier and still answer), so
+    labelling it verbatim would let one caller mint a series per string.
+    """
+    payload = _standard_logging_payload(model_parameters={"service_tier": "attacker-controlled-a1b2c3"})
+
+    assert get_service_tier_from_standard_logging_payload(payload) is None
+
+
+def test_unrecognized_served_tier_is_labelled():
+    """
+    The tier a provider reports is not caller-controlled, so a tier added by a
+    provider after this release still gets labelled instead of being dropped.
+    """
+    payload = _standard_logging_payload(
+        response={"service_tier": "tier-added-by-provider-later"},
+        model_parameters={"service_tier": "auto"},
+    )
+
+    assert get_service_tier_from_standard_logging_payload(payload) == "tier-added-by-provider-later"
+
+
+@pytest.mark.parametrize("tier", sorted(KNOWN_REQUEST_SERVICE_TIERS))
+def test_every_known_requested_tier_is_labelled(tier):
+    payload = _standard_logging_payload(model_parameters={"service_tier": tier})
+
+    assert get_service_tier_from_standard_logging_payload(payload) == tier
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Latency metrics cannot be split by service tier
- Moving traffic to flex tier shows no measurable effect
- Spend metric has the same blind spot

How it solves it:

- Add a `service_tier` label to the three request latency metrics
- Add the same label to `litellm_spend_metric`
- Label the tier the provider actually served

## Relevant issues

## Linear ticket

Resolves LIT-4296

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against the real OpenAI API (real requests, real spend), scraping `/metrics` with `callbacks: ["prometheus"]`. Same config, same model, same two requests on both runs; only the build differs

Config used for both runs:

```yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  callbacks: ["prometheus"]

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
```

### Before (base `litellm_internal_staging`, commit d91fd084f7)

Two real requests, one on the flex tier and one on the priority tier

```bash
$ for tier in flex priority; do
    curl -s http://127.0.0.1:4296/v1/chat/completions \
      -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
      -d "{\"model\":\"gpt-5.6\",\"service_tier\":\"$tier\",\"messages\":[{\"role\":\"user\",\"content\":\"reply with the single word: $tier\"}]}" \
      | python3 -c "import json,sys; d=json.load(sys.stdin); print('requested=$tier served=', d.get('service_tier'))"
  done
requested=flex served= flex
requested=priority served= priority

$ curl -sL http://127.0.0.1:4296/metrics -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    | grep -E '^litellm_request_total_latency_metric_count'
litellm_request_total_latency_metric_count{api_key_alias="None",api_provider="openai",end_user="None",hashed_api_key="litellm_proxy_master_key",model="gpt-5.6",model_id="7bf6346cff2f4b26dc83b61f0a1ec186ad3f75d72c9fa620d23f893c8ce5007d",org_alias="None",org_id="None",requested_model="gpt-5.6",team="None",team_alias="None",user="default_user_id"} 2.0

$ curl -sL http://127.0.0.1:4296/metrics -H "Authorization: Bearer $LITELLM_MASTER_KEY" | grep -c 'service_tier'
0
```

Both tiers land in one series with count 2, and `service_tier` appears nowhere in the scrape

### After (this branch, commit 29a44529ec)

Same two requests

```bash
$ curl -sL http://127.0.0.1:4296/metrics -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    | grep -E '^litellm_request_total_latency_metric_(count|sum)'
litellm_request_total_latency_metric_count{...,requested_model="gpt-5.6",service_tier="flex",team="None",team_alias="None",user="default_user_id"} 1.0
litellm_request_total_latency_metric_sum{...,requested_model="gpt-5.6",service_tier="flex",team="None",team_alias="None",user="default_user_id"} 4.579048
litellm_request_total_latency_metric_count{...,requested_model="gpt-5.6",service_tier="priority",team="None",team_alias="None",user="default_user_id"} 1.0
litellm_request_total_latency_metric_sum{...,requested_model="gpt-5.6",service_tier="priority",team="None",team_alias="None",user="default_user_id"} 0.599737

$ curl -sL http://127.0.0.1:4296/metrics -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    | grep -E '^litellm_llm_api_latency_metric_sum'
litellm_llm_api_latency_metric_sum{...,service_tier="flex",...} 4.573844
litellm_llm_api_latency_metric_sum{...,service_tier="priority",...} 0.597786

$ curl -sL http://127.0.0.1:4296/metrics -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    | grep -E '^litellm_spend_metric_total'
litellm_spend_metric_total{...,service_tier="flex",...,user_agent="curl/8.7.1",user_email="None"} 9.25e-05
litellm_spend_metric_total{...,service_tier="priority",...,user_agent="curl/8.7.1",user_email="None"} 0.00037
```

The flex request took 4.58s and cost $0.0000925; the priority request took 0.60s and cost $0.00037. That is exactly the tradeoff the label is meant to make visible, and it is now queryable per tier

### Edge cases, same run

```bash
$ curl -s http://127.0.0.1:4296/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    -H "Content-Type: application/json" \
    -d '{"model":"gpt-5.6","service_tier":"auto","messages":[{"role":"user","content":"say: auto"}]}' \
    | python3 -c "import json,sys; print('requested=auto served=', json.load(sys.stdin).get('service_tier'))"
requested=auto served= default

$ curl -s -N http://127.0.0.1:4296/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    -H "Content-Type: application/json" \
    -d '{"model":"gpt-5.6","service_tier":"flex","stream":true,"messages":[{"role":"user","content":"say: stream"}]}' >/dev/null

$ curl -sL http://127.0.0.1:4296/metrics -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    | grep -Eo '^litellm_request_total_latency_metric_count.*service_tier="[^"]*"' \
    | grep -o 'service_tier="[^"]*"' | sort | uniq -c
   1 service_tier="default"
   1 service_tier="flex"
   1 service_tier="priority"

$ curl -sL http://127.0.0.1:4296/metrics -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
    | grep -E '^litellm_llm_api_time_to_first_token_metric_count' | grep -o 'service_tier="[^"]*"'
service_tier="flex"
```

A request asking for `auto` is labelled with the tier the provider actually picked (`default`), not with `auto`, and a streaming request carries the label on the time-to-first-token histogram

### Re-verified on the final head (commit 654165fd51)

Same commands after the caller-supplied fallback was allowlisted, two non-streaming requests (flex, priority) plus one streaming flex request:

```
litellm_request_total_latency_metric_count{...,service_tier="flex",...} 2.0
litellm_request_total_latency_metric_sum{...,service_tier="flex",...} 5.654654
litellm_request_total_latency_metric_count{...,service_tier="priority",...} 1.0
litellm_request_total_latency_metric_sum{...,service_tier="priority",...} 1.004726
litellm_spend_metric_total{...,service_tier="flex",...} 0.00035500000000000006
litellm_spend_metric_total{...,service_tier="priority",...} 0.00037
litellm_llm_api_time_to_first_token_metric_count{...,service_tier="flex",...} 1.0
```

The streaming request still carries the label: its tier comes from the request, which the allowlist admits


### Unrecognized tiers do not mint series

A requested tier is caller-controlled and survives param mapping even where the provider ignores it, so it is only labelled when it names a tier providers accept. OpenAI rejects an unknown value outright:

```bash
$ curl -s -w 'http_status=%{http_code}\n' http://127.0.0.1:4296/v1/chat/completions \
    -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
    -d '{"model":"gpt-5.6","service_tier":"attacker-controlled-a1b2c3","messages":[{"role":"user","content":"hi"}]}'
http_status=400
litellm.BadRequestError: OpenAIException - Invalid value: 'att...2c3'. Supported values are: 'auto', 'default', 'flex', and 'priority'.

$ curl -sL http://127.0.0.1:4296/metrics -H "Authorization: Bearer $LITELLM_MASTER_KEY" | grep -c 'attacker-controlled-a1b2c3'
0
```

Bedrock and Groq do not; they accept the request and drop the unrecognized tier, and the raw string reaches `model_parameters`:

```
$ get_optional_params(model="anthropic.claude-sonnet-4-20250514-v1:0", custom_llm_provider="bedrock_converse", service_tier="bogus-x1y2")
service_tier in optional_params: 'bogus-x1y2'
```

That is why the fallback is allowlisted. Tiers a provider itself reports stay unrestricted, so a tier added by a provider after this release is still labelled rather than dropped

### Preserving the historical label set

An operator who wants a metric to keep its pre-change label set can pin it, no new flag needed:

```yaml
litellm_settings:
  prometheus_metrics_config:
    - group: "historical_latency_schema"
      metrics: ["litellm_request_total_latency_metric"]
      include_labels: ["end_user", "hashed_api_key", "api_key_alias", "requested_model",
                       "team", "team_alias", "user", "model", "model_id", "api_provider"]
```

```
litellm_request_total_latency_metric_count{api_key_alias="None",api_provider="openai",end_user="None",hashed_api_key="litellm_proxy_master_key",model="gpt-5.6",model_id="7bf634...",requested_model="gpt-5.6",team="None",team_alias="None",user="default_user_id"} 1.0
```

## Type

🆕 New Feature

## Changes

`service_tier` is added to `litellm_llm_api_latency_metric`, `litellm_llm_api_time_to_first_token_metric`, `litellm_request_total_latency_metric` and `litellm_spend_metric`. The value is resolved once per request on the success path from the standard logging payload, preferring the tier the provider reports it served (top level of the response for OpenAI, Bedrock and Groq; the usage object for Anthropic) and falling back to the tier the caller requested, which is what covers streaming responses that carry no served tier. That fallback is caller-controlled, so it is allowlisted to the tiers providers accept (`auto`, `batch`, `default`, `flex`, `priority`, `scale`, `standard`, `standard_only`); provider-reported tiers stay unrestricted so a tier added later still labels correctly. A request that names no recognized tier and gets none back is labelled empty, like every other unset label

Queue time and the two overhead latency metrics are deliberately left alone: they measure work inside LiteLLM before or around the provider call, so the provider's tier does not explain their value

Tests are in `tests/test_litellm/integrations/test_prometheus_service_tier_label.py`: label declaration on each of the four metrics, the served-over-requested precedence and its fallbacks, and an end-to-end pass through `async_log_success_event` asserting the collected samples carry `service_tier="flex"`. Three mutations were checked against them: dropping the label declarations fails 3 tests, dropping the value assignment fails the end-to-end test, and inverting the precedence fails 3 tests. The exact-label assertions in the enterprise callback tests are updated for the added label

Docs for the four metrics' label sets are updated in BerriAI/litellm-docs

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
