### PR TITLE
fix(otel): make OTLP export work against Grafana Cloud

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -27,6 +27,7 @@ from litellm.integrations.opentelemetry_utils.gen_ai_semconv import (
     OTELSemconvCategory,
     parse_semconv_opt_in,
 )
+from litellm.integrations.otel.model.semconv import Metric
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.litellm_core_utils.secret_redaction import redact_string
 from litellm.secret_managers.main import get_secret_bool, str_to_bool
@@ -597,32 +598,32 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         meter = meter_provider.get_meter(__name__)
 
         self._operation_duration_histogram = meter.create_histogram(
-            name="gen_ai.client.operation.duration",  # Replace with semconv constant in otel 1.38
+            name=Metric.OPERATION_DURATION,
             description="GenAI operation duration",
             unit="s",
         )
         self._token_usage_histogram = meter.create_histogram(
-            name="gen_ai.client.token.usage",  # Replace with semconv constant in otel 1.38
+            name=Metric.TOKEN_USAGE,
             description="GenAI token usage",
             unit="{token}",
         )
         self._cost_histogram = meter.create_histogram(
-            name="gen_ai.client.token.cost",
+            name=Metric.TOKEN_COST,
             description="GenAI request cost",
             unit="USD",
         )
         self._time_to_first_token_histogram = meter.create_histogram(
-            name="gen_ai.client.response.time_to_first_token",
+            name=Metric.TIME_TO_FIRST_TOKEN,
             description="Time to first token for streaming requests",
             unit="s",
         )
         self._time_per_output_token_histogram = meter.create_histogram(
-            name="gen_ai.client.response.time_per_output_token",
+            name=Metric.TIME_PER_OUTPUT_TOKEN,
             description="Average time per output token (generation time / completion tokens)",
             unit="s",
         )
         self._response_duration_histogram = meter.create_histogram(
-            name="gen_ai.client.response.duration",
+            name=Metric.RESPONSE_DURATION,
             description="Total LLM API generation time (excludes LiteLLM overhead)",
             unit="s",
         )
@@ -2980,10 +2981,12 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
     def _get_metric_reader(self):
         """
         Get the appropriate metric reader based on the configuration.
+
+        Histograms keep the SDK's default cumulative temporality: Prometheus-backed
+        OTLP receivers reject delta histograms and drop the whole batch, while
+        backends that prefer delta still accept cumulative.
         """
-        from opentelemetry.sdk.metrics import Histogram
         from opentelemetry.sdk.metrics.export import (
-            AggregationTemporality,
             ConsoleMetricExporter,
             PeriodicExportingMetricReader,
         )
@@ -3014,7 +3017,6 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             exporter = OTLPMetricExporter(
                 endpoint=normalized_endpoint,
                 headers=_split_otel_headers,
-                preferred_temporality={Histogram: AggregationTemporality.DELTA},
             )
             return PeriodicExportingMetricReader(exporter, export_interval_millis=5000)
 
@@ -3032,7 +3034,6 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             exporter = OTLPMetricExporter(
                 endpoint=normalized_endpoint,
                 headers=_split_otel_headers,
-                preferred_temporality={Histogram: AggregationTemporality.DELTA},
             )
             return PeriodicExportingMetricReader(exporter, export_interval_millis=5000)
 

--- a/litellm/integrations/otel/model/semconv.py
+++ b/litellm/integrations/otel/model/semconv.py
@@ -257,13 +257,27 @@ class LiteLLM:
 
 
 class Metric:
-    """GenAI metric instrument names."""
+    """GenAI metric instrument names.
+
+    Every name here that a convention or a backend defines uses that name, so a
+    consumer charting GenAI telemetry finds litellm's series where it looks for
+    them. ``TOKEN_USAGE``, ``OPERATION_DURATION``, ``TIME_TO_FIRST_TOKEN`` and
+    ``TIME_PER_OUTPUT_TOKEN`` are semconv instruments, defined in the GenAI
+    conventions; the ``gen_ai.client.response.*`` spellings litellm used for the
+    latter two are not conventions at all, so nothing downstream could chart
+    them. Cost has no semconv instrument, so it takes ``gen_ai.usage.cost``, the
+    name backends already query for spend.
+
+    ``RESPONSE_DURATION`` keeps its vendor spelling deliberately: the closest
+    convention, ``gen_ai.server.request.duration``, would collide in meaning with
+    ``OPERATION_DURATION``, which litellm already emits for the whole operation.
+    """
 
     TOKEN_USAGE: Final = "gen_ai.client.token.usage"
     OPERATION_DURATION: Final = "gen_ai.client.operation.duration"
