### PR TITLE
feat(gemini): add include_thoughts to suppress returned thought text

### DIFF
--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -859,9 +859,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         model: Optional[str] = None,
         include_thoughts: Optional[bool] = None,
     ) -> GeminiThinkingConfig:
-        include = VertexGeminiConfig._resolve_include_thoughts(
-            reasoning_effort, include_thoughts
-        )
+        include = VertexGeminiConfig._resolve_include_thoughts(reasoning_effort, include_thoughts)
         if reasoning_effort == "minimal":
             # Use model-specific minimum thinking budget or fallback
             # Check for exact matches first, then partial matches
@@ -923,9 +921,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         Returns:
             GeminiThinkingConfig with thinkingLevel and includeThoughts
         """
-        include = VertexGeminiConfig._resolve_include_thoughts(
-            reasoning_effort, include_thoughts
-        )
+        include = VertexGeminiConfig._resolve_include_thoughts(reasoning_effort, include_thoughts)
         # Check if this is gemini-3-flash which supports MINIMAL thinking level
         # Covers gemini-3-flash, gemini-3-flash-preview, gemini-3.1-flash, gemini-3.1-flash-lite-preview,
         # gemini-3.5-flash, and any future 3.x-flash variants.
@@ -959,6 +955,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 return {"thinkingLevel": "low", "includeThoughts": False}
         else:
             raise ValueError(f"Invalid reasoning effort: {reasoning_effort}")
+
     @staticmethod
     def _is_thinking_budget_zero(thinking_budget: Optional[int]) -> bool:
         return thinking_budget is not None and thinking_budget == 0
@@ -1142,9 +1139,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         gemini_sampling_params_warned: bool = False
         thoughts_locked_off: bool = False
         include_thoughts_value = non_default_params.get("include_thoughts")
-        if include_thoughts_value is not None and not isinstance(
-            include_thoughts_value, bool
-        ):
+        if include_thoughts_value is not None and not isinstance(include_thoughts_value, bool):
             raise ValueError("include_thoughts must be a boolean when provided")
         for param, value in non_default_params.items():
             if param == "temperature":
@@ -1292,12 +1287,10 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         if include_thoughts_value is not None:
             thinking_config = optional_params.get("thinkingConfig")
             if isinstance(thinking_config, dict):
-                optional_params["thinkingConfig"] = (
-                    VertexGeminiConfig._apply_include_thoughts_override(
-                        thinking_config,
-                        include_thoughts_value,
-                        thoughts_locked_off=thoughts_locked_off,
-                    )
+                optional_params["thinkingConfig"] = VertexGeminiConfig._apply_include_thoughts_override(
+                    thinking_config,
+                    include_thoughts_value,
+                    thoughts_locked_off=thoughts_locked_off,
                 )
 
         if litellm.vertex_ai_safety_settings is not None:
@@ -1319,6 +1312,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         self._drop_search_tools_mixed_with_functions(optional_params)
 
         return optional_params
+
     def get_mapped_special_auth_params(self) -> dict:
         """
         Common auth params across bedrock/vertex_ai/azure/watsonx

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -342,6 +342,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         if supports_reasoning(model):
             supported_params.append("reasoning_effort")
             supported_params.append("thinking")
+            supported_params.append("include_thoughts")
         return supported_params
 
     def map_tool_choice_values(self, model: str, tool_choice: Union[str, dict]) -> Optional[ToolConfig]:
@@ -816,10 +817,32 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 optional_params["response_schema"] = self._map_response_schema(value=schema)
 
     @staticmethod
+    def _resolve_include_thoughts(
+        reasoning_effort: str,
+        include_thoughts: Optional[bool],
+    ) -> bool:
+        """Resolve Gemini ``includeThoughts`` for a reasoning_effort value.
+
+        ``none`` / ``disable`` always suppress returned thought text.
+        For active effort levels, ``include_thoughts`` defaults to ``True``
+        (legacy behavior) and can be set to ``False`` to keep internal
+        reasoning without returning thought summaries to the client.
+        """
+        if reasoning_effort in ("none", "disable"):
+            return False
+        if include_thoughts is None:
+            return True
+        return bool(include_thoughts)
+
+    @staticmethod
     def _map_reasoning_effort_to_thinking_budget(
         reasoning_effort: str,
         model: Optional[str] = None,
+        include_thoughts: Optional[bool] = None,
     ) -> GeminiThinkingConfig:
+        include = VertexGeminiConfig._resolve_include_thoughts(
+            reasoning_effort, include_thoughts
+        )
         if reasoning_effort == "minimal":
             # Use model-specific minimum thinking budget or fallback
             # Check for exact matches first, then partial matches
@@ -834,22 +857,22 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
             return {
                 "thinkingBudget": budget,
-                "includeThoughts": True,
+                "includeThoughts": include,
             }
         elif reasoning_effort == "low":
             return {
                 "thinkingBudget": DEFAULT_REASONING_EFFORT_LOW_THINKING_BUDGET,
-                "includeThoughts": True,
+                "includeThoughts": include,
             }
         elif reasoning_effort == "medium":
             return {
                 "thinkingBudget": DEFAULT_REASONING_EFFORT_MEDIUM_THINKING_BUDGET,
-                "includeThoughts": True,
+                "includeThoughts": include,
             }
         elif reasoning_effort == "high":
             return {
                 "thinkingBudget": DEFAULT_REASONING_EFFORT_HIGH_THINKING_BUDGET,
-                "includeThoughts": True,
+                "includeThoughts": include,
             }
         elif reasoning_effort == "disable":
             return {
@@ -868,16 +891,22 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     def _map_reasoning_effort_to_thinking_level(
         reasoning_effort: str,
         model: Optional[str] = None,
+        include_thoughts: Optional[bool] = None,
     ) -> GeminiThinkingConfig:
         """
         Map reasoning_effort to thinking_level for Gemini 3+ models.
         Args:
             reasoning_effort: The reasoning effort value
             model: The model name
+            include_thoughts: Optional override for Gemini includeThoughts.
+                Defaults to True for active efforts; ignored for none/disable.
 
         Returns:
             GeminiThinkingConfig with thinkingLevel and includeThoughts
         """
+        include = VertexGeminiConfig._resolve_include_thoughts(
+            reasoning_effort, include_thoughts
+        )
         # Check if this is gemini-3-flash which supports MINIMAL thinking level
         # Covers gemini-3-flash, gemini-3-flash-preview, gemini-3.1-flash, gemini-3.1-flash-lite-preview,
         # gemini-3.5-flash, and any future 3.x-flash variants.
@@ -885,18 +914,18 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         is_gemini31pro = model and ("gemini-3.1-pro-preview" in model.lower())
         if reasoning_effort == "minimal":
             if is_gemini3flash:
-                return {"thinkingLevel": "minimal", "includeThoughts": True}
+                return {"thinkingLevel": "minimal", "includeThoughts": include}
             else:
-                return {"thinkingLevel": "low", "includeThoughts": True}
+                return {"thinkingLevel": "low", "includeThoughts": include}
         elif reasoning_effort == "low":
-            return {"thinkingLevel": "low", "includeThoughts": True}
+            return {"thinkingLevel": "low", "includeThoughts": include}
         elif reasoning_effort == "medium":
             if is_gemini31pro or is_gemini3flash:
-                return {"thinkingLevel": "medium", "includeThoughts": True}
+                return {"thinkingLevel": "medium", "includeThoughts": include}
             else:
-                return {"thinkingLevel": "high", "includeThoughts": True}
+                return {"thinkingLevel": "high", "includeThoughts": include}
         elif reasoning_effort == "high":
-            return {"thinkingLevel": "high", "includeThoughts": True}
+            return {"thinkingLevel": "high", "includeThoughts": include}
         elif reasoning_effort == "disable":
             # Gemini 3 cannot fully disable thinking, so we use "minimal" for gemini-3-flash-preview, "low" for others
             if is_gemini3flash:
@@ -911,7 +940,6 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 return {"thinkingLevel": "low", "includeThoughts": False}
         else:
             raise ValueError(f"Invalid reasoning effort: {reasoning_effort}")
-
     @staticmethod
     def _is_thinking_budget_zero(thinking_budget: Optional[int]) -> bool:
         return thinking_budget is not None and thinking_budget == 0
@@ -1195,14 +1223,28 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                         param_name="reasoning_effort",
                         param_description="thinking_budget",
                     )
