### PR TITLE
fix(chatgpt): strip unknown Codex item fields before building ResponsesAPIResponse

### DIFF
--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -214,8 +214,7 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             for _, item in sorted(streamed_output_items.items()):
                 ci = {k: v for k, v in item.items() if k not in _EXTRA_FIELDS}
                 ci["content"] = [
-                    {k2: v2 for k2, v2 in c.items() if k2 not in _EXTRA_FIELDS}
-                    for c in ci.get("content", [])
+                    {k2: v2 for k2, v2 in c.items() if k2 not in _EXTRA_FIELDS} for c in ci.get("content", [])
                 ]
                 clean_items.append(ci)
             response_payload["output"] = clean_items

--- a/litellm/llms/chatgpt/responses/transformation.py
+++ b/litellm/llms/chatgpt/responses/transformation.py
@@ -203,7 +203,22 @@ class ChatGPTResponsesAPIConfig(OpenAIResponsesAPIConfig):
             return None
         response_payload = dict(response_payload)
         if not response_payload.get("output") and streamed_output_items:
-            response_payload["output"] = [item for _, item in sorted(streamed_output_items.items())]
+            # The Codex backend includes provider-specific fields (e.g. `phase`,
+            # `logprobs`) in output items that are not part of the Responses API
+            # schema.  Passing them verbatim to ResponsesAPIResponse causes
+            # Pydantic validation to fail, which leaves `output` empty and
+            # raises "Unknown items in responses API response: []".  Strip the
+            # extra fields before building the response object.
+            _EXTRA_FIELDS = {"phase", "logprobs"}
+            clean_items = []
+            for _, item in sorted(streamed_output_items.items()):
+                ci = {k: v for k, v in item.items() if k not in _EXTRA_FIELDS}
+                ci["content"] = [
+                    {k2: v2 for k2, v2 in c.items() if k2 not in _EXTRA_FIELDS}
+                    for c in ci.get("content", [])
+                ]
+                clean_items.append(ci)
+            response_payload["output"] = clean_items
         if "created_at" in response_payload:
             response_payload["created_at"] = _safe_convert_created_field(response_payload["created_at"])
         try:


### PR DESCRIPTION
## Problem

When using the chatgpt/ provider (ChatGPT/Codex OAuth subscription), streaming calls to Codex models fail with:

  ChatgptException - Unknown items in responses API response: []

Reproduces with: chatgpt/gpt-5.5, chatgpt/gpt-5.6-sol, chatgpt/gpt-5.6-terra, chatgpt/gpt-5.6-luna.

## Root cause

The Codex backend includes provider-specific fields in response.output_item.done SSE events that are not part of the OpenAI Responses API schema: phase on the output item (e.g. `"phase": "final_answer"`) and logprobs inside content parts. _build_completed_response_from_chunk passes these items verbatim to ResponsesAPIResponse(**response_payload); Pydantic validation fails, the code falls through to model_construct, and output ends up empty.

## Fix

Strip phase and logprobs from each streamed output item and its content parts before building ResponsesAPIResponse, so Pydantic validation succeeds and the assistant reply is recovered correctly.