-    TOKEN_COST: Final = "gen_ai.client.token.cost"
-    TIME_TO_FIRST_TOKEN: Final = "gen_ai.client.response.time_to_first_token"
-    TIME_PER_OUTPUT_TOKEN: Final = "gen_ai.client.response.time_per_output_token"
+    TOKEN_COST: Final = "gen_ai.usage.cost"
+    TIME_TO_FIRST_TOKEN: Final = "gen_ai.server.time_to_first_token"
+    TIME_PER_OUTPUT_TOKEN: Final = "gen_ai.server.time_per_output_token"
     RESPONSE_DURATION: Final = "gen_ai.client.response.duration"
 
 

--- a/litellm/integrations/otel/model/utils.py
+++ b/litellm/integrations/otel/model/utils.py
@@ -1,9 +1,11 @@
 """Shared, OpenTelemetry-free helpers for the otel integration.
 
-Generic value coercion (for reading heterogeneous logging-payload dicts), time
-conversion, and header parsing — pulled out of the individual modules so they
-live in one place. Deliberately free of any ``opentelemetry`` import so the
-OTel-free sources of truth (payloads, semconv, spans, config) can use it too.
+Generic value coercion (for reading heterogeneous logging-payload dicts) and
+time conversion — pulled out of the individual modules so they live in one
+place. Deliberately free of any ``opentelemetry`` import so the OTel-free
+sources of truth (payloads, semconv, spans, config) can use it too. OTLP header
+parsing lives in :mod:`litellm.integrations.otel.plumbing.providers` instead,
+because it delegates to the OTel SDK's own W3C Baggage parser.
 """
 
 from datetime import datetime
@@ -89,15 +91,3 @@ def to_seconds(value: datetime | float | int | str | None) -> float | None:
             except ValueError:
                 continue
     return None
-
-
-def parse_headers(raw: str | None) -> dict[str, str]:
-    """Parse an OTLP ``"k=v,k=v"`` header string into a dict."""
-    headers: dict[str, str] = {}
-    if not raw:
-        return headers
-    for pair in raw.split(","):
-        if "=" in pair:
-            key, _, value = pair.partition("=")
-            headers[key.strip()] = value.strip()
-    return headers

--- a/litellm/integrations/otel/plumbing/providers.py
+++ b/litellm/integrations/otel/plumbing/providers.py
@@ -29,14 +29,12 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
 from opentelemetry.trace import Span, SpanKind, Tracer
+from opentelemetry.util.re import parse_env_headers
 
 from litellm._version import version as litellm_version
 from litellm.integrations.otel.model.config import ExporterSpec, OpenTelemetryV2Config
 from litellm.integrations.otel.model.semconv import LiteLLM
 from litellm.integrations.otel.model.spans import LiteLLMSpanKind
-
-# Re-exported so ``providers.parse_headers`` remains a stable entry point.
-from litellm.integrations.otel.model.utils import parse_headers as parse_headers
 
 if TYPE_CHECKING:
     from opentelemetry.metrics import Meter
@@ -119,6 +117,23 @@ def _otlp_traces_endpoint(endpoint: str | None) -> str | None:
     return endpoint + "/v1/traces"
 
 
