### PR TITLE
fix(proxy): isolate rate limiter metadata for responses

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -2447,13 +2447,13 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                 data["litellm_proxy_rate_limit_response"] = response
                 # Mirror into metadata so streaming success logging can find
                 # it via ``kwargs["litellm_params"]["metadata"]``.
-                self._stash_value_in_metadata_channels(
+                self._stash_value_in_metadata_channel(
                     data=data,
                     key=RATE_LIMIT_RESPONSE_KEY,
                     value=response,
                 )
                 if parallel_slot_id is not None:
-                    self._stash_value_in_metadata_channels(
+                    self._stash_value_in_metadata_channel(
                         data=data,
                         key=MAX_PARALLEL_SLOT_ACQUIRED_KEY,
                         value={
@@ -2533,7 +2533,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                         requested_model=requested_model,
                     )
                 else:
-                    self._stash_value_in_metadata_channels(
+                    self._stash_value_in_metadata_channel(
                         data=data,
                         key=RATE_LIMIT_DESCRIPTORS_KEY,
                         value=descriptors,
@@ -2566,7 +2566,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                         data["litellm_proxy_rate_limit_response"] = tpm_response
                         # Keep the metadata stash in sync when this is the
                         # first snapshot written.
-                        self._stash_value_in_metadata_channels(
+                        self._stash_value_in_metadata_channel(
                             data=data,
                             key=RATE_LIMIT_RESPONSE_KEY,
                             value=tpm_response,
@@ -2803,19 +2803,19 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         return merged
 
     @staticmethod
-    def _stash_value_in_metadata_channels(
+    def _stash_value_in_metadata_channel(
         data: Dict[str, Any],
         key: str,
         value: Any,
     ) -> None:
-        for channel in ("metadata", "litellm_metadata"):
-            existing = data.get(channel)
-            if isinstance(existing, dict):
-                existing[key] = value
-            elif channel == "metadata":
-                # ``litellm_metadata`` is owned by the router; don't conjure
-                # it here.
-                data[channel] = {key: value}
+        channel: Literal["metadata", "litellm_metadata"] = (
+            "litellm_metadata" if "litellm_metadata" in data else "metadata"
+        )
+        existing = data.get(channel)
+        if isinstance(existing, dict):
+            existing[key] = value
+            return
+        data[channel] = {key: value}
 
     @classmethod
     def _stash_reservation_in_data(
@@ -2831,11 +2831,11 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         """
         scopes_payload: Optional[List[List[str]]] = [[k, v] for k, v in reserved_scopes] if reserved_scopes else None
 
-        cls._stash_value_in_metadata_channels(data=data, key=TPM_RESERVED_TOKENS_KEY, value=estimated_tokens)
+        cls._stash_value_in_metadata_channel(data=data, key=TPM_RESERVED_TOKENS_KEY, value=estimated_tokens)
         if reserved_model:
-            cls._stash_value_in_metadata_channels(data=data, key=TPM_RESERVED_MODEL_KEY, value=reserved_model)
+            cls._stash_value_in_metadata_channel(data=data, key=TPM_RESERVED_MODEL_KEY, value=reserved_model)
         if scopes_payload is not None:
-            cls._stash_value_in_metadata_channels(data=data, key=TPM_RESERVED_SCOPES_KEY, value=scopes_payload)
+            cls._stash_value_in_metadata_channel(data=data, key=TPM_RESERVED_SCOPES_KEY, value=scopes_payload)
 
     @staticmethod
     def _lookup_stashed_value(
@@ -2858,9 +2858,12 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                         return candidate
             litellm_params = kwargs.get("litellm_params")
             if isinstance(litellm_params, dict):
-                lp_metadata = litellm_params.get("metadata")
-                if isinstance(lp_metadata, dict):
-                    candidate = lp_metadata.get(key)
+                for channel in ("metadata", "litellm_metadata"):
+                    channel_dict = litellm_params.get(channel)
+                    if isinstance(channel_dict, dict) and key in channel_dict:
+                        candidate = channel_dict.get(key)
+                        if candidate is not None:
+                            return candidate
         if candidate is None and isinstance(standard_logging_metadata, dict):
             candidate = standard_logging_metadata.get(key)
         return candidate

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -3165,6 +3165,80 @@ async def test_pre_call_hook_does_not_leak_internal_stash_to_request_body():
     assert isinstance(metadata.get(RATE_LIMIT_DESCRIPTORS_KEY), list)
 
 
+@pytest.mark.parametrize(
+    "provider_metadata",
+    [None, {"request_type": "interactive"}],
+)
+@pytest.mark.asyncio
+async def test_responses_rate_limit_stash_uses_litellm_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    provider_metadata: Optional[Dict[str, str]],
+) -> None:
+    from litellm.proxy.hooks.parallel_request_limiter_v3 import (
+        RATE_LIMIT_DESCRIPTORS_KEY,
+        RATE_LIMIT_RESPONSE_KEY,
+        TPM_RESERVED_MODEL_KEY,
+        TPM_RESERVED_SCOPES_KEY,
+        TPM_RESERVED_TOKENS_KEY,
+    )
+
+    monkeypatch.setenv("LITELLM_RATE_LIMIT_WINDOW_SIZE", "60")
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key=hash_token("sk-responses-rate-limit"),
+        rpm_limit=100,
+        tpm_limit=10000,
+    )
+    local_cache = DualCache()
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(local_cache),
+    )
+    data: Dict[str, Any] = {
+        "model": "responses-model",
+        "input": "Reply with OK",
+        "max_tokens": 10,
+        "litellm_metadata": {},
+        **(
+            {"metadata": dict(provider_metadata)}
+            if provider_metadata is not None
+            else {}
+        ),
+    }
+
+    await handler.async_pre_call_hook(
+        user_api_key_dict=user_api_key_dict,
+        cache=local_cache,
+        data=data,
+        call_type="aresponses",
+    )
+
+    if provider_metadata is None:
+        assert "metadata" not in data
+    else:
+        assert data["metadata"] == provider_metadata
+
+    litellm_metadata = data["litellm_metadata"]
+    assert {
+        RATE_LIMIT_DESCRIPTORS_KEY,
+        RATE_LIMIT_RESPONSE_KEY,
+        TPM_RESERVED_MODEL_KEY,
+        TPM_RESERVED_SCOPES_KEY,
+        TPM_RESERVED_TOKENS_KEY,
+    }.issubset(litellm_metadata)
+    assert (
+        handler._lookup_stashed_value(
+            kwargs={
+                "litellm_params": {
+                    "metadata": data.get("metadata", {}),
+                    "litellm_metadata": litellm_metadata,
+                }
+            },
+            standard_logging_metadata=None,
+            key=RATE_LIMIT_RESPONSE_KEY,
+        )
+        == litellm_metadata[RATE_LIMIT_RESPONSE_KEY]
+    )
+
+
 @pytest.mark.asyncio
 async def test_pre_call_hook_rejects_caller_supplied_stash_values():
     """Caller cannot pre-populate stash keys in body metadata to drive a


### PR DESCRIPTION
## Relevant issues

Fixes #35197

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Before the fix, a native `/v1/responses` request with DB-backed RPM limits failed on the initial provider attempt at merge commit `2c1d62ce2b586e047307c83d3ed79c64857287e8`

```shell
litellm.BadRequestError: OpenAIException - {"detail":"Unsupported parameter: metadata"}
```

The request succeeded only when `additional_drop_params: ["metadata"]` removed the limiter-created provider parameter

Live after-fix proof requires deploying commit `41d202c1bb` to the affected proxy and is not included yet. The exact reproduction request and deployment condition are documented in #35197

## Type

🐛 Bug Fix

## Changes

Route internal rate-limiter stash values through `litellm_metadata` whenever the request already has that internal channel. Legacy API surfaces continue using `metadata`, while native Responses provider metadata remains untouched

Read callback stash values from both `metadata` and `litellm_metadata` under `litellm_params`, preserving streaming `x-ratelimit-*` headers and TPM reconciliation

Add regression coverage for RPM and TPM limited Responses requests both with and without caller-supplied provider metadata

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