+                    include_thoughts_value = non_default_params.get("include_thoughts")
+                    if include_thoughts_value is not None and not isinstance(
+                        include_thoughts_value, bool
+                    ):
+                        raise ValueError(
+                            "include_thoughts must be a boolean when provided"
+                        )
                     if VertexGeminiConfig._is_gemini_3_or_newer(model):
                         optional_params["thinkingConfig"] = VertexGeminiConfig._map_reasoning_effort_to_thinking_level(
-                            effort_value, model
+                            effort_value,
+                            model,
+                            include_thoughts=include_thoughts_value,
                         )
                     else:
                         optional_params["thinkingConfig"] = VertexGeminiConfig._map_reasoning_effort_to_thinking_budget(
-                            effort_value, model
+                            effort_value,
+                            model,
+                            include_thoughts=include_thoughts_value,
                         )
+            elif param == "include_thoughts":
+                # Consumed alongside reasoning_effort above; ignore when alone / after map.
+                continue
             elif param == "thinking":
                 # Validate no conflict with thinking_level
                 VertexGeminiConfig._validate_thinking_config_conflicts(

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -835,6 +835,25 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         return bool(include_thoughts)
 
     @staticmethod
+    def _apply_include_thoughts_override(
+        thinking_config: Dict,
+        include_thoughts: bool,
+        *,
+        thoughts_locked_off: bool = False,
+    ) -> Dict:
+        """Apply ``include_thoughts`` onto an existing Gemini thinkingConfig.
+
+        ``none`` / ``disable`` mappings lock thoughts off and cannot be forced
+        back on. Otherwise ``include_thoughts`` overrides ``includeThoughts``.
+        """
+        patched = dict(thinking_config)
+        if thoughts_locked_off:
+            patched["includeThoughts"] = False
+        else:
+            patched["includeThoughts"] = bool(include_thoughts)
+        return patched
+
+    @staticmethod
     def _map_reasoning_effort_to_thinking_budget(
         reasoning_effort: str,
         model: Optional[str] = None,
@@ -1121,6 +1140,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     ) -> Dict:
         self._apply_include_server_side_tool_invocations(non_default_params, optional_params)
         gemini_sampling_params_warned: bool = False
+        thoughts_locked_off: bool = False
         for param, value in non_default_params.items():
             if param == "temperature":
                 if VertexGeminiConfig._is_gemini_3_or_newer(model):
@@ -1230,6 +1250,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                         raise ValueError(
                             "include_thoughts must be a boolean when provided"
                         )
+                    if effort_value in ("none", "disable"):
+                        thoughts_locked_off = True
                     if VertexGeminiConfig._is_gemini_3_or_newer(model):
                         optional_params["thinkingConfig"] = VertexGeminiConfig._map_reasoning_effort_to_thinking_level(
                             effort_value,
@@ -1243,8 +1265,10 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                             include_thoughts=include_thoughts_value,
                         )
             elif param == "include_thoughts":
-                # Consumed alongside reasoning_effort above; ignore when alone / after map.
-                continue
+                # Applied after the loop onto whatever thinkingConfig was built
+                # (reasoning_effort and/or Anthropic-style thinking). Validate early.
+                if value is not None and not isinstance(value, bool):
+                    raise ValueError("include_thoughts must be a boolean when provided")
             elif param == "thinking":
                 # Validate no conflict with thinking_level
                 VertexGeminiConfig._validate_thinking_config_conflicts(
@@ -1266,6 +1290,23 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 self._map_service_tier_param(value, optional_params)
             elif param == "include_server_side_tool_invocations" and value is True:
                 optional_params["include_server_side_tool_invocations"] = True
+
+        # Apply include_thoughts onto reasoning_effort and/or thinking configs so
+        # standalone/out-of-order use (e.g. thinking + include_thoughts=False) works.
+        include_thoughts_value = non_default_params.get("include_thoughts")
+        if include_thoughts_value is not None:
+            if not isinstance(include_thoughts_value, bool):
+                raise ValueError("include_thoughts must be a boolean when provided")
+            thinking_config = optional_params.get("thinkingConfig")
+            if isinstance(thinking_config, dict):
+                optional_params["thinkingConfig"] = (
+                    VertexGeminiConfig._apply_include_thoughts_override(
+                        thinking_config,
+                        include_thoughts_value,
+                        thoughts_locked_off=thoughts_locked_off,
+                    )
+                )
+
         if litellm.vertex_ai_safety_settings is not None:
             optional_params["safety_settings"] = litellm.vertex_ai_safety_settings
 
@@ -1285,7 +1326,6 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         self._drop_search_tools_mixed_with_functions(optional_params)
 
         return optional_params
-
     def get_mapped_special_auth_params(self) -> dict:
         """
         Common auth params across bedrock/vertex_ai/azure/watsonx

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -819,7 +819,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     @staticmethod
     def _resolve_include_thoughts(
         reasoning_effort: str,
-        include_thoughts: Optional[bool],
+        include_thoughts: bool | None,
     ) -> bool:
         """Resolve Gemini ``includeThoughts`` for a reasoning_effort value.
 
@@ -836,11 +836,11 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
     @staticmethod
     def _apply_include_thoughts_override(
-        thinking_config: Dict,
+        thinking_config: dict,
         include_thoughts: bool,
         *,
         thoughts_locked_off: bool = False,
-    ) -> Dict:
+    ) -> dict:
         """Apply ``include_thoughts`` onto an existing Gemini thinkingConfig.
 
         ``none`` / ``disable`` mappings lock thoughts off and cannot be forced
@@ -857,7 +857,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     def _map_reasoning_effort_to_thinking_budget(
         reasoning_effort: str,
         model: Optional[str] = None,
-        include_thoughts: Optional[bool] = None,
+        include_thoughts: bool | None = None,
     ) -> GeminiThinkingConfig:
         include = VertexGeminiConfig._resolve_include_thoughts(reasoning_effort, include_thoughts)
         if reasoning_effort == "minimal":
@@ -908,7 +908,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
     def _map_reasoning_effort_to_thinking_level(
         reasoning_effort: str,
         model: Optional[str] = None,
-        include_thoughts: Optional[bool] = None,
+        include_thoughts: bool | None = None,
     ) -> GeminiThinkingConfig:
         """
         Map reasoning_effort to thinking_level for Gemini 3+ models.

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -1141,6 +1141,11 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         self._apply_include_server_side_tool_invocations(non_default_params, optional_params)
         gemini_sampling_params_warned: bool = False
         thoughts_locked_off: bool = False
+        include_thoughts_value = non_default_params.get("include_thoughts")
+        if include_thoughts_value is not None and not isinstance(
+            include_thoughts_value, bool
+        ):
+            raise ValueError("include_thoughts must be a boolean when provided")
         for param, value in non_default_params.items():
             if param == "temperature":
                 if VertexGeminiConfig._is_gemini_3_or_newer(model):
@@ -1243,13 +1248,6 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                         param_name="reasoning_effort",
                         param_description="thinking_budget",
                     )
