### PR TITLE
fix: map verbosity to text.verbosity in chat-to-Responses API bridge

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -5,6 +5,7 @@ Handler for transforming /chat/completions api requests to litellm.responses req
 import json
 import os
 from typing import (
+    Mapping,
     TYPE_CHECKING,
     Any,
     AsyncIterator,
@@ -43,6 +44,7 @@ from litellm.types.llms.openai import (
     Reasoning,
     ResponsesAPIOptionalRequestParams,
     ResponsesAPIStreamEvents,
+    ResponseText,
 )
 from litellm.types.utils import GenericStreamingChunk, ModelResponseStream
 
@@ -298,6 +300,18 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
         return input_items, instructions
 
+    @staticmethod
+    def _merge_text_param(existing_text: Mapping[str, Any] | None, updates: Mapping[str, Any]) -> "ResponseText":
+        """Merge updates into the Responses API ``text`` param.
+
+        ``response_format`` writes ``text.format`` and ``verbosity`` writes
+        ``text.verbosity``; merging keeps both regardless of the order the
+        optional params are processed in.
+        """
+        merged = dict(existing_text or {})  # mutable-ok: shallow merge of the two text-param writers
+        merged.update(updates)
+        return cast("ResponseText", merged)  # cast-ok: format/verbosity are disjoint ResponseText keys
+
     def _map_optional_params_to_responses_api_request(
         self,
         optional_params: dict,
@@ -316,7 +330,15 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             elif key == "response_format":
                 text_format = self._transform_response_format_to_text_format(value)
                 if text_format:
-                    responses_api_request["text"] = text_format  # type: ignore
+                    responses_api_request["text"] = self._merge_text_param(
+                        responses_api_request.get("text"), text_format
+                    )
+            elif key == "verbosity":
+                # Chat Completions `verbosity` maps to `text.verbosity` on the
+                # Responses API.
+                responses_api_request["text"] = self._merge_text_param(
+                    responses_api_request.get("text"), {"verbosity": value}
+                )
             elif key == "tool_choice":
                 responses_api_request["tool_choice"] = (  # type: ignore[assignment]
                     self._normalize_tool_choice_for_responses_api(value)

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -2962,3 +2962,51 @@ async def test_acompletion_bridge_normalizes_stream_options_on_the_wire(
         assert "stream_options" not in request_body
     else:
         assert request_body["stream_options"] == expected_wire_stream_options
+
+
+def test_map_optional_params_verbosity_maps_to_text_verbosity():
+    """Chat Completions `verbosity` must map to Responses API `text.verbosity`.
+
+    Regression test: previously the chat->Responses bridge silently dropped
+    `verbosity`, so GPT-5.x + tools requests (which litellm routes through
+    /responses) always ran at the provider's default verbosity.
+    """
+    handler = LiteLLMResponsesTransformationHandler()
+
+    responses_api_request: dict = {}
+    handler._map_optional_params_to_responses_api_request(
+        optional_params={"verbosity": "low"},
+        responses_api_request=responses_api_request,  # pyright: ignore[reportArgumentType]  # plain dict stands in for the TypedDict in tests
+    )
+
+    assert responses_api_request["text"] == {"verbosity": "low"}
+
+
+def test_map_optional_params_verbosity_merges_with_response_format():
+    """`verbosity` and `response_format` both write text.* — neither may clobber
+    the other, in either iteration order."""
+    handler = LiteLLMResponsesTransformationHandler()
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "out",
+            "schema": {"type": "object", "properties": {"a": {"type": "string"}}},
+        },
+    }
+
+    # verbosity first, response_format second
+    request_a: dict = {}
+    handler._map_optional_params_to_responses_api_request(
+        optional_params={"verbosity": "high", "response_format": response_format},
+        responses_api_request=request_a,  # pyright: ignore[reportArgumentType]  # plain dict stands in for the TypedDict in tests
+    )
+    # response_format first, verbosity second
+    request_b: dict = {}
+    handler._map_optional_params_to_responses_api_request(
+        optional_params={"response_format": response_format, "verbosity": "high"},
+        responses_api_request=request_b,  # pyright: ignore[reportArgumentType]  # plain dict stands in for the TypedDict in tests
+    )
+
+    for request in (request_a, request_b):
+        assert request["text"]["verbosity"] == "high"
+        assert request["text"]["format"]["type"] == "json_schema"


### PR DESCRIPTION
## Title

fix: map `verbosity` to `text.verbosity` in the chat→Responses API bridge

## Relevant issues

Related to the `verbosity` support added in #16660 (Chat Completions path).

## Pre-Submission checklist

- [x] I have Added testing in the `tests/test_litellm/` directory
- [x] I have added a screenshot of my new test passing locally
- [x] My PR passes all unit tests on `make test-unit`
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`litellm.completion()` accepts `verbosity` for GPT-5 family models (added in #16660), but when the request is routed through the **Responses API** — which happens automatically for gpt-5.x models when `tools` are attached — the chat→Responses transformation (`_map_optional_params_to_responses_api_request`) maps `reasoning_effort` → `reasoning` while silently dropping `verbosity`. The provider then runs at its default verbosity with no error or warning.

Repro (any recent litellm, e.g. 1.93.0):

```python
litellm.completion(
    model="openai/gpt-5.4",
    messages=[{"role": "user", "content": "hi"}],
    tools=[...],                       # forces the /responses route
    reasoning_effort="low",            # arrives as reasoning={'effort': 'low'}  ✅
    verbosity="low",                   # silently dropped                        ❌
)
```

The outbound `/responses` body contains `"reasoning": {"effort": "low"}` but no `text.verbosity`; OpenAI's response echoes `"verbosity": "medium"` (its default).

This PR maps `verbosity` → `text.verbosity`, merging with the `text.format` that `response_format` may also write so neither param clobbers the other in either iteration order (both branches now merge into any existing `text` value).

Two regression tests added: plain mapping, and the merge with `response_format` in both orderings.

```
tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py::test_map_optional_params_verbosity_maps_to_text_verbosity PASSED
tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py::test_map_optional_params_verbosity_merges_with_response_format PASSED
```
