### PR TITLE
fix(tests): assert Content variants are identified by type, not by the discriminator keyword

### DIFF
--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -37,6 +37,13 @@ def _load_openapi_spec_dict() -> Dict[str, Any]:
         )
 
 
+def _declared_type_value(variant_schema: Dict[str, Any]) -> Any:
+    """The single `type` value a union variant pins, whether spelled as a const or a 1-item enum."""
+    type_property = variant_schema.get("properties", {}).get("type", {})
+    enum_values = type_property.get("enum") or []
+    return type_property.get("const") or (enum_values[0] if len(enum_values) == 1 else None)
+
+
 @pytest.fixture(scope="module")
 def spec_dict() -> Dict[str, Any]:
     """Load raw spec dict for manual validation."""
@@ -105,26 +112,51 @@ class TestRequestCompliance:
         assert "string" in input_types, "Input should support string"
         assert "array" in input_types, "Input should support array"
 
-    def test_content_schema_uses_discriminator(self, spec_dict):
-        """Verify Content uses type discriminator."""
+    def test_content_variants_are_identified_by_their_type_field(self, spec_dict):
+        """Verify a Content part can be told apart by its `type`, however the spec spells that.
+
+        Our transformation reads `type` off each content part to route it, so what has to hold is
+        that every variant of the union pins a distinct `type` value and that text is one of them.
+        A spec may express that with an OpenAPI `discriminator` on the union or with a `const` on
+        each member's own `type`; both are equivalent for us, so accepting only the first makes
+        this test fail on a stylistic change upstream that costs us nothing.
+        """
         content_schema = spec_dict["components"]["schemas"]["Content"]
 
