### PR TITLE
build(makefile): give local basedpyright runs the node heap CI uses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,8 @@ lint-ruff-FULL-dev: install-dev
 	if [ -n "$$files" ]; then echo "$$files" | xargs $(UV_RUN) ruff check; \
 	else echo "No changed .py files to check."; fi
 
+lint-basedpyright lint-basedpyright-budget-update: export NODE_OPTIONS := --max-old-space-size=12288
+
 lint-basedpyright: $(LINT_DEP_INSTALL) $(LINT_DEP_BASE)
 	($(UV_RUN) basedpyright --outputjson || true) | $(UV_RUN) python scripts/type_check_gate.py --base origin/litellm_internal_staging
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `make lint-basedpyright` OOMs node's stock 4GB heap on fresh worktrees
- CI already runs the same check with a 12GB heap

How it solves it:

- exports `NODE_OPTIONS=--max-old-space-size=12288` on both full-repo basedpyright targets
- whole-recipe scope so the gate's internal base pass inherits it too

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Both runs are the same command in the same freshly bootstrapped worktree; only this PR's Makefile change differs between them

Before, at 581f5c319e (base, without this change):

```
$ make lint-basedpyright
...
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
...
FAIL: basedpyright produced no errors, but basedpyright-code-budget.json allows up to ~217435. The type checker almost certainly crashed or emitted nothing; refusing to certify a vacuous run.
make: *** [lint-basedpyright] Error 1
```

After, at b8639fd5ee (this PR):

```
$ make lint-basedpyright
(uv run --no-sync basedpyright --outputjson || true) | uv run --no-sync python scripts/type_check_gate.py --base origin/litellm_internal_staging
OK: every rule is within its basedpyright limit or no higher than base (152853 errors total)
```

## Type

🚄 Infrastructure

## Changes

test-linting.yml's "Check basedpyright budget" step sets `NODE_OPTIONS: --max-old-space-size=12288`, but the local `lint-basedpyright` and `lint-basedpyright-budget-update` targets never got the same override, so a full-repo basedpyright run dies at node's default heap on any fresh worktree and `make pre-commit` / `make lint` die with it

The fix is one target-specific exported variable covering both targets. It is scoped to the whole recipe rather than prefixing the first command in the pipe because `scripts/type_check_gate.py` spawns a second basedpyright pass over the merge-base worktree on a base-count cache miss, and that child process needs the same headroom; this mirrors how the step-level `env:` in CI applies to everything the step runs. `lint-e2e-basedpyright` is left alone since it only checks `tests/e2e` and CI runs that step without the override

There are no tests because a make recipe env var has no unit-testable surface; the proof is the live before/after run above

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
