### PR TITLE
fix(a2a): keep config-defined agents registered and accept the documented `agents:` key

### DIFF
--- a/litellm/proxy/agent_endpoints/agent_registry.py
+++ b/litellm/proxy/agent_endpoints/agent_registry.py
@@ -89,6 +89,7 @@ def agents_table(prisma_client: PrismaClient) -> AgentTableClient:
 class AgentRegistry:
     def __init__(self):
         self.agent_list: list[AgentResponse] = []
+        self.config_agents: tuple[AgentConfig, ...] = ()
 
     def reset_agent_list(self):
         self.agent_list = []
@@ -117,8 +118,20 @@ class AgentRegistry:
         return hashlib.sha256(json.dumps(agent_config, sort_keys=True).encode()).hexdigest()
 
     def load_agents_from_config(self, agent_config: Sequence[AgentConfig] | None = None):
+        """
+        Register the agents declared in config.yaml and remember them for later rebuilds.
+
+        A config entry is skipped when its ``agent_name`` is already registered, so a
+        database record always wins over a config entry that reuses its name and the
+        registry never holds two agents under one name. Enforcing that here rather than
+        in the caller keeps the guarantee independent of the order the two sources load
+        in. Passing ``None`` leaves the remembered agents untouched; passing an empty
+        sequence clears them.
+        """
         if agent_config is None:
             return None
+
+        self.config_agents = tuple(agent_config)
 
         for agent_config_item in agent_config:
             if not isinstance(agent_config_item, dict):
@@ -127,6 +140,9 @@ class AgentRegistry:
             agent_name = agent_config_item.get("agent_name")
             agent_card_params = agent_config_item.get("agent_card_params")
             if not all([agent_name, agent_card_params]):
+                continue
+
+            if any(agent.agent_name == agent_name for agent in self.agent_list):
                 continue
 
             # create a stable hash id for config item
@@ -139,19 +155,20 @@ class AgentRegistry:
         agent_config: Sequence[AgentConfig] | None = None,
         db_agents: list[dict[str, Any]] | None = None,
     ):
+        """
+        Rebuild the registry from the DB rows plus the agents declared in config.yaml.
+
+        ``agent_config`` defaults to the agents remembered by the last
+        ``load_agents_from_config`` call, so a periodic DB reload does not drop
+        config-defined agents.
+
+        The DB rows are registered first so that a config entry reusing one of their
+        names is dropped by ``load_agents_from_config``, mirroring how config-declared
+        MCP servers are unioned under the database registry. Name lookups and
+        deregistration both address a single agent, so the registry must never hold two
+        under one name.
+        """
         self.reset_agent_list()
-
-        if agent_config:
-            for agent_config_item in agent_config:
-                if not isinstance(agent_config_item, dict):
-                    raise ValueError("agent_config must be a list of dictionaries")
-
-                self.register_agent(
-                    agent_config=AgentResponse(
-                        agent_id=self._create_agent_id(agent_config_item),
-                        **agent_config_item,
-                    )
-                )  # type: ignore
 
         if db_agents:
             for db_agent in db_agents:
@@ -159,6 +176,8 @@ class AgentRegistry:
                     raise ValueError("db_agents must be a list of dictionaries")
 
                 self.register_agent(agent_config=AgentResponse(**db_agent))  # type: ignore
+
+        self.load_agents_from_config(agent_config if agent_config is not None else self.config_agents)
         return self.agent_list
 
     ###########################################################

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -654,8 +654,6 @@ from fastapi.security import OAuth2PasswordBearer
 from fastapi.security.api_key import APIKeyHeader
 from fastapi.staticfiles import StaticFiles
 
-from litellm.types.agents import AgentConfig
-
 # import enterprise folder
 enterprise_router = APIRouter()
 try:
@@ -2000,7 +1998,6 @@ config_passthrough_endpoints: Optional[List[Dict[str, Any]]] = None
 log_file = "api_log.json"
 worker_config = None
 master_key: Optional[str] = None
-config_agents: Optional[List[AgentConfig]] = None
 otel_logging = False
 prisma_client: Optional[PrismaClient] = None
 shared_aiohttp_session: Optional["ClientSession"] = None  # Global shared session for connection reuse
