### PR TITLE
fix(mistral): parse chat.multi_completion responses from hosted tools

### DIFF
--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -13,7 +13,9 @@ from typing import (
     Iterator,
     List,
     Literal,
+    Mapping,
     Optional,
+    Sequence,
     Tuple,
     Union,
     cast,
@@ -462,6 +464,82 @@ class MistralConfig(OpenAIGPTConfig):
         return all_expected_values_are_empty
 
     @staticmethod
+    def _is_multi_completion_choice(choice: object) -> bool:
+        return isinstance(choice, dict) and "messages" in choice and "message" not in choice
+
+    @staticmethod
+    def _multi_completion_content_blocks(turn: Mapping[str, object]) -> Sequence[Mapping[str, object]]:
+        content = turn.get("content")
+        if isinstance(content, str):
+            return ({"type": "text", "text": content},)
+        if isinstance(content, list):
+            return tuple(block for block in content if isinstance(block, dict))
+        return ()
+
+    @staticmethod
+    def _flatten_multi_completion_choice(choice: Mapping[str, object]) -> Mapping[str, object]:
+        raw_turns = choice.get("messages")
+        turns = tuple(turn for turn in raw_turns if isinstance(turn, dict)) if isinstance(raw_turns, list) else ()
+        answered_ids = frozenset(
+            turn.get("tool_call_id") for turn in turns if turn.get("role") == "tool" and turn.get("tool_call_id")
+        )
+        assistant_turns = tuple(turn for turn in turns if turn.get("role") == "assistant")
+        tool_calls = [
+            tool_call
+            for turn in assistant_turns
+            for raw_tool_calls in (turn.get("tool_calls"),)
+            if isinstance(raw_tool_calls, list)
+            for tool_call in raw_tool_calls
+            if isinstance(tool_call, dict) and tool_call.get("id") not in answered_ids
+        ]
+        blocks = tuple(
+            block for turn in assistant_turns for block in MistralConfig._multi_completion_content_blocks(turn)
+        )
+        text_parts = [
+            text
+            for block in blocks
+            if block.get("type") == "text" and isinstance(text := block.get("text"), str) and text
+        ]
+        image_urls = tuple(
+            url for block in blocks if block.get("type") == "image_url" and (url := block.get("image_url"))
+        )
+        images = [
+            {"type": "image_url", "image_url": url if isinstance(url, dict) else {"url": url}, "index": index}
+            for index, url in enumerate(image_urls)
+        ]
+        message = {
+            "role": "assistant",
+            "content": "\n".join(text_parts) if text_parts else None,
+            **({"tool_calls": tool_calls} if tool_calls else {}),
+            **({"images": images} if images else {}),
+        }
+        return {**{key: value for key, value in choice.items() if key != "messages"}, "message": message}
+
+    @staticmethod
+    def _handle_multi_completion_response(response_data: Mapping[str, object]) -> Mapping[str, object]:
+        """
+        Mistral's hosted tools on /chat/completions (image_generation, connectors) return
+        ``object: "chat.multi_completion"`` where each choice carries ``messages`` (plural,
+        an array of turns) instead of the OpenAI ``message``. Flatten each such choice into
+        a single assistant message: concatenated text content, generated images mapped into
+        ``message.images``, and only tool calls left unanswered by a tool turn surfaced as
+        ``tool_calls`` (server-executed calls already have their results inlined).
+        """
+        choices = response_data.get("choices")
+        if not isinstance(choices, list) or not any(MistralConfig._is_multi_completion_choice(c) for c in choices):
+            return response_data
+        return {
+            **response_data,
+            "object": "chat.completion",
+            "choices": [
+                MistralConfig._flatten_multi_completion_choice(choice)
+                if MistralConfig._is_multi_completion_choice(choice)
+                else choice
+                for choice in choices
+            ],
+        }
+
+    @staticmethod
     def _handle_empty_content_response(response_data: dict) -> dict:
         """
         Handle Mistral-specific behavior where empty string content should be converted to None.
@@ -583,6 +661,7 @@ class MistralConfig(OpenAIGPTConfig):
         response_data = raw_response.json()
         response_data = self._handle_empty_content_response(response_data)
         response_data = self._handle_content_list_to_str_conversion(response_data)
+        response_data = {**self._handle_multi_completion_response(response_data)}
 
         final_response_obj = cast(
             ModelResponse,

--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -6,7 +6,7 @@ Why separate file? Make it easy to see how transformation works
 Docs - https://docs.mistral.ai/api/
 """
 
-from collections.abc import AsyncIterator, Coroutine, Iterator
+from collections.abc import AsyncIterator, Coroutine, Iterator, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Final, Literal, cast, get_type_hints, overload
 
 import httpx
@@ -448,6 +448,82 @@ class MistralConfig(OpenAIGPTConfig):
         return all_expected_values_are_empty
 
     @staticmethod
+    def _is_multi_completion_choice(choice: object) -> bool:
+        return isinstance(choice, dict) and "messages" in choice and "message" not in choice
+
+    @staticmethod
+    def _multi_completion_content_blocks(turn: Mapping[str, object]) -> Sequence[Mapping[str, object]]:
+        content = turn.get("content")
+        if isinstance(content, str):
+            return ({"type": "text", "text": content},)
+        if isinstance(content, list):
+            return tuple(block for block in content if isinstance(block, dict))
+        return ()
+
+    @staticmethod
+    def _flatten_multi_completion_choice(choice: Mapping[str, object]) -> Mapping[str, object]:
+        raw_turns = choice.get("messages")
+        turns = tuple(turn for turn in raw_turns if isinstance(turn, dict)) if isinstance(raw_turns, list) else ()
+        answered_ids = frozenset(
+            turn.get("tool_call_id") for turn in turns if turn.get("role") == "tool" and turn.get("tool_call_id")
+        )
+        assistant_turns = tuple(turn for turn in turns if turn.get("role") == "assistant")
+        tool_calls = [
+            tool_call
+            for turn in assistant_turns
+            for raw_tool_calls in (turn.get("tool_calls"),)
+            if isinstance(raw_tool_calls, list)
+            for tool_call in raw_tool_calls
+            if isinstance(tool_call, dict) and tool_call.get("id") not in answered_ids
+        ]
+        blocks = tuple(
+            block for turn in assistant_turns for block in MistralConfig._multi_completion_content_blocks(turn)
+        )
+        text_parts = [
+            text
+            for block in blocks
+            if block.get("type") == "text" and isinstance(text := block.get("text"), str) and text
+        ]
+        image_urls = tuple(
+            url for block in blocks if block.get("type") == "image_url" and (url := block.get("image_url"))
+        )
+        images = [
+            {"type": "image_url", "image_url": url if isinstance(url, dict) else {"url": url}, "index": index}
+            for index, url in enumerate(image_urls)
+        ]
+        message = {
+            "role": "assistant",
+            "content": "\n".join(text_parts) if text_parts else None,
+            **({"tool_calls": tool_calls} if tool_calls else {}),
+            **({"images": images} if images else {}),
+        }
+        return {**{key: value for key, value in choice.items() if key != "messages"}, "message": message}
+
+    @staticmethod
+    def _handle_multi_completion_response(response_data: Mapping[str, object]) -> Mapping[str, object]:
+        """
+        Mistral's hosted tools on /chat/completions (image_generation, connectors) return
+        ``object: "chat.multi_completion"`` where each choice carries ``messages`` (plural,
+        an array of turns) instead of the OpenAI ``message``. Flatten each such choice into
+        a single assistant message: concatenated text content, generated images mapped into
+        ``message.images``, and only tool calls left unanswered by a tool turn surfaced as
+        ``tool_calls`` (server-executed calls already have their results inlined).
+        """
+        choices = response_data.get("choices")
+        if not isinstance(choices, list) or not any(MistralConfig._is_multi_completion_choice(c) for c in choices):
+            return response_data
+        return {
+            **response_data,
+            "object": "chat.completion",
+            "choices": [
+                MistralConfig._flatten_multi_completion_choice(choice)
+                if MistralConfig._is_multi_completion_choice(choice)
+                else choice
+                for choice in choices
+            ],
+        }
+
+    @staticmethod
     def _handle_empty_content_response(response_data: dict) -> dict:
         """
         Handle Mistral-specific behavior where empty string content should be converted to None.
@@ -569,6 +645,7 @@ class MistralConfig(OpenAIGPTConfig):
         response_data = raw_response.json()
         response_data = self._handle_empty_content_response(response_data)
         response_data = self._handle_content_list_to_str_conversion(response_data)
+        response_data = {**self._handle_multi_completion_response(response_data)}
 
         final_response_obj: Final = cast(
             ModelResponse,

--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -453,22 +453,24 @@ class MistralConfig(OpenAIGPTConfig):
 
     @staticmethod
     def _multi_completion_content_blocks(turn: Mapping[str, object]) -> Sequence[Mapping[str, object]]:
-        content = turn.get("content")
+        content: Final = turn.get("content")
         if isinstance(content, str):
-            return ({"type": "text", "text": content},)
+            return ({"type": "text", "text": content},)  # mutable-ok: API message payload
         if isinstance(content, list):
             return tuple(block for block in content if isinstance(block, dict))
         return ()
 
     @staticmethod
     def _flatten_multi_completion_choice(choice: Mapping[str, object]) -> Mapping[str, object]:
-        raw_turns = choice.get("messages")
-        turns = tuple(turn for turn in raw_turns if isinstance(turn, dict)) if isinstance(raw_turns, list) else ()
-        answered_ids = frozenset(
+        raw_turns: Final = choice.get("messages")
+        turns: Final = (
+            tuple(turn for turn in raw_turns if isinstance(turn, dict)) if isinstance(raw_turns, list) else ()
+        )
+        answered_ids: Final = frozenset(
             turn.get("tool_call_id") for turn in turns if turn.get("role") == "tool" and turn.get("tool_call_id")
         )
-        assistant_turns = tuple(turn for turn in turns if turn.get("role") == "assistant")
-        tool_calls = [
+        assistant_turns: Final = tuple(turn for turn in turns if turn.get("role") == "assistant")
+        tool_calls: Final = [  # mutable-ok: API message payload
             tool_call
             for turn in assistant_turns
             for raw_tool_calls in (turn.get("tool_calls"),)
@@ -476,28 +478,35 @@ class MistralConfig(OpenAIGPTConfig):
             for tool_call in raw_tool_calls
             if isinstance(tool_call, dict) and tool_call.get("id") not in answered_ids
         ]
-        blocks = tuple(
+        blocks: Final = tuple(
             block for turn in assistant_turns for block in MistralConfig._multi_completion_content_blocks(turn)
         )
-        text_parts = [
+        text_parts: Final = tuple(
             text
             for block in blocks
             if block.get("type") == "text" and isinstance(text := block.get("text"), str) and text
-        ]
-        image_urls = tuple(
+        )
+        image_urls: Final = tuple(
             url for block in blocks if block.get("type") == "image_url" and (url := block.get("image_url"))
         )
-        images = [
-            {"type": "image_url", "image_url": url if isinstance(url, dict) else {"url": url}, "index": index}
+        images: Final = [  # mutable-ok: API message payload
+            {  # mutable-ok: API message payload
+                "type": "image_url",
+                "image_url": url if isinstance(url, dict) else {"url": url},  # mutable-ok: API message payload
+                "index": index,
+            }
             for index, url in enumerate(image_urls)
         ]
-        message = {
+        message: Final = {  # mutable-ok: API message payload
             "role": "assistant",
             "content": "\n".join(text_parts) if text_parts else None,
-            **({"tool_calls": tool_calls} if tool_calls else {}),
-            **({"images": images} if images else {}),
+            **({"tool_calls": tool_calls} if tool_calls else {}),  # mutable-ok: API message payload
+            **({"images": images} if images else {}),  # mutable-ok: API message payload
         }
-        return {**{key: value for key, value in choice.items() if key != "messages"}, "message": message}
+        return {  # mutable-ok: API message payload
+            **{key: value for key, value in choice.items() if key != "messages"},  # mutable-ok: API message payload
+            "message": message,
+        }
 
     @staticmethod
     def _handle_multi_completion_response(response_data: Mapping[str, object]) -> Mapping[str, object]:
@@ -509,13 +518,13 @@ class MistralConfig(OpenAIGPTConfig):
         ``message.images``, and only tool calls left unanswered by a tool turn surfaced as
         ``tool_calls`` (server-executed calls already have their results inlined).
         """
-        choices = response_data.get("choices")
+        choices: Final = response_data.get("choices")
         if not isinstance(choices, list) or not any(MistralConfig._is_multi_completion_choice(c) for c in choices):
             return response_data
-        return {
+        return {  # mutable-ok: API message payload
             **response_data,
             "object": "chat.completion",
-            "choices": [
+            "choices": [  # mutable-ok: API message payload
                 MistralConfig._flatten_multi_completion_choice(choice)
                 if MistralConfig._is_multi_completion_choice(choice)
                 else choice
@@ -645,7 +654,7 @@ class MistralConfig(OpenAIGPTConfig):
         response_data = raw_response.json()
         response_data = self._handle_empty_content_response(response_data)
         response_data = self._handle_content_list_to_str_conversion(response_data)
-        response_data = {**self._handle_multi_completion_response(response_data)}
+        response_data = {**self._handle_multi_completion_response(response_data)}  # mutable-ok: API message payload
 
         final_response_obj: Final = cast(
             ModelResponse,

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -906,7 +906,7 @@ class TestMistralMultiCompletionResponse:
                         "index": 0,
                         "finish_reason": "tool_calls",
                         "messages": [
-                            {"role": "assistant", "content": "", "tool_calls": [answered, unanswered]},
+                            {"role": "assistant", "content": None, "tool_calls": [answered, unanswered]},
                             {"role": "tool", "tool_call_id": "answered-1", "content": '{"url": "https://x"}'},
                         ],
                     }

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -809,3 +809,149 @@ class TestMistralStripsOutputOnlyFields:
             )
 
         assert "reasoning_content" not in result[-1]
+
+
+class TestMistralMultiCompletionResponse:
+    """Regression tests for issue #34228: Mistral hosted tools (image_generation,
+    connectors) return ``object: "chat.multi_completion"`` with plural
+    ``choices[].messages``, which used to crash the converter with KeyError: 'message'."""
+
+    @staticmethod
+    def _payload() -> dict:
+        return {
+            "id": "chatcmpl-multi-123",
+            "object": "chat.multi_completion",
+            "created": 1677652288,
+            "model": "mistral-medium-latest",
+            "usage": {"prompt_tokens": 716, "completion_tokens": 355, "total_tokens": 1071, "request_count": 2},
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "messages": [
+                        {
+                            "role": "assistant",
+                            "index": 0,
+                            "content": "",
+                            "tool_calls": [
+                                {
+                                    "id": "tool-call-1",
+                                    "type": "function",
+                                    "function": {"name": "generate_image", "arguments": '{"prompt": "a sunset"}'},
+                                    "index": 0,
+                                    "metadata": {"tool_type": "image", "integration_id": "img-1"},
+                                }
+                            ],
+                        },
+                        {
+                            "role": "tool",
+                            "index": 1,
+                            "tool_call_id": "tool-call-1",
+                            "content": '{"url": "https://cdn.example/image.jpg"}',
+                            "metadata": {"tool_call_result": {"type": "success"}},
+                        },
+                        {
+                            "role": "assistant",
+                            "index": 2,
+                            "content": [
+                                {"type": "text", "text": "Here is your image:"},
+                                {"type": "image_url", "image_url": "https://cdn.example/image.jpg"},
+                            ],
+                        },
+                    ],
+                }
+            ],
+        }
+
+    def test_completion_parses_hosted_image_generation_response(self, respx_mock, monkeypatch):
+        import litellm
+
+        monkeypatch.setenv("MISTRAL_API_KEY", "fake-mistral-api-key-12345")
+        litellm.disable_aiohttp_transport = True
+        respx_mock.post("https://api.mistral.ai/v1/chat/completions").respond(json=self._payload())
+
+        response = litellm.completion(
+            model="mistral/mistral-medium-latest",
+            messages=[{"role": "user", "content": "Generate an image of a sunset over the ocean."}],
+            tools=[{"type": "image_generation"}],
+        )
+
+        message = response.choices[0].message
+        assert message.content == "Here is your image:"
+        assert message.tool_calls is None
+        assert message.images == [
+            {"type": "image_url", "image_url": {"url": "https://cdn.example/image.jpg"}, "index": 0}
+        ]
+        assert response.choices[0].finish_reason == "stop"
+        assert response.object == "chat.completion"
+        assert response.usage.prompt_tokens == 716
+        assert response.usage.total_tokens == 1071
+
+    def test_flatten_surfaces_only_unanswered_tool_calls(self):
+        answered = {
+            "id": "answered-1",
+            "type": "function",
+            "function": {"name": "generate_image", "arguments": "{}"},
+        }
+        unanswered = {
+            "id": "pending-1",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+        }
+        flattened = MistralConfig._handle_multi_completion_response(
+            {
+                "object": "chat.multi_completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "tool_calls",
+                        "messages": [
+                            {"role": "assistant", "content": "", "tool_calls": [answered, unanswered]},
+                            {"role": "tool", "tool_call_id": "answered-1", "content": '{"url": "https://x"}'},
+                        ],
+                    }
+                ],
+            }
+        )
+        message = flattened["choices"][0]["message"]
+        assert message["tool_calls"] == [unanswered]
+        assert message["content"] is None
+        assert flattened["object"] == "chat.completion"
+        assert "messages" not in flattened["choices"][0]
+
+    def test_flatten_concatenates_assistant_text_across_turns(self):
+        flattened = MistralConfig._handle_multi_completion_response(
+            {
+                "object": "chat.multi_completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "messages": [
+                            {"role": "assistant", "content": "Searching now."},
+                            {"role": "tool", "tool_call_id": "t1", "content": "result"},
+                            {
+                                "role": "assistant",
+                                "content": [
+                                    {"type": "text", "text": "Done."},
+                                    {"type": "image_url", "image_url": {"url": "https://cdn.example/a.png"}},
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            }
+        )
+        message = flattened["choices"][0]["message"]
+        assert message["content"] == "Searching now.\nDone."
+        assert message["images"] == [
+            {"type": "image_url", "image_url": {"url": "https://cdn.example/a.png"}, "index": 0}
+        ]
+
+    def test_standard_chat_completion_response_untouched(self):
+        payload = {
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+        }
+        assert MistralConfig._handle_multi_completion_response(payload) is payload

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -844,3 +844,148 @@ def test_mistral_transform_request_hoists_tool_message_image():
         {"type": "text", "text": TOOL_RESULT_IMAGE_BOUNDARY},
         {"type": "image_url", "image_url": {"url": data_uri}},
     ]
+
+
+class TestMistralMultiCompletionResponse:
+    """Regression tests for issue #34228: Mistral hosted tools (image_generation,
+    connectors) return ``object: "chat.multi_completion"`` with plural
+    ``choices[].messages``, which used to crash the converter with KeyError: 'message'."""
+
+    @staticmethod
+    def _payload() -> dict:
+        return {
+            "id": "chatcmpl-multi-123",
+            "object": "chat.multi_completion",
+            "created": 1677652288,
+            "model": "mistral-medium-latest",
+            "usage": {"prompt_tokens": 716, "completion_tokens": 355, "total_tokens": 1071, "request_count": 2},
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "messages": [
+                        {
+                            "role": "assistant",
+                            "index": 0,
+                            "content": "",
+                            "tool_calls": [
+                                {
+                                    "id": "tool-call-1",
+                                    "type": "function",
+                                    "function": {"name": "generate_image", "arguments": '{"prompt": "a sunset"}'},
+                                    "index": 0,
+                                    "metadata": {"tool_type": "image", "integration_id": "img-1"},
+                                }
+                            ],
+                        },
+                        {
+                            "role": "tool",
+                            "index": 1,
+                            "tool_call_id": "tool-call-1",
+                            "content": '{"url": "https://cdn.example/image.jpg"}',
+                            "metadata": {"tool_call_result": {"type": "success"}},
+                        },
+                        {
+                            "role": "assistant",
+                            "index": 2,
+                            "content": [
+                                {"type": "text", "text": "Here is your image:"},
+                                {"type": "image_url", "image_url": "https://cdn.example/image.jpg"},
+                            ],
+                        },
+                    ],
+                }
+            ],
+        }
+
+    def test_completion_parses_hosted_image_generation_response(self, respx_mock, monkeypatch):
+        import litellm
+
+        monkeypatch.setenv("MISTRAL_API_KEY", "fake-mistral-api-key-12345")
+        respx_mock.post("https://api.mistral.ai/v1/chat/completions").respond(json=self._payload())
+
+        response = litellm.completion(
+            model="mistral/mistral-medium-latest",
+            messages=[{"role": "user", "content": "Generate an image of a sunset over the ocean."}],
+            tools=[{"type": "image_generation"}],
+        )
+
+        message = response.choices[0].message
+        assert message.content == "Here is your image:"
+        assert message.tool_calls is None
+        assert message.images == [
+            {"type": "image_url", "image_url": {"url": "https://cdn.example/image.jpg"}, "index": 0}
+        ]
+        assert response.choices[0].finish_reason == "stop"
+        assert response.object == "chat.completion"
+        assert response.usage.prompt_tokens == 716
+        assert response.usage.total_tokens == 1071
+
+    def test_flatten_surfaces_only_unanswered_tool_calls(self):
+        answered = {
+            "id": "answered-1",
+            "type": "function",
+            "function": {"name": "generate_image", "arguments": "{}"},
+        }
+        unanswered = {
+            "id": "pending-1",
+            "type": "function",
+            "function": {"name": "get_weather", "arguments": '{"city": "Paris"}'},
+        }
+        flattened = MistralConfig._handle_multi_completion_response(
+            {
+                "object": "chat.multi_completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "tool_calls",
+                        "messages": [
+                            {"role": "assistant", "content": "", "tool_calls": [answered, unanswered]},
+                            {"role": "tool", "tool_call_id": "answered-1", "content": '{"url": "https://x"}'},
+                        ],
+                    }
+                ],
+            }
+        )
+        message = flattened["choices"][0]["message"]
+        assert message["tool_calls"] == [unanswered]
+        assert message["content"] is None
+        assert flattened["object"] == "chat.completion"
+        assert "messages" not in flattened["choices"][0]
+
+    def test_flatten_concatenates_assistant_text_across_turns(self):
+        flattened = MistralConfig._handle_multi_completion_response(
+            {
+                "object": "chat.multi_completion",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "messages": [
+                            {"role": "assistant", "content": "Searching now."},
+                            {"role": "tool", "tool_call_id": "t1", "content": "result"},
+                            {
+                                "role": "assistant",
+                                "content": [
+                                    {"type": "text", "text": "Done."},
+                                    {"type": "image_url", "image_url": {"url": "https://cdn.example/a.png"}},
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            }
+        )
+        message = flattened["choices"][0]["message"]
+        assert message["content"] == "Searching now.\nDone."
+        assert message["images"] == [
+            {"type": "image_url", "image_url": {"url": "https://cdn.example/a.png"}, "index": 0}
+        ]
+
+    def test_standard_chat_completion_response_untouched(self):
+        payload = {
+            "id": "chatcmpl-1",
+            "object": "chat.completion",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+        }
+        assert MistralConfig._handle_multi_completion_response(payload) is payload

--- a/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
+++ b/tests/test_litellm/llms/mistral/test_mistral_chat_transformation.py
@@ -940,7 +940,7 @@ class TestMistralMultiCompletionResponse:
                         "index": 0,
                         "finish_reason": "tool_calls",
                         "messages": [
-                            {"role": "assistant", "content": "", "tool_calls": [answered, unanswered]},
+                            {"role": "assistant", "content": None, "tool_calls": [answered, unanswered]},
                             {"role": "tool", "tool_call_id": "answered-1", "content": '{"url": "https://x"}'},
                         ],
                     }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mistral hosted tools (image generation, connectors) crash the gateway with a 500
- Their response is `chat.multi_completion` with plural `messages` per choice
- The shared converter expects OpenAI's singular `message` and fails

How it solves it:

- Flatten each multi-completion choice into one assistant message before conversion
- Text across turns is concatenated, generated images land in `message.images`
- Only tool calls Mistral did not answer itself surface as `tool_calls`
- Standard `chat.completion` responses pass through untouched

## User Flow

Before: a developer asking a Mistral model to generate an image through the gateway gets a 500 instead of the image

1. They send POST https://litellm-domain/v1/chat/completions with `"model": "mistral-medium-latest"`, a prompt asking for an image, and `"tools": [{"type": "image_generation"}]`
2. Mistral generates the image and answers with its `chat.multi_completion` shape
3. They get back HTTP 500 `APIConnectionError: MistralException - Invalid response object` and never see the image (with retries enabled this could resurface as a 429, masking the real cause)

After: the same request comes back as a normal chat completion carrying the image

1. They send the same POST https://litellm-domain/v1/chat/completions with `"tools": [{"type": "image_generation"}]`
2. They get HTTP 200 with `choices[0].message.content` holding the assistant text and `choices[0].message.images[0].image_url.url` pointing at the generated image, `finish_reason` is `stop` and `object` is `chat.completion`
3. `usage` carries Mistral's token counts and its extra `request_count`

## Relevant issues

Fixes #34228

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [x] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs hit the real Mistral API and its hosted Black Forest Labs image tool through a live proxy started with `python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 4000` (the Before run from a worktree at the merge base, the After run from this branch's tip). `qa_config.yaml`:

```yaml
model_list:
  - model_name: mistral-medium-latest
    litellm_params:
      model: mistral/mistral-medium-latest
      api_key: os.environ/MISTRAL_API_KEY

general_settings:
  master_key: sk-1234
```

The request, identical in both runs:

```bash
curl -sS http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"mistral-medium-latest",
       "messages":[{"role":"user","content":"Generate an image of a sunset over the ocean."}],
       "tools":[{"type":"image_generation"}]}'
```

### Before (658f50663d)

1. Run the command above
2. Output: HTTP 500, the converter rejects Mistral's multi-completion shape

```json
{"error":{"message":"litellm.APIConnectionError: APIConnectionError: MistralException - Invalid response object","type":null,"param":null,"code":"500"}}
```

### After (239d3c8c79)

1. Run the same command
2. Output: HTTP 200 with the image in `message.images` (signed URL shortened)

```json
{"id":"chatcmpl-b102b01efbe3450284cc86d777ab9bb2","created":1788441521,"model":"mistral-medium-latest","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Here is your image of a sunset over the ocean:\n\n","role":"assistant","images":[{"image_url":{"url":"https://mistralaiblackforestprod.blob.core.windows.net/images/blackforest/98d8/f959/-443/9-4216-b024-4070b436bc0b/image.jpg?se=..."},"index":0,"type":"image_url"}]},"provider_specific_fields":{}}],"usage":{"completion_tokens":372,"prompt_tokens":697,"total_tokens":1069,"prompt_tokens_details":{"audio_tokens":0,"cached_tokens":0},"request_count":2,"service_tier":"standard"}}
```

## Type

Bug Fix

## Caveats (if any)

### Low

- Text from several assistant turns is joined with a newline, so a client sees one message, not the turn boundaries

## Changes

Mistral's hosted tools on `/chat/completions` (`image_generation`, connectors) do not return the OpenAI choice shape. They return `object: "chat.multi_completion"` where each choice carries `messages` (plural, an array of turns: assistant tool call turn, tool result turn, final assistant turn) instead of `message`. The response converter assumes the singular shape and fails with a 500

The fix is provider-local, in `MistralConfig.transform_response`: a `_handle_multi_completion_response` step flattens each multi-completion choice into a single OpenAI-style assistant message before the shared converter runs. Assistant text content is concatenated across turns (list content parts are flattened), generated images are mapped into `message.images` in the standard `{"type": "image_url", "image_url": {"url": ...}, "index": n}` shape, and `object` is rewritten to `chat.completion`. Tool calls that already have a matching tool result turn in the same response (server-executed hosted tools) are not surfaced, so `finish_reason` stays `stop` and clients don't try to answer a call Mistral already executed; only unanswered tool calls are kept as `message.tool_calls`. Normal `chat.completion` responses pass through untouched, and Mistral's extra `usage.request_count` is preserved via `Usage`'s extra params

The follow-up commit annotates the flatten helpers with `Final`, keeps the internal collections as tuples, and marks the response payload builds the shared converter consumes with the codebase's `API message payload` reason, to satisfy the lint gates the base branch added while the PR was open

Tests: an end-to-end respx regression test replaying the exact payload shape from the issue (fails with the pre-fix crash, passes now), plus unit tests for the answered/unanswered tool call split, cross-turn text concatenation with image extraction, a null-content assistant turn, and the untouched passthrough of standard responses
