### PR TITLE
fix(ui): point playground tooltip links at path-based routes

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
@@ -14,6 +14,9 @@ vi.mock("@/components/networking", () => ({
   vectorStoreListCall: vi.fn().mockResolvedValue({ data: [] }),
   getGuardrailsList: vi.fn().mockResolvedValue({ data: [] }),
   modelHubCall: vi.fn().mockResolvedValue({ data: [] }),
+  // migratedPages reads this to prefix hrefs with SERVER_ROOT_PATH; "" is the
+  // default deployment where the UI is mounted at /ui.
+  serverRootPath: "",
 }));
 
 // Mock scrollIntoView which is not available in jsdom
@@ -49,6 +52,33 @@ describe("ChatUI", () => {
       />,
     );
     expect(getByText("Test Key")).toBeInTheDocument();
+  });
+
+  // The playground lives at /ui/playground, so a relative `?page=<id>` href resolves to
+  // /ui/playground?page=<id> — a URL no route redirects, leaving the user on the playground.
+  // Only the dashboard root honours the legacy `?page=` switch, so these tooltips must point
+  // at the path-based routes.
+  it.each([
+    ["Vector Store", "/ui/vector-stores"],
+    ["Guardrails", "/ui/guardrails"],
+    ["Policies", "/ui/policies"],
+  ])("points the %s tooltip link at its path-based route", async (label, expectedHref) => {
+    render(
+      <ChatUI
+        accessToken="1234567890"
+        token="1234567890"
+        userRole="user"
+        userID="1234567890"
+        disabledPersonalKeyCreation={false}
+      />,
+    );
+
+    const infoIcon = (await screen.findByText(label)).querySelector(".anticon-info-circle");
+    expect(infoIcon).not.toBeNull();
+    fireEvent.mouseEnter(infoIcon!);
+
+    const link = await screen.findByRole("link", { name: "here" });
+    expect(link).toHaveAttribute("href", expectedHref);
   });
 
   it("should show the voice selector when the endpoint type is audio_speech", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -76,6 +76,7 @@ import RealtimePlayground from "./RealtimePlayground";
 import { A2ATaskMetadata, MessageType } from "@/components/chat_ui/types";
 import { useCodeInterpreter } from "../../hooks/useCodeInterpreter";
 import { useChatHistory } from "../../hooks/useChatHistory";
+import { MIGRATED_PAGES, migratedHref } from "@/utils/migratedPages";
 import { getSecureItem, setSecureItem } from "@/utils/secureStorage";
 import { useDebouncedCallback } from "@tanstack/react-pacer/debouncer";
 
@@ -1619,7 +1620,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                       title={
                         <span>
                           Select vector store(s) to use for this LLM API call. You can set up your vector store{" "}
-                          <a href="?page=vector-stores" style={{ color: "#1890ff" }}>
+                          <a href={migratedHref(MIGRATED_PAGES["vector-stores"])} style={{ color: "#1890ff" }}>
                             here
                           </a>
                           .
@@ -1645,7 +1646,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                       title={
                         <span>
                           Select guardrail(s) to use for this LLM API call. You can set up your guardrails{" "}
-                          <a href="?page=guardrails" style={{ color: "#1890ff" }}>
+                          <a href={migratedHref(MIGRATED_PAGES["guardrails"])} style={{ color: "#1890ff" }}>
                             here
                           </a>
                           .
@@ -1672,7 +1673,7 @@ const ChatUI: React.FC<ChatUIProps> = ({
                         <span>
                           Select policy/policies to apply to this LLM API call. Policies define which guardrails are
                           applied based on conditions. You can set up your policies{" "}
-                          <a href="?page=policies" style={{ color: "#1890ff" }}>
+                          <a href={migratedHref(MIGRATED_PAGES["policies"])} style={{ color: "#1890ff" }}>
                             here
                           </a>
                           .


### PR DESCRIPTION
## Title

fix(ui): point playground tooltip links at path-based routes

## Relevant issues

None filed — found while using the playground on a self-hosted proxy (v1.93.0).

## Pre-Submission checklist

- [x] I have Added testing in the tests/litellm/ directory — n/a, this is a UI-only change; tests added next to the component in `ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx`
- [ ] I have added a screenshot of my new test passing locally — pasted the runner output under **Testing** instead
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible

## Type

🐛 Bug Fix

## Changes

The **Vector Store**, **Guardrails** and **Policies** tooltips in the playground each link to a relative `?page=<id>` href:

```tsx
<a href="?page=guardrails" style={{ color: "#1890ff" }}>here</a>
```

The playground is served at `/ui/playground`, so a relative query-only href resolves to `/ui/playground?page=guardrails`. Only the dashboard root (`app/(dashboard)/page.tsx`) honours the legacy `?page=` switch and redirects it to the migrated path-based route — that effect never runs on `/ui/playground`. Clicking **here** therefore just reloads the playground and the user never reaches the page the tooltip points at.

All three target pages are already migrated (`MIGRATED_PAGES` maps `guardrails`, `policies` and `vector-stores`), so this builds the hrefs with the existing `migratedHref()` helper. That resolves them to `/ui/guardrails`, `/ui/policies` and `/ui/vector-stores`, and keeps them correct under a non-default `SERVER_ROOT_PATH` — which the hard-coded relative href never handled either.

`migratedPages` reads `serverRootPath` from `@/components/networking`, which `ChatUI.test.tsx` mocks with a partial object, so that export is added to the mock.

Added three regression tests that hover each tooltip and assert the resulting `href`. Verified they fail against the previous `?page=` hrefs and pass with this change.

## Testing

```
npx vitest run "src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx" -t "tooltip link"

 ✓ ChatUI > points the Vector Store tooltip link at its path-based route
 ✓ ChatUI > points the Guardrails tooltip link at its path-based route
 ✓ ChatUI > points the Policies tooltip link at its path-based route

npx vitest run "src/app/(dashboard)" "src/utils"
  Test Files  256 passed (256)
       Tests  2650 passed (2650)

npm run build   # succeeds; /guardrails, /policies, /vector-stores prerender as before
npx eslint <changed files>   # 0 errors
```
