### PR TITLE
fix(complexity_router): capture the classifier request body in spend logs

### DIFF
--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import random
 import re
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Literal, Union, cast
 
 from pydantic import BaseModel
@@ -113,12 +114,14 @@ def _classifier_call_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]
     }
 
 
-def _effective_turn_off_message_logging(request_kwargs: dict[str, Any] | None) -> bool | None:
+def _effective_turn_off_message_logging(request_kwargs: Mapping[str, Any] | None) -> bool | None:
     from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
         initialize_standard_callback_dynamic_params,
     )
 
-    return initialize_standard_callback_dynamic_params(request_kwargs or {}).get("turn_off_message_logging")
+    return initialize_standard_callback_dynamic_params(dict(request_kwargs) if request_kwargs else {}).get(
+        "turn_off_message_logging"
+    )
 
 
 class DimensionScore:

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -113,6 +113,14 @@ def _classifier_call_metadata(metadata: dict[str, Any] | None) -> dict[str, Any]
     }
 
 
+def _effective_turn_off_message_logging(request_kwargs: dict[str, Any] | None) -> bool | None:
+    from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
+        initialize_standard_callback_dynamic_params,
+    )
+
+    return initialize_standard_callback_dynamic_params(request_kwargs or {}).get("turn_off_message_logging")
+
+
 class DimensionScore:
     """Represents a score for a single dimension with optional signal."""
 
@@ -430,6 +438,7 @@ class ComplexityRouter(CustomLogger):
         # internal classifier call) is responsible for reconciling.
         request_metadata = (request_kwargs or {}).get("litellm_metadata") or (request_kwargs or {}).get("metadata")
         metadata = _classifier_call_metadata(request_metadata)
