### PR TITLE
fix(anthropic_messages): gate sampling params on /v1/messages like /chat/completions

### DIFF
--- a/litellm/llms/anthropic/experimental_pass_through/messages/utils.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/utils.py
@@ -44,6 +44,7 @@ class AnthropicMessagesRequestUtils:
         filtered_params: Final = {k: v for k, v in params.items() if k in valid_keys and v is not None}
         if model is not None:
             from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+            from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 
             AnthropicConfig._maybe_drop_speed_param(
                 model=model,
@@ -51,6 +52,22 @@ class AnthropicMessagesRequestUtils:
                 drop_params=drop_params,
                 custom_llm_provider=custom_llm_provider,
             )
+            # Claude 4.7+ removed sampling params (the API 400s on top_p, top_k,
+            # and any temperature other than 1). Mirror the /chat/completions
+            # gating — drop under drop_params, else raise a clean client-side
+            # 400 — instead of forwarding a known-rejected param upstream, where
+            # router fallbacks would mask the provider 400 as a silent model
+            # downgrade.
+            for param in ("temperature", "top_p", "top_k"):
+                if param in filtered_params:
+                    AnthropicModelInfo._apply_sampling_param(  # pyright: ignore[reportPrivateUsage]  # same gating the /chat/completions path applies; forking it would drift
+                        optional_params=filtered_params,
+                        model=model,
+                        param=param,
+                        value=filtered_params.pop(param),
+                        drop_params=drop_params,
+                        output_key=param,
+                    )
         return cast(AnthropicMessagesRequestOptionalParams, filtered_params)
 
 

--- a/litellm/llms/anthropic/experimental_pass_through/messages/utils.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/utils.py
@@ -44,6 +44,7 @@ class AnthropicMessagesRequestUtils:
         filtered_params = {k: v for k, v in params.items() if k in valid_keys and v is not None}
         if model is not None:
             from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+            from litellm.llms.anthropic.common_utils import AnthropicModelInfo
 
             AnthropicConfig._maybe_drop_speed_param(
                 model=model,
@@ -51,6 +52,22 @@ class AnthropicMessagesRequestUtils:
                 drop_params=drop_params,
                 custom_llm_provider=custom_llm_provider,
             )
+            # Claude 4.7+ removed sampling params (the API 400s on top_p, top_k,
+            # and any temperature other than 1). Mirror the /chat/completions
+            # gating — drop under drop_params, else raise a clean client-side
+            # 400 — instead of forwarding a known-rejected param upstream, where
+            # router fallbacks would mask the provider 400 as a silent model
+            # downgrade.
+            for param in ("temperature", "top_p", "top_k"):
+                if param in filtered_params:
+                    AnthropicModelInfo._apply_sampling_param(
+                        optional_params=filtered_params,
+                        model=model,
+                        param=param,
+                        value=filtered_params.pop(param),
+                        drop_params=drop_params,
+                        output_key=param,
+                    )
         return cast(AnthropicMessagesRequestOptionalParams, filtered_params)
 
 

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_request_optional_param_utils.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_request_optional_param_utils.py
@@ -88,3 +88,89 @@ def test_drop_params_keeps_speed_for_supporting_model():
         litellm.drop_params = original
 
     assert result == {"speed": "fast"}