@@ -5093,8 +5090,8 @@ class ProxyConfig:
             global_mcp_tool_registry.load_tools_from_config(mcp_tools_config, config_file_path=config_file_path)
 
         ## AGENTS
-        agent_config = config.get("agent_list", None)
-        if agent_config:
+        agent_config = config.get("agents", config.get("agent_list", None))
+        if agent_config is not None:
             from litellm.proxy.agent_endpoints.agent_registry import (
                 global_agent_registry,
             )
@@ -6824,7 +6821,7 @@ class ProxyConfig:
 
         try:
             db_agents = await AGENT_REGISTRY.get_all_agents_from_db(prisma_client=prisma_client)
-            AGENT_REGISTRY.load_agents_from_db_and_config(db_agents=db_agents, agent_config=config_agents)
+            AGENT_REGISTRY.load_agents_from_db_and_config(db_agents=db_agents)
         except Exception as e:
             verbose_proxy_logger.exception(
                 "litellm.proxy.proxy_server.py::ProxyConfig:_init_agents_in_db - {}".format(str(e))

--- a/tests/test_litellm/proxy/agent_endpoints/test_agent_registry.py
+++ b/tests/test_litellm/proxy/agent_endpoints/test_agent_registry.py
@@ -112,3 +112,170 @@ async def test_update_agent_in_db_preserves_explicit_static_headers_and_extra_he
 
     assert update_data["static_headers"] == '{"Authorization": "Bearer xyz"}'
     assert update_data["extra_headers"] == ["X-Custom-Header"]
+
+
+def test_load_agents_from_db_and_config_retains_previously_loaded_config_agents():
+    """
+    A DB reload calls this without an explicit agent_config. It resets the
+    registry, so it must fall back to the agents remembered from config.yaml
+    instead of dropping them.
+    """
+    registry = AgentRegistry()
+    registry.load_agents_from_config(
+        [
+            {
+                "agent_name": "config-agent",
+                "agent_card_params": _sample_agent_card_params(),
+            }
+        ]
+    )
+
+    registry.load_agents_from_db_and_config(
+        db_agents=[
+            {
+                "agent_id": "db-id",
+                "agent_name": "db-agent",
+                "agent_card_params": _sample_agent_card_params(),
+            }
+        ]
+    )
+
+    assert sorted(agent.agent_name for agent in registry.get_agent_list()) == [
+        "config-agent",
+        "db-agent",
+    ]
+
+
+def test_load_agents_from_db_and_config_skips_incomplete_config_entries():
+    """Config entries missing agent_card_params are skipped, not registered half-built."""
+    registry = AgentRegistry()
+    registry.load_agents_from_config([{"agent_name": "no-card"}])
+
+    registry.load_agents_from_db_and_config(db_agents=None)
+
+    assert registry.get_agent_list() == []
+
+
+@pytest.mark.parametrize(
+    "db_agent_names",
+    [
+        ("shared-name", "other-db-agent"),
+        ("other-db-agent", "shared-name"),
+    ],
+    ids=["colliding-db-row-first", "colliding-db-row-last"],
+)
+def test_load_agents_from_db_and_config_lets_db_rows_win_a_name_collision(db_agent_names):
+    """
+    A config entry that reuses a DB agent's name must not be registered next to it.
+
+    Name lookups and deregistration both address a single agent, so two entries
+    under one name would shadow the DB row for routing and let a single delete
+    drop both. Parametrized over both DB row orders because the registry is a
+    list and a first-match lookup would otherwise pass on ordering luck.
+    """
+    registry = AgentRegistry()
+    registry.load_agents_from_config(
+        [
+            {
+                "agent_name": "shared-name",
+                "agent_card_params": _sample_agent_card_params(),
+            },
+            {
+                "agent_name": "config-only",
+                "agent_card_params": _sample_agent_card_params(),
+            },
+        ]
+    )
+
+    registry.load_agents_from_db_and_config(
+        db_agents=[
+            {
+                "agent_id": f"db-id-{name}",
+                "agent_name": name,
+                "agent_card_params": _sample_agent_card_params(),
+            }
+            for name in db_agent_names
+        ]
+    )
+
+    registered = registry.get_agent_list()
+    assert sorted(agent.agent_name for agent in registered) == [
+        "config-only",
+        "other-db-agent",
+        "shared-name",
+    ]
+
+    shared = registry.get_agent_by_name("shared-name")
+    assert shared is not None
+    assert shared.agent_id == "db-id-shared-name", "the DB row must win the shared name, not the config entry"
+
+    registry.deregister_agent("shared-name")
+    assert [agent.agent_name for agent in registry.get_agent_list() if agent.agent_name == "shared-name"] == [], (
+        "deleting the DB agent must not leave a shadowed config duplicate behind"
+    )
+
+
+def test_load_agents_from_config_skips_a_name_already_held_by_a_db_agent():
+    """
+    The one-agent-per-name rule is enforced by the loader, not by the call order.
+
+    A config load that lands on a registry already holding DB rows must not append a
+    colliding entry, otherwise the duplicate is reachable any time the two sources are
+    loaded in the other order.
+    """
+    registry = AgentRegistry()
+    registry.load_agents_from_db_and_config(
+        db_agents=[
+            {
+                "agent_id": "db-id",
+                "agent_name": "shared-name",
+                "agent_card_params": _sample_agent_card_params(),
+            }
+        ]
+    )
+
+    registry.load_agents_from_config(
+        [
+            {
+                "agent_name": "shared-name",
+                "agent_card_params": _sample_agent_card_params(),
+            }
+        ]
+    )
+
+    assert [agent.agent_id for agent in registry.get_agent_list()] == ["db-id"]
+
+
+def test_load_agents_from_config_registers_one_agent_per_name_within_the_config():
+    """Two config entries sharing a name collapse to the first, keeping name lookups unambiguous."""
+    registry = AgentRegistry()
+    registry.load_agents_from_config(
+        [
+            {"agent_name": "dupe", "agent_card_params": _sample_agent_card_params()},
+            {"agent_name": "dupe", "agent_card_params": {**_sample_agent_card_params(), "url": "http://second"}},
+        ]
+    )
+
+    registered = registry.get_agent_list()
+    assert len(registered) == 1
+    assert registered[0].agent_card_params["url"] == "http://localhost"
+
+
+def test_load_agents_from_config_with_an_empty_list_clears_the_remembered_agents():
+    """
+    An explicitly empty config must forget the previously loaded agents.
+
+    Otherwise the next DB rebuild replays agents the operator removed from config.yaml.
+    ``None`` still means "no opinion" and leaves them alone.
+    """
+    registry = AgentRegistry()
+    registry.load_agents_from_config(
+        [{"agent_name": "removed-agent", "agent_card_params": _sample_agent_card_params()}]
+    )
+    assert registry.config_agents != ()
+
+    registry.load_agents_from_config([])
+    assert registry.config_agents == ()
+
+    registry.load_agents_from_db_and_config(db_agents=None)
+    assert registry.get_agent_list() == [], "a removed config agent must not come back on the next rebuild"

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -2354,3 +2354,133 @@ async def test_ProxyConfig_load_config_redacts_secret_litellm_setting_keeps_plai
     assert "num_retries=7" in rendered, (
         f"non-secret num_retries value was over-redacted; expected it visible in {rendered!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# ProxyConfig agents from config.yaml
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_agent_registry():
+    from litellm.proxy.agent_endpoints.agent_registry import global_agent_registry
+
+    original_agents = list(global_agent_registry.agent_list)
+    original_config_agents = getattr(global_agent_registry, "config_agents", ())
+    global_agent_registry.agent_list = []
+    global_agent_registry.config_agents = ()
+    try:
+        yield global_agent_registry
+    finally:
+        global_agent_registry.agent_list = original_agents
+        global_agent_registry.config_agents = original_config_agents
+
+
+def _config_agent(agent_name: str) -> Dict[str, Any]:
+    return {
+        "agent_name": agent_name,
+        "agent_card_params": {
+            "name": "Config Agent",
+            "url": "http://localhost:10001",
+            "protocolVersion": "1.0",
+        },
+    }
+
+
+class _FakeAgentRow:
+    """Stand-in for a prisma agent record: supports dict() and .object_permission."""
+
+    def __init__(self, agent_id: str, agent_name: str) -> None:
+        self.agent_id = agent_id
+        self.agent_name = agent_name
+        self.object_permission = None
+        self.spend = 0.0
+
+    def __iter__(self):
+        return iter(
+            {
+                "agent_id": self.agent_id,
+                "agent_name": self.agent_name,
+                "agent_card_params": {"name": self.agent_name, "url": "http://db-agent"},
+                "litellm_params": {},
+            }.items()
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("config_key", ["agents", "agent_list"])
+async def test_ProxyConfig__init_non_llm_configs_registers_agents_from_config(clean_agent_registry, config_key):
+    """The documented ``agents:`` key must register agents, as must the legacy ``agent_list:``."""
+    await ProxyConfig()._init_non_llm_configs(
+        config={config_key: [_config_agent("config-agent")]},
+        config_file_path=None,
+    )
+
+    assert [agent.agent_name for agent in clean_agent_registry.get_agent_list()] == ["config-agent"]
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__init_agents_in_db_keeps_config_defined_agents(clean_agent_registry):
+    """A DB reload rebuilds the registry; config-defined agents must survive it alongside DB rows."""
+    await ProxyConfig()._init_non_llm_configs(
+        config={"agents": [_config_agent("config-agent")]},
+        config_file_path=None,
+    )
+
+    prisma_client = MagicMock()
+    prisma_client.db.litellm_agentstable.find_many = AsyncMock(return_value=[_FakeAgentRow("db-id", "db-agent")])
+
+    await ProxyConfig()._init_agents_in_db(prisma_client=prisma_client)
+
+    assert sorted(agent.agent_name for agent in clean_agent_registry.get_agent_list()) == [
+        "config-agent",
+        "db-agent",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "config, expected_agent_names",
+    [
+        ({"agents": [], "agent_list": [_config_agent("legacy-agent")]}, []),
+        (
+            {
+                "agents": [_config_agent("documented-agent")],
+                "agent_list": [_config_agent("legacy-agent")],
+            },
+            ["documented-agent"],
+        ),
+        ({"agent_list": [_config_agent("legacy-agent")]}, ["legacy-agent"]),
+    ],
+    ids=["empty-agents-wins", "populated-agents-wins", "agent_list-alone-still-works"],
+)
+async def test_ProxyConfig__init_non_llm_configs_prefers_agents_key_by_presence(
+    clean_agent_registry, config, expected_agent_names
+):
+    """
+    ``agents`` outranks the legacy ``agent_list`` whenever the key is present.
+
+    Selecting on truthiness instead would silently register the legacy entries
+    for a config that spells out ``agents: []``.
+    """
+    await ProxyConfig()._init_non_llm_configs(config=config, config_file_path=None)
+
+    assert [agent.agent_name for agent in clean_agent_registry.get_agent_list()] == expected_agent_names
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__init_non_llm_configs_empty_agents_key_clears_remembered_agents(clean_agent_registry):
+    """
+    An explicitly empty ``agents:`` must reach the registry, not be skipped as falsy.
+
+    Skipping it leaves the previously remembered agents in place, so the next DB
+    rebuild replays agents the operator deleted from config.yaml.
+    """
+    clean_agent_registry.load_agents_from_config([_config_agent("stale-agent")])
+    assert clean_agent_registry.config_agents != ()
+
+    await ProxyConfig()._init_non_llm_configs(config={"agents": []}, config_file_path=None)
+
+    assert clean_agent_registry.config_agents == ()
+    clean_agent_registry.load_agents_from_db_and_config(db_agents=None)
+    assert clean_agent_registry.get_agent_list() == []


### PR DESCRIPTION
## TLDR

Problem this solves:

- Docs say `agents:`; the proxy only read `agent_list:`, so a config written from the guide was ignored with no warning
- Config-defined A2A agents never survive on a gateway with a DB, so `GET /v1/agents` returns `[]` even for the master key

How it solves it:

- Accepts the documented `agents:` key by presence, keeping `agent_list:` working
- Registry remembers its config agents and re-registers them on every DB reload
- A DB row wins a name collision, so lookups and deregistration address exactly one agent
- Drops the dead `config_agents` global the reload relied on

## Relevant issues

Docs companion: BerriAI/litellm-docs#714, which documents the config key this PR makes the proxy read. Merge this one first

## Linear ticket

Resolves LIT-4977
Resolves LIT-4978

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on a real Postgres, master key, agents table empty at the start of each run. The same `config.yaml` for every run, written the way the [A2A guide](https://docs.litellm.ai/docs/a2a) shows it:

```yaml
model_list:
  - model_name: gpt-5.1
    litellm_params:
      model: openai/gpt-5.1
      api_key: os.environ/OPENAI_API_KEY

agents:
  - agent_name: my-agent
    agent_card_params:
      name: "My Agent"
      url: "http://localhost:10001"
      protocolVersion: "1.0"

general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  store_model_in_db: true
  proxy_config_reload_interval_seconds: 10
```

`store_model_in_db` matters to the repro: the reload job that wipes the registry is only scheduled when it is on, which is why the loss shows up on DB-backed gateways and not on a config-only one

### Before, staging at `fa56283806`

```
### BEFORE, staging fa56283806, documented agents: key, DB attached, agents table empty
$ curl -s http://localhost:4978/v1/agents -H "Authorization: Bearer $LITELLM_MASTER_KEY"
[]

$ sleep 25; curl -s .../v1/agents        # across two reload cycles
[]
```

The same file with the key renamed to the legacy `agent_list:` is no better once a DB is attached, because the reload rebuilds the registry from the DB alone:

```
### BASE (unfixed), legacy agent_list: key, DB attached, store_model_in_db: true
t=0s  agents returned by GET /v1/agents: 0
t=12s  agents returned by GET /v1/agents: 0
t=24s  agents returned by GET /v1/agents: 0
```

### After, this PR at `a4d28e3df1`

```
### AFTER, this PR at a4d28e3df1, same config.yaml, same DB
$ curl -s http://localhost:4978/v1/agents -H "Authorization: Bearer $LITELLM_MASTER_KEY" | python3 -m json.tool
[
    {
        "agent_id": "4f01804d14ac4583ae2b5b85b5efd6224cfae1f9025638e8ea5333388e39817a",
        "agent_name": "my-agent",
        "litellm_params": {
            "is_public": false
        },
        "agent_card_params": {
            "name": "My Agent",
            "url": "http://localhost:10001",
            "protocolVersion": "1.0"
        },
        ...
    }
]

$ for i in 1 2 3 4 5 6; do curl -s .../v1/agents; sleep 10; done   # the reload used to wipe it
t=10s  ['my-agent']
t=20s  ['my-agent']
t=30s  ['my-agent']
t=40s  ['my-agent']
t=50s  ['my-agent']
t=60s  ['my-agent']
```

The Agents tab and the playground agent picker both read this same endpoint (`agentListCall` in `ui/litellm-dashboard/src/components/networking.tsx`), so the list above is exactly what the dashboard renders. No UI code changes here

### Name collisions between a config agent and a DB row

Retaining config agents across reloads makes it possible for a config entry and a DB row to share an `agent_name`, which Greptile flagged. `POST /v1/agents` rejects a duplicate name, so this only arises when the DB row predates the config entry. Seeding the row first and then restarting with `agents: my-agent` in the config reproduces it on the pre-review head of this PR:

```
### PRE-REVIEW head (retention without dedup), config agent + DB row share the name my-agent
  my-agent       id=4f01804d14ac   card.url=http://localhost:10001
  my-agent       id=35f647b8-aa7   card.url=http://localhost:10002
  db-only-agent  id=9c89a1fa-d6c   card.url=http://localhost:10003

  entries named my-agent: 2

### which one does name-based routing resolve to?
[{"agent_id":"4f01804d14ac...","agent_name":"my-agent","agent_card_params":{"url":"http://localhost:10001" ...
```

The config definition shadows the DB row that the admin can actually edit. On this head the DB row wins and there is one entry, and deleting it hands the name back to the config agent on the next reload:

```
### FIXED head, same DB + same config
  my-agent       id=35f647b8-aa7   card.url=http://localhost:10002
  db-only-agent  id=9c89a1fa-d6c   card.url=http://localhost:10003

  entries named my-agent: 1

### now delete the DB row; the config agent should take the name back on the next reload
{"message":"Agent 35f647b8-aa74-4aa6-9893-ad87fe44ae1e deleted successfully"}
  db-only-agent  id=9c89a1fa-d6c   card.url=http://localhost:10003
  my-agent       id=4f01804d14ac   card.url=http://localhost:10001
```

## Type

🐛 Bug Fix

## Changes

`_init_non_llm_configs` read `config.get("agent_list")` and nothing in the repo read a top-level `agents:`. Both spellings are accepted now, selected by key presence rather than truthiness, so `agents: []` beside a populated `agent_list:` registers nothing instead of silently falling back to the legacy entries

`_init_agents_in_db` rebuilt the whole registry from the DB rows plus `config_agents`, a module global declared at `proxy_server.py` and assigned nowhere in the repo. `load_agents_from_db_and_config` starts with `reset_agent_list()`, so every reload cleared what `_init_non_llm_configs` had registered from the config file and refilled the registry from the DB alone. It runs at startup and again on each `add_deployment` pass

`AgentRegistry` now keeps the agents it loaded from config on itself and falls back to them when a caller does not pass any, so the reload rebuilds the full picture and the dead global goes away. The reload path reuses `load_agents_from_config` instead of duplicating its registration loop, so an entry missing `agent_name` or `agent_card_params` is skipped on both paths rather than only the first one

`get_agent_by_name` and `deregister_agent` both address a single agent, so the registry must never hold two under one name. `load_agents_from_config` enforces that itself by skipping any `agent_name` already registered, and the rebuild registers the DB rows before it, so the database wins. That mirrors `MCPServerManager.get_registry`, which returns `self.config_mcp_servers | self.registry` and lets the DB side win the same way

Keeping the rule in the loader rather than in the caller means it does not depend on the order the two sources happen to load in, and it collapses duplicate names within a single config block for free. Today `load_config` only runs from `proxy_startup_event` and `initialize`, so config always loads first on an empty registry, but the guarantee should not rest on that staying true

`load_agents_from_config(None)` leaves the remembered agents alone while an empty sequence clears them, so `_init_non_llm_configs` guards on `is not None`. An explicit `agents: []` therefore forgets agents deleted from config.yaml instead of letting the next rebuild replay them

## QA runbook

Point a gateway with a database at a `config.yaml` carrying the block above, wait past one `proxy_config_reload_interval_seconds`, and confirm `GET /v1/agents` still lists the config agent. Repeat with the key spelled `agent_list:`. To exercise precedence, create an agent through the UI, add the same `agent_name` to `config.yaml`, restart, and confirm the list holds one entry pointing at the DB row

## Tests

Both mapped files. `tests/test_litellm/proxy/proxy_server/test_proxy_config.py` drives `_init_non_llm_configs` for both keys, pins presence-based precedence over empty-canonical, populated-canonical and legacy-alone, and drives `_init_agents_in_db` against a stubbed agents table. `tests/test_litellm/proxy/agent_endpoints/test_agent_registry.py` pins the registry contract directly: the collision case parametrized over both DB row orders so a first-match lookup cannot pass on ordering luck, a config load landing on a registry that already holds a colliding DB agent, duplicate names inside one config block, and the populated-to-empty transition

Mutation-checked on the final code. Removing the in-loader name dedup, registering config entries before the DB rows, and reverting either guard (the truthiness `or` for key selection, or the truthiness `if` that skipped an empty list) each make the suite fail

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent registry merge semantics and periodic DB reload behavior for routing and `GET /v1/agents`, but scope is limited to config/DB union with explicit precedence rules and broad tests.
> 
> **Overview**
> Fixes A2A agent registration so **config.yaml agents stay visible** on DB-backed gateways and the **documented `agents:` key** is honored.
> 
> **Proxy config** now reads `agents` when present (falling back to `agent_list`), including **`agents: []`**, and always calls `load_agents_from_config` when that value is not `None`. The unused module-level `config_agents` global is removed.
> 
> **`AgentRegistry`** stores config agents on the registry (`config_agents`) and **`load_agents_from_db_and_config`** rebuilds DB rows first, then reapplies remembered config (or an explicit list). Config entries **skip names already registered** (DB wins), duplicate names within config collapse to the first, and an **empty list clears** remembered config so removed agents do not reappear on reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4d28e3df189fa54c654cacf9f745ce4befda210. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->