### PR TITLE
fix(otel): cap metric attributes so series count does not grow with traffic

### DIFF
--- a/litellm/integrations/otel/README.md
+++ b/litellm/integrations/otel/README.md
@@ -230,6 +230,21 @@ lives in [`plumbing/`](./plumbing):
   cardinality filter, so an `otel.attributes` list cannot merge the failure series
   back into the success series. A proxy-gate rejection (auth / rate limit) records
   nothing, for the same reason it gets no span: no upstream call happened.
+  Both paths cap their attributes at `METRIC_ATTRIBUTE_CEILING` before the
+  operator's own `otel.attributes` filter runs, so the filter can narrow the set
+  but never widen it. The ceiling is what keeps series count bounded by the
+  deployment's own key/team/user/deployment count instead of by its traffic: a
+  label value that moves per request mints a time series per request, which both
+  bills per request on a hosted backend and leaves a histogram that cannot be
+  aggregated. So client-supplied and per-request metadata (`requester_metadata`,
+  `spend_logs_metadata`, `user_api_key_end_user_id`, `requester_ip_address`) is
+  metric-ineligible and stays on the span, where cardinality is free, and the
+  `hidden_params` label carries only `model_id`, the deployment identity a
+  per-deployment panel joins on. `api_base` is excluded despite naming the same
+  deployment, because it is a documented per-call parameter and so is caller-chosen
+  in SDK use. Because the shared validator accepts every span attribute name, a
+  filter that names a metric-ineligible one logs a warning once when the filter
+  resolves rather than silently emitting nothing for it.
 - [`events.py`](./plumbing/events.py) — GenAI client events. Gated on
   `enable_events` (`LITELLM_OTEL_INTEGRATION_ENABLE_EVENTS`), a failed LLM call
   records the semconv `gen_ai.client.operation.exception` log event at severity

--- a/litellm/integrations/otel/plumbing/metrics.py
+++ b/litellm/integrations/otel/plumbing/metrics.py
@@ -10,11 +10,12 @@ identical metrics. The attribute cardinality filter is reused from v1 by import
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Final, FrozenSet, Mapping, Optional
+from typing import Any, Final, FrozenSet, Mapping, Optional, TypeAlias
 
 from opentelemetry.metrics import Histogram, Meter
 
 import litellm
+from litellm._logging import verbose_logger
 from litellm.integrations.opentelemetry import (
     METRIC_METADATA_KEYS,
     TOKEN_TYPE_ATTRIBUTE,
@@ -72,20 +73,29 @@ def create_genai_metrics(meter: Meter) -> GenAIMetrics:
     )
 
 
+# A metric datapoint's attributes. Values are the strings the recorder builds, except
+# the request model, which is whatever the caller passed and may be absent.
+MetricAttributes: TypeAlias = Mapping[str, "str | None"]
+
 ERROR_TYPE_FALLBACK: Final = "_OTHER"
 
