### PR TITLE
test(e2e): skip passthrough headers test until stage can route custom paths to provider creds

### DIFF
--- a/tests/e2e/llm_translation/test_passthrough_headers_e2e.py
+++ b/tests/e2e/llm_translation/test_passthrough_headers_e2e.py
@@ -96,6 +96,11 @@ def _messages_body() -> AnthropicMessagesBody:
 
 
 class TestPassthroughHeaders:
+    @pytest.mark.skip(
+        reason="stage red: ALB sends custom passthrough paths to backend pods, which lack ANTHROPIC_API_KEY, "
+        "so the os.environ header forwards unresolved and Anthropic 401s; routing user-defined paths to the "
+        "gateway needs a product/infra decision (fixed path namespace or dynamic ingress)"
+    )
     @pytest.mark.covers(
         "other.config.passthrough.headers_forwarded",
         exercised_on=[],


### PR DESCRIPTION
## TLDR

Problem this solves:

- passthrough headers e2e test fails every stage run
- stage ALB sends custom passthrough paths to backend pods
- backend pods lack ANTHROPIC_API_KEY, so the configured header forwards unresolved

How it solves it:

- skips the test with a reason naming the infra gap
- unskip once custom passthrough routing through the gateway is decided

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (stage e2e run, pod litellm-e2e-1-0-0-main-20260728124622, finished 2026-07-28 14:28 UTC, pre-fix tip of litellm_internal_staging):

```
FAILED llm_translation/test_passthrough_headers_e2e.py::TestPassthroughHeaders::test_static_and_x_pass_headers_reach_upstream
= 6 failed, 411 passed, 31 skipped, 2 deselected, 13 warnings in 6022.63s (1:40:22) =
```

After (at 6888df6340), the test no longer executes and reports the reason instead:

```
$ python -m pytest llm_translation/test_passthrough_headers_e2e.py -rs -q
SKIPPED [1] llm_translation/test_passthrough_headers_e2e.py:99: stage red: ALB sends custom passthrough paths to backend pods, which lack ANTHROPIC_API_KEY, so the os.environ header forwards unresolved and Anthropic 401s; routing user-defined paths to the gateway needs a product/infra decision (fixed path namespace or dynamic ingress)
1 skipped in 0.01s
```

The real proof is the next stage e2e run after merge: this test moves from the failed column to the skipped column

## Type

✅ Test

## Changes

The stage ALB path-splits traffic: /v1/messages and /chat/completions go to gateway pods while everything else, including user-defined custom passthrough routes, lands on backend pods. Backend pods do not carry ANTHROPIC_API_KEY, so the endpoint's configured `x-api-key: os.environ/ANTHROPIC_API_KEY` header forwards as the literal placeholder and Anthropic returns 401. This is the same root cause that broke the a2a suite, but a2a lives under a fixed `/a2a` prefix so the ingress could simply route it to the gateway; custom passthrough paths are arbitrary user-defined strings, so routing them to the gateway needs a way for users to declare those paths and for the ingress to pick them up dynamically (or a fixed path namespace), which is a product/infra decision to make separately

Until that lands, the test is skipped with a reason naming the gap, following the existing "stage red:" convention already used in the claude_code suites. Coverage for the `other.config.passthrough.headers_forwarded` registry cell is paused, so it surfaces on the dashboard as an uncovered row instead of a permanently red run

## QA runbook

- tests/e2e/llm_translation/test_passthrough_headers_e2e.py::TestPassthroughHeaders::test_static_and_x_pass_headers_reach_upstream is now skipped everywhere. Running the llm_translation suite shows it reported as skipped with the "stage red:" reason before any fixture or network call runs, and the next stage e2e run should drop from 6 failures to 5 with this test in the skipped column
  - [ ] Sanity check: the skip reason names the exact infra gap so it reads as a deliberate pause, and the test body is unchanged so unskipping restores full coverage

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
