### PR TITLE
feat(ui): deep link team detail page via ?team= query param

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/teams/detailNavigation.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/teams/detailNavigation.test.ts
@@ -1,0 +1,53 @@
+/* @vitest-environment jsdom */
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useTeamDetailRouting } from "./detailNavigation";
+
+vi.mock("next/navigation", () => ({ useSearchParams: () => new URLSearchParams(window.location.search) }));
+
+describe("useTeamDetailRouting", () => {
+  beforeEach(() => {
+    window.history.pushState(null, "", "/teams/");
+  });
+
+  it("openTeam sets ?team= via history.pushState (no full navigation)", () => {
+    const spy = vi.spyOn(window.history, "pushState");
+    const { result } = renderHook(() => useTeamDetailRouting());
+    act(() => result.current.openTeam("team-abc123"));
+    expect(spy).toHaveBeenCalledWith(null, "", expect.stringContaining("team=team-abc123"));
+    spy.mockRestore();
+  });
+
+  it("openTeam preserves unrelated query params", () => {
+    window.history.pushState(null, "", "/teams/?foo=bar");
+    const spy = vi.spyOn(window.history, "pushState");
+    const { result } = renderHook(() => useTeamDetailRouting());
+    act(() => result.current.openTeam("team-abc123"));
+    const url = spy.mock.calls.at(-1)?.[2] as string;
+    expect(url).toContain("foo=bar");
+    expect(url).toContain("team=team-abc123");
+    spy.mockRestore();
+  });
+
+  it("close removes only the team param", () => {
+    window.history.pushState(null, "", "/teams/?foo=bar&team=team-abc123");
+    const spy = vi.spyOn(window.history, "pushState");
+    const { result } = renderHook(() => useTeamDetailRouting());
+    act(() => result.current.close());
+    const url = spy.mock.calls.at(-1)?.[2] as string;
+    expect(url).toContain("foo=bar");
+    expect(url).not.toContain("team=");
+    spy.mockRestore();
+  });
+
+  it("exposes teamId from ?team=", () => {
+    window.history.pushState(null, "", "/teams/?team=team-abc123");
+    const { result } = renderHook(() => useTeamDetailRouting());
+    expect(result.current.teamId).toBe("team-abc123");
+  });
+
+  it("teamId is null when no team param is present", () => {
+    const { result } = renderHook(() => useTeamDetailRouting());
+    expect(result.current.teamId).toBeNull();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/teams/detailNavigation.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/teams/detailNavigation.ts
@@ -1,0 +1,32 @@
+import { useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+import { navigateWithParams } from "../navigateWithParams";
+
+export interface TeamDetailRouting {
+  teamId: string | null;
+  openTeam: (id: string) => void;
+  close: () => void;
+}
+
+export function useTeamDetailRouting(): TeamDetailRouting {
+  const searchParams = useSearchParams();
+
+  const openTeam = useCallback((id: string) => {
+    navigateWithParams((params) => {
+      params.set("team", id);
+    });
+  }, []);
+
+  const close = useCallback(() => {
+    navigateWithParams((params) => {
+      params.delete("team");
+    });
+  }, []);
+
+  return {
+    teamId: searchParams?.get("team") ?? null,
+    openTeam,
+    close,
+  };
+}

--- a/ui/litellm-dashboard/src/components/Teams.test.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.test.tsx
@@ -72,6 +72,31 @@ vi.mock("@/components/team/TeamInfo", () => ({
   },
 }));
 
+// The selected team is URL-derived (?team=) via useTeamDetailRouting. Next's real useSearchParams
+// re-renders subscribers on history.pushState/replaceState; mirror that so URL changes propagate.
+vi.mock("next/navigation", async () => {
+  const { useSyncExternalStore } = await import("react");
+  const LOCATION_CHANGE_EVENT = "test-locationchange";
+  for (const method of ["pushState", "replaceState"] as const) {
+    const original = window.history[method].bind(window.history);
+    window.history[method] = (...args: Parameters<History["pushState"]>) => {
+      original(...args);
+      window.dispatchEvent(new Event(LOCATION_CHANGE_EVENT));
+    };
+  }
+  const subscribe = (onChange: () => void) => {
+    window.addEventListener(LOCATION_CHANGE_EVENT, onChange);
+    window.addEventListener("popstate", onChange);
+    return () => {
+      window.removeEventListener(LOCATION_CHANGE_EVENT, onChange);
+      window.removeEventListener("popstate", onChange);
+    };
+  };
+  return {
+    useSearchParams: () => new URLSearchParams(useSyncExternalStore(subscribe, () => window.location.search)),
+  };
+});
+
 vi.mock("./ModelSelect/ModelSelect", () => {
   const ModelSelect = React.forwardRef(({ value, onChange, dataTestId, id }: any, ref: any) => {
     return (
@@ -159,6 +184,7 @@ const renderWithQueryClient = (component: React.ReactElement) => {
 // Re-establish safe defaults before every test (clearAllMocks keeps return values, so restore them here).
 beforeEach(() => {
   mockTeamsTableProps = null;
+  window.history.replaceState(null, "", "/teams/");
 });
 
 describe("Teams - handleCreate organization handling", () => {
@@ -433,6 +459,47 @@ describe("Teams - premium props", () => {
 
     await waitFor(() => expect(mockTeamInfoView).toHaveBeenCalled());
     expect(mockTeamInfoView).toHaveBeenLastCalledWith(expect.objectContaining({ premiumUser: true }));
+  });
+});
+
+describe("Teams - team detail deep link (?team=)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTeamInfoView.mockClear();
+    vi.mocked(fetchAvailableModelsForTeamOrKey).mockResolvedValue([]);
+    vi.mocked(fetchMCPAccessGroups).mockResolvedValue([]);
+    vi.mocked(getGuardrailsList).mockResolvedValue({ guardrails: [] });
+    mockUseOrganizations.mockReturnValue({ data: [] });
+  });
+
+  it("selecting a team pushes ?team= to the URL", async () => {
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin" />);
+
+    await waitFor(() => expect(mockTeamsTableProps).not.toBeNull());
+    act(() => mockTeamsTableProps.onSelectTeam({ ...baseTableTeam, team_id: "team-deep-link" }));
+
+    expect(window.location.search).toContain("team=team-deep-link");
+    await waitFor(() => expect(mockTeamInfoView).toHaveBeenCalled());
+    expect(mockTeamInfoView).toHaveBeenLastCalledWith(expect.objectContaining({ teamId: "team-deep-link" }));
+  });
+
+  it("opens the team detail view directly from a ?team= deep link", async () => {
+    window.history.replaceState(null, "", "/teams/?team=team-from-url");
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin" />);
+
+    await waitFor(() => expect(mockTeamInfoView).toHaveBeenCalled());
+    expect(mockTeamInfoView).toHaveBeenLastCalledWith(expect.objectContaining({ teamId: "team-from-url" }));
+  });
+
+  it("closing the team detail view removes ?team= from the URL", async () => {
+    window.history.replaceState(null, "", "/teams/?team=team-from-url");
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin" />);
+
+    await waitFor(() => expect(mockTeamInfoView).toHaveBeenCalled());
+    act(() => mockTeamInfoView.mock.calls.at(-1)?.[0].onClose());
+
+    expect(window.location.search).not.toContain("team=");
+    await waitFor(() => expect(screen.queryByTestId("team-info-view")).not.toBeInTheDocument());
   });
 });
 

--- a/ui/litellm-dashboard/src/components/Teams.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.tsx
@@ -12,6 +12,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { Button as UIButton } from "@/components/ui/button";
 import { teamsTableKeys } from "@/app/(dashboard)/hooks/teams/useTeams";
+import { useTeamDetailRouting } from "@/app/(dashboard)/teams/detailNavigation";
 import { TeamsTable } from "./TeamsPage/TeamsTable";
 import AccessGroupSelector from "./common_components/AccessGroupSelector";
 import PassThroughRoutesSelector from "./common_components/PassThroughRoutesSelector";
@@ -135,7 +136,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
   const [editModalVisible, setEditModalVisible] = useState(false);
 
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
-  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
+  const { teamId: selectedTeamId, openTeam, close: closeTeamDetail } = useTeamDetailRouting();
   const [editTeam, setEditTeam] = useState<boolean>(false);
 
   const [isTeamModalVisible, setIsTeamModalVisible] = useState(false);
@@ -482,12 +483,12 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
             userID={userID}
             onSelectTeam={(team) => {
               setSelectedTeam(team);
-              setSelectedTeamId(team.team_id);
+              openTeam(team.team_id);
               setEditTeam(false);
             }}
             onEditTeam={(team) => {
               setSelectedTeam(team);
-              setSelectedTeamId(team.team_id);
+              openTeam(team.team_id);
               setEditTeam(true);
             }}
             onDeleteTeam={handleDelete}
@@ -547,11 +548,11 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
           }}
           onClose={() => {
             setSelectedTeam(null);
-            setSelectedTeamId(null);
+            closeTeamDetail();
             setEditTeam(false);
           }}
           accessToken={accessToken}
-          is_team_admin={is_team_admin(selectedTeam)}
+          is_team_admin={is_team_admin(selectedTeam?.team_id === selectedTeamId ? selectedTeam : null)}
           is_proxy_admin={userRole == "Admin"}
           userModels={userModels}
           editTeam={editTeam}

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.test.tsx
@@ -444,6 +444,29 @@ describe("TeamInfoView", () => {
       });
     });
 
+    it("shows edit tabs when the fetched team data marks the session user as team admin, even without the is_team_admin prop", async () => {
+      vi.mocked(networking.teamInfoCall).mockResolvedValue(
+        createMockTeamData({
+          members_with_roles: [
+            {
+              user_id: "user-1",
+              user_email: "admin@test.com",
+              role: "admin",
+              spend: 0,
+              budget_id: "budget1",
+            },
+          ],
+        }),
+      );
+
+      renderWithProviders(<TeamInfoView {...defaultProps} is_team_admin={false} is_proxy_admin={false} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("tab", { name: "Settings" })).toBeInTheDocument();
+      });
+      expect(screen.getByRole("tab", { name: "Members" })).toBeInTheDocument();
+    });
+
     it("should navigate to settings tab when clicked", async () => {
       const user = userEvent.setup({ delay: null });
       vi.mocked(networking.teamInfoCall).mockResolvedValue(createMockTeamData());

--- a/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
+++ b/ui/litellm-dashboard/src/components/team/TeamInfo.tsx
@@ -225,7 +225,15 @@ const TeamInfoView: React.FC<TeamInfoProps> = ({
     return unfurlWildcardModelsInList(selected, userModels);
   }, [selectedModelsInForm, teamData, userModels]);
 
-  const canEditTeam = is_team_admin || is_proxy_admin || is_org_admin || isOrgAdminForTeam;
+  const isTeamAdminFromTeamData = useMemo(
+    () =>
+      teamData?.team_info?.members_with_roles?.some(
+        (member) => member.user_id != null && member.user_id === userId && member.role === "admin",
+      ) ?? false,
+    [teamData, userId],
+  );
+
+  const canEditTeam = is_team_admin || is_proxy_admin || is_org_admin || isOrgAdminForTeam || isTeamAdminFromTeamData;
   const visibleTabs = useMemo(() => getTeamInfoVisibleTabs(canEditTeam), [canEditTeam]);
   const defaultTabKey = useMemo(() => getTeamInfoDefaultTab(editTeam, canEditTeam), [editTeam, canEditTeam]);
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Team detail pages have no URL; selection is in-memory React state
- Deep linking, bookmarking, or linking to a team from another page is impossible
- Browser back exits the teams page instead of closing the detail view

How it solves it:

- /ui/teams?team=<team_id> now opens that team's detail page
- Clicking a team pushes ?team= to the URL; back or close removes it
- TeamInfo also derives team-admin rights from fetched team data, so deep-linked team admins are not read-only

## Relevant issues

## Linear ticket

Refs LIT-4740

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at commit b47d1a948d against a live proxy (dev_config, real dev DB with 8 teams) and the dashboard dev server; the dark bar at the top of each screenshot displays the live address-bar URL

The teams list; clicking a row's team name opens its detail page

![teams list](https://raw.githubusercontent.com/BerriAI/litellm/assets_lit4740_deep_link_screenshots/teams-list.png)

After the click the URL carries `?team=<team_id>`; loading this exact URL in a fresh tab opens the same detail page directly with the full tab set, and both the browser back button and "Back to Teams" return to the list and drop the param

![team detail deep link](https://raw.githubusercontent.com/BerriAI/litellm/assets_lit4740_deep_link_screenshots/team-detail-deeplink.png)

To reproduce by hand:

1. Start the proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver`) and the UI dev server (`npm run dev` in `ui/litellm-dashboard`), then log in at http://localhost:4000/ui
2. Go to http://localhost:3000/teams and click any team row; the URL becomes `/teams?team=<team_id>` and the team detail page opens
3. Copy that URL into a fresh tab; the same team detail page opens directly, with the Members and Settings tabs present for a user with edit rights
4. Press the browser back button; the detail view closes and the teams list returns
5. Open a team again and click "Back to Teams"; the `?team=` param is removed from the URL

All five steps were walked in a real browser against the live proxy before opening this PR

## Type

🆕 New Feature

## Changes

`app/(dashboard)/teams/detailNavigation.ts` adds `useTeamDetailRouting`, reading and writing the `?team=` query param via `navigateWithParams`, mirroring the existing `?key=` (api-keys), `?model=` (models), and `?log_id=` (logs) deep-link hooks

`components/Teams.tsx` derives the open team from that hook instead of `useState`, so row clicks push the param, the back button and the close handler clear it, and a fresh page load with `?team=` opens the detail view directly. The `is_team_admin` prop is only passed when the locally tracked team row matches the URL, preventing a stale value after history navigation

`components/team/TeamInfo.tsx` additionally computes team-admin status from the fetched team's `members_with_roles` and the session user id. Deep links cannot supply the `is_team_admin` prop (the caller has no team object yet), and without this a team admin landing on a deep link got a read-only view. Any future entry point now gets correct permissions for free

Tests: hook unit tests for the param round-trip, Teams-level regression tests (row click pushes the param, deep link opens the detail view, close removes the param), and a TeamInfo test proving the fetched-data admin fallback shows the edit tabs. The TeamInfo test fails without the source change; the Teams tests fail if the URL wiring is removed

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