+        turn_off_message_logging = _effective_turn_off_message_logging(request_kwargs)
 
         proxy_server_request = {
             "body": {
@@ -446,6 +455,7 @@ class ComplexityRouter(CustomLogger):
             timeout=llm_config.timeout_ms / 1000,
             metadata=metadata,
             proxy_server_request=proxy_server_request,
+            turn_off_message_logging=turn_off_message_logging,
         )
         content = response.choices[0].message.content
         if not content:
@@ -832,6 +842,7 @@ class ComplexityRouter(CustomLogger):
         # key/team budget. Key/team attribution fields are preserved for spend logging.
         metadata = _classifier_call_metadata(request_kwargs.get("metadata"))
         litellm_metadata = _classifier_call_metadata(request_kwargs.get("litellm_metadata"))
+        turn_off_message_logging = _effective_turn_off_message_logging(request_kwargs)
         proxy_server_request = {"body": {"model": self.config.embedding_model, "input": [user_message]}}
         query_vector = (
             await encoder.aencode_queries(
@@ -839,6 +850,7 @@ class ComplexityRouter(CustomLogger):
                 metadata=metadata,
                 litellm_metadata=litellm_metadata,
                 proxy_server_request=proxy_server_request,
+                turn_off_message_logging=turn_off_message_logging,
             )
         )[0]
         route_choice = await routelayer.acall(vector=query_vector)

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -429,12 +429,21 @@ class ComplexityRouter(CustomLogger):
         # internal classifier call) is responsible for reconciling.
         metadata = _classifier_call_metadata((request_kwargs or {}).get("litellm_metadata"))
 
+        proxy_server_request = {
+            "body": {
+                "model": llm_config.model,
+                "messages": [{"role": "user", "content": classification_prompt}],
+                "response_format": TierClassification.model_json_schema(),
+            }
+        }
+
         response: ModelResponse = await self.litellm_router_instance.acompletion(
             model=llm_config.model,
             messages=[{"role": "user", "content": classification_prompt}],
             response_format=TierClassification,
             timeout=llm_config.timeout_ms / 1000,
             metadata=metadata,
+            proxy_server_request=proxy_server_request,
         )
         content = response.choices[0].message.content
         if not content:
@@ -821,8 +830,14 @@ class ComplexityRouter(CustomLogger):
         # key/team budget. Key/team attribution fields are preserved for spend logging.
         metadata = _classifier_call_metadata(request_kwargs.get("metadata"))
         litellm_metadata = _classifier_call_metadata(request_kwargs.get("litellm_metadata"))
+        proxy_server_request = {"body": {"model": self.config.embedding_model, "input": [user_message]}}
         query_vector = (
-            await encoder.aencode_queries([user_message], metadata=metadata, litellm_metadata=litellm_metadata)
+            await encoder.aencode_queries(
+                [user_message],
+                metadata=metadata,
+                litellm_metadata=litellm_metadata,
+                proxy_server_request=proxy_server_request,
+            )
         )[0]
         route_choice = await routelayer.acall(vector=query_vector)
 

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel
 from litellm._logging import verbose_router_logger
 from litellm.constants import RETURN_RAW_MODEL_NAME_METADATA_KEY
 from litellm.integrations.custom_logger import CustomLogger
+from litellm.llms.base_llm.base_utils import type_to_response_format_param
 from litellm.types.utils import ModelResponse
 
 from .config import (
@@ -427,13 +428,14 @@ class ComplexityRouter(CustomLogger):
         # attributed to the calling key/team instead of being dropped. Excludes the
         # parent request's budget reservation, which the routed completion (not this
         # internal classifier call) is responsible for reconciling.
-        metadata = _classifier_call_metadata((request_kwargs or {}).get("litellm_metadata"))
+        request_metadata = (request_kwargs or {}).get("litellm_metadata") or (request_kwargs or {}).get("metadata")
+        metadata = _classifier_call_metadata(request_metadata)
 
         proxy_server_request = {
             "body": {
                 "model": llm_config.model,
                 "messages": [{"role": "user", "content": classification_prompt}],
-                "response_format": TierClassification.model_json_schema(),
+                "response_format": type_to_response_format_param(TierClassification),
             }
         }
 

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1418,6 +1418,24 @@ class TestLLMClassifier:
         assert call_kwargs["metadata"] == request_metadata
 
     @pytest.mark.asyncio
+    async def test_aclassify_forwards_metadata_key_used_by_chat_completions(
+        self, llm_complexity_router, mock_router_instance
+    ):
+        """/v1/chat/completions puts the request metadata under "metadata", not "litellm_metadata".
+
+        Only the routes in LITELLM_METADATA_ROUTES (/v1/messages, /v1/responses, ...) get a
+        "litellm_metadata" bucket; chat completions gets "metadata". Reading only
+        "litellm_metadata" leaves the classifier call unattributed on the most common route,
+        so _should_track_cost_callback drops it and no spend-log row is written at all,
+        which also makes the captured request body unreachable in the Logs UI.
+        """
+        mock_router_instance.acompletion = AsyncMock(return_value=_llm_response('{"tier": "SIMPLE"}'))
+        request_metadata = {"user_api_key": "sk-abc", "user_api_key_team_id": "team-1"}
+        await llm_complexity_router.aclassify("hi", request_kwargs={"metadata": request_metadata})
+        call_kwargs = mock_router_instance.acompletion.call_args.kwargs
+        assert call_kwargs["metadata"] == request_metadata
+
+    @pytest.mark.asyncio
     async def test_aclassify_captures_request_body_in_proxy_server_request(
         self, llm_complexity_router, mock_router_instance
     ):
@@ -1439,6 +1457,13 @@ class TestLLMClassifier:
         assert body["model"] == "haiku-classifier"
         assert body["messages"] == call_kwargs["messages"]
         assert "explain quantum tunneling in depth" in body["messages"][0]["content"]
+        assert body["response_format"]["type"] == "json_schema"
+        assert body["response_format"]["json_schema"]["schema"]["properties"]["tier"]["enum"] == [
+            "SIMPLE",
+            "MEDIUM",
+            "COMPLEX",
+            "REASONING",
+        ]
 
     @pytest.mark.asyncio
     async def test_aclassify_strips_budget_reservation_from_classifier_metadata(

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1466,6 +1466,54 @@ class TestLLMClassifier:
         ]
 
     @pytest.mark.asyncio
+    async def test_aclassify_propagates_top_level_turn_off_message_logging(
+        self, llm_complexity_router, mock_router_instance
+    ):
+        """A caller's top-level turn_off_message_logging must reach the classifier call.
+
+        Without this, a caller who opts a request out of message logging still has their
+        prompt captured in full by the classifier's proxy_server_request: the spend-log
+        redaction gate (should_redact_message_logging) reads turn_off_message_logging off
+        the classifier call's own kwargs, and this internal call is not the caller's
+        request, so it never inherits the opt-out unless it's forwarded explicitly.
+        """
+        mock_router_instance.acompletion = AsyncMock(return_value=_llm_response('{"tier": "SIMPLE"}'))
+        await llm_complexity_router.aclassify("secret prompt", request_kwargs={"turn_off_message_logging": True})
+        call_kwargs = mock_router_instance.acompletion.call_args.kwargs
+        assert call_kwargs["turn_off_message_logging"] is True
+
+    @pytest.mark.asyncio
+    async def test_aclassify_propagates_metadata_slot_turn_off_message_logging(
+        self, llm_complexity_router, mock_router_instance
+    ):
+        """turn_off_message_logging set inside metadata/litellm_metadata must also propagate.
+
+        initialize_standard_callback_dynamic_params reads this flag from either the
+        top-level request kwargs or the metadata/litellm_metadata dicts (the same slots a
+        real HTTP request populates), so the classifier call must resolve it from there too.
+        """
+        mock_router_instance.acompletion = AsyncMock(return_value=_llm_response('{"tier": "SIMPLE"}'))
+        await llm_complexity_router.aclassify(
+            "secret prompt", request_kwargs={"litellm_metadata": {"turn_off_message_logging": True}}
+        )
+        call_kwargs = mock_router_instance.acompletion.call_args.kwargs
+        assert call_kwargs["turn_off_message_logging"] is True
+
+    @pytest.mark.asyncio
+    async def test_aclassify_defaults_turn_off_message_logging_to_none(
+        self, llm_complexity_router, mock_router_instance
+    ):
+        """With no caller opt-out, the classifier call must not force redaction on or off.
+
+        Passing None (rather than omitting the kwarg or defaulting to False) preserves the
+        existing header- and global-setting fallbacks in should_redact_message_logging.
+        """
+        mock_router_instance.acompletion = AsyncMock(return_value=_llm_response('{"tier": "SIMPLE"}'))
+        await llm_complexity_router.aclassify("hi")
+        call_kwargs = mock_router_instance.acompletion.call_args.kwargs
+        assert call_kwargs["turn_off_message_logging"] is None
+
+    @pytest.mark.asyncio
     async def test_aclassify_strips_budget_reservation_from_classifier_metadata(
         self, llm_complexity_router, mock_router_instance
     ):
@@ -2249,6 +2297,36 @@ class TestSemanticKeywordTierRules:
         body = fake_router.async_embedding_kwargs[0]["proxy_server_request"]["body"]
         assert body["model"] == "fake-embed"
         assert body["input"] == ["roll out my k8s cluster"]
+
+    @pytest.mark.asyncio
+    async def test_semantic_embedding_call_propagates_turn_off_message_logging(self, basic_config):
+        """A caller's turn_off_message_logging must reach the query embedding call.
+
+        The embedding now captures the user's prompt in proxy_server_request, so a caller
+        who opts out of message logging must have that opt-out forwarded; otherwise the
+        embedding's spend-log row stores the prompt in the clear despite the parent request
+        being redacted, exposing it to anyone authorized to read the team's spend logs.
+        """
+        fake_router = FakeEmbeddingRouter()
+        config = {
+            **basic_config,
+            "keyword_tier_rules": [{"keywords": ["kubernetes deployment"], "tier": "REASONING"}],
+            "semantic_keyword_matching": True,
+            "embedding_model": "fake-embed",
+            "match_threshold": 0.5,
+        }
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=fake_router,
+            complexity_router_config=config,
+        )
+        await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={"turn_off_message_logging": True},
+            messages=[{"role": "user", "content": "roll out my k8s cluster"}],
+        )
+        assert fake_router.async_embedding_kwargs, "expected an embedding call for the prompt"
+        assert fake_router.async_embedding_kwargs[0]["turn_off_message_logging"] is True
 
     @pytest.mark.asyncio
     async def test_semantic_embedding_call_strips_budget_reservation(self, basic_config):

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -1418,6 +1418,29 @@ class TestLLMClassifier:
         assert call_kwargs["metadata"] == request_metadata
 
     @pytest.mark.asyncio