-        assert "discriminator" in content_schema
-        assert content_schema["discriminator"]["propertyName"] == "type"
-
-        # Check TextContent is an option (via mapping if present, or via oneOf refs)
-        mapping = content_schema["discriminator"].get("mapping")
-        if mapping:
-            assert "text" in mapping
-            print(f"Content type discriminator mapping: {list(mapping.keys())}")
-        else:
-            # Discriminator without explicit mapping — verify via oneOf
-            one_of = content_schema.get("oneOf", [])
-            ref_names = [opt["$ref"].split("/")[-1] for opt in one_of if "$ref" in opt]
+        discriminator = content_schema.get("discriminator")
+        if discriminator is not None:
             assert (
-                "TextContent" in ref_names
-            ), f"TextContent not found in oneOf refs: {ref_names}"
-            print(f"Content type discriminator (no mapping), oneOf refs: {ref_names}")
+                discriminator.get("propertyName") == "type"
+            ), f"Content is discriminated on {discriminator.get('propertyName')!r}, not 'type'"
+
+        variant_names = [
+            option["$ref"].split("/")[-1]
+            for option in content_schema.get("oneOf", [])
+            if "$ref" in option
+        ]
+        assert variant_names, f"Content is not a union of named variants: {content_schema}"
+
+        mapping = (discriminator or {}).get("mapping") or {}
+        type_values = {
+            variant: mapping_value
+            for mapping_value, ref in mapping.items()
+            for variant in [ref.split("/")[-1]]
+        } or {
+            variant: _declared_type_value(spec_dict["components"]["schemas"].get(variant, {}))
+            for variant in variant_names
+        }
+
+        assert set(type_values) == set(variant_names) and all(type_values.values()), (
+            f"every Content variant needs a discoverable type value, "
+            f"got {type_values} for variants {sorted(variant_names)}"
+        )
+        assert len(set(type_values.values())) == len(type_values), (
+            f"Content variants must pin DISTINCT type values, got {type_values}"
+        )
+        assert type_values.get("TextContent") == "text", (
+            f"TextContent must be reachable as type 'text', got {type_values}"
+        )
+        print(f"Content variants by type: {type_values}")
 
     def test_text_content_schema(self, spec_dict):
         """Verify TextContent schema."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- The `misc / Run tests` shard is red on every open PR against `litellm_internal_staging`, at `tests/test_litellm/interactions/test_openapi_compliance.py::TestRequestCompliance::test_content_schema_uses_discriminator`
- Nothing in the repo caused it. That test fetches Google's Interactions OpenAPI document over the network at run time and asserted the `Content` union carries an OpenAPI `discriminator` keyword. Google has since removed it and now pins `type` with a `const` on each variant, so the assertion fails against the live spec and will keep failing

How it solves it:

- The test now asserts the property our transformation actually depends on, that every `Content` variant is identifiable by a distinct `type` value and that text is reachable as `text`, and accepts either spelling of it (a `discriminator` on the union, or a `const` / single-value `enum` on each member)
- It stays a real check. It still fails if the spec drops a variant's `type`, renames `text`, gives two variants the same `type`, stops making `Content` a union of named variants, or discriminates on some property other than `type`

## Relevant issues

## Linear ticket

Resolves LIT-4975

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This one is a test-only change against a third-party document, so the evidence is the document itself plus the failure it causes.

### What the live spec says today

```
$ curl -s https://ai.google.dev/static/api/interactions.openapi.json \
    | python3 -c "import json,sys; s=json.load(sys.stdin); c=s['components']['schemas']['Content']; \
        print('Content keys:', list(c.keys())); \
        print('has discriminator:', 'discriminator' in c); \
        print('oneOf:', [o['\$ref'].split('/')[-1] for o in c['oneOf']]); \
        print('TextContent.type:', s['components']['schemas']['TextContent']['properties']['type'])"

Content keys: ['description', 'type', 'oneOf', 'x-speakeasy-exports', 'x-speakeasy-model-namespace']
has discriminator: False
oneOf: ['AudioContent', 'DocumentContent', 'ImageContent', 'TextContent', 'VideoContent']
TextContent.type: {'const': 'text'}
```

The union is intact and every variant still pins its own `type`. Only the keyword went away.

### Before, on a clean `litellm_internal_staging` worktree

```
$ git log --oneline -1
551e5d097c feat(dashscope): add qwen3.7-plus and qwen3.7-max to the model cost map (#35123)

$ python -m pytest -q tests/test_litellm/interactions/test_openapi_compliance.py
tests/test_litellm/interactions/test_openapi_compliance.py:112: AssertionError
FAILED tests/test_litellm/interactions/test_openapi_compliance.py::TestRequestCompliance::test_content_schema_uses_discriminator
1 failed, 12 passed in 0.50s
```

### After, on this branch

```
$ python -m pytest -q tests/test_litellm/interactions/ -s
Content variants by type: {'AudioContent': 'audio', 'DocumentContent': 'document', 'ImageContent': 'image', 'TextContent': 'text', 'VideoContent': 'video'}
104 passed, 22 skipped, 5 warnings in 8.02s
```

### The rewritten test is not weaker

Each row is the live spec with one thing changed, run through the new assertion. The three that must pass are the current spec, the same information spelled as a single-value `enum`, and a spec that re-adds a `discriminator`.

```
PASS  real live spec (must PASS)
FAIL  TextContent loses its type property (must FAIL)  <- every Content variant needs a discoverable type value
FAIL  text renamed to plain_text (must FAIL)           <- TextContent must be reachable as type 'text'
FAIL  two variants share type 'text' (must FAIL)       <- Content variants must pin DISTINCT type values
FAIL  Content stops being a union (must FAIL)          <- Content is not a union of named variants
PASS  type spelled as 1-item enum (must PASS)
PASS  spec re-adds a discriminator (must PASS)
FAIL  discriminator on the wrong property (must FAIL)  <- Content is discriminated on 'kind', not 'type'
```

## Type

✅ Test

## Changes

One test in `tests/test_litellm/interactions/test_openapi_compliance.py`, renamed to say what it checks, plus a small `_declared_type_value` helper that reads the value a variant pins whether it is written as a `const` or a single-value `enum`.

Worth naming the shape of the underlying risk, since this file will hit it again. Every test in it asserts against a document a third party can change at any time, with no version pin; the fixture fetches it per module run and skips when the network is unavailable. That makes the whole file a CI liability rather than a test of our code, and it fails closed on upstream editorial changes that cost us nothing. This PR only fixes the assertion that is red now, and deliberately does not restructure the file. If the pattern bites again, the durable answer is to vendor a pinned copy of the spec and review the diff on a deliberate bump, so an upstream edit shows up as a reviewable change rather than as red CI on unrelated PRs.

## QA runbook

Not applicable; the change is confined to a test, and the before/after runs above are the verification. Anyone can reproduce the base failure by checking out `litellm_internal_staging` and running that one file.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
