### PR TITLE
feat(ui): mark Cost Optimization as beta in the left nav

### DIFF
--- a/ui/litellm-dashboard/src/components/leftnav.test.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.test.tsx
@@ -237,6 +237,24 @@ describe("Sidebar (leftnav)", () => {
     expect(link!.querySelector("svg")).not.toBeNull();
     expect(label).toHaveClass("group-data-[collapsed=true]/sidebar:hidden");
   });
+
+  it("shows Cost Optimization with a Beta badge and no feature-flag gate", () => {
+    const { container } = renderWithProviders(<Sidebar {...defaultProps} enableProjectsUI={false} />);
+
+    const costOptimization = container.querySelector('a[href*="cost-optimization"]');
+    expect(costOptimization).not.toBeNull();
+    expect(costOptimization!.textContent).toContain("Cost Optimization");
+    expect(costOptimization!.textContent).toContain("Beta");
+
+    expect(container.querySelector('a[href*="projects"]')).toBeNull();
+  });
+
+  it("keeps a readable collapsed-rail tooltip for items whose label carries a badge", () => {
+    const { container } = renderWithProviders(<Sidebar {...defaultProps} enableProjectsUI collapsed />);
+
+    expect(container.querySelector('a[href*="cost-optimization"]')).toHaveAttribute("title", "Cost Optimization");
+    expect(container.querySelector('a[href*="projects"]')).toHaveAttribute("title", "Projects");
+  });
 });
 
 describe("getBreadcrumb", () => {

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -187,7 +187,11 @@ const menuGroups: MenuGroup[] = [
         page: "cost-optimization",
         icon: <PiggyBank {...ICON} />,
         roles: [...all_admin_roles, ...internalUserRoles],
-        label: "Cost Optimization",
+        label: (
+          <span className="flex items-center gap-2">
+            Cost Optimization <BetaBadge />
+          </span>
+        ),
       },
       { key: "logs", page: "logs", label: "Logs", icon: <Activity {...ICON} /> },
       {
@@ -354,8 +358,6 @@ const findMenuItemKey = (page: string): string => {
   return "api-keys";
 };
 
-const labelText = (item: MenuItem): string => (typeof item.label === "string" ? item.label : item.key);
-
 const SECTION_DISPLAY: Record<string, string> = {
   "AI GATEWAY": "AI Gateway",
   OBSERVABILITY: "Observability",
@@ -369,6 +371,8 @@ const prettify = (key: string): string =>
     .split(/[-_]/)
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(" ");
+
+const labelText = (item: MenuItem): string => (typeof item.label === "string" ? item.label : prettify(item.key));
 
 // Breadcrumb ("Section" / "Page") for the top bar, derived from the same nav config.
 export const getBreadcrumb = (page: string): { section: string | null; title: string } => {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cost Optimization is new but the nav doesn't say so
- Badge-labeled nav items lose their collapsed-rail tooltip

How it solves it:

- Reuses the same `BetaBadge` label Projects already renders
- Tooltip fallback now prettifies the key instead of showing it raw

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

## Type

🆕 New Feature

## Changes

The Cost Optimization item in the left nav now carries the same Beta badge Projects uses, so its label goes from a plain string to a `<span>` wrapping the text plus `<BetaBadge />`. Unlike Projects there is no feature flag involved; Cost Optimization keeps showing for every role that could already see it (proxy admins, admin viewers, internal users)

That string-to-JSX switch has a side effect worth calling out. `labelText()` builds the `title` tooltip shown when the sidebar is collapsed to the icon rail, and its fallback for a non-string label was the raw menu key, so Cost Optimization would have shown "cost-optimization" and Projects has been showing "projects" for a while now. The fallback now runs the key through `prettify()`, which is exactly what `getBreadcrumb()` two functions below already does, so both items read properly in the rail

Two tests cover this. One asserts the Cost Optimization link renders both its text and the Beta badge while Projects stays hidden with its flag off, which pins the "no flag for this one" behavior. The other asserts the collapsed tooltip for both badge-labeled items. Reverting either source change turns exactly those two red

<img width="302" height="124" alt="image" src="https://github.com/user-attachments/assets/b3461cee-542a-4272-873d-ce8a676f5637" />


## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
