### PR TITLE
fix(batches): calculate cost and usage for completed Vertex AI batches

### DIFF
--- a/litellm/batches/batch_utils.py
+++ b/litellm/batches/batch_utils.py
@@ -212,9 +212,6 @@ async def _get_batch_output_file_content_as_dictionary(
         _is_base64_encoded_unified_file_id,
     )
 
-    if custom_llm_provider == "vertex_ai":
-        raise ValueError("Vertex AI does not support file content retrieval")
-
     if batch.output_file_id is None:
         raise ValueError("Output file id is None cannot retrieve file content")
 

--- a/litellm/batches/batch_utils.py
+++ b/litellm/batches/batch_utils.py
@@ -267,6 +267,8 @@ def _extract_file_access_credentials(litellm_params: Optional[dict]) -> dict:
             "vertex_project",
             "vertex_location",
             "vertex_credentials",
+            "gcs_bucket_name",
+            "bucket_name",
             "timeout",
             "max_retries",
         ]

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -236,6 +236,8 @@ def test_extract_credentials_only_known_keys():
         "api_key": "sk-1",
         "api_base": "https://b",
         "vertex_project": "proj",
+        "gcs_bucket_name": "my-bucket",
+        "bucket_name": "my-alias-bucket",
         "model": "gpt-4o",  # not a credential key
         "unrelated": "x",
     }
@@ -243,6 +245,8 @@ def test_extract_credentials_only_known_keys():
         "api_key": "sk-1",
         "api_base": "https://b",
         "vertex_project": "proj",
+        "gcs_bucket_name": "my-bucket",
+        "bucket_name": "my-alias-bucket",
     }
 
 
@@ -262,6 +266,8 @@ def test_extract_credentials_all_supported_keys():
         "vertex_project",
         "vertex_location",
         "vertex_credentials",
+        "gcs_bucket_name",
+        "bucket_name",
         "timeout",
         "max_retries",
     }
@@ -665,6 +671,7 @@ async def test_output_file_content_vertex_fetches_via_afile_content(monkeypatch)
             "vertex_project": "proj-1",
             "vertex_location": "us-central1",
             "vertex_credentials": "/path/to/creds.json",
+            "gcs_bucket_name": "litellm-bucket",
             "model": "vertex_ai/gemini-3.6-flash",
         },
     )
@@ -675,6 +682,7 @@ async def test_output_file_content_vertex_fetches_via_afile_content(monkeypatch)
     assert captured["vertex_project"] == "proj-1"
     assert captured["vertex_location"] == "us-central1"
     assert captured["vertex_credentials"] == "/path/to/creds.json"
