### PR TITLE
fix(ui): point the navbar and sidebar logos at the dashboard home route

### DIFF
--- a/ui/litellm-dashboard/src/components/leftnav.test.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.test.tsx
@@ -80,6 +80,12 @@ describe("Sidebar (leftnav)", () => {
     collapsed: false,
   };
 
+  it("should link the logo to the UI home route rather than the proxy origin", () => {
+    renderWithProviders(<Sidebar {...defaultProps} />);
+
+    expect(screen.getByRole("link", { name: /litellm home/i })).toHaveAttribute("href", "/ui");
+  });
+
   it("renders all top-level (non-nested) tabs for admin", () => {
     renderWithProviders(<Sidebar {...defaultProps} />);
 

--- a/ui/litellm-dashboard/src/components/leftnav.tsx
+++ b/ui/litellm-dashboard/src/components/leftnav.tsx
@@ -582,7 +582,7 @@ const Sidebar_: React.FC<SidebarProps> = ({
       <SidebarHeader className="h-14 border-b border-border group-data-[collapsed=true]/sidebar:h-auto">
         <div className="flex items-center justify-between gap-2 group-data-[collapsed=true]/sidebar:flex-col">
           <div className="flex min-w-0 items-center gap-2">
-            <Link href={baseUrl || "/"} className="flex min-w-0 items-center" aria-label="LiteLLM home">
+            <Link href={migratedHref("")} className="flex min-w-0 items-center" aria-label="LiteLLM home">
               <img
                 src={logoSrc}
                 alt="LiteLLM"

--- a/ui/litellm-dashboard/src/components/navbar.test.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.test.tsx
@@ -152,6 +152,12 @@ describe("Navbar", () => {
     expect(screen.getByRole("button", { name: /open account menu/i })).toBeInTheDocument();
   });
 
+  it("should link the logo to the UI home route rather than the proxy origin", () => {
+    renderWithProviders(<Navbar {...defaultProps} />);
+
+    expect(screen.getByRole("link", { name: /litellm brand/i })).toHaveAttribute("href", "/ui");
+  });
+
   it("should display user information in dropdown", async () => {
     const user = userEvent.setup();
     renderWithProviders(<Navbar {...defaultProps} />);

--- a/ui/litellm-dashboard/src/components/navbar.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.tsx
@@ -3,6 +3,7 @@ import { useDisableBouncingIcon } from "@/app/(dashboard)/hooks/useDisableBounci
 import { useDisableShowPrompts } from "@/app/(dashboard)/hooks/useDisableShowPrompts";
 import { useWorker } from "@/hooks/useWorker";
 import { getProxyBaseUrl } from "@/components/networking";
+import { migratedHref } from "@/utils/migratedPages";
 import { useTheme } from "@/contexts/ThemeContext";
 import { clearTokenCookies } from "@/utils/cookieUtils";
 import { clearStoredReturnUrl, getLoginUrl } from "@/utils/returnUrlUtils";
@@ -75,7 +76,7 @@ const Navbar: React.FC<NavbarProps> = ({
             )}
 
             <div className="flex items-center gap-2">
-              <Link href={baseUrl ? baseUrl : "/"} className="flex items-center">
+              <Link href={migratedHref("")} className="flex items-center">
                 <div className="relative">
                   <div className="flex h-10 max-w-48 items-center justify-center overflow-hidden">
                     <img


### PR DESCRIPTION
## TLDR

Problem this solves:

- Both logo links point at the proxy origin instead of the dashboard
- next/link prefetches that target as /__next._tree.txt at the domain root
- The proxy has no such path, so every dashboard page logs repeated 404s
- Clicking a logo leaves the dashboard with a full page load of the origin root

How it solves it:

- Logo hrefs now use migratedHref(""), which resolves to the /ui/ home route
- The prefetch resolves inside the mounted UI bundle, so the 404 noise stops
- Logo clicks become client-side navigations that stay in the dashboard

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

What happens today: the navbar and sidebar logos render a next/link Link whose href is getProxyBaseUrl(), the proxy origin. The dashboard is a Next.js static export served under /ui, and in that mode next/link prefetches a route by fetching its __next._tree.txt payload. For an origin href the browser therefore requests /__next._tree.txt at the domain root, which no route serves, so it 404s; the failed prefetch is not cached, so the request repeats as the link re-renders, and the network log fills with 404 rows on every dashboard page. Clicking a logo also does a full page navigation to the origin root instead of going to the dashboard home

Verified against a live proxy on localhost:4021 serving the built dashboard via LITELLM_UI_PATH, real Postgres-backed login with the master key

Before (bundle built from 2bb297efa0): loading any dashboard page logs repeated `GET /__next._tree.txt` 404 responses plus aborted `HEAD /` probes, all initiated by the logo link prefetch

After (bundle built from 623e620f96): zero /__next._tree.txt requests at the origin root across /ui/login/, /ui/, and /ui/models-and-endpoints/; the logo anchor renders href="/ui/"; `curl http://localhost:4021/ui/__next._tree.txt` returns 200 so the prefetch target now resolves; clicking the logo navigates to the dashboard home

To reproduce by hand and capture screenshots:

1. `cd ui/litellm-dashboard && npm run build`
2. From the repo root: `LITELLM_UI_PATH=$PWD/ui/litellm-dashboard/out python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --use_v2_migration_resolver`
3. Open http://localhost:4000/ui/, log in, open DevTools Network and filter for `_tree`
4. On this branch there are no requests to the domain root; on the base commit the same filter shows repeated `/__next._tree.txt` 404 rows on every page
5. Click the LiteLLM logo in the sidebar and confirm it lands on the dashboard home instead of the API root

## Type

🐛 Bug Fix

## Changes

navbar.tsx and leftnav.tsx now build the logo link with migratedHref("") from utils/migratedPages, which resolves to /ui/ in production, honors SERVER_ROOT_PATH, and stays "/" under next dev where the app is served at the root. The regression tests in navbar.test.tsx and leftnav.test.tsx assert the logo anchors point at the /ui home path rather than the proxy origin, so a reintroduced origin href fails both suites

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