+def parse_headers(raw: str | None) -> dict[str, str]:
+    """Parse an OTLP ``"k=v,k=v"`` header string into a dict.
+
+    ``OTEL_EXPORTER_OTLP_HEADERS`` is W3C Baggage encoded per the OTLP spec, so
+    values are percent-decoded: a vendor that documents
+    ``Authorization=Basic%20<token>`` (Grafana Cloud does, because a bare space
+    is not representable there) has to reach the exporter as ``Basic <token>``,
+    not with a literal ``%20`` that the backend rejects as malformed. The SDK's
+    own parser is used so litellm decodes exactly what the OTLP exporters do
+    when they read the env var themselves; ``liberal`` keeps values that are not
+    percent-encoded (``Authorization=Bearer <token>``) working unchanged.
+    """
+    if not raw:
+        return {}
+    return dict(parse_env_headers(raw, liberal=True))
+
+
 def _exporter_from_spec(spec: ExporterSpec) -> SpanExporter:
     kind = (spec.kind or "console").lower()
     factory = _EXPORTER_FACTORIES.get(kind)
@@ -191,6 +206,13 @@ def build_metric_reader(config: OpenTelemetryV2Config) -> "MetricReader":
     ``console`` (and any unrecognized kind) exports to the console; ``otlp_http``
     and ``otlp_grpc`` export over OTLP with the configured endpoint/headers. The
     reader exports on a 5s period, matching v1.
