### PR TITLE
fix(otel): label retrieval and agent metrics correctly and emit gen_ai.provider.name

### DIFF
--- a/litellm/a2a_protocol/main.py
+++ b/litellm/a2a_protocol/main.py
@@ -568,6 +568,7 @@ def _build_streaming_logging_obj(
     logging_obj.custom_llm_provider = "a2a_agent"
     logging_obj.model_call_details["model"] = model
     logging_obj.model_call_details["custom_llm_provider"] = "a2a_agent"
+    logging_obj.model_call_details["call_type"] = logging_obj.call_type
     if agent_id:
         logging_obj.model_call_details["agent_id"] = agent_id
 

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -118,6 +118,7 @@ TOKEN_TYPE_ATTRIBUTE: str = "gen_ai.token.type"
 VALID_METRIC_ATTRIBUTE_NAMES: FrozenSet[str] = frozenset(
     (
         "gen_ai.operation.name",
+        "gen_ai.provider.name",
         "gen_ai.system",
         "gen_ai.request.model",
         "gen_ai.framework",

--- a/litellm/integrations/otel/model/semconv.py
+++ b/litellm/integrations/otel/model/semconv.py
@@ -341,6 +341,7 @@ _OPERATION_BY_CALL_TYPE: dict[str, GenAIOperation] = {
     "aquery": GenAIOperation.RETRIEVAL,
     "send_message": GenAIOperation.INVOKE_AGENT,
     "asend_message": GenAIOperation.INVOKE_AGENT,
+    "asend_message_streaming": GenAIOperation.INVOKE_AGENT,
     "vector_store_create": GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT,
     "avector_store_create": GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT,
     "vector_store_retrieve": GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT,

--- a/litellm/integrations/otel/model/semconv.py
+++ b/litellm/integrations/otel/model/semconv.py
@@ -6,6 +6,8 @@ without a semconv equivalent lives under the ``litellm.*`` vendor namespace.
 from enum import Enum
 from typing import Final
 
+from litellm._logging import verbose_logger
+
 
 class GenAIOperation(str, Enum):
     """Values for ``gen_ai.operation.name``."""
@@ -14,8 +16,9 @@ class GenAIOperation(str, Enum):
     TEXT_COMPLETION = "text_completion"
     EMBEDDINGS = "embeddings"
     GENERATE_CONTENT = "generate_content"
+    RETRIEVAL = "retrieval"  # vector-store search spans
     CREATE_AGENT = "create_agent"  # reserved for future agent spans
-    INVOKE_AGENT = "invoke_agent"  # reserved for future agent spans
+    INVOKE_AGENT = "invoke_agent"  # agent (A2A) message spans
     EXECUTE_TOOL = "execute_tool"  # MCP tool-call spans
 
 
@@ -49,11 +52,17 @@ class MCPMethod(str, Enum):
 
 
 class GenAI:
-    """Canonical OTel GenAI span-attribute keys."""
+    """Canonical OTel GenAI attribute keys.
+
+    ``SYSTEM`` is the one exception: the convention deprecated it in favor of
+    ``PROVIDER_NAME``, and it survives here only so already-shipped series keep
+    resolving for consumers that query it. Nothing new should use it.
+    """
 
     # request
     OPERATION_NAME: Final = "gen_ai.operation.name"
     PROVIDER_NAME: Final = "gen_ai.provider.name"
+    SYSTEM: Final = "gen_ai.system"
     REQUEST_MODEL: Final = "gen_ai.request.model"
     REQUEST_TEMPERATURE: Final = "gen_ai.request.temperature"
     REQUEST_TOP_P: Final = "gen_ai.request.top_p"
@@ -316,6 +325,10 @@ _OPERATION_BY_CALL_TYPE: dict[str, GenAIOperation] = {
     "responses": GenAIOperation.CHAT,
     "aresponses": GenAIOperation.CHAT,
     "call_mcp_tool": GenAIOperation.EXECUTE_TOOL,
+    "vector_store_search": GenAIOperation.RETRIEVAL,
+    "avector_store_search": GenAIOperation.RETRIEVAL,
+    "send_message": GenAIOperation.INVOKE_AGENT,
+    "asend_message": GenAIOperation.INVOKE_AGENT,
 }
 
 
@@ -332,7 +345,21 @@ def resolve_provider(custom_llm_provider: str | None) -> str:
 
 
 def resolve_operation(call_type: str | None) -> GenAIOperation:
-    """Map a litellm ``call_type`` to a ``gen_ai.operation.name`` value."""
+    """Map a litellm ``call_type`` to a ``gen_ai.operation.name`` value.
+
+    An unmapped call type still falls back to ``chat`` so every series keeps an
+    operation label, but it logs at debug rather than falling through silently:
+    a new call type mislabelled as ``chat`` mixes its latency and cost into
+    everyone's chat charts, which is invisible until someone reads the numbers.
+    """
     if not call_type:
         return GenAIOperation.CHAT
-    return _OPERATION_BY_CALL_TYPE.get(call_type.lower(), GenAIOperation.CHAT)
+    mapped = _OPERATION_BY_CALL_TYPE.get(call_type.lower())
+    if mapped is not None:
+        return mapped
+    verbose_logger.debug(
+        "otel: call_type %r has no gen_ai.operation.name mapping; labelling it %r. Add it to _OPERATION_BY_CALL_TYPE.",
+        call_type,
+        GenAIOperation.CHAT.value,
+    )
+    return GenAIOperation.CHAT

--- a/litellm/integrations/otel/model/semconv.py
+++ b/litellm/integrations/otel/model/semconv.py
@@ -10,16 +10,26 @@ from litellm._logging import verbose_logger
 
 
 class GenAIOperation(str, Enum):
-    """Values for ``gen_ai.operation.name``."""
+    """Values for ``gen_ai.operation.name``.
+
+    The first block is the convention's own vocabulary. The ``LITELLM_`` members
+    are vendor values for operations the convention names nothing for; its note
+    on this attribute directs instrumentation to use a system-specific name in
+    exactly that case, the same allowance :func:`resolve_provider` relies on for
+    unmapped providers. They stay under the ``litellm.`` prefix so a value the
+    convention adds later can never collide with one of ours.
+    """
 
     CHAT = "chat"
     TEXT_COMPLETION = "text_completion"
     EMBEDDINGS = "embeddings"
     GENERATE_CONTENT = "generate_content"
-    RETRIEVAL = "retrieval"  # vector-store search spans
+    RETRIEVAL = "retrieval"  # vector-store search / RAG query spans
     CREATE_AGENT = "create_agent"  # reserved for future agent spans
     INVOKE_AGENT = "invoke_agent"  # agent (A2A) message spans
     EXECUTE_TOOL = "execute_tool"  # MCP tool-call spans
+    LITELLM_VECTOR_STORE_MANAGEMENT = "litellm.vector_store_management"
+    LITELLM_VECTOR_STORE_FILE_MANAGEMENT = "litellm.vector_store_file_management"
 
 
 class GenAIProvider(str, Enum):
@@ -327,8 +337,32 @@ _OPERATION_BY_CALL_TYPE: dict[str, GenAIOperation] = {
     "call_mcp_tool": GenAIOperation.EXECUTE_TOOL,
     "vector_store_search": GenAIOperation.RETRIEVAL,
     "avector_store_search": GenAIOperation.RETRIEVAL,
+    "query": GenAIOperation.RETRIEVAL,
+    "aquery": GenAIOperation.RETRIEVAL,
     "send_message": GenAIOperation.INVOKE_AGENT,
     "asend_message": GenAIOperation.INVOKE_AGENT,
+    "vector_store_create": GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT,
+    "avector_store_create": GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT,
+    "vector_store_retrieve": GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT,
+    "avector_store_retrieve": GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT,
+    "vector_store_list": GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT,
+    "avector_store_list": GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT,
+    "vector_store_update": GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT,
+    "avector_store_update": GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT,
+    "vector_store_delete": GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT,
+    "avector_store_delete": GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT,
+    "vector_store_file_create": GenAIOperation.LITELLM_VECTOR_STORE_FILE_MANAGEMENT,
+    "avector_store_file_create": GenAIOperation.LITELLM_VECTOR_STORE_FILE_MANAGEMENT,
+    "vector_store_file_list": GenAIOperation.LITELLM_VECTOR_STORE_FILE_MANAGEMENT,
+    "avector_store_file_list": GenAIOperation.LITELLM_VECTOR_STORE_FILE_MANAGEMENT,
+    "vector_store_file_retrieve": GenAIOperation.LITELLM_VECTOR_STORE_FILE_MANAGEMENT,
+    "avector_store_file_retrieve": GenAIOperation.LITELLM_VECTOR_STORE_FILE_MANAGEMENT,
+    "vector_store_file_content": GenAIOperation.LITELLM_VECTOR_STORE_FILE_MANAGEMENT,
+    "avector_store_file_content": GenAIOperation.LITELLM_VECTOR_STORE_FILE_MANAGEMENT,
+    "vector_store_file_update": GenAIOperation.LITELLM_VECTOR_STORE_FILE_MANAGEMENT,
+    "avector_store_file_update": GenAIOperation.LITELLM_VECTOR_STORE_FILE_MANAGEMENT,
+    "vector_store_file_delete": GenAIOperation.LITELLM_VECTOR_STORE_FILE_MANAGEMENT,
+    "avector_store_file_delete": GenAIOperation.LITELLM_VECTOR_STORE_FILE_MANAGEMENT,
 }
 
 

--- a/litellm/integrations/otel/plumbing/metrics.py
+++ b/litellm/integrations/otel/plumbing/metrics.py
@@ -23,9 +23,32 @@ from litellm.integrations.opentelemetry import (
     _resolve_metric_attribute_filter,
 )
 from litellm.integrations.otel.model.metadata import time_to_first_chunk_seconds
-from litellm.integrations.otel.model.semconv import Error, Metric, resolve_operation
+from litellm.integrations.otel.model.semconv import (
+    Error,
+    GenAI,
+    Metric,
+    resolve_operation,
+    resolve_provider,
+)
 from litellm.integrations.otel.model.utils import to_seconds
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
+
+
+def _provider_attributes(custom_llm_provider: object) -> Mapping[str, str]:
+    """The provider labels for one call's metrics.
+
+    ``gen_ai.provider.name`` carries the semconv-mapped value; the deprecated
+    ``gen_ai.system`` spelling is dual-emitted with the raw litellm provider
+    string it has always carried, so a dashboard already querying it keeps
+    matching. A call with no provider gets neither label: a placeholder value
+    would mint a permanent series that no operator can act on.
+    """
+    if not isinstance(custom_llm_provider, str) or not custom_llm_provider:
+        return {}
+    return {
+        GenAI.PROVIDER_NAME: resolve_provider(custom_llm_provider),
+        GenAI.SYSTEM: custom_llm_provider,
+    }
 
 
 @dataclass(frozen=True)
@@ -98,6 +121,7 @@ ERROR_TYPE_FALLBACK: Final = "_OTHER"
 METRIC_ATTRIBUTE_CEILING: Final[frozenset[str]] = frozenset(
     (
         "gen_ai.operation.name",
+        "gen_ai.provider.name",
         "gen_ai.system",
         "gen_ai.request.model",
         "gen_ai.framework",
@@ -223,11 +247,10 @@ class GenAIMetricRecorder:
 
     def _common_attributes(self, kwargs: Mapping[str, Any]) -> dict:
         params = kwargs.get("litellm_params") or {}
-        provider = params.get("custom_llm_provider", "Unknown")
         common_attrs: dict = {
-            "gen_ai.operation.name": resolve_operation(kwargs.get("call_type")).value,
-            "gen_ai.system": provider,
-            "gen_ai.request.model": kwargs.get("model"),
+            GenAI.OPERATION_NAME: resolve_operation(kwargs.get("call_type")).value,
+            **_provider_attributes(params.get("custom_llm_provider")),
+            GenAI.REQUEST_MODEL: kwargs.get("model"),
             "gen_ai.framework": "litellm",
         }
 

--- a/tests/test_litellm/a2a_protocol/test_main.py
+++ b/tests/test_litellm/a2a_protocol/test_main.py
@@ -104,3 +104,32 @@ async def test_streaming_trace_id_prefers_logging_trace_id():
                 pass
 
     assert captured["extra_headers"]["X-LiteLLM-Trace-Id"] == "trace-from-logging"
+
+
+def test_streaming_logging_obj_carries_call_type_into_model_call_details():
+    """The streaming logging object is built by hand rather than through
+    ``update_environment_variables``, which is the only place ``call_type`` normally
+    reaches ``model_call_details``. Callbacks read the call type from there, so
+    without this the streamed turn arrives at every logger with no call type at all
+    and OTel's GenAI metrics label it ``chat`` instead of ``invoke_agent``."""
+    from a2a.compat.v0_3.types import MessageSendParams, SendStreamingMessageRequest
+
+    from litellm.a2a_protocol.main import _build_streaming_logging_obj
+
+    request = SendStreamingMessageRequest(
+        id="rpc-call-type",
+        params=MessageSendParams(
+            message={"messageId": "m1", "role": "user", "parts": [{"kind": "text", "text": "hi"}]}
+        ),
+    )
+
+    logging_obj = _build_streaming_logging_obj(
+        request=request,
+        agent_name="some-agent",
+        agent_id=None,
+        litellm_params=None,
+        metadata=None,
+        proxy_server_request=None,
+    )
+
+    assert logging_obj.model_call_details["call_type"] == "asend_message_streaming"

--- a/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
@@ -68,6 +68,9 @@ ALL_METRICS = frozenset(
 
 TOKEN_TYPE = "gen_ai.token.type"
 MODEL_KEY = "gen_ai.request.model"
+OPERATION_KEY = "gen_ai.operation.name"
+PROVIDER_NAME_KEY = "gen_ai.provider.name"
+SYSTEM_KEY = "gen_ai.system"
 
 # Keys inside the ceiling that an operator's filter must still be able to remove.
 # Every one is bounded, so it survives the ceiling and only the operator's own
@@ -83,18 +86,25 @@ COMPLETION_TOKENS = 89
 RESPONSE_COST = 0.0023
 
 
-def _build_call(stream: bool = True):
+def _build_call(
+    stream: bool = True,
+    provider: str | None = "openai",
+    call_type: str = "completion",
+):
     """A captured success-call (kwargs, response_obj, start, end) that exercises
     every one of the six metrics: usage for token.usage, response_cost for cost,
-    streaming + timing for the response-time histograms."""
+    streaming + timing for the response-time histograms.
+
+    ``provider=None`` omits ``custom_llm_provider`` entirely, reproducing a call
+    litellm could not attribute to a provider."""
     start = datetime(2026, 6, 12, 12, 0, 0)
     api_call_start = start + timedelta(seconds=0.1)
     completion_start = start + timedelta(seconds=0.5)
     end = start + timedelta(seconds=1.0)
     kwargs = {
         "model": "gpt-4o-mini",
-        "call_type": "completion",
-        "litellm_params": {"custom_llm_provider": "openai"},
+        "call_type": call_type,
+        "litellm_params": ({"custom_llm_provider": provider} if provider is not None else {}),
         "optional_params": {"stream": stream},
         "response_cost": RESPONSE_COST,
         "api_call_start_time": api_call_start,
@@ -142,7 +152,7 @@ def _metrics_by_name(reader):
     return out
 
 
-def _drive_success(reader, callback_settings_attributes=None):
+def _drive_success(reader, callback_settings_attributes=None, **call_overrides):
     """Construct a metrics-on logger, optionally populate callback_settings AFTER
     construction (mirroring the proxy ordering), run the real success hook."""
     logger = _logger(reader, enable_metrics=True)
@@ -152,7 +162,7 @@ def _drive_success(reader, callback_settings_attributes=None):
             "otel": {"attributes": callback_settings_attributes}
         }
     try:
-        kwargs, response_obj, start, end = _build_call()
+        kwargs, response_obj, start, end = _build_call(**call_overrides)
         asyncio.run(logger.async_log_success_event(kwargs, response_obj, start, end))
     finally:
         litellm.callback_settings = previous
@@ -376,6 +386,77 @@ def test_success_attributes_are_capped_at_the_ceiling():
         for dp in metrics[name]:
             leaked = set(dp.attributes) - set(BOUNDED_KEYS) - {TOKEN_TYPE}
             assert not leaked, f"{name} leaked {leaked}"
+def test_provider_is_labelled_with_semconv_provider_name():
+    """Every recorded point carries gen_ai.provider.name holding the semconv
+    provider value (bedrock -> aws.bedrock), the key the GenAI convention and the
+    dashboards built on it query. The deprecated gen_ai.system spelling alone is
+    unreadable to them."""
+    metrics = _drive_success(InMemoryMetricReader(), provider="bedrock")
+
+    for name in ALL_METRICS:
+        points = metrics[name]
+        assert points, f"{name} was not recorded"
+        for dp in points:
+            assert dp.attributes[PROVIDER_NAME_KEY] == "aws.bedrock"
+
+
+def test_deprecated_gen_ai_system_is_dual_emitted_verbatim():
+    """gen_ai.system keeps its raw litellm provider value alongside the new key
+    for one release, so a dashboard already filtering on it keeps matching. Its
+    value must not be swapped for the mapped one, which would break exactly the
+    queries the dual emission exists to protect."""
+    metrics = _drive_success(InMemoryMetricReader(), provider="bedrock")
+
+    for dp in metrics[OPERATION_DURATION]:
+        assert dp.attributes[SYSTEM_KEY] == "bedrock"
+        assert dp.attributes[PROVIDER_NAME_KEY] == "aws.bedrock"
+
+
+def test_no_provider_attribute_when_provider_is_absent():
+    """A call litellm could not attribute to a provider carries no provider label
+    at all. A placeholder value ("Unknown") would mint a permanent series that
+    aggregates every unattributable request and that no operator can act on."""
+    metrics = _drive_success(InMemoryMetricReader(), provider=None)
+
+    for name in ALL_METRICS:
+        points = metrics[name]
+        assert points, f"{name} was not recorded"
+        for dp in points:
+            keys = set(dp.attributes.keys())
+            assert PROVIDER_NAME_KEY not in keys
+            assert SYSTEM_KEY not in keys
+            assert "Unknown" not in set(dp.attributes.values())
+
+
+def test_vector_store_search_is_not_labelled_as_chat():
+    """A vector-store search records under gen_ai.operation.name=retrieval, so its
+    latency and cost stay out of the chat series."""
+    metrics = _drive_success(InMemoryMetricReader(), call_type="avector_store_search")
+
+    for name in (OPERATION_DURATION, TOKEN_COST):
+        for dp in metrics[name]:
+            assert dp.attributes[OPERATION_KEY] == "retrieval"
+
+
+def test_agent_message_is_not_labelled_as_chat():
+    """An A2A agent send records under gen_ai.operation.name=invoke_agent."""
+    metrics = _drive_success(InMemoryMetricReader(), call_type="asend_message")
+
+    for name in (OPERATION_DURATION, TOKEN_COST):
+        for dp in metrics[name]:
+            assert dp.attributes[OPERATION_KEY] == "invoke_agent"
+
+
+def test_provider_name_is_filterable():
+    """gen_ai.provider.name is a member of the metric-attribute allowlist, so an
+    operator can include or exclude it; an unlisted name raises instead."""
+    metrics = _drive_success(
+        InMemoryMetricReader(),
+        callback_settings_attributes={"include_list": [PROVIDER_NAME_KEY]},
+    )
+
+    for dp in metrics[OPERATION_DURATION]:
+        assert set(dp.attributes.keys()) == {PROVIDER_NAME_KEY}
 
 
 def test_metrics_reach_operator_configured_global_provider(monkeypatch):
@@ -481,6 +562,7 @@ UNBOUNDED_KEYS = (
 BOUNDED_KEYS = (
     "hidden_params",
     "gen_ai.operation.name",
+    "gen_ai.provider.name",
     "gen_ai.system",
     "gen_ai.request.model",
     "gen_ai.framework",

--- a/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
@@ -457,9 +457,13 @@ def test_vector_store_management_is_not_labelled_as_chat(call_type, expected):
         assert dp.attributes[OPERATION_KEY] == expected
 
 
-def test_agent_message_is_not_labelled_as_chat():
-    """An A2A agent send records under gen_ai.operation.name=invoke_agent."""
-    metrics = _drive_success(InMemoryMetricReader(), call_type="asend_message")
+@pytest.mark.parametrize("call_type", ["asend_message", "asend_message_streaming"])
+def test_agent_message_is_not_labelled_as_chat(call_type):
+    """An A2A agent send records under gen_ai.operation.name=invoke_agent, streamed or
+    not. The streaming iterator dispatches the same success handlers under its own
+    ``asend_message_streaming`` call type, so an unmapped streaming spelling puts every
+    streamed agent turn's latency and cost back into the chat series."""
+    metrics = _drive_success(InMemoryMetricReader(), call_type=call_type)
 
     for name in (OPERATION_DURATION, TOKEN_COST):
         for dp in metrics[name]:

--- a/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
@@ -438,6 +438,25 @@ def test_vector_store_search_is_not_labelled_as_chat():
             assert dp.attributes[OPERATION_KEY] == "retrieval"
 
 
+@pytest.mark.parametrize(
+    "call_type,expected",
+    [
+        ("avector_store_create", "litellm.vector_store_management"),
+        ("avector_store_delete", "litellm.vector_store_management"),
+        ("avector_store_file_create", "litellm.vector_store_file_management"),
+        ("avector_store_file_list", "litellm.vector_store_file_management"),
+    ],
+)
+def test_vector_store_management_is_not_labelled_as_chat(call_type, expected):
+    """Store and file management reach the recorder through the same success hook as a
+    completion, so leaving them unmapped kept billing- and latency-relevant admin calls
+    inside the chat series."""
+    metrics = _drive_success(InMemoryMetricReader(), call_type=call_type)
+
+    for dp in metrics[OPERATION_DURATION]:
+        assert dp.attributes[OPERATION_KEY] == expected
+
+
 def test_agent_message_is_not_labelled_as_chat():
     """An A2A agent send records under gen_ai.operation.name=invoke_agent."""
     metrics = _drive_success(InMemoryMetricReader(), call_type="asend_message")

--- a/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
@@ -1,6 +1,8 @@
 """Tests for the OTel v2 sources of truth: span registry, semconv keys, config,
 and the typed StandardLoggingPayload adapter. These need no OTel SDK."""
 
+import logging
+
 import pytest
 
 from litellm.integrations.otel import (
@@ -206,6 +208,30 @@ def test_operation_resolution():
     assert resolve_operation(None) is GenAIOperation.CHAT
     # An MCP tool call is an ``execute_tool`` operation, not a chat completion.
     assert resolve_operation("call_mcp_tool") is GenAIOperation.EXECUTE_TOOL
+
+
+@pytest.mark.parametrize("call_type", ["vector_store_search", "avector_store_search"])
+def test_vector_store_search_is_a_retrieval_operation(call_type):
+    """A vector-store search is a retrieval, so its duration and cost must not
+    land in the chat series that dashboards read latency off."""
+    assert resolve_operation(call_type) is GenAIOperation.RETRIEVAL
+    assert resolve_operation(call_type).value == "retrieval"
+
+
+@pytest.mark.parametrize("call_type", ["send_message", "asend_message"])
+def test_agent_message_is_an_invoke_agent_operation(call_type):
+    """An agent (A2A) message send is an agent invocation, not a chat completion."""
+    assert resolve_operation(call_type) is GenAIOperation.INVOKE_AGENT
+    assert resolve_operation(call_type).value == "invoke_agent"
+
+
+def test_unmapped_call_type_falls_back_to_chat_loudly(caplog):
+    """The fallback still labels the series ``chat`` so it is never unlabelled,
+    but it says so at debug: a silent default is how retrieval and agent calls
+    ended up in the chat charts in the first place."""
+    with caplog.at_level(logging.DEBUG, logger="LiteLLM"):
+        assert resolve_operation("some_future_call_type") is GenAIOperation.CHAT
+    assert any("some_future_call_type" in record.getMessage() for record in caplog.records)
 
 
 # --- MCP tool-call (source of truth #1/#2/#3) ------------------------------- #

--- a/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
@@ -2,9 +2,12 @@
 and the typed StandardLoggingPayload adapter. These need no OTel SDK."""
 
 import logging
+import re
+from pathlib import Path
 
 import pytest
 
+import litellm
 from litellm.integrations.otel import (
     BAGGAGE_PROMOTED_KEYS,
     DB,
@@ -265,11 +268,37 @@ def test_vendor_operation_values_are_namespaced():
     assert all(op.value.startswith("litellm.") for op in vendor)
 
 
-@pytest.mark.parametrize("call_type", ["send_message", "asend_message"])
+@pytest.mark.parametrize("call_type", ["send_message", "asend_message", "asend_message_streaming"])
 def test_agent_message_is_an_invoke_agent_operation(call_type):
-    """An agent (A2A) message send is an agent invocation, not a chat completion."""
+    """An agent (A2A) message send is an agent invocation, not a chat completion.
+
+    The streaming spelling counts: ``_build_streaming_logging_obj`` in
+    ``litellm/a2a_protocol/main.py`` stamps ``asend_message_streaming`` on the
+    logging object the streaming iterator dispatches success handlers with, so a
+    missing entry sends every streamed agent turn into the chat series. There is
+    no sync spelling because A2A streaming is async-only.
+    """
     assert resolve_operation(call_type) is GenAIOperation.INVOKE_AGENT
     assert resolve_operation(call_type).value == "invoke_agent"
+
+
+def test_every_call_type_the_a2a_package_stamps_is_an_agent_operation():
+    """Pins the map to the call types the A2A code actually stamps on its logging
+    objects. A new spelling added there without a map entry fails here instead of
+    quietly landing in the chat series, which is how the streaming one was missed."""
+    a2a_package = Path(litellm.__file__).parent / "a2a_protocol"
+    stamped = {
+        call_type
+        for source in a2a_package.rglob("*.py")
+        for call_type in re.findall(r'call_type="([^"]+)"', source.read_text())
+    }
+    assert stamped, "no call_type literals found in litellm/a2a_protocol"
+    unmapped = {
+        call_type: resolve_operation(call_type).value
+        for call_type in stamped
+        if resolve_operation(call_type) is not GenAIOperation.INVOKE_AGENT
+    }
+    assert not unmapped, f"add these to _OPERATION_BY_CALL_TYPE: {unmapped}"
 
 
 def test_unmapped_call_type_falls_back_to_chat_loudly(caplog):

--- a/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py
@@ -218,6 +218,53 @@ def test_vector_store_search_is_a_retrieval_operation(call_type):
     assert resolve_operation(call_type).value == "retrieval"
 
 
+@pytest.mark.parametrize("call_type", ["query", "aquery"])
+def test_rag_query_is_a_retrieval_operation(call_type):
+    """``/rag/query`` reaches the same recorder as a vector-store search and is the
+    same operation, so it must not be the one retrieval surface left reading as chat."""
+    assert resolve_operation(call_type) is GenAIOperation.RETRIEVAL
+
+
+@pytest.mark.parametrize(
+    "call_type",
+    [
+        f"{prefix}vector_store_{verb}"
+        for verb in ("create", "retrieve", "list", "update", "delete")
+        for prefix in ("", "a")
+    ],
+)
+def test_vector_store_management_is_not_chat(call_type):
+    """The store lifecycle calls are not GenAI client operations and the convention
+    names nothing for them, so they take a vendor value rather than defaulting into
+    the chat series."""
+    assert resolve_operation(call_type) is GenAIOperation.LITELLM_VECTOR_STORE_MANAGEMENT
+    assert resolve_operation(call_type).value == "litellm.vector_store_management"
+
+
+@pytest.mark.parametrize(
+    "call_type",
+    [
+        f"{prefix}vector_store_file_{verb}"
+        for verb in ("create", "list", "retrieve", "content", "update", "delete")
+        for prefix in ("", "a")
+    ],
+)
+def test_vector_store_file_management_is_not_chat(call_type):
+    """The file operations are a distinct REST resource from the store lifecycle, so
+    they get their own vendor value instead of sharing one bucket."""
+    assert resolve_operation(call_type) is GenAIOperation.LITELLM_VECTOR_STORE_FILE_MANAGEMENT
+    assert resolve_operation(call_type).value == "litellm.vector_store_file_management"
+
+
+def test_vendor_operation_values_are_namespaced():
+    """A vendor value must stay under the ``litellm.`` prefix: an unprefixed invented
+    name could collide with a value the convention adds later, silently changing what
+    a conformant consumer thinks it is reading."""
+    vendor = [op for op in GenAIOperation if op.name.startswith("LITELLM_")]
+    assert vendor, "no vendor operation values defined"
+    assert all(op.value.startswith("litellm.") for op in vendor)
+
+
 @pytest.mark.parametrize("call_type", ["send_message", "asend_message"])
 def test_agent_message_is_an_invoke_agent_operation(call_type):
     """An agent (A2A) message send is an agent invocation, not a chat completion."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every vector-store and agent metric was labelled `operation.name=chat`
- Provider rode the deprecated `gen_ai.system` key, invisible to GenAI dashboards
- A providerless request minted a permanent `Unknown` provider series

How it solves it:

- Map search and RAG query to `retrieval`, agent sends to `invoke_agent`
- Give vector-store management a vendor name, since semconv has none
- Emit `gen_ai.provider.name` via the existing `resolve_provider` helper
- Omit the provider label instead of inventing a value

## Relevant issues

## Linear ticket

Resolves LIT-4954

Resolves LIT-4959

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The branch was rebased onto current staging after these captures, so the SHAs quoted below are the pre-rebase ones the measurements were actually taken at. They map to the current commits in order: `8818ac2056` -> `b8266b2810`, `bb885fa0f7` -> `0b26c2c595`, `61c6742e3c` -> `72a176debe`, on base `551e5d097c` -> `4eecf7a050`. Nothing was re-measured, so the old SHAs are quoted as-is rather than relabelled with commits the numbers did not come from


One live proxy, OTel v2 with the console metric exporter, a real OpenAI chat completion and a real OpenAI vector-store search (a vector store built from an uploaded file; both calls hit api.openai.com and cost real money). No database, no mocks

```bash
# scratch config (port derived from the ticket number)
cat otel_4954_config.yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY

litellm_settings:
  callbacks: ["otel"]

general_settings:
  master_key: sk-1234

# the exporter must not inherit a real collector endpoint from .env, hence the empty export
lsof -iTCP:4954 -sTCP:LISTEN || echo "4954 free"
set -a; source .env; set +a
export OTEL_ENDPOINT="" OTEL_EXPORTER=console LITELLM_OTEL_V2=1 \
       LITELLM_OTEL_INTEGRATION_ENABLE_METRICS=1 PYTHONUNBUFFERED=1
python litellm/proxy/proxy_cli.py --config otel_4954_config.yaml --port 4954 > run.log 2>&1 &

# 1. real chat completion
curl -sS -w "\nHTTP %{http_code}\n" http://127.0.0.1:4954/v1/chat/completions \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Reply with exactly: otel attribute proof"}]}'

# 2. real vector-store search
curl -sS -w "\nHTTP %{http_code}\n" http://127.0.0.1:4954/v1/vector_stores/$VS/search \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{"query":"which attribute carries the provider value?"}'

# 3. read the exported metric datapoints. gen_ai.framework is the last attribute of a
#    metric datapoint's attribute set, so -B4 of it is the semconv block
grep -B4 '"gen_ai.framework": "litellm"' run.log | grep -v '^--$' | sed 's/^ *//' | sort | uniq -c
```

Both calls returned 200 at both SHAs; the chat completion answered `otel attribute proof` for 14 prompt / 6 completion tokens and the search returned its indexed chunk at score 0.93

Before, at `551e5d097c`:

```
 103 "attributes": {
 103 "gen_ai.framework": "litellm",
 103 "gen_ai.operation.name": "chat",
  75 "gen_ai.request.model": "gpt-5.6",
  28 "gen_ai.request.model": null,
  75 "gen_ai.system": "openai",
  28 "gen_ai.system": null,
```

Every datapoint says `chat`, the vector-store ones included, and `gen_ai.provider.name` appears nowhere. The vector-store datapoint in full:

```
"gen_ai.operation.name": "chat",
"gen_ai.system": null,
"gen_ai.request.model": null,
"gen_ai.framework": "litellm",
```

After, at `8818ac2056`:

```
  21 "attributes": {
  21 "gen_ai.framework": "litellm",
  15 "gen_ai.operation.name": "chat",
   6 "gen_ai.operation.name": "retrieval",
  15 "gen_ai.provider.name": "openai",
  15 "gen_ai.request.model": "gpt-5.6",
   6 "gen_ai.request.model": null,
  15 "gen_ai.system": "openai",
```

The chat datapoint carries both spellings and the search is now its own operation:

```
"gen_ai.operation.name": "chat",
"gen_ai.provider.name": "openai",
"gen_ai.system": "openai",
"gen_ai.request.model": "gpt-5.6",
"gen_ai.framework": "litellm",

"gen_ai.operation.name": "retrieval",
"gen_ai.request.model": null,
"gen_ai.framework": "litellm",
```

The retrieval datapoint carries no provider label at all, where before it carried `gen_ai.system: null`. The counts differ between runs only because the console exporter re-exports the cumulative datapoints every 5 seconds and the before run stayed up longer; the distinct attribute sets are what matters

### Vector-store management, from the Greptile follow-up

Same rig, driving the management surface instead: create, retrieve, list, file-list and delete, all real OpenAI calls through the proxy, all HTTP 200

```bash
VS=$(curl -sS http://127.0.0.1:4954/v1/vector_stores "${H[@]}" -d '{"name":"litswarm-4954-mgmt"}' | jq -r .id)
curl -sS -o /dev/null -w "HTTP %{http_code}\n" "http://127.0.0.1:4954/v1/vector_stores/$VS"        "${H[@]}"
curl -sS -o /dev/null -w "HTTP %{http_code}\n" "http://127.0.0.1:4954/v1/vector_stores?limit=1"    "${H[@]}"
curl -sS -o /dev/null -w "HTTP %{http_code}\n" "http://127.0.0.1:4954/v1/vector_stores/$VS/files"  "${H[@]}"
curl -sS -o /dev/null -w "HTTP %{http_code}\n" -X DELETE "http://127.0.0.1:4954/v1/vector_stores/$VS" "${H[@]}"

grep -B4 '"gen_ai.framework": "litellm"' run.log \
  | grep -E 'operation.name|provider.name|gen_ai.system' | sed 's/^ *//' | sort | uniq -c
```

Before, at `8818ac2056` (the first commit on this branch, which mapped only the search):

```
  20 "gen_ai.operation.name": "chat",
   6 "gen_ai.provider.name": "openai",
   6 "gen_ai.system": "openai",
```

After, at `bb885fa0f7`:

```
   6 "gen_ai.operation.name": "litellm.vector_store_file_management",
  12 "gen_ai.operation.name": "litellm.vector_store_management",
   6 "gen_ai.provider.name": "openai",
   6 "gen_ai.system": "openai",
```

Not one datapoint reads `chat` any more. This also settles that the concern was live rather than theoretical: these management calls are `@client`-decorated and routed, so they reach the same success hook a completion does

### Streaming A2A, from the Bugbot follow-up

Cursor Bugbot flagged that a streamed A2A turn still records as `chat`. It does, but not for the reason given, and the difference matters: `_build_streaming_logging_obj` in `litellm/a2a_protocol/main.py` builds its `Logging` by hand and never calls `update_environment_variables`, which is the only place `call_type` is written into `model_call_details` (`litellm/litellm_core_utils/litellm_logging.py:553`; `Logging.__init__` seeds that dict at line 398 without it). The recorder was therefore seeing `call_type` as `None` and taking the `not call_type` branch. Adding the map entry alone changes nothing, which the middle capture below shows

A different rig from the vector-store one above: a real A2A agent, built on the a2a-sdk's own server routes, streaming a task plus three status updates plus a completed status, registered in `agent_list` and driven over HTTP through the proxy. Three streamed turns and one non-streamed turn per run, the non-streamed one being the control that was already labelled correctly. No database, no mocks

```bash
python agent_server.py 8959                       # real A2A agent, /.well-known/agent-card.json + JSON-RPC
export OTEL_ENDPOINT="" OTEL_EXPORTER=console LITELLM_OTEL_V2=1 \
       LITELLM_OTEL_INTEGRATION_ENABLE_METRICS=1
python litellm/proxy/proxy_cli.py --config config.yaml --port 4959 > run.log 2>&1 &

for i in 1 2 3; do
  curl -sS -N -X POST http://127.0.0.1:4959/a2a/streaming-proof-agent \
    -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
    -d "{\"jsonrpc\":\"2.0\",\"id\":\"$i\",\"method\":\"message/stream\",\"params\":{\"message\":{\"role\":\"user\",\"parts\":[{\"kind\":\"text\",\"text\":\"streamed turn $i\"}],\"messageId\":\"m$i\"}}}"
done
curl -sS -X POST http://127.0.0.1:4959/a2a/streaming-proof-agent \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{"jsonrpc":"2.0","id":"4","method":"message/send","params":{"message":{"role":"user","parts":[{"kind":"text","text":"non-streamed turn"}],"messageId":"m4"}}}'
```

All four calls HTTP 200 at every SHA, and the agent streamed its chunks back through the proxy each time. Attribute sets counted by brace-matching each `"attributes": {...}` object out of the exporter output and `json.loads`-ing it, since a regex stops at the first `}` inside a JSON-string label value and silently merges distinct series

Before, at `bb885fa0f7`:

```
x18  operation='chat'          provider=None          model='a2a_agent/otel-streaming-proof-agent'
x6   operation='invoke_agent'  provider='a2a_agent'   model='a2a_agent/otel-streaming-proof-agent'
```

With only the map entry added, which is the fix the finding implies:

```
x12  operation='chat'          provider=None          model='a2a_agent/otel-streaming-proof-agent'
x4   operation='invoke_agent'  provider='a2a_agent'   model='a2a_agent/otel-streaming-proof-agent'
```

After, at `61c6742e3c`:

```
x12  operation='invoke_agent'  provider=None          model='a2a_agent/otel-streaming-proof-agent'
x4   operation='invoke_agent'  provider='a2a_agent'   model='a2a_agent/otel-streaming-proof-agent'
```

Not one datapoint reads `chat`. The 3:1 split is the three streamed turns against the one non-streamed control

The streamed datapoints carry no `gen_ai.provider.name` while the non-streamed ones carry `a2a_agent`, which is this PR's own omit-rather-than-invent rule working as intended: the recorder reads the provider from `litellm_params["custom_llm_provider"]`, and on the non-bridge streaming path those params legitimately carry none. Making the two paths agree means changing what `litellm_params` holds for A2A streaming, which the cost calculator also reads, so it belongs in its own change

## Type

🐛 Bug Fix

## Changes

`resolve_operation` in `litellm/integrations/otel/model/semconv.py` mapped completion, text completion, embedding, responses and `call_mcp_tool`, and defaulted everything else to `chat`. Vector-store searches (`vector_store_search` / `avector_store_search`) and A2A agent sends (`send_message` / `asend_message`) therefore recorded their duration and cost into the chat series, so chat latency read off a GenAI dashboard silently included retrieval and agent time. Both now map to the values the GenAI convention defines for them: `retrieval`, whose registry entry names the OpenAI vector-store search API specifically, and `invoke_agent`. An unmapped call type still falls back to `chat` so a series is never unlabelled, but it now logs the call type at debug, because a silent default is how this landed in the first place

The rest of the vector-store family goes with it, which is the Greptile follow-up. The store lifecycle (`vector_store_create` / `_retrieve` / `_list` / `_update` / `_delete`) and the six file operations (`_file_create` / `_file_list` / `_file_retrieve` / `_file_content` / `_file_update` / `_file_delete`), each in both the sync and `a`-prefixed spelling, were all still landing on `chat`. Note these live as router `factory_function` call types rather than `CallTypes` members, so the enum understates the family; the router's `call_type=` strings are the authoritative list. `/rag/query` (`query` / `aquery`) goes to `retrieval` too, since it reaches the same recorder and is the same operation as a vector-store search, and mapping one retrieval surface but not the other would leave the defect half-fixed. `/rag/ingest` is a write with no semconv equivalent and no retrieval or agent confusion, so naming it belongs with the RAG owners rather than here

The convention names no operation for vector-store management, so those take vendor values, `litellm.vector_store_management` and `litellm.vector_store_file_management`, one per REST resource, under the `litellm.` prefix so a value the convention adds later can never collide. The convention's own note on `gen_ai.operation.name` directs instrumentation to use a system-specific name when no predefined value applies, which is the same allowance `resolve_provider` already relies on for unmapped providers, so this is the sanctioned move rather than a workaround. Two alternatives were considered and rejected. Excluding management calls from the GenAI metrics altogether is arguably cleaner semantically, since creating a vector store is not a GenAI client operation, but it deletes series an operator may be watching today and re-adding deleted telemetry is much harder than renaming a label, so it stays available as a follow-up instead of being decided here. Mapping them onto the semconv memory-store family (`create_memory_store`, `delete_memory_store`, and friends) was rejected outright: litellm vector stores hold documents, not an agent's memory records, and borrowing those names would push document-admin calls into whatever charts agent-memory operations, which is the same defect this PR exists to fix

For scope, the wider unmapped set (video, containers, files, skills, interactions, image edit, moderation, OCR) is out of this PR. Those are not retrieval or agent operations, so they are not what the ticket describes, and several need a product decision about whether they belong in `gen_ai.client.*` at all. The debug log added here is the mechanism that surfaces them rather than leaving the next person to discover it from a chart

The provider label was `gen_ai.system`, which the convention has moved to its deprecated registry in favor of `gen_ai.provider.name`. The v2 span path already resolves the semconv value through `resolve_provider` (bedrock becomes `aws.bedrock`); metrics never called it. They do now, and `gen_ai.provider.name` joins the metric-attribute allowlist so an operator can include or exclude it like any other label

The sharpest call here: `gen_ai.system` is dual-emitted with the raw litellm provider string it has always carried, not the mapped value. A query for `gen_ai.system="bedrock"` is exactly what the dual emission exists to keep working, so writing `aws.bedrock` into the deprecated key would break those queries while looking like compatibility. The new key gets the resolved semconv value; the old key's series stays byte-identical to what it emits today

Keeping the old key at all follows the precedent `litellm/integrations/prometheus.py` sets for renamed metrics. The label has shipped long enough that someone's dashboard is filtering on it, and a rename with no overlap breaks that dashboard silently at upgrade time rather than loudly. It should come out a release from now

The `"Unknown"` default is gone. A request litellm cannot attribute to a provider now carries no provider label, rather than a placeholder that mints a real, permanently-cardinal series aggregating every unattributable request into one bucket no operator can act on. The live capture shows this was not hypothetical: the vector-store search reached the recorder with `custom_llm_provider` set to `None`, so it was already emitting `gen_ai.system: null`

I left the v1 `litellm/integrations/opentelemetry.py` metric path on `gen_ai.system` (the only edit there is the one-line allowlist addition). Its `gen_ai.operation.name` is itself gated behind the `gen_ai_latest_experimental` opt-in and hardcodes `chat` otherwise, so renaming just its provider key would produce a half-migrated attribute set on an integration slated for deletion, while leaving it untouched keeps v1's output byte-identical and compatible with the v2 dual emission

The streamed A2A path needed a second change, not just a map entry. Its logging object is built by hand in `_build_streaming_logging_obj` rather than through `update_environment_variables`, so `call_type` never reached `model_call_details` and every callback, not only the metric recorder, saw a streamed agent turn with no call type at all. It is stamped there now alongside the `model` and `custom_llm_provider` the same function already sets, and `asend_message_streaming` joins the map. There is no sync spelling to add: A2A streaming is async-only, and this is the only `call_type` literal anywhere under `litellm/a2a_protocol`

The rebase brought in the metric-attribute ceiling that landed on staging as #34828, and `gen_ai.provider.name` had to join `METRIC_ATTRIBUTE_CEILING` for the new label to survive it. That is the correct side of that cap rather than a widening: the value is a fixed enum from `resolve_provider`, bounded exactly like the `gen_ai.system` entry it sits next to, and it is caller-independent. Without the entry the ceiling silently stripped the attribute this PR exists to add, which is what the three provider tests caught during the rebase

The sibling failure-path PR (LIT-4955) has since merged as #35152, and its `plumbing/metrics.py` changes are folded in by the rebase

Tests extend three mapped files: `tests/test_litellm/integrations/otel/test_otel_v2_sources_of_truth.py` for the call-type mapping, `test_otel_v2_metrics.py` for the recorded attributes, and `tests/test_litellm/a2a_protocol/test_main.py` for the streaming logging object's call type, which drive the real success hook into an in-memory metric reader. There is a test per call-type group pinning its operation name, one asserting every vendor value stays under the `litellm.` prefix, and the unmapped-fallback test uses a synthetic call type that can never accidentally become mapped

The streaming commit adds a test that pins the root cause rather than the map: reverting the stamping alone fails `test_streaming_logging_obj_carries_call_type_into_model_call_details` with a `KeyError`, and reverting the map entry alone fails the three mapping and recorder cases. A new `test_every_call_type_the_a2a_package_stamps_is_an_agent_operation` scans `litellm/a2a_protocol` for `call_type="..."` literals and asserts each resolves to `invoke_agent`, so a future spelling added there fails there instead of quietly landing in the chat series. `tests/test_litellm/a2a_protocol` plus `tests/test_litellm/integrations/otel` are green at 394 passed

All three commits were mutation-checked by reverting the production change and keeping the tests. For the first: 11 failed, 48 passed, then 59 passed restored. For the follow-up: 29 failed, 59 passed, then 88 passed restored, so every one of the 29 new cases fails without the mapping. The two full mapped files plus the v1 `test_opentelemetry.py` are green at 577 passed

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observability labels and time-series cardinality for OTel v2 metrics; behavior is well-tested but operators’ dashboards and alerts keyed on old operation or provider attributes may need review.
> 
> **Overview**
> **OTel v2 GenAI metrics** now use semconv-aligned labels so dashboards and cost/latency series are not skewed by mis-tagged operations.
> 
> **Operation names:** Vector-store search and RAG `query` map to `gen_ai.operation.name=retrieval`; A2A sends map to `invoke_agent`. Vector-store and file admin call types get vendor values `litellm.vector_store_management` and `litellm.vector_store_file_management` instead of defaulting to `chat`. Unmapped `call_type` values still fall back to `chat` but emit a **debug** log so new surfaces are visible.
> 
> **Provider labels:** Metrics emit **`gen_ai.provider.name`** via `resolve_provider` (e.g. bedrock → `aws.bedrock`), with **`gen_ai.system`** dual-emitted using the **raw** litellm provider string for backward compatibility. Calls with no provider omit both labels (no more permanent `"Unknown"` series). `gen_ai.provider.name` is on the metric-attribute allowlist.
> 
> **Scope:** v1 `opentelemetry.py` only gains the allowlist entry; v2 `GenAIMetricRecorder._common_attributes` implements the behavior. Tests cover mappings, dual emission, absent provider, and filterability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb885fa0f78aae47500466fb683c0abc600856e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


