### PR TITLE
feat(ui): deep link organization detail page via ?org= query param

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.test.tsx
@@ -2,6 +2,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render, screen } from "@testing-library/react";
 import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type OrganizationsTableComponent from "./OrganizationsTable";
+import type OrganizationInfoViewComponent from "@/components/organization/organization_view";
 
 vi.mock("@/components/vector_store_management/VectorStoreSelector", () => ({
   __esModule: true,
@@ -18,18 +20,21 @@ vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
     userRole: null,
   }),
 }));
-let capturedTableProps: any = null;
+type OrganizationsTableProps = React.ComponentProps<typeof OrganizationsTableComponent>;
+type OrganizationInfoViewProps = React.ComponentProps<typeof OrganizationInfoViewComponent>;
+
+let capturedTableProps: OrganizationsTableProps | null = null;
 vi.mock("./OrganizationsTable", () => ({
   __esModule: true,
-  default: (props: { isLoading: boolean }) => {
+  default: (props: OrganizationsTableProps) => {
     capturedTableProps = props;
     return <div data-testid="organizations-table">isLoading:{String(props.isLoading)}</div>;
   },
 }));
-const mockOrgInfoView = vi.fn();
+const mockOrgInfoView = vi.fn<(props: OrganizationInfoViewProps) => void>();
 vi.mock("@/components/organization/organization_view", () => ({
   __esModule: true,
-  default: (props: any) => {
+  default: (props: OrganizationInfoViewProps) => {
     mockOrgInfoView(props);
     return <div data-testid="organization-info-view" />;
   },
@@ -101,7 +106,7 @@ describe("OrganizationsPanel - org detail deep link (?org=)", () => {
   it("clicking an organization pushes ?org= and opens the detail view", () => {
     renderWithQueryClient(<OrganizationsPanel userRole="Admin" accessToken={null} premiumUser={true} />);
 
-    act(() => capturedTableProps.onOrganizationClick("org-deep-link"));
+    act(() => capturedTableProps?.onOrganizationClick("org-deep-link"));
 
     expect(window.location.search).toContain("org=org-deep-link");
     expect(mockOrgInfoView).toHaveBeenLastCalledWith(expect.objectContaining({ organizationId: "org-deep-link" }));
@@ -131,11 +136,25 @@ describe("OrganizationsPanel - org detail deep link (?org=)", () => {
   it("the edit action opens the detail in edit mode with ?org= set", () => {
     renderWithQueryClient(<OrganizationsPanel userRole="Admin" accessToken={null} premiumUser={true} />);
 
-    act(() => capturedTableProps.onEditClick("org-edit"));
+    act(() => capturedTableProps?.onEditClick("org-edit"));
 
     expect(window.location.search).toContain("org=org-edit");
     expect(mockOrgInfoView).toHaveBeenLastCalledWith(
       expect.objectContaining({ organizationId: "org-edit", editOrg: true }),
+    );
+  });
+
+  it("a plain row click after leaving an edit view via browser history does not reopen in edit mode", () => {
+    renderWithQueryClient(<OrganizationsPanel userRole="Admin" accessToken={null} premiumUser={true} />);
+
+    act(() => capturedTableProps?.onEditClick("org-edit"));
+    expect(mockOrgInfoView).toHaveBeenLastCalledWith(expect.objectContaining({ editOrg: true }));
+
+    act(() => window.history.pushState(null, "", "/organizations/"));
+    act(() => capturedTableProps?.onOrganizationClick("org-plain"));
+
+    expect(mockOrgInfoView).toHaveBeenLastCalledWith(
+      expect.objectContaining({ organizationId: "org-plain", editOrg: false }),
     );
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/components/vector_store_management/VectorStoreSelector", () => ({
   __esModule: true,
@@ -18,12 +18,47 @@ vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
     userRole: null,
   }),
 }));
+let capturedTableProps: any = null;
 vi.mock("./OrganizationsTable", () => ({
   __esModule: true,
-  default: (props: { isLoading: boolean }) => (
-    <div data-testid="organizations-table">isLoading:{String(props.isLoading)}</div>
-  ),
+  default: (props: { isLoading: boolean }) => {
+    capturedTableProps = props;
+    return <div data-testid="organizations-table">isLoading:{String(props.isLoading)}</div>;
+  },
 }));
+const mockOrgInfoView = vi.fn();
+vi.mock("@/components/organization/organization_view", () => ({
+  __esModule: true,
+  default: (props: any) => {
+    mockOrgInfoView(props);
+    return <div data-testid="organization-info-view" />;
+  },
+}));
+
+// The selected org is URL-derived (?org=) via useOrgDetailRouting. Next's real useSearchParams
+// re-renders subscribers on history.pushState/replaceState; mirror that so URL changes propagate.
+vi.mock("next/navigation", async () => {
+  const { useSyncExternalStore } = await import("react");
+  const LOCATION_CHANGE_EVENT = "test-locationchange";
+  for (const method of ["pushState", "replaceState"] as const) {
+    const original = window.history[method].bind(window.history);
+    window.history[method] = (...args: Parameters<History["pushState"]>) => {
+      original(...args);
+      window.dispatchEvent(new Event(LOCATION_CHANGE_EVENT));
+    };
+  }
+  const subscribe = (onChange: () => void) => {
+    window.addEventListener(LOCATION_CHANGE_EVENT, onChange);
+    window.addEventListener("popstate", onChange);
+    return () => {
+      window.removeEventListener(LOCATION_CHANGE_EVENT, onChange);
+      window.removeEventListener("popstate", onChange);
+    };
+  };
+  return {
+    useSearchParams: () => new URLSearchParams(useSyncExternalStore(subscribe, () => window.location.search)),
+  };
+});
 
 import OrganizationsPanel from "./OrganizationsPanel";
 
@@ -33,6 +68,12 @@ const renderWithQueryClient = (ui: React.ReactElement) => {
   });
   return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
 };
+
+beforeEach(() => {
+  capturedTableProps = null;
+  mockOrgInfoView.mockClear();
+  window.history.replaceState(null, "", "/organizations/");
+});
 
 describe("OrganizationsPanel", () => {
   it("gates non-premium users behind the enterprise notice", () => {
@@ -53,5 +94,48 @@ describe("OrganizationsPanel", () => {
 
     // A disabled React Query keeps isPending true forever; feeding isLoading avoids a stuck skeleton.
     expect(screen.getByTestId("organizations-table")).toHaveTextContent("isLoading:false");
+  });
+});
+
+describe("OrganizationsPanel - org detail deep link (?org=)", () => {
+  it("clicking an organization pushes ?org= and opens the detail view", () => {
+    renderWithQueryClient(<OrganizationsPanel userRole="Admin" accessToken={null} premiumUser={true} />);
+
+    act(() => capturedTableProps.onOrganizationClick("org-deep-link"));
+
+    expect(window.location.search).toContain("org=org-deep-link");
+    expect(mockOrgInfoView).toHaveBeenLastCalledWith(expect.objectContaining({ organizationId: "org-deep-link" }));
+  });
+
+  it("opens the org detail directly from a ?org= deep link", () => {
+    window.history.replaceState(null, "", "/organizations/?org=org-from-url");
+    renderWithQueryClient(<OrganizationsPanel userRole="Admin" accessToken={null} premiumUser={true} />);
+
+    expect(mockOrgInfoView).toHaveBeenLastCalledWith(
+      expect.objectContaining({ organizationId: "org-from-url", editOrg: false }),
+    );
+    expect(screen.queryByTestId("organizations-table")).not.toBeInTheDocument();
+  });
+
+  it("closing the org detail removes ?org= and returns to the list", () => {
+    window.history.replaceState(null, "", "/organizations/?org=org-from-url");
+    renderWithQueryClient(<OrganizationsPanel userRole="Admin" accessToken={null} premiumUser={true} />);
+
+    act(() => mockOrgInfoView.mock.calls.at(-1)?.[0].onClose());
+
+    expect(window.location.search).not.toContain("org=");
+    expect(screen.queryByTestId("organization-info-view")).not.toBeInTheDocument();
+    expect(screen.getByTestId("organizations-table")).toBeInTheDocument();
+  });
+
+  it("the edit action opens the detail in edit mode with ?org= set", () => {
+    renderWithQueryClient(<OrganizationsPanel userRole="Admin" accessToken={null} premiumUser={true} />);
+
+    act(() => capturedTableProps.onEditClick("org-edit"));
+
+    expect(window.location.search).toContain("org=org-edit");
+    expect(mockOrgInfoView).toHaveBeenLastCalledWith(
+      expect.objectContaining({ organizationId: "org-edit", editOrg: true }),
+    );
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
@@ -1,5 +1,6 @@
 import { organizationKeys, useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 import { useUserModels } from "@/app/(dashboard)/hooks/models/useModels";
+import { useOrgDetailRouting } from "@/app/(dashboard)/organizations/detailNavigation";
 import OrganizationFilters, { FilterState } from "@/app/(dashboard)/organizations/OrganizationFilters";
 import { useQueryClient } from "@tanstack/react-query";
 import React, { useState } from "react";
@@ -19,7 +20,7 @@ interface OrganizationsPanelProps {
 }
 
 const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, accessToken, premiumUser }) => {
-  const [selectedOrgId, setSelectedOrgId] = useState<string | null>(null);
+  const { orgId: selectedOrgId, openOrg, close: closeOrgDetail } = useOrgDetailRouting();
   const [editOrg, setEditOrg] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [orgToDelete, setOrgToDelete] = useState<string | null>(null);
@@ -108,7 +109,7 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
         <OrganizationInfoView
           organizationId={selectedOrgId}
           onClose={() => {
-            setSelectedOrgId(null);
+            closeOrgDetail();
             setEditOrg(false);
           }}
           accessToken={accessToken}
@@ -132,9 +133,9 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
             isLoading={isLoading}
             userRole={userRole}
             searchActive={searchActive}
-            onOrganizationClick={setSelectedOrgId}
+            onOrganizationClick={openOrg}
             onEditClick={(organizationId) => {
-              setSelectedOrgId(organizationId);
+              openOrg(organizationId);
               setEditOrg(true);
             }}
             onDeleteClick={handleDelete}

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
@@ -133,7 +133,10 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
             isLoading={isLoading}
             userRole={userRole}
             searchActive={searchActive}
-            onOrganizationClick={openOrg}
+            onOrganizationClick={(organizationId) => {
+              setEditOrg(false);
+              openOrg(organizationId);
+            }}
             onEditClick={(organizationId) => {
               openOrg(organizationId);
               setEditOrg(true);

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/detailNavigation.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/detailNavigation.test.ts
@@ -1,0 +1,53 @@
+/* @vitest-environment jsdom */
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useOrgDetailRouting } from "./detailNavigation";
+
+vi.mock("next/navigation", () => ({ useSearchParams: () => new URLSearchParams(window.location.search) }));
+
+describe("useOrgDetailRouting", () => {
+  beforeEach(() => {
+    window.history.pushState(null, "", "/organizations/");
+  });
+
+  it("openOrg sets ?org= via history.pushState (no full navigation)", () => {
+    const spy = vi.spyOn(window.history, "pushState");
+    const { result } = renderHook(() => useOrgDetailRouting());
+    act(() => result.current.openOrg("org-abc123"));
+    expect(spy).toHaveBeenCalledWith(null, "", expect.stringContaining("org=org-abc123"));
+    spy.mockRestore();
+  });
+
+  it("openOrg preserves unrelated query params", () => {
+    window.history.pushState(null, "", "/organizations/?foo=bar");
+    const spy = vi.spyOn(window.history, "pushState");
+    const { result } = renderHook(() => useOrgDetailRouting());
+    act(() => result.current.openOrg("org-abc123"));
+    const url = spy.mock.calls.at(-1)?.[2] as string;
+    expect(url).toContain("foo=bar");
+    expect(url).toContain("org=org-abc123");
+    spy.mockRestore();
+  });
+
+  it("close removes only the org param", () => {
+    window.history.pushState(null, "", "/organizations/?foo=bar&org=org-abc123");
+    const spy = vi.spyOn(window.history, "pushState");
+    const { result } = renderHook(() => useOrgDetailRouting());
+    act(() => result.current.close());
+    const url = spy.mock.calls.at(-1)?.[2] as string;
+    expect(url).toContain("foo=bar");
+    expect(url).not.toContain("org=");
+    spy.mockRestore();
+  });
+
+  it("exposes orgId from ?org=", () => {
+    window.history.pushState(null, "", "/organizations/?org=org-abc123");
+    const { result } = renderHook(() => useOrgDetailRouting());
+    expect(result.current.orgId).toBe("org-abc123");
+  });
+
+  it("orgId is null when no org param is present", () => {
+    const { result } = renderHook(() => useOrgDetailRouting());
+    expect(result.current.orgId).toBeNull();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/detailNavigation.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/detailNavigation.ts
@@ -1,0 +1,32 @@
+import { useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+import { navigateWithParams } from "../navigateWithParams";
+
+export interface OrgDetailRouting {
+  orgId: string | null;
+  openOrg: (id: string) => void;
+  close: () => void;
+}
+
+export function useOrgDetailRouting(): OrgDetailRouting {
+  const searchParams = useSearchParams();
+
+  const openOrg = useCallback((id: string) => {
+    navigateWithParams((params) => {
+      params.set("org", id);
+    });
+  }, []);
+
+  const close = useCallback(() => {
+    navigateWithParams((params) => {
+      params.delete("org");
+    });
+  }, []);
+
+  return {
+    orgId: searchParams?.get("org") ?? null,
+    openOrg,
+    close,
+  };
+}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Organization detail pages have no URL; selection is in-memory React state
- Deep linking, bookmarking, or linking to an org from another page is impossible
- Browser back exits the organizations page instead of closing the detail view

How it solves it:

- /ui/organizations?org=<organization_id> now opens that org's detail page
- Clicking an org (or its edit action) pushes ?org= to the URL; back or close removes it

## Relevant issues

## Linear ticket

Refs LIT-4740

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at commit e80c899cce against a live proxy (dev_config, real dev DB) and the dashboard dev server; the dark bar at the top of each screenshot displays the live address-bar URL

The organizations list; clicking a row's organization ID opens its detail page

![organizations list](https://raw.githubusercontent.com/BerriAI/litellm/assets_lit4740_deep_link_screenshots/orgs-list.png)

After the click the URL carries `?org=<organization_id>`; loading this exact URL in a fresh tab opens the same detail page directly, and both the browser back button and "Back to Organizations" return to the list and drop the param

![organization detail deep link](https://raw.githubusercontent.com/BerriAI/litellm/assets_lit4740_deep_link_screenshots/org-detail-deeplink.png)

## Type

🆕 New Feature

## Changes

`app/(dashboard)/organizations/detailNavigation.ts` adds `useOrgDetailRouting`, reading and writing the `?org=` query param via `navigateWithParams`, the same pattern as the existing `?key=` (api-keys), `?model=` (models), `?log_id=` (logs), and `?team=` (teams, #35112) deep-link hooks

`OrganizationsPanel.tsx` derives the open organization from that hook instead of `useState`, so row clicks and the edit action push the param, the back button and the close handler clear it, and a fresh page load with `?org=` opens the detail view directly. A plain row click also resets the edit flag: browser Back leaves the detail view without running onClose, so a stale editOrg would otherwise reopen the next organization on its Settings tab (flagged by Greptile, fixed in 57e6b783aa)

Tests: hook unit tests for the param round-trip plus panel-level regression tests (row click pushes the param and opens the detail, deep link opens it directly, close removes the param and restores the list, edit action opens in edit mode, and a row click after history navigation away from an edit view opens in view mode). The panel tests drive the real `OrganizationsPanel` with the table and detail view stubbed and typed from the real components' props, using a `useSearchParams` mock that re-renders on pushState the way Next's real hook does

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
