### PR TITLE
fix(complexity_router): route no-signal prompts to default_tier, not SIMPLE

### DIFF
--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -144,7 +144,9 @@ complexity_router_config:
 
 Set `default_tier: SIMPLE` to keep unmatched traffic on the cheapest tier, which is how the router behaved before this setting existed.
 
-`default_tier` names which tier no-signal traffic is classified as; it is resolved to a model by the same chain as any classified tier, so it can be served by its own entry in `tiers`, by `default_model`, or by the MEDIUM tier. A `default_tier` you set explicitly has to be servable by one of those, and the config is rejected at load time when it is not, rather than failing on the first unmatched request. With routing plugins configured that chain stops at the tier's own models, since a model the plugins never vetted must not serve, so the tier itself has to name one.
+`default_tier` names which tier no-signal traffic is classified as; it is resolved to a model by the same chain as any classified tier, so it can be served by its own entry in `tiers`, by `default_model`, or by the MEDIUM tier. It has to be servable by one of those whether you set it or take the default, and the config is rejected at load time when it is not, rather than failing on the first unmatched request. A partial `tiers` map is unaffected, since the proxy always derives a `default_model` from the MEDIUM-then-SIMPLE tier and the chain terminates there.
+
+With routing plugins configured that chain stops at the tier's own models, since a model the plugins never vetted must not serve. So a plugin config has to give `default_tier` models in `tiers`, or point it at a tier that has them; `default_model` will not stand in.
 
 The check is on the individual dimensions, not on the weighted score, because contributions cancel. `"hi, quick python question"` scores zero with three dimensions firing (short prompt, a simple indicator, a code keyword); it has real evidence of being simple and stays SIMPLE. Prompts shorter than the `simple` token threshold or longer than the `complex` one also fire `tokenCount`, so they score normally and are outside this path.
 

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -142,7 +142,9 @@ complexity_router_config:
   default_tier: MEDIUM  # SIMPLE | MEDIUM | COMPLEX | REASONING
 ```
 
-Set `default_tier: SIMPLE` to keep unmatched traffic on the cheapest tier, which is how the router behaved before this setting existed. A `default_tier` you set explicitly has to have a model behind it, either its own non-empty entry in `tiers` or a `default_model`; the config is rejected at load time otherwise, rather than failing on the first unmatched request.
+Set `default_tier: SIMPLE` to keep unmatched traffic on the cheapest tier, which is how the router behaved before this setting existed.
+
+`default_tier` names which tier no-signal traffic is classified as; it is resolved to a model by the same chain as any classified tier, so it can be served by its own entry in `tiers`, by `default_model`, or by the MEDIUM tier. A `default_tier` you set explicitly has to be servable by one of those, and the config is rejected at load time when it is not, rather than failing on the first unmatched request. With routing plugins configured that chain stops at the tier's own models, since a model the plugins never vetted must not serve, so the tier itself has to name one.
 
 The check is on the individual dimensions, not on the weighted score, because contributions cancel. `"hi, quick python question"` scores zero with three dimensions firing (short prompt, a simple indicator, a code keyword); it has real evidence of being simple and stays SIMPLE. Prompts shorter than the `simple` token threshold or longer than the `complex` one also fire `tokenCount`, so they score normally and are outside this path.
 

--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -34,6 +34,8 @@ The weighted sum is mapped to tiers using configurable boundaries:
 | COMPLEX | 0.35 - 0.60 | Technical, multi-part requests |
 | REASONING | > 0.60 | Chain-of-thought, analysis |
 
+A prompt that matches nothing at all never reaches that table. When no dimension fires, the scorer has no evidence in either direction, so the request goes to `default_tier` (MEDIUM unless you change it) rather than falling through a score of 0.0 into SIMPLE. See [No-Signal Default](#no-signal-default) below.
+
 ## Configuration
 
 ### Basic Configuration
@@ -71,6 +73,9 @@ model_list:
           simple_medium: 0.15
           medium_complex: 0.35
           complex_reasoning: 0.60
+
+        # Tier for prompts that match nothing at all (default: MEDIUM)
+        default_tier: MEDIUM
         
         # Token count thresholds
         token_thresholds:
@@ -125,6 +130,23 @@ response = litellm.completion(
 ```
 
 ## Special Behaviors
+
+### No-Signal Default
+
+The scorer only recognizes what is on its keyword lists, so a prompt can be genuinely hard and still match nothing: a logic puzzle, a business tradeoff, a piece of prose to edit. Every dimension then scores 0, and treating that silence as evidence of simplicity is how unmatched traffic used to end up on the cheapest model.
+
+When no dimension fires, the router returns `default_tier` instead of consulting the boundaries, and logs the classification with `signals=['no-signal']`:
+
+```yaml
+complexity_router_config:
+  default_tier: MEDIUM  # SIMPLE | MEDIUM | COMPLEX | REASONING
+```
+
+Set `default_tier: SIMPLE` to keep unmatched traffic on the cheapest tier, which is how the router behaved before this setting existed. A `default_tier` you set explicitly has to have a model behind it, either its own non-empty entry in `tiers` or a `default_model`; the config is rejected at load time otherwise, rather than failing on the first unmatched request.
+
+The check is on the individual dimensions, not on the weighted score, because contributions cancel. `"hi, quick python question"` scores zero with three dimensions firing (short prompt, a simple indicator, a code keyword); it has real evidence of being simple and stays SIMPLE. Prompts shorter than the `simple` token threshold or longer than the `complex` one also fire `tokenCount`, so they score normally and are outside this path.
+
+The LLM classifier falls back to this scorer when it times out or errors, so `default_tier` also decides where unmatched traffic lands during a classifier outage.
 
 ### Reasoning Override
 

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -46,6 +46,8 @@ from .config import (
     TIER_SEVERITY_ORDER,
     ComplexityRouterConfig,
     ComplexityTier,
+    TierModels,
+    TierUnservable,
 )
 
 if TYPE_CHECKING:
