### PR TITLE
fix(hosted_vllm): bill rerank requests per query

### DIFF
--- a/litellm/llms/hosted_vllm/rerank/transformation.py
+++ b/litellm/llms/hosted_vllm/rerank/transformation.py
@@ -176,7 +176,7 @@ class HostedVLLMRerankConfig(BaseRerankConfig):
     def _transform_response(self, response: dict) -> RerankResponse:
         # Extract usage information
         usage_data = response.get("usage", {})
-        _billed_units = RerankBilledUnits(total_tokens=usage_data.get("total_tokens", 0))
+        _billed_units = RerankBilledUnits(search_units=1, total_tokens=usage_data.get("total_tokens", 0))
         _tokens = RerankTokens(input_tokens=usage_data.get("total_tokens", 0))
         rerank_meta = RerankResponseMeta(billed_units=_billed_units, tokens=_tokens)
 

--- a/tests/test_litellm/llms/hosted_vllm/test_hosted_vllm_rerank_transformation.py
+++ b/tests/test_litellm/llms/hosted_vllm/test_hosted_vllm_rerank_transformation.py
@@ -128,8 +128,26 @@ class TestHostedVLLMRerankTransform:
         assert result.results[0]["index"] == 0
         assert result.results[0]["relevance_score"] == 0.9
         assert result.results[0]["document"]["text"] == "doc1 text"
+        assert result.meta["billed_units"]["search_units"] == 1
         assert result.meta["billed_units"]["total_tokens"] == 42
         assert result.meta["tokens"]["input_tokens"] == 42
+
+    def test_transform_response_enables_per_query_cost(self):
+        result = self.config._transform_response(
+            {
+                "results": [{"index": 0, "relevance_score": 0.9}],
+                "usage": {"total_tokens": 42},
+            }
+        )
+
+        prompt_cost, completion_cost = self.config.calculate_rerank_cost(
+            model=self.model,
+            billed_units=result.meta["billed_units"],
+            model_info={"input_cost_per_query": 0.002},
+        )
+
+        assert prompt_cost == 0.002
+        assert completion_cost == 0.0
 
     def test_transform_response_missing_results(self):
         response_dict = {"id": "abc123", "usage": {"total_tokens": 10}}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Hosted vLLM rerank calls record zero per-query cost
- Normalized responses omit the required `search_units`

How it solves it:

- Record one search unit for each successful rerank response
- Verify the configured per-query price reaches cost calculation

## Relevant issues

Fixes #35194

Related to #7258

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in PR merge, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Live proxy proof is pending while this PR is in draft

The regression test reproduces the current behavior before the fix: the Hosted vLLM response has no `search_units`, and `calculate_rerank_cost` returns `(0.0, 0.0)` with `input_cost_per_query=0.002`

With this change, the same response records `search_units=1`, and cost calculation returns `(0.002, 0.0)`

## Type

🐛 Bug Fix

✅ Test

## Changes

`HostedVLLMRerankConfig._transform_response` now records one search unit alongside the provider's `total_tokens`. Token data remains observational; the existing `BaseRerankConfig` continues to calculate cost only from `input_cost_per_query * search_units`

The Hosted vLLM rerank regression suite now verifies both the normalized billing unit and the resulting per-query cost

TDD evidence:

- RED: the two new assertions failed with missing `search_units` and cost `0.0`
- GREEN: all 13 Hosted vLLM rerank tests passed
- Related regression set: 34 Hosted vLLM, Bedrock, and Azure AI rerank tests passed
- Changed production line coverage: 100%
- Ruff, basedpyright budgets, type-discipline budgets, circular-import, and import-safety checks passed

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world use cases are not possible after this PR