+
+    Histograms keep the SDK's default cumulative temporality. Prometheus-backed
+    OTLP receivers (Grafana Cloud / Mimir, and the Prometheus OTLP endpoint)
+    reject delta histograms outright with ``invalid temporality and type
+    combination``, which drops the whole metric batch, while backends that
+    prefer delta still accept cumulative. The enterprise billing exporter
+    already relies on the same default.
     """
     from opentelemetry.sdk.metrics.export import (
         ConsoleMetricExporter,
@@ -202,18 +224,12 @@ def build_metric_reader(config: OpenTelemetryV2Config) -> "MetricReader":
         from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
             OTLPMetricExporter as HTTPMetricExporter,
         )
-        from opentelemetry.sdk.metrics import Histogram
-        from opentelemetry.sdk.metrics.export import AggregationTemporality
 
         exporter: Any = HTTPMetricExporter(
             endpoint=_otlp_metrics_endpoint(config.endpoint),
             headers=parse_headers(config.headers),
-            preferred_temporality={Histogram: AggregationTemporality.DELTA},
         )
     elif kind in ("otlp_grpc", "grpc"):
-        from opentelemetry.sdk.metrics import Histogram
-        from opentelemetry.sdk.metrics.export import AggregationTemporality
-
         try:
             from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
                 OTLPMetricExporter as GRPCMetricExporter,
@@ -227,7 +243,6 @@ def build_metric_reader(config: OpenTelemetryV2Config) -> "MetricReader":
         exporter = GRPCMetricExporter(
             endpoint=config.endpoint,
             headers=parse_headers(config.headers),
-            preferred_temporality={Histogram: AggregationTemporality.DELTA},
         )
     else:
         exporter = ConsoleMetricExporter()

--- a/tests/test_litellm/integrations/otel/test_otel_v2_components.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_components.py
@@ -451,6 +451,30 @@ def test_parse_headers():
     assert providers.parse_headers("no-equals") == {}
 
 
+def test_parse_headers_percent_decodes_values():
+    """A percent-encoded OTLP header value reaches the exporter decoded.
+
+    ``OTEL_EXPORTER_OTLP_HEADERS`` is W3C Baggage encoded, and Grafana Cloud
+    documents ``Authorization=Basic%20<token>``. Forwarding the literal ``%20``
+    makes the backend reject the export as a malformed credential.
+    """
+    token = "MTMzNzc4MzpnbGNfZXlKdklqb2lNVEl6TkNJPQ=="
+    assert providers.parse_headers(f"Authorization=Basic%20{token}") == {"authorization": f"Basic {token}"}
+    assert providers.parse_headers("x-scope-orgid=team%20a") == {"x-scope-orgid": "team a"}
+
+
+def test_parse_headers_keeps_unencoded_values_working():
+    """Values that are not percent-encoded keep parsing unchanged.
+
+    Vendors that document a bare space, and litellm's own presets, must survive
+    the switch to the spec-compliant parser. Base64 padding also means a value
+    can contain ``=``, so only the first one may split the pair.
+    """
+    assert providers.parse_headers("Authorization=Bearer sk-123") == {"authorization": "Bearer sk-123"}
+    assert providers.parse_headers("api_key=abc,space_id=xyz") == {"api_key": "abc", "space_id": "xyz"}
+    assert providers.parse_headers("api_key=YWJjZA==") == {"api_key": "YWJjZA=="}
+
+
 def test_otlp_traces_endpoint_normalization():
     norm = providers._otlp_traces_endpoint
     # A base endpoint gets the signal path appended (the common OTLP env shape).
@@ -485,6 +509,24 @@ def test_build_span_exporter_variants():
         OpenTelemetryV2Config(exporter="otlp_http", endpoint="http://h:4318")
     )
     assert "OTLPSpanExporter" in type(http_exporter).__name__
+
+
+def test_otlp_metric_exporter_uses_cumulative_histogram_temporality():
+    """Histograms must export as cumulative, not delta.
+
+    Prometheus-backed OTLP receivers (Grafana Cloud / Mimir) reject delta
+    histograms with ``invalid temporality and type combination`` and drop the
+    entire metric batch, so a delta default silently loses every GenAI metric.
+    """
+    from opentelemetry.sdk.metrics import Histogram
+    from opentelemetry.sdk.metrics.export import AggregationTemporality
+
+    reader = providers.build_metric_reader(
+        OpenTelemetryV2Config(exporter="otlp_http", endpoint="http://h:4318")
+    )
+    temporality = reader._exporter._preferred_temporality  # noqa: SLF001  # exporter exposes no public accessor
+
+    assert temporality[Histogram] is AggregationTemporality.CUMULATIVE
 
 
 def test_otlp_logs_endpoint_normalization():

--- a/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_logger.py
@@ -2120,9 +2120,9 @@ def test_valid_metric_filter_records_six_metrics(monkeypatch):
     assert _emitted_metric_names(reader) == {
         "gen_ai.client.operation.duration",
         "gen_ai.client.token.usage",
-        "gen_ai.client.token.cost",
-        "gen_ai.client.response.time_to_first_token",
-        "gen_ai.client.response.time_per_output_token",
+        "gen_ai.usage.cost",
+        "gen_ai.server.time_to_first_token",
+        "gen_ai.server.time_per_output_token",
         "gen_ai.client.response.duration",
     }
 

--- a/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
@@ -39,9 +39,9 @@ from litellm.integrations.otel.plumbing.providers import (  # noqa: E402
 
 OPERATION_DURATION = "gen_ai.client.operation.duration"
 TOKEN_USAGE = "gen_ai.client.token.usage"
-TOKEN_COST = "gen_ai.client.token.cost"
-TIME_TO_FIRST_TOKEN = "gen_ai.client.response.time_to_first_token"
-TIME_PER_OUTPUT_TOKEN = "gen_ai.client.response.time_per_output_token"
+TOKEN_COST = "gen_ai.usage.cost"
+TIME_TO_FIRST_TOKEN = "gen_ai.server.time_to_first_token"
+TIME_PER_OUTPUT_TOKEN = "gen_ai.server.time_per_output_token"
 RESPONSE_DURATION = "gen_ai.client.response.duration"
 
 ALL_METRICS = frozenset(

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -415,6 +415,40 @@ class TestOpenTelemetryProviderInitialization(unittest.TestCase):
     @patch.dict(
         os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_METRICS": "true"}, clear=True
     )
+    def test_init_metrics_creates_instruments_under_their_published_names(self):
+        """
+        The v1 engine's instrument names are a public contract.
+
+        Every name here is what a backend queries: four are GenAI semantic
+        conventions and gen_ai.usage.cost is the name backends query for spend.
+        A rename is breaking for anyone charting them, so it has to be a
+        deliberate edit to the shared Metric constants and to this list, never
+        a silent drift between the v1 and v2 engines.
+        """
+        from opentelemetry import metrics
+
+        metrics.set_meter_provider(MeterProvider(metric_readers=[InMemoryMetricReader()]))
+        otel_integration = OpenTelemetry(config=OpenTelemetryConfig.from_env())
+
+        assert {
+            otel_integration._operation_duration_histogram.name,
+            otel_integration._token_usage_histogram.name,
+            otel_integration._cost_histogram.name,
+            otel_integration._time_to_first_token_histogram.name,
+            otel_integration._time_per_output_token_histogram.name,
+            otel_integration._response_duration_histogram.name,
+        } == {
+            "gen_ai.client.operation.duration",
+            "gen_ai.client.token.usage",
+            "gen_ai.usage.cost",
+            "gen_ai.server.time_to_first_token",
+            "gen_ai.server.time_per_output_token",
+            "gen_ai.client.response.duration",
+        }
+
+    @patch.dict(
+        os.environ, {"LITELLM_OTEL_INTEGRATION_ENABLE_METRICS": "true"}, clear=True
+    )
     def test_init_metrics_respects_existing_meter_provider(self):
         """
         Unit test: _init_metrics() should respect existing MeterProvider.


