### PR TITLE
fix: clamp output_config.effort when thinking is disabled on opus 5

### DIFF
--- a/ci_cd/generate_model_prices_schema.py
+++ b/ci_cd/generate_model_prices_schema.py
@@ -200,6 +200,14 @@ def string_key_schemas(modes: tuple) -> dict[str, JsonSchema]:
             "description": "Highest reasoning effort the Bedrock output_config accepts for this model.",
             "enum": ["low", "medium", "high", "max", "xhigh"],
         },
+        "disabled_thinking_output_config_effort_ceiling": {
+            "type": "string",
+            "description": (
+                "Highest reasoning effort this model accepts while thinking is explicitly disabled "
+                "(thinking.type: disabled); higher levels are rejected with a 400."
+            ),
+            "enum": ["low", "medium", "high", "max", "xhigh"],
+        },
         "comment": STRING,
         "audio_transcription_config": STRING,
     }

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -95,6 +95,7 @@ from litellm.utils import (
 from ..common_utils import (
     AnthropicError,
     AnthropicModelInfo,
+    clamped_effort_for_disabled_thinking,
     process_anthropic_headers,
     strip_advisor_blocks_from_messages,
 )
@@ -1991,7 +1992,15 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 model=model,
                 llm_provider=self._resolved_provider,
             )
-        data["output_config"] = output_config
+        clamped_effort = clamped_effort_for_disabled_thinking(
+            model=model,
+            custom_llm_provider=self._resolved_provider,
+            optional_params=optional_params,
+        )
+        if clamped_effort is None:
+            data["output_config"] = output_config
+            return
+        data["output_config"] = {**output_config, "effort": clamped_effort}
 
     def _resolve_json_mode_non_streaming(
         self,

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -4,11 +4,13 @@ This file contains common utils for anthropic calls.
 
 import copy
 import re
-from typing import Any, Dict, List, Optional, Union
+from types import MappingProxyType
+from typing import Any, Dict, List, Mapping, Optional, Union
 
 import httpx
 
 import litellm
+from litellm._logging import verbose_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     get_file_ids_from_messages,
 )
@@ -30,6 +32,23 @@ _BEDROCK_VERSION_SUFFIX_RE = re.compile(r"-v\d+(?::\d+)?$")
 _INFERENCE_PROFILE_MINOR_RE = re.compile(r":\d+$")
 _DATED_RELEASE_SUFFIX_RE = re.compile(r"-\d{8}$")
 _DOTTED_VERSION_RE = re.compile(r"(\d)\.(\d)")
+
+ANTHROPIC_OUTPUT_CONFIG_EFFORT_ORDER: Mapping[str, int] = MappingProxyType(
+    {
+        "low": 0,
+        "medium": 1,
+        "high": 2,
+        "xhigh": 3,
+        "max": 4,
+    }
+)
+
+DISABLED_THINKING_EFFORT_CEILING_KEY = "disabled_thinking_output_config_effort_ceiling"
+
+CLAMPED_EFFORT_FOR_DISABLED_THINKING_MESSAGE = (
+    "Lowering output_config.effort %s -> %s for model=%s: the model caps effort at that level "
+    "while `thinking` is explicitly disabled."
+)
 
 
 def _strip_bedrock_id_suffixes(model: str) -> str:
@@ -348,6 +367,38 @@ class AnthropicModelInfo(BaseLLMModelInfo):
                 for cand in candidates:
                     value = model_cost.get(cand, {}).get(key)
                     if isinstance(value, bool):
+                        return value
+        except Exception:
+            pass
+        return None
+
+    @staticmethod
+    def _get_model_string_capability(model: str, key: str, custom_llm_provider: str) -> Optional[str]:
+        """Read string-valued model-map field ``key`` for ``model``, or None when no
+        entry declares it.
+
+        The string sibling of ``_supports_model_capability``: the provider-aware lookup
+        (which also applies ``fallback_generalizations``) is authoritative, and the raw
+        model-map walk over ``_model_map_lookup_candidates`` is the backstop for alias
+        forms that lookup misses.
+        """
+        from litellm.utils import _get_bundled_model_cost_map, _get_model_info_helper
+
+        try:
+            resolved_model, resolved_provider, _, _ = litellm.get_llm_provider(
+                model=model, custom_llm_provider=custom_llm_provider
+            )
+            value = _get_model_info_helper(model=resolved_model, custom_llm_provider=resolved_provider).get(key)
+            if isinstance(value, str):
+                return value
+        except Exception:  # noqa: BLE001  # _get_model_info_helper raises bare Exception for unmapped models
+            pass
+        try:
+            candidates = AnthropicModelInfo._model_map_lookup_candidates(model)
+            for model_cost in (litellm.model_cost, _get_bundled_model_cost_map()):
+                for cand in candidates:
+                    value = model_cost.get(cand, {}).get(key)
+                    if isinstance(value, str):
                         return value
         except Exception:
             pass
@@ -816,6 +867,60 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         )
 
         return AnthropicTokenCounter()
+
+
+def _nested_string_value(container: object, key: str) -> Optional[str]:
+    """Read ``key`` off ``container`` when it is a mapping holding a string there.
+
+    Provider payloads reach these transforms as untyped dicts, so the read is validated
+    rather than asserted: anything that is not a mapping, or that holds a non-string at
+    ``key``, reads as absent.
+    """
+    if not isinstance(container, Mapping):
+        return None
+    entries: Mapping[object, object] = container
+    value = entries.get(key)
+    return value if isinstance(value, str) else None
+
+
+def clamped_effort_for_disabled_thinking(
+    *,
+    model: str,
+    custom_llm_provider: str,
+    optional_params: Mapping[str, object],
+) -> Optional[str]:
+    """Lowered ``output_config.effort`` for a request that explicitly disables thinking, or
+    ``None`` when the request needs no change.
+
+    Anthropic caps effort while ``thinking`` is explicitly disabled: Claude Opus 5 accepts
+    ``thinking={"type": "disabled"}`` only at effort ``high`` or below, and rejects ``xhigh``
+    or ``max`` with a 400 ("output_config.effort 'xhigh' is not supported when thinking is
+    disabled on this model"). Clients like Claude Code hit this by disabling thinking for a
+    hosted-tool hop (e.g. web search) while still carrying a session-wide ``xhigh``.
+
+    The cap is per model generation, not universal: Opus 4.7/4.8 accept the same combination,
+    so the ceiling is read from the model map
+    (``disabled_thinking_output_config_effort_ceiling``) rather than assumed. Effort is lowered
+    instead of re-enabling thinking because the caller asked not to think, and ``high`` is the
+    API default, so the clamped request behaves exactly like one that omits effort.
+
+    An unrecognized effort value reads as no change so the surface's own validation still
+    owns rejecting it.
+    """
+    effort = _nested_string_value(optional_params.get("output_config"), "effort")
+    if effort is None or effort not in ANTHROPIC_OUTPUT_CONFIG_EFFORT_ORDER:
+        return None
+    if _nested_string_value(optional_params.get("thinking"), "type") != "disabled":
+        return None
+    ceiling = AnthropicModelInfo._get_model_string_capability(
+        model, DISABLED_THINKING_EFFORT_CEILING_KEY, custom_llm_provider
+    )
+    if ceiling is None or ceiling not in ANTHROPIC_OUTPUT_CONFIG_EFFORT_ORDER:
+        return None
+    if ANTHROPIC_OUTPUT_CONFIG_EFFORT_ORDER[effort] <= ANTHROPIC_OUTPUT_CONFIG_EFFORT_ORDER[ceiling]:
+        return None
+    verbose_logger.debug(CLAMPED_EFFORT_FOR_DISABLED_THINKING_MESSAGE, effort, ceiling, model)
+    return ceiling
 
 
 def strip_advisor_blocks_from_messages(messages: List[Any], replace_with_text: bool = False) -> List[Any]:

