### PR TITLE
fix(ci): accept tagged Interactions content union

### DIFF
--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -105,26 +105,19 @@ class TestRequestCompliance:
         assert "string" in input_types, "Input should support string"
         assert "array" in input_types, "Input should support array"
 
-    def test_content_schema_uses_discriminator(self, spec_dict):
-        """Verify Content uses type discriminator."""
+    def test_content_schema_uses_tagged_union(self, spec_dict):
+        """Verify Content options are distinguishable by their type field."""
         content_schema = spec_dict["components"]["schemas"]["Content"]
 
-        assert "discriminator" in content_schema
-        assert content_schema["discriminator"]["propertyName"] == "type"
+        one_of = content_schema.get("oneOf", [])
+        ref_names = [option["$ref"].split("/")[-1] for option in one_of if "$ref" in option]
+        assert "TextContent" in ref_names, f"TextContent not found in oneOf refs: {ref_names}"
 
-        # Check TextContent is an option (via mapping if present, or via oneOf refs)
-        mapping = content_schema["discriminator"].get("mapping")
-        if mapping:
-            assert "text" in mapping
-            print(f"Content type discriminator mapping: {list(mapping.keys())}")
-        else:
-            # Discriminator without explicit mapping — verify via oneOf
-            one_of = content_schema.get("oneOf", [])
-            ref_names = [opt["$ref"].split("/")[-1] for opt in one_of if "$ref" in opt]
-            assert (
-                "TextContent" in ref_names
-            ), f"TextContent not found in oneOf refs: {ref_names}"
-            print(f"Content type discriminator (no mapping), oneOf refs: {ref_names}")
+        for ref_name in ref_names:
+            type_schema = spec_dict["components"]["schemas"][ref_name]["properties"]["type"]
+            assert "const" in type_schema, f"{ref_name}.type must identify the union member"
+
+        print(f"Content tagged-union refs: {ref_names}")
 
     def test_text_content_schema(self, spec_dict):
         """Verify TextContent schema."""


### PR DESCRIPTION
## TLDR

Google's live Interactions OpenAPI schema now models `Content` as a `oneOf` tagged union without a top-level `discriminator`. The compliance test still required the removed discriminator, causing the `misc` CI shard to fail across unrelated PRs.

This updates the test to verify the current contract: `Content` includes `TextContent` in its `oneOf` references and every referenced content schema identifies itself with a constant `type` field.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all relevant CI/CD checks locally
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Proof

```text
uv run pytest tests/test_litellm/interactions/test_openapi_compliance.py -q
13 passed in 5.91s

NODE_OPTIONS=--max-old-space-size=8192 make -o lint-fetch-base lint
passed
```

## Type

Bug Fix

## Changes

- Replace the stale explicit-discriminator assertion with tagged-union validation.
- Require `TextContent` among `Content.oneOf` references.
- Require every referenced content schema to expose a constant `type` field.

### Final Attestation

- [x] The test validates the current live Google Interactions OpenAPI contract without weakening content-union coverage.
