### PR TITLE
fix(guardrails): run bedrock guardrail on MCP tool calls in during_mcp_call mode

### DIFF
--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -1182,6 +1182,7 @@ class CustomGuardrail(CustomLogger):
             call_type == CallTypes.completion.value
             or call_type == CallTypes.acompletion.value
             or call_type == CallTypes.anthropic_messages.value
+            or call_type == CallTypes.call_mcp_tool.value
         ):
             return data.get("messages")
 

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -1634,6 +1634,8 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
         )
 
         event_type: GuardrailEventHooks = GuardrailEventHooks.during_call
+        if call_type == CallTypes.call_mcp_tool.value:
+            event_type = GuardrailEventHooks.during_mcp_call
         if self.should_run_guardrail(data=data, event_type=event_type) is not True:
             return
 
@@ -1666,7 +1668,7 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             source="INPUT",
             messages=filtered_messages,
             request_data=data,
-            logging_event_type=GuardrailEventHooks.during_call,
+            logging_event_type=event_type,
         )
         #########################################################
 

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_bedrock_guardrails.py
@@ -21,7 +21,7 @@ from litellm.proxy.guardrails.guardrail_hooks.bedrock_guardrails import (
 )
 from litellm.proxy.utils import ProxyLogging
 from litellm.types.guardrails import GuardrailEventHooks
-from litellm.types.utils import ModelResponse
+from litellm.types.utils import CallTypes, ModelResponse
 
 
 @pytest.mark.asyncio
@@ -3614,3 +3614,59 @@ class TestBedrockIncrementalFlagInteractions:
             )
             scanned = [m["content"] for m in mock_api.call_args.kwargs["messages"]]
             assert scanned == ["q1"], "latest-role selection must exclude the system prompt"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mode, call_type, should_scan",
+    [
+        ("during_mcp_call", "call_mcp_tool", True),
+        ("during_call", "completion", True),
+        ("during_mcp_call", "completion", False),
+        ("during_call", "call_mcp_tool", False),
+    ],
+)
+async def test_moderation_hook_honors_the_mcp_event_type(mode, call_type, should_scan):
+    """A guardrail configured mode: during_mcp_call must actually scan MCP tool calls.
+
+    ProxyLogging.during_call_hook remaps call_mcp_tool to during_mcp_call before
+    dispatching, so re-checking during_call here would reject the very requests the
+    guardrail was configured for and let the tool call through unscanned.
+    """
+    guardrail = BedrockGuardrail(
+        guardrail_name="bedrock-mcp",
+        guardrailIdentifier="gid",
+        guardrailVersion="1",
+        event_hook=mode,
+        default_on=True,
+    )
+    data = {
+        "messages": [{"role": "user", "content": "scan me"}],
+        "mcp_tool_name": "search",
+        "mcp_arguments": {"query": "scan me"},
+    }
+
+    with patch.object(guardrail, "make_bedrock_api_request", new_callable=AsyncMock) as mock_api:
+        mock_api.return_value = MagicMock(
+            action="NONE", output=[], outputs=[], assessments=[]
+        )
+        await guardrail.async_moderation_hook(
+            data=data,
+            user_api_key_dict=UserAPIKeyAuth(api_key="sk-test", user_id="u"),
+            call_type=call_type,
+        )
+
+    assert (mock_api.call_count == 1) is should_scan, (
+        f"mode={mode} call_type={call_type}: expected scan={should_scan}, "
+        f"bedrock api called {mock_api.call_count} times"
+    )
+    if should_scan:
+        expected_event = (
+            GuardrailEventHooks.during_mcp_call
+            if call_type == CallTypes.call_mcp_tool.value
+            else GuardrailEventHooks.during_call
+        )
+        assert mock_api.call_args.kwargs["logging_event_type"] == expected_event, (
+            "the scan must be logged under the event it actually ran for, so guardrail logs, "
+            "OTel spans, and Langfuse metadata do not misclassify MCP enforcement as an LLM call"
+        )


### PR DESCRIPTION
## TLDR

Problem this solves:

- bedrock guardrail set to `during_mcp_call` never ran
- it re-checked `during_call` after the proxy remapped
- MCP tool call proceeded unscanned, silently

How it solves it:

- remap `call_mcp_tool` the way model_armor already does
- teach the shared message helper about MCP tool calls
- regression test over all four mode/call-type pairs

## Relevant issues

## Linear ticket

Resolves LIT-4946

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The defect is a disagreement between two gates in the same request, so the proof is the gate itself. Driving the real predicate against a guardrail configured exactly as an operator would (`mode: during_mcp_call`) on staging `440b1bcf65`:

```
configured mode: during_mcp_call
  should_run(during_mcp_call) = True     <- what ProxyLogging.during_call_hook asks
  should_run(during_call)     = False    <- what bedrock re-checks internally
```

The first check dispatches the guardrail, the second one throws it away, and nothing is logged as skipped.

End to end through `BedrockGuardrail.async_moderation_hook` with the bedrock API stubbed so the assertion is purely "did the guardrail scan or not", across every combination that matters:

```
mode=during_mcp_call call_type=call_mcp_tool  -> scanned: False   (before)  /  True  (after)
mode=during_call     call_type=completion     -> scanned: True    (before)  /  True  (after)
mode=during_mcp_call call_type=completion     -> scanned: False   (before)  /  False (after)
mode=during_call     call_type=call_mcp_tool  -> scanned: True    (before)  /  False (after)
```

The last row is the other half of the fix: before, a guardrail scoped to LLM traffic only was also scanning MCP tool calls, because the hard-coded `during_call` matched regardless of what the request actually was.

## Type

🐛 Bug Fix

## Changes

`ProxyLogging.during_call_hook` remaps the event type for MCP tool calls before dispatching, and because `BedrockGuardrail` sets `use_native_during_call_hook = True` the proxy calls bedrock's own `async_moderation_hook` rather than the unified wrapper. That method opened by hard-coding `event_type = GuardrailEventHooks.during_call` and re-running `should_run_guardrail`, with no `call_mcp_tool` branch, so the two gates disagreed in both directions: a guardrail configured for MCP was dropped, and a guardrail configured for LLM traffic was applied to MCP. `model_armor` and `noma` already do this remap correctly and are the reference.

Fixing only that surfaced a second gap one layer down. With the gate passing, the hook bailed immediately on `Bedrock AI: not running guardrail. No messages in data`, because `CustomGuardrail.get_guardrails_messages_for_call_type` had no `call_mcp_tool` branch and returned `None`. An MCP tool call carries its tool name and arguments as a synthetic chat message under the same `messages` key (built by `ProxyLogging._convert_mcp_to_llm_format`), so it reads out exactly like a completion. That helper is shared by every guardrail using the native hook path, so the branch fixes the same latent gap for all of them; it can only be reached by a guardrail that was configured with an MCP mode and already passed `should_run_guardrail`, so it does not widen what runs on LLM traffic.

A third site needed the same treatment: the Bedrock request passed `logging_event_type=GuardrailEventHooks.during_call` as a literal, so a scan gated on `during_mcp_call` was still reported as LLM-call enforcement in guardrail logs, OTel spans, and Langfuse metadata. It now passes the remapped `event_type`.

The regression test is parametrized over all four mode/call-type pairs and asserts on whether the bedrock API was actually called, which is the only observable that distinguishes "ran" from "silently skipped". All three fix sites are independently load-bearing: reverting the remap alone fails two of the four cases, and reverting either the message branch or the logging label alone fails one, so none is dead code riding along.

Worth flagging: a deployment that configured bedrock with `during_mcp_call` has been running with no MCP scanning at all, so this turns enforcement on for them for the first time. A deployment that configured `during_call` and relied on the accident of MCP traffic being scanned will stop seeing that; `during_mcp_call` (or both) is the correct configuration.

2790 tests across `tests/test_litellm/proxy/guardrails/`, `tests/test_litellm/integrations/test_custom_guardrail.py`, and `tests/mcp_tests/test_mcp_guardrails.py` pass.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