### PR DESCRIPTION
## TLDR

Problem this solves:

- Percent-encoded OTLP auth headers reached backends undecoded, causing 401
- Delta histograms are rejected by Prometheus-backed OTLP receivers
- Three GenAI metrics used names no convention or backend defines

How it solves it:

- Parse OTLP headers with the OTel SDK's own W3C Baggage parser
- Drop the delta override so histograms export as cumulative
- Give cost, TTFT and TPOT the names their consumers query

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

All proof captured against a real Grafana Cloud stack with a live proxy making real gpt-5.6 calls.

**1. Header decoding.** `OTEL_EXPORTER_OTLP_HEADERS` is W3C Baggage encoded, so vendors document `Authorization=Basic%20<token>`. The literal `%20` was forwarded to the backend. Against Grafana Cloud's OTLP gateway, before versus after:

```
$ curl -o /dev/null -w "%{http_code}\n" -X POST https://otlp-gateway-prod-us-west-0.grafana.net/otlp/v1/traces \
    -H "Authorization: Basic%20<b64>"    # what litellm sent before
401

$ curl -o /dev/null -w "%{http_code}\n" -X POST https://otlp-gateway-prod-us-west-0.grafana.net/otlp/v1/traces \
    -H "Authorization: Basic <b64>"      # what litellm sends now
200
```

Confirmed through the proxy itself with a recording OTLP receiver, one run per commit, identical config:

```
before   /otlp/v1/traces   Authorization: Basic%20MTMzNzc4MzpnbGNfZmFrZXRva2Vu
         /otlp/v1/metrics  Authorization: Basic%20MTMzNzc4MzpnbGNfZmFrZXRva2Vu
after    /otlp/v1/traces   Authorization: Basic MTMzNzc4MzpnbGNfZmFrZXRva2Vu
         /otlp/v1/metrics  Authorization: Basic MTMzNzc4MzpnbGNfZmFrZXRva2Vu
```

**2. Histogram temporality.** With auth fixed, metrics still never arrived. Grafana rejected every batch:

```
Failed to export batch code: 400, reason: otlp parse error:
  invalid temporality and type combination for metric "gen_ai.usage.cost"
  invalid temporality and type combination for metric "gen_ai.client.token.usage"
  invalid temporality and type combination for metric "gen_ai.server.time_to_first_token"
  ... all six gen_ai instruments plus the three http.server.* ones
```

After, same 9 calls, `grep -c "Failed to export"` returns 0 and the data is queryable in Grafana:

```
gen_ai_usage_cost_USD_sum                        0.00243     (real spend)
gen_ai_client_token_usage_sum                    166         (tokens)
gen_ai_client_operation_duration_seconds_count   9           (matches 9 calls)
gen_ai_server_time_to_first_token_seconds_count  3           (matches 3 streaming calls)
```

Traces were unaffected throughout; they have no temporality and landed in Tempo in both runs.

**3. Metric names and temporality, live from the proxy.** One non-streaming and one streaming real call through a live proxy with `callbacks: ["otel"]`, `LITELLM_OTEL_V2=true`, `LITELLM_OTEL_INTEGRATION_ENABLE_METRICS=true` and the console exporter:

