### PR TITLE
feat(ui): link organization teams to their team detail pages

### DIFF
--- a/ui/litellm-dashboard/src/components/organization/organization_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.test.tsx
@@ -6,7 +6,14 @@ import { renderWithProviders } from "../../../tests/test-utils";
 import OrganizationInfoView from "./organization_view";
 import { useOrganization } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 
-// Mock networking calls used by the component's mutation handlers
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/organizations",
+  useSearchParams: () => new URLSearchParams(window.location.search),
+}));
+
+// Mock networking calls used by the component's mutation handlers. entityLinks -> migratedPages
+// imports serverRootPath from the same module, so the mock must export it too.
 vi.mock("../networking", () => {
   return {
     __esModule: true,
@@ -14,6 +21,7 @@ vi.mock("../networking", () => {
     organizationMemberUpdateCall: vi.fn(),
     organizationMemberDeleteCall: vi.fn(),
     organizationUpdateCall: vi.fn(),
+    serverRootPath: "",
   };
 });
 
@@ -204,6 +212,58 @@ test("should display team ID as fallback when alias is not found", async () => {
   await waitFor(() => {
     expect(screen.getByText("team_999")).toBeInTheDocument();
   });
+});
+
+test("links each team badge to that team's detail page", async () => {
+  const orgWithTeams = {
+    ...mockOrg,
+    teams: [{ team_id: "team_123" }, { team_id: "team_456" }],
+  };
+  mockUseOrganization.mockReturnValue({ data: orgWithTeams, isLoading: false } as any);
+
+  renderWithProviders(
+    <OrganizationInfoView
+      organizationId="org_123"
+      onClose={() => {}}
+      accessToken="test-token"
+      is_org_admin={false}
+      is_proxy_admin={false}
+      userModels={[]}
+      editOrg={false}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByRole("link", { name: "Engineering Team" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/teams?team=team_123"),
+    );
+    expect(screen.getByRole("link", { name: "Marketing Team" })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/teams?team=team_456"),
+    );
+  });
+});
+
+test("model badges stay non-clickable", async () => {
+  mockUseOrganization.mockReturnValue({ data: mockOrg, isLoading: false } as any);
+
+  renderWithProviders(
+    <OrganizationInfoView
+      organizationId="org_123"
+      onClose={() => {}}
+      accessToken="test-token"
+      is_org_admin={false}
+      is_proxy_admin={false}
+      userModels={[]}
+      editOrg={false}
+    />,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByText("gpt-4o-mini")).toBeInTheDocument();
+  });
+  expect(screen.queryByRole("link", { name: "gpt-4o-mini" })).not.toBeInTheDocument();
 });
 
 test("should keep unsaved settings edits when switching tabs and back", async () => {

--- a/ui/litellm-dashboard/src/components/organization/organization_view.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.tsx
@@ -4,7 +4,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useVisitedTabs } from "@/hooks/useVisitedTabs";
 import { MoneyCell } from "@/components/shared/table_cells";
 import CopyButton from "@/components/shared/CopyButton";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -222,13 +221,9 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
                 <p className="text-sm text-muted-foreground">Models</p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {orgData.models.length === 0 ? (
-                    <Badge variant="secondary">All proxy models</Badge>
+                    <BadgeLink>All proxy models</BadgeLink>
                   ) : (
-                    orgData.models.map((model, index) => (
-                      <Badge key={index} variant="secondary">
-                        {model}
-                      </Badge>
-                    ))
+                    orgData.models.map((model, index) => <BadgeLink key={index}>{model}</BadgeLink>)
                   )}
                 </div>
               </CardContent>
@@ -311,9 +306,7 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
                     <p className="font-medium text-foreground">Models</p>
                     <div className="mt-1 flex flex-wrap gap-2">
                       {orgData.models.map((model, index) => (
-                        <Badge key={index} variant="secondary">
-                          {model}
-                        </Badge>
+                        <BadgeLink key={index}>{model}</BadgeLink>
                       ))}
                     </div>
                   </div>

--- a/ui/litellm-dashboard/src/components/organization/organization_view.tsx
+++ b/ui/litellm-dashboard/src/components/organization/organization_view.tsx
@@ -9,7 +9,9 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
+import { teamDetailHref } from "@/utils/entityLinks";
 import { createTeamAliasMap } from "@/utils/teamUtils";
+import { BadgeLink } from "@/components/shared/BadgeLink";
 import type { ColumnsType } from "antd/es/table";
 import { ArrowLeft } from "lucide-react";
 import React, { useMemo, useState } from "react";
@@ -237,9 +239,9 @@ const OrganizationInfoView: React.FC<OrganizationInfoProps> = ({
                 <p className="text-sm text-muted-foreground">Teams</p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {orgData.teams?.map((team, index) => (
-                    <Badge key={index} variant="secondary">
+                    <BadgeLink key={index} href={teamDetailHref(team.team_id)}>
                       {teamAliasMap[team.team_id] || team.team_id}
-                    </Badge>
+                    </BadgeLink>
                   ))}
                 </div>
               </CardContent>

--- a/ui/litellm-dashboard/src/components/shared/BadgeLink.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/BadgeLink.test.tsx
@@ -1,0 +1,36 @@
+/* @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BadgeLink } from "./BadgeLink";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push }) }));
+
+describe("BadgeLink", () => {
+  beforeEach(() => {
+    push.mockClear();
+  });
+
+  it("renders an anchor pointing at the target href", () => {
+    render(<BadgeLink href="/ui/teams?team=t1">My Team</BadgeLink>);
+    expect(screen.getByRole("link", { name: "My Team" })).toHaveAttribute("href", "/ui/teams?team=t1");
+  });
+
+  it("navigates client-side on plain click", async () => {
+    const user = userEvent.setup();
+    render(<BadgeLink href="/ui/teams?team=t1">My Team</BadgeLink>);
+    await user.click(screen.getByRole("link", { name: "My Team" }));
+    expect(push).toHaveBeenCalledWith("/ui/teams?team=t1");
+  });
+
+  it("leaves modified clicks to the browser so new-tab shortcuts keep working", async () => {
+    const user = userEvent.setup();
+    render(<BadgeLink href="/ui/teams?team=t1">My Team</BadgeLink>);
+    await user.keyboard("{Meta>}");
+    await user.click(screen.getByRole("link", { name: "My Team" }));
+    await user.keyboard("{/Meta}");
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/ui/litellm-dashboard/src/components/shared/BadgeLink.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/BadgeLink.test.tsx
@@ -33,4 +33,10 @@ describe("BadgeLink", () => {
     await user.keyboard("{/Meta}");
     expect(push).not.toHaveBeenCalled();
   });
+
+  it("renders a plain same-sized badge when no href is given", () => {
+    render(<BadgeLink>all-proxy-models</BadgeLink>);
+    expect(screen.getByText("all-proxy-models")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "all-proxy-models" })).not.toBeInTheDocument();
+  });
 });

--- a/ui/litellm-dashboard/src/components/shared/BadgeLink.tsx
+++ b/ui/litellm-dashboard/src/components/shared/BadgeLink.tsx
@@ -6,8 +6,10 @@ import * as React from "react";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/cva.config";
 
+const ENTITY_BADGE_SIZE = "px-2.5 py-1 text-sm";
+
 interface BadgeLinkProps {
-  href: string;
+  href?: string;
   variant?: React.ComponentProps<typeof Badge>["variant"];
   className?: string;
   children: React.ReactNode;
@@ -15,6 +17,14 @@ interface BadgeLinkProps {
 
 export function BadgeLink({ href, variant = "secondary", className, children }: BadgeLinkProps) {
   const router = useRouter();
+
+  if (!href) {
+    return (
+      <Badge variant={variant} className={cn(ENTITY_BADGE_SIZE, className)}>
+        {children}
+      </Badge>
+    );
+  }
 
   const handleClick = (e: React.MouseEvent) => {
     const hasModifierKey = e.metaKey || e.ctrlKey || e.shiftKey;
@@ -27,7 +37,7 @@ export function BadgeLink({ href, variant = "secondary", className, children }: 
   return (
     <Badge
       variant={variant}
-      className={cn("cursor-pointer px-2.5 py-1 text-sm", className)}
+      className={cn("cursor-pointer", ENTITY_BADGE_SIZE, className)}
       render={<a href={href} onClick={handleClick} />}
     >
       {children}

--- a/ui/litellm-dashboard/src/components/shared/BadgeLink.tsx
+++ b/ui/litellm-dashboard/src/components/shared/BadgeLink.tsx
@@ -17,13 +17,19 @@ export function BadgeLink({ href, variant = "secondary", className, children }: 
   const router = useRouter();
 
   const handleClick = (e: React.MouseEvent) => {
-    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return;
+    const hasModifierKey = e.metaKey || e.ctrlKey || e.shiftKey;
+    const isNativeNewTabClick = hasModifierKey || e.button === 1;
+    if (isNativeNewTabClick) return;
     e.preventDefault();
     router.push(href);
   };
 
   return (
-    <Badge variant={variant} className={cn("cursor-pointer", className)} render={<a href={href} onClick={handleClick} />}>
+    <Badge
+      variant={variant}
+      className={cn("cursor-pointer px-2.5 py-1 text-sm", className)}
+      render={<a href={href} onClick={handleClick} />}
+    >
       {children}
     </Badge>
   );

--- a/ui/litellm-dashboard/src/components/shared/BadgeLink.tsx
+++ b/ui/litellm-dashboard/src/components/shared/BadgeLink.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import * as React from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/cva.config";
+
+interface BadgeLinkProps {
+  href: string;
+  variant?: React.ComponentProps<typeof Badge>["variant"];
+  className?: string;
+  children: React.ReactNode;
+}
+
+export function BadgeLink({ href, variant = "secondary", className, children }: BadgeLinkProps) {
+  const router = useRouter();
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.button === 1) return;
+    e.preventDefault();
+    router.push(href);
+  };
+
+  return (
+    <Badge variant={variant} className={cn("cursor-pointer", className)} render={<a href={href} onClick={handleClick} />}>
+      {children}
+    </Badge>
+  );
+}

--- a/ui/litellm-dashboard/src/utils/entityLinks.ts
+++ b/ui/litellm-dashboard/src/utils/entityLinks.ts
@@ -1,0 +1,5 @@
+import { migratedHref } from "@/utils/migratedPages";
+
+export function teamDetailHref(teamId: string): string {
+  return `${migratedHref("teams")}?team=${encodeURIComponent(teamId)}`;
+}


### PR DESCRIPTION
## TLDR

Problem this solves:

- An org's teams render as plain badges on the org info page
- Walking org to team means copying an id and finding it by hand

How it solves it:

- Org detail team badges link to /teams?team=<team_id> (opens the team directly since #35112)
- Adds shared BadgeLink + teamDetailHref for future entity links

## Relevant issues

## Linear ticket

Refs LIT-4740

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured against a live proxy and the dashboard dev server; the dark bar at the top of each screenshot displays the live address-bar URL

Before (litellm_internal_staging): the org info page renders teams and models as small inert badges

![before: plain badges](https://raw.githubusercontent.com/BerriAI/litellm/assets_lit4740_deep_link_screenshots/org-detail-before.png)

After (cc77d2cc3a): each Teams badge is a real link (pointer cursor, hover shade, cmd-click opens a new tab) and all badges are slightly larger; model badges share the same component and size but stay non-clickable

![after: linked team badges](https://raw.githubusercontent.com/BerriAI/litellm/assets_lit4740_deep_link_screenshots/org-detail-after.png)

Clicking the qa-lit4688-team badge lands directly on that team's detail page at /teams?team=<team_id>; browser Back returns to the org

![org to team walk](https://raw.githubusercontent.com/BerriAI/litellm/assets_lit4740_deep_link_screenshots/org-to-team-walk.png)

## Type

🆕 New Feature

## Changes

Scope note: an earlier revision of this PR also linked the org's model badges to the models page. That half depends on #35119 (`?model_group=` filter) which is parked for now, so it was dropped from this PR; the branch was rebased and force-pushed to contain only the org-to-team walk. The model links will return as their own PR once #35119 lands

`utils/entityLinks.ts` adds `teamDetailHref`, building on `migratedHref` so links work in dev and under the /ui mount in production

`components/shared/BadgeLink.tsx` is a Badge rendered as a real anchor with modifier-aware onClick doing client-side `router.push` (the same pattern the left nav uses), so plain clicks stay in-app while cmd/ctrl/shift-click and middle-click keep native new-tab behavior. It renders slightly larger than a default badge; when no href is given it renders the same enlarged badge as a plain span, which the org page's model badges use so both sections share one component and size

`organization_view.tsx` renders each team badge as a BadgeLink to that team's detail page and model badges as href-less BadgeLinks

Tests: BadgeLink unit tests (href rendering, client-side push on plain click, native behavior preserved on modified click, plain-span rendering without an href) and organization_view tests asserting each team badge links to its team page and model badges stay non-clickable

CI note: the required lint job fails on current litellm_internal_staging itself (duplicate Mapping import in router.py, ruff F811); #35122 fixes that separately since it is unrelated to this change

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