+    assert captured["gcs_bucket_name"] == "litellm-bucket"
     assert "model" not in captured
 
 

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -14,6 +14,7 @@ maps (litellm.completion_cost, batch_cost_calculator), the tokenizer
 deterministic stand-ins so the arithmetic under test is the only variable.
 """
 
+import json
 import os
 import sys
 
@@ -615,10 +616,117 @@ def _batch(output_file_id):
     )
 
 
+def _vertex_openai_row(custom_id, model, prompt_tokens, completion_tokens):
+    return {
+        "id": f"batch_req_{custom_id}",
+        "custom_id": custom_id,
+        "response": {
+            "status_code": 200,
+            "request_id": custom_id,
+            "body": {
+                "id": f"chatcmpl-{custom_id}",
+                "object": "chat.completion",
+                "model": model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": "assistant", "content": "ok"},
+                        "finish_reason": "stop",
+                    }
+                ],
+                "usage": _usage(prompt_tokens, completion_tokens),
+            },
+        },
+        "error": None,
+    }
+
+
+def _vertex_jsonl(rows):
+    return "\n".join(json.dumps(row) for row in rows).encode()
+
+
 @pytest.mark.asyncio
-async def test_output_file_content_vertex_raises():
-    with pytest.raises(ValueError, match="Vertex AI does not support"):
-        await bu._get_batch_output_file_content_as_dictionary(_batch("of"), custom_llm_provider="vertex_ai")
+async def test_output_file_content_vertex_fetches_via_afile_content(monkeypatch):
+    import litellm.files.main as files_main
+
+    rows = [_vertex_openai_row("request-1", "gemini-3.6-flash", 10, 5)]
+    captured: dict = {}
+
+    async def fake_afile_content(**kw):
+        captured.update(kw)
+        return type("R", (), {"content": _vertex_jsonl(rows)})()
+
+    monkeypatch.setattr(files_main, "afile_content", fake_afile_content)
+
+    result = await bu._get_batch_output_file_content_as_dictionary(
+        _batch("gs://litellm-bucket/output/predictions.jsonl"),
+        custom_llm_provider="vertex_ai",
+        litellm_params={
+            "vertex_project": "proj-1",
+            "vertex_location": "us-central1",
+            "vertex_credentials": "/path/to/creds.json",
+            "model": "vertex_ai/gemini-3.6-flash",
+        },
+    )
+
+    assert result == rows
+    assert captured["file_id"] == "gs://litellm-bucket/output/predictions.jsonl"
+    assert captured["custom_llm_provider"] == "vertex_ai"
+    assert captured["vertex_project"] == "proj-1"
+    assert captured["vertex_location"] == "us-central1"
+    assert captured["vertex_credentials"] == "/path/to/creds.json"
+    assert "model" not in captured
+
+
+@pytest.mark.asyncio
+async def test_output_file_content_vertex_unified_file_id_extracts_gcs_uri(monkeypatch):
+    import base64
+
+    import litellm.files.main as files_main
+
+    captured: dict = {}
+
+    async def fake_afile_content(**kw):
+        captured.update(kw)
+        return type("R", (), {"content": b'{"a": 1}'})()
+
+    monkeypatch.setattr(files_main, "afile_content", fake_afile_content)
+    unified_id = (
+        "litellm_proxy:application/jsonl;unified_id,uuid-1;target_model_names,vertex-model;"
+        "llm_output_file_id,gs://litellm-bucket/output/predictions.jsonl;llm_output_file_model_id,model-1"
+    )
+    encoded_id = base64.urlsafe_b64encode(unified_id.encode()).decode().rstrip("=")
+
+    await bu._get_batch_output_file_content_as_dictionary(_batch(encoded_id), custom_llm_provider="vertex_ai")
+
+    assert captured["file_id"] == "gs://litellm-bucket/output/predictions.jsonl"
+    assert captured["custom_llm_provider"] == "vertex_ai"
+
+
+@pytest.mark.asyncio
+async def test_handle_completed_vertex_batch_computes_cost_usage_and_models(monkeypatch):
+    import litellm.files.main as files_main
+
+    rows = [
+        _vertex_openai_row("request-1", "gemini-3.6-flash", 10, 5),
+        _vertex_openai_row("request-2", "gemini-3.6-flash", 20, 10),
+    ]
+
+    async def fake_afile_content(**kw):
+        return type("R", (), {"content": _vertex_jsonl(rows)})()
+
+    monkeypatch.setattr(files_main, "afile_content", fake_afile_content)
+
+    cost, usage, models = await bu._handle_completed_batch(
+        _batch("gs://litellm-bucket/output/predictions.jsonl"),
+        custom_llm_provider="vertex_ai",
+        litellm_params={"vertex_project": "proj-1", "vertex_location": "us-central1"},
+    )
+
+    assert cost > 0
+    assert cost == pytest.approx(30 * 7.5e-07 + 15 * 3.75e-06)
+    assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (30, 15, 45)
+    assert models == ["gemini-3.6-flash", "gemini-3.6-flash"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -18,7 +18,9 @@ import json
 import os
 import sys
 
+import httpx
 import pytest
+import respx
 
 sys.path.insert(0, os.path.abspath("../../../.."))
 
@@ -709,6 +711,97 @@ async def test_output_file_content_vertex_unified_file_id_extracts_gcs_uri(monke
 
     assert captured["file_id"] == "gs://litellm-bucket/output/predictions.jsonl"
     assert captured["custom_llm_provider"] == "vertex_ai"
+
+
+def _vertex_predictions_row(custom_id, prompt_tokens, completion_tokens):
+    return {
+        "request": {
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "labels": {"litellm_custom_id": custom_id},
+        },
+        "status": "",
+        "response": {
+            "candidates": [
+                {
+                    "content": {"role": "model", "parts": [{"text": "ok"}]},
+                    "finishReason": "STOP",
+                }
+            ],
+            "usageMetadata": {
+                "promptTokenCount": prompt_tokens,
+                "candidatesTokenCount": completion_tokens,
+                "totalTokenCount": prompt_tokens + completion_tokens,
+            },
+            "modelVersion": "gemini-3.6-flash",
+        },
+        "processed_time": "2026-07-30T00:00:00.000000+00:00",
+    }
+
+
+@pytest.fixture
+def respx_interceptable_httpx_client(monkeypatch):
+    monkeypatch.setattr(litellm, "disable_aiohttp_transport", True)
+    litellm.in_memory_llm_clients_cache.flush_cache()
+    yield
+    litellm.in_memory_llm_clients_cache.flush_cache()
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_output_file_content_vertex_managed_uri_accepted_by_real_validation(respx_interceptable_httpx_client):
+    managed_output_uri = (
+        "gs://litellm-bucket/litellm-vertex-files/publishers/google/models/"
+        "gemini-3.6-flash/abc-123/prediction-model/predictions.jsonl"
+    )
+    rows = [
+        _vertex_predictions_row("request-1", 10, 5),
+        _vertex_predictions_row("request-2", 20, 10),
+    ]
+    route = respx.get(url__regex=r"https://storage\.googleapis\.com/storage/v1/b/litellm-bucket/o/.*").mock(
+        return_value=httpx.Response(200, content=_vertex_jsonl(rows))
+    )
+
+    result = await bu._get_batch_output_file_content_as_dictionary(
+        _batch(managed_output_uri),
+        custom_llm_provider="vertex_ai",
+        litellm_params={
+            "api_key": "test-token",
+            "vertex_project": "proj-1",
+            "vertex_location": "us-central1",
+            "gcs_bucket_name": "litellm-bucket",
+        },
+    )
+
+    assert route.call_count == 1
+    request = route.calls.last.request
+    assert request.url.raw_path == (
+        b"/storage/v1/b/litellm-bucket/o/"
+        b"litellm-vertex-files%2Fpublishers%2Fgoogle%2Fmodels%2Fgemini-3.6-flash"
+        b"%2Fabc-123%2Fprediction-model%2Fpredictions.jsonl?alt=media"
+    )
+    assert [row["custom_id"] for row in result] == ["request-1", "request-2"]
+    assert all(row["response"]["status_code"] == 200 for row in result)
+    assert all(row["response"]["body"]["model"] == "gemini-3.6-flash" for row in result)
+    assert [row["response"]["body"]["usage"]["prompt_tokens"] for row in result] == [10, 20]
+    assert [row["response"]["body"]["usage"]["completion_tokens"] for row in result] == [5, 10]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_output_file_content_vertex_foreign_bucket_rejected_by_real_validation():
+    with pytest.raises(Exception, match="does not match the configured storage bucket"):
+        await bu._get_batch_output_file_content_as_dictionary(
+            _batch("gs://attacker-bucket/litellm-vertex-files/x/predictions.jsonl"),
+            custom_llm_provider="vertex_ai",
+            litellm_params={
+                "api_key": "test-token",
+                "vertex_project": "proj-1",
+                "vertex_location": "us-central1",
+                "gcs_bucket_name": "litellm-bucket",
+            },
+        )
+
+    assert respx.mock.calls.call_count == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Completed Vertex AI batches always record $0 spend
- A stale hard raise blocked reading the batch output file

How it solves it:

- Remove the raise so afile_content fetches the GCS output file
- The GCS read path already returns OpenAI-format lines, so cost and usage compute
- Forward the per-model gcs_bucket_name to the output file read so the bucket resolves without a GCS_BUCKET_NAME environment variable

## Relevant issues

Issue #32640 reported this $0 spend symptom alongside the output file read failure; the read path was fixed via the Vertex files config, but the cost tracking half remained broken because `_get_batch_output_file_content_as_dictionary` still raised "Vertex AI does not support file content retrieval" before ever fetching the file

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live e2e against real Vertex AI Gemini batch prediction jobs (real tokens billed by Google), using the managed files flow exactly as a customer would: gcs_bucket_name set only on the model entry, no GCS_BUCKET_NAME environment variable, a virtual key, and the standard OpenAI-style endpoints via curl. Before captured at the PR base commit 072a6eef50b8b995e9f600c2eb27cec1046930d3, after at commit 27ccc444715ff9c8e98ddc2d102ff92c4e703962, same commands and config in both legs. The runtime code is unchanged since that commit; the only later commit adds tests

```yaml
model_list:
  - model_name: gemini-3.6-flash
    litellm_params:
      model: vertex_ai/gemini-3.6-flash
      vertex_project: vertex-check-481318
      vertex_location: global
      gcs_bucket_name: litellm-qa34847-model-bucket
```

The flow, identical in both legs:

```
$ curl -s http://localhost:$PORT/v1/files -H "Authorization: Bearer $KEY" \
    -F purpose=batch -F target_model_names="gemini-3.6-flash" -F file=@batch_input.jsonl
{"id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07dW5pZmllZF9pZCxhMThlMjM2OC1...", "bytes": 497, "object": "file", "purpose": "batch", "status": "uploaded", ...}

$ curl -s http://localhost:$PORT/v1/batches -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d '{"input_file_id": "<file id from above>", "endpoint": "/v1/chat/completions", "completion_window": "24h", "model": "gemini-3.6-flash"}'
{"id": "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDo1MDJiYTc4Yi4uLjtsbG1fYmF0Y2hfaWQ6...", "status": "validating", ...}

$ curl -s http://localhost:$PORT/v1/batches/$BATCH_ID -H "Authorization: Bearer $KEY"   # repeated until completed, then 3 more times
{"id": "...", "status": "completed", "output_file_id": "...predictions.jsonl (unified id)", ...}
```

### Before, at 072a6eef50b8b995e9f600c2eb27cec1046930d3: batch completes, cost tracking dies, nothing billed

Vertex job 2730330088959639552 reached JOB_STATE_SUCCEEDED and every retrieve returned 200, but each retrieve of the completed batch killed the cost callback

```
$ grep -c "Vertex AI does not support file content retrieval" proxy_before.log
21
```

```
20:23:49 - LiteLLM:ERROR: logging_worker.py:102 - LoggingWorker error: Vertex AI does not support file content retrieval
  File ".../litellm/litellm_core_utils/litellm_logging.py", line 2451, in async_success_handler
    ) = await _handle_completed_batch(
  File ".../litellm/batches/batch_utils.py", line 216, in _get_batch_output_file_content_as_dictionary
    raise ValueError("Vertex AI does not support file content retrieval")
```

```
$ psql "$DATABASE_URL" -c 'select call_type, spend, model, total_tokens from "LiteLLM_SpendLogs" order by "startTime";'
   call_type   | spend |           model            | total_tokens
---------------+-------+----------------------------+--------------
 acreate_file  |     0 | vertex_ai/gemini-3.6-flash |            0
 acreate_batch |     0 | vertex_ai/gemini-3.6-flash |            0
 afile_content |     0 |                            |            0
(3 rows)
```

No aretrieve_batch spend row exists at all despite four retrieves of the completed batch, so the 104 real tokens Vertex billed were never recorded

### After, at 27ccc444715ff9c8e98ddc2d102ff92c4e703962: same flow, spend recorded exactly

Vertex job 5224761332569473024 reached JOB_STATE_SUCCEEDED with successfulCount 2, with zero occurrences of either error

```
$ grep -c "Vertex AI does not support file content retrieval" proxy_after2.log
0
$ grep -c "GCS bucket_name is required" proxy_after2.log
0
$ psql "$DATABASE_URL" -c 'select call_type, spend, model, prompt_tokens, completion_tokens, total_tokens, "user" from "LiteLLM_SpendLogs" order by "startTime";'
    call_type    |   spend    |           model            | prompt_tokens | completion_tokens | total_tokens |      user
-----------------+------------+----------------------------+---------------+-------------------+--------------+----------------
 acreate_file    |          0 | vertex_ai/gemini-3.6-flash |             0 |                 0 |            0 | qa-vbcost-user
 acreate_batch   |          0 | vertex_ai/gemini-3.6-flash |             0 |                 0 |            0 | qa-vbcost-user
 aretrieve_batch | 0.00035025 | vertex_ai/gemini-3.6-flash |            12 |                91 |          103 | qa-vbcost-user
(3 rows)
```

The recorded spend matches the output file exactly: the two responses used 12 prompt and 91 completion tokens, and with the gemini-3.6-flash batch prices from model_prices_and_context_window.json (input_cost_per_token_batches 7.5e-07, output_cost_per_token_batches 3.75e-06) the expected cost is 12\*7.5e-07 + 91\*3.75e-06 = 0.00035025, which is the value in the spend row, attributed to the requesting user. The row was written by the retrieve path itself; the hourly batch cost job never ran during the window. The batch object returned on the final retrieve also now carries usage {"prompt_tokens": 12, "completion_tokens": 91, "total_tokens": 103}, where the before leg returned usage null

## Type

🐛 Bug Fix

## Changes

Removes the stale vertex_ai early raise in `_get_batch_output_file_content_as_dictionary` (litellm/batches/batch_utils.py) so a completed Vertex batch fetches its gs:// output file through `afile_content`, which already routes vertex_ai through the provider files config, downloads predictions.jsonl from GCS, and transforms it into OpenAI-format batch output lines. The generic cost, usage, and model extraction logic then works unchanged, and the vertex credentials (vertex_project, vertex_location, vertex_credentials) were already forwarded from litellm_params. Regression tests cover the direct gs:// output_file_id, the base64 unified file id unwrapping, and an end-to-end `_handle_completed_batch` run asserting nonzero cost, exact summed usage, and the batch models

Live QA at the prior head surfaced a second gap in the customer configuration, where gcs_bucket_name is set only per model in litellm_params and no GCS_BUCKET_NAME environment variable exists: `_extract_file_access_credentials` did not whitelist the bucket keys, so the output file read failed with "GCS bucket_name is required" inside the LoggingWorker. The second commit adds gcs_bucket_name and its bucket_name alias to the forwarded credential keys, with regression tests asserting the vertex fetch passes gcs_bucket_name through to `afile_content`

The third commit adds regression tests that run the real GCS validation instead of mocking `afile_content`: with only the outbound HTTP intercepted (respx) and the token fetch skipped via a static api_key, a managed `litellm-vertex-files/` output URI flows through `validate_managed_cloud_file_id` to the exact encoded storage.googleapis.com object URL and transforms Vertex predictions.jsonl into OpenAI rows, while an output URI on a foreign bucket is rejected before any HTTP leaves the process. This pins both halves of the read path's contract: real completed-batch output URIs pass validation, and the bucket allowlist cannot be silently loosened

Two known follow-ups outside this PR's scope: the managed batch endpoint marks the batch processed on the first retrieve that sees completion even if the async cost callback fails, so the periodic cost job will not retry such a batch, and pre-completion retrieves at the SDK layer still attempt the output file read because of operator precedence in should_compute_batch_data (litellm_core_utils/litellm_logging.py), which now surfaces as a benign "No such object" log line per poll until the job completes

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