--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -374,14 +374,8 @@ class AnthropicModelInfo(BaseLLMModelInfo):
 
     @staticmethod
     def _get_model_string_capability(model: str, key: str, custom_llm_provider: str) -> Optional[str]:
-        """Read string-valued model-map field ``key`` for ``model``, or None when no
-        entry declares it.
-
-        The string sibling of ``_supports_model_capability``: the provider-aware lookup
-        (which also applies ``fallback_generalizations``) is authoritative, and the raw
-        model-map walk over ``_model_map_lookup_candidates`` is the backstop for alias
-        forms that lookup misses.
-        """
+        """Read string-valued model-map field ``key`` for ``model``, or None when no entry
+        declares it. The string sibling of ``_supports_model_capability``."""
         from litellm.utils import _get_bundled_model_cost_map, _get_model_info_helper
 
         try:
@@ -870,12 +864,7 @@ class AnthropicModelInfo(BaseLLMModelInfo):
 
 
 def _nested_string_value(container: object, key: str) -> Optional[str]:
-    """Read ``key`` off ``container`` when it is a mapping holding a string there.
-
-    Provider payloads reach these transforms as untyped dicts, so the read is validated
-    rather than asserted: anything that is not a mapping, or that holds a non-string at
-    ``key``, reads as absent.
-    """
+    """Read ``key`` off ``container`` when it is a mapping holding a string there."""
     if not isinstance(container, Mapping):
         return None
     entries: Mapping[object, object] = container
@@ -892,20 +881,10 @@ def clamped_effort_for_disabled_thinking(
     """Lowered ``output_config.effort`` for a request that explicitly disables thinking, or
     ``None`` when the request needs no change.
 
-    Anthropic caps effort while ``thinking`` is explicitly disabled: Claude Opus 5 accepts
-    ``thinking={"type": "disabled"}`` only at effort ``high`` or below, and rejects ``xhigh``
-    or ``max`` with a 400 ("output_config.effort 'xhigh' is not supported when thinking is
-    disabled on this model"). Clients like Claude Code hit this by disabling thinking for a
-    hosted-tool hop (e.g. web search) while still carrying a session-wide ``xhigh``.
-
-    The cap is per model generation, not universal: Opus 4.7/4.8 accept the same combination,
-    so the ceiling is read from the model map
-    (``disabled_thinking_output_config_effort_ceiling``) rather than assumed. Effort is lowered
-    instead of re-enabling thinking because the caller asked not to think, and ``high`` is the
-    API default, so the clamped request behaves exactly like one that omits effort.
-
-    An unrecognized effort value reads as no change so the surface's own validation still
-    owns rejecting it.
+    Opus 5 rejects ``thinking={"type": "disabled"}`` above effort ``high`` with a 400; Opus
+    4.7/4.8 accept it, so the ceiling comes from the model map
+    (``disabled_thinking_output_config_effort_ceiling``). Effort is lowered rather than
+    thinking re-enabled: the caller asked not to think, and ``high`` is the API default.
     """
     effort = _nested_string_value(optional_params.get("output_config"), "effort")
     if effort is None or effort not in ANTHROPIC_OUTPUT_CONFIG_EFFORT_ORDER:

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -26,6 +26,7 @@ from litellm.types.router import GenericLiteLLMParams
 from ...common_utils import (
     AnthropicError,
     AnthropicModelInfo,
+    clamped_effort_for_disabled_thinking,
     optionally_handle_anthropic_oauth,
     strip_advisor_blocks_from_messages,
 )
@@ -514,6 +515,18 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
             max_tokens=max_tokens,
             custom_llm_provider=self._resolved_provider,
         )
+
+        clamped_effort = clamped_effort_for_disabled_thinking(
+            model=model,
+            custom_llm_provider=self._resolved_provider,
+            optional_params=anthropic_messages_optional_request_params,
+        )
+        existing_output_config = anthropic_messages_optional_request_params.get("output_config")
+        if clamped_effort is not None and isinstance(existing_output_config, dict):
+            anthropic_messages_optional_request_params["output_config"] = {
+                **existing_output_config,
+                "effort": clamped_effort,
+            }
 
         self._drop_incompatible_temperature_for_thinking(
             model=model,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -1534,6 +1534,7 @@
         "supports_xhigh_reasoning_effort": true,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
@@ -1570,6 +1571,7 @@
         "supports_xhigh_reasoning_effort": true,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
@@ -1606,6 +1608,7 @@
         "supports_xhigh_reasoning_effort": true,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
@@ -1642,6 +1645,7 @@
         "supports_xhigh_reasoning_effort": true,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
@@ -1678,6 +1682,7 @@
         "supports_xhigh_reasoning_effort": true,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
@@ -1714,6 +1719,7 @@
         "supports_xhigh_reasoning_effort": true,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
@@ -3002,6 +3008,7 @@
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "prompt_cache_min_tokens": 512
     },
     "azure_ai/claude-opus-4-8": {
@@ -12124,6 +12131,7 @@
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "provider_specific_entry": {
             "us": 1.1,
             "fast": 2.0
@@ -37262,6 +37270,7 @@
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "prompt_cache_min_tokens": 512
     },
     "vertex_ai/claude-opus-5@default": {
@@ -37294,6 +37303,7 @@
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "prompt_cache_min_tokens": 512
     },
     "vertex_ai/claude-opus-4-8": {
@@ -46241,6 +46251,14 @@
                 "description": "Claude at version 4.8 or higher, in any id shape that contains claude-<family>-: minors 4.8 through 4.99, any later major-minor, and bare 5+ majors so a new family like claude-fable-5 matches. Anthropic introduced mid-conversation system messages with Opus 4.8 and every newer Claude keeps them; 4.7 and below reject the system role inside messages.",
                 "model_info": {
                     "supports_mid_conversation_system": true
+                }
+            },
+            {
+                "name": "claude-opus-disabled-thinking-effort-ceiling",
+                "pattern": "claude-opus-(?:[5-9]|[1-9]\\d)(?!\\d)(?:[-._]\\d{1,2}(?!\\d))?",
+                "description": "Claude Opus at major version 5 or higher, in any id shape that contains claude-opus-: bare 5+ majors and any later major-minor. Anthropic caps output_config.effort at high while thinking is explicitly disabled starting with Opus 5, so xhigh and max combined with thinking.type: disabled return a 400 there, and the restriction carries forward to later Opus versions. Scoped to the Opus family because that is what Anthropic documents; other families are only capped where their own entry says so.",
+                "model_info": {
+                    "disabled_thinking_output_config_effort_ceiling": "high"
                 }
             }
         ]

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -164,6 +164,7 @@ class ProviderSpecificModelInfo(TypedDict, total=False):
     supports_output_config: Optional[bool]
     supports_image_size: Optional[bool]
     bedrock_output_config_effort_ceiling: Optional[Literal["low", "medium", "high", "max", "xhigh"]]
