### PR TITLE
fix(spend-tracking): coerce None api_key to empty string

### DIFF
--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -282,7 +282,14 @@ def get_logging_payload(kwargs, response_obj, start_time, end_time) -> SpendLogs
 
     end_user_id = get_end_user_id_for_cost_tracking(litellm_params)
 
-    api_key = metadata.get("user_api_key", "")
+    # `metadata.get("user_api_key", "")` returns `None` when the key exists
+    # but its value is `None` (e.g. unauthenticated requests that fail auth
+    # before a key is resolved — the auth-exception handler fabricates a
+    # synthetic user record with `api_key=None`). Coerce `None` to "" here
+    # so downstream `or`-chaining and the final `str(api_key)` coercion in
+    # `SpendLogsPayload` don't end up storing the literal string "None".
+    raw_api_key = metadata.get("user_api_key")
+    api_key = raw_api_key if raw_api_key is not None else ""
 
     standard_logging_prompt_tokens: int = 0
     standard_logging_completion_tokens: int = 0
@@ -416,7 +423,7 @@ def get_logging_payload(kwargs, response_obj, start_time, end_time) -> SpendLogs
         payload: SpendLogsPayload = SpendLogsPayload(
             request_id=str(id),
             call_type=call_type or "",
-            api_key=str(api_key),
+            api_key=str(api_key) if api_key is not None else "",
             cache_hit=str(cache_hit),
             startTime=_ensure_datetime_utc(start_time),
             endTime=_ensure_datetime_utc(end_time),

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -2902,3 +2902,118 @@ async def test_compression_savings_survive_to_spend_log_payload_metadata(monkeyp
         "tokens_saved": 7000,
         "source": "compression_interception",
     }
+
+
+def test_get_logging_payload_unauthenticated_request_does_not_store_string_none():
+    """Regression for unauthenticated-request spend-log bug.
+
+    When a request reaches an LLM-API route without an Authorization header,
+    the auth-exception handler fabricates a synthetic UserAPIKeyAuth with
+    `api_key=None`. The failure hook then seeds
+    `metadata["user_api_key"] = None`. Prior to the fix, this None propagated
+    through to `SpendLogsPayload.api_key = str(None)`, producing the literal
+    four-character string "None" in the database. This makes the row
+    un-joinable to `LiteLLM_VerificationToken` and pollutes downstream
+    analysis with noise rows that look like real keys.
+
+    The fix coerces None to "" at both the read site (so downstream `or`
+    chains behave) and at the SpendLogsPayload call site (defense in depth).
+    """
+    kwargs = {
+        "model": "openai/gpt-4.1",
+        "call_type": "acompletion",
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": None,  # synthesized by auth_exception_handler
+                "user_api_key_user_id": "test_user",
+                "user_api_key_team_id": "test_team",
+                "status": "failure",
+            }
+        },
+    }
+
+    payload = get_logging_payload(
+        kwargs=kwargs,
+        response_obj=Exception("No api key passed in."),
+        start_time=datetime.datetime.now(timezone.utc),
+        end_time=datetime.datetime.now(timezone.utc),
+    )
+
+    # The bug: api_key column held the literal string "None".
+    # The fix: api_key column holds empty string.
+    assert payload["api_key"] == "", (
+        f"Expected empty string for unauthenticated request, "
+        f"got api_key={payload['api_key']!r}"
+    )
+    assert payload["api_key"] != "None", (
+        "Regression: api_key='None' string leaked into spend log"
+    )
+
+    # Metadata should still reflect the input (don't silently rewrite user
+    # metadata; the failure-hook author is responsible for that). The bug
+    # only affected the column write, not the metadata blob.
+    metadata_dict = json.loads(payload["metadata"])
+    assert metadata_dict["user_api_key"] is None
+
+
+def test_get_logging_payload_missing_user_api_key_remains_empty_string():
+    """Sanity check: when user_api_key is absent from metadata entirely,
+    api_key stays "" (not None, not 'None', not absent).
+    """
+    kwargs = {
+        "model": "openai/gpt-4.1",
+        "call_type": "acompletion",
+        "litellm_params": {
+            "metadata": {
+                # user_api_key not set at all
+                "user_api_key_user_id": "test_user",
+                "status": "success",
+            }
+        },
+    }
+
+    payload = get_logging_payload(
+        kwargs=kwargs,
+        response_obj=None,
+        start_time=datetime.datetime.now(timezone.utc),
+        end_time=datetime.datetime.now(timezone.utc),
+    )
+
+    assert payload["api_key"] == "", (
+        f"Expected empty string when user_api_key missing, "
+        f"got api_key={payload['api_key']!r}"
+    )
+
+
+def test_get_logging_payload_happy_path_still_hashes_real_key():
+    """Sanity check that the None-fix doesn't break the real-key path.
+
+    A real string key should still flow through the existing
+    _hash_api_key_for_spend_log path and produce a hashed value, not "".
+    """
+    raw_key = "sk-WLi4iRn4JmbVlTaYw12IOA"
+
+    kwargs = {
+        "model": "openai/gpt-4.1",
+        "call_type": "acompletion",
+        "litellm_params": {
+            "metadata": {
+                "user_api_key": raw_key,
+                "user_api_key_user_id": "test_user",
+                "status": "success",
+            }
+        },
+    }
+
+    payload = get_logging_payload(
+        kwargs=kwargs,
+        response_obj=None,
+        start_time=datetime.datetime.now(timezone.utc),
+        end_time=datetime.datetime.now(timezone.utc),
+    )
+
+    assert payload["api_key"] != ""
+    assert payload["api_key"] != "None"
+    assert not payload["api_key"].startswith("sk-"), (
+        f"Real key should have been hashed, got api_key={payload['api_key']!r}"
+    )