-                    include_thoughts_value = non_default_params.get("include_thoughts")
-                    if include_thoughts_value is not None and not isinstance(
-                        include_thoughts_value, bool
-                    ):
-                        raise ValueError(
-                            "include_thoughts must be a boolean when provided"
-                        )
                     if effort_value in ("none", "disable"):
                         thoughts_locked_off = True
                     if VertexGeminiConfig._is_gemini_3_or_newer(model):
@@ -1265,10 +1263,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                             include_thoughts=include_thoughts_value,
                         )
             elif param == "include_thoughts":
-                # Applied after the loop onto whatever thinkingConfig was built
-                # (reasoning_effort and/or Anthropic-style thinking). Validate early.
-                if value is not None and not isinstance(value, bool):
-                    raise ValueError("include_thoughts must be a boolean when provided")
+                # Validated up-front; applied after the loop onto thinkingConfig.
+                continue
             elif param == "thinking":
                 # Validate no conflict with thinking_level
                 VertexGeminiConfig._validate_thinking_config_conflicts(
@@ -1293,10 +1289,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         # Apply include_thoughts onto reasoning_effort and/or thinking configs so
         # standalone/out-of-order use (e.g. thinking + include_thoughts=False) works.
-        include_thoughts_value = non_default_params.get("include_thoughts")
         if include_thoughts_value is not None:
-            if not isinstance(include_thoughts_value, bool):
-                raise ValueError("include_thoughts must be a boolean when provided")
             thinking_config = optional_params.get("thinkingConfig")
             if isinstance(thinking_config, dict):
                 optional_params["thinkingConfig"] = (

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -836,17 +836,17 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
     @staticmethod
     def _apply_include_thoughts_override(
-        thinking_config: dict,
+        thinking_config: GeminiThinkingConfig,
         include_thoughts: bool,
         *,
         thoughts_locked_off: bool = False,
-    ) -> dict:
+    ) -> GeminiThinkingConfig:
         """Apply ``include_thoughts`` onto an existing Gemini thinkingConfig.
 
         ``none`` / ``disable`` mappings lock thoughts off and cannot be forced
         back on. Otherwise ``include_thoughts`` overrides ``includeThoughts``.
         """
-        patched = dict(thinking_config)
+        patched: GeminiThinkingConfig = dict(thinking_config)  # mutable-ok: copy before patching includeThoughts
         if thoughts_locked_off:
             patched["includeThoughts"] = False
         else:

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5626,3 +5626,39 @@ def test_none_locks_include_thoughts_true_override():
         drop_params=False,
     )
     assert optional_params["thinkingConfig"]["includeThoughts"] is False