+    disabled_thinking_output_config_effort_ceiling: Optional[Literal["low", "medium", "high", "max", "xhigh"]]
     bedrock_converse_supports_strict_tools: Optional[bool]
 
 

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -5521,6 +5521,9 @@ def _get_model_info_helper(
                 supports_xhigh_reasoning_effort=_model_info.get("supports_xhigh_reasoning_effort", None),
                 supports_max_reasoning_effort=_model_info.get("supports_max_reasoning_effort", None),
                 bedrock_output_config_effort_ceiling=_model_info.get("bedrock_output_config_effort_ceiling", None),
+                disabled_thinking_output_config_effort_ceiling=_model_info.get(
+                    "disabled_thinking_output_config_effort_ceiling", None
+                ),
                 bedrock_converse_supports_strict_tools=_model_info.get("bedrock_converse_supports_strict_tools", None),
                 supports_computer_use=_model_info.get("supports_computer_use", None),
                 search_context_cost_per_query=_model_info.get("search_context_cost_per_query", None),

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1534,6 +1534,7 @@
         "supports_xhigh_reasoning_effort": true,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
@@ -1570,6 +1571,7 @@
         "supports_xhigh_reasoning_effort": true,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
@@ -1606,6 +1608,7 @@
         "supports_xhigh_reasoning_effort": true,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
@@ -1642,6 +1645,7 @@
         "supports_xhigh_reasoning_effort": true,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
@@ -1678,6 +1682,7 @@
         "supports_xhigh_reasoning_effort": true,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
@@ -1714,6 +1719,7 @@
         "supports_xhigh_reasoning_effort": true,
         "supports_native_structured_output": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "supports_output_config": true,
         "supports_parallel_tool_use_config": true,
         "prompt_cache_min_tokens": 512
@@ -3002,6 +3008,7 @@
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "prompt_cache_min_tokens": 512
     },
     "azure_ai/claude-opus-4-8": {
@@ -12124,6 +12131,7 @@
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "provider_specific_entry": {
             "us": 1.1,
             "fast": 2.0
@@ -37353,6 +37361,7 @@
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "prompt_cache_min_tokens": 512
     },
     "vertex_ai/claude-opus-5@default": {
@@ -37385,6 +37394,7 @@
         "supports_vision": true,
         "supports_xhigh_reasoning_effort": true,
         "supports_max_reasoning_effort": true,
+        "disabled_thinking_output_config_effort_ceiling": "high",
         "prompt_cache_min_tokens": 512
     },
     "vertex_ai/claude-opus-4-8": {
@@ -46363,6 +46373,14 @@
                 "description": "Claude at version 4.8 or higher, in any id shape that contains claude-<family>-: minors 4.8 through 4.99, any later major-minor, and bare 5+ majors so a new family like claude-fable-5 matches. Anthropic introduced mid-conversation system messages with Opus 4.8 and every newer Claude keeps them; 4.7 and below reject the system role inside messages.",
                 "model_info": {
                     "supports_mid_conversation_system": true
+                }
+            },
+            {
+                "name": "claude-opus-disabled-thinking-effort-ceiling",
+                "pattern": "claude-opus-(?:[5-9]|[1-9]\\d)(?!\\d)(?:[-._]\\d{1,2}(?!\\d))?",
+                "description": "Claude Opus at major version 5 or higher, in any id shape that contains claude-opus-: bare 5+ majors and any later major-minor. Anthropic caps output_config.effort at high while thinking is explicitly disabled starting with Opus 5, so xhigh and max combined with thinking.type: disabled return a 400 there, and the restriction carries forward to later Opus versions. Scoped to the Opus family because that is what Anthropic documents; other families are only capped where their own entry says so.",
+                "model_info": {
+                    "disabled_thinking_output_config_effort_ceiling": "high"
                 }
             }
         ]

--- a/model_prices_and_context_window.schema.json
+++ b/model_prices_and_context_window.schema.json
@@ -170,6 +170,17 @@
           "format": "date",
           "pattern": "^\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01])$"
         },
+        "disabled_thinking_output_config_effort_ceiling": {
+          "type": "string",
+          "description": "Highest reasoning effort this model accepts while thinking is explicitly disabled (thinking.type: disabled); higher levels are rejected with a 400.",
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "max",
+            "xhigh"
+          ]
+        },
         "gemini_audio_only_live": {
           "type": "boolean"
         },

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1903,6 +1903,60 @@ def test_anthropic_drop_params_false_forwards_to_unsupported_model():
     assert result.get("output_config") == {"effort": "low"}
 
 
