### PR TITLE
fix(proxy): stamp session_total_count on /spend/logs/session/ui rows

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -3364,6 +3364,12 @@ async def ui_view_session_spend_logs(
 
         total_pages = (total_records + page_size - 1) // page_size
 
+        # Every row here shares session_id, so total_records IS each row's session_total_count.
+        # The UI drawer needs this to stay in session mode when a row selected from this endpoint
+        # (rather than /spend/logs/ui) becomes the displayed log.
+        for row in result:
+            row["session_total_count"] = total_records
+
         return {
             "data": result,
             "total": total_records,

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1583,6 +1583,57 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_ui_view_session_spend_logs_includes_session_total_count(client, monkeypatch):
+    """
+    Regression test: /spend/logs/session/ui must stamp session_total_count onto
+    every row it returns. The UI logs drawer falls back to this field to decide
+    whether the currently displayed log belongs to a multi-call session; before
+    this fix the endpoint never set it, so selecting a row from inside an open
+    session (rather than from /spend/logs/ui) silently dropped the drawer out of
+    session mode.
+    """
+    mock_spend_logs = [
+        {"id": "log1", "request_id": "req1", "session_id": "session-123", "startTime": "2024-01-01T00:00:00Z"},
+        {"id": "log2", "request_id": "req2", "session_id": "session-123", "startTime": "2024-01-02T00:00:00Z"},
+    ]
+
+    class MockDB:
+        async def count(self, *args, **kwargs):
+            return len(mock_spend_logs)
+
+        async def query_raw(self, sql_query, session_id, page_size, skip):
+            # page_size=1 deliberately returns fewer rows than the session's real
+            # total, so a naive `len(result)` fallback would get this wrong too.
+            return [mock_spend_logs[0]]
+
+    class MockPrismaClient:
+        def __init__(self):
+            self.db = MockDB()
+            self.db.litellm_spendlogs = self.db
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MockPrismaClient())
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+
+    try:
+        response = client.get(
+            "/spend/logs/session/ui",
+            params={"session_id": "session-123", "page": 1, "page_size": 1},
+            headers={"Authorization": "Bearer sk-test"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total"] == 2
+        assert len(data["data"]) == 1
+        assert data["data"][0]["session_total_count"] == 2
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
 async def test_ui_view_session_spend_logs_scopes_non_admin_to_own_logs(client, monkeypatch):
     own_log = {
         "id": "log1",


### PR DESCRIPTION
## TLDR

Problem this solves:

- Clicking a row inside an already-open session drawer silently drops session context
- /spend/logs/session/ui never set session_total_count on the rows it returns

How it solves it:

- The endpoint now stamps its own total_records onto every row it returns

## Relevant issues

- Selecting a row from inside an open multi-call session collapses the drawer into a 1-request "Trace" view instead of staying in session mode
- Root cause: the UI's session-mode fallback reads `session_total_count`, a field only the main `/spend/logs/ui` list endpoint ever populated
- Surfaced by #34879 (shareable log links), which added the routing path that depends on this field being reliably set

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Ran against a live proxy (real Anthropic traffic through an `auto_router/complexity_router` deployment) rather than a synthetic session.

**Before (commit 04177e7419, unfixed):**

```bash
curl -s -G "http://localhost:4100/spend/logs/session/ui" \
  --data-urlencode "session_id=17d20e4a-f8dc-472a-bffb-35a5c5fd55e4" \
  --data-urlencode "page=1" --data-urlencode "page_size=5" \
  -H "Authorization: Bearer sk-1234" | python3 -c "
import json,sys
d = json.load(sys.stdin)
for r in d['data']:
    print(r['request_id'], 'session_total_count:', r.get('session_total_count'))
"
```
```
chatcmpl-68c3219d-6970-4b48-b646-501d7ab06b6a session_total_count: None
88fe99fd-2cdb-4dc6-b4f2-eec8ab5dfd6c session_total_count: None
chatcmpl-628cad43-d667-4c77-8fd4-ebb2ab09edb2 session_total_count: None
b0b98e21-7cdb-4a72-8525-848c8f9004e2 session_total_count: None
chatcmpl-57de53bb-f8e0-48e6-976c-5b355efad18d session_total_count: None
```

**After (commit 5f4f8b433a, this PR):** same request, same session, restarted proxy on the fix:

```
total: 212
chatcmpl-efbef485-9125-44b0-b2fb-12333ce4b3a7 session_total_count: 212
b29068b1-431b-4801-828d-bf7930425a71 session_total_count: 212
chatcmpl-19d8db4b-8ad7-4c6b-b411-95bdfb77d067 session_total_count: 212
chatcmpl-2fb1d25f-8754-4034-abad-638ab59ce43c session_total_count: 212
chatcmpl-56ddb090-a331-4d59-8e52-6af45277c7c5 session_total_count: 212
```

**UI reproduction (a reviewer can do this by hand):**

1. Go to `/ui/?page=logs`, find a session with 2+ requests, click its Session ID pill (opens the drawer showing e.g. "SESSION ... N req")
2. Scroll down the session's request list in the left panel and click on a request that is *not* the one the drawer opened on
3. Before this fix: the drawer collapses to a single-request "TRACE" view and the rest of the session's requests disappear from the sidebar
4. After this fix: the drawer stays in "SESSION ... N req" mode and the row selection just updates the right-hand detail panel

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/spend_tracking/spend_management_endpoints.py`: `ui_view_session_spend_logs` now sets `session_total_count = total_records` on every row it returns, matching what `/spend/logs/ui` already does for its rows
- `tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py`: regression test asserting the field is present and correct, including when the requested page returns fewer rows than the session's real total

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