+
+def test_include_thoughts_rejects_non_bool():
+    with pytest.raises(ValueError, match="include_thoughts must be a boolean"):
+        VertexGeminiConfig().map_openai_params(
+            non_default_params={
+                "reasoning_effort": "low",
+                "include_thoughts": "false",
+            },
+            optional_params={},
+            model="gemini-3.6-flash",
+            drop_params=False,
+        )
+
+
+def test_include_thoughts_alone_without_thinking_config_is_noop():
+    optional_params = VertexGeminiConfig().map_openai_params(
+        non_default_params={"include_thoughts": False},
+        optional_params={},
+        model="gemini-3.6-flash",
+        drop_params=False,
+    )
+    assert "thinkingConfig" not in optional_params
+
+
+def test_map_openai_params_include_thoughts_budget_path():
+    optional_params = VertexGeminiConfig().map_openai_params(
+        non_default_params={
+            "reasoning_effort": "low",
+            "include_thoughts": False,
+        },
+        optional_params={},
+        model="gemini-2.5-flash",
+        drop_params=False,
+    )
+    assert optional_params["thinkingConfig"]["includeThoughts"] is False
+    assert "thinkingBudget" in optional_params["thinkingConfig"]

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5520,3 +5520,69 @@ def test_accumulated_json_skips_non_dict_leading_value():
 
     assert len(out) == 1
     assert out[0].choices[0].delta.content == "a"