@@ -85,6 +87,24 @@ def _append_custom_keywords(base_keywords: list[str], custom_keywords: list[str]
     base_lowered = frozenset(keyword.lower() for keyword in base_keywords)
     deduped_custom = {keyword.lower(): keyword for keyword in custom_keywords if keyword.lower() not in base_lowered}
     return [*base_keywords, *deduped_custom.values()]
+
+
+def _servable_models(config: ComplexityRouterConfig, tier: ComplexityTier) -> tuple[str, ...]:
+    """The models that may serve this tier, raising the resolver's own reason when none may.
+
+    The one place a `TierUnservable` becomes an exception, so every caller reports the same
+    gap the same way and none of them re-derives when a tier is servable.
+    """
+    match config.resolve_tier(tier):
+        case TierModels(models=models):
+            return models
+        case TierUnservable() as unservable:
+            raise ValueError(unservable.describe())
+
+
+def _pick_model(models: tuple[str, ...]) -> str:
+    """One model out of a resolved, non-empty pool; a single pin never consults the RNG."""
+    return models[0] if len(models) == 1 else random.choice(models)
 
 
 # Metadata keys that carry only the parent request's budget reservation state. These
@@ -328,15 +348,15 @@ class ComplexityRouter(CustomLogger):
         self.model_name = model_name
         self.litellm_router_instance = litellm_router_instance
 
-        # Parse config - always create a new instance to avoid singleton mutation
-        if complexity_router_config:
-            self.config = ComplexityRouterConfig(**complexity_router_config)
-        else:
-            self.config = ComplexityRouterConfig()
-
-        # Override default_model if provided
+        # Parse config - always create a new instance to avoid singleton mutation.
+        # The deployment-level default_model goes in before validation, not onto the
+        # validated model afterwards, so the config that gets checked is the config that
+        # routes; assigning it later left validation judging a default_model that requests
+        # would never see.
+        config_fields: dict[str, Any] = dict(complexity_router_config or {})
         if default_model:
-            self.config.default_model = default_model
+            config_fields["default_model"] = default_model
+        self.config = ComplexityRouterConfig(**config_fields)
 
         # Build effective keyword lists (use config overrides or defaults)
         self.code_keywords = self.config.code_keywords or DEFAULT_CODE_KEYWORDS
@@ -833,30 +853,10 @@ class ComplexityRouter(CustomLogger):
         Returns:
             The model name configured for that tier.
         """
-        tier_key = tier.value if isinstance(tier, ComplexityTier) else tier
+        return _pick_model(_servable_models(self.config, tier))
 
-        if tier_key in self.config.tiers:
-            return self._pick_from_tier_value(self.config.tiers[tier_key], tier_key)
-
-        if self.config.default_model:
-            return self.config.default_model
-
-        medium_key = ComplexityTier.MEDIUM.value
-        if medium_key in self.config.tiers:
-            return self._pick_from_tier_value(self.config.tiers[medium_key], medium_key)
-
-        raise ValueError(f"No model configured for tier {tier_key} and no default_model set")
-
-    @staticmethod
-    def _pick_from_tier_value(model: str | list[str], tier_key: str) -> str:
-        if isinstance(model, str):
-            return model
-        if not model:
-            raise ValueError(f"Empty model pool for tier {tier_key}")
-        return random.choice(model)
-
-    def _tier_pools(self) -> dict[str, list[str]]:
-        return {tier: (models if isinstance(models, list) else [models]) for tier, models in self.config.tiers.items()}
+    def _tier_pools(self) -> dict[str, tuple[str, ...]]:
+        return {tier: self.config.models_for(tier) for tier in self.config.tiers}
 
     async def _pick_model_for_tier(
         self,
@@ -871,20 +871,11 @@ class ComplexityRouter(CustomLogger):
         from litellm.types.router import RoutingContext
 
         tier_key = tier.value
-        candidates = list(self._tier_pools().get(tier_key, []))
-        if not candidates:
-            # Distinct from the plugin denial below: nothing was filtered out, the tier was
-            # never given models. Saying "after routing-plugin filtering" would send an
-            # operator to read plugin code for what is a gap in `tiers`.
-            raise ValueError(
-                f"Tier {tier_key} has no models configured. Routing plugins are configured, so "
-                f"default_model is not consulted: a model the plugins never vetted must not serve"
-            )
         metadata_key = "litellm_metadata" if "litellm_metadata" in request_kwargs else "metadata"
         context = RoutingContext(
             raw_messages=raw_messages or [],
             structured_messages=resolved_messages or [],
-            candidate_models=candidates,
+            candidate_models=list(_servable_models(self.config, tier)),
             metadata=request_kwargs.get(metadata_key) or {},
         )
         for plugin in self.config.plugins:
@@ -897,7 +888,7 @@ class ComplexityRouter(CustomLogger):
             # silently bypassed. Raise instead, matching the Router-level plugin
             # pipeline's own fail-closed behavior for the same situation.
             raise ValueError(f"No candidate models left for tier {tier_key} after routing-plugin filtering")
-        return self._pick_from_tier_value(context.candidate_models, tier_key)
+        return _pick_model(tuple(context.candidate_models))
 
     def _ensure_adaptive_router(self) -> Any | None:
         if not self.config.adaptive:

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -42,6 +42,7 @@ from .config import (
     DEFAULT_REASONING_KEYWORDS,
     DEFAULT_SIMPLE_KEYWORDS,
     DEFAULT_TECHNICAL_KEYWORDS,
+    NO_SIGNAL_MARKER,
     TIER_SEVERITY_ORDER,
     ComplexityRouterConfig,
     ComplexityTier,
@@ -473,9 +474,26 @@ class ComplexityRouter(CustomLogger):
 
     def _score_and_classify(
         self, prompt: str, system_prompt: str | None = None
-    ) -> tuple[ComplexityTier, float, tuple[str, ...], Literal["heuristic_scorer", "reasoning_override"]]:
+    ) -> tuple[
+        ComplexityTier,
+        float,
+        tuple[str, ...],
+        Literal["heuristic_scorer", "reasoning_override", "no_signal_default"],
+    ]:
         """
         Classify a prompt by complexity, reporting whether the score chose the tier.
+
+        When no dimension fires at all, the prompt carries no evidence either way, so
+        `default_tier` (MEDIUM unless configured otherwise) is returned instead of letting
+        the score of 0.0 fall through the band mapping into SIMPLE.
+
+        That check reads the signals, not the score, and not the individual dimension
+        scores either. A weighted score of zero does not mean nothing was recognised,
+        because contributions cancel: "hi, quick python question" comes to zero with three
+        dimensions firing and is genuinely simple. A dimension scoring zero does not mean
+        it stayed silent either, since a scorer is free to treat "no match" as a nonzero
+        baseline or to report a neutral finding; a signal is the one thing a dimension
+        emits only when it recognised something.
 
         Args:
             prompt: The user's prompt/message.
@@ -557,6 +575,9 @@ class ComplexityRouter(CustomLogger):
         # Reuse match count from _score_keyword_match to avoid scanning twice
         if reasoning_match_count >= 2:
             return ComplexityTier.REASONING, weighted_score, tuple(signals), "reasoning_override"
+
+        if not signals:
+            return self.config.default_tier, weighted_score, (NO_SIGNAL_MARKER,), "no_signal_default"
 
         # Map score to tier
         boundaries = self._effective_tier_boundaries()

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -871,11 +871,20 @@ class ComplexityRouter(CustomLogger):
         from litellm.types.router import RoutingContext
 
         tier_key = tier.value
+        candidates = list(self._tier_pools().get(tier_key, []))
+        if not candidates:
+            # Distinct from the plugin denial below: nothing was filtered out, the tier was
+            # never given models. Saying "after routing-plugin filtering" would send an
+            # operator to read plugin code for what is a gap in `tiers`.
+            raise ValueError(
+                f"Tier {tier_key} has no models configured. Routing plugins are configured, so "
+                f"default_model is not consulted: a model the plugins never vetted must not serve"
+            )
         metadata_key = "litellm_metadata" if "litellm_metadata" in request_kwargs else "metadata"
         context = RoutingContext(
             raw_messages=raw_messages or [],
             structured_messages=resolved_messages or [],
-            candidate_models=list(self._tier_pools().get(tier_key, [])),
+            candidate_models=candidates,
             metadata=request_kwargs.get(metadata_key) or {},
         )
         for plugin in self.config.plugins:

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -34,6 +34,8 @@ DEFAULT_TIER_DISTANCE_PENALTY: float = 0.5
 DEFAULT_CLASSIFIER_CONTEXT_WINDOW_SIZE: int = 3
 DEFAULT_CLASSIFIER_CONTEXT_PER_TURN_CHARS: int = 200
 
+NO_SIGNAL_MARKER: str = "no-signal"
+
 
 class KeywordTierRule(BaseModel):
     """A deterministic override: if any keyword matches, route to this tier."""
@@ -269,6 +271,17 @@ class ComplexityRouterConfig(BaseModel):
         description="Score boundaries between tiers",
     )
 
+    default_tier: ComplexityTier = Field(
+        default=ComplexityTier.MEDIUM,
+        description=(
+            "Tier used when no scoring dimension fires, i.e. the prompt matched no keyword, "
+            "pattern or token-count threshold and the scorer has no evidence either way. "
+            "When set explicitly it must have a model behind it: a non-empty entry in `tiers`, "
+            "or `default_model`. "
+            "Set to SIMPLE to restore the previous behavior of treating unmatched traffic as simple"
+        ),
+    )
+
     # Token count thresholds
     token_thresholds: dict[str, int] = Field(
         default_factory=lambda: DEFAULT_TOKEN_THRESHOLDS.copy(),
@@ -458,6 +471,20 @@ class ComplexityRouterConfig(BaseModel):
         if self.classifier_type == "llm" and self.classifier_llm_config is None:
             raise ValueError("classifier_llm_config is required when classifier_type is 'llm'")
         return self
+
+    @model_validator(mode="after")
+    def _validate_default_tier_is_servable(self) -> "ComplexityRouterConfig":
+        if "default_tier" not in self.model_fields_set:
+            return self
+        if self.tiers.get(self.default_tier.value) or self.default_model:
+            return self
+        raise ValueError(
+            f"default_tier {self.default_tier.value} is not a non-empty entry in tiers "
+            f"({sorted(self.tiers)}). Add it to tiers, name a tier that is configured, or set "
+            f"default_model in complexity_router_config; the deployment-level "
+            f"complexity_router_default_model does not count here, because falling through to it "
+            f"would serve every no-signal request from a model this tier never names"
+        )
 
     @model_validator(mode="after")
     def _validate_adaptive_pools(self) -> "ComplexityRouterConfig":

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -540,13 +540,16 @@ class ComplexityRouterConfig(BaseModel):
 
     @model_validator(mode="after")
     def _validate_default_tier_is_servable(self) -> "ComplexityRouterConfig":
-        """Reject an explicit `default_tier` that nothing can serve.
+        """Reject a `default_tier` that nothing can serve, whether it was set or defaulted.
 
-        Left implicit it is not checked, so a partial `tiers` map keeps loading and MEDIUM
-        resolves through the same chain every other tier does.
+        Every prompt the scorer recognises nothing in lands on this tier, so a config that
+        cannot serve it is broken for a whole class of traffic and says so at load rather
+        than on the first such request. Exempting the implicit MEDIUM would only move that
+        failure to request time, and the check is not the blunt "must be its own entry in
+        tiers" it would need to be for that exemption to earn its keep: MEDIUM resolves
+        through the same chain as any classified tier, so a partial `tiers` map backed by
+        `default_model` still loads.
         """
-        if "default_tier" not in self.model_fields_set:
-            return self
         match self.resolve_tier(self.default_tier):
             case TierModels():
                 return self

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -476,14 +476,28 @@ class ComplexityRouterConfig(BaseModel):
     def _validate_default_tier_is_servable(self) -> "ComplexityRouterConfig":
         if "default_tier" not in self.model_fields_set:
             return self
-        if self.tiers.get(self.default_tier.value) or self.default_model:
+        if self.tiers.get(self.default_tier.value):
             return self
+        # default_model rescues this only without plugins. The plugin path never falls back
+        # to it, since a model the plugins did not vet must not serve, so accepting it here
+        # would validate a config whose every no-signal request fails at routing time.
+        if self.default_model and not self.plugins:
+            return self
+        remedy = (
+            "Add it to tiers, or name a tier that is configured"
+            if self.plugins
+            else "Add it to tiers, name a tier that is configured, or set default_model in complexity_router_config"
+        )
+        because = (
+            "routing plugins are configured, so default_model is not consulted: a model the plugins "
+            "never vetted must not serve"
+            if self.plugins
+            else "the deployment-level complexity_router_default_model does not count here, because "
+            "falling through to it would serve every no-signal request from a model this tier never names"
+        )
         raise ValueError(
             f"default_tier {self.default_tier.value} is not a non-empty entry in tiers "
-            f"({sorted(self.tiers)}). Add it to tiers, name a tier that is configured, or set "
-            f"default_model in complexity_router_config; the deployment-level "
-            f"complexity_router_default_model does not count here, because falling through to it "
-            f"would serve every no-signal request from a model this tier never names"
+            f"({sorted(self.tiers)}). {remedy}; {because}"
         )
 
     @model_validator(mode="after")

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -5,8 +5,9 @@ Contains default keyword lists, weights, tier boundaries, and configuration clas
 All values are configurable via proxy config.yaml.
 """
 
+from dataclasses import dataclass
 from enum import Enum
-from typing import Literal
+from typing import Literal, assert_never
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -253,6 +254,43 @@ class ClassifierLLMConfig(BaseModel):
     )
 
 
