### PR TITLE
fix(proxy): never rewrite team model aliases to deleted deployments and clean up aliases on model delete

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -87,7 +87,6 @@ def _sanitize_for_log(value: Any) -> str:
 
 
 from litellm.router import Router
-from litellm.secret_managers.main import get_secret_bool
 from litellm.types.llms.anthropic import ANTHROPIC_API_HEADERS
 from litellm.types.services import ServiceTypes
 from litellm.types.utils import (
@@ -102,8 +101,6 @@ service_logger_obj = ServiceLogging()  # used for tracking latency on OTEL
 # Bounded dedup for stale-alias warnings (FIFO eviction when over cap).
 _MAX_STALE_ALIAS_WARNING_KEYS = 10_000
 _STALE_TEAM_ALIAS_WARNING_KEYS: OrderedDict[str, None] = OrderedDict()
-# Cache the stale alias bypass flag at module load to avoid hot-path secret lookups
-_ENABLE_TEAM_STALE_ALIAS_BYPASS: Optional[bool] = None
 
 
 if TYPE_CHECKING:
@@ -1785,6 +1782,7 @@ async def add_litellm_data_to_request(
     _update_model_if_team_alias_exists(
         data=data,
         user_api_key_dict=user_api_key_dict,
+        llm_router=llm_router,
     )
 
     # Key Model Aliases
@@ -1832,6 +1830,7 @@ async def add_litellm_data_to_request(
 def _update_model_if_team_alias_exists(
     data: dict,
     user_api_key_dict: UserAPIKeyAuth,
+    llm_router: Router | None,
 ) -> None:
     """
     Update the model if the team alias exists
@@ -1845,52 +1844,53 @@ def _update_model_if_team_alias_exists(
         }
         - requested_model = "gpt-4o-team-1"
 
+    The rewrite is skipped when the alias target no longer resolves to any live
+    deployment in the router (e.g. a dangling `model_name_{team_id}_{uuid}` alias
+    left behind after its team-scoped deployment was deleted); the request keeps
+    the model name the caller sent so routing can resolve it normally.
+
     Note: model_aliases for team models are deprecated. This function only applies
     to legacy non-team-scoped aliases. Team-scoped deployments use team_public_model_name
     and are resolved via map_team_model in route_llm_request.
     """
     _model = data.get("model")
-    if _model and user_api_key_dict.team_model_aliases and _model in user_api_key_dict.team_model_aliases:
-        from litellm.proxy.proxy_server import llm_router
+    if not _model or not user_api_key_dict.team_model_aliases:
+        return
+    if _model not in user_api_key_dict.team_model_aliases:
+        return
 
-        # Skip alias rewrite if this model resolves to team-specific deployments
-        # (team models use team_public_model_name, not model_aliases)
-        aliased_target = user_api_key_dict.team_model_aliases[_model]
+    aliased_target = user_api_key_dict.team_model_aliases[_model]
+    if llm_router is not None and not llm_router.get_model_list(
+        model_name=aliased_target, team_id=user_api_key_dict.team_id
+    ):
+        _warn_once_dangling_team_alias(
+            requested_model=_model,
+            aliased_target=aliased_target,
+            team_id=user_api_key_dict.team_id,
+        )
+        return
 
-        # Optional bypass for stale aliases from pre-PR deployments:
-        # only enabled via feature flag to preserve backwards compatibility.
-        # Cached at module level to avoid hot-path secret lookups on every request.
-        global _ENABLE_TEAM_STALE_ALIAS_BYPASS
-        if _ENABLE_TEAM_STALE_ALIAS_BYPASS is None:
-            _ENABLE_TEAM_STALE_ALIAS_BYPASS = get_secret_bool("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", False)
-        enable_stale_alias_bypass = _ENABLE_TEAM_STALE_ALIAS_BYPASS
-        # Check if the alias points to a team-scoped UUID name
-        # (format: "model_name_{team_id}_{uuid}")
-        is_stale_team_alias = aliased_target.startswith(f"model_name_{user_api_key_dict.team_id}_")
-        if is_stale_team_alias and llm_router:
-            # This is a stale alias from pre-PR deployments.
-            # Check if current team deployments exist for the public name.
-            key = (user_api_key_dict.team_id, _model)
-            if key in llm_router.team_model_to_deployment_indices:
-                if enable_stale_alias_bypass:
-                    # Team deployments exist; skip stale alias
-                    return
-                warning_key = f"{user_api_key_dict.team_id}:{_model}:{aliased_target}"
-                if warning_key not in _STALE_TEAM_ALIAS_WARNING_KEYS:
-                    _STALE_TEAM_ALIAS_WARNING_KEYS[warning_key] = None
-                    while len(_STALE_TEAM_ALIAS_WARNING_KEYS) > _MAX_STALE_ALIAS_WARNING_KEYS:
-                        _STALE_TEAM_ALIAS_WARNING_KEYS.popitem(last=False)
-                    verbose_proxy_logger.warning(
-                        "Stale team model alias detected for model='%s', team_id='%s'. "
-                        "New sibling deployments may be unreachable. "
-                        "Set LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS=true to enable "
-                        "team-scoped sibling routing.",
-                        _sanitize_for_log(_model),
-                        user_api_key_dict.team_id,
-                    )
+    data["model"] = aliased_target
 
-        data["model"] = aliased_target
-    return
+
+def _warn_once_dangling_team_alias(
+    requested_model: str,
+    aliased_target: str,
+    team_id: str | None,
+) -> None:
+    warning_key = f"{team_id}:{requested_model}:{aliased_target}"
+    if warning_key in _STALE_TEAM_ALIAS_WARNING_KEYS:
+        return
+    _STALE_TEAM_ALIAS_WARNING_KEYS[warning_key] = None
+    while len(_STALE_TEAM_ALIAS_WARNING_KEYS) > _MAX_STALE_ALIAS_WARNING_KEYS:
+        _STALE_TEAM_ALIAS_WARNING_KEYS.popitem(last=False)
+    verbose_proxy_logger.warning(
+        "Team model alias '%s' -> '%s' for team_id='%s' has no live deployments; "
+        "ignoring the alias and routing the requested model name directly.",
+        _sanitize_for_log(requested_model),
+        _sanitize_for_log(aliased_target),
+        team_id,
+    )
 
 
 def _update_model_if_key_alias_exists(

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -800,14 +800,12 @@ async def _remove_unbacked_team_models(
     if team_id is None:
         return
 
-    # BYOK models carry an internal `model_name_{team_id}_{uuid}` name that can never
-    # be a team alias value, so skip the full litellm_modeltable scan for them.
-    removed_model_aliases: List[Tuple[str, str]] = []
-    if not model_params.model_name.startswith(f"model_name_{team_id}_"):
-        removed_model_aliases = await delete_team_model_alias(
-            public_model_name=model_params.model_name,
-            prisma_client=prisma_client,
-        )
+    removed_model_aliases = await delete_team_model_alias(
+        deleted_model_name=model_params.model_name,
+        prisma_client=prisma_client,
+        team_id=team_id,
+        team_public_model_name=model_params.model_info.team_public_model_name,
+    )
     names_to_remove = {alias for alias_team_id, alias in removed_model_aliases if alias_team_id == team_id}
     if model_params.model_info.team_public_model_name is not None:
         names_to_remove.add(model_params.model_info.team_public_model_name)
@@ -1162,35 +1160,61 @@ async def delete_model(
 
 
 async def delete_team_model_alias(
-    public_model_name: str,
+    deleted_model_name: str,
     prisma_client: PrismaClient,
+    team_id: str | None = None,
+    team_public_model_name: str | None = None,
 ) -> List[Tuple[str, str]]:
     """
-    Delete a team model alias
+    Remove team model alias entries that reference a deleted deployment.
 
-    Iterate through all team model aliases and delete the one that matches the model_id
+    Two alias row shapes exist in LiteLLM_ModelTable.model_aliases:
+    - legacy rows: {"alias": "public model name"}, matched when an entry's value
+      equals the deleted deployment's model_name
+    - team-scoped rows: {"public name": "model_name_{team_id}_{uuid}"}, matched when
+      the entry belongs to the deleted deployment's team, its key equals the
+      deployment's team_public_model_name, and its value has the team-internal shape
 
     Returns:
     - List of team id + model alias pairs that were removed
     """
     team_model_aliases = await ModelTableRepository(prisma_client).table.find_many(include={"team": True})
+    internal_name_prefix = f"model_name_{team_id}_" if team_id is not None else None
     tasks = []
-    removed_model_aliases = []
+    removed_model_aliases: List[Tuple[str, str]] = []
     for team_model_alias in team_model_aliases:
-        model_aliases = team_model_alias.model_aliases  # {"alias": "public model name"}
-        id = team_model_alias.id
-
-        if public_model_name in model_aliases.values():
-            key = list(model_aliases.keys())[list(model_aliases.values()).index(public_model_name)]
-            if team_model_alias.team is not None:
-                removed_model_aliases.append((team_model_alias.team.team_id, key))
-            del model_aliases[key]
-            tasks.append(
-                ModelTableRepository(prisma_client).table.update(
-                    where={"id": id},
-                    data={"model_aliases": json.dumps(model_aliases)},
-                )
+        raw_aliases = team_model_alias.model_aliases
+        model_aliases = json.loads(raw_aliases) if isinstance(raw_aliases, str) else raw_aliases
+        if not isinstance(model_aliases, dict):
+            continue
+        row_team_id = team_model_alias.team.team_id if team_model_alias.team is not None else None
+        keys_to_remove = frozenset(
+            alias_key
+            for alias_key, alias_target in model_aliases.items()
+            if alias_target == deleted_model_name
+            or (
+                internal_name_prefix is not None
+                and row_team_id == team_id
+                and alias_key == team_public_model_name
+                and alias_target.startswith(internal_name_prefix)
             )
+        )
+        if not keys_to_remove:
+            continue
+
+        if row_team_id is not None:
+            removed_model_aliases.extend((row_team_id, alias_key) for alias_key in keys_to_remove)
+        remaining_aliases = {
+            alias_key: alias_target
+            for alias_key, alias_target in model_aliases.items()
+            if alias_key not in keys_to_remove
+        }
+        tasks.append(
+            ModelTableRepository(prisma_client).table.update(
+                where={"id": team_model_alias.id},
+                data={"model_aliases": json.dumps(remaining_aliases)},
+            )
+        )
     await asyncio.gather(*tasks)
 
     return removed_model_aliases

--- a/tests/proxy_unit_tests/test_proxy_utils.py
+++ b/tests/proxy_unit_tests/test_proxy_utils.py
@@ -2168,23 +2168,24 @@ def test_update_model_if_team_alias_exists(data, user_api_key_dict, expected_mod
 
     # Call the function
     _update_model_if_team_alias_exists(
-        data=test_data, user_api_key_dict=user_api_key_dict
+        data=test_data, user_api_key_dict=user_api_key_dict, llm_router=None
     )
 
     # Check if model was updated correctly
     assert test_data.get("model") == expected_model
 
 
-def test_team_alias_stale_bypass_disabled_by_default(monkeypatch):
-    monkeypatch.delenv("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", raising=False)
-    import litellm.proxy.litellm_pre_call_utils as pre_call_utils
+def test_team_alias_with_dead_target_keeps_requested_model():
     from litellm.proxy.litellm_pre_call_utils import _update_model_if_team_alias_exists
 
-    # Reset module-level cache to ensure test isolation
-    pre_call_utils._ENABLE_TEAM_STALE_ALIAS_BYPASS = None
-
-    class _MockRouter:
-        team_model_to_deployment_indices = {("team-1", "gpt-4o"): [0]}
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4o",
+                "litellm_params": {"model": "openai/gpt-5.6", "api_key": "fake-key"},
+            }
+        ]
+    )
 
     test_data = {"model": "gpt-4o"}
     user_api_key_dict = UserAPIKeyAuth(
@@ -2193,38 +2194,37 @@ def test_team_alias_stale_bypass_disabled_by_default(monkeypatch):
         team_model_aliases={"gpt-4o": "model_name_team-1_legacy-uuid"},
     )
 
-    with patch("litellm.proxy.proxy_server.llm_router", _MockRouter()):
-        _update_model_if_team_alias_exists(
-            data=test_data, user_api_key_dict=user_api_key_dict
-        )
-
-    assert test_data.get("model") == "model_name_team-1_legacy-uuid"
-
-
-def test_team_alias_stale_bypass_enabled_by_flag(monkeypatch):
-    import litellm.proxy.litellm_pre_call_utils as pre_call_utils
-    from litellm.proxy.litellm_pre_call_utils import _update_model_if_team_alias_exists
-
-    # Reset module-level cache to ensure test isolation
-    pre_call_utils._ENABLE_TEAM_STALE_ALIAS_BYPASS = None
-
-    class _MockRouter:
-        team_model_to_deployment_indices = {("team-1", "gpt-4o"): [0]}
-
-    test_data = {"model": "gpt-4o"}
-    user_api_key_dict = UserAPIKeyAuth(
-        api_key="test_key",
-        team_id="team-1",
-        team_model_aliases={"gpt-4o": "model_name_team-1_legacy-uuid"},
+    _update_model_if_team_alias_exists(
+        data=test_data, user_api_key_dict=user_api_key_dict, llm_router=router
     )
-    monkeypatch.setenv("LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS", "true")
-
-    with patch("litellm.proxy.proxy_server.llm_router", _MockRouter()):
-        _update_model_if_team_alias_exists(
-            data=test_data, user_api_key_dict=user_api_key_dict
-        )
 
     assert test_data.get("model") == "gpt-4o"
+
+
+def test_team_alias_with_live_target_is_rewritten():
+    from litellm.proxy.litellm_pre_call_utils import _update_model_if_team_alias_exists
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "gpt-4o-team-1",
+                "litellm_params": {"model": "openai/gpt-5.6", "api_key": "fake-key"},
+            }
+        ]
+    )
+
+    test_data = {"model": "gpt-4o"}
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test_key",
+        team_id="team-1",
+        team_model_aliases={"gpt-4o": "gpt-4o-team-1"},
+    )
+
+    _update_model_if_team_alias_exists(
+        data=test_data, user_api_key_dict=user_api_key_dict, llm_router=router
+    )
+
+    assert test_data.get("model") == "gpt-4o-team-1"
 
 
 @pytest.fixture

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -329,7 +329,7 @@ class TestDeleteTeamModelAlias:
 
         # Call the function
         await delete_team_model_alias(
-            public_model_name="public_model_1", prisma_client=mock_prisma
+            deleted_model_name="public_model_1", prisma_client=mock_prisma
         )
 
         # Verify results
@@ -387,12 +387,123 @@ class TestDeleteTeamModelAlias:
 
         # Call the function with non-existent model
         await delete_team_model_alias(
-            public_model_name="non_existent_model", prisma_client=mock_prisma
+            deleted_model_name="non_existent_model", prisma_client=mock_prisma
         )
 
         # Verify no updates were made
         mock_db = mock_prisma.db.litellm_modeltable
         assert len(mock_db.update_calls) == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_team_scoped_alias_matched_by_internal_value(self):
+        """Regression: team-scoped alias rows are {public_name: internal_name}. Deleting
+        the internal deployment must scrub the entry via the value direction."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            delete_team_model_alias,
+        )
+
+        team = LiteLLM_TeamTable(team_id="team-1", team_alias="team-1-alias")
+        model_aliases_list = [
+            {
+                "id": 1,
+                "model_aliases": {
+                    "claude-fast": "model_name_team-1_uuid-1",
+                    "kept-alias": "some-public-model",
+                },
+                "updated_by": "test_user",
+                "created_by": "test_user",
+                "team": team,
+            },
+        ]
+        mock_prisma = MockPrismaClient(team_exists=True)
+        mock_prisma.db = MockPrismaWrapper(model_aliases_list)
+
+        removed = await delete_team_model_alias(
+            deleted_model_name="model_name_team-1_uuid-1",
+            prisma_client=mock_prisma,
+            team_id="team-1",
+            team_public_model_name="claude-fast",
+        )
+
+        assert removed == [("team-1", "claude-fast")]
+        update_calls = mock_prisma.db.litellm_modeltable.update_calls
+        assert len(update_calls) == 1
+        assert json.loads(update_calls[0]["data"]["model_aliases"]) == {
+            "kept-alias": "some-public-model"
+        }
+
+    @pytest.mark.asyncio
+    async def test_delete_team_scoped_alias_matched_by_public_key_when_value_drifted(self):
+        """Regression: the alias value may point at a stale uuid that matches no row at
+        all. The entry must still be scrubbed via the key direction (public name) when
+        the owning team's deployment for that public name is deleted."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            delete_team_model_alias,
+        )
+
+        team = LiteLLM_TeamTable(team_id="team-1", team_alias="team-1-alias")
+        model_aliases_list = [
+            {
+                "id": 1,
+                "model_aliases": {"claude-fast": "model_name_team-1_other-uuid"},
+                "updated_by": "test_user",
+                "created_by": "test_user",
+                "team": team,
+            },
+        ]
+        mock_prisma = MockPrismaClient(team_exists=True)
+        mock_prisma.db = MockPrismaWrapper(model_aliases_list)
+
+        removed = await delete_team_model_alias(
+            deleted_model_name="model_name_team-1_uuid-1",
+            prisma_client=mock_prisma,
+            team_id="team-1",
+            team_public_model_name="claude-fast",
+        )
+
+        assert removed == [("team-1", "claude-fast")]
+        update_calls = mock_prisma.db.litellm_modeltable.update_calls
+        assert len(update_calls) == 1
+        assert json.loads(update_calls[0]["data"]["model_aliases"]) == {}
+
+    @pytest.mark.asyncio
+    async def test_delete_team_scoped_alias_keeps_legacy_alias_and_other_teams(self):
+        """A legacy alias {public: other-gateway-model} in the deleting team's row and
+        another team's alias rows must survive a team-scoped deployment delete."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            delete_team_model_alias,
+        )
+
+        team_1 = LiteLLM_TeamTable(team_id="team-1", team_alias="team-1-alias")
+        team_2 = LiteLLM_TeamTable(team_id="team-2", team_alias="team-2-alias")
+        model_aliases_list = [
+            {
+                "id": 1,
+                "model_aliases": {"claude-fast": "azure-claude"},
+                "updated_by": "test_user",
+                "created_by": "test_user",
+                "team": team_1,
+            },
+            {
+                "id": 2,
+                "model_aliases": {"claude-fast": "model_name_team-2_uuid-2"},
+                "updated_by": "test_user",
+                "created_by": "test_user",
+                "team": team_2,
+            },
+        ]
+        mock_prisma = MockPrismaClient(team_exists=True)
+        mock_prisma.db = MockPrismaWrapper(model_aliases_list)
+
+        removed = await delete_team_model_alias(
+            deleted_model_name="model_name_team-1_uuid-1",
+            prisma_client=mock_prisma,
+            team_id="team-1",
+            team_public_model_name="claude-fast",
+        )
+
+        assert removed == []
+        assert mock_prisma.db.litellm_modeltable.update_calls == []
 
 
 class TestClearCache:
@@ -1997,9 +2108,20 @@ class TestDeleteTeamBYOKModelGhost:
         mock_prisma.db.litellm_teamtable.update = AsyncMock(
             return_value=updated_team_row
         )
-        # Team BYOK models have no alias row; delete_team_model_alias finds nothing.
+        # Legacy versions wrote a hidden alias row {public_name: internal_name};
+        # deleting the deployment must scrub it (regression for dangling aliases).
+        alias_row = LiteLLM_ModelTable(
+            id=7,
+            model_aliases={public_name: f"model_name_{team_id}_abc-uuid"},
+            created_by="admin",
+            updated_by="admin",
+            team=_team([public_name, kept_name]),
+        )
         mock_prisma.db.litellm_modeltable = AsyncMock()
-        mock_prisma.db.litellm_modeltable.find_many = AsyncMock(return_value=[])
+        mock_prisma.db.litellm_modeltable.find_many = AsyncMock(
+            return_value=[alias_row]
+        )
+        mock_prisma.db.litellm_modeltable.update = AsyncMock(return_value=None)
 
         admin_user = UserAPIKeyAuth(
             user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
@@ -2031,8 +2153,12 @@ class TestDeleteTeamBYOKModelGhost:
 
         mock_refresh.assert_awaited_once()
         assert mock_refresh.await_args.kwargs["team_row"] is updated_team_row
-        # BYOK internal name can't be an alias value -> the alias-table scan is skipped.
-        mock_prisma.db.litellm_modeltable.find_many.assert_not_awaited()
+        # The dangling alias row {public_name: internal_name} is scrubbed on delete.
+        mock_prisma.db.litellm_modeltable.find_many.assert_awaited()
+        mock_prisma.db.litellm_modeltable.update.assert_awaited_once()
+        alias_update_kwargs = mock_prisma.db.litellm_modeltable.update.await_args.kwargs
+        assert alias_update_kwargs["where"] == {"id": 7}
+        assert json.loads(alias_update_kwargs["data"]["model_aliases"]) == {}
 
     @pytest.mark.asyncio
     async def test_delete_non_internal_team_model_still_scans_aliases(self):

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -23,6 +23,7 @@ from litellm.proxy.litellm_pre_call_utils import (
     _resolve_credential_from_model_config,
     _resolve_provider_from_deployment,
     _update_model_if_key_alias_exists,
+    _update_model_if_team_alias_exists,
     add_guardrails_from_policy_engine,
     add_litellm_data_to_request,
     check_if_token_is_service_account,
@@ -5457,3 +5458,73 @@ def test_get_sanitized_user_information_from_key_drops_callback_config():
     # UserAPIKeyAuth is the live auth object; the per-key callbacks are resolved
     # from it during pre-call, so it must not be mutated by building the log view
     assert "logging" in (user_api_key_dict.metadata or {})
+
+
+class TestUpdateModelIfTeamAliasExists:
+    """Regression tests for dangling team model aliases.
+
+    Team-scoped deployments used to write a hidden alias
+    {public_name: "model_name_{team_id}_{uuid}"} into LiteLLM_ModelTable. When the
+    team-scoped deployment was deleted the alias row survived, and the pre-call
+    rewrite sent every request for the public name to the deleted deployment,
+    returning 400 "no healthy deployments" even though a gateway-level deployment
+    still served the public name.
+    """
+
+    def _router(self, model_name: str) -> litellm.Router:
+        return litellm.Router(
+            model_list=[
+                {
+                    "model_name": model_name,
+                    "litellm_params": {"model": "openai/gpt-5.6", "api_key": "fake-key"},
+                }
+            ]
+        )
+
+    def test_dangling_alias_keeps_requested_model(self):
+        data = {"model": "claude-fast"}
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="test-key",
+            team_id="team-1",
+            team_model_aliases={"claude-fast": "model_name_team-1_dead-uuid"},
+        )
+
+        _update_model_if_team_alias_exists(
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+            llm_router=self._router("claude-fast"),
+        )
+
+        assert data["model"] == "claude-fast"
+
+    def test_alias_to_live_model_group_is_rewritten(self):
+        data = {"model": "gpt-4o"}
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="test-key",
+            team_id="team-1",
+            team_model_aliases={"gpt-4o": "gpt-4o-team-1"},
+        )
+
+        _update_model_if_team_alias_exists(
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+            llm_router=self._router("gpt-4o-team-1"),
+        )
+
+        assert data["model"] == "gpt-4o-team-1"
+
+    def test_alias_is_rewritten_when_router_unavailable(self):
+        data = {"model": "gpt-4o"}
+        user_api_key_dict = UserAPIKeyAuth(
+            api_key="test-key",
+            team_id="team-1",
+            team_model_aliases={"gpt-4o": "gpt-4o-team-1"},
+        )
+
+        _update_model_if_team_alias_exists(
+            data=data,
+            user_api_key_dict=user_api_key_dict,
+            llm_router=None,
+        )
+
+        assert data["model"] == "gpt-4o-team-1"


### PR DESCRIPTION
Draft for implementation comparison against #34993; one of the two will be closed after review

## TLDR

Problem this solves:

- Team-scoped models wrote hidden aliases {public_name: model_name_team_uuid} into LiteLLM_ModelTable
- Deleting the team deployment left the alias row behind
- Pre-call rewrote the public name to the deleted deployment unconditionally
- Every call using that public name then 400'd with "no healthy deployments"
- /model/delete explicitly skipped alias cleanup for exactly these rows

How it solves it:

- Alias rewrite now no-ops when the target has zero deployments in the router
- The request keeps the public model name the caller actually sent
- This is default behavior; the LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS env gate is removed
- /model/delete now always scrubs alias entries referencing the deleted deployment
- Matching covers both row shapes: {alias: public} values and {public: internal} keys

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two live proxies against real Postgres DBs and real OpenAI calls (gpt-5.6). Before runs: litellm_internal_staging at 7cd009caf7 on port 27431. After runs: this branch at 037bdb10d3 on port 27432. Same flow on both: create a gateway-level model, create a team plus a team-scoped duplicate of the same public name, write the legacy hidden alias row {public: internal} the way v1.92.0-era team model creation did (via /team/update model_aliases), generate a team key, call chat completions, delete the team-scoped deployment, and call again

| # | commit | scenario | route | result |
|---|--------|----------|-------|--------|
| 1 | 7cd009caf7 (before) | alias target live, pre-delete | /v1/chat/completions | PASS 200 |
| 2 | 7cd009caf7 (before) | team deployment deleted | /v1/chat/completions | FAIL 400 |
| 3 | 037bdb10d3 (after) | alias target live, pre-delete | /v1/chat/completions | PASS 200 |
| 4 | 037bdb10d3 (after) | team deployment deleted | /v1/chat/completions | PASS 200 |
| 5 | 7cd009caf7 (before) | dangling alias, no delete involved | /v1/chat/completions | FAIL 400 |
| 6 | 7cd009caf7 (before) | dangling alias, no delete involved | /v1/responses | FAIL 400 |
| 7 | 037bdb10d3 (after) | dangling alias, no delete involved | /v1/chat/completions | PASS 200 |
| 8 | 037bdb10d3 (after) | dangling alias, no delete involved | /v1/responses | PASS 200 |

Before, at 7cd009caf7 (the customer symptom, checkpoint 2):

```
$ curl -s -X POST http://localhost:27431/v1/chat/completions \
    -H "Authorization: Bearer $TEAM_KEY" -H 'Content-Type: application/json' \
    -d '{"model": "gpt-5.6-prod", "messages": [{"role": "user", "content": "Reply with exactly: alias-qa-ok"}]}'
{"error":{"message":"litellm.BadRequestError: You passed in model=model_name_7828062c-e146-483d-9caa-542a3a88d879_9653ce0a-67fd-468d-b7e7-df087eb75116. There are no healthy deployments for this model. Received Model Group=model_name_7828062c-e146-483d-9caa-542a3a88d879_9653ce0a-67fd-468d-b7e7-df087eb75116\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
HTTP_STATUS:400
```

After, at 037bdb10d3 (checkpoints 3 and 4; step numbers from the flow above):

```
### 6. chat completion BEFORE deleting the team-scoped deployment
HTTP_STATUS:200
{"model":"gpt-5.6-prod","content":"alias-qa-ok","error":null}
### 7. delete the team-scoped deployment
{"message":"Model: 350ef7e5-c27f-4c84-9aae-9abd1d4b2c05 deleted successfully"}
### 8. chat completion AFTER delete, same team key, same public model name
HTTP_STATUS:200
{"model":"gpt-5.6-prod","content":"alias-qa-ok","error":null}
```

Delete-time scrub (second half of the fix), same runs, alias row in LiteLLM_ModelTable after /model/delete:

```
$ psql -d litellm_qa_alias_base -c 'SELECT id, aliases FROM "LiteLLM_ModelTable";'   # before, 7cd009caf7
  1 | {"gpt-5.6-prod": "model_name_7828062c-..._9653ce0a-..."}
$ psql -d litellm_qa_alias_fix  -c 'SELECT id, aliases FROM "LiteLLM_ModelTable";'   # after, 037bdb10d3
  1 | {}
```

Rewrite guard in isolation (first half; checkpoints 5 to 8): point the team alias at an internal name that never had a deployment, with no delete involved, then call both routes with a team key

```
$ curl -s -X POST http://localhost:$PORT/team/update -H "Authorization: Bearer sk-qa-master-1234" \
    -H 'Content-Type: application/json' \
    -d '{"team_id": "'$TEAM_ID'", "model_aliases": {"gpt-5.6-prod": "model_name_'$TEAM_ID'_deadbeef-0000-0000-0000-000000000000"}}'

# before, 7cd009caf7 (port 27431):
/v1/chat/completions -> HTTP_STATUS:400  "Invalid model name passed in model=model_name_7828062c-..._deadbeef-..."
/v1/responses        -> HTTP_STATUS:400  "Invalid model name passed in model=model_name_7828062c-..._deadbeef-..."

# after, 037bdb10d3 (port 27432):
/v1/chat/completions -> HTTP_STATUS:200  {"model":"gpt-5.6-prod","content":"guard-qa-ok"}
/v1/responses        -> HTTP_STATUS:200  output_text "guard-qa-ok"
```

The after run logs a deduped warning once per (team, model, target) so admins can find the leftover rows:

```
19:08:30 - LiteLLM Proxy:WARNING: litellm_pre_call_utils.py:1887 - Team model alias 'gpt-5.6-prod' -> 'model_name_d461d911-..._deadbeef-...' for team_id='d461d911-...' has no live deployments; ignoring the alias and routing the requested model name directly.
```

## Type

🐛 Bug Fix

## Changes

`_update_model_if_team_alias_exists` (litellm/proxy/litellm_pre_call_utils.py) now takes the router as an injected parameter and only rewrites `data["model"]` when `llm_router.get_model_list(model_name=aliased_target, team_id=...)` returns at least one deployment; that lookup covers plain model groups, team-scoped deployments, router model_group_alias entries, and wildcard routes, so working aliases keep rewriting exactly as before. When the target resolves to nothing the request falls through with the public name the caller sent, which team routing resolves via team_public_model_name. The guard sits in add_litellm_data_to_request, so every surface that goes through pre-call (chat completions, responses, embeddings, etc.) gets it. The old LITELLM_ENABLE_TEAM_STALE_ALIAS_BYPASS flag only helped when the team still had live team-scoped deployments for the public name (it consulted team_model_to_deployment_indices, which is empty once all team deployments are gone, exactly the outage case), so the env gate and its module-level flag cache are removed and the no-op is the default

`_remove_unbacked_team_models` (litellm/proxy/management_endpoints/model_management_endpoints.py) no longer skips alias cleanup for internal `model_name_{team_id}_{uuid}` names; that skip assumed the internal name "can never be a team alias value" when it is precisely the value of the hidden {public: internal} rows. `delete_team_model_alias` now matches both directions: any entry whose value equals the deleted deployment's model_name (the legacy {alias: public} shape), and, for team-scoped deletes, the owning team's entry whose key equals the deployment's team_public_model_name and whose value has that team's internal shape (catches drifted rows pointing at uuids that no longer match any deployment). Entries in other teams' rows or entries pointing at non-internal targets (a real gateway model group) are left alone

Regression tests cover: a dangling alias keeps the requested public name, a live alias target still rewrites, the no-router fallback still rewrites, delete scrubs {public: internal} by value, delete scrubs drifted values by public-name key, legacy aliases and other teams' rows survive, and the full /model/delete endpoint path scrubs the alias row and strips team.models

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
