### PR TITLE
feat(inferx): add InferX as OpenAI-compatible provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -15,6 +15,10 @@
     "base_url": "https://ai-gateway.helicone.ai/",
     "api_key_env": "HELICONE_API_KEY"
   },
+  "inferx": {
+    "base_url": "https://model.inferx.net/v1",
+    "api_key_env": "INFERX_API_KEY"
+  },
   "veniceai": {
     "base_url": "https://api.venice.ai/api/v1",
     "api_key_env": "VENICE_AI_API_KEY"

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -1335,6 +1335,25 @@
         "interactions": true
       }
     },
+    "inferx": {
+      "display_name": "InferX (`inferx`)",
+      "url": "https://inferx.net",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "rerank": false,
+        "batches": false,
+        "image_edits": false,
+        "vector_stores_create": false,
+        "vector_stores_search": false,
+        "video_generations": false
+      }
+    },
     "infinity": {
       "display_name": "Infinity (`infinity`)",
       "url": "https://docs.litellm.ai/docs/providers/infinity",


### PR DESCRIPTION
Adds InferX as an OpenAI-compatible inference provider.

- Base URL: https://model.inferx.net/v1
- OpenAI-compatible API
- Supports DeepSeek V4, Mimo v2.5, GLM 5.2, Qwen3, Gemma4 and more
- Website: inferx.net