+    async def test_aclassify_captures_request_body_in_proxy_server_request(
+        self, llm_complexity_router, mock_router_instance
+    ):
+        """The classifier call must supply proxy_server_request so its request body is logged.
+
+        proxy_server_request["body"] is populated only by the proxy's HTTP ingress
+        middleware, which never runs for this internally-initiated router.acompletion
+        call. Without it _get_proxy_server_request_for_spend_logs_payload reads nothing
+        and stores "{}" for the request, so the classifier's spend-log row shows a
+        populated response but an empty request and the log cannot show which prompt
+        drove the tier decision. The captured body must carry the classification prompt
+        actually sent, so the classifier model, the classification prompt, and the user
+        text are all asserted here.
+        """
+        mock_router_instance.acompletion = AsyncMock(return_value=_llm_response('{"tier": "COMPLEX"}'))
+        await llm_complexity_router.aclassify("explain quantum tunneling in depth")
+        call_kwargs = mock_router_instance.acompletion.call_args.kwargs
+        body = call_kwargs["proxy_server_request"]["body"]
+        assert body["model"] == "haiku-classifier"
+        assert body["messages"] == call_kwargs["messages"]
+        assert "explain quantum tunneling in depth" in body["messages"][0]["content"]
+
+    @pytest.mark.asyncio
     async def test_aclassify_strips_budget_reservation_from_classifier_metadata(
         self, llm_complexity_router, mock_router_instance
     ):
