### PR TITLE
test(e2e): retry a2a calls that hit a worker whose agent registry has not synced

### DIFF
--- a/tests/e2e/a2a/a2a_client.py
+++ b/tests/e2e/a2a/a2a_client.py
@@ -13,11 +13,12 @@ from __future__ import annotations
 
 import time
 import warnings
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from e2e_http import NoBody, Result, Success, get_external, is_ok
+from e2e_http import NoBody, Result, Success, UnknownApiError, get_external, is_ok
 from proxy_client import ProxyClient
 
 
@@ -286,6 +287,20 @@ class A2AResponse(BaseModel):
     error: A2AError | None = None
 
 
+def _is_agent_unknown[R: BaseModel](result: Result[R], agent_id: str) -> bool:
+    """True when `result` is the data plane reporting `agent_id` as not found.
+
+    Both /a2a surfaces answer an unsynced worker's lookup miss with HTTP 404 naming the
+    agent: the card read as a FastAPI `detail`, message/send as a JSON-RPC error object.
+    Matching on the id keeps an unrelated 404 (a mistyped route, say) from being retried.
+    """
+    match result:
+        case UnknownApiError(status_code=404, body=body):
+            return agent_id in body
+        case _:
+            return False
+
+
 @dataclass(frozen=True, slots=True)
 class A2AClient:
     proxy: ProxyClient
@@ -351,20 +366,49 @@ class A2AClient:
             warnings.warn(f"delete_agent({agent_id!r}) failed: {result}", stacklevel=2)
 
     def agent_card(self, agent_id: str, key: str) -> Result[ServedAgentCard]:
