### PR TITLE
perf(proxy): cache the public provider and agent field endpoints

### DIFF
--- a/litellm/proxy/public_endpoints/public_endpoints.py
+++ b/litellm/proxy/public_endpoints/public_endpoints.py
@@ -1,6 +1,8 @@
 import json
 import os
 import re
+from collections.abc import Mapping
+from functools import lru_cache
 from importlib.resources import files
 from typing import Any, Final
 
@@ -143,6 +145,49 @@ def _build_endpoints(raw: dict[str, Any]) -> list[dict[str, Any]]:
 def _load_endpoints() -> list[dict[str, Any]]:
     raw = json.loads(files("litellm").joinpath("provider_endpoints_support_backup.json").read_text(encoding="utf-8"))
     return _build_endpoints(raw)
+
+
+def _read_bundled_json(filename: str) -> tuple[Mapping[str, Any], ...]:
+    """Read one of the JSON data files bundled alongside this module."""
+    with open(os.path.join(os.path.dirname(__file__), filename), "r") as f:
+        return tuple(json.load(f))
+
+
+@lru_cache(maxsize=1)
+def _get_provider_create_fields() -> tuple[Mapping[str, Any], ...]:
+    """Provider metadata for the dashboard create-model flow, read from disk once per process."""
+    return _read_bundled_json("provider_create_fields.json")
+
+
+def _agent_with_inherited_credentials(
+    agent: Mapping[str, Any], provider_map: Mapping[str, Mapping[str, Any]]
+) -> Mapping[str, Any]:
+    """One agent entry with its provider's credential fields appended after its own.
+
+    ``inherit_credentials_from_provider`` is dropped from the result; the frontend
+    does not consume it. Inherited fields are marked ``include_in_litellm_params``.
+    """
+    inherit_from: Final = agent.get("inherit_credentials_from_provider")
+    provider: Final = provider_map.get(inherit_from) if inherit_from else None
+    merged: Final = {key: value for key, value in agent.items() if key != "inherit_credentials_from_provider"}
+
+    if provider is not None:
+        inherited: Final = tuple(
+            {**field, "include_in_litellm_params": True} for field in provider.get("credential_fields") or ()
+        )
+        merged["credential_fields"] = tuple(agent.get("credential_fields") or ()) + inherited
+
+    return merged
+
+
+@lru_cache(maxsize=1)
+def _get_agent_create_fields() -> tuple[Mapping[str, Any], ...]:
+    """Agent metadata for the dashboard create-agent flow, built once per process."""
+    provider_map: Final = {provider["provider"]: provider for provider in _get_provider_create_fields()}
+    return tuple(
+        _agent_with_inherited_credentials(agent, provider_map)
+        for agent in _read_bundled_json("agent_create_fields.json")
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -332,19 +377,12 @@ async def get_supported_providers() -> list[str]:
 async def get_provider_fields() -> list[ProviderCreateInfo]:
     """
     Return provider metadata required by the dashboard create-model flow.
+
+    Reads from the bundled local file. Result is cached in-process for the
+    lifetime of the server process.
     """
 
-    provider_create_fields_path: Final = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
-        "proxy",
-        "public_endpoints",
-        "provider_create_fields.json",
-    )
-
-    with open(provider_create_fields_path, "r") as f:
-        provider_create_fields: Final = json.load(f)
-
-    return provider_create_fields
+    return _get_provider_create_fields()  # pyright: ignore[reportReturnType]  # response_model validates the dicts
 
 
 @router.get(
@@ -419,39 +457,8 @@ async def get_agent_fields() -> list[AgentCreateInfo]:
 
     If an agent has `inherit_credentials_from_provider`, the provider's credential
     fields are automatically appended to the agent's credential_fields.
+
+    Reads from the bundled local files. Result is cached in-process for the
+    lifetime of the server process.
     """
-    base_path: Final = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
-        "proxy",
-        "public_endpoints",
-    )
-
-    agent_create_fields_path: Final = os.path.join(base_path, "agent_create_fields.json")
-    provider_create_fields_path: Final = os.path.join(base_path, "provider_create_fields.json")
-
-    with open(agent_create_fields_path, "r") as f:
-        agent_create_fields: Final = json.load(f)
-
-    with open(provider_create_fields_path, "r") as f:
-        provider_create_fields: Final = json.load(f)
-
-    # Build a lookup map for providers by name
-    provider_map: Final = {p["provider"]: p for p in provider_create_fields}
-
-    # Merge inherited credential fields
-    for agent in agent_create_fields:
-        inherit_from = agent.get("inherit_credentials_from_provider")
-        if inherit_from and inherit_from in provider_map:
-            provider = provider_map[inherit_from]
-            # Copy provider fields and mark them for inclusion in litellm_params
-            inherited_fields = []
-            for field in provider.get("credential_fields", []):
-                field_copy = field.copy()
-                field_copy["include_in_litellm_params"] = True
-                inherited_fields.append(field_copy)
-            # Append provider credential fields after agent's own fields
-            agent["credential_fields"] = agent.get("credential_fields", []) + inherited_fields
-        # Remove the inherit field from response (not needed by frontend)
-        agent.pop("inherit_credentials_from_provider", None)
-
-    return agent_create_fields
+    return _get_agent_create_fields()  # pyright: ignore[reportReturnType]  # response_model validates the dicts

--- a/litellm/proxy/public_endpoints/public_endpoints.py
+++ b/litellm/proxy/public_endpoints/public_endpoints.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from functools import lru_cache
 from importlib.resources import files
 from typing import TYPE_CHECKING, Final, Protocol
 
@@ -205,6 +206,65 @@ def _load_endpoints() -> list[_EndpointEntry]:
     return _build_endpoints(raw)
 
 
+BundledRecord = Mapping[str, object]
+
+
+def _read_bundled_json(filename: str) -> tuple[BundledRecord, ...]:
+    """Read one of the JSON data files bundled alongside this module."""
+    with open(os.path.join(os.path.dirname(__file__), filename), "r") as f:
+        loaded: object = json.load(f)
+    if not isinstance(loaded, Sequence):
+        return ()
+    return tuple(record for record in loaded if isinstance(record, Mapping))
+
+
+def _credential_fields(record: BundledRecord) -> tuple[BundledRecord, ...]:
+    """A record's ``credential_fields``, empty when the key is absent or not a list."""
+    fields: Final = record.get("credential_fields")
+    if not isinstance(fields, Sequence) or isinstance(fields, (str, bytes)):
+        return ()
+    return tuple(field for field in fields if isinstance(field, Mapping))
+
+
+@lru_cache(maxsize=1)
+def _get_provider_create_fields() -> tuple[BundledRecord, ...]:
+    """Provider metadata for the dashboard create-model flow, read from disk once per process."""
+    return _read_bundled_json("provider_create_fields.json")
+
+
+def _agent_with_inherited_credentials(agent: BundledRecord, provider_map: Mapping[str, BundledRecord]) -> BundledRecord:
+    """One agent entry with its provider's credential fields appended after its own.
+
+    ``inherit_credentials_from_provider`` is dropped from the result; the frontend
+    does not consume it. Inherited fields are marked ``include_in_litellm_params``.
+    """
+    inherit_from: Final = agent.get("inherit_credentials_from_provider")
+    provider: Final = provider_map.get(inherit_from) if isinstance(inherit_from, str) else None
+    merged: Final[dict[str, object]] = {
+        key: value for key, value in agent.items() if key != "inherit_credentials_from_provider"
+    }
+
+    if provider is not None:
+        inherited: Final = tuple({**field, "include_in_litellm_params": True} for field in _credential_fields(provider))
+        merged["credential_fields"] = _credential_fields(agent) + inherited
+
+    return merged
+
+
+@lru_cache(maxsize=1)
+def _get_agent_create_fields() -> tuple[BundledRecord, ...]:
+    """Agent metadata for the dashboard create-agent flow, built once per process."""
+    provider_map: Final = {
+        name: provider
+        for provider in _get_provider_create_fields()
+        if isinstance(name := provider.get("provider"), str)
+    }
+    return tuple(
+        _agent_with_inherited_credentials(agent, provider_map)
+        for agent in _read_bundled_json("agent_create_fields.json")
+    )
+
+
 # ---------------------------------------------------------------------------
 
 
@@ -387,19 +447,12 @@ async def get_supported_providers() -> list[str]:
 async def get_provider_fields() -> list[ProviderCreateInfo]:
     """
     Return provider metadata required by the dashboard create-model flow.
+
+    Reads from the bundled local file. Result is cached in-process for the
+    lifetime of the server process.
     """
 
-    provider_create_fields_path: Final = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
-        "proxy",
-        "public_endpoints",
-        "provider_create_fields.json",
-    )
-
-    with open(provider_create_fields_path, "r") as f:
-        provider_create_fields: Final = json.load(f)
-
-    return provider_create_fields
+    return _get_provider_create_fields()  # pyright: ignore[reportReturnType]  # response_model validates the dicts
 
 
 @router.get(
@@ -576,39 +629,8 @@ async def get_agent_fields() -> list[AgentCreateInfo]:
 
     If an agent has `inherit_credentials_from_provider`, the provider's credential
     fields are automatically appended to the agent's credential_fields.
+
+    Reads from the bundled local files. Result is cached in-process for the
+    lifetime of the server process.
     """
-    base_path: Final = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
-        "proxy",
-        "public_endpoints",
-    )
-
-    agent_create_fields_path: Final = os.path.join(base_path, "agent_create_fields.json")
-    provider_create_fields_path: Final = os.path.join(base_path, "provider_create_fields.json")
-
-    with open(agent_create_fields_path, "r") as f:
-        agent_create_fields: Final = json.load(f)
-
-    with open(provider_create_fields_path, "r") as f:
-        provider_create_fields: Final = json.load(f)
-
-    # Build a lookup map for providers by name
-    provider_map: Final = {p["provider"]: p for p in provider_create_fields}
-
-    # Merge inherited credential fields
-    for agent in agent_create_fields:
-        inherit_from = agent.get("inherit_credentials_from_provider")
-        if inherit_from and inherit_from in provider_map:
-            provider = provider_map[inherit_from]
-            # Copy provider fields and mark them for inclusion in litellm_params
-            inherited_fields = []
-            for field in provider.get("credential_fields", []):
-                field_copy = field.copy()
-                field_copy["include_in_litellm_params"] = True
-                inherited_fields.append(field_copy)
-            # Append provider credential fields after agent's own fields
-            agent["credential_fields"] = agent.get("credential_fields", []) + inherited_fields
-        # Remove the inherit field from response (not needed by frontend)
-        agent.pop("inherit_credentials_from_provider", None)
-
-    return agent_create_fields
+    return _get_agent_create_fields()  # pyright: ignore[reportReturnType]  # response_model validates the dicts

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -952,3 +952,112 @@ def test_public_mcp_hub_does_not_expose_upstream_url():
     assert all("url" not in item for item in data)
     assert secret_url not in response.text
     app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# /public/providers/fields + /public/agents/fields are cached in-process
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=False)
+def reset_create_fields_caches():
+    """Clear the create-fields memoization before and after each test."""
+    _pe_module._get_provider_create_fields.cache_clear()
+    _pe_module._get_agent_create_fields.cache_clear()
+    yield
+    _pe_module._get_provider_create_fields.cache_clear()
+    _pe_module._get_agent_create_fields.cache_clear()
+
+
+def _bundled_reads(mock_read, filename):
+    return [call for call in mock_read.call_args_list if call.args[0] == filename]
+
+
+def test_get_provider_fields_reads_from_disk_once(reset_create_fields_caches):
+    """provider_create_fields.json is read once per process, not once per request."""
+    client = _make_client()
+
+    with patch(
+        "litellm.proxy.public_endpoints.public_endpoints._read_bundled_json",
+        wraps=_pe_module._read_bundled_json,
+    ) as mock_read:
+        first = client.get("/public/providers/fields")
+        second = client.get("/public/providers/fields")
+        third = client.get("/public/providers/fields")
+
+    assert first.status_code == 200
+    reads = _bundled_reads(mock_read, "provider_create_fields.json")
+    assert len(reads) == 1, f"expected 1 disk read across 3 requests, got {len(reads)}"
+    assert first.json() == second.json() == third.json()
+
+
+def test_get_agent_fields_reads_each_file_from_disk_once(reset_create_fields_caches):
+    """Both bundled files backing /public/agents/fields are read once, not per request."""
+    client = _make_client()
+
+    with patch(
+        "litellm.proxy.public_endpoints.public_endpoints._read_bundled_json",
+        wraps=_pe_module._read_bundled_json,
+    ) as mock_read:
+        first = client.get("/public/agents/fields")
+        second = client.get("/public/agents/fields")
+        third = client.get("/public/agents/fields")
+
+    assert first.status_code == 200
+    agent_reads = _bundled_reads(mock_read, "agent_create_fields.json")
+    provider_reads = _bundled_reads(mock_read, "provider_create_fields.json")
+    assert len(agent_reads) == 1, f"expected 1 agent-file read, got {len(agent_reads)}"
+    assert len(provider_reads) == 1, f"expected 1 provider-file read, got {len(provider_reads)}"
+    assert first.json() == second.json() == third.json()
+
+
+def test_get_agent_fields_merge_does_not_compound_across_requests(
+    reset_create_fields_caches,
+):
+    """The inherited-credentials merge runs once, so credential_fields cannot grow per request.
+
+    Caching the raw file contents instead of the merged result would let the merge
+    append inherited fields again on every request.
+    """
+    client = _make_client()
+
+    def counts():
+        return {
+            agent["agent_type"]: len(agent.get("credential_fields") or [])
+            for agent in client.get("/public/agents/fields").json()
+        }
+
+    first = counts()
+    assert first, "expected at least one agent type"
+    assert first == counts() == counts()
+
+
+def test_get_agent_fields_still_merges_inherited_provider_credentials(
+    reset_create_fields_caches,
+):
+    """Caching must not change what the merge produces."""
+    agents = _make_client().get("/public/agents/fields").json()
+
+    inheriting = [
+        agent
+        for agent in agents
+        if any(field.get("include_in_litellm_params") for field in (agent.get("credential_fields") or []))
+    ]
+    assert inheriting, "expected at least one agent to inherit provider credential fields"
+    assert all("inherit_credentials_from_provider" not in agent for agent in agents)
+
+
+def test_provider_fields_cache_is_shared_with_agent_fields(reset_create_fields_caches):
+    """Warming /public/providers/fields means /public/agents/fields re-reads only its own file."""
+    client = _make_client()
+    client.get("/public/providers/fields")
+
+    with patch(
+        "litellm.proxy.public_endpoints.public_endpoints._read_bundled_json",
+        wraps=_pe_module._read_bundled_json,
+    ) as mock_read:
+        response = client.get("/public/agents/fields")
+
+    assert response.status_code == 200
+    assert _bundled_reads(mock_read, "provider_create_fields.json") == []
+    assert len(_bundled_reads(mock_read, "agent_create_fields.json")) == 1

--- a/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
+++ b/tests/test_litellm/proxy/public_endpoints/test_public_endpoints.py
@@ -1,4 +1,7 @@
+import builtins
+import os
 import re
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1159,7 +1162,6 @@ def test_public_mcp_hub_does_not_expose_upstream_url():
     app.dependency_overrides.clear()
 
 
-
 @pytest.fixture
 def reset_autorouter_presets_cache():
     from litellm.proxy.public_endpoints.public_endpoints import _AutoRouterPresetsCache
@@ -1407,3 +1409,115 @@ async def test_fetch_remote_autorouter_presets_parses_and_rejects_empty(monkeypa
     response.json = MagicMock(return_value={})
     with pytest.raises(ValueError, match="empty"):
         await _fetch_remote_autorouter_presets("https://example.test/presets.json")
+
+
+# ---------------------------------------------------------------------------
+# /public/providers/fields + /public/agents/fields are cached in-process
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=False)
+def reset_create_fields_caches():
+    """Clear the create-fields memoization before and after each test."""
+    _pe_module._get_provider_create_fields.cache_clear()
+    _pe_module._get_agent_create_fields.cache_clear()
+    yield
+    _pe_module._get_provider_create_fields.cache_clear()
+    _pe_module._get_agent_create_fields.cache_clear()
+
+
+@contextmanager
+def _bundled_file_opens():
+    """Record which bundled create-fields files get opened from disk inside the block."""
+    real_open = builtins.open
+    opened = []
+
+    def counting_open(file, *args, **kwargs):
+        name = os.path.basename(str(file))
+        if name in ("provider_create_fields.json", "agent_create_fields.json"):
+            opened.append(name)
+        return real_open(file, *args, **kwargs)
+
+    with patch("builtins.open", counting_open):
+        yield opened
+
+
+def test_get_provider_fields_reads_from_disk_once(reset_create_fields_caches):
+    """provider_create_fields.json is read once per process, not once per request."""
+    client = _make_client()
+
+    with _bundled_file_opens() as opened:
+        first = client.get("/public/providers/fields")
+        second = client.get("/public/providers/fields")
+        third = client.get("/public/providers/fields")
+
+    assert first.status_code == 200
+    reads = opened.count("provider_create_fields.json")
+    assert reads == 1, f"expected 1 disk read across 3 requests, got {reads}"
+    assert first.json() == second.json() == third.json()
+
+
+def test_get_agent_fields_reads_each_file_from_disk_once(reset_create_fields_caches):
+    """Both bundled files backing /public/agents/fields are read once, not per request."""
+    client = _make_client()
+
+    with _bundled_file_opens() as opened:
+        first = client.get("/public/agents/fields")
+        second = client.get("/public/agents/fields")
+        third = client.get("/public/agents/fields")
+
+    assert first.status_code == 200
+    agent_reads = opened.count("agent_create_fields.json")
+    provider_reads = opened.count("provider_create_fields.json")
+    assert agent_reads == 1, f"expected 1 agent-file read, got {agent_reads}"
+    assert provider_reads == 1, f"expected 1 provider-file read, got {provider_reads}"
+    assert first.json() == second.json() == third.json()
+
+
+def test_get_agent_fields_merge_does_not_compound_across_requests(
+    reset_create_fields_caches,
+):
+    """The inherited-credentials merge runs once, so credential_fields cannot grow per request.
+
+    Caching the raw file contents instead of the merged result would let the merge
+    append inherited fields again on every request.
+    """
+    client = _make_client()
+
+    def counts():
+        return {
+            agent["agent_type"]: len(agent.get("credential_fields") or [])
+            for agent in client.get("/public/agents/fields").json()
+        }
+
+    first = counts()
+    assert first, "expected at least one agent type"
+    assert first == counts() == counts()
+
+
+def test_get_agent_fields_still_merges_inherited_provider_credentials(
+    reset_create_fields_caches,
+):
+    """Caching must not change what the merge produces."""
+    agents = _make_client().get("/public/agents/fields").json()
+
+    inheriting = [
+        agent
+        for agent in agents
+        if any(field.get("include_in_litellm_params") for field in (agent.get("credential_fields") or []))
+    ]
+    assert inheriting, "expected at least one agent to inherit provider credential fields"
+    assert all("inherit_credentials_from_provider" not in agent for agent in agents)
+
+
+def test_provider_fields_cache_is_shared_with_agent_fields(reset_create_fields_caches):
+    """Warming /public/providers/fields means /public/agents/fields re-reads only its own file."""
+    client = _make_client()
+    client.get("/public/providers/fields")
+
+    with _bundled_file_opens() as opened:
+        response = client.get("/public/agents/fields")
+
+    assert response.status_code == 200
+    assert opened.count("provider_create_fields.json") == 0
+    assert opened.count("agent_create_fields.json") == 1

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -11044,6 +11044,9 @@ export interface paths {
          *
          *     If an agent has `inherit_credentials_from_provider`, the provider's credential
          *     fields are automatically appended to the agent's credential_fields.
+         *
+         *     Reads from the bundled local files. Result is cached in-process for the
+         *     lifetime of the server process.
          */
         get: operations["get_agent_fields_public_agents_fields_get"];
         put?: never;
@@ -11202,6 +11205,9 @@ export interface paths {
         /**
          * Get Provider Fields
          * @description Return provider metadata required by the dashboard create-model flow.
+         *
+         *     Reads from the bundled local file. Result is cached in-process for the
+         *     lifetime of the server process.
          */
         get: operations["get_provider_fields_public_providers_fields_get"];
         put?: never;

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -12179,6 +12179,9 @@ export interface paths {
          *
          *     If an agent has `inherit_credentials_from_provider`, the provider's credential
          *     fields are automatically appended to the agent's credential_fields.
+         *
+         *     Reads from the bundled local files. Result is cached in-process for the
+         *     lifetime of the server process.
          */
         get: operations["get_agent_fields_public_agents_fields_get"];
         put?: never;
@@ -12382,6 +12385,9 @@ export interface paths {
         /**
          * Get Provider Fields
          * @description Return provider metadata required by the dashboard create-model flow.
+         *
+         *     Reads from the bundled local file. Result is cached in-process for the
+         *     lifetime of the server process.
          */
         get: operations["get_provider_fields_public_providers_fields_get"];
         put?: never;
@@ -16781,7 +16787,6 @@ export interface paths {
          *     - permissions: Optional[dict] - [Not Implemented Yet] User-specific permissions, eg. turning off pii masking.
          *     - metadata: Optional[dict] - Metadata for user, store information for user. Example metadata = {"team": "core-infra", "app": "app2", "email": "ishaan@berri.ai" }
          *     - max_parallel_requests: Optional[int] - Rate limit a user based on the number of parallel requests. Raises 429 error, if user's parallel requests > x.
-         *     - soft_budget: Optional[float] - Get alerts when user crosses given budget, doesn't block requests.
          *     - model_max_budget: Optional[dict] - Model-specific max budget for user. [Docs](https://docs.litellm.ai/docs/proxy/users#add-model-specific-budgets-to-keys)
          *     - budget_fallbacks: Optional[Dict[str, List[str]]] - Per-model fallback chain tried in order when that model's own `model_max_budget` is exceeded, e.g. {"gpt-4o": ["gpt-4o-mini"]}.
          *     - model_rpm_limit: Optional[float] - Model-specific rpm limit for user. [Docs](https://docs.litellm.ai/docs/proxy/users#add-model-specific-limits-to-keys)
@@ -16887,7 +16892,6 @@ export interface paths {
          *         - permissions: Optional[dict] - [Not Implemented Yet] User-specific permissions, eg. turning off pii masking.
          *         - metadata: Optional[dict] - Metadata for user, store information for user. Example metadata = {"team": "core-infra", "app": "app2", "email": "ishaan@berri.ai" }
          *         - max_parallel_requests: Optional[int] - Rate limit a user based on the number of parallel requests. Raises 429 error, if user's parallel requests > x.
-         *         - soft_budget: Optional[float] - Get alerts when user crosses given budget, doesn't block requests.
          *         - model_max_budget: Optional[dict] - Model-specific max budget for user. [Docs](https://docs.litellm.ai/docs/proxy/users#add-model-specific-budgets-to-keys)
          *         - budget_fallbacks: Optional[Dict[str, List[str]]] - Per-model fallback chain tried in order when that model's own `model_max_budget` is exceeded, e.g. {"gpt-4o": ["gpt-4o-mini"]}.
          *         - model_rpm_limit: Optional[float] - Model-specific rpm limit for user. [Docs](https://docs.litellm.ai/docs/proxy/users#add-model-specific-limits-to-keys)


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/public/providers/fields` re-parses an 85K JSON file every request
- `/public/agents/fields` re-parses that file plus another one
- Both do it inside `async def`, blocking the event loop
- Both are unauthenticated, so anyone can trigger it

How it solves it:

- Memoize both with `lru_cache`, one read per process
- Matches what `/public/endpoints` in the same module already does
- Merge logic made pure so the cached value stays correct

## Relevant issues

None; found by following up an ASYNC230 report from `ruff --config ruff-strict.toml`

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Greptile returned 5/5

## Screenshots / Proof of Fix

Captured at commit `adb41b9` and re-verified at `c906b11c` after two rebases onto
litellm_internal_staging; the byte-identical comparison in section 1 was re-run against the
current base and still holds. Run against a live proxy started with
`uv run --no-sync python litellm/proxy/proxy_cli.py --config /tmp/proof_config.yaml --port 4000`
using a config with an empty `model_list` (both endpoints read bundled local files, so no
provider credentials or database are involved)

### 1. Responses are byte identical before and after

The whole point is that behavior must not change, so this is the important one. Same proxy,
same requests, `before` captured with `public_endpoints.py` stashed back to the base commit:

```
$ curl -s http://127.0.0.1:4000/public/providers/fields | python3 -m json.tool --sort-keys > before_providers.json
$ curl -s http://127.0.0.1:4000/public/agents/fields   | python3 -m json.tool --sort-keys > before_agents.json
# ... restart proxy with this branch applied ...
$ curl -s http://127.0.0.1:4000/public/providers/fields | python3 -m json.tool --sort-keys > after_providers.json
$ curl -s http://127.0.0.1:4000/public/agents/fields   | python3 -m json.tool --sort-keys > after_agents.json

$ diff before_providers.json after_providers.json && echo IDENTICAL
IDENTICAL
$ diff before_agents.json after_agents.json && echo IDENTICAL
IDENTICAL
```

That covers 3233 lines of provider JSON and 483 lines of agent JSON, including the 30
inherited credential fields that the agent endpoint merges in

### 2. Serial latency on the live proxy

Before, at the base commit:

```
### /public/providers/fields
call 1: http=200 total=0.003454s size=60301B
call 2: http=200 total=0.002073s size=60301B
call 3: http=200 total=0.002196s size=60301B
call 4: http=200 total=0.001914s size=60301B
call 5: http=200 total=0.002291s size=60301B

### /public/agents/fields
call 1: http=200 total=0.002245s size=13034B
call 2: http=200 total=0.001669s size=13034B
call 3: http=200 total=0.001817s size=13034B
call 4: http=200 total=0.001514s size=13034B
call 5: http=200 total=0.001848s size=13034B
```

After, on this branch:

```
### /public/providers/fields
call 1: http=200 total=0.002931s size=60301B
call 2: http=200 total=0.001656s size=60301B
call 3: http=200 total=0.001530s size=60301B
call 4: http=200 total=0.001609s size=60301B
call 5: http=200 total=0.001551s size=60301B

### /public/agents/fields
call 1: http=200 total=0.000934s size=13034B
call 2: http=200 total=0.000891s size=13034B
call 3: http=200 total=0.000936s size=13034B
call 4: http=200 total=0.000900s size=13034B
call 5: http=200 total=0.000900s size=13034B
```

### 3. The work actually removed

Timed directly against the bundled files, 200 iterations each:

```
provider_create_fields.json: 85K -> 0.396 ms per read+parse
agent_create_fields.json: 11K -> 0.049 ms per read+parse
```

So `/public/providers/fields` was spending about 0.40 ms of synchronous work per request and
`/public/agents/fields` about 0.45 ms, all of it on the event loop

I also ran a 300 request, 50 concurrency load test on both versions. The first pair of runs
looked like a 45% throughput win, but it did not reproduce across three runs each; one
baseline run beat every patched run. On this hardware the end to end difference is inside
run to run noise, so I am not claiming a throughput number. The per request work above is the
reproducible part, along with the disk read counts asserted in the new tests

## Type

🐛 Bug Fix

## Changes

`get_provider_fields` and `get_agent_fields` each rebuilt their whole response from disk on
every call. `/public/endpoints`, three functions further down the same module, already caches
its bundled file in `_cached_endpoints` and says so in its docstring, so this brings the other
two in line with the pattern already there

Caching the agent endpoint needed one real change rather than just a wrapper. The old code
mutated the dicts it had just loaded: it appended inherited provider credential fields onto
`agent["credential_fields"]` and popped `inherit_credentials_from_provider`. That is safe only
while the data is re-read on every request. Caching the raw file contents and re-running the
merge would compound the appends. So the merge is now pure: `_agent_with_inherited_credentials`
returns a new mapping per agent, `_get_agent_create_fields` caches the merged result, and the
raw file contents are never handed out or mutated

`lru_cache` on module level zero argument functions rather than module globals, because
`global` trips PLW0603, which is at its ceiling in `ruff-strict-budget.json`. It also gives the
tests a `cache_clear()` hook, the same way `router.py` clears `_cached_get_model_group_info`

Annotations use `tuple[Mapping[str, Any], ...]` rather than `List[Dict[...]]` so LIT001 stays
within its ceiling; the read only view is also the honest type here, since callers must not
mutate a cached value

Not included on purpose: this drops 3 of the 11 ASYNC230 violations and 8 basedpyright errors
in this file, but I have left `ruff-strict-budget.json` and `basedpyright-code-budget.json`
alone. Those files see 11 to 18 commits every 60 days, so ratcheting them here would almost
certainly conflict before review, and the gates only fail when a total goes over a ceiling.
Happy to add the ratchet if you would rather it ride along

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

The five new tests were validated by mutation rather than by assuming they work. Removing the
caching fails all three read count tests. Caching the raw file contents and re-running the
merge without the `pop` guard fails
`test_get_agent_fields_merge_does_not_compound_across_requests`. One mutation is deliberately
not covered: caching raw contents while keeping the `pop` produces identical output, because
the `pop` makes the merge idempotent, so there is nothing to catch
