### PR TITLE
fix(e2e/ui): seed the role users via API in global setup

### DIFF
--- a/tests/e2e/ui/fixtures/users.ts
+++ b/tests/e2e/ui/fixtures/users.ts
@@ -39,6 +39,13 @@ export const users: Record<Role, { email: string; password: string }> = {
 
 // Re-exported from constants so the paths have one definition; they must honor
 // ARTIFACT_DIR, since the suite runs from a read-only cwd in the e2e image.
+export const DB_ROLE_USERS: ReadonlyArray<{ role: Role; userId: string; dbRole: string }> = [
+  { role: Role.ProxyAdminViewer, userId: "e2e-admin-viewer", dbRole: "proxy_admin_viewer" },
+  { role: Role.InternalUser, userId: "e2e-internal-user", dbRole: "internal_user" },
+  { role: Role.InternalUserViewer, userId: "e2e-internal-viewer", dbRole: "internal_user_viewer" },
+  { role: Role.TeamAdmin, userId: "e2e-team-admin", dbRole: "internal_user" },
+];
+
 export const STORAGE_PATHS: Record<Role, string> = {
   [Role.ProxyAdmin]: ADMIN_STORAGE_PATH,
   [Role.ProxyAdminViewer]: ADMIN_VIEWER_STORAGE_PATH,

--- a/tests/e2e/ui/globalSetup.ts
+++ b/tests/e2e/ui/globalSetup.ts
@@ -24,7 +24,7 @@ async function ensureDbRoleUser(
   });
   if (created.ok()) return;
   const body = await created.text();
-  if (created.status() === 400 && body.includes("already exists")) {
+  if ((created.status() === 409 || created.status() === 400) && body.includes("already exists")) {
     const updated = await api.post(`${baseUrl}/user/update`, {
       headers: auth,
       data: { user_id: entry.userId, user_role: entry.dbRole, password },

--- a/tests/e2e/ui/globalSetup.ts
+++ b/tests/e2e/ui/globalSetup.ts
@@ -1,8 +1,43 @@
-import { chromium, expect, request } from "@playwright/test";
-import { users, Role, STORAGE_PATHS } from "./fixtures/users";
+import { chromium, expect, request, APIRequestContext } from "@playwright/test";
+import { users, Role, STORAGE_PATHS, DB_ROLE_USERS } from "./fixtures/users";
 import { ARTIFACT_DIR, UI_BASE_URL } from "./constants";
 import * as fs from "fs";
 import * as path from "path";
+
+async function ensureDbRoleUser(
+  api: APIRequestContext,
+  baseUrl: string,
+  masterKey: string,
+  entry: { role: Role; userId: string; dbRole: string },
+): Promise<void> {
+  const { email, password } = users[entry.role];
+  const auth = { Authorization: `Bearer ${masterKey}` };
+  const created = await api.post(`${baseUrl}/user/new`, {
+    headers: auth,
+    data: {
+      user_id: entry.userId,
+      user_email: email,
+      user_role: entry.dbRole,
+      password,
+      auto_create_key: false,
+    },
+  });
+  if (created.ok()) return;
+  const body = await created.text();
+  if (created.status() === 400 && body.includes("already exists")) {
+    const updated = await api.post(`${baseUrl}/user/update`, {
+      headers: auth,
+      data: { user_id: entry.userId, user_role: entry.dbRole, password },
+    });
+    if (!updated.ok()) {
+      throw new Error(
+        `Ensuring UI role user ${entry.userId} failed on /user/update (${updated.status()}): ${await updated.text()}`,
+      );
+    }
+    return;
+  }
+  throw new Error(`Ensuring UI role user ${entry.userId} failed on /user/new (${created.status()}): ${body}`);
+}
 
 async function globalSetup() {
   const browser = await chromium.launch();
@@ -28,6 +63,9 @@ async function globalSetup() {
   });
   if (!settingsRes.ok()) {
     throw new Error(`Enabling enable_projects_ui failed (${settingsRes.status()}): ${await settingsRes.text()}`);
+  }
+  for (const entry of DB_ROLE_USERS) {
+    await ensureDbRoleUser(api, `${UI_BASE_URL}${rootPath}`, masterKey, entry);
   }
   await api.dispose();
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Playwright UI suite dies in global setup on stage, every run
- Role users only exist in seed.sql; stage DB never seeded

How it solves it:

- Global setup ensures each role user via /user/new
- Falls back to /user/update when the row already exists

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (stage e2e run of 2026-07-28, from the live pod and backend logs): global setup logged in `proxy_admin` fine at 14:28:15 (`POST /v2/login 200`; master-key login needs no DB row), then the `proxy_admin_viewer` login got `POST /v2/login 401` at 14:28:18 with the backend raising the no-row branch of `authenticate_user` ("Invalid credentials used to access UI. Check 'UI_USERNAME', 'UI_PASSWORD'", litellm/proxy/auth/login_utils.py:311; the row-exists-wrong-password branch has a different message, so the user provably does not exist). The page stayed on /ui/login, `waitForURL` timed out after 30s, and playwright exited 1 with zero UI tests run; the same failure appears in every stage run on record because `fixtures/seed.sql` only ever runs in the local runner's throwaway postgres (run_e2e.sh:185-186), never against the shared stage DB

After (this branch at 462f3d8435): global setup creates each DB-backed role user through the management API with the master key before the login loop, using the same authenticated-request pattern the file already uses for `/update/ui_settings`. It is idempotent: a 409 "already exists" (rerun on stage, or the seeded local DB) falls through to `/user/update` enforcing the expected password and role, so stale or half-seeded rows also converge. Verified locally with `tsc --noEmit`; the live proof is the next scheduled stage run reaching past global setup, with the current run as the failing baseline

Note on scope: this unblocks login and the storageState snapshots for all five roles. UI tests that additionally assume seed.sql's teams and orgs may surface their own gaps on stage once the suite actually runs; those have never executed against the shared gateway before

## Type

🐛 Bug Fix

## Changes

tests/e2e/ui/fixtures/users.ts adds DB_ROLE_USERS, the four DB-backed login roles with their stable user ids and DB roles mirroring seed.sql (note teamadmin's DB role is internal_user; its team-admin nature comes from team membership, which login does not need)

tests/e2e/ui/globalSetup.ts adds ensureDbRoleUser (create via /user/new with auto_create_key false, update on "already exists", loud failure otherwise) and calls it for each DB_ROLE_USERS entry before the per-role login loop

## QA runbook

- tests/e2e/ui/globalSetup.ts (global setup, runs before every UI test) - all five UI roles can log in against a database nobody pre-seeded
  - [ ] With only the master key configured, run the playwright suite against a proxy whose DB has no e2e users
  - [ ] Global setup first enables enable_projects_ui, then creates the four DB-backed role users via /user/new with their fixture emails, passwords, and DB roles
  - [ ] Each role then logs in through /ui/login and lands on the dashboard with the Virtual Keys link visible, and its storageState snapshot is written
  - [ ] Rerun the suite against the now-populated DB and expect the "already exists" path to update the users instead of failing setup
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
