### PR TITLE
fix(e2e): poll for both spend rows before asserting the cache-hit contract

### DIFF
--- a/tests/e2e/quota_management/spend_tracking/test_spend_tracking_e2e.py
+++ b/tests/e2e/quota_management/spend_tracking/test_spend_tracking_e2e.py
@@ -230,7 +230,9 @@ def test_cache_hit_is_zero_cost_and_suffixed(
     _ = unwrap(client.chat(scoped_key, "gemini-2.5-flash", prompt, max_tokens=16))
 
     rows = client.poll_logs_for_key(
-        scoped_key, predicate=lambda rs: any(r.cache_hit == "True" for r in rs)
+        scoped_key,
+        predicate=lambda rs: any(r.cache_hit == "True" for r in rs)
+        and any(r.cache_hit != "True" for r in rs),
     )
     cache_row = _require_row(
         rows,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cache-hit spend e2e flakes on multi-pod stage
- Poll stopped on the cache-hit row before the paid row flushed

How it solves it:

- Poll predicate now requires both row kinds before stopping

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (stage e2e run of 2026-07-28 14:28 UTC): the test failed with `AssertionError: the non-cached call should still be charged` and the failure output shows exactly one spend-log row, the zero-cost `_cache_hit` row; the paid row for the first call had not flushed yet. The two driver calls round-robin onto different gateway pods and each pod batches SpendLogs writes on its own `update_spend` interval timer, so the two rows land in the DB on independent clocks. The poll's predicate was satisfied by the cache-hit row alone, so whenever the hit-serving pod's timer fired first the test asserted against a half-arrived result set

After (this branch): the poll keeps waiting until the result set contains both a cache-hit row and a non-cache-hit row, so the existing 120s deadline absorbs whichever pod flushes slower. No assertion is weakened; a cache hit that gets charged, a missing `_cache_hit` suffix, or a paid row that never lands (now a poll timeout instead of an instant false negative) all still fail. The next scheduled stage e2e run is the live proof; the 14:28 UTC run is the failing baseline

## Type

🐛 Bug Fix

## Changes

tests/e2e/quota_management/spend_tracking/test_spend_tracking_e2e.py: the `poll_logs_for_key` predicate for test_cache_hit_is_zero_cost_and_suffixed now requires `any(cache_hit == "True")` and `any(cache_hit != "True")` instead of the cache-hit row alone

## QA runbook

- tests/e2e/quota_management/spend_tracking/test_spend_tracking_e2e.py::test_cache_hit_is_zero_cost_and_suffixed - a repeated identical call hits the response cache, is billed zero, and gets the _cache_hit request_id suffix while the original call is still charged
  - [ ] Send the same uniquely marked chat completion twice with one key; the first is a paid cache miss, the second a cache hit
  - [ ] Poll the key's spend logs until the result set contains both a cache_hit=True row and a non-cache-hit row, since the two rows flush from different pods on independent update_spend timers
  - [ ] Expect the cache-hit row to have zero spend and a request_id carrying the _cache_hit suffix, and the paid row to have spend greater than zero
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