-        return self.proxy.transport.get(
-            f"/a2a/{agent_id}/.well-known/agent-card.json",
-            headers=self.proxy.transport.bearer(key),
-            params=NoBody(),
-            response_type=ServedAgentCard,
+        return self._retry_while_unsynced(
+            lambda: self.proxy.transport.get(
+                f"/a2a/{agent_id}/.well-known/agent-card.json",
+                headers=self.proxy.transport.bearer(key),
+                params=NoBody(),
+                response_type=ServedAgentCard,
+            ),
+            agent_id=agent_id,
         )
 
     def send_message(self, agent_id: str, key: str, body: A2AJsonRpcRequest) -> Result[A2AResponse]:
-        return self.proxy.transport.post(
-            f"/a2a/{agent_id}",
-            headers=self.proxy.transport.bearer(key),
-            json=body,
-            response_type=A2AResponse,
+        return self._retry_while_unsynced(
+            lambda: self.proxy.transport.post(
+                f"/a2a/{agent_id}",
+                headers=self.proxy.transport.bearer(key),
+                json=body,
+                response_type=A2AResponse,
+            ),
+            agent_id=agent_id,
         )
+
+    def _retry_while_unsynced[R: BaseModel](
+        self, call: Callable[[], Result[R]], *, agent_id: str
+    ) -> Result[R]:
+        """Re-issue `call` while it reports `agent_id` as unknown, up to poll_timeout.
+
+        Each data-plane worker keeps its own in-process agent registry and refreshes it
+        on an independent periodic DB sync, and several workers sit behind one address.
+        So the card read in `_await_agent_servable` only proves that *whichever* worker
+        answered it has synced; a later call load-balanced onto a slower worker still
+        sees no such agent. Retrying is safe rather than wasteful here because this
+        rejection happens during agent lookup, before any provider call, so a retried
+        message/send bills nothing extra. Any other outcome, including a real error from
+        the bridge, is returned on the first try so genuine failures stay loud.
+        """
+        deadline = time.monotonic() + self.proxy.poll_timeout
+        while True:
+            result = call()
+            if not _is_agent_unknown(result, agent_id):
+                return result
+            if time.monotonic() >= deadline:
+                return result
+            time.sleep(self.proxy.poll_interval)
 
 
 def build_a2a_client(proxy: ProxyClient) -> A2AClient:


### PR DESCRIPTION
## TLDR

Problem this solves:

- a2a message/send 404s on an agent that registered fine
- Each worker syncs its agent registry independently

How it solves it:

- Retry a2a calls while the data plane reports the agent unknown
- Retries cost nothing; the 404 precedes any provider call

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Four a2a tests were failing on stage with `Missing Anthropic API Key`. That turned out to be a routing bug, not a credentials one: `/a2a/{id}` had no ingress rule, so it fell through the catch-all to litellm-backend, which deliberately carries no provider keys. #34958 fixed the routing. This PR fixes the second failure that the routing fix newly exposes

Root cause of the original failure, captured on `daf22ec` (stage's then-current image), driving the same agent against each plane in-cluster with a unique prompt so the shared Redis cache cannot mask it:

```
$ REG=$(curl -s -X POST "$BE/v1/agents" -H "Authorization: Bearer $MK" -d '{...,"litellm_params":{"custom_llm_provider":"anthropic","model":"claude-haiku-4-5"}}')

== BACKEND (where the missing ingress rule sent it) ==
$ curl -s -X POST "$BE/a2a/$AID" -H "Authorization: Bearer $MK" -d '{...,"text":"Say the word uniq-1785272852 back to me"}'
{"jsonrpc":"2.0","id":"be-1","error":{"code":-32603,"message":"Internal error: litellm.AuthenticationError: Missing Anthropic API Key - A call is being made to anthropic but no key is set either in the environment variables or via params. Please set `ANTHROPIC_API_KEY` or `ANTHROPIC_AUTH_TOKEN` in your environment vars"}}

== GATEWAY (where it belongs) ==
$ curl -s -X POST "$GW/a2a/$AID" -H "Authorization: Bearer $MK" -d '{...,"text":"Say the word uniq2-1785272852 back to me"}'
{"id":"gw-1","jsonrpc":"2.0","result":{"kind":"message","role":"agent","parts":[{"kind":"text","text":"uniq2-1785272852"}],"messageId":"82f101792a60438a8a9b1ccb8e794d04"}}
```

Then running the suite in-cluster in the post-#34958 topology (registration on the backend, `/a2a` served by the gateway) on `daf22ec`, which reproduces what stage will do once the routing fix ships. The auth error is gone and 2 of the 4 turn into a different failure:

```
$ python -m pytest a2a/test_a2a_agent_e2e.py -p no:randomly -q
result = UnknownApiError(kind='unknown', status_code=404, body='{"jsonrpc":"2.0","id":"e2e-ffae595f0347","error":{"code":-32000,"message":"Agent \'c2aca265-e030-4bca-ad79-7e659c6de933\' not found"}}')
FAILED a2a/test_a2a_agent_e2e.py::TestA2AAgentLifecycle::test_semver_protocol_version_registers_and_serves
FAILED a2a/test_a2a_agent_e2e.py::TestA2AAgentLifecycle::test_message_send_runs_completion_bridge
2 failed, 7 passed in 14.01s
```

That 404 is this PR's target. The gateway runs `NUM_WORKERS=2`, and `_init_agents_in_db` refreshes a per-worker in-process registry on each worker's own `proxy_config_reload_interval_seconds` tick, so the one card read in `_await_agent_servable` only proves whichever worker answered it has synced; the next call can land on the other and 404. Raising `E2E_POLL_TIMEOUT` to 240 did not help, which is the tell that this is per-worker state rather than a slow single sync

I could not capture an after-run of the suite on stage: the ingress rule from #34958 is only in the chart, stage still runs the pre-fix image plus a chart a day behind, and ArgoCD `selfHeal` reverted a hand-patched ingress within ~2 minutes (it also restored its own `automated` policy after I disabled it, since a parent app manages it). So the after-state needs the nightly rebuild to pick up `b930e2f`; I would like a reviewer to confirm the suite is green on the first stage run that includes both this and #34958

## Type

✅ Test

## Changes

`agent_card` and `send_message` now go through a `_retry_while_unsynced` helper that re-issues the call while the data plane reports that specific agent id as unknown, bounded by the existing `poll_timeout`. The predicate matches a 404 whose body names the agent, so an unrelated 404 is not retried, and any other result, including a real error from the completion bridge, returns on the first try so genuine failures stay loud

Retrying is the right tool rather than a workaround here because the rejection happens during agent lookup, before the bridge issues any provider call, so a retried `message/send` bills nothing extra. I first wrote this as a run of consecutive card-read successes and threw it away: that only raises the probability of having touched every worker, it never guarantees it, and it has no precedent in the harness

No test accompanies this. The change is retry plumbing in the suite's own client, and the behavior it fixes only reproduces against a real multi-worker data plane, which is what the e2e run itself exercises

## QA runbook

- tests/e2e/a2a/test_a2a_agent_e2e.py::TestA2AAgentLifecycle::test_message_send_runs_completion_bridge - an agent registered through the control plane answers a real A2A message/send via the completion bridge, even when the call lands on a data-plane worker that has not synced yet
  - [ ] Run a proxy with more than one worker and `store_model_in_db` on, so the per-worker agent registry sync is in play (stage: gateway `NUM_WORKERS=2`)
  - [ ] Register an agent: POST /v1/agents with the master key, `agent_card_params.protocolVersion` "0.3", and `litellm_params` `{"custom_llm_provider":"anthropic","model":"claude-haiku-4-5"}` (needs ANTHROPIC_API_KEY on the pod serving /a2a)
  - [ ] Immediately POST /a2a/{agent_id} with a virtual key and a JSON-RPC `message/send` body asking for the word PONG
  - [ ] Expect a 200 whose result text contains PONG; before this change the same call could return 404 "Agent '{id}' not found" while the agent existed and GET /v1/agents/{id} listed it
  - [ ] Confirm a spend row lands for the request id with call_type `asend_message` and model `a2a_agent/{card name}`
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
