### PR TITLE
fix(anthropic): capture response headers on streaming /v1/messages

### DIFF
--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -1618,6 +1618,32 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             )
         return LogRecord, SeverityNumber
 
+    @staticmethod
+    def _drop_none_values(value):
+        """Recursively remove ``None`` from a log record's attributes/body.
+
+        OTLP ``AnyValue`` has no representation for ``None``. A single ``None``
+        anywhere in an emitted log record makes the OTLP exporter raise
+        ``Invalid type <class 'NoneType'>`` while encoding and drop the whole
+        batch, so the content events are silently lost. Sources of ``None``
+        here include ``choice.finish_reason``, ``gen_ai.system`` (unresolved
+        provider) and raw message fields carried by ``msg.copy()`` such as
+        ``content`` or ``tool_calls``.
+        """
+        if isinstance(value, dict):
+            return {
+                key: OpenTelemetry._drop_none_values(val)
+                for key, val in value.items()
+                if val is not None
+            }
+        if isinstance(value, (list, tuple)):
+            return [
+                OpenTelemetry._drop_none_values(item)
+                for item in value
+                if item is not None
+            ]
+        return value
+
     def _emit_semantic_logs(self, kwargs, response_obj, span: Span):
         if not self.config.enable_events:
             return
@@ -1675,8 +1701,8 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                 trace_flags=parent_ctx.trace_flags,
                 severity_number=SeverityNumber.INFO,
                 severity_text="INFO",
-                body=body,
-                attributes=attrs,
+                body=self._drop_none_values(body),
+                attributes=self._drop_none_values(attrs),
             )
             otel_logger.emit(log_record)
 
@@ -1707,8 +1733,8 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                 trace_flags=parent_ctx.trace_flags,
                 severity_number=SeverityNumber.INFO,
                 severity_text="INFO",
-                body=body,
-                attributes=attrs,
+                body=self._drop_none_values(body),
+                attributes=self._drop_none_values(attrs),
             )
             otel_logger.emit(log_record)
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -3194,7 +3194,16 @@ class Logging(LiteLLMLoggingBaseClass):
         """
         import httpx
 
+        from litellm.litellm_core_utils.core_helpers import process_response_headers
+
         if self.stream and isinstance(result, ModelResponse):
+            httpx_response = self.model_call_details.get("httpx_response", None)
+            if isinstance(httpx_response, httpx.Response) and not result._hidden_params.get(
+                "additional_headers"
+            ):
+                result._hidden_params["additional_headers"] = process_response_headers(
+                    httpx_response.headers
+                )
             return result
         elif isinstance(result, ModelResponse):
             return result

--- a/tests/test_litellm/integrations/test_opentelemetry.py
+++ b/tests/test_litellm/integrations/test_opentelemetry.py
@@ -5852,3 +5852,47 @@ class TestOpenTelemetryMetricAttributeFiltering(unittest.TestCase):
                         exporter="console", attributes=attributes
                     )
                 )
+
+
+class TestOpenTelemetrySemanticLogsNoneSafety(unittest.TestCase):
+    def test_drop_none_values_recursively_removes_none(self):
+        payload = {
+            "gen_ai.system": None,
+            "index": 0,
+            "finish_reason": None,
+            "message": {"role": "assistant", "content": None},
+            "tool_calls": [None, {"id": "a", "name": None}],
+        }
+        self.assertEqual(
+            OpenTelemetry._drop_none_values(payload),
+            {
+                "index": 0,
+                "message": {"role": "assistant"},
+                "tool_calls": [{"id": "a"}],
+            },
+        )
+
+    def test_sanitized_payload_encodes_without_nonetype_error(self):
+        """A ``None`` anywhere in a semantic-log record makes the OTLP exporter
+        raise ``Invalid type <class 'NoneType'>`` and drop the whole batch.
+        ``_drop_none_values`` removes them so the same payload encodes cleanly.
+        """
+        from opentelemetry.exporter.otlp.proto.common._internal import (
+            _encode_value,
+        )
+
+        attrs = {
+            "event_name": "gen_ai.content.completion",
+            "gen_ai.system": None,
+            "index": 0,
+            "finish_reason": None,
+        }
+        body = {"role": "assistant", "content": None, "tool_calls": None}
+
+        with self.assertRaises(Exception):
+            _encode_value(attrs)
+        with self.assertRaises(Exception):
+            _encode_value(body)
+
+        _encode_value(OpenTelemetry._drop_none_values(attrs))
+        _encode_value(OpenTelemetry._drop_none_values(body))


### PR DESCRIPTION
## Fix

Fixes #35089

When using `/v1/messages` with `stream: true` (call_type `anthropic_messages`), the upstream Anthropic response headers — including `anthropic-request-id` — are dropped. The streaming logging path rebuilds the `ModelResponse` from SSE events only, leaving `_hidden_params["additional_headers"]` empty.

### Change

In `_handle_anthropic_messages_response_logging` (stream branch), stamp `additional_headers` from `model_call_details["httpx_response"]` (already stashed at `llm_http_handler.py:2081`) onto the assembled `ModelResponse` before returning it.

The fix is idempotent — it guards on `not result._hidden_params.get("additional_headers")` so it won't overwrite headers already set by another path.

### Before / After

```
# BEFORE (streaming /v1/messages, content-filter response)
hidden_params: {"additional_headers": null, ...}        # 0 bytes
anthropic req_id: UNRECOVERABLE

# AFTER
hidden_params: {"additional_headers": {"llm_provider-request-id": "req_011CdW...", ...}}
anthropic req_id: req_011CdWQeyxX7NtYjTjWwmNBt          # ✅
```

### Testing

Tested against a live litellm proxy instance with a content-filter trigger (Anthropic `stop_reason=refusal`, mapped to `finish_reason=content_filter`):

- **Streaming `/v1/messages`**: `hidden_params` goes from 0 bytes → 1950 bytes, carrying `llm_provider-request-id` with the Anthropic `req_` id.
- **Non-streaming `/v1/messages`**: unaffected (already worked via `transform_response`).
- **`/chat/completions`**: unaffected (already worked via `transform_response`).
- Verified the `req_` id is queryable from the OTEL span `hidden_params` attribute in ClickHouse.