### PR TITLE
feat: add minimax/MiniMax-M2.7 to model cost map

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -27193,6 +27193,20 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000
     },
+    "minimax/MiniMax-M2.7": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 6e-08,
+        "cache_creation_input_token_cost": 3.75e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "max_input_tokens": 204800
+    },
     "mistral.devstral-2-123b": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "bedrock_converse",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -27268,6 +27268,20 @@
         "max_input_tokens": 1000000,
         "max_output_tokens": 128000
     },
+    "minimax/MiniMax-M2.7": {
+        "input_cost_per_token": 3e-07,
+        "output_cost_per_token": 1.2e-06,
+        "cache_read_input_token_cost": 6e-08,
+        "cache_creation_input_token_cost": 3.75e-07,
+        "litellm_provider": "minimax",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_system_messages": true,
+        "max_input_tokens": 204800
+    },
     "mistral.devstral-2-123b": {
         "input_cost_per_token": 4e-07,
         "litellm_provider": "bedrock_converse",

--- a/tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py
+++ b/tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py
@@ -248,3 +248,27 @@ def test_azure_ai_claude_1m_context_entries(cost_map: dict):
         "azure_ai/claude-haiku-4-5",
     ]:
         assert cost_map[model]["max_input_tokens"] == 200000, model
+
+
+@pytest.mark.parametrize(
+    "cost_map",
+    [_load_root_cost_map(), GetModelCostMap.load_local_model_cost_map()],
+    ids=["root", "bundled_backup"],
+)
+def test_minimax_m2_7_native_entry(cost_map: dict):
+    """The native ``minimax/`` route must expose a MiniMax-M2.7 entry so callers
+    resolve pricing and context without falling back to a generic default. It is a
+    204,800-token text model with always-on reasoning, and its cache read and
+    cache write prices are both published, so both fields are asserted. Root and
+    bundled maps are checked together so they can never drift apart."""
+    entry = cost_map["minimax/MiniMax-M2.7"]
+    assert entry["litellm_provider"] == "minimax"
+    assert entry["mode"] == "chat"
+    assert entry["max_input_tokens"] == 204800
+    assert entry["input_cost_per_token"] == 3e-07
+    assert entry["output_cost_per_token"] == 1.2e-06
+    assert entry["cache_read_input_token_cost"] == 6e-08
+    assert entry["cache_creation_input_token_cost"] == 3.75e-07
+    assert entry["supports_reasoning"] is True
+    # MiniMax-M2.7 accepts text input only, so it must not advertise vision.
+    assert "supports_vision" not in entry


### PR DESCRIPTION
Reason: The model cost map has no native `minimax/MiniMax-M2.7` entry, so requests to that model resolve neither its pricing nor its context limits.

## What changed
- Add a `minimax/MiniMax-M2.7` entry to both the canonical `model_prices_and_context_window.json` and the bundled fallback `litellm/model_prices_and_context_window_backup.json`. It is a chat model with a 204,800-token input window and always-on reasoning, priced at $0.30/1M input, $1.20/1M output, $0.06/1M cache read, and $0.375/1M cache write. It accepts text input only, so it does not advertise vision.
- Add a parametrized regression test in `tests/test_litellm/litellm_core_utils/test_get_model_cost_map.py` that asserts the entry is present with this pricing and metadata in both the root map and the bundled fallback, so the two cannot drift apart.

No new schema keys are introduced, so the committed schema stays in sync.

## Checks
- `python3 -m pytest tests/test_litellm/test_model_prices_schema.py` — 17 passed (validates the updated cost map against the committed JSON schema and confirms the schema does not need regeneration).
