### PR TITLE
fix(copilot): set X-Initiator from Responses input

### DIFF
--- a/litellm/llms/github_copilot/chat/transformation.py
+++ b/litellm/llms/github_copilot/chat/transformation.py
@@ -16,6 +16,7 @@ from ..common_utils import (
     DEFAULT_GITHUB_COPILOT_API_BASE,
     GetAPIKeyError,
     get_copilot_default_headers,
+    get_copilot_initiator,
 )
 
 
@@ -102,7 +103,7 @@ class GithubCopilotConfig(OpenAIConfig):
             pass  # Will be handled later in the request flow
 
         # Add X-Initiator header based on message roles
-        initiator = self._determine_initiator(messages)
+        initiator = get_copilot_initiator(messages)
         validated_headers["X-Initiator"] = initiator
 
         # Add Copilot-Vision-Request header if request contains images
@@ -140,11 +141,7 @@ class GithubCopilotConfig(OpenAIConfig):
         Determine if request is user or agent initiated based on message roles.
         Returns 'agent' if any message has role 'tool' or 'assistant', otherwise 'user'.
         """
-        for message in messages:
-            role = message.get("role")
-            if role in ["tool", "assistant"]:
-                return "agent"
-        return "user"
+        return get_copilot_initiator(messages)
 
     def _has_vision_content(self, messages: List[AllMessageValues]) -> bool:
         """

--- a/litellm/llms/github_copilot/common_utils.py
+++ b/litellm/llms/github_copilot/common_utils.py
@@ -2,7 +2,7 @@
 Constants for Copilot integration
 """
 
-from typing import Any, Optional, Union
+from typing import Optional, Union
 from uuid import uuid4
 
 import httpx
@@ -17,7 +17,7 @@ API_VERSION = "2025-04-01"
 DEFAULT_GITHUB_COPILOT_API_BASE = "https://api.githubcopilot.com"
 
 
-def get_copilot_initiator(input_param: Any) -> str:
+def get_copilot_initiator(input_param: object) -> str:
     """Classify a Copilot request as user- or agent-initiated.
 
     Responses API history contains assistant/tool/function-call/reasoning items

