### PR TITLE
fix(ui): add missing cost-optimization page description on rc/1.94.0

### DIFF
--- a/ui/litellm-dashboard/src/components/page_metadata.ts
+++ b/ui/litellm-dashboard/src/components/page_metadata.ts
@@ -19,6 +19,7 @@ export const pageDescriptions: Record<string, string> = {
   "tool-policies": "Configure tool use policies and permissions",
   "vector-stores": "Manage vector databases for embeddings",
   new_usage: "View usage analytics and metrics",
+  "cost-optimization": "Track and configure cost-saving features: prompt compression, caching, and auto routing",
   logs: "Access request and response logs",
   "guardrails-monitor": "Monitor guardrail performance and view logs",
   users: "Manage internal user accounts and permissions",


### PR DESCRIPTION
`ui/litellm-dashboard/src/components/page_utils.test.ts` fails two assertions on a pristine `rc/1.94.0` checkout. The cost-optimization page was backported onto this line with its leftnav entry in `leftnav.tsx` but without its matching entry in `page_metadata.ts`, so it resolves to the `"No description available"` placeholder and lands in `missingDescriptions`

```
× should have descriptions for all pages
  → Page "cost-optimization" should not have placeholder description
× should have pageDescriptions entry for all navigable pages in menuGroups
  → These pages are missing descriptions in page_metadata.ts: cost-optimization
```

The fix restores the entry verbatim from `litellm_internal_staging`, which makes `page_metadata.ts` byte-identical to staging. The description mentions prompt compression, caching and auto routing, and all three tabs are genuinely present on this line: `PromptCompressionTab.tsx`, `PromptCachingTab.tsx` and `AutorouterTab.tsx`. In fact the whole `cost-optimization/_components/` file set matches staging, so the wording is accurate here and not aspirational

Pre-existing on the line and unrelated to #34964, which deliberately left it alone

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

No new test here on purpose. `page_utils.test.ts` already is the regression guard for exactly this class of bug: it walks every navigable page in `menuGroups` and fails when one has no real description. It caught this correctly, it was red before the change and green after, and a second test asserting the same thing would add no signal. The gap was that nobody ran it on this branch, not that the coverage was missing

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Red before, green after, captured on this branch. Baseline at pristine `rc/1.94.0` (47eae0d23e):

```
$ cd ui/litellm-dashboard && npx vitest run src/components/page_utils.test.ts

 ❯ src/components/page_utils.test.ts (9 tests | 2 failed) 9ms
   × should have descriptions for all pages
     → Page "cost-optimization" should not have placeholder description: expected 'No description available' not to be 'No description available'
   × should have pageDescriptions entry for all navigable pages in menuGroups
     → These pages are missing descriptions in page_metadata.ts: cost-optimization: expected [ 'cost-optimization' ] to have a length of +0 but got 1

 Test Files  1 failed (1)
      Tests  2 failed | 7 passed (9)
```

After the one-line change, same command:

```
 ✓ src/components/page_utils.test.ts (9 tests) 4ms

 Test Files  1 passed (1)
      Tests  9 passed (9)
```

Full dashboard suite, before and after, to show nothing else moved:

```
before:  Test Files  1 failed | 484 passed (485)
              Tests  2 failed | 4885 passed (4887)

after:   Test Files  485 passed (485)
              Tests  4887 passed (4887)
```

The two baseline failures flip to passes and nothing else changes

Visible effect in the product: go to http://localhost:4000/ui/?page=settings, open the page-visibility settings, and the Cost Optimization row now reads "Track and configure cost-saving features: prompt compression, caching, and auto routing" instead of "No description available"

## Type

🐛 Bug Fix

## Changes

One line in `ui/litellm-dashboard/src/components/page_metadata.ts`, adding the `cost-optimization` key to `pageDescriptions` in the same position staging has it, between `new_usage` and `logs`

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
