### PR TITLE
test(interactions): remove the Content discriminator canary test

### DIFF
--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -105,27 +105,6 @@ class TestRequestCompliance:
         assert "string" in input_types, "Input should support string"
         assert "array" in input_types, "Input should support array"
 
-    def test_content_schema_uses_discriminator(self, spec_dict):
-        """Verify Content uses type discriminator."""
-        content_schema = spec_dict["components"]["schemas"]["Content"]
-
-        assert "discriminator" in content_schema
-        assert content_schema["discriminator"]["propertyName"] == "type"
-
-        # Check TextContent is an option (via mapping if present, or via oneOf refs)
-        mapping = content_schema["discriminator"].get("mapping")
-        if mapping:
-            assert "text" in mapping
-            print(f"Content type discriminator mapping: {list(mapping.keys())}")
-        else:
-            # Discriminator without explicit mapping — verify via oneOf
-            one_of = content_schema.get("oneOf", [])
-            ref_names = [opt["$ref"].split("/")[-1] for opt in one_of if "$ref" in opt]
-            assert (
-                "TextContent" in ref_names
-            ), f"TextContent not found in oneOf refs: {ref_names}"
-            print(f"Content type discriminator (no mapping), oneOf refs: {ref_names}")
-
     def test_text_content_schema(self, spec_dict):
         """Verify TextContent schema."""
         text_schema = spec_dict["components"]["schemas"]["TextContent"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Google removed the `discriminator` keyword from the Interactions `Content` schema
- The OpenAPI canary test now fails CI on every PR

How it solves it:

- Removes the discriminator canary test outright

## Relevant issues

Example failing run on an unrelated PR: https://github.com/BerriAI/litellm/actions/runs/30500899420/job/90740110330?pr=35159

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The removed test asserted `"discriminator" in Content` against Google's live spec. What that spec serves today, captured at e644e27d37:

```bash
curl -s https://ai.google.dev/static/api/interactions.openapi.json | jq '.components.schemas.Content | with_entries(select(.key | startswith("x-") | not))'
```

```json
{
  "description": "The content of the response.",
  "type": "object",
  "oneOf": [
    { "$ref": "#/components/schemas/AudioContent" },
    { "$ref": "#/components/schemas/DocumentContent" },
    { "$ref": "#/components/schemas/ImageContent" },
    { "$ref": "#/components/schemas/TextContent" },
    { "$ref": "#/components/schemas/VideoContent" }
  ]
}
```

There is no `discriminator` key anymore, so the assertion can never pass again. Nothing in our SDK depends on that annotation either: the generated union in `litellm/types/interactions/generated.py` discriminates on `Literal` type tags, which rely only on the `type` const each variant still carries in the live spec:

```bash
for s in AudioContent DocumentContent ImageContent TextContent VideoContent; do curl -s https://ai.google.dev/static/api/interactions.openapi.json | jq -c --arg s "$s" '{($s): {type: .components.schemas[$s].properties.type, required: .components.schemas[$s].required}}'; done
```

```json
{"AudioContent":{"type":{"const":"audio"},"required":["type"]}}
{"DocumentContent":{"type":{"const":"document"},"required":["type"]}}
{"ImageContent":{"type":{"const":"image"},"required":["type"]}}
{"TextContent":{"type":{"const":"text"},"required":["text","type"]}}
{"VideoContent":{"type":{"const":"video"},"required":["type"]}}
```

Before: the linked CI run above fails at `assert "discriminator" in content_schema` (base commit 0a6b372126). After: the `tests/test_litellm/interactions` CI job on this PR runs the remaining suite against the live spec at e644e27d37

## Type

✅ Test

## Changes

Deletes `test_content_schema_uses_discriminator` from `tests/test_litellm/interactions/test_openapi_compliance.py`. The rest of the compliance suite is untouched and keeps canarying the live spec, including `test_text_content_schema`, which still pins TextContent's `type` const, the actual field our generated Pydantic union keys on

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