+
+@pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high"])
+@pytest.mark.parametrize("include_thoughts,expected", [(None, True), (True, True), (False, False)])
+def test_map_reasoning_effort_to_thinking_level_include_thoughts(effort, include_thoughts, expected):
+    cfg = VertexGeminiConfig._map_reasoning_effort_to_thinking_level(
+        effort, "gemini-3.6-flash", include_thoughts=include_thoughts
+    )
+    assert cfg["includeThoughts"] is expected
+    assert "thinkingLevel" in cfg
+
+
+@pytest.mark.parametrize("effort", ["minimal", "low", "medium", "high"])
+@pytest.mark.parametrize("include_thoughts,expected", [(None, True), (True, True), (False, False)])
+def test_map_reasoning_effort_to_thinking_budget_include_thoughts(effort, include_thoughts, expected):
+    cfg = VertexGeminiConfig._map_reasoning_effort_to_thinking_budget(
+        effort, "gemini-2.5-flash", include_thoughts=include_thoughts
+    )
+    assert cfg["includeThoughts"] is expected
+    assert "thinkingBudget" in cfg
+
+
+@pytest.mark.parametrize("effort", ["none", "disable"])
+@pytest.mark.parametrize("include_thoughts", [None, True, False])
+def test_none_disable_always_suppress_thoughts_level(effort, include_thoughts):
+    cfg = VertexGeminiConfig._map_reasoning_effort_to_thinking_level(
+        effort, "gemini-3.6-flash", include_thoughts=include_thoughts
+    )
+    assert cfg["includeThoughts"] is False
+
+
+@pytest.mark.parametrize("effort", ["none", "disable"])
+@pytest.mark.parametrize("include_thoughts", [None, True, False])
+def test_none_disable_always_suppress_thoughts_budget(effort, include_thoughts):
+    cfg = VertexGeminiConfig._map_reasoning_effort_to_thinking_budget(
+        effort, "gemini-2.5-flash", include_thoughts=include_thoughts
+    )
+    assert cfg["includeThoughts"] is False
+
+
+def test_map_openai_params_include_thoughts_false_gemini3():
+    optional_params = VertexGeminiConfig().map_openai_params(
+        non_default_params={
+            "reasoning_effort": "low",
+            "include_thoughts": False,
+        },
+        optional_params={},
+        model="gemini-3.6-flash",
+        drop_params=False,
+    )
+    assert optional_params["thinkingConfig"]["thinkingLevel"] == "low"
+    assert optional_params["thinkingConfig"]["includeThoughts"] is False
+
+
+def test_map_openai_params_include_thoughts_default_true_gemini3():
+    optional_params = VertexGeminiConfig().map_openai_params(
+        non_default_params={"reasoning_effort": "low"},
+        optional_params={},
+        model="gemini-3.6-flash",
+        drop_params=False,
+    )
+    assert optional_params["thinkingConfig"]["includeThoughts"] is True
+
+
+def test_include_thoughts_in_supported_openai_params():
+    params = VertexGeminiConfig().get_supported_openai_params("gemini-3.6-flash")
+    assert "include_thoughts" in params

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5586,3 +5586,43 @@ def test_map_openai_params_include_thoughts_default_true_gemini3():
 def test_include_thoughts_in_supported_openai_params():
     params = VertexGeminiConfig().get_supported_openai_params("gemini-3.6-flash")
     assert "include_thoughts" in params
+
+def test_map_openai_params_include_thoughts_with_thinking_param():
+    """include_thoughts must apply when paired with Anthropic-style thinking."""
+    optional_params = VertexGeminiConfig().map_openai_params(
+        non_default_params={
+            "thinking": {"type": "enabled", "budget_tokens": 1024},
+            "include_thoughts": False,
+        },
+        optional_params={},
+        model="gemini-3.6-flash",
+        drop_params=False,
+    )
+    assert optional_params["thinkingConfig"]["includeThoughts"] is False
+
+
+def test_map_openai_params_include_thoughts_false_after_thinking_order():
+    """Param order must not matter: thinking first, then include_thoughts."""
+    optional_params = VertexGeminiConfig().map_openai_params(
+        non_default_params={
+            "thinking": {"type": "enabled", "budget_tokens": 1024},
+            "include_thoughts": False,
+        },
+        optional_params={},
+        model="gemini-2.5-flash",
+        drop_params=False,
+    )
+    assert optional_params["thinkingConfig"]["includeThoughts"] is False
+
+
+def test_none_locks_include_thoughts_true_override():
+    optional_params = VertexGeminiConfig().map_openai_params(
+        non_default_params={
+            "reasoning_effort": "none",
+            "include_thoughts": True,
+        },
+        optional_params={},
+        model="gemini-3.6-flash",
+        drop_params=False,
+    )
+    assert optional_params["thinkingConfig"]["includeThoughts"] is False


### PR DESCRIPTION
## Summary
- Adds optional `include_thoughts` boolean for Gemini/Vertex so `reasoning_effort` can keep internal thinking while setting `includeThoughts: false` (thought text not returned).
- `none` / `disable` still always force `includeThoughts: false` (not overridable).
- Default for active efforts remains `includeThoughts: true` (backward compatible).

Related: #27753, #14802 (stalled prior attempt)

## Usage
```python
response = litellm.completion(
    model="gemini/gemini-3.6-flash",
    messages=[...],
    reasoning_effort="low",
    include_thoughts=False,  # think internally; do not return thought summaries
)
```

## Test plan
- [x] Unit tests for thinking_level + thinking_budget mappers across efforts
- [x] `none`/`disable` always suppress even when include_thoughts=True
- [x] map_openai_params integration for Gemini 3
- [x] include_thoughts listed in supported openai params