### PR TITLE
fix(triton): consume chat_template_kwargs locally, do not forward to Triton server

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -365,7 +365,14 @@ def phind_codellama_pt(messages):
     return prompt
 
 
-def _render_chat_template(env, chat_template: str, bos_token: str, eos_token: str, messages: list) -> str:
+def _render_chat_template(
+    env,
+    chat_template: str,
+    bos_token: str,
+    eos_token: str,
+    messages: list,
+    chat_template_kwargs: Optional[dict] = None,
+) -> str:
     """
     Shared template rendering logic for both sync and async hf_chat_template
 
@@ -375,10 +382,14 @@ def _render_chat_template(env, chat_template: str, bos_token: str, eos_token: st
         bos_token: Beginning of sequence token
         eos_token: End of sequence token
         messages: Messages to render
+        chat_template_kwargs: Extra kwargs forwarded verbatim to template.render()
+            (e.g. ``{"enable_thinking": False}`` for Qwen3 thinking control).
 
     Returns:
         Rendered template string
     """
+    extra = chat_template_kwargs or {}
+
     try:
         template = env.from_string(chat_template)  # type: ignore
     except Exception as e:
@@ -406,6 +417,7 @@ def _render_chat_template(env, chat_template: str, bos_token: str, eos_token: st
                 eos_token=eos_token,
                 messages=messages,
                 add_generation_prompt=True,
+                **extra,
             )
         else:
             # treat a system message as a user message, if system not in template
@@ -421,6 +433,7 @@ def _render_chat_template(env, chat_template: str, bos_token: str, eos_token: st
                     eos_token=eos_token,
                     messages=reformatted_messages,
                     add_generation_prompt=True,
+                    **extra,
                 )
             except Exception as e:
                 if "Conversation roles must alternate user/assistant" in str(e):
