### PR TITLE
fix(responses): pass plain-string tool output through unchanged in ch…

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -242,24 +242,23 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                         }
                     )
             elif role == "tool":
-                # Convert tool message to function call output format
-                # The Responses API expects 'output' to be a list with input_text/input_image types
-                # Using list format for consistency across text and multimodal content
-                tool_output: List[Dict[str, Any]]
+                # Convert tool message to function call output format.
+                # Per the Responses API spec, function_call_output.output is a plain
+                # string for text results; only multimodal (list) content needs
+                # conversion to input_text/input_image items.
+                tool_output: Union[str, List[Dict[str, Any]]]
                 if content is None:
-                    tool_output = []
+                    tool_output = ""
                 elif isinstance(content, str):
-                    # Convert string to list with input_text
-                    tool_output = [{"type": "input_text", "text": content}]
+                    tool_output = content
                 elif isinstance(content, list):
-                    # Transform list content to Responses API format
+                    # Multimodal tool output: convert to Responses API content items
                     tool_output = self._convert_content_to_responses_format(
                         content,
                         "user",  # Use "user" role to get input_* types
                     )
                 else:
-                    # Fallback: convert unexpected types to input_text
-                    tool_output = [{"type": "input_text", "text": str(content)}]
+                    tool_output = str(content)
                 input_items.append(
                     {
                         "type": "function_call_output",

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1,10 +1,7 @@
-import datetime
 import json
 import os
 import sys
-import unittest
-from typing import List, Optional, Tuple
-from unittest.mock import ANY, MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import httpx
 import pytest
@@ -51,7 +48,6 @@ def test_convert_chat_completion_messages_to_responses_api_image_input():
     assert user_content in response_str
     assert user_image in response_str
 
-    print("response: ", response)
     assert response[0]["content"][1]["image_url"] == user_image
 
 
@@ -142,22 +138,21 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_imag
     ), "image_url should be a flat string, not a nested object"
     assert "detail" in image_item, "detail field should be present"
 
-    print("✓ Tool result with image correctly transformed to Responses API format")
 
 
 def test_convert_chat_completion_messages_to_responses_api_tool_result_with_text():
     """
-    Test that tool messages with text content are correctly transformed to Responses API format.
+    Test that tool messages with plain-string content pass through as a plain string.
 
-    This is a regression test for the issue where tool results were being transformed
-    with type='output_text' instead of type='input_text', which caused OpenAI's Responses API
-    to reject the request with "Invalid value: 'output_text'".
+    The Responses API documents function_call_output.output as a plain string.
+    A previous implementation wrapped the string in [{"type": "input_text", ...}],
+    which caused strict/enterprise Responses API backends to reject the request.
 
     Chat Completion format:
         {"role": "tool", "tool_call_id": "call_abc123", "content": "15 degrees"}
 
-    Responses API format should use input_text, not output_text:
-        {"type": "function_call_output", "call_id": "call_abc123", "output": [{"type": "input_text", "text": "15 degrees"}]}
+    Responses API format (correct):
+        {"type": "function_call_output", "call_id": "call_abc123", "output": "15 degrees"}
     """
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
         LiteLLMResponsesTransformationHandler,
@@ -165,7 +160,6 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_text
 
     handler = LiteLLMResponsesTransformationHandler()
 
-    # Chat Completion format with tool result containing text
     messages = [
         {
             "role": "user",
@@ -194,7 +188,6 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_text
 
     response, _ = handler.convert_chat_completion_messages_to_responses_api(messages)
 
-    # Find the function_call_output item
     function_call_output = None
     for item in response:
         if item.get("type") == "function_call_output":
@@ -206,23 +199,9 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_text
     ), "function_call_output not found in response"
     assert function_call_output["call_id"] == "call_abc123"
 
-    # Check that the output is correctly transformed to use input_text, not output_text
     output = function_call_output["output"]
-    assert isinstance(output, list), "output should be a list"
-    assert len(output) == 1, "output should have one item"
-
-    text_item = output[0]
-    # Should be transformed to use input_text for tool results in Responses API format
-    assert (
-        text_item["type"] == "input_text"
-    ), f"Expected type 'input_text' for tool result, got '{text_item.get('type')}'"
-    assert (
-        text_item["text"] == "15 degrees"
-    ), f"Expected text '15 degrees', got '{text_item.get('text')}'"
-
-    print(
-        "✓ Tool result with text correctly transformed to use input_text for Responses API format"
-    )
+    assert isinstance(output, str), f"output should be a plain string, got {type(output)}"
+    assert output == "15 degrees", f"Expected '15 degrees', got '{output}'"
 
 
 def test_openai_responses_chunk_parser_reasoning_summary():
@@ -508,7 +487,6 @@ and I learn to carry this small calm home."""
     # Check reasoning content
     assert choice.message.reasoning_content == reasoning_summary.text
 
-    print("✓ transform_response correctly handled reasoning items and output messages")
 
 
 def _make_empty_responses_api_response(model: str = "gpt-5.4"):
@@ -961,9 +939,6 @@ def test_transform_request_single_char_keys_not_matched():
     assert result_correct.get("metadata") == {"user_id": "123"}
     assert result_correct.get("previous_response_id") == "resp_abc"
 
-    print(
-        "✓ Single-character keys are not incorrectly matched to metadata/previous_response_id"
-    )
 
 
 # =============================================================================
@@ -1294,16 +1269,11 @@ def test_text_plus_tool_calls_sequence():
 
 def test_tool_message_output_uses_input_text_not_output_text():
     """
-    Test that tool message content uses input_text type, not output_text.
+    Test that plain-string tool message content passes through as a plain string.
 
-    This is a regression test for a bug where tool results were transformed to:
-        {"type": "function_call_output", "output": [{"type": "output_text", "text": "..."}]}
-
-    But the Responses API expects input_text for tool results:
-        {"type": "function_call_output", "output": [{"type": "input_text", "text": "..."}]}
-
-    The incorrect format caused OpenAI to reject with:
-        "Invalid value: 'output_text'. Supported values are: 'input_text', 'input_image', and 'input_file'."
+    The Responses API documents function_call_output.output as a plain string.
+    Wrapping it in [{"type": "input_text", ...}] caused strict backends to reject
+    the request. This test verifies the output is the raw string, not a list.
     """
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
         LiteLLMResponsesTransformationHandler,
@@ -1336,7 +1306,6 @@ def test_tool_message_output_uses_input_text_not_output_text():
 
     response, _ = handler.convert_chat_completion_messages_to_responses_api(messages)
 
-    # Find the function_call_output item
     function_call_output = None
     for item in response:
         if item.get("type") == "function_call_output":
@@ -1346,16 +1315,9 @@ def test_tool_message_output_uses_input_text_not_output_text():
     assert function_call_output is not None, "function_call_output not found"
     assert function_call_output["call_id"] == "call_abc123"
 
-    # The output should be a list with input_text type
     output = function_call_output["output"]
-    assert isinstance(output, list), f"output should be a list, got {type(output)}"
-    assert len(output) == 1
-    assert (
-        output[0]["type"] == "input_text"
-    ), f"Expected input_text, got {output[0].get('type')}"
-    assert output[0]["text"] == '{"temperature": 15, "condition": "sunny"}'
-
-    print("✓ Tool message output correctly uses input_text type")
+    assert isinstance(output, str), f"output should be a plain string, got {type(output)}"
+    assert output == '{"temperature": 15, "condition": "sunny"}'
 
 
 def test_multiple_tool_calls_in_single_choice():
@@ -1498,7 +1460,6 @@ def test_multiple_tool_calls_in_single_choice():
     assert tool_calls[2]["id"] == "call_horoscope"
     assert tool_calls[2]["function"]["name"] == "get_horoscope"
 
-    print("✓ Multiple tool calls are correctly grouped in a single choice")
 
 
 def test_map_reasoning_effort_adds_summary_detailed():
@@ -1542,9 +1503,6 @@ def test_map_reasoning_effort_adds_summary_detailed():
                 "summary" not in result
             ), f"Summary should NOT be present by default for effort={effort}"
 
-            print(
-                f"✓ reasoning_effort='{effort}' correctly maps to effort='{effort}' (no summary by default)"
-            )
 
         # Test 2: With flag enabled - summary IS added
         litellm.reasoning_auto_summary = True
@@ -1558,9 +1516,6 @@ def test_map_reasoning_effort_adds_summary_detailed():
                 result["summary"] == "detailed"
             ), f"Summary should be 'detailed' when flag is enabled for effort={effort}"
 
-            print(
-                f"✓ reasoning_effort='{effort}' correctly maps to effort='{effort}', summary='detailed' (flag enabled)"
-            )
 
         # Test 3: With env var enabled (flag disabled) - summary IS added
         litellm.reasoning_auto_summary = False
@@ -1570,7 +1525,6 @@ def test_map_reasoning_effort_adds_summary_detailed():
         assert (
             result["summary"] == "detailed"
         ), "Summary should be 'detailed' when env var is enabled"
-        print("✓ LITELLM_REASONING_AUTO_SUMMARY env var works correctly")
 
         # Test 4: Dict input is passed through as-is (no modification)
         litellm.reasoning_auto_summary = False
@@ -1581,16 +1535,11 @@ def test_map_reasoning_effort_adds_summary_detailed():
         result_dict = handler._map_reasoning_effort(dict_input)
         assert result_dict["effort"] == "high"
         assert result_dict["summary"] == "custom_summary"
-        print("✓ Dict input is passed through without modification")
 
         # Test 5: None/unknown values return None
         result_unknown = handler._map_reasoning_effort("unknown_value")
         assert result_unknown is None
-        print("✓ Unknown reasoning_effort values return None")
 
-        print(
-            "✓ All reasoning_effort behaviors work correctly with flag/env var control"
-        )
 
     finally:
         # Restore original values
@@ -1783,9 +1732,6 @@ def test_transform_response_preserves_annotations():
     assert result.usage.completion_tokens == 20
     assert result.usage.total_tokens == 30
 
-    print(
-        "✓ Annotations from Responses API are correctly preserved in Chat Completions format"
-    )
 
 
 def test_apply_patch_tool_call_converted_to_chat_completion_tool_call():
@@ -2080,9 +2026,6 @@ def test_multi_tool_call_stream_no_premature_finish():
                 f"— only response.completed should terminate the stream"
             )
 
-    print(
-        "✓ Multi-tool-call stream completes without premature finish_reason termination"
-    )
 
 
 # =============================================================================
@@ -2396,9 +2339,6 @@ def test_parallel_tool_calls_comprehensive_streaming_integration():
         1,
     }, f"Parallel tool calls must have distinct indices {{0, 1}}, got: {set(added_tool_call_indices)}"
 
-    print(
-        "✓ Parallel tool calls with split argument deltas stream correctly end-to-end"
-    )
 
 
 def test_map_optional_params_preserves_reasoning_summary():

--- a/tests/test_litellm/completion_extras/test_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/test_litellm_responses_transformation_transformation.py
@@ -257,3 +257,79 @@ def test_translate_responses_chunk_passthrough_chat_completion_chunk():
 
     assert result.choices[0].delta.content == "Hi! How can I help?"
     assert result.choices[0].finish_reason is None
+
+
+def test_tool_message_plain_string_passed_through_as_string():
+    """
+    Plain-string tool output must reach function_call_output.output as a string.
+
+    The Responses API spec documents function_call_output.output as a plain string.
+    Strict/enterprise backends reject the list-of-input_text form for simple text.
+    Regression guard for the fix to #34978.
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    t = LiteLLMResponsesTransformationHandler()
+    messages = [
+        {"role": "user", "content": "What is the capital of France?"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "Paris"},
+    ]
+
+    items, _ = t.convert_chat_completion_messages_to_responses_api(messages)
+    tool_item = next(i for i in items if i.get("type") == "function_call_output")
+
+    assert isinstance(tool_item["output"], str), (
+        "Plain-string tool content must pass through as a string, not be wrapped in a list"
+    )
+    assert tool_item["output"] == "Paris"
+
+
+def test_tool_message_multimodal_list_still_converted():
+    """
+    Multimodal (list) tool output must still be converted to Responses API content items.
+    This ensures the #17507 fix is preserved for the multimodal case.
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    t = LiteLLMResponsesTransformationHandler()
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_2",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_2",
+            "content": [{"type": "text", "text": "result text"}],
+        },
+    ]
+
+    items, _ = t.convert_chat_completion_messages_to_responses_api(messages)
+    tool_item = next(i for i in items if i.get("type") == "function_call_output")
+
+    assert isinstance(tool_item["output"], list), (
+        "Multimodal list tool content must be converted to a list of Responses API items"
+    )

--- a/tests/test_litellm/completion_extras/test_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/test_litellm_responses_transformation_transformation.py
@@ -333,3 +333,70 @@ def test_tool_message_multimodal_list_still_converted():
     assert isinstance(tool_item["output"], list), (
         "Multimodal list tool content must be converted to a list of Responses API items"
     )
+
+
+def test_tool_message_none_content_becomes_empty_string():
+    """
+    A tool message with content=None must produce an empty string, not an empty
+    list. function_call_output.output is a plain string for text results, so the
+    empty case has to stay string-typed for strict backends.
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    t = LiteLLMResponsesTransformationHandler()
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_3",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_3", "content": None},
+    ]
+
+    items, _ = t.convert_chat_completion_messages_to_responses_api(messages)
+    tool_item = next(i for i in items if i.get("type") == "function_call_output")
+
+    assert tool_item["output"] == ""
+    assert isinstance(tool_item["output"], str)
+
+
+def test_tool_message_non_string_content_is_stringified():
+    """
+    Unexpected (non-str, non-list) tool content falls back to str(), keeping
+    function_call_output.output string-typed rather than wrapping it in a list.
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    t = LiteLLMResponsesTransformationHandler()
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_4",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_4", "content": 42},
+    ]
+
+    items, _ = t.convert_chat_completion_messages_to_responses_api(messages)
+    tool_item = next(i for i in items if i.get("type") == "function_call_output")
+
+    assert tool_item["output"] == "42"
+    assert isinstance(tool_item["output"], str)


### PR DESCRIPTION
…at-to-responses bridge

Per the Responses API spec, function_call_output.output is a plain string. Wrapping all tool output in a list of input_text items (introduced when fixing #17507) breaks strict/enterprise backends that validate the schema.

Only multimodal (list) content still goes through _convert_content_to_responses_format; plain strings are passed through directly. None is mapped to an empty string.

Fixes #34978

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- <blah>
- ...

How it solves it:

- <blah>
- ...

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
