### PR TITLE
fix(mcp): enforce tool entitlements on every MCP tool dispatch path

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -4422,12 +4422,17 @@ class MCPServerManager:
         arguments: dict[str, Any],
         server_name: str,
         user_api_key_auth: Optional[UserAPIKeyAuth],
-        proxy_logging_obj: ProxyLogging,
+        proxy_logging_obj: ProxyLogging | None,
         server: MCPServer,
         raw_headers: Optional[dict[str, str]] = None,
     ) -> dict[str, Any]:
         """
         Run pre-call checks and guardrail hooks for an MCP tool call.
+
+        Authorization runs unconditionally; only the guardrail hooks, which are
+        dispatched through ``proxy_logging_obj``, depend on a logger being
+        present. An absent logger must never be able to turn an authorization
+        decision into a no-op.
 
         Returns a dict that may contain:
         - "arguments": hook-modified tool arguments (only if changed)
@@ -4455,6 +4460,10 @@ class MCPServerManager:
             arguments=arguments,
             server=server,
         )
+
+        hook_result: dict[str, Any] = {}
+        if proxy_logging_obj is None:
+            return hook_result
 
         # Extract incoming Bearer token from raw request headers so
         # guardrails like MCPJWTSigner can verify + re-sign it (FR-5).
@@ -4485,7 +4494,6 @@ class MCPServerManager:
         # Convert to LLM format for existing guardrail compatibility
         synthetic_llm_data = proxy_logging_obj._convert_mcp_to_llm_format(mcp_request_obj, pre_hook_kwargs)
 
-        hook_result: dict[str, Any] = {}
         try:
             # Use standard pre_call_hook
             modified_data = await proxy_logging_obj.pre_call_hook(
@@ -5111,19 +5119,17 @@ class MCPServerManager:
         # Allow validation and modification of tool calls before execution
         # Using standard pre_call_hook
         #########################################################
-        hook_result: dict[str, Any] = {}
-        if proxy_logging_obj:
-            hook_result = await self.pre_call_tool_check(
-                name=name,
-                arguments=arguments,
-                server_name=server_name,
-                user_api_key_auth=user_api_key_auth,
-                proxy_logging_obj=proxy_logging_obj,
-                server=mcp_server,
-                raw_headers=raw_headers,
-            )
-            if "arguments" in hook_result:
-                arguments = hook_result["arguments"]
+        hook_result: dict[str, Any] = await self.pre_call_tool_check(
+            name=name,
+            arguments=arguments,
+            server_name=server_name,
+            user_api_key_auth=user_api_key_auth,
+            proxy_logging_obj=proxy_logging_obj,
+            server=mcp_server,
+            raw_headers=raw_headers,
+        )
+        if "arguments" in hook_result:
+            arguments = hook_result["arguments"]
 
         # Prepare tasks for during hooks
         tasks = []

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -2902,6 +2902,54 @@ if MCP_AVAILABLE:
         # Deprecated: Local MCP Server Tool
         #########################################################
         else:
+            # Gate only what can actually dispatch. When the unprefixed name is
+            # not in the registry either, `_handle_local_mcp_tool` below reports
+            # 404 and nothing runs, so demanding a server here would turn every
+            # unknown tool name into a misleading 503.
+            if global_mcp_tool_registry.get_tool(original_tool_name) is not None:
+                # `mcp_server` is None here because the tool name is not in the
+                # tool -> server mapping, but the name still carries a prefix
+                # that the server-level check above compared against the
+                # caller's `allowed_mcp_servers` by exact `name`. So the named
+                # server is in that list and can carry the tool-level checks,
+                # even with the mapping cold. Resolve it from
+                # `allowed_mcp_servers` rather than the registry: the registry
+                # would happily return a server the caller holds no grant for,
+                # and matching anything other than `name` would accept a server
+                # the check never validated.
+                prefix_server = next(
+                    (candidate for candidate in allowed_mcp_servers if candidate.name == server_name),
+                    None,
+                )
+                if prefix_server is None:
+                    # A non-empty prefix that passed the server-level check
+                    # always matches here, so this arm only fires when the
+                    # prefix was empty, which is exactly the case that check
+                    # skips. Fail closed rather than dispatch with no server to
+                    # evaluate a tool ceiling against.
+                    raise HTTPException(
+                        status_code=503,
+                        detail=(
+                            f"MCP server for tool '{original_tool_name}' is not available; "
+                            "refusing to dispatch without authorization checks. "
+                            "Retry once the server is registered."
+                        ),
+                    )
+
+                from litellm.proxy.proxy_server import proxy_logging_obj
+
+                hook_result = await global_mcp_server_manager.pre_call_tool_check(
+                    name=original_tool_name,
+                    arguments=arguments,
+                    server_name=server_name,
+                    user_api_key_auth=user_api_key_auth,
+                    proxy_logging_obj=proxy_logging_obj,
+                    server=prefix_server,
+                    raw_headers=raw_headers,
+                )
+                if "arguments" in hook_result:
+                    arguments = hook_result["arguments"]  # pyright: ignore[reportAny]  # hook returns untyped args
+
             local_content = await _handle_local_mcp_tool(original_tool_name, arguments)
             response = CallToolResult(content=cast(Any, local_content), isError=False)
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -45,10 +45,13 @@ from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
 )
 from litellm.proxy._types import (
     LiteLLM_MCPServerTable,
+    LiteLLM_ObjectPermissionTable,
+    LitellmUserRoles,
     MCPApprovalStatus,
     MCPEnvVar,
     MCPEnvVarScope,
     MCPTransport,
+    UserAPIKeyAuth,
 )
 from litellm.types.mcp import MCPAuth
 from litellm.types.mcp_server.mcp_server_manager import MCPOAuthMetadata, MCPServer
@@ -9688,3 +9691,75 @@ class TestOpenAPIRegistryKeyMatchesRegistration:
 
         assert result.isError is True
         assert "not found in registry" in result.content[0].text
+
+
+class TestToolAuthorizationIsNotConditionalOnLogging:
+    """`call_tool` used to run `pre_call_tool_check` — the only place tool-level
+    MCP entitlements are enforced — inside `if proxy_logging_obj:`, so a caller
+    reached with no logging object got no authorization decision at all. Both
+    production call sites pass the module-level `ProxyLogging` singleton, which
+    is never None, so this was not a live hole; the invariant being restored is
+    that an authorization decision cannot be skipped by an absent logger.
+    """
+
+    @staticmethod
+    def _manager_with_scoped_server() -> tuple[MCPServerManager, UserAPIKeyAuth]:
+        manager = MCPServerManager()
+        manager.registry["srv-gated"] = MCPServer(
+            server_id="srv-gated",
+            name="gated_server",
+            server_name="gated_server",
+            alias="gated_server",
+            url="http://127.0.0.1:1/mcp",
+            transport=MCPTransport.http,
+            auth_type=MCPAuth.none,
+        )
+        for tool_name in ("read_only_tool", "delete_everything"):
+            manager.tool_name_to_mcp_server_name_mapping[tool_name] = "gated_server"
+        user = UserAPIKeyAuth(
+            api_key="sk-caller",
+            user_id="alice",
+            user_role=LitellmUserRoles.INTERNAL_USER.value,
+            object_permission=LiteLLM_ObjectPermissionTable(
+                object_permission_id="op-gated",
+                mcp_servers=["srv-gated"],
+                mcp_tool_permissions={"srv-gated": ["read_only_tool"]},
+            ),
+        )
+        return manager, user
+
+    @pytest.mark.asyncio
+    async def test_unentitled_tool_refused_without_proxy_logging_obj(self):
+        manager, user = self._manager_with_scoped_server()
+        upstream = AsyncMock(return_value=CallToolResult(content=[], isError=False))
+
+        with patch.object(manager, "_call_regular_mcp_tool", new=upstream):
+            with pytest.raises(HTTPException) as exc:
+                await manager.call_tool(
+                    server_name="gated_server",
+                    name="delete_everything",
+                    arguments={},
+                    user_api_key_auth=user,
+                    proxy_logging_obj=None,
+                )
+
+        assert exc.value.status_code == 403
+        upstream.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_entitled_tool_still_dispatches_without_proxy_logging_obj(self):
+        """The gate must refuse only what the entitlement excludes; an allowed
+        tool still reaches the upstream when there is no logging object."""
+        manager, user = self._manager_with_scoped_server()
+        upstream = AsyncMock(return_value=CallToolResult(content=[], isError=False))
+
+        with patch.object(manager, "_call_regular_mcp_tool", new=upstream):
+            await manager.call_tool(
+                server_name="gated_server",
+                name="read_only_tool",
+                arguments={},
+                user_api_key_auth=user,
+                proxy_logging_obj=None,
+            )
+
+        upstream.assert_awaited_once()

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_tool_auth.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_openapi_tool_auth.py
@@ -9,7 +9,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy._types import (
+    LiteLLM_ObjectPermissionTable,
+    LitellmUserRoles,
+    UserAPIKeyAuth,
+)
+from litellm.types.mcp import MCPAuth, MCPTransport
+from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
 
 @pytest.mark.asyncio
@@ -305,3 +311,241 @@ async def test_openapi_local_tool_injects_resolved_oauth_token():
 
     assert captured["resolved"] == {"Authorization": "Bearer stored-user-token"}
     assert _request_resolved_auth_headers.get() is None
+
+
+
+LEGACY_SERVER_ID = "srv-legacy-petstore"
+LEGACY_SERVER_NAME = "legacy_petstore"
+LEGACY_TOOL = "dump_secrets"
+
+
+@pytest.fixture
+def legacy_local_tool():
+    """A bare `mcp_tools`-style handler plus a registered server whose tools were
+    never listed, which is what leaves `tool_name_to_mcp_server_name_mapping`
+    cold and routes `{server}-{tool}` into `execute_mcp_tool`'s legacy fallback.
+
+    Yields the server and the list the handler appends to, so a test can tell
+    "refused" from "dispatched" by whether the handler actually ran.
+    """
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+    from litellm.proxy._experimental.mcp_server.tool_registry import (
+        global_mcp_tool_registry,
+    )
+
+    executed: list[dict] = []
+    server = MCPServer(
+        server_id=LEGACY_SERVER_ID,
+        name=LEGACY_SERVER_NAME,
+        server_name=LEGACY_SERVER_NAME,
+        alias=LEGACY_SERVER_NAME,
+        url="http://127.0.0.1:1/mcp",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.none,
+    )
+    global_mcp_tool_registry.register_tool(
+        name=LEGACY_TOOL,
+        description="bare tool registered from the mcp_tools config block",
+        input_schema={"type": "object", "properties": {}},
+        handler=lambda **kwargs: executed.append(kwargs) or "legacy local tool ran",
+    )
+    global_mcp_server_manager.registry[LEGACY_SERVER_ID] = server
+    assert (
+        global_mcp_server_manager._get_mcp_server_from_tool_name(
+            f"{LEGACY_SERVER_NAME}-{LEGACY_TOOL}"
+        )
+        is None
+    ), "fixture precondition: the prefixed name must resolve to no server"
+    try:
+        yield server, executed
+    finally:
+        global_mcp_tool_registry.tools.pop(LEGACY_TOOL, None)
+        global_mcp_server_manager.registry.pop(LEGACY_SERVER_ID, None)
+
+
+def _caller_entitled_to(tools: list[str]) -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(
+        api_key="sk-caller",
+        user_id="alice",
+        user_role=LitellmUserRoles.INTERNAL_USER.value,
+        object_permission=LiteLLM_ObjectPermissionTable(
+            object_permission_id="op-legacy-fallback",
+            mcp_servers=[LEGACY_SERVER_ID],
+            mcp_tool_permissions={LEGACY_SERVER_ID: tools},
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_legacy_local_tool_fallback_refuses_unentitled_caller(legacy_local_tool):
+    """The legacy fallback dispatched into the local tool registry with no
+    tool-level authorization at all: no allowed/banned check, no key/team/org
+    tool permissions, no parameter validation. It must now run the same gate,
+    so a caller whose entitlement excludes the tool is refused and the handler
+    never runs.
+
+    Nothing is mocked: the real registries and the real entitlement gate decide.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._experimental.mcp_server import server as mcp_module
+    from litellm.proxy._experimental.mcp_server.auth.user_api_key_auth_mcp import (
+        MCPRequestHandler,
+    )
+
+    server, executed = legacy_local_tool
+    user = _caller_entitled_to(["list_pets"])
+
+    # The gate answers "no" for this caller/tool pair, so a dispatch below would
+    # be an entitlement bypass rather than a routing quirk.
+    assert (
+        await MCPRequestHandler.is_tool_allowed_for_server(
+            tool_name=LEGACY_TOOL,
+            server_id=LEGACY_SERVER_ID,
+            user_api_key_auth=user,
+        )
+        is False
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await mcp_module.execute_mcp_tool(
+            name=f"{LEGACY_SERVER_NAME}-{LEGACY_TOOL}",
+            arguments={},
+            allowed_mcp_servers=[server],
+            start_time=datetime.now(timezone.utc),
+            user_api_key_auth=user,
+        )
+
+    assert exc.value.status_code == 403
+    # Pin the refusal to the ENTITLEMENT gate. The server-level check earlier in
+    # execute_mcp_tool also raises 403 (with a plain-string detail), and the
+    # allowed/banned-tools check raises a dict naming the server rather than the
+    # key/team, so asserting on the status alone would pass for the wrong reason.
+    detail = exc.value.detail
+    assert isinstance(detail, dict), detail
+    assert "not allowed for your key/team" in detail["error"], detail
+    assert executed == []
+
+
+@pytest.mark.asyncio
+async def test_legacy_local_tool_fallback_still_dispatches_entitled_caller(
+    legacy_local_tool,
+):
+    """The gate must do per-tool work rather than disabling the fallback: the
+    same shape of call, from a caller entitled to the tool, still dispatches.
+
+    This is the backwards-compatibility half. Refusing this call would trade an
+    authorization hole for an outage on a configuration that worked before.
+    """
+    from litellm.proxy._experimental.mcp_server import server as mcp_module
+
+    server, executed = legacy_local_tool
+    user = _caller_entitled_to([LEGACY_TOOL])
+
+    result = await mcp_module.execute_mcp_tool(
+        name=f"{LEGACY_SERVER_NAME}-{LEGACY_TOOL}",
+        arguments={},
+        allowed_mcp_servers=[server],
+        start_time=datetime.now(timezone.utc),
+        user_api_key_auth=user,
+    )
+
+    assert result.isError is False
+    assert executed == [{}]
+    assert "legacy local tool ran" in result.content[0].text
+
+
+@pytest.mark.asyncio
+async def test_legacy_local_tool_fallback_fails_closed_on_empty_prefix(
+    legacy_local_tool,
+):
+    """An empty prefix segment skips the server-level check outright:
+    `split_server_prefix_from_name` yields an empty `server_name`, and `execute_mcp_tool`
+    only runs `is_tool_allowed` `if server_name`. The legacy fallback then dispatched for a
+    caller holding no server grant at all, so this arm of the guard is reachable rather than
+    defensive. Nothing is patched here; the empty prefix segment is the whole of it.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._experimental.mcp_server import server as mcp_module
+
+    _server, executed = legacy_local_tool
+
+    with pytest.raises(HTTPException) as exc:
+        await mcp_module.execute_mcp_tool(
+            name=f"-{LEGACY_TOOL}",
+            arguments={},
+            allowed_mcp_servers=[],
+            start_time=datetime.now(timezone.utc),
+            user_api_key_auth=_caller_entitled_to([LEGACY_TOOL]),
+        )
+
+    assert exc.value.status_code == 503
+    assert executed == []
+
+
+@pytest.mark.asyncio
+async def test_legacy_local_tool_fallback_fails_closed_when_prefix_names_no_server(
+    legacy_local_tool,
+):
+    """Second arm of the same guard: a non-empty prefix that named a server the caller does
+    hold, but which is absent from `allowed_mcp_servers` by the time dispatch runs. Patching
+    the server-level check (which would otherwise refuse first) is what makes the arm
+    observable, so a later refactor cannot make the branch dispatch with no server to
+    evaluate a tool ceiling against.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._experimental.mcp_server import server as mcp_module
+
+    _server, executed = legacy_local_tool
+    other_server = MCPServer(
+        server_id="srv-unrelated",
+        name="unrelated_server",
+        server_name="unrelated_server",
+        alias="unrelated_server",
+        url="http://127.0.0.1:1/mcp",
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.none,
+    )
+
+    with patch(
+        "litellm.proxy._experimental.mcp_server.server.MCPRequestHandler.is_tool_allowed",
+        return_value=True,
+    ):
+        with pytest.raises(HTTPException) as exc:
+            await mcp_module.execute_mcp_tool(
+                name=f"{LEGACY_SERVER_NAME}-{LEGACY_TOOL}",
+                arguments={},
+                allowed_mcp_servers=[other_server],
+                start_time=datetime.now(timezone.utc),
+                user_api_key_auth=_caller_entitled_to([LEGACY_TOOL]),
+            )
+
+    assert exc.value.status_code == 503
+    assert executed == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_name_still_reports_not_found():
+    """The guard must gate dispatch, not existence. An unprefixed name that no registry
+    knows cannot dispatch anything, so it has to keep reporting 404 rather than collapsing
+    into the guard's 503; every typo'd tool name takes this branch.
+    """
+    from fastapi import HTTPException
+
+    from litellm.proxy._experimental.mcp_server import server as mcp_module
+
+    with pytest.raises(HTTPException) as exc:
+        await mcp_module.execute_mcp_tool(
+            name="tool_no_registry_knows",
+            arguments={},
+            allowed_mcp_servers=[],
+            start_time=datetime.now(timezone.utc),
+            user_api_key_auth=_caller_entitled_to([LEGACY_TOOL]),
+        )
+
+    assert exc.value.status_code == 404
+    assert "not found" in str(exc.value.detail)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Legacy local-tool dispatch skipped the MCP tool entitlement gate
- Tool authorization was conditional on a logging object being present

How it solves it:

- The legacy fallback now runs the gate; entitled callers still dispatch
- Authorization runs unconditionally; only guardrail hooks need the logger

## Relevant issues

## Linear ticket

Resolves LIT-4956

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy on port 4956 against a fresh Postgres. The config declares two legacy `mcp_tools` handlers plus one registered MCP server whose tools have never been listed, and the virtual key is scoped to that server with a tool allowlist containing only one of the two handlers.

```yaml
mcp_tools:
  - name: list_pets
    description: legacy local tool the caller IS entitled to
    input_schema: {type: object, properties: {}}
    handler: legacy_tools.list_pets
  - name: dump_secrets
    description: legacy local tool the caller is NOT entitled to
    input_schema: {type: object, properties: {}}
    handler: legacy_tools.dump_secrets

mcp_servers:
  petstore:
    url: http://127.0.0.1:9/mcp
    transport: http
    auth_type: none
    description: registered server whose tools have never been listed
```

```
$ curl -s -X POST http://127.0.0.1:4956/key/generate -H 'Authorization: Bearer sk-1234' \
    -H 'Content-Type: application/json' -d '{
      "key_alias": "lit4956-scoped-caller",
      "object_permission": {
        "mcp_servers": ["6ca60cf9ffa8fc4e0ec1f06f37661669"],
        "mcp_tool_permissions": {"6ca60cf9ffa8fc4e0ec1f06f37661669": ["list_pets"]}}}'
sk-tWf_VHL5zvN2daDTCWacfQ
```

Both captures run the identical sequence on `http://127.0.0.1:4956/mcp/`: `initialize`, `notifications/initialized`, then `tools/call` for each of the two tools **inside the same MCP session with the same key**, so the pairing shows the gate doing per-tool work rather than blanket allowing or blanket refusing.

```
curl -s -D headers -o /dev/null -X POST http://127.0.0.1:4956/mcp/ \
  -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
  -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"lit4956","version":"1"}}}'
SID=$(grep -i '^mcp-session-id:' headers | tr -d '\r' | awk '{print $2}')

curl -s -X POST http://127.0.0.1:4956/mcp/ \
  -H "Authorization: Bearer $KEY" -H "mcp-session-id: $SID" \
  -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'

for TOOL in list_pets dump_secrets; do
  curl -s -X POST http://127.0.0.1:4956/mcp/ \
    -H "Authorization: Bearer $KEY" -H "mcp-session-id: $SID" \
    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
    -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"petstore-$TOOL\",\"arguments\":{}}}"
done
```

Before, at `551e5d097c11f08fd2400a25a651b1844fcf89c2` (current staging); the entitlement is ignored and both handlers run, including the one the key's allowlist excludes:

```
mcp-session-id: a3bc908720664f49a5a63f73aaa5083d
--- tools/call petstore-list_pets ---
data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"LEGACY LOCAL TOOL EXECUTED - list_pets"}],"isError":false}}

--- tools/call petstore-dump_secrets ---
data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"LEGACY LOCAL TOOL EXECUTED - dump_secrets"}],"isError":false}}
```

After, at `f67e174de3cc4ebcd187589ae5df35544b3af422`; the entitled tool still dispatches and only the unentitled one is refused, by the entitlement gate naming the key/team:

```
mcp-session-id: 1d0f641329b04188b4d68b9c8db54c31
--- tools/call petstore-list_pets ---
data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"LEGACY LOCAL TOOL EXECUTED - list_pets"}],"isError":false}}

--- tools/call petstore-dump_secrets ---
data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Error: {'error': \"Tool 'dump_secrets' is not allowed for your key/team on server 'petstore'. Contact proxy admin for access.\"}"}],"isError":true}}
```

Both captures ran with `PYTHONPATH` pinned to this worktree, confirmed at each launch with `python -c "import litellm,os;print(os.path.dirname(litellm.__file__))"`. The Postgres container and the proxy were torn down afterwards

## Type

🐛 Bug Fix

## Changes

Tool-level MCP entitlements are enforced in exactly one place, `check_tool_permission_for_key_team`, reached from `pre_call_tool_check`. Two dispatch paths could reach a tool handler without passing through it, and both predate the per-user entitlement work, so the key, team, org and agent levels were affected equally

### The legacy local-tool fallback dispatched ungated

`execute_mcp_tool` has a legacy fallback that retries the unprefixed tool name against the local tool registry when nothing else matched. It dispatched the handler directly, with no allowed/banned-tool check, no key/team/org tool permissions and no parameter validation. It now runs the same gate the other dispatch paths run

The server those checks need is available even though the tool name is absent from the tool to server mapping. Reaching this branch requires a non-empty prefix, because a bare name would have hit `get_tool(name)` and taken the branch above, and the server-level check at `server.py:2719-2727` has already compared that prefix against the caller's `allowed_mcp_servers` by exact `name`. So the named server is sitting in that list. It is resolved from `allowed_mcp_servers` rather than from the manager's registry on purpose: the registry can return a server the caller holds no grant for, and matching on `alias` or `server_name` as well would accept a server the server-level check never validated. A prefix that matches nothing in that list still fails closed with a 503, which is defensive rather than live, since given the upstream check it is not reachable today

The practical effect, measured rather than argued. Five call shapes, same probe, real registries and real gate:

| call shape | staging | this PR |
|---|---|---|
| bare name, no MCP servers registered | 503 | 503 |
| bare name, one allowed server registered | 503 | 503 |
| prefixed, prefix names an allowed server, caller entitled | dispatched | dispatched |
| prefixed, prefix names an allowed server, caller not entitled | dispatched | 403 from the entitlement gate |
| prefixed, prefix names nothing the caller is allowed | 403 | 403 |

Only the fourth row changes. An entitled caller's legacy call keeps working, so this does not trade an authorization hole for an outage on a configuration that worked before. The first two rows already 503 on staging, from the earlier fix to the `if local_tool:` branch rather than from this PR

Worth stating as context: bare `mcp_tools` handlers are never advertised in `tools/list`. The only registry listing is `mcp_server_manager.py:3303`, scoped to `spec_path` servers by that server's prefix, and OpenAPI tools register as `{server}-{tool}` so they resolve through `get_tool(name)` and take the gated branch. So the preserved shape only ever worked for a client that already knew the name. That is context, not justification; breaking a supported configuration needs a better reason than the call being hard to discover, which is why it is preserved rather than refused

### Authorization was conditional on a logging object

`call_tool` ran `pre_call_tool_check` inside `if proxy_logging_obj:`, so an absent logging object would have skipped the authorization decision silently. To be plain about it: this is defensive and there is no live hole. All four relevant call sites were checked and every one passes a non-None logger. `pre_call_tool_check` is called from `server.py:2809` (the local-registry dispatch) and from `mcp_server_manager.py:5130` (inside `call_tool`); `call_tool` is called from `server.py:3232` (`_handle_managed_mcp_tool`) and from `litellm/responses/mcp/litellm_proxy_mcp_handler.py:786`. Each sources `proxy_logging_obj` from `proxy_server.py:2051`, a module-level `ProxyLogging` built at import time that is never None and never reassigned

The shape was still wrong, because an authorization decision must not hang off a logging object. `pre_call_tool_check` now runs its three authorization checks unconditionally and returns early only from the guardrail-hook portion, which genuinely needs a logger to dispatch through

### The third reported path is not a defect

A third path was reported, where `allow_all_keys` servers, BYOM-submitted servers and the anonymous upstream-delegated set are unioned into the reachable servers after the resolver has applied its ceilings. It was investigated and found not to be a defect, so nothing here changes it

The widening is real as observed: a key scoped to one server does reach an `allow_all_keys` server, and with no `mcp_tool_permissions` entry for that server its tool ceiling resolves to None, meaning every tool. What makes it not a gap is that the narrowing mechanism already exists at the right level. `MCPServer.allowed_tools` and `disallowed_tools` bound a server's tool surface for every caller at registration time, and `check_allowed_or_banned_tools` enforces them inside `pre_call_tool_check` before the entitlement check runs, so an operator who opens a server to all keys can still bound what that server exposes. Per-caller narrowing remains available through an explicit `mcp_tool_permissions` entry for that server, and the org tool ceiling still binds either way

Spelling the bound per principal instead would break every existing `allow_all_keys` deployment, because the callers that feature exists to serve are precisely the ones nobody enumerated, so by construction almost none of them hold an entry for the open server. The same union carries BYOM-submitted servers and the anonymous upstream-delegated set, so the breakage would not be limited to one flag

The gateway-admitted path was also checked and does not diverge here. `_resolve_admitted_subject_tools` resolves an open-channel server's ceiling by calling `get_allowed_tools_for_server(server_id, source, keyless_source=True)` against the user's own source, which takes the same key/team branch and reads an absent entry the same way a key does

### Tests

Tests live in the mapped file for each source file changed, and each pairs a refusal with a dispatch so neither half can pass by being uniformly strict or uniformly permissive

`test_openapi_tool_auth.py` covers the fallback with the real tool registry, the real server registry and the real entitlement gate, nothing mocked. One test asserts the gate refuses the caller/tool pair and the handler never runs, pinning the refusal to the entitlement gate rather than to any 403: the server-level check also raises 403 with a plain-string detail, and the allowed/banned-tools check raises a dict naming the server, so the assertion matches on the key/team wording. A second test asserts the same call shape from an entitled caller still dispatches, which is what proves the hole was not traded for an outage. A third pins the fail-closed arm for a prefix that matches no allowed server, labelled defensive since the upstream check makes it unreachable today

`test_mcp_server_manager.py` covers `call_tool` with no logging object, one test asserting an unentitled tool is refused before the upstream is reached and a companion asserting an entitled tool still dispatches

With both source files reverted to staging and the tests kept, the mapped directory reports 3 failed and 2645 passed, the three failures being exactly the new negative tests; with the fix in place it reports 2648 passed. Both runs exclude `test_semantic_tool_filter.py`, whose failures come from the missing optional `semantic_router` dependency and are unrelated to this change

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