+@dataclass(frozen=True, slots=True)
+class TierModels:
+    """The models that may serve a tier."""
+
+    models: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class TierUnservable:
+    """Why no configured model may serve a tier."""
+
+    tier: str
+    configured_tiers: tuple[str, ...]
+    reason: Literal["nothing_configured", "plugins_require_own_pool"]
+
+    def describe(self) -> str:
+        match self.reason:
+            case "plugins_require_own_pool":
+                why = (
+                    "routing plugins are configured, so only this tier's own models may serve it: "
+                    "a model the plugins never vetted must not serve"
+                )
+                remedy = "give it models in tiers, or name a tier that has them"
+            case "nothing_configured":
+                why = "it has no models, and neither default_model nor the MEDIUM tier supplies one"
+                remedy = "give it models in tiers, or set default_model"
+            case _:
+                assert_never(self.reason)
+        return (
+            f"No model can serve tier {self.tier}: {why}. "
+            f"Configured tiers: {', '.join(self.configured_tiers) or 'none'}. To fix, {remedy}"
+        )
+
+
+TierResolution = TierModels | TierUnservable
+
+
 class ComplexityRouterConfig(BaseModel):
     """Configuration for the ComplexityRouter."""
 
@@ -276,8 +314,8 @@ class ComplexityRouterConfig(BaseModel):
         description=(
             "Tier used when no scoring dimension fires, i.e. the prompt matched no keyword, "
             "pattern or token-count threshold and the scorer has no evidence either way. "
-            "When set explicitly it must have a model behind it: a non-empty entry in `tiers`, "
-            "or `default_model`. "
+            "It resolves to a model the same way a classified tier does, and when set explicitly "
+            "it is rejected at load unless that resolution finds one. "
             "Set to SIMPLE to restore the previous behavior of treating unmatched traffic as simple"
         ),
     )
@@ -472,33 +510,48 @@ class ComplexityRouterConfig(BaseModel):
             raise ValueError("classifier_llm_config is required when classifier_type is 'llm'")
         return self
 
+    def models_for(self, tier: ComplexityTier | str) -> tuple[str, ...]:
+        """The models this tier itself names; absent, an empty pool and an empty pin all mean none."""
+        configured = self.tiers.get(tier.value if isinstance(tier, ComplexityTier) else tier)
+        if isinstance(configured, str):
+            return (configured,) if configured else ()
+        return tuple(configured or ())
+
+    def resolve_tier(self, tier: ComplexityTier | str) -> TierResolution:
+        """Which models may serve this tier, or why none may.
+
+        Config validation and request-time selection both ask here, so a config that loads
+        is a config that routes. A second hand-kept copy of this precedence drifts from it
+        one case at a time, until an accepted config raises on its first request.
+        """
+        tier_key = tier.value if isinstance(tier, ComplexityTier) else tier
+        configured = tuple(sorted(self.tiers))
+        own = self.models_for(tier_key)
+        if own:
+            return TierModels(own)
+        if self.plugins:
+            return TierUnservable(tier_key, configured, "plugins_require_own_pool")
+        if self.default_model:
+            return TierModels((self.default_model,))
+        medium = self.models_for(ComplexityTier.MEDIUM)
+        if medium:
+            return TierModels(medium)
+        return TierUnservable(tier_key, configured, "nothing_configured")
+
     @model_validator(mode="after")
     def _validate_default_tier_is_servable(self) -> "ComplexityRouterConfig":
+        """Reject an explicit `default_tier` that nothing can serve.
+
+        Left implicit it is not checked, so a partial `tiers` map keeps loading and MEDIUM
+        resolves through the same chain every other tier does.
+        """
         if "default_tier" not in self.model_fields_set:
             return self