@@ -2168,6 +2191,39 @@ class TestSemanticKeywordTierRules:
         assert fake_router.async_embedding_kwargs, "expected an embedding call for the prompt"
         assert fake_router.async_embedding_kwargs[0]["metadata"] == caller_metadata
         assert fake_router.async_embedding_kwargs[0]["litellm_metadata"] == caller_litellm_metadata
+
+    @pytest.mark.asyncio
+    async def test_semantic_embedding_call_captures_request_body_in_proxy_server_request(self, basic_config):
+        """The query embedding call must supply proxy_server_request so its request is logged.
+
+        Like the LLM classifier, this embedding is fired internally and never passes
+        through the proxy's HTTP ingress middleware, so proxy_server_request is unset and
+        the embedding's spend-log row stores "{}" for the request while its response is
+        captured. The captured body must carry the embedded input so the log shows what
+        was classified.
+        """
+        fake_router = FakeEmbeddingRouter()
+        config = {
+            **basic_config,
+            "keyword_tier_rules": [{"keywords": ["kubernetes deployment"], "tier": "REASONING"}],
+            "semantic_keyword_matching": True,
+            "embedding_model": "fake-embed",
+            "match_threshold": 0.5,
+        }
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=fake_router,
+            complexity_router_config=config,
+        )
+        await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "roll out my k8s cluster"}],
+        )
+        assert fake_router.async_embedding_kwargs, "expected an embedding call for the prompt"
+        body = fake_router.async_embedding_kwargs[0]["proxy_server_request"]["body"]
+        assert body["model"] == "fake-embed"
+        assert body["input"] == ["roll out my k8s cluster"]
 
     @pytest.mark.asyncio
     async def test_semantic_embedding_call_strips_budget_reservation(self, basic_config):


### PR DESCRIPTION
## TLDR

Problem this solves:

- LLM classifier spend-log rows stored `{}` for the request
- Same gap on the semantic keyword query-embedding sub-call
- On `/v1/chat/completions` the classifier logged no row at all
- Logged `response_format` did not match what was sent
- Neither sub-call forwarded a caller's per-request `turn_off_message_logging` opt-out, so a redacted request's classification prompt was still stored in the clear