```
$ curl -s http://127.0.0.1:4061/v1/chat/completions -H "Authorization: Bearer $KEY" \
    -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Say OK"}]}'
OK | usage: {'completion_tokens': 4, 'prompt_tokens': 8, 'total_tokens': 12}

$ curl -s http://127.0.0.1:4061/v1/chat/completions -H "Authorization: Bearer $KEY" \
    -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Count to three"}],"stream":true}'
data: [DONE]

$ grep -oE '"name": "gen_ai[^"]*"' proxy.log | sort -u
"name": "gen_ai.client.operation.duration"
"name": "gen_ai.client.response.duration"
"name": "gen_ai.client.token.usage"
"name": "gen_ai.server.time_per_output_token"     <- renamed
"name": "gen_ai.server.time_to_first_token"       <- renamed
"name": "gen_ai.usage.cost"                       <- renamed

$ grep -oE '"aggregation_temporality": [0-9]+' proxy.log | sort -u
"aggregation_temporality": 2                       (2 = CUMULATIVE, on every instrument)
```

The recorded values line up with the two calls: `gen_ai.usage.cost` summed 0.000475 USD of real spend across two data points, `gen_ai.client.token.usage` recorded 8 input / 4 output then 9 / 9, and both `gen_ai.server.time_to_first_token` (1.258 s) and `gen_ai.server.time_per_output_token` (0.0075 s) carry exactly one data point, from the streaming call.

## Type

🐛 Bug Fix

## Changes

**Header parsing.** `parse_headers` delegates to `opentelemetry.util.re.parse_env_headers` in liberal mode, so percent-encoded values decode exactly as the OTLP exporters decode them when reading the env var themselves, and values that were never encoded keep working. It moves from `model/utils.py` to `plumbing/providers.py`, since `model/` is deliberately free of `opentelemetry` imports and `providers.parse_headers` was already the entry point every caller used.

**Temporality.** The `preferred_temporality={Histogram: DELTA}` override is removed from both engines, leaving the SDK default of cumulative. Prometheus-backed receivers reject delta outright and drop the whole batch; backends that prefer delta still accept cumulative. The enterprise billing exporter already relies on this default.

**Metric names.** Three instruments carried names that no convention and no backend defines, so nothing downstream could chart them:

| before | after | defined by |
|---|---|---|
| `gen_ai.client.response.time_to_first_token` | `gen_ai.server.time_to_first_token` | [semconv](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/metrics.yaml) |
| `gen_ai.client.response.time_per_output_token` | `gen_ai.server.time_per_output_token` | [semconv](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/metrics.yaml) |
| `gen_ai.client.token.cost` | `gen_ai.usage.cost` | no semconv instrument; the name backends query for spend |

All three of the new names, and only the new names, appear verbatim in [Grafana Cloud's AI Observability integration reference](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-ai-observability/) as `gen_ai_server_time_to_first_token_seconds_bucket` and `gen_ai_usage_cost_USD_bucket` / `_count` / `_sum`, alongside `gen_ai_client_token_usage_*` and `gen_ai_client_operation_duration_seconds_*`, which litellm already matched. So the prebuilt AI Observability panels find LiteLLM's series, which is the point of the rest of this PR.

`gen_ai.client.response.duration` keeps its vendor spelling deliberately. The nearest convention, `gen_ai.server.request.duration`, would collide in meaning with `gen_ai.client.operation.duration`, which litellm already emits for the whole operation. Both engines now read every name from the shared `Metric` constants instead of repeating string literals, so v1 and v2 cannot drift.

This is a breaking change for anyone charting the three former names. The blast radius is narrow: metrics are off by default in both engines behind `LITELLM_OTEL_INTEGRATION_ENABLE_METRICS`, v2 is additionally gated behind `LITELLM_OTEL_V2`, and a panel charting the old names could only have been hand-built, since no convention or vendor dashboard ever referenced them. The migration is documented in the OTel pages (BerriAI/litellm-docs#706) and called out in the release changelog.

Tests cover percent-decoded and unencoded header values, base64 padding, cumulative temporality, and the emitted name set on both engines. Each fails if its fix is reverted.

Docs are in BerriAI/litellm-docs#706; merge that first so no page describes names this has not shipped.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
