### PR TITLE
fix: correct non-TLS Redis async connection pools by removing ssl_* kwargs

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -12,6 +12,7 @@ import json
 
 # s/o [@Frank Colson](https://www.linkedin.com/in/frank-colson-422b9b183/) for this redis implementation
 import os
+from collections.abc import Mapping
 from typing import Callable, List, Optional, Union
 
 import redis  # type: ignore
@@ -652,6 +653,34 @@ def get_redis_async_client(
     )
 
 
+SSL_CONNECTION_KWARGS = frozenset(inspect.signature(async_redis.SSLConnection.__init__).parameters) - frozenset(
+    ("self", "kwargs")
+)
+
+
+def _connection_pool_kwargs(redis_kwargs: Mapping[str, object]) -> Mapping[str, object]:
+    """
+    Build the kwargs for a BlockingConnectionPool from a resolved Redis config.
+
+    The pool forwards every leftover kwarg to its connection class, and only
+    ``SSLConnection`` accepts the ``ssl_*`` arguments. Callers routinely carry
+    those alongside a plaintext target (the admin UI's cache settings form
+    submits ``ssl_check_hostname`` on every save), so they have to be dropped
+    when TLS is off, or each connection the pool makes dies with a TypeError.
+    """
+    ssl_enabled = bool(redis_kwargs.get("ssl"))
+    supported_ssl_kwargs = SSL_CONNECTION_KWARGS if ssl_enabled else frozenset()
+    pool_kwargs = {
+        key: value
+        for key, value in redis_kwargs.items()
+        if key != "ssl" and (not key.startswith("ssl_") or key in supported_ssl_kwargs)
+    }
+
+    if ssl_enabled:
+        return {**pool_kwargs, "connection_class": async_redis.SSLConnection}
+    return pool_kwargs
+
+
 def get_redis_connection_pool(
     **env_overrides,
 ) -> Optional[async_redis.BlockingConnectionPool]:
@@ -688,9 +717,9 @@ def get_redis_connection_pool(
     elif redis_connect_func and hasattr(redis_connect_func, "_gcp_service_account"):
         redis_kwargs["credential_provider"] = GCPIAMCredentialProvider(redis_connect_func._gcp_service_account)
 
-    if redis_kwargs.pop("ssl", None):
-        redis_kwargs["connection_class"] = async_redis.SSLConnection
-    return async_redis.BlockingConnectionPool(timeout=REDIS_CONNECTION_POOL_TIMEOUT, **redis_kwargs)
+    return async_redis.BlockingConnectionPool(
+        timeout=REDIS_CONNECTION_POOL_TIMEOUT, **_connection_pool_kwargs(redis_kwargs)
+    )
 
 
 def _pretty_print_redis_config(redis_kwargs: dict) -> None:

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -1,4 +1,5 @@
 import json
+import ssl as ssl_module
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -737,3 +738,53 @@ def test_connection_pool_env_redis_ssl_false_uses_plain_connection(monkeypatch):
     assert pool is not None
     assert pool.connection_class is async_redis.Connection
     assert "ssl" not in pool.connection_kwargs
+
+
+def test_connection_pool_drops_ssl_kwargs_when_ssl_is_off(monkeypatch):
+    """
+    ssl_* values must not reach a plain Connection.
+
+    BlockingConnectionPool hands every kwarg to its connection class, and only
+    SSLConnection accepts ssl_*. The admin UI's cache settings form submits
+    ssl_check_hostname on every save, so leaving it in poisons the pool: each
+    connection it makes raises TypeError and all async Redis traffic fails.
+    """
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_SSL", raising=False)
+    monkeypatch.delenv("REDIS_CLUSTER_NODES", raising=False)
+
+    pool = get_redis_connection_pool(
+        host="plain-redis.example.com",
+        port=6379,
+        ssl=False,
+        ssl_check_hostname=False,
+        ssl_cert_reqs=None,
+    )
+
+    assert pool is not None
+    assert pool.connection_class is async_redis.Connection
+    assert not [key for key in pool.connection_kwargs if key.startswith("ssl")]
+    assert isinstance(pool.make_connection(), async_redis.Connection)
+
+
+def test_connection_pool_keeps_ssl_kwargs_when_ssl_is_on(monkeypatch):
+    """ssl=True must still hand the ssl_* settings to the SSL connection."""
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_SSL", raising=False)
+    monkeypatch.delenv("REDIS_CLUSTER_NODES", raising=False)
+
+    pool = get_redis_connection_pool(
+        host="tls-redis.example.com",
+        port=6380,
+        ssl=True,
+        ssl_check_hostname=True,
+        ssl_cert_reqs="required",
+    )
+
+    assert pool is not None
+    assert pool.connection_class is async_redis.SSLConnection
+
+    connection = pool.make_connection()
+    assert isinstance(connection, async_redis.SSLConnection)
+    assert connection.check_hostname is True
+    assert connection.cert_reqs == ssl_module.CERT_REQUIRED


### PR DESCRIPTION
## TLDR

Fix non-TLS async connection pools by removing ssl_* kwargs.

Disclosure: this code was written by Anthropic's Opus 5.

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- Log spam and constantly invalid cache health on a Redis cache connection without TLS.

How it solves it:

- Drops the TLS-specific keywords from the `redis-py` init call.

## Relevant issues

N/A?

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

With commit `2cd62cfb83505d2e2cc86bb065512073e75263b4`:

  ```
  litellm-1     | 02:01:18 - LiteLLM:ERROR: redis_cache.py:672 - LiteLLM Redis Caching: async set() - Got exception from REDIS AbstractConnection.__init__() got an unexpected keyword argument 'ssl_check_hostname', Writing value=__litellm_config_param_miss__
  ```

This is also emitted on startup:

```
  litellm-1     | 01:59:18 - LiteLLM:ERROR: redis_cache.py:285 - Error connecting to Sync Redis client
  litellm-1     | 01:59:18 - LiteLLM:ERROR: redis_cache.py:1247 - LiteLLM Redis Cache PING: - Got exception from REDIS : AbstractConnection.__init__() got an unexpected keyword argument 'ssl_check_hostname'
  litellm-1     | Task exception was never retrieved
  litellm-1     | future: <Task finished name='Task-29' coro=<RedisCache.ping() done, defined at /app/.venv/lib/python3.13/site-packages/litel6> exception=TypeError("AbstractConnection.__init__() got an unexpected keyword argument 'ssl_check_hostname'")>
  litellm-1     | Traceback (most recent call last):
  litellm-1     |   File "/app/.venv/lib/python3.13/site-packages/redis/asyncio/connection.py", line 1110, in get_available_connection
  litellm-1     |     connection = self._available_connections.pop()
  litellm-1     | IndexError: pop from empty list
  litellm-1     |
  litellm-1     | During handling of the above exception, another exception occurred:
  litellm-1     |
  litellm-1     | Traceback (most recent call last):
  litellm-1     |   File "/app/.venv/lib/python3.13/site-packages/litellm/caching/redis_cache.py", line 1248, in ping
  litellm-1     |     raise e
  litellm-1     |   File "/app/.venv/lib/python3.13/site-packages/litellm/caching/redis_cache.py", line 1222, in ping
  litellm-1     |     response = await _redis_client.ping()
  litellm-1     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  litellm-1     |   File "/app/.venv/lib/python3.13/site-packages/redis/asyncio/client.py", line 641, in execute_command
  litellm-1     |     conn = self.connection or await pool.get_connection()
  litellm-1     |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  litellm-1     |   File "/app/.venv/lib/python3.13/site-packages/redis/asyncio/connection.py", line 1274, in get_connection
  litellm-1     |     connection = super().get_available_connection()
  litellm-1     |   File "/app/.venv/lib/python3.13/site-packages/redis/asyncio/connection.py", line 1114, in get_available_connection
  litellm-1     |     connection = self.make_connection()
  litellm-1     |   File "/app/.venv/lib/python3.13/site-packages/redis/asyncio/connection.py", line 1129, in make_connection
  litellm-1     |     return self.connection_class(**self.connection_kwargs)
  litellm-1     |            ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  litellm-1     |   File "/app/.venv/lib/python3.13/site-packages/redis/asyncio/connection.py", line 709, in __init__
  litellm-1     |     super().__init__(**kwargs)
  litellm-1     |     ~~~~~~~~~~~~~~~~^^^^^^^^^^
  litellm-1     | TypeError: AbstractConnection.__init__() got an unexpected keyword argument 'ssl_check_hostname'
```

## Type

🐛 Bug Fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