How it solves it:

- Pass an explicit `proxy_server_request` on both internal sub-calls
- Read the classifier's metadata from `metadata` too, not only `litellm_metadata`
- Log `response_format` in litellm's wire shape
- Resolve the caller's effective `turn_off_message_logging` (top-level or metadata-slot) and forward it to both sub-calls

## Relevant issues

The classifier and query-embedding sub-calls are fired internally by the router, so they skip the proxy's HTTP ingress that normally records the request body; their spend-log rows stored `{}` for the request while the response was captured, so the rows looked half-populated and you could not see which prompt drove the tier decision

On `/v1/chat/completions` the problem was worse than an empty request body: the classifier read its metadata only from `request_kwargs["litellm_metadata"]`, a bucket the proxy populates for `LITELLM_METADATA_ROUTES` (`/v1/messages`, `/v1/responses`, ...) but not for chat completions, which uses `metadata`. The call therefore arrived with no key/team/user attribution, `_should_track_cost_callback` returned False, and no spend-log row was written at all; the captured body had nowhere to show up. The semantic path already forwarded both buckets

Once the sub-calls started carrying the real request body, a caller opting a request out of message logging via top-level `turn_off_message_logging=true` needed that opt-out to reach the sub-calls too: `should_redact_message_logging` reads the flag off each call's own kwargs, and neither the classifier nor the embedding call inherited it from the parent request, so a redacted request's classification prompt still landed in the clear in that call's spend-log row, readable by anyone with access to the team's spend logs

The fix carries the request body and the effective redaction setting into the same spend-logging path the ingress uses

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Live proxy against real Anthropic and OpenAI APIs, postgres-backed spend logs, `general_settings.store_prompts_in_spend_logs: true`, and a `smart-router` deployment with `classifier_type: llm` classifying through `anthropic-haiku-4-5`