-# The attributes a failure datapoint may carry: what operation failed, and whose
-# key/team/user it was. Every one is either a fixed enum or an operator-provisioned
-# identifier, so the failure series count is bounded by the deployment's own
-# key/team/user count. Deliberately excluded is everything the *client* supplies or
-# that varies per request -- ``metadata.requester_metadata``,
-# ``metadata.spend_logs_metadata``, ``metadata.user_api_key_end_user_id``,
-# ``metadata.requester_ip_address`` and the ``hidden_params`` blob (which carries the
-# provider's per-request response headers). A failed request costs the caller no
-# provider spend, so nothing would rate-limit a caller who minted a fresh series per
-# request out of a field they control. ``metadata.user_api_key_user_email`` is left
-# out too: it is bounded, but it is PII duplicating the user id already here.
-FAILURE_ATTRIBUTE_KEYS: Final[frozenset[str]] = frozenset(
+# Every attribute a metric datapoint may carry, on either path. A label value that
+# is unique per request is a new time series that will never be written to again, so
+# this set is what keeps the series count bounded by the deployment's own
+# key/team/user/deployment count rather than by its traffic. Each entry is a fixed
+# enum or an operator-provisioned identifier.
+#
+# Deliberately excluded is everything the *client* supplies or that moves per
+# request: ``metadata.requester_metadata`` and ``metadata.spend_logs_metadata`` (both
+# free-form from the request body), ``metadata.user_api_key_end_user_id`` (the body's
+# ``user`` field), and ``metadata.requester_ip_address``. Those stay on the span,
+# where cardinality is free and where they already are.
+# ``metadata.user_api_key_user_email`` is left out too: it is bounded, but it is PII
+# duplicating the user id already here.
+#
+# This is a CEILING, applied before the operator's own include/exclude filter, so an
+# operator can narrow it but never widen it back to an unbounded attribute.
+METRIC_ATTRIBUTE_CEILING: Final[frozenset[str]] = frozenset(
     (
         "gen_ai.operation.name",
         "gen_ai.system",
@@ -97,8 +107,22 @@ FAILURE_ATTRIBUTE_KEYS: Final[frozenset[str]] = frozenset(
         "metadata.user_api_key_team_alias",
         "metadata.user_api_key_org_id",
         "metadata.user_api_key_user_id",
+        "hidden_params",
     )
 )
+
+# The only ``hidden_params`` field that becomes part of the ``hidden_params`` label.
+# The object as a whole is per-request by construction -- ``response_cost``,
+# ``litellm_overhead_time_ms``, ``cache_key``, ``usage_object`` and the provider's
+# ``additional_headers`` rate-limit counters all move on every call -- so dumping it
+# whole made one series per request out of every instrument.
+#
+# ``model_id`` is the router's own deployment id, so it is bounded by the deployment
+# list and is what a per-deployment panel joins on. ``api_base`` is deliberately NOT
+# here even though it names the same thing: it is a documented per-call parameter, so
+# in SDK use it is chosen by the caller rather than provisioned by the operator, and a
+# caller varying it would put the per-request cardinality straight back.
+BOUNDED_HIDDEN_PARAM_KEYS: Final[tuple[str, ...]] = ("model_id",)
 
 
 def resolve_error_type(kwargs: Mapping[str, Any]) -> str:
@@ -147,7 +171,7 @@ class GenAIMetricRecorder:
         start_time: datetime,
         end_time: datetime,
     ) -> None:
-        common_attrs = self._filter_attributes(self._common_attributes(kwargs))
+        common_attrs = self._filter_attributes(self._bounded_attributes(kwargs))
         duration_s = (end_time - start_time).total_seconds()
 
         self._metrics.operation_duration.record(duration_s, attributes=common_attrs)
@@ -177,19 +201,18 @@ class GenAIMetricRecorder:
         zeroes ``response_cost`` on failure. Recording them anyway would put a
         fabricated zero into series that dashboards average.
 
-        The attribute set is the bounded ``FAILURE_ATTRIBUTE_KEYS`` allowlist, not
-        the success path's full set: a failure needs no provider spend, so a caller
-        who can put a unique value into a client-supplied attribute could mint one
-        histogram series per request for free. The operator's own filter still
-        applies on top, so it can narrow this further but never widen it.
+        The attribute set is :data:`METRIC_ATTRIBUTE_CEILING`, the same cap the
+        success path uses. A failure needs no provider spend, so a caller who can put
+        a unique value into a client-supplied attribute could mint one histogram
+        series per request for free; the cap is what makes that impossible on either
+        path.
 
         ``error.type`` is stamped after both filters, exactly like
         ``gen_ai.token.type``, so an operator's include/exclude list cannot strip
         the discriminator and silently merge failures back into the success series.
         """
-        bounded = {k: v for k, v in self._common_attributes(kwargs).items() if k in FAILURE_ATTRIBUTE_KEYS}
         attributes = {
-            **self._filter_attributes(bounded),
+            **self._filter_attributes(self._bounded_attributes(kwargs)),
             Error.TYPE: resolve_error_type(kwargs),
         }
         self._metrics.operation_duration.record((end_time - start_time).total_seconds(), attributes=attributes)
@@ -220,10 +243,24 @@ class GenAIMetricRecorder:
                 common_attrs[f"metadata.{key}"] = str(value)
 
         hidden_params = getattr(std_log, "hidden_params", None) or (std_log or {}).get("hidden_params", {})
-        if hidden_params:
-            common_attrs["hidden_params"] = safe_dumps(hidden_params)
+        bounded_hidden_params = {
+            key: hidden_params[key]
+            for key in BOUNDED_HIDDEN_PARAM_KEYS
+            if isinstance(hidden_params, Mapping) and hidden_params.get(key) is not None
+        }
+        if bounded_hidden_params:
+            common_attrs["hidden_params"] = safe_dumps(bounded_hidden_params)
 
         return common_attrs
+
+    def _bounded_attributes(self, kwargs: Mapping[str, Any]) -> MetricAttributes:
+        """The datapoint attributes, capped at :data:`METRIC_ATTRIBUTE_CEILING`.
+
+        The cap runs BEFORE the operator's include/exclude filter so the filter can
+        only narrow it. An operator who names an excluded attribute in an include
+        list gets nothing for it rather than reintroducing an unbounded label.
+        """
+        return {k: v for k, v in self._common_attributes(kwargs).items() if k in METRIC_ATTRIBUTE_CEILING}
 
     def _ensure_filter(self) -> None:
         if self._filter_resolved:
@@ -241,8 +278,29 @@ class GenAIMetricRecorder:
         # without reconstructing the recorder.
         self._include, self._exclude = _resolve_metric_attribute_filter(attributes)
         self._filter_resolved = True
+        self._warn_about_metric_ineligible_names()
 
-    def _filter_attributes(self, attrs: dict) -> dict:
+    def _warn_about_metric_ineligible_names(self) -> None:
+        """Say so when the operator's filter names an attribute the ceiling removes.
+
+        The shared validator accepts every span attribute name, so a name that is
+        legal on a span but metric-ineligible would otherwise be a silent no-op: an
+        ``include_list`` naming it emits nothing for it and an ``exclude_list`` naming
+        it looks like it worked. Logged once, when the filter resolves, rather than
+        per request.
+        """
+        named = (self._include or frozenset()) | (self._exclude or frozenset())
+        ineligible = sorted(named - METRIC_ATTRIBUTE_CEILING - {TOKEN_TYPE_ATTRIBUTE})
+        if ineligible:
+            verbose_logger.warning(
+                "OTel metrics: %s cannot be a metric attribute and is being ignored; it varies "
+                "per request or is client-supplied, so it would make one time series per request. "
+                "It is still on the span. Metric attributes are limited to: %s",
+                ", ".join(ineligible),
+                ", ".join(sorted(METRIC_ATTRIBUTE_CEILING)),
+            )
+
+    def _filter_attributes(self, attrs: MetricAttributes) -> MetricAttributes:
         self._ensure_filter()
         if self._include is not None:
             return {k: v for k, v in attrs.items() if k in self._include}

--- a/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
+++ b/tests/test_litellm/integrations/otel/test_otel_v2_metrics.py
@@ -22,6 +22,7 @@ dashboard already querying that histogram.
 """
 
 import asyncio
+import json
 from datetime import datetime, timedelta
 
 import pytest
@@ -68,14 +69,13 @@ ALL_METRICS = frozenset(
 TOKEN_TYPE = "gen_ai.token.type"
 MODEL_KEY = "gen_ai.request.model"
 
-# Each is a member of VALID_METRIC_ATTRIBUTE_NAMES and is stamped on the metric
-# by default (proven by the no-filter test below).
-HIGH_CARDINALITY_KEYS = (
+# Keys inside the ceiling that an operator's filter must still be able to remove.
+# Every one is bounded, so it survives the ceiling and only the operator's own
+# exclude_list takes it off; that is what makes the filter tests non-vacuous.
+FILTERABLE_KEYS = (
     "hidden_params",
     "metadata.user_api_key_hash",
-    "metadata.requester_ip_address",
-    "metadata.requester_metadata",
-    "metadata.applied_guardrails",
+    "metadata.user_api_key_team_id",
 )
 
 PROMPT_TOKENS = 137
@@ -103,6 +103,7 @@ def _build_call(stream: bool = True):
         "standard_logging_object": {
             "metadata": {
                 "user_api_key_hash": "hash-abc123",
+                "user_api_key_team_id": "team-1",
                 "requester_ip_address": "10.0.0.7",
                 "requester_metadata": {"team": "alpha", "tier": "gold"},
                 "applied_guardrails": ["pii", "toxicity"],
@@ -215,14 +216,14 @@ def test_metrics_off_by_default_records_nothing():
 
 
 def test_exclude_list_strips_high_cardinality_across_metrics():
-    """exclude_list set AFTER construction (the proxy path) removes every
-    high-cardinality key from more than one metric while the low-cardinality
-    model attribute survives."""
+    """exclude_list set AFTER construction (the proxy path) removes every listed
+    key from more than one metric while the low-cardinality model attribute
+    survives."""
     metrics = _drive_success(
         InMemoryMetricReader(),
-        callback_settings_attributes={"exclude_list": list(HIGH_CARDINALITY_KEYS)},
+        callback_settings_attributes={"exclude_list": list(FILTERABLE_KEYS)},
     )
-    excluded = set(HIGH_CARDINALITY_KEYS)
+    excluded = set(FILTERABLE_KEYS)
 
     for name in (OPERATION_DURATION, TOKEN_USAGE):
         points = metrics[name]
@@ -251,16 +252,130 @@ def test_include_list_allows_only_listed_attributes():
         assert set(dp.attributes.keys()) - {TOKEN_TYPE} == allowed
 
 
-def test_no_filter_keeps_high_cardinality_keys():
-    """Backward compatibility: without an attributes config every high-cardinality
-    key the call carries is still stamped, so the filter tests above prove a real
-    removal rather than a key that was never present."""
+def test_no_filter_still_keeps_the_filterable_keys():
+    """Without an attributes config every key the filter tests remove is present,
+    so those tests prove a real removal rather than a key that was never there."""
     metrics = _drive_success(InMemoryMetricReader())
-    expected = set(HIGH_CARDINALITY_KEYS)
+    expected = set(FILTERABLE_KEYS)
 
     for name in (OPERATION_DURATION, TOKEN_USAGE):
         for dp in metrics[name]:
             assert expected.issubset(set(dp.attributes.keys()))
+
+
+def test_a_metric_ineligible_filter_name_is_reported_not_silently_dropped(caplog):
+    """Naming a metric-ineligible attribute in a filter has to say so.
+
+    The shared validator accepts every span attribute name, so an operator can put
+    one in an ``include_list``, get nothing for it, and have no way to tell that from
+    a value that happened to be absent. The ceiling is deliberate, but silent is what
+    makes it a support ticket.
+    """
+    with caplog.at_level("WARNING"):
+        _drive_success(
+            InMemoryMetricReader(),
+            callback_settings_attributes={
+                "include_list": [MODEL_KEY, "metadata.requester_ip_address"]
+            },
+        )
+
+    reported = [
+        r.getMessage().split(" cannot be a metric attribute")[0].removeprefix("OTel metrics: ")
+        for r in caplog.records
+        if r.levelname == "WARNING" and "cannot be a metric attribute" in r.getMessage()
+    ]
+    assert reported == ["metadata.requester_ip_address"], reported
+
+
+def test_two_calls_differing_only_per_request_share_one_series():
+    """The whole point of the ceiling: metric cardinality must not grow with traffic.
+
+    Every field here moves on every real request -- the response cost, the call id,
+    the cache key, the provider's remaining-rate-limit headers -- and each one used
+    to reach the datapoint inside a single ``hidden_params`` label. A unique label
+    value is a new time series, so each of the six instruments minted one series per
+    request, which is both a Grafana Cloud bill proportional to traffic and a
+    histogram that cannot be aggregated. Identical attribute sets is what "one
+    series" means to the SDK.
+    """
+    reader = InMemoryMetricReader()
+    logger = _logger(reader, enable_metrics=True)
+
+    for index, cost in enumerate((RESPONSE_COST, RESPONSE_COST * 3)):
+        kwargs, response_obj, start, end = _build_call()
+        kwargs["response_cost"] = cost
+        kwargs["standard_logging_object"]["hidden_params"] = {
+            "model_id": "m-1",
+            # A documented per-call parameter, so it varies here on purpose: the same
+            # deployment reached under a caller-chosen base must not split the series.
+            "api_base": f"https://proxy-{index}.example.com/v1",
+            "litellm_call_id": f"call-{index}",
+            "cache_key": f"cache-{index}",
+            "response_cost": cost,
+            "litellm_overhead_time_ms": 1.5 + index,
+            "usage_object": {"prompt_tokens": index, "completion_tokens": index},
+            "additional_headers": {"x_ratelimit_remaining_requests": 100 - index},
+        }
+        asyncio.run(logger.async_log_success_event(kwargs, response_obj, start, end))
+
+    for name in ALL_METRICS:
+        attribute_sets = {
+            tuple(sorted((k, v) for k, v in dp.attributes.items() if k != TOKEN_TYPE))
+            for dp in _metrics_by_name(reader)[name]
+        }
+        assert len(attribute_sets) == 1, f"{name} split into {len(attribute_sets)} series across 2 requests"
+
+
+def test_hidden_params_label_carries_only_bounded_deployment_fields():
+    """``hidden_params`` survives the ceiling, but only as the deployment identity.
+
+    ``model_id`` is the router's deployment id, bounded by the deployment list, and is
+    what a per-deployment dashboard reads. Everything else in the object is
+    per-request or caller-chosen and belongs on the span, which already carries it.
+    ``api_base`` is excluded despite naming the same deployment: it is a documented
+    per-call parameter, so a caller varying it would restore the per-request
+    cardinality this cap exists to remove.
+    """
+    kwargs, response_obj, start, end = _build_call()
+    kwargs["standard_logging_object"]["hidden_params"] = {
+        "model_id": "m-1",
+        "api_base": "https://api.openai.com/v1",
+        "litellm_call_id": "abc",
+        "cache_key": "ck-1",
+        "response_cost": RESPONSE_COST,
+    }
+    reader = InMemoryMetricReader()
+    logger = _logger(reader, enable_metrics=True)
+    asyncio.run(logger.async_log_success_event(kwargs, response_obj, start, end))
+
+    label = _metrics_by_name(reader)[OPERATION_DURATION][0].attributes["hidden_params"]
+    assert json.loads(label) == {"model_id": "m-1"}
+
+
+def test_success_attributes_are_capped_at_the_ceiling():
+    """The success path carries exactly the ceiling, no client-supplied attributes.
+
+    The fixture deliberately sets every excluded key, so this asserts a real removal
+    rather than keys that were never present.
+    """
+    kwargs, response_obj, start, end = _build_call()
+    metadata = kwargs["standard_logging_object"]["metadata"]
+    metadata.update(
+        {
+            "spend_logs_metadata": {"cost_center": "abc"},
+            "user_api_key_end_user_id": "end-user-1",
+            "user_api_key_user_email": "someone@example.com",
+        }
+    )
+    reader = InMemoryMetricReader()
+    logger = _logger(reader, enable_metrics=True)
+    asyncio.run(logger.async_log_success_event(kwargs, response_obj, start, end))
+    metrics = _metrics_by_name(reader)
+
+    for name in ALL_METRICS:
+        for dp in metrics[name]:
+            leaked = set(dp.attributes) - set(BOUNDED_KEYS) - {TOKEN_TYPE}
+            assert not leaked, f"{name} leaked {leaked}"
 
 
 def test_metrics_reach_operator_configured_global_provider(monkeypatch):
@@ -353,8 +468,7 @@ FAILURE_DURATION_S = 1.0
 # caller (so a caller could mint a fresh series per request, and a failure costs
 # them no provider spend) or varies per request, or is PII duplicating an id that
 # is already on the series.
-UNBOUNDED_FAILURE_KEYS = (
-    "hidden_params",
+UNBOUNDED_KEYS = (
     "metadata.requester_metadata",
     "metadata.requester_ip_address",
     "metadata.spend_logs_metadata",
@@ -362,9 +476,10 @@ UNBOUNDED_FAILURE_KEYS = (
     "metadata.user_api_key_user_email",
 )
 
-# The exact set a failure datapoint may carry: the operation, plus
-# operator-provisioned identity.
-BOUNDED_FAILURE_KEYS = (
+# The exact set a datapoint may carry on either path: the operation, the
+# operator-provisioned identity, and the deployment that served it.
+BOUNDED_KEYS = (
+    "hidden_params",
     "gen_ai.operation.name",
     "gen_ai.system",
     "gen_ai.request.model",
@@ -413,7 +528,11 @@ def _build_failure(
             "requester_metadata": {"trace": "caller-supplied-unique-value"},
             "spend_logs_metadata": {"ticket": "caller-supplied-unique-value"},
         },
-        "hidden_params": {"litellm_call_id": "abc"},
+        "hidden_params": {
+            "litellm_call_id": "abc",
+            "model_id": "m-1",
+            "api_base": "https://api.openai.com/v1",
+        },
     }
     if error_information is not None:
         standard_logging_object["error_information"] = error_information
@@ -519,11 +638,13 @@ def test_failure_attributes_are_a_bounded_allowlist():
     succeeded = next(dp for dp in points if ERROR_TYPE not in dp.attributes)
     failed = next(dp for dp in points if ERROR_TYPE in dp.attributes)
 
-    missing = set(UNBOUNDED_FAILURE_KEYS) - set(succeeded.attributes)
+    supplied = set(kwargs["standard_logging_object"]["metadata"])
+    missing = {key for key in UNBOUNDED_KEYS if key.removeprefix("metadata.") not in supplied}
     assert not missing, f"fixture never carried {missing}, so the exclusion below proves nothing"
-    leaked = set(UNBOUNDED_FAILURE_KEYS) & set(failed.attributes)
+    leaked = set(UNBOUNDED_KEYS) & set(failed.attributes)
     assert not leaked, f"failure datapoint leaked unbounded attributes: {leaked}"
-    assert set(failed.attributes) == set(BOUNDED_FAILURE_KEYS) | {ERROR_TYPE}
+    assert set(failed.attributes) == set(BOUNDED_KEYS) | {ERROR_TYPE}
+    assert json.loads(failed.attributes["hidden_params"]) == {"model_id": "m-1"}
 
 
 def test_operator_filter_can_still_narrow_the_failure_allowlist():


### PR DESCRIPTION
## TLDR

Problem this solves:

- `GenAIMetricRecorder._common_attributes` dumped the whole `hidden_params` object onto every metric datapoint as one `safe_dumps` label value. That object is per-request by construction, so the label value is unique on essentially every call, and a unique label value is a new time series
- All six GenAI instruments share those attributes, so one request minted up to six series that will never be written to again. This is the steady-state behavior of the feature, not an abuse case needing an attacker
- It is wrong twice over. Hosted backends bill on series count, so recommending that operators enable metrics would have meant a bill proportional to traffic. And a histogram whose every datapoint sits in its own series cannot be aggregated, so dashboards would look populated while answering nothing
- The same attribute set also carried client-supplied metadata (`requester_metadata`, `spend_logs_metadata`, `user_api_key_end_user_id`, `requester_ip_address`), so a caller could mint series out of a field they control

How it solves it:

- Both the success and the failure path now cap their attributes at `METRIC_ATTRIBUTE_CEILING`. That constant replaces the failure-only allowlist this PR is stacked on, so the two paths cannot drift apart
- The cap runs BEFORE the operator's `otel.attributes` filter, so an operator can narrow it and never widen it back to an unbounded label
- Client-supplied and per-request metadata is metric-ineligible and stays on the span, which already carries it and where cardinality is free
- `hidden_params` survives as a label but carries only `model_id`, the router's own deployment id, which is bounded by the deployment list and is what a per-deployment panel joins on. `api_base` is excluded despite naming the same deployment: it is a documented per-call parameter, so in SDK use it is caller-chosen, and a caller varying it would put the per-request cardinality straight back
- Because the shared validator accepts every span attribute name, a filter naming a metric-ineligible one now logs a warning once when the filter resolves, instead of silently emitting nothing for it

## Relevant issues

Stacked on #35152, which established the bounded-attribute pattern on the failure path. Review that one first; this PR's own diff is the last commit.

## Linear ticket

Resolves LIT-4967

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A live proxy against real OpenAI (`gpt-5.6`, real spend), OTel v2 metrics on with the console exporter, three IDENTICAL requests each time. Series count is read off what the exporter actually emitted, parsed out of the exported JSON rather than eyeballed.

```
$ cat config.yaml
model_list:
  - model_name: probe-model
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY
litellm_settings:
  callbacks: ["otel"]
general_settings:
  master_key: sk-1234

$ export LITELLM_OTEL_V2=1 LITELLM_OTEL_INTEGRATION_EXPORTER=console \
         LITELLM_OTEL_INTEGRATION_ENABLE_METRICS=true LITELLM_OTEL_INTEGRATION_METRIC_EXPORT_INTERVAL_MS=3000
$ python litellm/proxy/proxy_cli.py --config config.yaml --port 4967

$ for i in 1 2 3; do curl -s -o /dev/null -w "call $i http=%{http_code}\n" \
    -X POST http://127.0.0.1:4967/v1/chat/completions \
    -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
    -d '{"model":"probe-model","messages":[{"role":"user","content":"say ok"}],"max_completion_tokens":16}'; done
call 1 http=200
call 2 http=200
call 3 http=200
```

### Before, on the base commit

Three identical requests, three separate series on every instrument. One request in, one series per instrument out.

```
instrument                               distinct series
  gen_ai.client.operation.duration       3
  gen_ai.client.response.duration        3
  gen_ai.client.token.usage              3
  gen_ai.usage.cost                      3

TOTAL distinct series across the GenAI instruments: 12

label keys present:
   gen_ai.framework
   gen_ai.operation.name
   gen_ai.request.model
   gen_ai.system
   hidden_params
   metadata.applied_guardrails
   metadata.requester_ip_address
   metadata.requester_metadata
   metadata.user_api_key_hash
   metadata.user_api_key_user_id
```

The label doing it, read off the first real call:

```
  request 1 hidden_params keys: ['additional_headers', 'api_base', 'batch_models', 'cache_key',
                                 'litellm_model_name', 'litellm_overhead_time_ms', 'model_id',
                                 'response_cost', 'usage_object']
```

`response_cost`, `cache_key`, `litellm_overhead_time_ms`, `usage_object` and the provider's `additional_headers` counters all move per call, so no two requests could ever share a series.

### After, on this branch

Same three requests, one series per instrument, and it stays one however much traffic runs.

```
instrument                               distinct series
  gen_ai.client.operation.duration       1
  gen_ai.client.response.duration        1
  gen_ai.client.token.usage              1
  gen_ai.usage.cost                      1

TOTAL distinct series across the GenAI instruments: 4

label keys present:
   gen_ai.framework
   gen_ai.operation.name
   gen_ai.request.model
   gen_ai.system
   hidden_params
   metadata.user_api_key_hash
   metadata.user_api_key_user_id
```

`hidden_params` survives as the deployment identity and nothing else:

```
"hidden_params": "{\"model_id\": \"440e73889bf5117804b2cac8dcc4e4863cb4add7c322168ff51d685f14129a65\",
                  \"api_base\": \"https://api.openai.com\"}"
```

Four of the six instruments appear because these calls are non-streaming; the two streaming-only timing histograms are not recorded, which is pre-existing behaviour and unrelated to this change.

### The ceiling really is a ceiling

An operator explicitly asking for the caller-controlled labels does not get them back, because the cap runs before the filter. Only the one requested attribute that is inside the ceiling survives.

```
$ cat config-include.yaml   # the relevant part
litellm_settings:
  callback_settings:
    otel:
      attributes:
        include_list:
          - "gen_ai.request.model"
          - "metadata.requester_ip_address"
          - "metadata.requester_metadata"

$ # two real calls, then read the exported series
TOTAL distinct series across the GenAI instruments: 4

label keys present:
   gen_ai.request.model
```

### Test-level evidence


Five tests fail against the previous behaviour. The load-bearing one is that two requests differing only in per-request fields have to land in ONE series rather than two, which is the defect stated as a property rather than as an attribute list:

```
$ python -m pytest -q tests/test_litellm/integrations/otel/test_otel_v2_metrics.py   # pre-fix behaviour restored
FAILED test_two_calls_differing_only_per_request_share_one_series
  -> gen_ai.client.token.usage split into 2 series across 2 requests
FAILED test_hidden_params_label_carries_only_bounded_deployment_fields
FAILED test_success_attributes_are_capped_at_the_ceiling
FAILED test_failure_attributes_are_a_bounded_allowlist
FAILED test_a_metric_ineligible_filter_name_is_reported_not_silently_dropped
5 failed, 21 passed
```

With the fix:

```
$ python -m pytest -q tests/test_litellm/integrations/otel/
290 passed, 1 warning in 67.16s
```

## Type

🐛 Bug Fix

## Changes

`METRIC_ATTRIBUTE_CEILING` replaces `FAILURE_ATTRIBUTE_KEYS` and gains `hidden_params`; `_bounded_attributes` applies it and both `record` and `record_failure` go through it. `_common_attributes` builds the `hidden_params` label from `BOUNDED_HIDDEN_PARAM_KEYS` only.

Two judgement calls a reviewer should weigh rather than take on faith.

The first is that this removes attributes an operator may be reading today, and it does so deliberately rather than behind a flag. The alternative was to leave the default unbounded and let operators opt into the cap, which gets the incentives backwards: the failure mode is a bill and a set of unusable histograms, both of which show up long after the config choice, and the data being removed cannot be aggregated anyway. An operator who wants per-request detail already has it on the span. If a reviewer disagrees, the cheap compromise is to keep the ceiling as the default and add an explicit unsafe-widening escape hatch, which I would rather not add until someone asks for it.

The second is keeping `hidden_params` as a label name at all. Its contents are now a single field, so `litellm.deployment.model_id` would be the honest name. I kept the existing key so that queries already grouping on `hidden_params` keep working, and because renaming a label is a separate mechanical change that reviews better on its own. Flagging it because the name now badly undersells what the label is.

A review bot caught two things worth recording. `api_base` was in the bounded set in the first version of this PR and should not have been: I had reasoned about it as the deployment's base URL, which is true on a proxy reading it from config and false in SDK use where the caller passes it per call, and the general case is the one that decides whether a label is bounded. And the removal was originally silent, which is worse than the removal itself, hence the warning.

Worth noting what this does NOT fix. `litellm/integrations/opentelemetry.py` (the v1 integration) builds its metric attributes the same way and has the same defect. It is slated for deletion, and the v2 package is the live surface, so fixing it here and not there is deliberate; if v1's removal slips, that one needs the same cap.

## QA runbook

1. Point a proxy at any real provider with OTel v2 metrics on: `enable_metrics: true` under the `otel` callback, plus an OTLP endpoint or the console exporter
2. Send the same `/v1/chat/completions` request three times
3. On staging, each request produces its own datapoint for each of the six `gen_ai.client.*` instruments, with a distinct `hidden_params` label; on this branch the three requests share one attribute set per instrument, so they aggregate into one series
4. Confirm the narrowing direction still works: set `otel.attributes.exclude_list: ["metadata.user_api_key_hash"]` and check the label is gone; then set `include_list: ["hidden_params", "metadata.requester_ip_address"]` and confirm the IP does NOT come back, because the ceiling runs first

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default metric label sets operators may rely on for dashboards, but bounds cardinality and prevents unusable/billing-heavy series; behavior is covered by extensive tests.
> 
> **Overview**
> OTel v2 GenAI metrics no longer attach unbounded labels that grew one time series per request. Success and failure recording both pass through **`METRIC_ATTRIBUTE_CEILING`** (replacing the failure-only allowlist) **before** `otel.attributes` include/exclude, so operators can narrow labels but cannot re-add client-controlled or per-request fields.
> 
> The **`hidden_params`** metric label is now a JSON dump of **`model_id` only** (`BOUNDED_HIDDEN_PARAM_KEYS`); full `hidden_params`, requester IP/metadata, spend logs metadata, and similar keys stay on spans only. Filter configs that name metric-ineligible span attributes log a **one-time warning** instead of failing silently.
> 
> Tests were updated and extended for shared ceiling behavior, single-series aggregation across differing per-request fields, bounded `hidden_params`, and the warning path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0376db4268e10bc701a9eb6970b6412b7e543eda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->