+def _transform_with_thinking_and_effort(model, thinking, effort, **output_config_extra):
+    return AnthropicConfig().transform_request(
+        model=model,
+        messages=[{"role": "user", "content": "Hello"}],
+        optional_params={
+            "max_tokens": 4096,
+            "thinking": thinking,
+            "output_config": {"effort": effort, **output_config_extra},
+        },
+        litellm_params={},
+        headers={},
+    )
+
+
+@pytest.mark.parametrize("effort", ["xhigh", "max"])
+def test_anthropic_clamps_effort_when_thinking_disabled_for_opus_5(effort):
+    """Opus 5 caps ``output_config.effort`` at ``high`` while ``thinking`` is explicitly
+    disabled and 400s above it ("output_config.effort 'xhigh' is not supported when thinking
+    is disabled on this model"). The chat path builds the same Anthropic payload as the
+    /v1/messages pass-through, so it has to lower the effort too."""
+    result = _transform_with_thinking_and_effort("claude-opus-5", {"type": "disabled"}, effort)
+
+    assert result["output_config"] == {"effort": "high"}
+    assert result["thinking"] == {"type": "disabled"}
+
+
+def test_anthropic_keeps_effort_below_ceiling_when_thinking_disabled_for_opus_5():
+    result = _transform_with_thinking_and_effort("claude-opus-5", {"type": "disabled"}, "medium")
+
+    assert result["output_config"] == {"effort": "medium"}
+
+
+def test_anthropic_keeps_xhigh_effort_with_adaptive_thinking_for_opus_5():
+    """The cap is tied to disabled thinking; adaptive thinking must keep ``xhigh``."""
+    result = _transform_with_thinking_and_effort("claude-opus-5", {"type": "adaptive"}, "xhigh")
+
+    assert result["output_config"] == {"effort": "xhigh"}
+
+
+def test_anthropic_keeps_xhigh_effort_when_thinking_disabled_for_opus_4_8():
+    """Opus 4.8 accepts the combination, so clamping there would silently downgrade it."""
+    result = _transform_with_thinking_and_effort("claude-opus-4-8", {"type": "disabled"}, "xhigh")
+
+    assert result["output_config"] == {"effort": "xhigh"}
+
+
+def test_anthropic_effort_clamp_preserves_other_output_config_keys():
+    result = _transform_with_thinking_and_effort(
+        "claude-opus-5", {"type": "disabled"}, "xhigh", format={"type": "text"}
+    )
+
+    assert result["output_config"] == {"effort": "high", "format": {"type": "text"}}
+
+
 @pytest.mark.parametrize(
     "model",
     [

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -1919,10 +1919,8 @@ def _transform_with_thinking_and_effort(model, thinking, effort, **output_config
 
 @pytest.mark.parametrize("effort", ["xhigh", "max"])
 def test_anthropic_clamps_effort_when_thinking_disabled_for_opus_5(effort):
-    """Opus 5 caps ``output_config.effort`` at ``high`` while ``thinking`` is explicitly
-    disabled and 400s above it ("output_config.effort 'xhigh' is not supported when thinking
-    is disabled on this model"). The chat path builds the same Anthropic payload as the
-    /v1/messages pass-through, so it has to lower the effort too."""
+    """The chat path builds the same Anthropic payload as the /v1/messages pass-through, so
+    it has to lower the effort for disabled thinking too."""
     result = _transform_with_thinking_and_effort("claude-opus-5", {"type": "disabled"}, effort)
 
     assert result["output_config"] == {"effort": "high"}
@@ -1936,14 +1934,14 @@ def test_anthropic_keeps_effort_below_ceiling_when_thinking_disabled_for_opus_5(
 
 
 def test_anthropic_keeps_xhigh_effort_with_adaptive_thinking_for_opus_5():
-    """The cap is tied to disabled thinking; adaptive thinking must keep ``xhigh``."""
+    """The cap is tied to disabled thinking."""
     result = _transform_with_thinking_and_effort("claude-opus-5", {"type": "adaptive"}, "xhigh")
 
     assert result["output_config"] == {"effort": "xhigh"}
 
 
 def test_anthropic_keeps_xhigh_effort_when_thinking_disabled_for_opus_4_8():
-    """Opus 4.8 accepts the combination, so clamping there would silently downgrade it."""
+    """Opus 4.8 accepts the combination; clamping there would silently downgrade it."""
     result = _transform_with_thinking_and_effort("claude-opus-4-8", {"type": "disabled"}, "xhigh")
 
     assert result["output_config"] == {"effort": "xhigh"}

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
@@ -22,6 +22,15 @@ def _claude_code_payload(effort="medium", max_tokens=8192, **output_config_extra
     }
 
 
+def _claude_code_web_search_payload(effort="xhigh", **output_config_extra):
+    """The shape Claude Code sends for a hosted web-search hop: thinking off for the
+    hop, the session-wide effort still attached."""
+    params = _claude_code_payload(effort=effort, **output_config_extra)
+    params["thinking"] = {"type": "disabled"}
+    params["tools"] = [{"type": "web_search_20250305", "name": "web_search", "max_uses": 5}]
+    return params
+
+
 def _transform(model, params, litellm_params=None):
     return AnthropicMessagesConfig().transform_anthropic_messages_request(
         model=model,
@@ -294,3 +303,82 @@ def test_non_adaptive_request_without_effort_is_untouched():
 
     assert "thinking" not in result
     assert "output_config" not in result
+
+
+@pytest.mark.parametrize("effort", ["xhigh", "max"])
+def test_disabled_thinking_effort_clamped_to_ceiling_for_opus_5(effort):
+    """Regression: Claude Code's web-search hop disables thinking while still carrying the
+    session-wide ``xhigh``. Opus 5 accepts ``thinking={"type": "disabled"}`` only at effort
+    ``high`` or below and 400s otherwise ("output_config.effort 'xhigh' is not supported when
+    thinking is disabled on this model"), so the effort must be lowered to the ceiling while
+    the caller's request not to think is honored."""
+    result = _transform("claude-opus-5", _claude_code_web_search_payload(effort=effort))
+
+    assert result["thinking"] == {"type": "disabled"}
+    assert result["output_config"] == {"effort": "high"}
+
+
+@pytest.mark.parametrize("effort", ["high", "medium", "low"])
+def test_disabled_thinking_effort_at_or_below_ceiling_untouched(effort):
+    """Only levels above the ceiling are invalid; everything at or below it must pass
+    through unchanged."""
+    result = _transform("claude-opus-5", _claude_code_web_search_payload(effort=effort))
+
+    assert result["thinking"] == {"type": "disabled"}
+    assert result["output_config"] == {"effort": effort}
+
+
+def test_adaptive_thinking_keeps_xhigh_effort_for_opus_5():
+    """The cap applies only while thinking is explicitly disabled; adaptive thinking is
+    exactly how ``xhigh`` is meant to be used and must survive."""
+    result = _transform("claude-opus-5", _claude_code_payload(effort="xhigh"))
+
+    assert result["thinking"] == {"type": "adaptive"}
+    assert result["output_config"] == {"effort": "xhigh"}
+
+
+def test_omitted_thinking_keeps_xhigh_effort_for_opus_5():
+    """Omitting ``thinking`` means adaptive on Opus 5, not disabled, so no clamp applies."""
+    params = _claude_code_web_search_payload(effort="xhigh")
+    params.pop("thinking")
+
+    result = _transform("claude-opus-5", params)
+
+    assert "thinking" not in result
+    assert result["output_config"] == {"effort": "xhigh"}
+
+
+def test_disabled_thinking_effort_not_clamped_for_opus_4_8():
+    """The cap is per model generation, not universal: Opus 4.8 accepts disabled thinking at
+    ``xhigh``, so clamping there would silently downgrade a working request."""
+    result = _transform("claude-opus-4-8", _claude_code_web_search_payload(effort="xhigh"))
+
+    assert result["thinking"] == {"type": "disabled"}
+    assert result["output_config"] == {"effort": "xhigh"}
+
+
+def test_disabled_thinking_clamp_preserves_other_output_config_keys():
+    """Only ``effort`` is rewritten; sibling ``output_config`` keys must survive."""
+    result = _transform(
+        "claude-opus-5",
+        _claude_code_web_search_payload(effort="max", format={"type": "text"}),
+    )
+
+    assert result["output_config"] == {"effort": "high", "format": {"type": "text"}}
+
+
+def test_disabled_thinking_clamp_does_not_mutate_caller_output_config():
+    """The transform must not rewrite the caller's ``output_config`` in place; the router
+    hands the same dict to fallbacks and retries."""
+    params = _claude_code_web_search_payload(effort="xhigh")
+    caller_output_config = params["output_config"]
+
+    AnthropicMessagesConfig().transform_anthropic_messages_request(
+        model="claude-opus-5",
+        messages=[{"role": "user", "content": "Hello"}],
+        anthropic_messages_optional_request_params=params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert caller_output_config == {"effort": "xhigh"}

--- a/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
+++ b/tests/test_litellm/llms/anthropic/experimental_pass_through/messages/test_anthropic_messages_effort.py
@@ -23,8 +23,7 @@ def _claude_code_payload(effort="medium", max_tokens=8192, **output_config_extra
 
 
 def _claude_code_web_search_payload(effort="xhigh", **output_config_extra):
-    """The shape Claude Code sends for a hosted web-search hop: thinking off for the
-    hop, the session-wide effort still attached."""
+    """The shape Claude Code sends for a hosted web-search hop: thinking off, effort kept."""
     params = _claude_code_payload(effort=effort, **output_config_extra)
     params["thinking"] = {"type": "disabled"}
     params["tools"] = [{"type": "web_search_20250305", "name": "web_search", "max_uses": 5}]
@@ -307,11 +306,8 @@ def test_non_adaptive_request_without_effort_is_untouched():
 
 @pytest.mark.parametrize("effort", ["xhigh", "max"])
 def test_disabled_thinking_effort_clamped_to_ceiling_for_opus_5(effort):
-    """Regression: Claude Code's web-search hop disables thinking while still carrying the
-    session-wide ``xhigh``. Opus 5 accepts ``thinking={"type": "disabled"}`` only at effort
-    ``high`` or below and 400s otherwise ("output_config.effort 'xhigh' is not supported when
-    thinking is disabled on this model"), so the effort must be lowered to the ceiling while
-    the caller's request not to think is honored."""
+    """Regression: Opus 5 400s on disabled thinking above ``high``, which is what Claude
+    Code's web-search hop sends. Lower the effort, keep thinking off."""
     result = _transform("claude-opus-5", _claude_code_web_search_payload(effort=effort))
 
     assert result["thinking"] == {"type": "disabled"}
@@ -320,8 +316,7 @@ def test_disabled_thinking_effort_clamped_to_ceiling_for_opus_5(effort):
 
 @pytest.mark.parametrize("effort", ["high", "medium", "low"])
 def test_disabled_thinking_effort_at_or_below_ceiling_untouched(effort):
-    """Only levels above the ceiling are invalid; everything at or below it must pass
-    through unchanged."""
+    """Only levels above the ceiling are invalid."""
     result = _transform("claude-opus-5", _claude_code_web_search_payload(effort=effort))
 
     assert result["thinking"] == {"type": "disabled"}
@@ -329,8 +324,7 @@ def test_disabled_thinking_effort_at_or_below_ceiling_untouched(effort):
 
 
 def test_adaptive_thinking_keeps_xhigh_effort_for_opus_5():
-    """The cap applies only while thinking is explicitly disabled; adaptive thinking is
-    exactly how ``xhigh`` is meant to be used and must survive."""
+    """The cap applies only while thinking is explicitly disabled."""
     result = _transform("claude-opus-5", _claude_code_payload(effort="xhigh"))
 
     assert result["thinking"] == {"type": "adaptive"}
@@ -349,8 +343,7 @@ def test_omitted_thinking_keeps_xhigh_effort_for_opus_5():
 
 
 def test_disabled_thinking_effort_not_clamped_for_opus_4_8():
-    """The cap is per model generation, not universal: Opus 4.8 accepts disabled thinking at
-    ``xhigh``, so clamping there would silently downgrade a working request."""
+    """Opus 4.8 accepts the combination; clamping there would silently downgrade it."""
     result = _transform("claude-opus-4-8", _claude_code_web_search_payload(effort="xhigh"))
 
     assert result["thinking"] == {"type": "disabled"}
@@ -368,8 +361,8 @@ def test_disabled_thinking_clamp_preserves_other_output_config_keys():
 
 
 def test_disabled_thinking_clamp_does_not_mutate_caller_output_config():
-    """The transform must not rewrite the caller's ``output_config`` in place; the router
-    hands the same dict to fallbacks and retries."""
+    """The router hands the same dict to fallbacks and retries, so it must not be rewritten
+    in place."""
     params = _claude_code_web_search_payload(effort="xhigh")
     caller_output_config = params["output_config"]
 

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1845,17 +1845,13 @@ class TestCapabilityProbeUsesCallerProvider:
 
 
 class TestClampedEffortForDisabledThinking:
-    """Anthropic caps ``output_config.effort`` while ``thinking`` is explicitly disabled:
-    Opus 5 accepts ``thinking={"type": "disabled"}`` only at effort ``high`` or below and
-    400s above it ("output_config.effort 'xhigh' is not supported when thinking is disabled
-    on this model"). Claude Code hits this on every WebSearch hop, which disables thinking
-    for the hop while keeping the session-wide ``xhigh``. The ceiling is cost-map driven
-    because Opus 4.7/4.8 accept the same combination."""
+    """Opus 5 rejects ``thinking={"type": "disabled"}`` above effort ``high`` with a 400,
+    which Claude Code triggers on every WebSearch hop; Opus 4.7/4.8 accept it, so the
+    ceiling is cost-map driven."""
 
     @staticmethod
     def _forwarded_effort(model, provider, thinking, effort):
-        """The effort the request ends up carrying: the clamp when one applies, otherwise the
-        caller's own value (``None`` from the helper means "leave the request alone")."""
+        """The effort the request ends up carrying (``None`` from the helper means no change)."""
         from litellm.llms.anthropic.common_utils import (
             clamped_effort_for_disabled_thinking,
         )
@@ -1910,19 +1906,20 @@ class TestClampedEffortForDisabledThinking:
         ],
     )
     def test_models_without_a_ceiling_are_untouched(self, local_model_cost_map, model, provider):
-        """Opus 4.7/4.8 accept disabled thinking at ``xhigh``; clamping there would silently
-        downgrade a working request."""
+        """Clamping a model that accepts the combination would silently downgrade it."""
         assert self._forwarded_effort(model, provider, {"type": "disabled"}, "xhigh") == "xhigh"
 
     def test_unmapped_future_opus_inherits_ceiling_from_generalization_rule(self, local_model_cost_map):
-        """Anthropic documents the cap as applying to Opus 5 "and later models", so an Opus
-        release that has not reached the cost map yet must still be capped."""
         assert self._forwarded_effort("claude-opus-6", "anthropic", {"type": "disabled"}, "xhigh") == "high"
 
     def test_unmapped_non_opus_family_not_capped_by_generalization_rule(self, local_model_cost_map):
-        """The rule is scoped to the Opus family, which is what Anthropic documents; other
-        families are only capped where their own cost-map entry says so."""
         assert self._forwarded_effort("claude-newfamily-6", "anthropic", {"type": "disabled"}, "xhigh") == "xhigh"
+
+    def test_clamp_applies_when_the_fetched_cost_map_predates_the_ceiling_entry(self):
+        """No ``local_model_cost_map``: a released proxy resolves ``litellm.model_cost`` from
+        the remote ``main`` copy, which lacks this entry until merge. The clamp has to fall
+        back to the bundled map, or the fix would not reach users on a released build."""
+        assert self._forwarded_effort("claude-opus-5", "anthropic", {"type": "disabled"}, "xhigh") == "high"
 
     @pytest.mark.parametrize(
         "optional_params",
@@ -1936,8 +1933,7 @@ class TestClampedEffortForDisabledThinking:
         ],
     )
     def test_requests_without_a_usable_effort_report_no_change(self, local_model_cost_map, optional_params):
-        """``None`` means "nothing to rewrite"; an unrecognized effort in particular must be
-        left for the existing validation to reject rather than silently replaced."""
+        """An unrecognized effort stays for the existing validation to reject, not replaced."""
         from litellm.llms.anthropic.common_utils import (
             clamped_effort_for_disabled_thinking,
         )

--- a/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
+++ b/tests/test_litellm/llms/anthropic/test_anthropic_common_utils.py
@@ -1842,3 +1842,111 @@ class TestCapabilityProbeUsesCallerProvider:
             AnthropicModelInfo._is_adaptive_thinking_model("claude-opus-4-8", "anthropic")
             is True
         )
+
+
+class TestClampedEffortForDisabledThinking:
+    """Anthropic caps ``output_config.effort`` while ``thinking`` is explicitly disabled:
+    Opus 5 accepts ``thinking={"type": "disabled"}`` only at effort ``high`` or below and
+    400s above it ("output_config.effort 'xhigh' is not supported when thinking is disabled
+    on this model"). Claude Code hits this on every WebSearch hop, which disables thinking
+    for the hop while keeping the session-wide ``xhigh``. The ceiling is cost-map driven
+    because Opus 4.7/4.8 accept the same combination."""
+
+    @staticmethod
+    def _forwarded_effort(model, provider, thinking, effort):
+        """The effort the request ends up carrying: the clamp when one applies, otherwise the
+        caller's own value (``None`` from the helper means "leave the request alone")."""
+        from litellm.llms.anthropic.common_utils import (
+            clamped_effort_for_disabled_thinking,
+        )
+
+        optional_params = {"output_config": {"effort": effort}}
+        if thinking is not None:
+            optional_params["thinking"] = thinking
+        clamped = clamped_effort_for_disabled_thinking(
+            model=model,
+            custom_llm_provider=provider,
+            optional_params=optional_params,
+        )
+        return effort if clamped is None else clamped
+
+    @pytest.mark.parametrize(
+        "model,provider",
+        [
+            ("claude-opus-5", "anthropic"),
+            ("anthropic/claude-opus-5", "anthropic"),
+            ("vertex_ai/claude-opus-5", "vertex_ai"),
+            ("vertex_ai/claude-opus-5@default", "vertex_ai"),
+            ("azure_ai/claude-opus-5", "azure_ai"),
+            ("us.anthropic.claude-opus-5", "bedrock"),
+            ("bedrock/us.anthropic.claude-opus-5", "bedrock"),
+            ("bedrock/invoke/global.anthropic.claude-opus-5", "bedrock"),
+            ("claude-opus-5-20260115", "anthropic"),
+        ],
+    )
+    @pytest.mark.parametrize("effort", ["xhigh", "max"])
+    def test_effort_above_ceiling_clamped_for_every_opus_5_routing_shape(
+        self, local_model_cost_map, model, provider, effort
+    ):
+        assert self._forwarded_effort(model, provider, {"type": "disabled"}, effort) == "high"
+
+    @pytest.mark.parametrize("effort", ["high", "medium", "low"])
+    def test_effort_at_or_below_ceiling_untouched(self, local_model_cost_map, effort):
+        assert self._forwarded_effort("claude-opus-5", "anthropic", {"type": "disabled"}, effort) == effort
+
+    @pytest.mark.parametrize(
+        "thinking", [None, {"type": "adaptive"}, {"type": "enabled"}, {}, "not-a-dict"]
+    )
+    def test_effort_untouched_unless_thinking_explicitly_disabled(self, local_model_cost_map, thinking):
+        assert self._forwarded_effort("claude-opus-5", "anthropic", thinking, "xhigh") == "xhigh"
+
+    @pytest.mark.parametrize(
+        "model,provider",
+        [
+            ("claude-opus-4-8", "anthropic"),
+            ("claude-opus-4-7", "anthropic"),
+            ("claude-sonnet-4-6", "anthropic"),
+            ("bedrock/us.anthropic.claude-opus-4-8", "bedrock"),
+        ],
+    )
+    def test_models_without_a_ceiling_are_untouched(self, local_model_cost_map, model, provider):
+        """Opus 4.7/4.8 accept disabled thinking at ``xhigh``; clamping there would silently
+        downgrade a working request."""
+        assert self._forwarded_effort(model, provider, {"type": "disabled"}, "xhigh") == "xhigh"
+
+    def test_unmapped_future_opus_inherits_ceiling_from_generalization_rule(self, local_model_cost_map):
+        """Anthropic documents the cap as applying to Opus 5 "and later models", so an Opus
+        release that has not reached the cost map yet must still be capped."""
+        assert self._forwarded_effort("claude-opus-6", "anthropic", {"type": "disabled"}, "xhigh") == "high"
+
+    def test_unmapped_non_opus_family_not_capped_by_generalization_rule(self, local_model_cost_map):
+        """The rule is scoped to the Opus family, which is what Anthropic documents; other
+        families are only capped where their own cost-map entry says so."""
+        assert self._forwarded_effort("claude-newfamily-6", "anthropic", {"type": "disabled"}, "xhigh") == "xhigh"
+
+    @pytest.mark.parametrize(
+        "optional_params",
+        [
+            {},
+            {"thinking": {"type": "disabled"}},
+            {"thinking": {"type": "disabled"}, "output_config": {}},
+            {"thinking": {"type": "disabled"}, "output_config": {"format": {"type": "text"}}},
+            {"thinking": {"type": "disabled"}, "output_config": "not-a-dict"},
+            {"thinking": {"type": "disabled"}, "output_config": {"effort": "bogus"}},
+        ],
+    )
+    def test_requests_without_a_usable_effort_report_no_change(self, local_model_cost_map, optional_params):
+        """``None`` means "nothing to rewrite"; an unrecognized effort in particular must be
+        left for the existing validation to reject rather than silently replaced."""
+        from litellm.llms.anthropic.common_utils import (
+            clamped_effort_for_disabled_thinking,
+        )
+
+        assert (
+            clamped_effort_for_disabled_thinking(
+                model="claude-opus-5",
+                custom_llm_provider="anthropic",
+                optional_params=optional_params,
+            )
+            is None
+        )

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_messages_config.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_messages_config.py
@@ -414,6 +414,35 @@ def test_messages_request_strips_effort_for_haiku_45():
     assert opus_result["output_config"] == {"effort": "high"}
 
 
+def test_messages_request_clamps_effort_when_thinking_disabled_for_opus_5():
+    """Regression: Claude Code on ``vertex_ai/claude-opus-5`` 400s the moment it uses
+    WebSearch — the hop sends ``thinking={"type": "disabled"}`` while the session-wide
+    ``output_config.effort: xhigh`` stays attached, and Opus 5 caps effort at ``high``
+    while thinking is disabled ("output_config.effort 'xhigh' is not supported when
+    thinking is disabled on this model", ``req_vrtx_*``). The pass-through must lower the
+    effort instead of forwarding the rejected combination, and must leave the rest of the
+    Vertex shaping intact."""
+    config = VertexAIPartnerModelsAnthropicMessagesConfig()
+
+    result = config.transform_anthropic_messages_request(
+        model="claude-opus-5",
+        messages=[{"role": "user", "content": "search the web for litellm releases"}],
+        anthropic_messages_optional_request_params={
+            "max_tokens": 8192,
+            "thinking": {"type": "disabled"},
+            "output_config": {"effort": "xhigh"},
+            "tools": [{"type": "web_search_20250305", "name": "web_search", "max_uses": 5}],
+        },
+        litellm_params=GenericLiteLLMParams(),
+        headers={},
+    )
+
+    assert result["output_config"] == {"effort": "high"}
+    assert result["thinking"] == {"type": "disabled"}
+    assert result["anthropic_version"] == "vertex-2023-10-16"
+    assert "model" not in result
+
+
 def test_provider_config_manager_reuses_vertex_anthropic_messages_config_instance():
     """
     Regression test: repeated provider config lookups for the same Vertex Claude model

--- a/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_messages_config.py
+++ b/tests/test_litellm/llms/vertex_ai/vertex_ai_partner_models/anthropic/test_vertex_ai_partner_models_anthropic_messages_config.py
@@ -416,12 +416,8 @@ def test_messages_request_strips_effort_for_haiku_45():
 
 def test_messages_request_clamps_effort_when_thinking_disabled_for_opus_5():
     """Regression: Claude Code on ``vertex_ai/claude-opus-5`` 400s the moment it uses
-    WebSearch — the hop sends ``thinking={"type": "disabled"}`` while the session-wide
-    ``output_config.effort: xhigh`` stays attached, and Opus 5 caps effort at ``high``
-    while thinking is disabled ("output_config.effort 'xhigh' is not supported when
-    thinking is disabled on this model", ``req_vrtx_*``). The pass-through must lower the
-    effort instead of forwarding the rejected combination, and must leave the rest of the
-    Vertex shaping intact."""
+    WebSearch, which sends disabled thinking with the session-wide ``xhigh``. Lower the
+    effort and leave the rest of the Vertex shaping intact."""
     config = VertexAIPartnerModelsAnthropicMessagesConfig()
 
     result = config.transform_anthropic_messages_request(

--- a/tests/test_litellm/test_claude_opus_5_config.py
+++ b/tests/test_litellm/test_claude_opus_5_config.py
@@ -282,15 +282,10 @@ def test_opus_5_all_variants_carry_512_token_cache_minimum(cost_map):
     ids=["root", "bundled_backup"],
 )
 def test_disabled_thinking_effort_ceiling_declared_on_opus_5_only(cost_map):
-    """Opus 5 caps ``output_config.effort`` at ``high`` while ``thinking`` is explicitly
-    disabled and 400s above it, which is what Claude Code hits on every WebSearch hop
-    (thinking off for the hop, session-wide ``xhigh`` still attached). The clamp is
-    cost-map driven, so every Opus 5 variant needs the ceiling.
-
-    The set equality also pins the other direction: Opus 4.7/4.8 accept the same
-    combination, so a stray ceiling on them would silently downgrade a working request.
-    Sonnet 5 is deliberately absent; Anthropic documents the cap for Opus 5 and later and
-    a Sonnet 5 entry should only be added once a live request confirms it."""
+    """The clamp is cost-map driven, so every Opus 5 variant needs the ceiling. The set
+    equality pins the other direction too: Opus 4.7/4.8 accept the combination, so a stray
+    ceiling would silently downgrade them. Sonnet 5 is deliberately absent until a live
+    request confirms the cap applies there."""
     flagged = {
         name
         for name, entry in cost_map.items()

--- a/tests/test_litellm/test_claude_opus_5_config.py
+++ b/tests/test_litellm/test_claude_opus_5_config.py
@@ -275,3 +275,29 @@ def test_opus_5_all_variants_carry_512_token_cache_minimum(cost_map):
         if cost_map[k].get("prompt_cache_min_tokens") != 512
     }
     assert not wrong, f"prompt_cache_min_tokens must be 512: {wrong}"
+
+@pytest.mark.parametrize(
+    "cost_map",
+    [_load_root_cost_map(), GetModelCostMap.load_local_model_cost_map()],
+    ids=["root", "bundled_backup"],
+)
+def test_disabled_thinking_effort_ceiling_declared_on_opus_5_only(cost_map):
+    """Opus 5 caps ``output_config.effort`` at ``high`` while ``thinking`` is explicitly
+    disabled and 400s above it, which is what Claude Code hits on every WebSearch hop
+    (thinking off for the hop, session-wide ``xhigh`` still attached). The clamp is
+    cost-map driven, so every Opus 5 variant needs the ceiling.
+
+    The set equality also pins the other direction: Opus 4.7/4.8 accept the same
+    combination, so a stray ceiling on them would silently downgrade a working request.
+    Sonnet 5 is deliberately absent; Anthropic documents the cap for Opus 5 and later and
+    a Sonnet 5 entry should only be added once a live request confirms it."""
+    flagged = {
+        name
+        for name, entry in cost_map.items()
+        if isinstance(entry, dict) and entry.get("disabled_thinking_output_config_effort_ceiling")
+    }
+    expected = {name for name in cost_map if "claude-opus-5" in name}
+
+    assert expected, "no claude-opus-5 entries found in cost map"
+    assert flagged == expected
+    assert {cost_map[name]["disabled_thinking_output_config_effort_ceiling"] for name in flagged} == {"high"}

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -923,6 +923,10 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                     "type": "string",
                     "enum": ["low", "medium", "high", "max", "xhigh"],
                 },
+                "disabled_thinking_output_config_effort_ceiling": {
+                    "type": "string",
+                    "enum": ["low", "medium", "high", "max", "xhigh"],
+                },
                 "bedrock_converse_supports_strict_tools": {"type": "boolean"},
                 "tpm": {"type": "number"},
                 "provider_specific_entry": {"type": "object"},


### PR DESCRIPTION
## TLDR

Problem this solves:

- Claude Code + Opus 5 400s on every WebSearch hop
- The hop disables thinking but keeps effort `xhigh`
- Opus 5 caps effort at `high` when thinking is disabled
- LiteLLM forwarded the rejected combination unchanged

How it solves it:

- Lower the effort to the model's ceiling before sending
- Ceiling comes from the model map, not from code
- Applied on both `/v1/messages` and chat completions
- Opus 4.7/4.8 accept the combination and stay untouched

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Pending; will be captured against a live proxy on real Vertex Opus 5 (before/after runs with their commit hashes)

## Type

🐛 Bug Fix

## Changes

Anthropic added a validation with Opus 5 that earlier models don't have: `thinking: {"type": "disabled"}` is accepted only at effort `high` or below, and pairing it with `xhigh` or `max` returns a 400 reading `output_config.effort 'xhigh' is not supported when thinking is disabled on this model`. Claude Code walks straight into it; its hosted web-search hop turns thinking off for the hop while the session-wide `xhigh` stays attached, so an Opus 5 session works fine until the first WebSearch call and then fails. It reproduces on Vertex (`req_vrtx_*`) and is not Vertex-specific; the request body is what upstream rejects.

Nothing in the existing normalization chain caught it. `_translate_reasoning_effort_to_anthropic` only fires when an OpenAI-style `reasoning_effort` key is present, `_translate_legacy_thinking_for_adaptive_model` requires `thinking.type == "enabled"`, and both `_translate_adaptive_effort_for_non_adaptive_model` and `_drop_incompatible_temperature_for_thinking` early-return for adaptive-thinking models. On the Vertex side `sanitize_vertex_anthropic_output_params` only drops `effort` for models that reject the parameter outright, and Opus 5 advertises `supports_xhigh_reasoning_effort`, so the value passed through untouched.

The cap is per model generation rather than universal: Anthropic documents it as applying to Opus 5 and later, and Opus 4.7/4.8 accept the same combination today. Clamping unconditionally would silently downgrade those working requests, so the ceiling is declared in the model map as `disabled_thinking_output_config_effort_ceiling`, following the shape of the existing `bedrock_output_config_effort_ceiling`. All ten Opus 5 entries carry it, and a `fallback_generalizations` capability rule scoped to `claude-opus-` at major version 5 or higher covers an Opus release that hasn't reached the map yet. Sonnet 5 is deliberately left out; the documented statement covers Opus 5 and later, and a Sonnet 5 entry should only be added once a live request confirms the cap applies there.

Effort is lowered rather than thinking re-enabled. The caller explicitly asked not to think, which is a latency and cost decision, and `high` is the API default, so a clamped request behaves exactly like one that omits `effort` and does not disturb prompt caching. This also matches how the codebase already handles provider-invalid effort values instead of failing the request.

The clamp itself is a pure function in `litellm/llms/anthropic/common_utils.py`, called from the `/v1/messages` pass-through transform (which covers the direct Anthropic API, Vertex, Bedrock invoke, Azure AI Foundry and Claude Platform, since they all funnel through the shared base transform) and from the chat completions `output_config` boundary in `AnthropicConfig._apply_output_config`. Bedrock Converse is not covered here: it maintains its own effort pipeline with a separate Bedrock-specific ceiling, and stacking two ceiling concepts there deserves its own change. The `reasoning_effort` path in Converse can't reach the invalid combination anyway, because `_map_reasoning_effort` overwrites `thinking` with the adaptive shape.

Tests cover both directions. `disabled` plus `xhigh` or `max` clamps to `high` across every Opus 5 routing shape (bare, Bedrock-dotted with and without a `bedrock/` prefix, Vertex, Vertex `@default`, Azure AI, dated alias); `disabled` at or below the ceiling, adaptive thinking, and omitted thinking all pass through unchanged; Opus 4.7, 4.8 and Sonnet 4.6 keep `xhigh` under disabled thinking so the clamp can't over-apply; sibling `output_config` keys survive; the caller's `output_config` dict is not mutated in place; a model-map assertion pins the ceiling to exactly the Opus 5 entries in both the root and bundled cost maps; and one test runs without the local-cost-map fixture to pin the bundled-map fallback, which is what makes the clamp work on a released build whose fetched cost map predates this entry.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
