### PR TITLE
fix(proxy): kill mid-drain retired prisma engines at shutdown instead of abandoning them

### DIFF
--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -64,6 +64,12 @@ class _PrismaClient(Protocol):
     def _engine(self) -> _PrismaEngine: ...
 
 
+@dataclass(frozen=True, slots=True)
+class _EngineRetirement:
+    pid: int
+    task: "asyncio.Task[None]"
+
+
 class _PrismaDrainTracker:
     def __init__(self) -> None:
         self._active_operations = 0
@@ -222,7 +228,7 @@ class PrismaWrapper:
         self._reconnection_lock = asyncio.Lock()
         self._last_refresh_time: datetime | None = None
         self._active_drain_tracker = self._instrument_prisma_client(original_prisma)
-        self._retirement_tasks: frozenset[asyncio.Task[None]] = frozenset()
+        self._retirement_tasks: frozenset[_EngineRetirement] = frozenset()
 
         # Coordination for planned engine restarts (issue #29176). Every
         # `recreate_prisma_client` SIGTERMs the running query-engine on
@@ -282,30 +288,59 @@ class PrismaWrapper:
         return 0
 
     async def _retire_engine_when_drained(self, pid: int, tracker: _PrismaDrainTracker | None) -> None:
-        if tracker is not None:
-            try:
-                await asyncio.wait_for(
-                    tracker.wait_until_drained(),
-                    timeout=self.ENGINE_RETIREMENT_DRAIN_TIMEOUT_SECONDS,
-                )
-            except asyncio.TimeoutError:
-                verbose_proxy_logger.warning(
-                    "%sReplaced prisma engine PID %s did not drain within %ss; killing it with work still in flight.",
-                    self._log_prefix,
-                    pid,
-                    self.ENGINE_RETIREMENT_DRAIN_TIMEOUT_SECONDS,
-                )
-        await self._kill_engine_process(pid)
+        try:
+            if tracker is not None:
+                try:
+                    await asyncio.wait_for(
+                        tracker.wait_until_drained(),
+                        timeout=self.ENGINE_RETIREMENT_DRAIN_TIMEOUT_SECONDS,
+                    )
+                except asyncio.TimeoutError:
+                    verbose_proxy_logger.warning(
+                        "%sReplaced prisma engine PID %s did not drain within %ss; killing it with work still in flight.",
+                        self._log_prefix,
+                        pid,
+                        self.ENGINE_RETIREMENT_DRAIN_TIMEOUT_SECONDS,
+                    )
+            await self._kill_engine_process(pid)
+        except asyncio.CancelledError:
+            self._kill_engine_process_now(pid)
+            raise
+
+    def _kill_engine_process_now(self, pid: int) -> None:
+        if pid <= 0:
+            return
+        try:
+            os.kill(pid, getattr(signal, "SIGKILL", signal.SIGTERM))
+        except (ProcessLookupError, PermissionError, OSError):
+            return
+        verbose_proxy_logger.warning(
+            "%sSent SIGKILL to prisma-query-engine PID %s while flushing engine retirements.",
+            self._log_prefix,
+            pid,
+        )
+
+    async def flush_engine_retirements(self) -> None:
+        pending = self._retirement_tasks
+        if not pending:
+            return
+        for retirement in pending:
+            retirement.task.cancel()
+        await asyncio.gather(*(retirement.task for retirement in pending), return_exceptions=True)
+        for retirement in pending:
+            self._kill_engine_process_now(retirement.pid)
 
     def _schedule_engine_retirement(self, pid: int, tracker: _PrismaDrainTracker | None) -> None:
         if pid <= 0:
             return
         retirement_task = asyncio.create_task(self._retire_engine_when_drained(pid, tracker))
-        self._retirement_tasks = self._retirement_tasks.union((retirement_task,))
+        self._retirement_tasks = self._retirement_tasks.union((_EngineRetirement(pid=pid, task=retirement_task),))
         retirement_task.add_done_callback(self._retirement_finished)
 
     def _retirement_finished(self, retirement_task: asyncio.Task[None]) -> None:
