### PR TITLE
fix(ui): size Object Permissions card grid by container width

### DIFF
--- a/ui/litellm-dashboard/src/components/object_permissions_view.tsx
+++ b/ui/litellm-dashboard/src/components/object_permissions_view.tsx
@@ -28,7 +28,7 @@ export function ObjectPermissionsView({
   const searchTools = objectPermission?.search_tools || [];
 
   const content = (
-    <div className={variant === "card" ? "grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" : "space-y-4"}>
+    <div className={variant === "card" ? "grid grid-cols-1 @xl:grid-cols-2 @4xl:grid-cols-3 gap-6" : "space-y-4"}>
       <VectorStorePermissions vectorStores={vectorStores} accessToken={accessToken} />
       <MCPServerPermissions
         mcpServers={mcpServers}
@@ -53,7 +53,7 @@ export function ObjectPermissionsView({
 
   if (variant === "card") {
     return (
-      <div className={`bg-white border border-gray-200 rounded-lg p-6 ${className}`}>
+      <div className={`@container bg-white border border-gray-200 rounded-lg p-6 ${className}`}>
         <div className="flex items-center gap-2 mb-6">
           <div>
             <Text className="font-semibold text-gray-900">Object Permissions</Text>


### PR DESCRIPTION
## TLDR

Problem this solves:

- Object Permissions card on team info squeezes text out of its boxes
- Inner grid used viewport breakpoints while the card is one third wide

How it solves it:

- Inner grid now uses Tailwind container queries sized by the card itself
- Narrow card renders one column; columns only appear when the card is wide

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Object Permissions card on the team info Overview tab, dev Admin UI against a live worktree proxy, 1440px wide viewport where the card sits in a one-third-width grid cell. Before captured at 32a4377acd, after at 490b5aeecf

| Before | After |
| --- | --- |
| <img src="https://gist.githubusercontent.com/ryan-crabbe-berri/a7f55680dcb58aeade8386b803cb286a/raw/before.png" width="340" alt="before: three crushed columns, letters overflow the boxes" /> | <img src="https://gist.githubusercontent.com/ryan-crabbe-berri/a7f55680dcb58aeade8386b803cb286a/raw/after.png" width="340" alt="after: single readable column sized by the card width" /> |

## Type

🐛 Bug Fix

## Changes

The card variant of `ObjectPermissionsView` (used on team info, key info, and organization info) laid out its four sections with `md:grid-cols-2 lg:grid-cols-3`. Those breakpoints track the viewport, but every card usage sits inside a one-third-width grid cell, so on a desktop screen the ~380px card still rendered three internal columns of roughly 100px each; headers wrapped per word and letters overflowed the empty-state boxes

The wrapper is now a `@container` and the grid uses `@xl:grid-cols-2 @4xl:grid-cols-3`, so the column count follows the card's own width. In the usual one-third-width cell the sections stack in a single readable column, and multiple columns only come back when the card itself is actually wide enough to fit them
