### PR TITLE
fix(router): drop duplicate Mapping import that fails ruff F811

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -31,7 +31,6 @@ from typing import (
     Generator,
     List,
     Literal,
-    Mapping,
     Optional,
     Set,
     Tuple,


### PR DESCRIPTION
## TLDR

Problem this solves:

- litellm_internal_staging fails the required lint check on every open PR
- router.py imports Mapping from both collections.abc and typing (ruff F811)

How it solves it:

- Drop the typing import; keep the collections.abc one

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

On litellm_internal_staging:

```
$ ruff check litellm/router.py
router.py:34:5: F811 Redefinition of unused `Mapping` from line 22
Found 1 error.
```

With this change:

```
$ ruff check litellm/router.py
All checks passed!
```

No test additions; the change deletes a duplicate import line and `Mapping[...]` annotations resolve to the identical collections.abc class the module already imported first

## Type

🧹 Refactoring

## Changes

Removes `Mapping` from the `typing` import block in `litellm/router.py`; the module already imports it from `collections.abc` two lines above, and ruff F811 fails the lint job for the redefinition. Every open PR based on current staging inherits this failure, so landing this unblocks their required lint checks

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