+
+
+def test_drop_params_strips_sampling_params_for_unsupported_model():
+    # claude-opus-4-7 removed sampling params (supports_sampling_params: false
+    # in the model map) — with drop_params they must be stripped instead of
+    # forwarded raw (the API 400s on them).
+    original = litellm.drop_params
+    litellm.drop_params = True
+    try:
+        result = (
+            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+                params={"temperature": 0.3, "top_p": 0.9, "top_k": 40, "stream": True},
+                model="claude-opus-4-7",
+            )
+        )
+    finally:
+        litellm.drop_params = original
+
+    assert result == {"stream": True}
+
+
+def test_drop_params_strips_sampling_params_for_provider_prefixed_model():
+    # Vertex-routed ids must resolve the same capability flag.
+    original = litellm.drop_params
+    litellm.drop_params = True
+    try:
+        result = (
+            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+                params={"temperature": 0.3, "top_p": 0.9, "top_k": 40},
+                model="vertex_ai/claude-opus-4-7",
+            )
+        )
+    finally:
+        litellm.drop_params = original
+
+    assert result == {}
+
+
+def test_sampling_params_kept_for_supporting_model():
+    original = litellm.drop_params
+    litellm.drop_params = True
+    try:
+        result = (
+            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+                params={"temperature": 0.3, "top_p": 0.9, "top_k": 40},
+                model="claude-sonnet-4-6",
+            )
+        )
+    finally:
+        litellm.drop_params = original
+
+    assert result == {"temperature": 0.3, "top_p": 0.9, "top_k": 40}
+
+
+def test_temperature_1_kept_for_unsupported_model():
+    # temperature=1 stays the one allowed value on models that removed
+    # sampling params.
+    original = litellm.drop_params
+    litellm.drop_params = True
+    try:
+        result = (
+            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+                params={"temperature": 1},
+                model="claude-opus-4-7",
+            )
+        )
+    finally:
+        litellm.drop_params = original
+
+    assert result == {"temperature": 1}
+
+
+def test_sampling_param_raises_clean_400_without_drop_params():
+    import pytest
+
+    original = litellm.drop_params
+    litellm.drop_params = False
+    try:
+        with pytest.raises(litellm.utils.UnsupportedParamsError):
+            AnthropicMessagesRequestUtils.get_requested_anthropic_messages_optional_param(
+                params={"temperature": 0.3},
+                model="claude-opus-4-7",
+                drop_params=False,
+            )
+    finally:
+        litellm.drop_params = original


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/messages` forwards `temperature`/`top_p`/`top_k` raw to models that removed them
- Provider 400s; router fallbacks mask them as silent model downgrades
- `/chat/completions` already drops the same params for the same models

How it solves it:

- Reuse the chat path's `AnthropicModelInfo._apply_sampling_param` gating in the `/v1/messages` param builder
- Drop under `drop_params` (matching `/chat/completions`), else clean client-side 400
- No-op for models that still support sampling params (`temperature=1` stays allowed everywhere)

## Relevant issues

Fixes #35053

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

## Screenshots / Proof of Fix

Real Vertex AI call (project-billed, no mocks), identical script before/after this change — `litellm.anthropic_interface.acreate` with `model="vertex_ai/claude-sonnet-5"`, `temperature=0.3, top_p=0.9, top_k=40`, `litellm.drop_params = True`:

**Before (base branch)** — provider rejects the forwarded param:

```
litellm.llms.base_llm.chat.transformation.BaseLLMException: {"type":"error","error":
{"type":"invalid_request_error","message":"`temperature` is deprecated for this model."},
"request_id":"req_vrtx_011CdVrHWmLgPLyK75cwfNSC"}
```

**After (this branch)** — params dropped, request succeeds:

```
model: claude-sonnet-5 | stop_reason: end_turn
content: [{'type': 'text', 'text': 'Ok'}]
```

The same asymmetry was reproduced through a full proxy deployment (litellm 1.94.0 on the stock docker image) in #35053, including the silent-downgrade behavior when `router_settings.fallbacks` are configured — full 16-param × 2-endpoint × 2-generation sweep table there.

Unit tests: `tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_request_optional_param_utils.py` — drop for `supports_sampling_params: false` models (bare and `vertex_ai/`-prefixed ids), keep for supporting models, `temperature=1` allowed, clean `UnsupportedParamsError` without `drop_params`. `tests/test_litellm/llms/anthropic/` locally: 1184 passed vs 1179 on base, same 41 pre-existing env-dependent failures in both runs.