-        self._retirement_tasks = self._retirement_tasks.difference((retirement_task,))
+        self._retirement_tasks = frozenset(
+            retirement for retirement in self._retirement_tasks if retirement.task is not retirement_task
+        )
 
     async def connect(self, timeout: int | timedelta | None = None) -> None:
         if timeout is None:
@@ -649,16 +684,16 @@ class PrismaWrapper:
 
         Should be called during application shutdown to clean up resources.
         """
-        if self._token_refresh_task is None:
-            return
+        if self._token_refresh_task is not None:
+            self._token_refresh_task.cancel()
+            try:
+                await self._token_refresh_task
+            except asyncio.CancelledError:
+                pass
+            self._token_refresh_task = None
+            verbose_proxy_logger.info("%sStopped RDS IAM token refresh background task", self._log_prefix)
 
-        self._token_refresh_task.cancel()
-        try:
-            await self._token_refresh_task
-        except asyncio.CancelledError:
-            pass
-        self._token_refresh_task = None
-        verbose_proxy_logger.info("%sStopped RDS IAM token refresh background task", self._log_prefix)
+        await self.flush_engine_retirements()
 
     async def _token_refresh_loop(self) -> None:
         """

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -229,6 +229,7 @@ class PrismaWrapper:
         self._last_refresh_time: datetime | None = None
         self._active_drain_tracker = self._instrument_prisma_client(original_prisma)
         self._retirement_tasks: frozenset[_EngineRetirement] = frozenset()
+        self._retirements_flushed = False
 
         # Coordination for planned engine restarts (issue #29176). Every
         # `recreate_prisma_client` SIGTERMs the running query-engine on
@@ -321,6 +322,7 @@ class PrismaWrapper:
         )
 
     async def flush_engine_retirements(self) -> None:
+        self._retirements_flushed = True
         pending = self._retirement_tasks
         if not pending:
             return
@@ -332,6 +334,9 @@ class PrismaWrapper:
 
     def _schedule_engine_retirement(self, pid: int, tracker: _PrismaDrainTracker | None) -> None:
         if pid <= 0:
+            return
+        if self._retirements_flushed:
+            self._kill_engine_process_now(pid)
             return
         retirement_task = asyncio.create_task(self._retire_engine_when_drained(pid, tracker))
         self._retirement_tasks = self._retirement_tasks.union((_EngineRetirement(pid=pid, task=retirement_task),))

--- a/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
+++ b/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
@@ -71,7 +71,7 @@ def test_wrapper_instruments_generated_prisma_engine() -> None:
 
 
 async def _wait_for_retirements(wrapper: PrismaWrapper) -> None:
-    await asyncio.gather(*tuple(wrapper._retirement_tasks))
+    await asyncio.gather(*tuple(retirement.task for retirement in wrapper._retirement_tasks))
 
 
 @pytest.mark.asyncio