Before, at `0a6b372126` (this branch's merge base, `complexity_router.py` unpatched):

```bash
curl -s localhost:4000/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"smart-router","max_tokens":30,"messages":[{"role":"user","content":"BASELINE: prove the halting problem is undecidable, step by step"}]}'

psql -c 'select model, call_type, left(proxy_server_request::text,120) from "LiteLLM_SpendLogs" order by "startTime" desc limit 2;'
anthropic/claude-sonnet-4-5|anthropic_messages|{"model": "smart-router", "messages": [{"role": "user", "content": "BASELINE: prove the halting problem is undecidable,
anthropic/claude-haiku-4-5|acompletion|{}
```

The classifier row is the `claude-haiku-4-5` one: response populated, request `{}`

Same commit, on `/v1/chat/completions`, the classifier row is missing entirely (only the routed completion is logged):

```bash
curl -s localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"smart-router","messages":[{"role":"user","content":"Think step by step: design a distributed rate limiter for our multi-region API gateway"}],"max_tokens":30}'

psql -c 'select model, call_type from "LiteLLM_SpendLogs" order by "startTime" desc limit 2;'
anthropic/claude-sonnet-4-5|acompletion
anthropic/claude-sonnet-4-5|anthropic_messages
```

After, at `deada4efac`, on `/v1/chat/completions`, read back through the endpoint the Logs UI itself calls:

```bash
curl -s localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"smart-router","messages":[{"role":"user","content":"CHATCOMPLETIONS-FIX2: prove Fermats little theorem and explain each step"}],"max_tokens":30}'

RID=$(psql -At -c 'select request_id from "LiteLLM_SpendLogs" where model like '"'"'%haiku%'"'"' order by "startTime" desc limit 1;')
curl -s -H 'Authorization: Bearer sk-1234' "localhost:4000/spend/logs/ui/$RID" | jq -r .proxy_server_request
{
 "model": "anthropic-haiku-4-5",
 "messages": [
  {
   "role": "user",
   "content": "Classify the complexity of the following user request into exactly one tier.\n\nJudge the intellectual difficulty of answering correctly, not how short the request is.\n\nTiers:\n- SIMPLE: greetings, chitchat, or factual lookups ...\n\nRequest:\nCHATCOMPLETIONS-FIX2: prove Fermats little theorem and explain each step"
  }
 ],
 "response_format": {
  "type": "json_schema",
  "json_schema": {
   "name": "TierClassification",
   "schema": {"type": "object", "title": "TierClassification", "required": ["tier"],
              "properties": {"tier": {"enum": ["SIMPLE", "MEDIUM", "COMPLEX", "REASONING"], "type": "string", "title": "Tier"}}}
  }
 }
}
```

The stored prompt is byte-for-byte the classification prompt the proxy sent to Anthropic (`--detailed_debug` shows the same text in the outgoing `-d` payload), and `response_format` now matches the shape litellm actually puts on the wire

Semantic keyword path at the same commit, with `semantic_keyword_matching: true` and `embedding_model: text-embedding-3-small`:

```bash
curl -s localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"model":"smart-router-semantic","messages":[{"role":"user","content":"SEMANTIC-QA: help me roll out my k8s cluster deployment"}],"max_tokens":20}'

psql -c 'select model, call_type, left(proxy_server_request::text,200) from "LiteLLM_SpendLogs" order by "startTime" desc limit 2;'
anthropic/claude-sonnet-4-5|acompletion|{"model": "smart-router-semantic", "messages": [{"role": "user", "content": "SEMANTIC-QA: help me roll out my k8s cluster deployment"}], ...
openai/text-embedding-3-small|aembedding|{"input": ["SEMANTIC-QA: help me roll out my k8s cluster deployment"], "model": "text-embedding-3-small"}
```

Regression tests cover the redaction-propagation fix (mutation-verified: reverting either sub-call's `turn_off_message_logging` kwarg fails the corresponding test with `KeyError`); a live-proxy run of that specific fix hit unavailable provider credentials in this session, so it's proven by the mutation-checked tests below rather than a fresh curl transcript

## Type

🐛 Bug Fix

## Changes

- `complexity_router.py` `_classify_with_llm`: build a `proxy_server_request` from the classifier model, the classification prompt, and `type_to_response_format_param(TierClassification)`, and pass it to `acompletion`; resolve the forwarded metadata from `litellm_metadata` or `metadata` so chat completions attribute (and therefore log) the call; resolve and forward the caller's effective `turn_off_message_logging`
- `complexity_router.py` `_semantic_tier_override`: build a `proxy_server_request` from the embedding model and the user message, and pass it through `aencode_queries` to `aembedding`; forward the caller's effective `turn_off_message_logging`
- Regression tests for each internal sub-call's captured body, the `response_format` wire shape, the chat-completions metadata bucket, and redaction propagation from both the top-level and metadata-slot forms of `turn_off_message_logging`

## QA runbook

Configure a `smart-router` model with `complexity_router_config.classifier_type: llm`, `store_prompts_in_spend_logs: true`, and no global `turn_off_message_logging`. Send a request with top-level `turn_off_message_logging: true` in the body through `smart-router`, then open the classifier model's spend-log row at http://localhost:4000/ui/?page=logs; the Request tab should show the redacted placeholder, not the classification prompt

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches spend logging and privacy-sensitive prompt capture on internal router sub-calls; behavior is narrow but affects observability and redaction for all smart-router traffic.
> 
> **Overview**
> Internal **complexity router** sub-calls (LLM tier classifier and semantic keyword **embedding**) now pass an explicit `proxy_server_request` body so spend logs show the real request instead of `{}`, matching what the proxy ingress would record.
> 
> For the **LLM classifier**, metadata is taken from `litellm_metadata` **or** `metadata` so `/v1/chat/completions` still attributes and logs the call; `response_format` is logged in LiteLLM’s wire shape via `type_to_response_format_param`. The caller’s effective **`turn_off_message_logging`** (top-level or metadata slots) is resolved with `initialize_standard_callback_dynamic_params` and forwarded to both sub-calls so redaction applies when those bodies are stored.
> 
> Regression tests cover chat-completions metadata, captured bodies, `response_format`, and redaction propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 074eda52222da35bd43a6f9e6666aa4203eedeb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->