### PR TITLE
feat(ui): mark Cost Optimization as beta in the left nav (#34984)

### DIFF
--- a/ui/litellm-dashboard/src/components/leftnav.test.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.test.tsx
@@ -237,6 +237,24 @@ describe("Sidebar (leftnav)", () => {
     expect(link!.querySelector("svg")).not.toBeNull();
     expect(label).toHaveClass("group-data-[collapsed=true]/sidebar:hidden");
   });
+
+  it("shows Cost Optimization with a Beta badge and no feature-flag gate", () => {
+    const { container } = renderWithProviders(<Sidebar {...defaultProps} enableProjectsUI={false} />);
+
+    const costOptimization = container.querySelector('a[href*="cost-optimization"]');
+    expect(costOptimization).not.toBeNull();
+    expect(costOptimization!.textContent).toContain("Cost Optimization");
+    expect(costOptimization!.textContent).toContain("Beta");
+
+    expect(container.querySelector('a[href*="projects"]')).toBeNull();
+  });
+
+  it("keeps a readable collapsed-rail tooltip for items whose label carries a badge", () => {
+    const { container } = renderWithProviders(<Sidebar {...defaultProps} enableProjectsUI collapsed />);
+
+    expect(container.querySelector('a[href*="cost-optimization"]')).toHaveAttribute("title", "Cost Optimization");
+    expect(container.querySelector('a[href*="projects"]')).toHaveAttribute("title", "Projects");
+  });
 });
 
 describe("getBreadcrumb", () => {

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -187,7 +187,11 @@ const menuGroups: MenuGroup[] = [
         page: "cost-optimization",
         icon: <PiggyBank {...ICON} />,
         roles: [...all_admin_roles, ...internalUserRoles],
-        label: "Cost Optimization",
+        label: (
+          <span className="flex items-center gap-2">
+            Cost Optimization <BetaBadge />
+          </span>
+        ),
       },
       { key: "logs", page: "logs", label: "Logs", icon: <Activity {...ICON} /> },
       {
@@ -348,8 +352,6 @@ const findMenuItemKey = (page: string): string => {
   return "api-keys";
 };
 
-const labelText = (item: MenuItem): string => (typeof item.label === "string" ? item.label : item.key);
-
 const SECTION_DISPLAY: Record<string, string> = {
   "AI GATEWAY": "AI Gateway",
   OBSERVABILITY: "Observability",
@@ -363,6 +365,8 @@ const prettify = (key: string): string =>
     .split(/[-_]/)
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(" ");
+
+const labelText = (item: MenuItem): string => (typeof item.label === "string" ? item.label : prettify(item.key));
 
 // Breadcrumb ("Section" / "Page") for the top bar, derived from the same nav config.
 export const getBreadcrumb = (page: string): { section: string | null; title: string } => {


### PR DESCRIPTION
Cherry-pick of #34984 onto `rc/1.94.0`, picked with `-x` from `f4a68a75ff4afa946e1e9f94d003ad0a7d41eb08`

The pick applied cleanly (auto-merge on `leftnav.tsx`, no conflicts) and is byte-for-byte the upstream change; `git patch-id --stable` is `fc05e4ae2193f202b78a6e4131f4bbc8fe7d4e91` on both the staging commit and this one

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

To capture at `3db78a88ed`, with the dashboard dev server pointed at a local proxy:

1. `npm run dev` in `ui/litellm-dashboard`, then open http://localhost:3000/ui/ and sign in as a proxy admin
2. In the left nav under AI Gateway, Cost Optimization should read "Cost Optimization" followed by the same grey Beta pill that Projects carries
3. Collapse the sidebar to the icon rail and hover the Cost Optimization icon; the native tooltip should read "Cost Optimization", not "cost-optimization". With `enableProjectsUI` on, hovering Projects should read "Projects", not "projects"

## Type

🆕 New Feature

## Changes

Everything in the picked commit already applied on this line: `rc/1.94.0` carries `BetaBadge` (from #33449), the `cost-optimization` nav entry, and the `labelText` / `prettify` pair the change reorders, so nothing had to be adapted

The Cost Optimization nav item gains the Beta badge Projects already renders, which turns its `label` from a plain string into JSX. Because `labelText()` fell back to the raw menu key for non-string labels, that switch would have made the collapsed-rail tooltip read "cost-optimization"; the fallback now runs the key through `prettify()`, the same helper `getBreadcrumb()` uses, which also fixes Projects showing "projects" in the rail on this line today

Verification on `rc/1.94.0`: `npx vitest run src/components/leftnav.test.tsx` is 15 passed. Reverting only `leftnav.tsx` back to the rc parent, keeping the new tests, turns exactly the two new tests red ("expected 'Cost Optimization' to contain 'Beta'" and the collapsed-tooltip assertion) at 2 failed / 13 passed, then green again once the source is restored. `prettier --check` passes on both files and `eslint` reports 0 errors on them

One thing to be aware of for the release: this changes dashboard source only, so the committed bundle under `litellm/proxy/_experimental/out/` on `rc/1.94.0` will not show the badge until the UI build is re-run for this line

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