@@ -423,6 +423,24 @@ async def test_retirement_kills_old_engine_when_drain_never_completes(
         await asyncio.wait_for(_wait_for_retirements(wrapper), timeout=2)
 
     mock_kill.assert_any_call(111, signal.SIGTERM)
+
+
+@pytest.mark.asyncio
+async def test_stop_token_refresh_flushes_pending_engine_retirement(mock_prisma_binary):
+    """Shutdown must kill a mid-drain replaced engine immediately instead of
+    abandoning its retirement task at event-loop teardown (which would orphan
+    the engine and its DB connection pool)."""
+    wrapper = _make_wrapper(engine_pid=111, iam=True)
+    old_engine = wrapper._original_prisma._engine
+    old_engine._engine.start_transaction = AsyncMock(return_value="transaction-1")
+    await old_engine.start_transaction(content="transaction")
+    wrapper._schedule_engine_retirement(111, wrapper._active_drain_tracker)
+
+    with patch("os.kill") as mock_kill:
+        await asyncio.wait_for(wrapper.stop_token_refresh_task(), timeout=2)
+
+    assert mock_kill.call_args_list == [call(111, signal.SIGKILL)]
+    assert wrapper._retirement_tasks == frozenset()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
+++ b/tests/test_litellm/proxy/db/test_prisma_planned_engine_restart.py
@@ -444,6 +444,21 @@ async def test_stop_token_refresh_flushes_pending_engine_retirement(mock_prisma_
 
 
 @pytest.mark.asyncio
+async def test_retirement_scheduled_after_flush_kills_engine_synchronously(mock_prisma_binary):
+    """A rotation that completes during shutdown (e.g. an in-flight __getattr__
+    refresh) must not create an unowned retirement task after the flush; the
+    old engine is killed inline instead."""
+    wrapper = _make_wrapper(engine_pid=111, iam=True)
+    await wrapper.stop_token_refresh_task()
+
+    with patch("os.kill") as mock_kill:
+        wrapper._schedule_engine_retirement(333, wrapper._active_drain_tracker)
+
+    assert mock_kill.call_args_list == [call(333, signal.SIGKILL)]
+    assert wrapper._retirement_tasks == frozenset()
+
+
+@pytest.mark.asyncio
 async def test_safe_refresh_cancellation_restores_token_and_cleans_replacement(
     mock_prisma_binary, monkeypatch
 ):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Shutdown abandoned engine retirement tasks still waiting on their drain deadline
- The replaced query engine survived as an orphan holding DB connections

How it solves it:

- Proxy shutdown now flushes pending retirements: cancel, await, SIGKILL the engine
- Retirements track (pid, task) so even never-started tasks get their kill

## Relevant issues

Follow-up to #34749

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The bug only manifests when the proxy shuts down while a warm IAM rotation's drain window (up to 90s) is open, which needs an IAM-enabled RDS instance to reach; there is no curl-visible surface because the leak is a child process outliving the proxy. Manual verification recipe for an IAM environment: run the proxy against IAM RDS, wait for a rotation log line ("RDS IAM token refreshed successfully"), immediately SIGTERM the proxy inside the drain window, then `ps aux | grep query-engine`. At `7cd009caf7` (before) the old engine pid survives the proxy exit until Postgres idle timeouts reap its connections; at `1219fde8a1` (after) no query-engine process remains

Deterministic reproduction is the added regression test: at `7cd009caf7` it fails because `stop_token_refresh_task` returns without touching the pending retirement (no kill signal is ever sent), and at `1219fde8a1` it passes. The full database suites (615 tests across `tests/test_litellm/proxy/db/`, `tests/test_litellm/proxy/utils/prisma_and_spend/`, and the engine watchdog suite) pass at `1219fde8a1`

## Type

🐛 Bug Fix

## Changes

PR #34749 retires a replaced engine via a background task that waits for in-flight work to drain (bounded at 90s) before killing the old engine. Those retirement tasks had no shutdown owner: a task still mid-drain when the proxy shut down was cancelled at event-loop teardown before its kill ever ran, orphaning the replaced query-engine subprocess and the DB connections it holds. Containers reap the orphan with the pod; bare-metal and dev deployments leaked it until Postgres idle timeouts fired

`stop_token_refresh_task`, which the proxy shutdown hook already calls on every wrapper (the routing wrapper forwards it to writer and reader), now flushes pending retirements after stopping the refresh loop so a mid-rotation cancellation can still schedule its cleanup before the flush runs. The flush cancels each retirement task, awaits it, and then SIGKILLs the engine pid directly. The direct kill matters because a task cancelled before its first run never executes its body, so relying on the task's own cancellation handler would silently skip the kill; retirements are therefore tracked as (pid, task) pairs. Independently, a retirement task cancelled from anywhere now SIGKILLs its engine before propagating the cancellation, covering the window between the drain deadline's SIGTERM and its SIGKILL backstop

A rotation completing after the flush has taken its snapshot (an in-flight refresh spawned by the __getattr__ stale-token fallback) cannot escape either: once the flush has run, _schedule_engine_retirement kills the old engine inline instead of creating a task. The event loop is single threaded and both the flag-set-plus-snapshot and the schedule are synchronous, so every schedule either lands in the flush snapshot or sees the flag

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
