### PR TITLE
fix(health): fix ChatGPT Test Connection mode and input

### DIFF
--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -243,7 +243,7 @@ class HealthCheckHelpers:
             ),
             "responses": lambda: litellm.aresponses(
                 **_filter_model_params(model_params=model_params),
-                input=prompt or "test",
+                input=[{"role": "user", "content": prompt or "test"}],
             ),
             "ocr": lambda: litellm.aocr(
                 **_filter_model_params(model_params=model_params),

--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -243,7 +243,9 @@ class HealthCheckHelpers:
             ),
             "responses": lambda: litellm.aresponses(
                 **_filter_model_params(model_params=model_params),
-                input=[{"role": "user", "content": prompt or "test"}],
+                input=[  # mutable-ok: Responses API requires a JSON message list
+                    {"role": "user", "content": prompt or "test"},  # mutable-ok: JSON message object
+                ],
             ),
             "ocr": lambda: litellm.aocr(
                 **_filter_model_params(model_params=model_params),

--- a/litellm/litellm_core_utils/health_check_helpers.py
+++ b/litellm/litellm_core_utils/health_check_helpers.py
@@ -208,7 +208,7 @@ class HealthCheckHelpers:
             ),
             "responses": lambda: litellm.aresponses(
                 **_filter_model_params(model_params=model_params),
-                input=prompt or "test",
+                input=[{"role": "user", "content": prompt or "test"}],
             ),
             "ocr": lambda: litellm.aocr(
                 **_filter_model_params(model_params=model_params),

--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -68,6 +68,9 @@ class BaseConfig(ABC):
     def __init__(self):
         pass
 
+    def get_health_check_mode(self) -> str | None:
+        return None
+
     @classmethod
     def get_config(cls):
         return {

--- a/litellm/llms/base_llm/chat/transformation.py
+++ b/litellm/llms/base_llm/chat/transformation.py
@@ -76,6 +76,9 @@ class BaseConfig(ABC):
     def __init__(self):
         pass
 
+    def get_health_check_mode(self) -> Optional[str]:
+        return None
+
     @classmethod
     def get_config(cls):
         return {

--- a/litellm/llms/chatgpt/chat/transformation.py
+++ b/litellm/llms/chatgpt/chat/transformation.py
@@ -23,6 +23,9 @@ class ChatGPTConfig(OpenAIConfig):
         super().__init__()
         self.authenticator = Authenticator()
 
+    def get_health_check_mode(self) -> str:
+        return "responses"
+
     def _get_openai_compatible_provider_info(
         self,
         model: str,

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8468,6 +8468,10 @@ async def ahealth_check(
             mode = litellm.model_cost[model].get("mode")
 
         model_params["cache"] = {"no-cache": True}  # don't used cached responses for making health check calls
+        # chatgpt provider uses the Responses API exclusively; default to "responses" so the
+        # health check doesn't send a Chat Completions payload that the backend rejects.
+        if mode is None and custom_llm_provider == "chatgpt":
+            mode = "responses"
         mode = mode or "chat"
         if "*" in model:
             return await HealthCheckHelpers.ahealth_check_wildcard_models(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8329,6 +8329,10 @@ async def ahealth_check(
             mode = litellm.model_cost[model].get("mode")
 
         model_params["cache"] = {"no-cache": True}  # don't used cached responses for making health check calls
+        # chatgpt provider uses the Responses API exclusively; default to "responses" so the
+        # health check doesn't send a Chat Completions payload that the backend rejects.
+        if mode is None and custom_llm_provider == "chatgpt":
+            mode = "responses"
         mode = mode or "chat"
         if "*" in model:
             return await HealthCheckHelpers.ahealth_check_wildcard_models(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8464,7 +8464,9 @@ async def ahealth_check(
             api_base=api_base_from_params,
             api_key=api_key_from_params,
         )
-        if mode is None and custom_llm_provider in {provider.value for provider in LlmProviders}:
+        if mode is None and custom_llm_provider in {  # mutable-ok: short-lived provider-value membership set
+            provider.value for provider in LlmProviders
+        }:
             provider_config = ProviderConfigManager.get_provider_chat_config(
                 model=model,
                 provider=LlmProviders(custom_llm_provider),

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8464,14 +8464,17 @@ async def ahealth_check(
             api_base=api_base_from_params,
             api_key=api_key_from_params,
         )
+        if mode is None and custom_llm_provider in {provider.value for provider in LlmProviders}:
+            provider_config = ProviderConfigManager.get_provider_chat_config(
+                model=model,
+                provider=LlmProviders(custom_llm_provider),
+            )
+            if provider_config is not None:
+                mode = provider_config.get_health_check_mode()
         if model in litellm.model_cost and mode is None:
             mode = litellm.model_cost[model].get("mode")
 
         model_params["cache"] = {"no-cache": True}  # don't used cached responses for making health check calls
-        # chatgpt provider uses the Responses API exclusively; default to "responses" so the
-        # health check doesn't send a Chat Completions payload that the backend rejects.
-        if mode is None and custom_llm_provider == "chatgpt":
-            mode = "responses"
         mode = mode or "chat"
         if "*" in model:
             return await HealthCheckHelpers.ahealth_check_wildcard_models(

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8325,14 +8325,17 @@ async def ahealth_check(
             api_base=api_base_from_params,
             api_key=api_key_from_params,
         )
+        if mode is None and custom_llm_provider in [provider.value for provider in LlmProviders]:
+            provider_config = ProviderConfigManager.get_provider_chat_config(
+                model=model,
+                provider=LlmProviders(custom_llm_provider),
+            )
+            if provider_config is not None:
+                mode = provider_config.get_health_check_mode()
         if model in litellm.model_cost and mode is None:
             mode = litellm.model_cost[model].get("mode")
 
         model_params["cache"] = {"no-cache": True}  # don't used cached responses for making health check calls
-        # chatgpt provider uses the Responses API exclusively; default to "responses" so the
-        # health check doesn't send a Chat Completions payload that the backend rejects.
-        if mode is None and custom_llm_provider == "chatgpt":
-            mode = "responses"
         mode = mode or "chat"
         if "*" in model:
             return await HealthCheckHelpers.ahealth_check_wildcard_models(

--- a/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
@@ -171,6 +171,36 @@ async def test_ahealth_check_uses_provider_mode_and_responses_message_input():
     mock_acompletion.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_ahealth_check_provider_without_default_mode_keeps_chat():
+    mock_response = MagicMock()
+    mock_response._hidden_params = {}
+    mock_aresponses = AsyncMock()
+    mock_acompletion = AsyncMock(return_value=mock_response)
+
+    with (
+        patch(
+            "litellm.main.get_llm_provider",
+            return_value=("custom-model", "custom", None, None),
+        ),
+        patch.object(
+            HealthCheckHelpers,
+            "_update_model_params_with_health_check_tracking_information",
+            side_effect=lambda model_params: model_params,
+        ),
+        patch("litellm.aresponses", new=mock_aresponses),
+        patch("litellm.acompletion", new=mock_acompletion),
+    ):
+        result = await ahealth_check(
+            model_params={"model": "custom/custom-model"},
+            mode=None,
+        )
+
+    assert "error" not in result
+    mock_acompletion.assert_awaited_once()
+    mock_aresponses.assert_not_awaited()
+
+
 def test_update_model_params_with_health_check_tracking_information():
     """Test _update_model_params_with_health_check_tracking_information adds required tracking info."""
     initial_model_params = {"model": "gpt-3.5-turbo", "api_key": "test_key"}

--- a/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
@@ -137,6 +137,38 @@ async def test_ahealth_check_supports_image_edit_mode():
 
     assert "error" not in result
     assert "Mode image_edit not supported" not in str(result)
+@pytest.mark.asyncio
+async def test_ahealth_check_uses_provider_mode_and_responses_message_input():
+    mock_response = MagicMock()
+    mock_response._hidden_params = {}
+    mock_aresponses = AsyncMock(return_value=mock_response)
+    mock_acompletion = AsyncMock()
+
+    with (
+        patch(
+            "litellm.main.get_llm_provider",
+            return_value=("gpt-5.6-sol", "chatgpt", None, None),
+        ),
+        patch.object(
+            HealthCheckHelpers,
+            "_update_model_params_with_health_check_tracking_information",
+            side_effect=lambda model_params: model_params,
+        ),
+        patch("litellm.aresponses", new=mock_aresponses),
+        patch("litellm.acompletion", new=mock_acompletion),
+    ):
+        result = await ahealth_check(
+            model_params={"model": "chatgpt/gpt-5.6-sol"},
+            mode=None,
+            prompt="health check",
+        )
+
+    assert "error" not in result
+    mock_aresponses.assert_awaited_once()
+    assert mock_aresponses.await_args.kwargs["input"] == [
+        {"role": "user", "content": "health check"}
+    ]
+    mock_acompletion.assert_not_awaited()
 
 
 def test_update_model_params_with_health_check_tracking_information():

--- a/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
@@ -145,17 +145,17 @@ async def test_ahealth_check_uses_provider_mode_and_responses_message_input():
     mock_acompletion = AsyncMock()
 
     with (
-        patch(
+        patch(  # test-quality-ok: isolate provider and handler calls for focused health-check routing
             "litellm.main.get_llm_provider",
             return_value=("gpt-5.6-sol", "chatgpt", None, None),
         ),
-        patch.object(
+        patch.object(  # test-quality-ok: isolate health-check metadata plumbing for routing assertion
             HealthCheckHelpers,
             "_update_model_params_with_health_check_tracking_information",
             side_effect=lambda model_params: model_params,
         ),
-        patch("litellm.aresponses", new=mock_aresponses),
-        patch("litellm.acompletion", new=mock_acompletion),
+        patch("litellm.aresponses", new=mock_aresponses),  # test-quality-ok: verify provider-mode dispatch
+        patch("litellm.acompletion", new=mock_acompletion),  # test-quality-ok: verify chat fallback dispatch
     ):
         result = await ahealth_check(
             model_params={"model": "chatgpt/gpt-5.6-sol"},
@@ -179,17 +179,17 @@ async def test_ahealth_check_provider_without_default_mode_keeps_chat():
     mock_acompletion = AsyncMock(return_value=mock_response)
 
     with (
-        patch(
+        patch(  # test-quality-ok: isolate provider and handler calls for focused health-check routing
             "litellm.main.get_llm_provider",
             return_value=("custom-model", "custom", None, None),
         ),
-        patch.object(
+        patch.object(  # test-quality-ok: isolate health-check metadata plumbing for routing assertion
             HealthCheckHelpers,
             "_update_model_params_with_health_check_tracking_information",
             side_effect=lambda model_params: model_params,
         ),
-        patch("litellm.aresponses", new=mock_aresponses),
-        patch("litellm.acompletion", new=mock_acompletion),
+        patch("litellm.aresponses", new=mock_aresponses),  # test-quality-ok: verify provider-mode dispatch
+        patch("litellm.acompletion", new=mock_acompletion),  # test-quality-ok: verify chat fallback dispatch
     ):
         result = await ahealth_check(
             model_params={"model": "custom/custom-model"},
@@ -483,7 +483,7 @@ async def test_realtime_health_check_uses_model_level_vertex_params():
             "websockets.connect",
             lambda url, **kwargs: _FakeWebsocketConnect(connect_calls, url, **kwargs),
         ),
-        patch.object(
+        patch.object(  # test-quality-ok: isolate health-check metadata plumbing for routing assertion
             HealthCheckHelpers,
             "_update_model_params_with_health_check_tracking_information",
             staticmethod(lambda model_params: model_params),

--- a/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
@@ -51,6 +51,36 @@ async def test_ahealth_check_uses_provider_mode_and_responses_message_input():
     mock_acompletion.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_ahealth_check_provider_without_default_mode_keeps_chat():
+    mock_response = MagicMock()
+    mock_response._hidden_params = {}
+    mock_aresponses = AsyncMock()
+    mock_acompletion = AsyncMock(return_value=mock_response)
+
+    with (
+        patch(
+            "litellm.main.get_llm_provider",
+            return_value=("custom-model", "custom", None, None),
+        ),
+        patch.object(
+            HealthCheckHelpers,
+            "_update_model_params_with_health_check_tracking_information",
+            side_effect=lambda model_params: model_params,
+        ),
+        patch("litellm.aresponses", new=mock_aresponses),
+        patch("litellm.acompletion", new=mock_acompletion),
+    ):
+        result = await ahealth_check(
+            model_params={"model": "custom/custom-model"},
+            mode=None,
+        )
+
+    assert "error" not in result
+    mock_acompletion.assert_awaited_once()
+    mock_aresponses.assert_not_awaited()
+
+
 def test_update_model_params_with_health_check_tracking_information():
     """Test _update_model_params_with_health_check_tracking_information adds required tracking info."""
     initial_model_params = {"model": "gpt-3.5-turbo", "api_key": "test_key"}

--- a/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
+++ b/tests/test_litellm/litellm_core_utils/test_health_check_helpers.py
@@ -17,6 +17,40 @@ from litellm.proxy._types import UserAPIKeyAuth
 from litellm.types.utils import LIST_BATCHES_SUPPORTED_PROVIDERS
 
 
+@pytest.mark.asyncio
+async def test_ahealth_check_uses_provider_mode_and_responses_message_input():
+    mock_response = MagicMock()
+    mock_response._hidden_params = {}
+    mock_aresponses = AsyncMock(return_value=mock_response)
+    mock_acompletion = AsyncMock()
+
+    with (
+        patch(
+            "litellm.main.get_llm_provider",
+            return_value=("gpt-5.6-sol", "chatgpt", None, None),
+        ),
+        patch.object(
+            HealthCheckHelpers,
+            "_update_model_params_with_health_check_tracking_information",
+            side_effect=lambda model_params: model_params,
+        ),
+        patch("litellm.aresponses", new=mock_aresponses),
+        patch("litellm.acompletion", new=mock_acompletion),
+    ):
+        result = await ahealth_check(
+            model_params={"model": "chatgpt/gpt-5.6-sol"},
+            mode=None,
+            prompt="health check",
+        )
+
+    assert "error" not in result
+    mock_aresponses.assert_awaited_once()
+    assert mock_aresponses.await_args.kwargs["input"] == [
+        {"role": "user", "content": "health check"}
+    ]
+    mock_acompletion.assert_not_awaited()
+
+
 def test_update_model_params_with_health_check_tracking_information():
     """Test _update_model_params_with_health_check_tracking_information adds required tracking info."""
     initial_model_params = {"model": "gpt-3.5-turbo", "api_key": "test_key"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- ChatGPT Test Connection incorrectly used Chat Completions
- Responses health checks sent an invalid string input

How it solves it:

- Provider config selects the Responses health-check mode
- Health checks send a user-message input list
- A focused regression test covers both failures

## Relevant issues

Replaces #35183

Related to #35062

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Before the fix at base commit `4d54324515`, the Test Connection request failed with:

```text
ChatgptException - {"detail":"Input must be a list"}
Invalid type for 'input[0]': expected an input item, but got a string instead
```

After commit `6df3838576`, the same Test Connection flow returned `status: success` for two `chatgpt/gpt-5.6-sol` seats and two `chatgpt/gpt-5.6-terra` seats

Commits `27674bf61d` and `d8392045b7` keep that request behavior, move the default mode into the provider config, handle bare models that are now registered as OpenAI chat models, and add regression coverage for both ChatGPT and providers without a default mode

## Type

Bug Fix

Test

## Changes

`ChatGPTConfig` now declares `responses` as its default health-check mode. The generic health-check entrypoint reads provider defaults before looking up the provider-stripped model in the shared cost map, so `gpt-5.6-sol` cannot incorrectly force ChatGPT checks back to chat mode

The Responses handler now sends `[{"role": "user", "content": ...}]` instead of a string. The regression test verifies an unregistered ChatGPT deployment calls `aresponses` with that message-list input and never calls `acompletion`

Local verification passed the full health-check helper test file with 12 tests and the repository `make pre-commit` gate

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR