### PR TITLE
fix(vertex_ai): skip context caching when the cached block ends on a model turn

### DIFF
--- a/litellm/llms/vertex_ai/context_caching/transformation.py
+++ b/litellm/llms/vertex_ai/context_caching/transformation.py
@@ -156,11 +156,14 @@ def cached_messages_end_on_supported_turn(cached_messages: Sequence[AllMessageVa
     """
     The cachedContents API rejects contents ending on a model turn, which is how it
     classifies both assistant messages and tool results, with HTTP 400
-    "Requests ending with a model turn are not supported".
+    "Requests ending with a model turn are not supported". System messages are
+    extracted into system_instruction before contents are built, so the terminal
+    turn is the last non-system message.
     """
-    if not cached_messages:
-        return False
-    return cached_messages[-1].get("role") not in ("assistant", "tool", "function")
+    non_system_messages = tuple(message for message in cached_messages if message.get("role") != "system")
+    if not non_system_messages:
+        return bool(cached_messages)
+    return non_system_messages[-1].get("role") not in ("assistant", "tool", "function")
 
 
 def transform_openai_messages_to_gemini_context_caching(

--- a/litellm/llms/vertex_ai/context_caching/transformation.py
+++ b/litellm/llms/vertex_ai/context_caching/transformation.py
@@ -5,7 +5,7 @@ Why separate file? Make it easy to see how transformation works
 """
 
 import re
-from typing import List, Optional, Tuple, Literal
+from typing import List, Optional, Sequence, Tuple, Literal
 
 from litellm.types.llms.openai import AllMessageValues
 from litellm.types.llms.vertex_ai import CachedContentRequestBody
@@ -150,6 +150,17 @@ def separate_cached_messages(
         non_cached_messages = messages
 
     return cached_messages, non_cached_messages
+
+
+def cached_messages_end_on_supported_turn(cached_messages: Sequence[AllMessageValues]) -> bool:
+    """
+    The cachedContents API rejects contents ending on a model turn, which is how it
+    classifies both assistant messages and tool results, with HTTP 400
+    "Requests ending with a model turn are not supported".
+    """
+    if not cached_messages:
+        return False
+    return cached_messages[-1].get("role") not in ("assistant", "tool", "function")
 
 
 def transform_openai_messages_to_gemini_context_caching(

--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -311,8 +311,9 @@ class ContextCachingEndpoints(VertexBase):
 
         if not cached_messages_end_on_supported_turn(cached_messages):
             verbose_logger.debug(
-                "Vertex AI context caching: cached message block ends on an assistant or "
-                "tool turn, which the cachedContents API rejects. Skipping context caching."
+                "Vertex AI context caching: cached message block ends on a model turn once "
+                "system messages are extracted, which the cachedContents API rejects. "
+                "Skipping context caching."
             )
             return messages, optional_params, None
 
@@ -469,8 +470,9 @@ class ContextCachingEndpoints(VertexBase):
 
         if not cached_messages_end_on_supported_turn(cached_messages):
             verbose_logger.debug(
-                "Vertex AI context caching: cached message block ends on an assistant or "
-                "tool turn, which the cachedContents API rejects. Skipping context caching."
+                "Vertex AI context caching: cached message block ends on a model turn once "
+                "system messages are extracted, which the cachedContents API rejects. "
+                "Skipping context caching."
             )
             return messages, optional_params, None
 

--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -22,6 +22,7 @@ from litellm.types.llms.vertex_ai import (
 from ..common_utils import VertexAIError, get_vertex_base_url
 from ..vertex_llm_base import VertexBase
 from .transformation import (
+    cached_messages_end_on_supported_turn,
     separate_cached_messages,
     transform_openai_messages_to_gemini_context_caching,
 )
@@ -308,6 +309,13 @@ class ContextCachingEndpoints(VertexBase):
         if len(cached_messages) == 0:
             return messages, optional_params, None
 
+        if not cached_messages_end_on_supported_turn(cached_messages):
+            verbose_logger.debug(
+                "Vertex AI context caching: cached message block ends on an assistant or "
+                "tool turn, which the cachedContents API rejects. Skipping context caching."
+            )
+            return messages, optional_params, None
+
         # Gemini requires a minimum of 1024 tokens for context caching.
         # Skip caching if the cached content is too small to avoid API errors.
         if not is_prompt_caching_valid_prompt(
@@ -457,6 +465,13 @@ class ContextCachingEndpoints(VertexBase):
         cached_messages, non_cached_messages = separate_cached_messages(messages=messages)
 
         if len(cached_messages) == 0:
+            return messages, optional_params, None
+
+        if not cached_messages_end_on_supported_turn(cached_messages):
+            verbose_logger.debug(
+                "Vertex AI context caching: cached message block ends on an assistant or "
+                "tool turn, which the cachedContents API rejects. Skipping context caching."
+            )
             return messages, optional_params, None
 
         # Gemini requires a minimum of 1024 tokens for context caching.

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -1458,18 +1458,24 @@ class TestContextCachingEndpoints:
             "type": "function",
             "function": {"name": "get_weather", "arguments": '{"location": "Boston"}'},
         }
-        cached_tail = (
-            [
+        cached_tail = {
+            "assistant": [],
+            "tool": [
                 {
                     "role": "tool",
                     "tool_call_id": "call_abc123",
                     "content": "72F and sunny",
                     "cache_control": {"type": "ephemeral"},
                 }
-            ]
-            if final_cached_role == "tool"
-            else []
-        )
+            ],
+            "system": [
+                {
+                    "role": "system",
+                    "content": "Tool results are authoritative.",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+        }[final_cached_role]
         return [
             {
                 "role": "user",
@@ -1491,7 +1497,7 @@ class TestContextCachingEndpoints:
             {"role": "user", "content": "What is the weather in Boston?"},
         ]
 
-    @pytest.mark.parametrize("final_cached_role", ["assistant", "tool"])
+    @pytest.mark.parametrize("final_cached_role", ["assistant", "tool", "system"])
     def test_check_and_create_cache_skips_when_cached_block_ends_on_model_turn(
         self, final_cached_role
     ):
@@ -1525,7 +1531,7 @@ class TestContextCachingEndpoints:
         self.mock_client.get.assert_not_called()
         self.mock_client.post.assert_not_called()
 
-    @pytest.mark.parametrize("final_cached_role", ["assistant", "tool"])
+    @pytest.mark.parametrize("final_cached_role", ["assistant", "tool", "system"])
     @pytest.mark.asyncio
     async def test_async_check_and_create_cache_skips_when_cached_block_ends_on_model_turn(
         self, final_cached_role
@@ -1571,6 +1577,22 @@ def test_cached_messages_end_on_supported_turn():
     )
     assert cached_messages_end_on_supported_turn([{"role": "system", "content": "be brief"}]) is True
     assert cached_messages_end_on_supported_turn([{"role": "assistant", "content": "hi"}]) is False
+    assert (
+        cached_messages_end_on_supported_turn(
+            [
+                {"role": "user", "content": "hello"},
+                {"role": "assistant", "content": "hi"},
+                {"role": "system", "content": "be brief"},
+            ]
+        )
+        is False
+    )
+    assert (
+        cached_messages_end_on_supported_turn(
+            [{"role": "system", "content": "be brief"}, {"role": "user", "content": "hello"}]
+        )
+        is True
+    )
     assert (
         cached_messages_end_on_supported_turn([{"role": "tool", "tool_call_id": "x", "content": "y"}])
         is False

--- a/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
+++ b/tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py
@@ -1452,6 +1452,135 @@ class TestContextCachingEndpoints:
         # Restart the patcher so teardown_method can stop it cleanly
         self._token_check_patcher.start()
 
+    def _model_turn_final_messages(self, final_cached_role):
+        tool_call = {
+            "id": "call_abc123",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"location": "Boston"}'},
+        }
+        cached_tail = (
+            [
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_abc123",
+                    "content": "72F and sunny",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ]
+            if final_cached_role == "tool"
+            else []
+        )
+        return [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "Use the weather tool for every answer.",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [tool_call],
+                "cache_control": {"type": "ephemeral"},
+            },
+            *cached_tail,
+            {"role": "user", "content": "What is the weather in Boston?"},
+        ]
+
+    @pytest.mark.parametrize("final_cached_role", ["assistant", "tool"])
+    def test_check_and_create_cache_skips_when_cached_block_ends_on_model_turn(
+        self, final_cached_role
+    ):
+        """The cachedContents API rejects contents ending on an assistant or tool turn
+        with HTTP 400 "Requests ending with a model turn are not supported", so the
+        request must proceed uncached instead of failing.
+        """
+        all_messages = self._model_turn_final_messages(final_cached_role)
+        optional_params = self.sample_optional_params.copy()
+
+        result = self.context_caching.check_and_create_cache(
+            messages=all_messages,
+            optional_params=optional_params,
+            api_key="test_key",
+            api_base=None,
+            model="gemini-3.6-flash",
+            client=self.mock_client,
+            timeout=30.0,
+            logging_obj=self.mock_logging,
+            cached_content=None,
+            custom_llm_provider="vertex_ai",
+            vertex_project="test_project",
+            vertex_location="us-central1",
+            vertex_auth_header="test_token",
+        )
+
+        messages, returned_params, returned_cache = result
+        assert messages == all_messages
+        assert returned_cache is None
+        assert "tools" in returned_params
+        self.mock_client.get.assert_not_called()
+        self.mock_client.post.assert_not_called()
+
+    @pytest.mark.parametrize("final_cached_role", ["assistant", "tool"])
+    @pytest.mark.asyncio
+    async def test_async_check_and_create_cache_skips_when_cached_block_ends_on_model_turn(
+        self, final_cached_role
+    ):
+        """Async variant: an unsupported terminal turn skips caching instead of failing."""
+        all_messages = self._model_turn_final_messages(final_cached_role)
+        optional_params = self.sample_optional_params.copy()
+
+        result = await self.context_caching.async_check_and_create_cache(
+            messages=all_messages,
+            optional_params=optional_params,
+            api_key="test_key",
+            api_base=None,
+            model="gemini-3.6-flash",
+            client=self.mock_async_client,
+            timeout=30.0,
+            logging_obj=self.mock_logging,
+            cached_content=None,
+            custom_llm_provider="vertex_ai",
+            vertex_project="test_project",
+            vertex_location="us-central1",
+            vertex_auth_header="test_token",
+        )
+
+        messages, returned_params, returned_cache = result
+        assert messages == all_messages
+        assert returned_cache is None
+        assert "tools" in returned_params
+        self.mock_async_client.get.assert_not_called()
+        self.mock_async_client.post.assert_not_called()
+
+
+def test_cached_messages_end_on_supported_turn():
+    from litellm.llms.vertex_ai.context_caching.transformation import (
+        cached_messages_end_on_supported_turn,
+    )
+
+    assert (
+        cached_messages_end_on_supported_turn(
+            [{"role": "assistant", "content": "hi"}, {"role": "user", "content": "hello"}]
+        )
+        is True
+    )
+    assert cached_messages_end_on_supported_turn([{"role": "system", "content": "be brief"}]) is True
+    assert cached_messages_end_on_supported_turn([{"role": "assistant", "content": "hi"}]) is False
+    assert (
+        cached_messages_end_on_supported_turn([{"role": "tool", "tool_call_id": "x", "content": "y"}])
+        is False
+    )
+    assert (
+        cached_messages_end_on_supported_turn([{"role": "function", "name": "f", "content": "y"}])
+        is False
+    )
+    assert cached_messages_end_on_supported_turn([]) is False
+
 
 class TestCheckCachePagination:
     """Test pagination logic in check_cache and async_check_cache methods."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Anthropic-style `cache_control` on a tool-call history 400s on Vertex/Gemini
- Google's cachedContents API rejects cached blocks ending on a model or tool turn
- The whole chat completion hard-fails instead of degrading to an uncached call
- Common in agent loops that mark the last history message as the cache boundary

How it solves it:

- Skips context caching when the cached block ends on an assistant or tool turn
- Evaluates the terminal turn after system-message extraction, since Vertex moves system messages into `system_instruction` and a trailing cached system message can leave an assistant or tool turn terminal in `contents`
- Mirrors the existing minimum-token skip, so the request proceeds uncached
- Valid cached blocks (ending on a user turn, or system-only blocks) still cache as before

## Relevant issues

## Linear ticket

Resolves LIT-4988

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against real Vertex AI, no mocks. Config:

```yaml
model_list:
  - model_name: vertex-gemini-3
    litellm_params:
      model: vertex_ai/gemini-3.6-flash
      vertex_project: os.environ/VERTEXAI_PROJECT
      vertex_location: global

general_settings:
  master_key: sk-1234
```

The failing shape is a two-turn tool exchange where the contiguous cached block ends on the tool result. A first call (as in PR #34603's proof) returns a real Vertex tool call; the second call marks the padded user question, the assistant tool call, and the tool result with `cache_control` and asks an uncached follow-up:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{
    "model": "vertex-gemini-3",
    "messages": [
      {"role": "user", "content": [{"type": "text", "text": "<~7.7k tokens of padding> What is the weather in Boston, MA? Use the tool.", "cache_control": {"type": "ephemeral"}}]},
      {"role": "assistant", "content": "", "tool_calls": [<tool call from turn 1>], "cache_control": {"type": "ephemeral"}},
      {"role": "tool", "tool_call_id": "<id from turn 1>", "content": "{\"temp_f\": 42, \"conditions\": \"cloudy\"}", "cache_control": {"type": "ephemeral"}},
      {"role": "user", "content": "Answer using the tool result: what is the weather in Boston, MA?"}
    ],
    "tools": [{"type": "function", "function": {"name": "get_current_weather", "description": "Get the current weather in a given location", "parameters": {"type": "object", "properties": {"location": {"type": "string", "description": "City and state"}}, "required": ["location"]}}}]
  }'
```

**Before** (litellm_internal_staging at 0a6b372), the cachedContents create 400s and the whole request fails:

```json
{
  "error": {
    "message": "litellm.BadRequestError: Vertex_aiException BadRequestError - {\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Requests ending with a model turn are not supported. ...\",\n    \"status\": \"INVALID_ARGUMENT\"\n  }\n}...",
    "code": "400"
  }
}
```

**After** (this PR, 819dc7812a), the identical request succeeds uncached, with the skip visible in `--detailed_debug`:

```json
{
  "content": "The current weather in Boston, MA is 42°F and cloudy.",
  "cached_tokens": null
}
```

```
LiteLLM:DEBUG: vertex_ai_context_caching.py:472 - Vertex AI context caching: cached message block ends on a model turn once system messages are extracted, which the cachedContents API rejects. Skipping context caching.
```

Greptile's review caught a second variant of the same failure: a cached block ending on a system message after a tool exchange passes a naive last-role check, but Vertex extracts system messages into `system_instruction`, so `contents` still ends on the model turn. Reproduced live by appending `{"role": "system", "content": "Tool results are authoritative.", "cache_control": {"type": "ephemeral"}}` after the tool result in the request above. At the previous head (dbc0d23c1e) it 400s identically; at 819dc7812a it returns 200 uncached with the same skip debug line

Control, also at 819dc7812a: the same conversation with a cached trailing user text message (a supported terminal turn) still caches, and the cachedContents create plus the cache read both happen:

```json
{
  "content": "The current weather in Boston, MA is 42°F and cloudy.",
  "cached_tokens": 7711
}
```

## Type

🐛 Bug Fix

## Changes

`cached_messages_end_on_supported_turn` in `litellm/llms/vertex_ai/context_caching/transformation.py` returns whether the cached block's final message is a turn the cachedContents API accepts. It filters out system messages first, because `_transform_system_message` moves them into `system_instruction` at any position, and then rejects assistant, tool, and function roles as the terminal turn. A block of only system messages stays cacheable since the Vertex transformation appends a default user message for that case. Both `check_and_create_cache` and `async_check_and_create_cache` call it right after `separate_cached_messages` and skip caching (returning the original messages untouched, before tools are popped from `optional_params`) when it is false, mirroring the existing minimum-token skip

Tests in `tests/test_litellm/llms/vertex_ai/context_caching/test_vertex_ai_context_caching.py` cover the helper's truth table (including trailing-system-after-assistant and system-then-user blocks) and, for both the sync and async paths, assert that a tool-final, assistant-final, or system-final cached block returns the messages unchanged, keeps `tools` in `optional_params`, returns no cached content, and never touches the HTTP client. Mutation-checked: forcing the guard to always pass fails all six skip tests, and reverting the system filtering to a raw last-role check fails the three system-final ones

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