--- a/litellm/llms/github_copilot/common_utils.py
+++ b/litellm/llms/github_copilot/common_utils.py
@@ -2,7 +2,7 @@
 Constants for Copilot integration
 """
 
-from typing import Optional, Union
+from typing import Any, Optional, Union
 from uuid import uuid4
 
 import httpx
@@ -15,6 +15,27 @@ EDITOR_PLUGIN_VERSION = f"copilot-chat/{COPILOT_VERSION}"
 USER_AGENT = f"GitHubCopilotChat/{COPILOT_VERSION}"
 API_VERSION = "2025-04-01"
 DEFAULT_GITHUB_COPILOT_API_BASE = "https://api.githubcopilot.com"
+
+
+def get_copilot_initiator(input_param: Any) -> str:
+    """Classify a Copilot request as user- or agent-initiated.
+
+    Responses API history contains assistant/tool/function-call/reasoning items
+    as well as role-less items. Any such prior item means the request continues
+    an agent turn; a string or user-only input is a new user turn.
+    """
+    if isinstance(input_param, str):
+        return "user"
+    if isinstance(input_param, list):
+        for item in input_param:
+            if not isinstance(item, dict):
+                continue
+            role = item.get("role")
+            if not role or (isinstance(role, str) and role.lower() in {"assistant", "tool"}):
+                return "agent"
+            if item.get("type") in {"function_call", "function_call_output", "reasoning"}:
+                return "agent"
+    return "user"
 
 
 class GithubCopilotError(BaseLLMException):

--- a/litellm/llms/github_copilot/responses/transformation.py
+++ b/litellm/llms/github_copilot/responses/transformation.py
@@ -130,10 +130,10 @@ class GithubCopilotResponsesAPIConfig(OpenAIResponsesAPIConfig):
         self,
         model: str,
         input: Union[str, ResponseInputParam],
-        response_api_optional_request_params: Dict,
+        response_api_optional_request_params: dict[str, object],
         litellm_params: GenericLiteLLMParams,
-        headers: dict,
-    ) -> Dict:
+        headers: dict[str, object],
+    ) -> dict[str, object]:
         """Set Copilot's initiator header from the actual Responses input."""
         headers["X-Initiator"] = get_copilot_initiator(input)
         return super().transform_responses_api_request(

--- a/litellm/llms/github_copilot/responses/transformation.py
+++ b/litellm/llms/github_copilot/responses/transformation.py
@@ -130,10 +130,10 @@ class GithubCopilotResponsesAPIConfig(OpenAIResponsesAPIConfig):
         self,
         model: str,
         input: Union[str, ResponseInputParam],
-        response_api_optional_request_params: Dict,  # mutable-ok: must match parent override signature
+        response_api_optional_request_params: dict,  # mutable-ok: must match parent override signature
         litellm_params: GenericLiteLLMParams,
         headers: dict,  # mutable-ok: must match parent override signature
-    ) -> Dict:  # mutable-ok: must match parent override signature
+    ) -> dict:  # mutable-ok: must match parent override signature
         """Set Copilot's initiator header from the actual Responses input."""
         headers["X-Initiator"] = get_copilot_initiator(input)
         return super().transform_responses_api_request(

--- a/litellm/llms/github_copilot/responses/transformation.py
+++ b/litellm/llms/github_copilot/responses/transformation.py
@@ -30,6 +30,7 @@ from ..common_utils import (
     DEFAULT_GITHUB_COPILOT_API_BASE,
     GetAPIKeyError,
     get_copilot_default_headers,
+    get_copilot_initiator,
 )
 
 if TYPE_CHECKING:
@@ -124,6 +125,24 @@ class GithubCopilotResponsesAPIConfig(OpenAIResponsesAPIConfig):
         so no transformation is needed.
         """
         return dict(response_api_optional_params)
+
+    def transform_responses_api_request(
+        self,
+        model: str,
+        input: Union[str, ResponseInputParam],
+        response_api_optional_request_params: Dict,
+        litellm_params: GenericLiteLLMParams,
+        headers: dict,
+    ) -> Dict:
+        """Set Copilot's initiator header from the actual Responses input."""
+        headers["X-Initiator"] = get_copilot_initiator(input)
+        return super().transform_responses_api_request(
+            model=model,
+            input=input,
+            response_api_optional_request_params=response_api_optional_request_params,
+            litellm_params=litellm_params,
+            headers=headers,
+        )
 
     def transform_streaming_response(
         self,
@@ -337,27 +356,7 @@ class GithubCopilotResponsesAPIConfig(OpenAIResponsesAPIConfig):
         Returns:
             "agent" or "user"
         """
-        # If input is a string, it's user-initiated
-        if isinstance(input_param, str):
-            return "user"
-
-        # If input is a list, analyze items
-        if isinstance(input_param, list):
-            for item in input_param:
-                if not isinstance(item, dict):
-                    continue
-
-                # Check if item has no role (agent-initiated)
-                if "role" not in item or not item.get("role"):
-                    return "agent"
-
-                # Check if role is assistant (agent-initiated)
-                role = item.get("role")
-                if isinstance(role, str) and role.lower() == "assistant":
-                    return "agent"
-
-        # Default to user-initiated
-        return "user"
+        return get_copilot_initiator(input_param)
 
     def _has_vision_input(self, input_param: Union[str, ResponseInputParam]) -> bool:
         """

--- a/litellm/llms/github_copilot/responses/transformation.py
+++ b/litellm/llms/github_copilot/responses/transformation.py
@@ -130,10 +130,10 @@ class GithubCopilotResponsesAPIConfig(OpenAIResponsesAPIConfig):
         self,
         model: str,
         input: Union[str, ResponseInputParam],
-        response_api_optional_request_params: dict[str, object],
+        response_api_optional_request_params: Dict,  # mutable-ok: must match parent override signature
         litellm_params: GenericLiteLLMParams,
-        headers: dict[str, object],
-    ) -> dict[str, object]:
+        headers: dict,  # mutable-ok: must match parent override signature
+    ) -> Dict:  # mutable-ok: must match parent override signature
         """Set Copilot's initiator header from the actual Responses input."""
         headers["X-Initiator"] = get_copilot_initiator(input)
         return super().transform_responses_api_request(

--- a/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
@@ -181,6 +181,44 @@ class TestGithubCopilotResponsesAPITransformation:
         initiator = config._get_initiator("Hello, how are you?")
         assert initiator == "user", "Should return 'user' for string input"
 
+    @pytest.mark.parametrize(
+        "prior_item",
+        [
+            {"role": "assistant", "content": "Hi"},
+            {"role": "tool", "content": "result"},
+            {"type": "function_call", "call_id": "call_1"},
+            {"type": "reasoning", "summary": []},
+            {"type": "message", "content": []},
+        ],
+    )
+    def test_transform_request_sets_agent_initiator_for_prior_agent_items(self, prior_item):
+        config = GithubCopilotResponsesAPIConfig()
+        headers = {}
+        body = config.transform_responses_api_request(
+            model="gpt-5.1-codex",
+            input=[{"role": "user", "content": "Hello"}, prior_item],
+            response_api_optional_request_params={"stream": False},
+            litellm_params=MagicMock(),
+            headers=headers,
+        )
+        assert headers["X-Initiator"] == "agent"
+        assert body["model"] == "gpt-5.1-codex"
+        assert body["input"][1] == prior_item
+        assert body["stream"] is False
+
+    def test_transform_request_sets_user_initiator_for_user_input(self):
+        config = GithubCopilotResponsesAPIConfig()
+        headers = {}
+        body = config.transform_responses_api_request(
+            model="gpt-5.1-codex",
+            input=[{"role": "user", "content": "Hello"}],
+            response_api_optional_request_params={},
+            litellm_params=MagicMock(),
+            headers=headers,
+        )
+        assert headers["X-Initiator"] == "user"
+        assert body["input"] == [{"role": "user", "content": "Hello"}]
+
     def test_has_vision_input_with_input_image(self):
         """Test _has_vision_input detects input_image type"""
         config = GithubCopilotResponsesAPIConfig()

--- a/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
+++ b/tests/test_litellm/llms/github_copilot/responses/test_github_copilot_responses_transformation.py
@@ -181,6 +181,18 @@ class TestGithubCopilotResponsesAPITransformation:
         initiator = config._get_initiator("Hello, how are you?")
         assert initiator == "user", "Should return 'user' for string input"
 
+    def test_get_initiator_ignores_non_dict_items(self):
+        """Test _get_initiator skips non-dict items and returns 'user' for user-only input"""
+        config = GithubCopilotResponsesAPIConfig()
+
+        input_with_non_dict = [
+            {"role": "user", "content": "Hello"},
+            "raw string item",  # non-dict item should be skipped, not crash
+        ]
+
+        initiator = config._get_initiator(input_with_non_dict)
+        assert initiator == "user", "Should skip non-dict items and return 'user'"
+
     @pytest.mark.parametrize(
         "prior_item",
         [


### PR DESCRIPTION
## TLDR

Problem this solves:

- Copilot Responses requests can miss X-Initiator
- Multi-turn agentic requests may be billed as premium user requests

How it solves it:

- Classifies the actual Responses input before transformation
- Reuses one classifier across Chat and Responses paths
- Adds focused regression coverage for agent history items

## Relevant issues

Follow-up to #26686

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The focused regression suite passes locally. A live provider proof was not run because it would require Copilot credentials and incur real request cost; CI and maintainer review are still required.

## Type

🐛 Bug Fix

## Changes

`GithubCopilotResponsesAPIConfig` now sets `X-Initiator` from the actual Responses input in `transform_responses_api_request()` before delegating to the base transformer. The shared classifier handles user input, assistant/tool history, function-call items, reasoning items, and role-less items. The existing Chat path reuses the same classifier.

## Verification

- 11 focused Responses tests passed
- 42 full Copilot Responses transformation tests passed
- `py_compile` passed
- `git diff --check` passed

### Final Attestation

- [x] The tests cover the Responses regression and relevant agent-history edge cases
- [ ] CI and maintainer review remain pending
