### PR TITLE
fix(a2a): send agent static_headers when routing the a2a/<name> chat model

### DIFF
--- a/litellm/proxy/agent_endpoints/a2a_routing.py
+++ b/litellm/proxy/agent_endpoints/a2a_routing.py
@@ -29,6 +29,7 @@ async def route_a2a_agent_request(
     from litellm.proxy.agent_endpoints.auth.agent_permission_handler import (
         AgentRequestHandler,
     )
+    from litellm.proxy.agent_endpoints.utils import merge_agent_headers
     from litellm.proxy.route_llm_request import (
         ROUTE_ENDPOINT_MAPPING,
         ProxyModelNotFoundError,
@@ -74,6 +75,19 @@ async def route_a2a_agent_request(
 
     # Inject API base and route to litellm
     data["api_base"] = agent.agent_card_params["url"]
+
+    # Attach the agent's admin-configured upstream credentials. ``POST
+    # /a2a/{agent_id}`` already sends these; without them here, an agent that
+    # authenticates its callers rejects every request that arrives through the
+    # ``a2a/<agent-name>`` chat model. Static headers win over anything the
+    # caller supplied, matching the A2A endpoint's precedence.
+    merged_headers = merge_agent_headers(
+        dynamic_headers=data.get("headers"),
+        static_headers=agent.static_headers,
+    )
+    if merged_headers:
+        data["headers"] = merged_headers
+
     verbose_proxy_logger.debug(f"[A2A] Routing {model_name} to {data['api_base']}")
 
     return getattr(litellm, f"{route_type}")(**data)

--- a/tests/test_litellm/proxy/test_route_a2a_models.py
+++ b/tests/test_litellm/proxy/test_route_a2a_models.py
@@ -104,3 +104,103 @@ async def test_route_non_a2a_model_raises_error_if_not_in_router():
             user_model=None,
             route_type="acompletion",
         )
+
+
+def _router_without_a2a_models():
+    """A router that knows nothing about the agent, so routing falls to the A2A branch."""
+    router = Mock()
+    router.model_names = ["gpt-4"]
+    router.deployment_names = []
+    router.has_model_id = Mock(return_value=False)
+    router.model_group_alias = None
+    router.router_general_settings = Mock(pass_through_all_models=False)
+    router.default_deployment = None
+    router.pattern_router = Mock(patterns=[])
+    router.map_team_model = Mock(return_value=None)
+    return router
+
+
+def _registry_with_agent(**agent_kwargs):
+    from litellm.types.agents import AgentResponse
+
+    agent = AgentResponse(
+        agent_id="test-agent-id",
+        agent_name="test-agent",
+        agent_card_params={"url": "http://agent.example.com"},
+        litellm_params=None,
+        **agent_kwargs,
+    )
+    registry = Mock()
+    registry.get_agent_by_name = Mock(return_value=agent)
+    return registry
+
+
+async def _route(data, registry):
+    mock_acompletion = AsyncMock(return_value={"id": "test-response"})
+    with patch("litellm.acompletion", mock_acompletion):
+        with patch(
+            "litellm.proxy.agent_endpoints.agent_registry.global_agent_registry",
+            registry,
+        ):
+            await route_request(
+                data=data,
+                llm_router=_router_without_a2a_models(),
+                user_model=None,
+                route_type="acompletion",
+            )
+    mock_acompletion.assert_called_once()
+    return mock_acompletion.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_static_headers_are_sent_to_the_agent():
+    """
+    Regression: an agent whose upstream authenticates its callers answered fine
+    over ``POST /a2a/{agent_id}`` but rejected every request routed through the
+    ``a2a/<agent-name>`` chat model with a 401, because this path injected only
+    ``api_base`` and dropped the agent's ``static_headers``.
+    """
+    registry = _registry_with_agent(static_headers={"Authorization": "Bearer upstream-secret"})
+
+    call_kwargs = await _route(
+        {"model": "a2a/test-agent", "messages": [{"role": "user", "content": "Hello"}]},
+        registry,
+    )
+
+    assert call_kwargs["headers"] == {"Authorization": "Bearer upstream-secret"}
+
+
+@pytest.mark.asyncio
+async def test_static_headers_win_over_caller_supplied_headers():
+    """
+    The admin-configured credential wins on a case-insensitive collision, and
+    unrelated caller headers survive — the same precedence ``merge_agent_headers``
+    applies for ``POST /a2a/{agent_id}``.
+    """
+    registry = _registry_with_agent(static_headers={"Authorization": "Bearer upstream-secret"})
+
+    call_kwargs = await _route(
+        {
+            "model": "a2a/test-agent",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "headers": {"authorization": "Bearer caller-supplied", "X-Trace": "keep-me"},
+        },
+        registry,
+    )
+
+    assert call_kwargs["headers"]["Authorization"] == "Bearer upstream-secret"
+    assert call_kwargs["headers"]["X-Trace"] == "keep-me"
+    assert "authorization" not in call_kwargs["headers"]
+
+
+@pytest.mark.asyncio
+async def test_agent_without_static_headers_sends_no_headers():
+    """An agent with nothing configured must not gain a headers kwarg it never had."""
+    registry = _registry_with_agent()
+
+    call_kwargs = await _route(
+        {"model": "a2a/test-agent", "messages": [{"role": "user", "content": "Hello"}]},
+        registry,
+    )
+
+    assert not call_kwargs.get("headers")


### PR DESCRIPTION
## TLDR

Problem this solves:

- `a2a/<agent-name>` chat model returns 401 from authenticated agents
- Same agent answers fine over `POST /a2a/{agent_id}`
- Agent `static_headers` never reach the upstream on that route

How it solves it:

- Merge `agent.static_headers` into the call in `route_a2a_agent_request`
- Reuse `merge_agent_headers`, so precedence matches the A2A endpoint

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

An A2A agent that authenticates its callers with a bearer secret, registered with that secret in `static_headers`, reviewed against a live proxy started from source with `python litellm/proxy/proxy_cli.py --config config.yaml --port 4000`. The agent runs the review by calling a real provider, so both runs below are real LLM calls costing real money.

The agent config used for both runs:

```yaml
agent_list:
  - agent_name: github-pr-agent
    agent_card_params:
      protocolVersion: "0.3"
      name: "GitHub PR Reviewer"
      url: "http://127.0.0.1:8083"
      version: "1.0.0"
      capabilities: {streaming: false}
      defaultInputModes: ["text"]
      defaultOutputModes: ["text"]
      skills: [{id: review_pr, name: Review a pull request, description: review a PR, tags: ["github"]}]
    static_headers:
      Authorization: "Bearer <agent shared secret>"
```

### Before, at `24123269cc` (this branch's base, fix not applied)

```bash
curl -sS http://127.0.0.1:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-local-proof" -H "Content-Type: application/json" \
  -d '{"model":"a2a/github-pr-agent","messages":[{"role":"user","content":"review BerriAI/litellm#27703"}]}' \
  -w '\nHTTP %{http_code}\n'
```

```
{"error":{"message":"litellm.APIConnectionError: A2aException - unauthorized\n","type":null,"param":null,"code":"500"}}
HTTP 500
```

The same agent, registered the same way, answers normally over `POST /a2a/{agent_id}` at this commit; that endpoint sends the static headers already. The asymmetry between the two surfaces is the bug.

### After, at `c3c83c6c8f`

```bash
curl -sS http://127.0.0.1:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-local-proof" -H "Content-Type: application/json" \
  -d '{"model":"a2a/github-pr-agent","messages":[{"role":"user","content":"review andinianst93/kubeops-ai#4"}]}' \
  -w '\nHTTP %{http_code} total=%{time_total}s\n'
```

```
HTTP 200 total=34.958352s

model: a2a/github-pr-agent

**andinianst93/kubeops-ai#4** — [Update workflows and add OAuth2 sign-out functionality](https://github.com/andinianst93/kubeops-ai/pull/4)

## Summary
This PR updates GitHub Actions workflows to use `GITHUB_TOKEN` for container registry authentication and
modifies the image tagging strategy to include the repository name. It also introduces an `OAuth2SignOutRD`
configuration for `id-cookie-transformer` to control post-sign-out redirects...

## Findings
1. `[bug] id-cookie-transformer/config.go:153 — Default values for ProvisionFirstName and ProvisionLastName
   were changed from "Trusted" and "User" to empty strings.`
    - Impact: If the environment variables are not explicitly set, the application will now attempt to
      provision users with empty names...
```

## Type

🐛 Bug Fix

## Changes

`route_a2a_agent_request` resolved the agent from the registry and injected `api_base`, then handed the call to `litellm.acompletion` with no credentials attached. Every other A2A surface sends the agent's admin-configured `static_headers`: `POST /a2a/{agent_id}` builds them through `merge_agent_headers` before calling `asend_message`, and the dashboard writes that field precisely so an agent can authenticate the gateway. The chat-model route was the one path that dropped them, so an agent that guards its JSON-RPC endpoint worked over A2A and failed over `/chat/completions`.

The fix reuses `merge_agent_headers` rather than assembling a dict locally, which keeps one behaviour in one place: static headers overwrite a caller-supplied header of the same name case-insensitively, unrelated caller headers survive, and an agent with nothing configured gains no `headers` kwarg at all.

Worth flagging for a follow-up, since it is adjacent but out of scope here: `A2AConfig.resolve_agent_config_from_registry` looks up the registry by splitting `"a2a/<name>"`, but `get_llm_provider` has already rewritten the model to `<name>` by the time `_complete_a2a` runs, so `agent_name` is always `None` and that lookup never fires from `litellm.completion`. It is dead today; fixing the credential leak there instead of in the proxy route would have looked correct and changed nothing.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