### PR DESCRIPTION
## Summary

Unauthenticated requests to LLM-API routes fail auth before a virtual key is resolved. The auth-exception handler fabricates a synthetic `UserAPIKeyAuth` with `api_key=None`, which the failure-hook seeds into `metadata["user_api_key"]`. The spend-log payload builder then ran `api_key = str(api_key)` and persisted the literal four-character string `"None"` in `LiteLLM_SpendLogs.api_key`.

Symptoms observed on a production proxy (v1.83.14 → v1.92.0, both affected):

- 200+ `api_key = 'None'` rows accumulated over ~3 months, all with `status='failure'` and `spend=0`
- Those rows are un-joinable to `LiteLLM_VerificationToken`, so any analysis that joins `s.api_key = vt.token` produces silently missing data
- Auth failures visually look like real keys at a glance

## Fix

Two-layer defense (both added):

1. **Read site** (`litellm/proxy/spend_tracking/spend_tracking_utils.py:285`): coerce `None` to `""` so the `or`-chain at line 300 keeps working as intended.
2. **Write site** (line 426): guard the `str()` coercion so a stray `None` can never become the string `"None"` downstream.

## Tests

Three regression tests added to `tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py`:

- `test_get_logging_payload_unauthenticated_request_does_not_store_string_none` — the bug case
- `test_get_logging_payload_missing_user_api_key_remains_empty_string` — when the metadata key is absent entirely
- `test_get_logging_payload_happy_path_still_hashes_real_key` — guard that real keys still flow through `_hash_api_key_for_spend_log` and don't get coerced to `""`

Pattern is mirrored from the existing `test_get_logging_payload_hashes_bearer_prefixed_api_key` (LIT-4121) which fixed the same column for a different path.

## Notes

- I could not run the test suite locally — no Python 3.13 + litellm venv on this host. The patch is small and the new tests mirror an existing passing test pattern. Please run the suite in CI.
- Total scope: 2 source lines + 3 tests, ~124 insertions.
- Identical pattern likely affects `proxy_track_cost_callback.py:async_post_call_failure_hook` if `user_api_key_dict.api_key` is also passed through without coercion there — happy to extend the fix in a follow-up if reviewers want broader coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)