@@ -434,7 +447,7 @@ def _render_chat_template(env, chat_template: str, bos_token: str, eos_token: st
                             else:
                                 new_messages.append({"role": "user", "content": ""})
                     new_messages.append(reformatted_messages[-1])
-                    rendered_text = template.render(bos_token=bos_token, eos_token=eos_token, messages=new_messages)
+                    rendered_text = template.render(bos_token=bos_token, eos_token=eos_token, messages=new_messages, **extra)
 
         return rendered_text
     except Exception as e:
@@ -578,7 +591,12 @@ async def ahf_chat_template(model: str, messages: list, chat_template: Optional[
     )
 
 
-def hf_chat_template(model: str, messages: list, chat_template: Optional[Any] = None):
+def hf_chat_template(
+    model: str,
+    messages: list,
+    chat_template: Optional[Any] = None,
+    chat_template_kwargs: Optional[dict] = None,
+):
     """HuggingFace chat template (sync version)"""
     from litellm.litellm_core_utils.prompt_templates.huggingface_template_handler import (
         _get_chat_template_file,
@@ -602,6 +620,7 @@ def hf_chat_template(model: str, messages: list, chat_template: Optional[Any] = 
         bos_token=bos_token,
         eos_token=eos_token,
         messages=messages,
+        chat_template_kwargs=chat_template_kwargs,
     )
 
 
@@ -5247,6 +5266,7 @@ def prompt_factory(
     messages: list,
     custom_llm_provider: Optional[str] = None,
     api_key: Optional[str] = None,
+    chat_template_kwargs: Optional[dict] = None,
 ):
     original_model_name = model
     model = model.lower()
@@ -5341,7 +5361,7 @@ def prompt_factory(
             chat_template = "{% if messages|length % 2 == 0 %}{% set role = 'Agent' %}{% else %}{% set role = 'User' %}{% endif %}{{ \"[INST] Task: Check if there is unsafe content in '\" + role + \"' messages in conversations according our safety policy with the below categories.\n\n<BEGIN UNSAFE CONTENT CATEGORIES>\nO1: Violence and Hate. \nShould not\n- Help people plan or engage in violence.\n- Encourage people to engage in violence.\n- Express hateful, derogatory, or demeaning sentiments against people based on sensitive personal characteristics like their race, color, religion, national origin, sexual orientation, gender, gender identity, or disability.\n- Encourage discrimination against people based on those characteristics and should not use slurs or create insults based on those characteristics.\nCan\n- Provide information on violence and discrimination.\n- Discuss the topics of hate and violence, and can discuss historical events involving violence.\nO2: Sexual Content.\nShould not\n- Engage in sexually explicit (i.e., erotic) conversations and should not encourage people to engage in sexual activities.\nCan\n- Discuss topics related to sexuality and sexual education.\n- Provide general information regarding sexual activities.\n- Provide guidance on topics related to sexual health.\nO3: Criminal Planning.\nShould not\n- Help people plan or engage in criminal activities like theft, kidnapping, or financial crimes, especially when the person indicates that they may act on the information provided to them.\n- Encourage people to engage in criminal activities or condone criminal behavior.\nCan\n- Help people understand how crimes are committed, provided that the response is not so detailed that it could be used to provide a roadmap for future crimes.\n- Help people understand how systems work that are used to prevent crimes, provided those descriptions do not provide detailed information on how to defeat those systems.\nO4: Guns and Illegal Weapons.\nShould not\n- Assist in the planning or execution of firearm or illegal weapons crimes, especially when the person indicates that they may act on the information provided to them.\n- Encourage people to engage in firearm or illegal weapons crimes or condone such behavior.\nCan\n- Discuss firearms and the arguments for and against firearm ownership.\nO5: Regulated or Controlled Substances.\nShould not\n- Encourage or assist people in the trafficking, consumption, or use of regulated or controlled substances, including but not limited to illegal drugs, tobacco, alcohol, and cannabis.\n- Assist or encourage people to create such substances when it is illegal to do so.\nCan\n- Discuss the use of regulated or controlled substances, and can provide general information on those substances (ex: what their chemical composition is and what their effects are).\n- Provide information on how those substances are manufactured, provided that the information is not so detailed as to provide step-by-step instructions for their creation.\nO6: Self-Harm.\nShould not\n- Encourage people to harm themselves.\n- Romanticize or condone self-harm or suicide.\n- Provide information regarding the methods of suicide or self-harm.\n- Provide any information or advice, other than information regarding appropriate health resources, to people who express or imply that they wish to harm themselves.\nCan\n- Provide general information regarding self-harm and suicide (ex: statistics, the mental health challenges faced by those who take these actions).\nShould\n- Provide information regarding appropriate health resources to people who imply or express the desire to harm themselves.\n<END UNSAFE CONTENT CATEGORIES>\n\n<BEGIN CONVERSATION>\n\n\" }}{% for message in messages %}{% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}{{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}{% endif %}{% set content = message['content'] %}{% if message['role'] == 'user' %}{% set role = 'User' %}{% elif message['role'] == 'assistant' %}{% set role = 'Agent' %}{% endif %}{{ role + ': ' + content.strip() + '\n\n' }}{% endfor %}{{ \"<END CONVERSATION>\n\nProvide your safety assessment for \" + role + \" in the above conversation:\n- First line must read 'safe' or 'unsafe'.\n- If unsafe, a second line must include a comma-separated list of violated categories. [/INST]\" }}"
             return hf_chat_template(model=model, messages=messages, chat_template=chat_template)
         else:
-            return hf_chat_template(original_model_name, messages)
+            return hf_chat_template(original_model_name, messages, chat_template_kwargs=chat_template_kwargs)
     except Exception:
         return default_pt(
             messages=messages

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -371,7 +371,7 @@ def _render_chat_template(
     bos_token: str,
     eos_token: str,
     messages: list,
-    chat_template_kwargs: Optional[dict] = None,
+    chat_template_kwargs: dict | None = None,
 ) -> str:
     """
     Shared template rendering logic for both sync and async hf_chat_template
@@ -597,7 +597,7 @@ def hf_chat_template(
     model: str,
     messages: list,
     chat_template: Optional[Any] = None,
-    chat_template_kwargs: Optional[dict] = None,
+    chat_template_kwargs: dict | None = None,
 ):
     """HuggingFace chat template (sync version)"""
     from litellm.litellm_core_utils.prompt_templates.huggingface_template_handler import (
@@ -5268,7 +5268,7 @@ def prompt_factory(
     messages: list,
     custom_llm_provider: Optional[str] = None,
     api_key: Optional[str] = None,
-    chat_template_kwargs: Optional[dict] = None,
+    chat_template_kwargs: dict | None = None,
 ):
     original_model_name = model
     model = model.lower()

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -371,7 +371,7 @@ def _render_chat_template(
     bos_token: str,
     eos_token: str,
     messages: list,
-    chat_template_kwargs: dict[str, Any] | None = None,
+    chat_template_kwargs: Mapping[str, Any] | None = None,
 ) -> str:
     """
     Shared template rendering logic for both sync and async hf_chat_template
@@ -597,7 +597,7 @@ def hf_chat_template(
     model: str,
     messages: list,
     chat_template: Optional[Any] = None,
-    chat_template_kwargs: dict[str, Any] | None = None,
+    chat_template_kwargs: Mapping[str, Any] | None = None,
 ):
     """HuggingFace chat template (sync version)"""
     from litellm.litellm_core_utils.prompt_templates.huggingface_template_handler import (
@@ -5268,7 +5268,7 @@ def prompt_factory(
     messages: list,
     custom_llm_provider: Optional[str] = None,
     api_key: Optional[str] = None,
-    chat_template_kwargs: dict[str, Any] | None = None,
+    chat_template_kwargs: Mapping[str, Any] | None = None,
 ):
     original_model_name = model
     model = model.lower()

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -447,7 +447,9 @@ def _render_chat_template(
                             else:
                                 new_messages.append({"role": "user", "content": ""})
                     new_messages.append(reformatted_messages[-1])
-                    rendered_text = template.render(bos_token=bos_token, eos_token=eos_token, messages=new_messages, **extra)
+                    rendered_text = template.render(
+                        bos_token=bos_token, eos_token=eos_token, messages=new_messages, **extra
+                    )
 
         return rendered_text
     except Exception as e:

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -371,7 +371,7 @@ def _render_chat_template(
     bos_token: str,
     eos_token: str,
     messages: list,
-    chat_template_kwargs: dict | None = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
 ) -> str:
     """
     Shared template rendering logic for both sync and async hf_chat_template
@@ -597,7 +597,7 @@ def hf_chat_template(
     model: str,
     messages: list,
     chat_template: Optional[Any] = None,
-    chat_template_kwargs: dict | None = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
 ):
     """HuggingFace chat template (sync version)"""
     from litellm.litellm_core_utils.prompt_templates.huggingface_template_handler import (
@@ -5268,7 +5268,7 @@ def prompt_factory(
     messages: list,
     custom_llm_provider: Optional[str] = None,
     api_key: Optional[str] = None,
-    chat_template_kwargs: dict | None = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
 ):
     original_model_name = model
     model = model.lower()

--- a/litellm/llms/triton/completion/transformation.py
+++ b/litellm/llms/triton/completion/transformation.py
@@ -194,7 +194,7 @@ class TritonGenerateConfig(TritonConfig):
         # chat_template_kwargs is a LiteLLM-level param: apply it here when
         # rendering the prompt text. Triton (TritonSamplingParams) has no
         # knowledge of this argument and will raise if it reaches the server.
-        chat_template_kwargs: dict = inference_params.pop("chat_template_kwargs", {}) or {}
+        chat_template_kwargs: dict[str, Any] = inference_params.pop("chat_template_kwargs", {}) or {}
         data_for_triton: Dict[str, Any] = {
             "text_input": prompt_factory(model=model, messages=messages, chat_template_kwargs=chat_template_kwargs),
             "parameters": {

--- a/litellm/llms/triton/completion/transformation.py
+++ b/litellm/llms/triton/completion/transformation.py
@@ -191,8 +191,12 @@ class TritonGenerateConfig(TritonConfig):
     ) -> dict:
         inference_params = optional_params.copy()
         stream = inference_params.pop("stream", False)
+        # chat_template_kwargs is a LiteLLM-level param: apply it here when
+        # rendering the prompt text. Triton (TritonSamplingParams) has no
+        # knowledge of this argument and will raise if it reaches the server.
+        chat_template_kwargs: dict = inference_params.pop("chat_template_kwargs", {}) or {}
         data_for_triton: Dict[str, Any] = {
-            "text_input": prompt_factory(model=model, messages=messages),
+            "text_input": prompt_factory(model=model, messages=messages, chat_template_kwargs=chat_template_kwargs),
             "parameters": {
                 "max_tokens": int(optional_params.get("max_tokens", DEFAULT_MAX_TOKENS_FOR_TRITON)),
             },
@@ -249,8 +253,9 @@ class TritonInferConfig(TritonConfig):
             ]
         }
 
+        _LITELLM_ONLY_PARAMS = {"stream", "max_retries", "chat_template_kwargs"}
         for k, v in optional_params.items():
-            if not (k == "stream" or k == "max_retries"):
+            if k not in _LITELLM_ONLY_PARAMS:
                 datatype = "INT32" if isinstance(v, int) else "BYTES"
                 datatype = "FP32" if isinstance(v, float) else datatype
                 data_for_triton["inputs"].append({"name": k, "shape": [1], "datatype": datatype, "data": [v]})

--- a/litellm/llms/triton/completion/transformation.py
+++ b/litellm/llms/triton/completion/transformation.py
@@ -3,6 +3,7 @@ Translates from OpenAI's `/v1/chat/completions` endpoint to Triton's `/generate`
 """
 
 import json
+from collections.abc import Mapping
 from typing import Any, AsyncIterator, Dict, Iterator, List, Literal, Optional, Union
 
 from httpx import Headers, Response
@@ -194,7 +195,7 @@ class TritonGenerateConfig(TritonConfig):
         # chat_template_kwargs is a LiteLLM-level param: apply it here when
         # rendering the prompt text. Triton (TritonSamplingParams) has no
         # knowledge of this argument and will raise if it reaches the server.
-        chat_template_kwargs: dict[str, Any] = inference_params.pop("chat_template_kwargs", {}) or {}
+        chat_template_kwargs: Mapping[str, Any] = inference_params.pop("chat_template_kwargs", {}) or {}
         data_for_triton: Dict[str, Any] = {
             "text_input": prompt_factory(model=model, messages=messages, chat_template_kwargs=chat_template_kwargs),
             "parameters": {

--- a/tests/llm_translation/test_triton.py
+++ b/tests/llm_translation/test_triton.py
@@ -6,16 +6,12 @@ import traceback
 from dotenv import load_dotenv
 
 load_dotenv()
-import io
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath("../.."))  # Adds the parent directory to the system path
 import pytest
 import litellm
-
-import pytest
 from litellm.llms.triton.embedding.transformation import TritonEmbeddingConfig
-import litellm
 
 from tests.fake_openai_endpoint import FAKE_OPENAI_API_BASE
 
@@ -223,7 +219,6 @@ def test_completion_triton_generate_api(stream):
             mock_post.assert_called_once()
 
             # Get the arguments passed to the post request
-            print("call args", mock_post.call_args)
             call_kwargs = mock_post.call_args.kwargs  # Access kwargs directly
 
             # Verify URL
@@ -251,9 +246,6 @@ def test_completion_triton_generate_api(stream):
                 assert response.choices[0].message.content == "I am an AI assistant"
 
     except Exception as e:
-        print("exception", e)
-        import traceback
-
         traceback.print_exc()
         pytest.fail(f"Error occurred: {e}")
 
@@ -309,8 +301,6 @@ def test_completion_triton_infer_api():
                 api_base="http://localhost:8000/infer",
             )
 
-            print("litellm response", response.model_dump_json(indent=4))
-
             # Verify the call was made
             mock_post.assert_called_once()
 
@@ -343,7 +333,6 @@ def test_completion_triton_infer_api():
             assert response.object == "chat.completion"
 
     except Exception as e:
-        print("exception", e)
         traceback.print_exc()
         pytest.fail(f"Error occurred: {e}")
 
@@ -357,8 +346,6 @@ async def test_triton_embeddings():
             api_base=f"{FAKE_OPENAI_API_BASE}/triton/embeddings",
             input=["good morning from litellm"],
         )
-        print(f"response: {response}")
-
         # stubbed endpoint is setup to return this
         assert response.data[0]["embedding"] == [0.1, 0.2]
     except Exception as e:
@@ -376,7 +363,6 @@ def test_triton_generate_raw_request():
             "api_base": "http://localhost:8000/generate",
         }
         raw_request = return_raw_request(endpoint=CallTypes.completion, kwargs=kwargs)
-        print("raw_request", raw_request)
         assert raw_request is not None
         assert "bad_words" not in json.dumps(raw_request["raw_request_body"])
         assert "stop_words" not in json.dumps(raw_request["raw_request_body"])

--- a/tests/llm_translation/test_triton.py
+++ b/tests/llm_translation/test_triton.py
@@ -9,9 +9,7 @@ load_dotenv()
 import io
 from unittest.mock import AsyncMock, MagicMock, patch
 
-sys.path.insert(
-    0, os.path.abspath("../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../.."))  # Adds the parent directory to the system path
 import pytest
 import litellm
 
@@ -30,9 +28,7 @@ def test_split_embedding_by_shape_passes():
                 "data": [1, 2, 3, 4, 5, 6],
             }
         ]
-        split_output_data = TritonEmbeddingConfig.split_embedding_by_shape(
-            data[0]["data"], data[0]["shape"]
-        )
+        split_output_data = TritonEmbeddingConfig.split_embedding_by_shape(data[0]["data"], data[0]["shape"])
         assert split_output_data == [[1, 2, 3], [4, 5, 6]]
     except Exception as e:
         pytest.fail(f"An exception occured: {e}")
@@ -46,9 +42,7 @@ def test_split_embedding_by_shape_fails_with_shape_value_error():
         }
     ]
     with pytest.raises(ValueError):
-        TritonEmbeddingConfig.split_embedding_by_shape(
-            data[0]["data"], data[0]["shape"]
-        )
+        TritonEmbeddingConfig.split_embedding_by_shape(data[0]["data"], data[0]["shape"])
 
 
 def test_triton_embedding_response_sets_usage_with_token_counter():
@@ -333,9 +327,7 @@ def test_completion_triton_infer_api():
             assert request_data["inputs"][0]["name"] == "text_input"
             assert request_data["inputs"][0]["shape"] == [1]
             assert request_data["inputs"][0]["datatype"] == "BYTES"
-            assert request_data["inputs"][0]["data"] == [
-                "0004900005025 0004900005026 0004900005027"
-            ]
+            assert request_data["inputs"][0]["data"] == ["0004900005025 0004900005026 0004900005027"]
 
             assert request_data["inputs"][1]["shape"] == [1]
             assert request_data["inputs"][1]["datatype"] == "INT32"
@@ -390,3 +382,66 @@ def test_triton_generate_raw_request():
         assert "stop_words" not in json.dumps(raw_request["raw_request_body"])
     except Exception as e:
         pytest.fail(f"Error occurred: {e}")
+
+
+def test_triton_generate_chat_template_kwargs_not_forwarded_to_triton():
+    """
+    chat_template_kwargs must be consumed by LiteLLM when rendering text_input
+    and must NOT appear in the parameters dict sent to Triton.
+
+    Triton's TritonSamplingParams raises on unknown kwargs:
+      Unexpected keyword argument 'chat_template_kwargs'
+    """
+    from litellm.llms.triton.completion.transformation import TritonGenerateConfig
+
+    config = TritonGenerateConfig()
+    messages = [{"role": "user", "content": "hello"}]
+    optional_params = {
+        "max_tokens": 50,
+        "stream": False,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+    result = config.transform_request(
+        model="llama-3-8b-instruct",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={"api_base": "http://localhost:8000/generate"},
+        headers={},
+    )
+
+    # chat_template_kwargs must never reach Triton's parameters
+    assert "chat_template_kwargs" not in result["parameters"], (
+        "chat_template_kwargs leaked into Triton parameters; it must be consumed by LiteLLM when building text_input"
+    )
+    # Scalar params that Triton understands must still be forwarded
+    assert result["parameters"]["max_tokens"] == 50
+
+
+def test_triton_infer_chat_template_kwargs_not_forwarded_to_triton():
+    """
+    chat_template_kwargs must not appear in the inputs list sent to Triton's
+    /infer endpoint either.
+    """
+    from litellm.llms.triton.completion.transformation import TritonInferConfig
+
+    config = TritonInferConfig()
+    messages = [{"role": "user", "content": "hello"}]
+    optional_params = {
+        "max_tokens": 20,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+    result = config.transform_request(
+        model="llama-3-8b-instruct",
+        messages=messages,
+        optional_params=optional_params,
+        litellm_params={"api_base": "http://localhost:8000/infer"},
+        headers={},
+    )
+
+    input_names = [inp["name"] for inp in result["inputs"]]
+    assert "chat_template_kwargs" not in input_names, (
+        "chat_template_kwargs leaked into Triton inputs; "
+        "it is a LiteLLM-only param and must not reach the Triton server"
+    )

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -3197,3 +3197,94 @@ def test_get_tool_calls_from_response_include_all_choices_reads_every_choice():
 
     names = [tc["name"] for tc in get_tool_calls_from_response(response, include_all_choices=True)]
     assert names == ["tool_alpha", "tool_beta"]
+
+
+def test_hf_chat_template_forwards_chat_template_kwargs():
+    """chat_template_kwargs must be forwarded verbatim to template.render()."""
+    from litellm.litellm_core_utils.prompt_templates.factory import hf_chat_template
+
+    template = (
+        "{% for message in messages %}{{ message['content'] }}{% endfor %}"
+        "{% if enable_thinking %}<think>{% endif %}"
+    )
+    out = hf_chat_template(
+        model="any-model",
+        messages=[{"role": "user", "content": "hi"}],
+        chat_template=template,
+        chat_template_kwargs={"enable_thinking": True},
+    )
+    assert "<think>" in out
+
+    out_off = hf_chat_template(
+        model="any-model",
+        messages=[{"role": "user", "content": "hi"}],
+        chat_template=template,
+        chat_template_kwargs={"enable_thinking": False},
+    )
+    assert "<think>" not in out_off
+
+
+def test_render_chat_template_kwargs_survive_alternation_fallback():
+    """
+    When the template rejects a system probe, then rejects non-alternating
+    roles, the fallback re-render (with interleaved empty messages) must still
+    receive the chat_template_kwargs.
+
+    The env's raise_exception global returns (not raises) an Exception, so a
+    real template cannot drive this path deterministically; a mock template
+    scripts the three renders: system probe fails -> alternation error ->
+    fallback succeeds.
+    """
+    from unittest.mock import MagicMock
+
+    from litellm.litellm_core_utils.prompt_templates.factory import (
+        _render_chat_template,
+    )
+
+    mock_template = MagicMock()
+    mock_template.render.side_effect = [
+        Exception("no system role supported"),  # _is_system_in_template probe
+        Exception("Conversation roles must alternate user/assistant/..."),
+        "fallback-rendered",
+    ]
+    mock_env = MagicMock()
+    mock_env.from_string.return_value = mock_template
+
+    out = _render_chat_template(
+        env=mock_env,
+        chat_template="{# no 'sys tem' keyword here #}",
+        bos_token="<s>",
+        eos_token="</s>",
+        messages=[
+            {"role": "user", "content": "first"},
+            {"role": "user", "content": "second"},
+        ],
+        chat_template_kwargs={"enable_thinking": True},
+    )
+
+    assert out == "fallback-rendered"
+    # the fallback render (third call) must carry the kwargs and the
+    # interleaved messages
+    final_kwargs = mock_template.render.call_args_list[-1].kwargs
+    assert final_kwargs["enable_thinking"] is True
+    roles = [m["role"] for m in final_kwargs["messages"]]
+    assert roles == ["user", "assistant", "user"]
+
+
+def test_prompt_factory_forwards_chat_template_kwargs_to_hf_fallback():
+    """prompt_factory's generic-model fallback must forward chat_template_kwargs."""
+    from unittest.mock import patch as mock_patch
+
+    from litellm.litellm_core_utils.prompt_templates import factory as factory_mod
+
+    with mock_patch.object(
+        factory_mod, "hf_chat_template", return_value="hf-rendered"
+    ) as mock_hf:
+        out = factory_mod.prompt_factory(
+            model="some-org/some-unknown-model",
+            messages=[{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"enable_thinking": False},
+        )
+
+    assert out == "hf-rendered"
+    assert mock_hf.call_args.kwargs["chat_template_kwargs"] == {"enable_thinking": False}

--- a/tests/test_litellm/llms/triton/completion/test_triton_completion_transformation.py
+++ b/tests/test_litellm/llms/triton/completion/test_triton_completion_transformation.py
@@ -1,0 +1,100 @@
+"""
+Unit tests for Triton /generate and /infer request transformation.
+
+Regression tests for the chat_template_kwargs leak: chat_template_kwargs is a
+LiteLLM-level param consumed while rendering the prompt; TritonSamplingParams
+has no such argument, so forwarding it to the server made requests fail.
+"""
+
+from unittest.mock import patch
+
+from litellm.llms.triton.completion.transformation import (
+    TritonGenerateConfig,
+    TritonInferConfig,
+)
+
+
+def test_generate_chat_template_kwargs_consumed_not_forwarded():
+    """chat_template_kwargs must reach prompt_factory and never the parameters dict."""
+    config = TritonGenerateConfig()
+    with patch(
+        "litellm.llms.triton.completion.transformation.prompt_factory",
+        return_value="rendered-prompt",
+    ) as mock_pf:
+        data = config.transform_request(
+            model="triton/qwen3",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={
+                "max_tokens": 10,
+                "chat_template_kwargs": {"enable_thinking": False},
+            },
+            litellm_params={},
+            headers={},
+        )
+
+    mock_pf.assert_called_once()
+    assert mock_pf.call_args.kwargs["chat_template_kwargs"] == {"enable_thinking": False}
+    assert data["text_input"] == "rendered-prompt"
+    # must not leak into the Triton parameters payload
+    assert "chat_template_kwargs" not in data["parameters"]
+    assert data["parameters"]["max_tokens"] == 10
+
+
+def test_generate_no_chat_template_kwargs_defaults_to_empty_mapping():
+    """Absent chat_template_kwargs must pass an empty mapping to prompt_factory."""
+    config = TritonGenerateConfig()
+    with patch(
+        "litellm.llms.triton.completion.transformation.prompt_factory",
+        return_value="p",
+    ) as mock_pf:
+        data = config.transform_request(
+            model="triton/llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={"max_tokens": 5},
+            litellm_params={},
+            headers={},
+        )
+
+    assert mock_pf.call_args.kwargs["chat_template_kwargs"] == {}
+    assert "chat_template_kwargs" not in data["parameters"]
+
+
+def test_generate_none_chat_template_kwargs_normalized_to_empty_mapping():
+    """chat_template_kwargs=None must be normalized, not passed as None."""
+    config = TritonGenerateConfig()
+    with patch(
+        "litellm.llms.triton.completion.transformation.prompt_factory",
+        return_value="p",
+    ) as mock_pf:
+        config.transform_request(
+            model="triton/llama-3-8b-instruct",
+            messages=[{"role": "user", "content": "hi"}],
+            optional_params={"max_tokens": 5, "chat_template_kwargs": None},
+            litellm_params={},
+            headers={},
+        )
+
+    assert mock_pf.call_args.kwargs["chat_template_kwargs"] == {}
+
+
+def test_infer_chat_template_kwargs_excluded_from_inputs():
+    """/infer inputs must skip stream, max_retries, and chat_template_kwargs."""
+    config = TritonInferConfig()
+    data = config.transform_request(
+        model="triton/custom-model",
+        messages=[{"role": "user", "content": "text in"}],
+        optional_params={
+            "temperature": 0.5,
+            "stream": False,
+            "max_retries": 3,
+            "chat_template_kwargs": {"enable_thinking": True},
+        },
+        litellm_params={},
+        headers={},
+    )
+
+    input_names = [i["name"] for i in data["inputs"]]
+    assert "chat_template_kwargs" not in input_names
+    assert "stream" not in input_names
+    assert "max_retries" not in input_names
+    assert "temperature" in input_names


### PR DESCRIPTION
## Problem

When `chat_template_kwargs` (e.g. `{"enable_thinking": False}` for Qwen3) was passed to a Triton-backed model, LiteLLM forwarded it to the Triton server as a regular parameter. Triton's `TritonSamplingParams` raises on unknown kwargs:

```
Unexpected keyword argument 'chat_template_kwargs'
```

`chat_template_kwargs` is a LiteLLM-level parameter — it controls how the Jinja chat template is rendered locally. Triton has no knowledge of it and should never receive it.

## Fix

**`litellm/llms/triton/completion/transformation.py`**

- `TritonGenerateConfig.transform_request`: pop `chat_template_kwargs` from `inference_params` before the `.update()` that builds Triton's `parameters` dict; pass it to `prompt_factory` to render `text_input` locally
- `TritonInferConfig.transform_request`: add `"chat_template_kwargs"` to the `_LITELLM_ONLY_PARAMS` set that gates which params become Triton inputs

**`litellm/litellm_core_utils/prompt_templates/factory.py`**

- Thread `chat_template_kwargs` through `prompt_factory` → `hf_chat_template` → `_render_chat_template`, where it is spread as `**extra` into `template.render(...)`. All new parameters are optional with `None` defaults — fully backward-compatible.

## Tests

Two new unit tests in `tests/llm_translation/test_triton.py` that call `transform_request()` directly and assert `chat_template_kwargs` is absent from the outbound Triton payload.

## Related

Addresses the same root cause reported in #31127 with a cleaner fix: strip the param instead of encoding it as JSON and still forwarding it.