-        if self.tiers.get(self.default_tier.value):
-            return self
-        # default_model rescues this only without plugins. The plugin path never falls back
-        # to it, since a model the plugins did not vet must not serve, so accepting it here
-        # would validate a config whose every no-signal request fails at routing time.
-        if self.default_model and not self.plugins:
-            return self
-        remedy = (
-            "Add it to tiers, or name a tier that is configured"
-            if self.plugins
-            else "Add it to tiers, name a tier that is configured, or set default_model in complexity_router_config"
-        )
-        because = (
-            "routing plugins are configured, so default_model is not consulted: a model the plugins "
-            "never vetted must not serve"
-            if self.plugins
-            else "the deployment-level complexity_router_default_model does not count here, because "
-            "falling through to it would serve every no-signal request from a model this tier never names"
-        )
-        raise ValueError(
-            f"default_tier {self.default_tier.value} is not a non-empty entry in tiers "
-            f"({sorted(self.tiers)}). {remedy}; {because}"
-        )
+        match self.resolve_tier(self.default_tier):
+            case TierModels():
+                return self
+            case TierUnservable() as unservable:
+                raise ValueError(f"default_tier {self.default_tier.value} is unservable. {unservable.describe()}")
 
     @model_validator(mode="after")
     def _validate_adaptive_pools(self) -> "ComplexityRouterConfig":

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2699,6 +2699,7 @@ RoutingDecisionCause = Literal[
     # that tells a reader the score did NOT choose the tier; encoding it as free text
     # meant anything that filtered `signals` silently changed what the row claimed.
     "reasoning_override",
+    "no_signal_default",
     "llm_classifier",
     "literal_keyword_match",
     "semantic_keyword_match",

--- a/tests/e2e/router/conftest.py
+++ b/tests/e2e/router/conftest.py
@@ -33,6 +33,7 @@ ROUTER_PARAMS = LiteLLMParamsBody(
     complexity_router_config={
         "classifier_type": "llm",
         "classifier_llm_config": {"model": "gpt-5.5"},
+        "default_tier": "SIMPLE",
         "tiers": {
             "SIMPLE": "gpt-5.5",
             "MEDIUM": "claude-haiku-4-5",

--- a/tests/e2e/router/test_complexity_router_e2e.py
+++ b/tests/e2e/router/test_complexity_router_e2e.py
@@ -14,9 +14,13 @@ to the openai backend and every higher tier to the anthropic backend. The prompt
 below carries none of the heuristic scorer's reasoning/technical/code keywords and
 stays short, so heuristic scoring lands it in SIMPLE (openai), but an LLM classifier
 reads it as a decision that has to weigh tradeoffs and lands it above SIMPLE
-(anthropic). The served deployment is read back from the spend log's `model`, so
-anthropic proves the classifier ran and openai proves it silently fell back - the
-exact failure before the fix.
+(anthropic). The router config pins `default_tier: SIMPLE` to keep that split intact:
+a prompt with no scoring signal otherwise abstains to MEDIUM, the same anthropic
+backend the LLM arm picks, and the fallback would stop being visible.
+
+The served deployment is read back from the spend log's `model`, so anthropic proves
+the classifier ran and openai proves it silently fell back - the exact failure before
+the fix.
 """
 
 import pytest

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -373,12 +373,22 @@ class TestModelSelection:
         assert empty.get_model_for_tier(ComplexityTier.SIMPLE) == absent.get_model_for_tier(ComplexityTier.SIMPLE)
         assert empty.get_model_for_tier(ComplexityTier.SIMPLE) == "mid"
 
-    def test_a_tier_with_no_models_and_nothing_to_fall_through_to_raises(self, mock_router_instance):
+    def test_a_tier_with_no_models_raises_only_where_nothing_can_stand_in(self, mock_router_instance):
+        """Under plugins the chain stops at the tier's own models, so an empty tier has
+        nothing to stand in for it. Without plugins this is unreachable by construction: a
+        config whose MEDIUM cannot be served is rejected at load, and a MEDIUM that can be
+        served is also what every other tier falls through to."""
+
+        class NoOpPlugin:
+            async def run(self, context):
+                return context
+
         router = ComplexityRouter(
             model_name="test-router",
             litellm_router_instance=mock_router_instance,
-            complexity_router_config={"tiers": {"SIMPLE": []}},
+            complexity_router_config={"tiers": {"SIMPLE": [], "MEDIUM": "mid"}, "plugins": [NoOpPlugin()]},
         )
+        assert router.get_model_for_tier(ComplexityTier.MEDIUM) == "mid"
         with pytest.raises(ValueError, match="No model can serve tier SIMPLE"):
             router.get_model_for_tier(ComplexityTier.SIMPLE)
 
@@ -1838,6 +1848,7 @@ class TestAdaptiveSoftFloors:
         config = ComplexityRouterConfig(
             adaptive=True,
             tiers={"SIMPLE": ["cheap"]},
+            default_tier=ComplexityTier.SIMPLE,
         )
         assert config.adaptive_weights.quality == pytest.approx(0.3)
         assert config.adaptive_weights.cost == pytest.approx(0.7)
@@ -3179,6 +3190,7 @@ class TestRoutingPlugins:
             litellm_router_instance=mock_router_instance,
             complexity_router_config={
                 "tiers": {"SIMPLE": ["gpt-4o-mini", "gpt-4o-nano"]},
+                "default_tier": "SIMPLE",
                 "plugins": [ExcludeGpt4oMini()],
             },
         )
@@ -3207,6 +3219,7 @@ class TestRoutingPlugins:
             litellm_router_instance=mock_router_instance,
             complexity_router_config={
                 "tiers": {"SIMPLE": "gpt-4o-mini"},
+                "default_tier": "SIMPLE",
                 "default_model": "gpt-4o-fallback",
                 "plugins": [BlockEverything()],
             },
@@ -3230,6 +3243,7 @@ class TestRoutingPlugins:
             litellm_router_instance=mock_router_instance,
             complexity_router_config={
                 "tiers": {"SIMPLE": "gpt-4o-mini"},
+                "default_tier": "SIMPLE",
                 "plugins": [BlockEverything()],
             },
         )
@@ -3254,6 +3268,7 @@ class TestRoutingPlugins:
             litellm_router_instance=mock_router_instance,
             complexity_router_config={
                 "tiers": {"SIMPLE": "gpt-4o-mini"},
+                "default_tier": "SIMPLE",
                 "plugins": [CaptureMetadata()],
             },
         )
@@ -3278,6 +3293,7 @@ class TestRoutingPlugins:
             litellm_router_instance=mock_router_instance,
             complexity_router_config={
                 "tiers": {"SIMPLE": ["gpt-4o-mini", "gpt-4o-nano"]},
+                "default_tier": "SIMPLE",
                 "keyword_tier_rules": [{"keywords": ["hello"], "tier": "SIMPLE"}],
                 "plugins": [ExcludeGpt4oMini()],
             },
@@ -3352,6 +3368,7 @@ class TestRoutingPlugins:
         with pytest.raises(ValidationError, match="plugins and adaptive=True cannot both be set"):
             ComplexityRouterConfig(
                 tiers={"SIMPLE": ["gpt-4o-mini"]},
+                default_tier=ComplexityTier.SIMPLE,
                 adaptive=True,
                 plugins=[_DummyPlugin()],
             )
@@ -3384,6 +3401,7 @@ class TestRoutingPlugins:
             litellm_router_instance=mock_router_instance,
             complexity_router_config={
                 "tiers": {"SIMPLE": ["gpt-4o-mini"]},
+                "default_tier": "SIMPLE",
                 "session_affinity": True,
                 "plugins": [AllowAll()],
             },
@@ -3430,7 +3448,7 @@ class TestEscalationKeywords:
         router = ComplexityRouter(
             model_name="test-router",
             litellm_router_instance=mock_router_instance,
-            complexity_router_config={"tiers": {"SIMPLE": "gpt-4o-mini", "REASONING": "o1-preview"}},
+            complexity_router_config={"tiers": {"SIMPLE": "gpt-4o-mini", "REASONING": "o1-preview"}, "default_tier": "SIMPLE"},
         )
         assert router._escalate_tier(ComplexityTier.SIMPLE) == ComplexityTier.REASONING
 
@@ -3438,7 +3456,7 @@ class TestEscalationKeywords:
         router = ComplexityRouter(
             model_name="test-router",
             litellm_router_instance=mock_router_instance,
-            complexity_router_config={"tiers": {"SIMPLE": "shared", "COMPLEX": "shared", "REASONING": "top"}},
+            complexity_router_config={"tiers": {"SIMPLE": "shared", "COMPLEX": "shared", "REASONING": "top"}, "default_tier": "SIMPLE"},
         )
         assert router._tier_for_model("shared") == ComplexityTier.COMPLEX
         assert router._tier_for_model("top") == ComplexityTier.REASONING
@@ -3716,7 +3734,7 @@ class TestEscalationKeywords:
         router = ComplexityRouter(
             model_name="test-router",
             litellm_router_instance=mock_router_instance,
-            complexity_router_config={"tiers": {"SIMPLE": "gpt-4o-mini", "REASONING": ["o1-a", "o1-b", "o1-c"]}},
+            complexity_router_config={"tiers": {"SIMPLE": "gpt-4o-mini", "REASONING": ["o1-a", "o1-b", "o1-c"]}, "default_tier": "SIMPLE"},
         )
         for pinned in ("o1-a", "o1-b", "o1-c"):
             assert router._escalated_pin(pinned) == pinned
@@ -3729,6 +3747,7 @@ class TestEscalationKeywords:
             litellm_router_instance=mock_router_instance,
             complexity_router_config={
                 "tiers": {"SIMPLE": "gpt-4o-mini", "REASONING": ["o1-a", "o1-b", "o1-c"]},
+                "default_tier": "SIMPLE",
                 "session_affinity": True,
             },
         )
@@ -4122,6 +4141,7 @@ class TestEscalationIsRecordedConsistently:
 
     CEILING_CONFIG = {
         "tiers": {"SIMPLE": ["gpt-4o-mini"], "REASONING": ["o1-preview"]},
+        "default_tier": "SIMPLE",
         "session_affinity": False,
     }
 
@@ -4693,6 +4713,7 @@ class TestContextAwareClassifier:
             litellm_router_instance=mock_router_instance,
             complexity_router_config={
                 "tiers": {"SIMPLE": "gpt-4o-mini", "COMPLEX": "claude-sonnet-4-20250514"},
+                "default_tier": "SIMPLE",
                 "classifier_type": "llm",
                 "classifier_llm_config": {"model": "haiku-classifier"},
                 "classifier_context_window_size": 0,
@@ -4737,6 +4758,7 @@ class TestClassifierTrustBoundary:
             litellm_router_instance=mock_router_instance,
             complexity_router_config={
                 "tiers": {"SIMPLE": "gpt-4o-mini", "REASONING": "o1-preview"},
+                "default_tier": "SIMPLE",
                 "classifier_type": "llm",
                 "classifier_llm_config": {"model": "haiku-classifier"},
             },
@@ -4956,31 +4978,27 @@ class TestNoSignalDefaultTier:
                 },
             )
 
-    @pytest.mark.asyncio
-    async def test_an_unconfigured_default_tier_under_plugins_names_the_real_gap(self, mock_router_instance):
-        """The implicit MEDIUM default is deliberately not validated at load, so a partial
-        tiers map keeps loading. With plugins configured it has no fallback, so the request
-        fails; the error has to name the missing tier rather than blaming the plugins for a
-        filter they never applied."""
+    def test_an_unconfigured_default_tier_under_plugins_is_rejected_at_load(self, mock_router_instance):
+        """With plugins the chain stops at the tier's own models, so a map with no MEDIUM
+        cannot serve no-signal traffic at all; `default_model` is derived on every proxy
+        deployment but the plugins never vetted it. Before, this loaded and raised on the
+        first such request. The error names the missing tier rather than blaming the plugins
+        for a filter they never applied."""
 
         class NoOpPlugin:
             async def run(self, context):
                 return context
 
-        router = ComplexityRouter(
-            model_name="test-router",
-            litellm_router_instance=mock_router_instance,
-            complexity_router_config={
-                "tiers": {"SIMPLE": "simple-model", "COMPLEX": "complex-model"},
-                "plugins": [NoOpPlugin()],
-                "session_affinity": False,
-            },
-        )
-        with pytest.raises(ValueError, match="No model can serve tier MEDIUM: routing plugins are configured"):
-            await router.async_pre_routing_hook(
-                model="test-model",
-                request_kwargs={},
-                messages=[{"role": "user", "content": RIVER_CROSSING}],
+        with pytest.raises(ValidationError, match="default_tier MEDIUM is unservable"):
+            ComplexityRouter(
+                model_name="test-router",
+                litellm_router_instance=mock_router_instance,
+                complexity_router_config={
+                    "tiers": {"SIMPLE": "simple-model", "COMPLEX": "complex-model"},
+                    "plugins": [NoOpPlugin()],
+                    "session_affinity": False,
+                },
+                default_model="derived-from-tiers",
             )
 
     def test_default_tier_outside_tiers_is_allowed_with_default_model(self, mock_router_instance):
@@ -4995,15 +5013,30 @@ class TestNoSignalDefaultTier:
         )
         assert router.get_model_for_tier(router.classify(RIVER_CROSSING)[0]) == "fallback-model"
 
-    def test_partial_tiers_map_still_loads_without_an_explicit_default_tier(self, mock_router_instance):
-        """The implicit MEDIUM default must not turn an existing partial tiers map into a
-        startup failure; it keeps the same resolution chain every other tier already has."""
+    def test_a_partial_tiers_map_keeps_loading_when_default_model_backs_it(self, mock_router_instance):
+        """The implicit MEDIUM default must not turn an ordinary partial tiers map into a
+        startup failure. `router.py` always derives complexity_router_default_model, so on
+        the proxy this is every partial map, and MEDIUM resolves through the same chain any
+        classified tier does."""
         router = ComplexityRouter(
             model_name="test-router",
             litellm_router_instance=mock_router_instance,
             complexity_router_config={"tiers": {"SIMPLE": "simple-model", "REASONING": "reasoning-model"}},
+            default_model="derived-from-tiers",
         )
         assert router.config.default_tier == ComplexityTier.MEDIUM
+        assert router.get_model_for_tier(ComplexityTier.MEDIUM) == "derived-from-tiers"
+
+    def test_an_implicit_default_tier_nothing_can_serve_is_rejected_at_load(self, mock_router_instance):
+        """The default is checked like any explicit value. Every prompt the scorer
+        recognises nothing in lands on this tier, so a config that cannot serve it is broken
+        for a whole class of traffic and has to say so at load."""
+        with pytest.raises(ValidationError, match="default_tier MEDIUM is unservable"):
+            ComplexityRouter(
+                model_name="test-router",
+                litellm_router_instance=mock_router_instance,
+                complexity_router_config={"tiers": {"SIMPLE": "simple-model", "REASONING": "reasoning-model"}},
+            )
 
     def test_abstain_does_not_consult_tier_boundaries(self, mock_router_instance):
         """Boundaries that would map 0.0 to COMPLEX must not reach the no-signal path."""

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -347,7 +347,7 @@ class TestModelSelection:
                 "default_model": "mid",
             },
         )
-        pool = ["cheap", "premium"]
+        pool = ("cheap", "premium")
         with patch(
             "litellm.router_strategy.complexity_router.complexity_router.random.choice",
             return_value="premium",
@@ -356,16 +356,30 @@ class TestModelSelection:
             choice.assert_called_once_with(pool)
         assert router.get_model_for_tier(ComplexityTier.MEDIUM) == "mid"
 
-    def test_get_model_for_tier_empty_pool_raises(self, mock_router_instance):
+    @pytest.mark.parametrize("no_models", [[], ""], ids=["empty_pool", "empty_pin"])
+    def test_a_tier_with_no_models_falls_through_like_an_absent_one(self, mock_router_instance, no_models):
+        """`{"SIMPLE": []}` and a `tiers` map with no SIMPLE key say the same thing, so they
+        have to resolve the same way. Selecting on the key being present sent the empty one
+        into a pool it then refused to pick from, raising where the absent one served
+        default_model."""
+        absent, empty = (
+            ComplexityRouter(
+                model_name="test-router",
+                litellm_router_instance=mock_router_instance,
+                complexity_router_config={"tiers": tiers, "default_model": "mid"},
+            )
+            for tiers in ({}, {"SIMPLE": no_models})
+        )
+        assert empty.get_model_for_tier(ComplexityTier.SIMPLE) == absent.get_model_for_tier(ComplexityTier.SIMPLE)
+        assert empty.get_model_for_tier(ComplexityTier.SIMPLE) == "mid"
+
+    def test_a_tier_with_no_models_and_nothing_to_fall_through_to_raises(self, mock_router_instance):
         router = ComplexityRouter(
             model_name="test-router",
             litellm_router_instance=mock_router_instance,
-            complexity_router_config={
-                "tiers": {"SIMPLE": []},
-                "default_model": "mid",
-            },
+            complexity_router_config={"tiers": {"SIMPLE": []}},
         )
-        with pytest.raises(ValueError, match="Empty model pool for tier SIMPLE"):
+        with pytest.raises(ValueError, match="No model can serve tier SIMPLE"):
             router.get_model_for_tier(ComplexityTier.SIMPLE)
 
 
@@ -1911,7 +1925,7 @@ class TestAdaptiveSoftFloors:
                 "default_model": "mid",
             },
         )
-        pool = ["cheap", "premium"]
+        pool = ("cheap", "premium")
         with patch(
             "litellm.router_strategy.complexity_router.complexity_router.random.choice",
             return_value="premium",
@@ -4869,29 +4883,57 @@ class TestNoSignalDefaultTier:
         with pytest.raises(ValidationError):
             _router_with_default_tier(mock_router_instance, "CHEAPEST")
 
-    def test_default_tier_without_a_model_is_rejected_at_config_time(self, mock_router_instance):
-        """An explicit default_tier naming a tier with no model would only surface as a routing
+    def test_default_tier_with_no_model_anywhere_is_rejected_at_config_time(self, mock_router_instance):
+        """An explicit default_tier that nothing can serve would only surface as a routing
         failure on the first no-signal request, so reject the config instead."""
-        with pytest.raises(ValidationError, match="default_tier COMPLEX is not a non-empty entry in tiers"):
+        with pytest.raises(ValidationError, match="default_tier COMPLEX is unservable"):
             ComplexityRouter(
                 model_name="test-router",
                 litellm_router_instance=mock_router_instance,
-                complexity_router_config={
-                    "tiers": {"SIMPLE": "simple-model", "MEDIUM": "medium-model"},
-                    "default_tier": "COMPLEX",
-                },
+                complexity_router_config={"tiers": {"COMPLEX": []}, "default_tier": "COMPLEX"},
             )
 
-    def test_default_tier_with_an_empty_pool_is_rejected(self, mock_router_instance):
-        with pytest.raises(ValidationError, match="default_tier MEDIUM is not a non-empty entry in tiers"):
-            ComplexityRouter(
-                model_name="test-router",
-                litellm_router_instance=mock_router_instance,
-                complexity_router_config={
-                    "tiers": {"SIMPLE": "simple-model", "MEDIUM": []},
-                    "default_tier": "MEDIUM",
-                },
-            )
+    @pytest.mark.parametrize(
+        "config_overrides, deployment_default_model, expected",
+        [
+            ({"tiers": {"SIMPLE": "s", "MEDIUM": "m"}}, None, "m"),
+            ({"tiers": {"SIMPLE": "s", "MEDIUM": "m"}, "default_model": "f"}, None, "f"),
+            ({"tiers": {"SIMPLE": "s", "MEDIUM": "m"}}, "d", "d"),
+            ({"tiers": {"SIMPLE": "s", "COMPLEX": []}, "default_model": "f"}, None, "f"),
+        ],
+        ids=["medium_tier", "config_default_model", "deployment_default_model", "empty_pool_falls_through"],
+    )
+    def test_a_default_tier_the_config_accepts_is_one_a_request_can_land_on(
+        self, mock_router_instance, config_overrides, deployment_default_model, expected
+    ):
+        """The invariant the validator exists to hold: loading and routing agree.
+
+        default_tier is not a special tier; it names which tier no-signal traffic is
+        classified as, and that tier resolves through the same chain as any classified
+        one. Every accepted config here therefore has to serve, and a validator that
+        re-derives that chain by hand instead of asking `resolve_tier` drifts from it
+        one case at a time, accepting configs whose first no-signal request raises."""
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={"default_tier": "COMPLEX", **config_overrides},
+            default_model=deployment_default_model,
+        )
+        assert router.get_model_for_tier(ComplexityTier.COMPLEX) == expected
+
+    def test_the_deployment_level_default_model_is_visible_to_validation(self, mock_router_instance):
+        """router.py always hands ComplexityRouter a derived complexity_router_default_model,
+        so a default_tier outside `tiers` is servable on every proxy deployment. Validating
+        before that value was applied failed those configs at startup for a gap that routing
+        did not have."""
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={"tiers": {"SIMPLE": "s"}, "default_tier": "COMPLEX"},
+            default_model="derived-from-tiers",
+        )
+        assert router.config.default_model == "derived-from-tiers"
+        assert router.get_model_for_tier(ComplexityTier.COMPLEX) == "derived-from-tiers"
 
     def test_default_model_does_not_rescue_the_default_tier_when_plugins_are_configured(self, mock_router_instance):
         """The plugin path builds candidates from the tier pool alone and never consults
@@ -4934,7 +4976,7 @@ class TestNoSignalDefaultTier:
                 "session_affinity": False,
             },
         )
-        with pytest.raises(ValueError, match="Tier MEDIUM has no models configured"):
+        with pytest.raises(ValueError, match="No model can serve tier MEDIUM: routing plugins are configured"):
             await router.async_pre_routing_hook(
                 model="test-model",
                 request_kwargs={},

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -4914,6 +4914,33 @@ class TestNoSignalDefaultTier:
                 },
             )
 
+    @pytest.mark.asyncio
+    async def test_an_unconfigured_default_tier_under_plugins_names_the_real_gap(self, mock_router_instance):
+        """The implicit MEDIUM default is deliberately not validated at load, so a partial
+        tiers map keeps loading. With plugins configured it has no fallback, so the request
+        fails; the error has to name the missing tier rather than blaming the plugins for a
+        filter they never applied."""
+
+        class NoOpPlugin:
+            async def run(self, context):
+                return context
+
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": "simple-model", "COMPLEX": "complex-model"},
+                "plugins": [NoOpPlugin()],
+                "session_affinity": False,
+            },
+        )
+        with pytest.raises(ValueError, match="Tier MEDIUM has no models configured"):
+            await router.async_pre_routing_hook(
+                model="test-model",
+                request_kwargs={},
+                messages=[{"role": "user", "content": RIVER_CROSSING}],
+            )
+
     def test_default_tier_outside_tiers_is_allowed_with_default_model(self, mock_router_instance):
         router = ComplexityRouter(
             model_name="test-router",

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -4893,6 +4893,27 @@ class TestNoSignalDefaultTier:
                 },
             )
 
+    def test_default_model_does_not_rescue_the_default_tier_when_plugins_are_configured(self, mock_router_instance):
+        """The plugin path builds candidates from the tier pool alone and never consults
+        default_model, since a model the plugins did not vet must not serve. Accepting
+        default_model here would validate a config whose every no-signal request raises."""
+
+        class NoOpPlugin:
+            async def run(self, context):
+                return context
+
+        with pytest.raises(ValidationError, match="routing plugins are configured"):
+            ComplexityRouter(
+                model_name="test-router",
+                litellm_router_instance=mock_router_instance,
+                complexity_router_config={
+                    "tiers": {"SIMPLE": "simple-model", "MEDIUM": "medium-model"},
+                    "default_tier": "COMPLEX",
+                    "default_model": "fallback-model",
+                    "plugins": [NoOpPlugin()],
+                },
+            )
+
     def test_default_tier_outside_tiers_is_allowed_with_default_model(self, mock_router_instance):
         router = ComplexityRouter(
             model_name="test-router",

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -28,7 +28,9 @@ from litellm.router_strategy.complexity_router.complexity_router import (
 )
 from litellm.router_strategy.complexity_router.config import (
     DEFAULT_COMPLEXITY_CONFIG,
+    DEFAULT_DIMENSION_WEIGHTS,
     DEFAULT_TECHNICAL_KEYWORDS,
+    NO_SIGNAL_MARKER,
     ComplexityRouterConfig,
     ComplexityTier,
 )
@@ -4738,3 +4740,377 @@ class TestClassifierTrustBoundary:
         assert system_message["content"] == _CLASSIFICATION_SYSTEM_RUBRIC
         assert hostile not in system_message["content"]
         assert hostile in user_message["content"]
+
+
+DEFAULT_TIER_MODELS_FOR_TEST = {
+    "SIMPLE": "simple-model",
+    "MEDIUM": "medium-model",
+    "COMPLEX": "complex-model",
+    "REASONING": "reasoning-model",
+}
+
+RIVER_CROSSING = (
+    "A farmer must ferry a wolf, a goat, and a cabbage across a river. The boat holds the farmer "
+    "and one other item. Left alone, the wolf eats the goat and the goat eats the cabbage. Give "
+    "the shortest sequence of crossings."
+)
+
+ESCALATION_TRIAGE = (
+    "Three of our largest accounts have all asked for the same thing this quarter, but each one "
+    "wants it on a different timeline and two of them have contracts that expire before the "
+    "earliest date we could deliver. Draft the note to the leadership team laying out what we "
+    "should promise, to whom, and in what order."
+)
+
+BOARD_SUMMARY = (
+    "Summarize the attached quarterly report for a board audience and highlight anything that "
+    "changed materially from last quarter, keeping it to roughly one page and avoiding jargon "
+    "that a non-specialist reader would stumble over."
+)
+
+NO_SIGNAL_PROMPTS = (RIVER_CROSSING, ESCALATION_TRIAGE, BOARD_SUMMARY)
+
+CANCELLING_PROMPT = "hi, quick python question"
+
+
+@pytest.fixture
+def default_boundaries_router(mock_router_instance):
+    """Router on the shipped defaults: only the tier -> model map is overridden."""
+    return ComplexityRouter(
+        model_name="test-default-tier-router",
+        litellm_router_instance=mock_router_instance,
+        complexity_router_config={"tiers": dict(DEFAULT_TIER_MODELS_FOR_TEST)},
+    )
+
+
+def _router_with_default_tier(mock_router_instance, default_tier):
+    return ComplexityRouter(
+        model_name="test-default-tier-router",
+        litellm_router_instance=mock_router_instance,
+        complexity_router_config={
+            "tiers": dict(DEFAULT_TIER_MODELS_FOR_TEST),
+            "default_tier": default_tier,
+        },
+    )
+
+
+class TestNoSignalDefaultTier:
+    """LIT-4898: a prompt that fires no dimension is unclassifiable, not simple."""
+
+    @pytest.mark.parametrize("prompt", NO_SIGNAL_PROMPTS)
+    def test_no_signal_prompt_abstains_to_medium(self, default_boundaries_router, prompt):
+        tier, score, signals = default_boundaries_router.classify(prompt)
+        assert tier == ComplexityTier.MEDIUM
+        assert score == 0.0
+        assert signals == [NO_SIGNAL_MARKER]
+
+    def test_cancelling_dimensions_score_zero_but_do_not_abstain(self, default_boundaries_router):
+        """Guards the predicate itself: this prompt cancels to a score of zero with three
+        dimensions firing (short prompt, simple indicator, code keyword), so an abstain branch
+        written against the weighted score would wrongly promote it to MEDIUM."""
+        tier, score, signals = default_boundaries_router.classify(CANCELLING_PROMPT)
+        assert score == pytest.approx(0.0, abs=1e-9)
+        assert tier == ComplexityTier.SIMPLE
+        assert NO_SIGNAL_MARKER not in signals
+        assert signals == ["short (6 tokens)", "code (python)", "simple (quick, hi)"]
+
+    def test_exactly_zero_weighted_score_with_signal_does_not_abstain(self, mock_router_instance):
+        """Same guard as above, but with weights that cancel to a bit-exact 0.0 rather than to
+        float dust, so `weighted_score == 0.0` is a live substitution the suite has to reject."""
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": dict(DEFAULT_TIER_MODELS_FOR_TEST),
+                "dimension_weights": {**DEFAULT_DIMENSION_WEIGHTS, "tokenCount": 0.25, "codePresence": 0.5},
+            },
+        )
+        tier, score, signals = router.classify("please add a def here")
+        assert score == 0.0
+        assert signals == ["short (5 tokens)", "code (def)"]
+        assert tier == ComplexityTier.SIMPLE
+
+    def test_only_simple_indicator_fires_stays_simple(self, default_boundaries_router):
+        tier, _, signals = default_boundaries_router.classify("What is machine learning?")
+        assert tier == ComplexityTier.SIMPLE
+        assert NO_SIGNAL_MARKER not in signals
+
+    def test_only_token_count_fires_stays_simple(self, default_boundaries_router):
+        tier, _, signals = default_boundaries_router.classify("Where did we land on the offer letter")
+        assert signals == ["short (9 tokens)"]
+        assert tier == ComplexityTier.SIMPLE
+
+    def test_default_tier_simple_restores_previous_behavior(self, mock_router_instance):
+        router = _router_with_default_tier(mock_router_instance, "SIMPLE")
+        for prompt in NO_SIGNAL_PROMPTS:
+            tier, score, _ = router.classify(prompt)
+            assert tier == ComplexityTier.SIMPLE, prompt
+            assert score == 0.0
+
+    @pytest.mark.parametrize(
+        "configured, expected",
+        [
+            ("SIMPLE", ComplexityTier.SIMPLE),
+            ("MEDIUM", ComplexityTier.MEDIUM),
+            ("COMPLEX", ComplexityTier.COMPLEX),
+            ("REASONING", ComplexityTier.REASONING),
+        ],
+    )
+    def test_default_tier_is_configurable(self, mock_router_instance, configured, expected):
+        router = _router_with_default_tier(mock_router_instance, configured)
+        tier, _, _ = router.classify(RIVER_CROSSING)
+        assert tier == expected
+
+    def test_default_tier_defaults_to_medium(self):
+        assert ComplexityRouterConfig().default_tier == ComplexityTier.MEDIUM
+        assert DEFAULT_COMPLEXITY_CONFIG.default_tier == ComplexityTier.MEDIUM
+
+    def test_unknown_default_tier_is_rejected(self, mock_router_instance):
+        with pytest.raises(ValidationError):
+            _router_with_default_tier(mock_router_instance, "CHEAPEST")
+
+    def test_default_tier_without_a_model_is_rejected_at_config_time(self, mock_router_instance):
+        """An explicit default_tier naming a tier with no model would only surface as a routing
+        failure on the first no-signal request, so reject the config instead."""
+        with pytest.raises(ValidationError, match="default_tier COMPLEX is not a non-empty entry in tiers"):
+            ComplexityRouter(
+                model_name="test-router",
+                litellm_router_instance=mock_router_instance,
+                complexity_router_config={
+                    "tiers": {"SIMPLE": "simple-model", "MEDIUM": "medium-model"},
+                    "default_tier": "COMPLEX",
+                },
+            )
+
+    def test_default_tier_with_an_empty_pool_is_rejected(self, mock_router_instance):
+        with pytest.raises(ValidationError, match="default_tier MEDIUM is not a non-empty entry in tiers"):
+            ComplexityRouter(
+                model_name="test-router",
+                litellm_router_instance=mock_router_instance,
+                complexity_router_config={
+                    "tiers": {"SIMPLE": "simple-model", "MEDIUM": []},
+                    "default_tier": "MEDIUM",
+                },
+            )
+
+    def test_default_tier_outside_tiers_is_allowed_with_default_model(self, mock_router_instance):
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": {"SIMPLE": "simple-model"},
+                "default_tier": "MEDIUM",
+                "default_model": "fallback-model",
+            },
+        )
+        assert router.get_model_for_tier(router.classify(RIVER_CROSSING)[0]) == "fallback-model"
+
+    def test_partial_tiers_map_still_loads_without_an_explicit_default_tier(self, mock_router_instance):
+        """The implicit MEDIUM default must not turn an existing partial tiers map into a
+        startup failure; it keeps the same resolution chain every other tier already has."""
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={"tiers": {"SIMPLE": "simple-model", "REASONING": "reasoning-model"}},
+        )
+        assert router.config.default_tier == ComplexityTier.MEDIUM
+
+    def test_abstain_does_not_consult_tier_boundaries(self, mock_router_instance):
+        """Boundaries that would map 0.0 to COMPLEX must not reach the no-signal path."""
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                "tiers": dict(DEFAULT_TIER_MODELS_FOR_TEST),
+                "tier_boundaries": {
+                    "simple_medium": -1.0,
+                    "medium_complex": -0.5,
+                    "complex_reasoning": 1.0,
+                },
+            },
+        )
+        tier, _, _ = router.classify(RIVER_CROSSING)
+        assert tier == ComplexityTier.MEDIUM
+
+    def test_reasoning_override_wins_over_abstain(self, default_boundaries_router):
+        tier, _, signals = default_boundaries_router.classify(
+            "Let's think step by step and reason through this carefully"
+        )
+        assert tier == ComplexityTier.REASONING
+        assert NO_SIGNAL_MARKER not in signals
+
+    @pytest.mark.asyncio
+    async def test_no_signal_request_routes_to_the_medium_model(self, default_boundaries_router):
+        result = await default_boundaries_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[{"role": "user", "content": RIVER_CROSSING}],
+        )
+        assert result is not None
+        assert result.model == "medium-model"
+
+    @pytest.mark.asyncio
+    async def test_no_signal_decision_names_its_own_cause(self, default_boundaries_router):
+        """Same argument as reasoning_override: the fact worth logging is that the score did
+        not choose the tier, so it is a cause rather than a marker only inside signals."""
+        response = await default_boundaries_router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[{"role": "user", "content": RIVER_CROSSING}],
+        )
+        decision = response.routing_decision
+        assert decision["cause"] == "no_signal_default"
+        assert decision["tier"] == "MEDIUM"
+        assert decision["signals"] == [NO_SIGNAL_MARKER]
+        assert decision["routed_model"] == "medium-model"
+
+    @pytest.mark.asyncio
+    async def test_no_signal_request_honors_default_tier_simple(self, mock_router_instance):
+        router = _router_with_default_tier(mock_router_instance, "SIMPLE")
+        result = await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[{"role": "user", "content": RIVER_CROSSING}],
+        )
+        assert result is not None
+        assert result.model == "simple-model"
+
+    @pytest.mark.asyncio
+    async def test_abstain_still_escalates(self, mock_router_instance):
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={"tiers": dict(DEFAULT_TIER_MODELS_FOR_TEST)},
+        )
+        result = await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[{"role": "user", "content": f"LITELLM ESCALATE {RIVER_CROSSING}"}],
+        )
+        assert result is not None
+        assert result.model == "complex-model"
+
+
+LONG_UNMATCHED_PROMPT = " ".join(
+    [
+        "The tenant moved out on the fifteenth and left the place in a state that neither of us",
+        "expected. We had walked through it together in the spring and everything looked ordinary",
+        "then. Now there are marks along the hallway that were not in the move-in photos, the back",
+        "door does not sit flush in its frame, and the garden that was part of the agreement has",
+        "clearly been left to itself for most of the summer. I have the deposit, the signed",
+        "inventory from the start of the tenancy, and about forty photographs taken on the day they",
+        "handed the keys back. The tenant says the hallway marks were there when they arrived and",
+        "that the garden was never their responsibility because we had someone come round for the",
+        "first two months. I would like a letter to send them that sets out what I intend to hold",
+        "back from the deposit and why, that reads as reasonable rather than aggressive, and that",
+        "leaves room for them to come back with their side before I file anything formally. Keep it",
+        "to a page. I want the tone to be the sort a longtime neighbour would use, firm about the",
+        "money but not spoiling for a fight, because they may well end up renting the flat upstairs",
+        "from my sister and I would rather this ended quietly than turned into a matter that follows",
+        "everyone around for a year afterwards. Mention the walkthrough, mention the photographs,",
+        "and leave the specific figures blank for me to fill in myself once I have the quotes back",
+        "from the two people I asked to look at the door and the hallway this coming week, and say",
+        "plainly that I would rather settle the difference between us than have either of us spend",
+        "another weekend on it.",
+    ]
+)
+
+TIER_CORPUS = (
+    (RIVER_CROSSING, ComplexityTier.MEDIUM),
+    (ESCALATION_TRIAGE, ComplexityTier.MEDIUM),
+    (BOARD_SUMMARY, ComplexityTier.MEDIUM),
+    ("The quarterly numbers came in under what we told the board in April. Walk me through how "
+     "you would open that conversation with them, what you would concede up front, and where you "
+     "would push back if they ask whether the forecast was ever realistic.", ComplexityTier.MEDIUM),
+    (CANCELLING_PROMPT, ComplexityTier.SIMPLE),
+    ("Hi there!", ComplexityTier.SIMPLE),
+    ("Thanks!", ComplexityTier.SIMPLE),
+    ("What is machine learning?", ComplexityTier.SIMPLE),
+    ("Explain how REST APIs work with HTTP methods", ComplexityTier.SIMPLE),
+    (LONG_UNMATCHED_PROMPT, ComplexityTier.SIMPLE),
+    ("Write a function that reverses a linked list in python", ComplexityTier.MEDIUM),
+    ("Design a distributed microservice architecture for a high-throughput real-time data "
+     "processing pipeline with Kubernetes orchestration, implementing proper authentication "
+     "and encryption protocols", ComplexityTier.COMPLEX),
+    ("Think step by step and reason through the pros and cons of different database "
+     "architectures", ComplexityTier.REASONING),
+)
+
+
+class TestDefaultConfigTierCorpus:
+    """Pins the shipped-default tier mix so a weight or keyword edit cannot silently walk
+    unmatched traffic back onto the cheapest tier."""
+
+    @pytest.mark.parametrize("prompt, expected", TIER_CORPUS)
+    def test_corpus_tier(self, default_boundaries_router, prompt, expected):
+        tier, score, signals = default_boundaries_router.classify(prompt)
+        assert tier == expected, f"{prompt[:60]!r} -> {tier} (score={score:.4f}, signals={signals})"
+
+    def test_no_signal_share_of_corpus_never_lands_on_simple(self, default_boundaries_router):
+        abstained = [
+            prompt
+            for prompt, _ in TIER_CORPUS
+            if default_boundaries_router.classify(prompt)[2] == [NO_SIGNAL_MARKER]
+        ]
+        assert len(abstained) == 4
+        for prompt in abstained:
+            assert default_boundaries_router.classify(prompt)[0] != ComplexityTier.SIMPLE
+
+    def test_long_unmatched_prompt_fires_token_count_and_is_not_abstain(self, default_boundaries_router):
+        """The >400-token band is outside the abstain set by design: tokenCount fires, so the
+        prompt scores +0.10 and the boundary (not default_tier) decides. Moving that boundary
+        is the separate pricing decision tracked as a follow-up."""
+        _, score, signals = default_boundaries_router.classify(LONG_UNMATCHED_PROMPT)
+        assert len(signals) == 1 and signals[0].startswith("long (")
+        assert score == pytest.approx(0.10)
+
+
+class TestDimensionSignalInvariant:
+    """The abstain branch reads the signals, so a dimension has to say when it recognised
+    something. A scorer returning a nonzero score with no signal would be evidence the
+    abstain check cannot see; one returning zero with a signal would be silence it mistakes
+    for evidence. Either way the no-signal default would fire on the wrong requests."""
+
+    def _dimension_scores(self, router):
+        keyword_args = (
+            (router.code_keywords, "codePresence", "code", (1, 2), (0, 0.5, 1.0)),
+            (router.reasoning_keywords, "reasoningMarkers", "reasoning", (1, 2), (0, 0.7, 1.0)),
+            (router.technical_keywords, "technicalTerms", "technical", (2, 4), (0, 0.5, 1.0)),
+            (router.simple_keywords, "simpleIndicators", "simple", (1, 2), (0, -1.0, -1.0)),
+        )
+        texts = (
+            "",
+            "the meeting moved again",
+            "def foo",
+            "import a function to refactor the database schema",
+            "step by step, think through and analyze this",
+            "distributed architecture with encryption and authentication and latency budgets",
+            "hi, thanks, quick question",
+        )
+        keyword_dimensions = [
+            router._score_keyword_match(text, text, keywords, name, label, thresholds, scores)[0]
+            for text in texts
+            for keywords, name, label, thresholds, scores in keyword_args
+        ]
+        other_dimensions = [
+            *(router._score_token_count(count) for count in (0, 3, 14, 15, 100, 400, 401, 5000)),
+            *(router._score_multi_step(text) for text in (*texts, "first do this, then do that")),
+            *(router._score_question_complexity(text) for text in (*texts, "a? b? c? d? e?")),
+        ]
+        return keyword_dimensions + other_dimensions
+
+    def test_a_signal_is_emitted_exactly_when_a_dimension_scores(self, default_boundaries_router):
+        for dimension in self._dimension_scores(default_boundaries_router):
+            assert (dimension.score != 0) == (dimension.signal is not None), (
+                f"{dimension.name} broke the invariant: score={dimension.score!r} signal={dimension.signal!r}"
+            )
+
+    def test_a_system_prompt_only_match_still_signals(self, default_boundaries_router):
+        """The signal withholds the matched term when only the system prompt supplied it,
+        reporting a count instead. It must still be a signal, or a prompt whose evidence
+        came entirely from the system prompt would read as no signal at all."""
+        _, _, signals = default_boundaries_router.classify(
+            "please help with that", system_prompt="You are a kubernetes and docker expert"
+        )
+        assert signals == ["short (5 tokens)", "code (2 matches)"]
+        assert NO_SIGNAL_MARKER not in signals


### PR DESCRIPTION
## TLDR

Problem this solves:

- The heuristic scorer has no way to say "I don't know". Its dimensions are a roughly 100-word software-vocabulary whitelist, so a prompt matching none of them scores exactly 0.0, and 0.0 falls under `simple_medium` (0.15) into SIMPLE. Absence of evidence was scored as evidence of simplicity, on 50.2% of prompts in a graded 809-question benchmark and 36.6% of turns in a 257-session agent corpus
- The same path catches LLM-classifier outages, since a timeout or error falls back to this scorer

How it solves it:

- `_score_and_classify` returns a new `default_tier` (MEDIUM by default) when nothing was recognised, under its own decision cause `no_signal_default` and with `signals=['no-signal']`
- `default_tier: SIMPLE` restores the previous behavior exactly, for anyone who wants unmatched traffic on the cheapest tier
- The branch reads the signals, not the score and not the individual dimension scores, because neither of those means "nothing was recognised"

## Relevant issues

- Routes prompts that fire no scoring dimension to a configurable `default_tier` instead of letting a 0.0 score fall through into SIMPLE, and logs them as `cause=no_signal_default`
- Keeps genuinely-simple traffic on SIMPLE: a prompt whose only evidence is a greeting, a "what is", or a short length still scores and still lands SIMPLE
- Pins `default_tier: SIMPLE` in the router e2e fixture, whose classifier-vs-fallback discriminator is itself a no-signal prompt and would otherwise have gone false-green

## Linear ticket

Resolves LIT-4898

The tier fallback ladder that came out of the same discussion is split into its own PR, #35331, based on staging rather than stacked on this one

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on this branch at 2d25d23566. Two routers over the same three models: `smart-router` on the new default, and `smart-router-legacy` carrying `default_tier: SIMPLE`, which is the behavior on staging today

```yaml
  - model_name: smart-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        tiers: {SIMPLE: gpt-5.4-nano, MEDIUM: gpt-5.4-mini, COMPLEX: gpt-5.4, REASONING: gpt-5.4}
        session_affinity: false

  - model_name: smart-router-legacy
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        default_tier: SIMPLE
        tiers: {SIMPLE: gpt-5.4-nano, MEDIUM: gpt-5.4-mini, COMPLEX: gpt-5.4, REASONING: gpt-5.4}
        session_affinity: false
```

```
LITELLM_LOG=INFO python litellm/proxy/proxy_cli.py --config lit4898_abstain.yaml --port 4897
```

A prompt that matches nothing. It used to be asserted simple; it now abstains, and the row says why:

```
$ curl -s -X POST http://localhost:4897/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model": "smart-router", "messages": [{"role": "user", "content": "A farmer must ferry a wolf, a goat, and a cabbage across a river. ..."}]}'
ComplexityRouter: routing decision cause=no_signal_default, tier=MEDIUM, score=0.000, signals=('no-signal',), routed_model=gpt-5.4-mini
```

A prompt with real evidence of being simple, unchanged:

```
$ curl -s -X POST http://localhost:4897/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model": "smart-router", "messages": [{"role": "user", "content": "What is 2+2?"}]}'
ComplexityRouter: routing decision cause=heuristic_scorer, tier=SIMPLE, score=-0.150, signals=('short (3 tokens)', 'simple (what is)'), routed_model=gpt-5.4-nano
```

The case that keeps the fix honest. This one scores zero, but with three dimensions firing, so it is not silence and stays on the cheap tier:

```
$ curl -s -X POST http://localhost:4897/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model": "smart-router", "messages": [{"role": "user", "content": "hi, quick python question"}]}'
ComplexityRouter: routing decision cause=heuristic_scorer, tier=SIMPLE, score=-0.000, signals=('short (6 tokens)', 'code (python)', 'simple (quick, hi)'), routed_model=gpt-5.4-nano
```

The opt-out, same no-signal prompt against the router carrying `default_tier: SIMPLE`:

```
$ curl -s -X POST http://localhost:4897/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model": "smart-router-legacy", "messages": [{"role": "user", "content": "A farmer must ferry a wolf, a goat, and a cabbage across a river. ..."}]}'
ComplexityRouter: routing decision cause=no_signal_default, tier=SIMPLE, score=0.000, signals=('no-signal',), routed_model=gpt-5.4-nano
```

The upstream completions returned 429 (the OpenAI key on this box is out of quota, and the other provider keys available locally are unfunded), so these transcripts prove the routing decision and the deployment handoff, not the provider response. The runbook below reruns the same commands against a funded key for the 200s

## Type

🐛 Bug Fix

## Changes

`_score_and_classify` returns `config.default_tier` with `signals=['no-signal']` and `cause=no_signal_default` when nothing was recognised, placed after the 2-or-more-reasoning-marker override and before the band mapping. The cause is a first-class value for the same reason `reasoning_override` is: it is the fact that says the score did not choose the tier, and burying it in `signals` would let anything that filters signals change what the row claims

The branch reads `signals`, not the weighted score, and not the individual dimension scores either. Both of those look like "nothing was recognised" without being it. The weighted score cancels: `hi, quick python question` is `tokenCount -1.0x0.10` plus `simpleIndicators -1.0x0.05` plus `codePresence 0.5x0.30`, which comes to zero with three dimensions firing and is real evidence of a simple request. A per-dimension zero is not silence either, since `_score_keyword_match` takes the no-match score as a parameter, so a future dimension with a nonzero baseline would silently kill the branch. A signal is the one thing a dimension emits only when it recognised something, and a test pins that invariant across every scorer, in both directions

Short prompts (under 15 estimated tokens) and long ones (over 400) fire `tokenCount` and score normally, so this path holds prompts of roughly 15 to 400 estimated tokens with zero keyword and pattern hits

`default_tier` defaults to MEDIUM, so no config change turns it on; setting it only overrides. `default_tier: SIMPLE` restores the previous behavior

`default_tier` is not a special tier. It names which tier no-signal traffic is classified as, and that tier resolves to a model through the same chain as any classified one. `ComplexityRouterConfig.resolve_tier` is that chain, returning either the models that may serve a tier or the reason none may, and both config validation and request-time selection go through it. So a `default_tier` that nothing can serve is rejected at load rather than surfacing on the first unmatched request, and every config that loads is one the default tier can actually be served from

That check covers the defaulted MEDIUM as well as a value you typed. It was originally skipped when the field was left implicit, so that a partial `tiers` map would not become a startup failure; through `resolve_tier` it no longer can, because the proxy always derives a `default_model` from the MEDIUM-then-SIMPLE tier and the chain terminates there. What is left is one shape, and it is the reason the exemption had to go: with routing plugins configured the chain stops at the tier's own models, since a model the plugins never vetted must not serve, so a plugin config whose `tiers` has no MEDIUM cannot serve no-signal traffic at all. Abstaining moved those prompts off SIMPLE, so before this it loaded and raised on every one of them

Two things fell out of putting that chain in one place. Resolution now keys off whether a tier has models rather than whether its key is present, so `tiers: {MEDIUM: []}` and a tiers map with no MEDIUM at all behave the same; before, the empty one entered the pool and refused to pick from it while the absent one fell through to `default_model`. And the deployment-level `complexity_router_default_model` is folded in before validation instead of being assigned onto the validated model afterwards. `router.py` derives that value from the MEDIUM-then-SIMPLE tier whenever it is unset, so an explicit `default_tier` outside `tiers` is servable on every proxy deployment; validating before it was applied failed those configs at startup for a gap routing did not have

Tests cover the abstain itself, the config validation, both cancelling cases (the shipped-weights one that lands on float dust, and a configured-weights one that lands on a bit-exact 0.0, so the cheaper predicate is a live substitution the suite rejects), the scorer signal invariant the predicate now depends on, the SIMPLE-only and short-prompt-only edges that must not abstain, `default_tier` across all four tiers, escalation on top of an abstain, and a fixed 13-prompt corpus pinning the tier of each so a later weight or keyword edit cannot walk the default back toward all-SIMPLE. The servability tests pin the invariant rather than the instances: a config the validator accepts is one the default tier can be served from, parameterized over the tier's own models, `default_model` at either level, and an empty pool falling through

Docs: the router README gains a "No-Signal Default" section, and the proxy docs page is updated in a separate PR

## Known limits, not fixed here

Unmatched prompts over 400 estimated tokens fire `tokenCount`, score +0.10, and still land SIMPLE under the 0.15 boundary. Moving that boundary is a pricing decision tracked separately, as is the `complex_reasoning` calibration. On the graded corpus this leaves hard-labelled questions on SIMPLE at 31.9%, down from 67.0%

This alters spend for every deployment on the heuristic default with no config change on their side. On the agent corpus the blended per-turn price proxy goes from 2.78 to 4.24, about +53%, with tier mix moving 84/13/3/0 to 47/49/3/0. It needs a release-note call-out, and `default_tier: SIMPLE` is the one-line opt-out

## QA runbook

1. Check out this branch, `make bootstrap`, and write the config above to `lit4898_abstain.yaml` with a funded `OPENAI_API_KEY` in the environment
2. `LITELLM_LOG=INFO python litellm/proxy/proxy_cli.py --config lit4898_abstain.yaml --port 4897`
3. Run the four curl commands above. Each returns a 200 completion. Adding `return_raw_model_name: true` to either router's config puts the deployment that served into the response `model` field, so routing is visible without reading logs
4. Expected: the river-crossing prompt serves gpt-5.4-mini on `smart-router` and gpt-5.4-nano on `smart-router-legacy`; `What is 2+2?` and `hi, quick python question` serve gpt-5.4-nano on both
5. `python -m pytest tests/test_litellm/router_strategy/test_complexity_router.py -q` for the unit coverage

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default routing behavior changes for existing deployments without config edits (more unmatched traffic to MEDIUM and higher spend), though default_tier: SIMPLE opt-out exists; routing logic is well-tested.
> 
> **Overview**
> When the heuristic scorer gets **no signals** from any dimension, it no longer maps a **0.0** score into **SIMPLE**. It returns configurable **`default_tier`** (default **MEDIUM**), logs **`signals=['no-signal']`**, and records **`cause=no_signal_default`**. The branch keys off empty **signals**, not the weighted score, so prompts like **`hi, quick python question`** that cancel to zero but still have evidence stay on **SIMPLE**.
> 
> **`default_tier: SIMPLE`** restores the old behavior. Explicit **`default_tier`** values are validated at config load so the tier has a servable model (with stricter rules when routing **plugins** are enabled). The plugin tier-pick path now errors clearly when a tier has no models configured instead of implying plugin filtering removed them.
> 
> Docs, **`RoutingDecisionCause`**, e2e fixture **`default_tier: SIMPLE`** (so classifier-vs-fallback tests stay valid), and broad unit/corpus tests cover abstain, config validation, and the dimension signal invariant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be7b23ce0ff16cc146c58c06fdd918ea6b1830ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
