### PR TITLE
feat(provider): add Atlas TTS as JSON-configured OpenAI-compatible provider

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -716,6 +716,7 @@ openai_compatible_endpoints: List = [
     "https://nano-gpt.com/api/v1",
     "https://api.poe.com/v1",
     "https://llm.chutes.ai/v1/",
+    "https://api.tts.runatlas.com/v1",
     "https://api.v0.dev/v1",
     "https://api.morphllm.com/v1",
     "https://api.lambda.ai/v1",
@@ -771,6 +772,7 @@ openai_compatible_providers: List = [
     "nano-gpt",  # Nano-GPT - JSON-configured provider
     "poe",  # Poe - JSON-configured provider
     "chutes",  # Chutes - JSON-configured provider
+    "atlas",
     "parasail",  # Parasail - JSON-configured provider
     "libertai",  # LibertAI - JSON-configured provider
     "featherless_ai",

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -325,6 +325,9 @@ def get_llm_provider(
                     elif endpoint == "https://llm.chutes.ai/v1/":
                         custom_llm_provider = "chutes"
                         dynamic_api_key = get_secret_str("CHUTES_API_KEY")
+                    elif endpoint == "https://api.tts.runatlas.com/v1":
+                        custom_llm_provider = "atlas"
+                        dynamic_api_key = get_secret_str("ATLAS_API_KEY")
                     elif endpoint == "https://api.v0.dev/v1":
                         custom_llm_provider = "v0"
                         dynamic_api_key = get_secret_str("V0_API_KEY")

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -183,5 +183,11 @@
       "max_completion_tokens": "max_tokens"
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+  },
+  "atlas": {
+    "base_url": "https://api.tts.runatlas.com/v1",
+    "api_key_env": "ATLAS_API_KEY",
+    "api_base_env": "ATLAS_API_BASE",
+    "supported_endpoints": ["/v1/audio/speech"]
   }
 }

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -7957,6 +7957,15 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "atlas/atlas-tts": {
+        "input_cost_per_character": 0.0,
+        "litellm_provider": "atlas",
+        "mode": "audio_speech",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ],
+        "source": "https://api.tts.runatlas.com"
+    },
     "azure/speech/azure-tts": {
         "input_cost_per_character": 1.5e-05,
         "litellm_provider": "azure",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3589,6 +3589,7 @@ class LlmProviders(str, Enum):
     NANOGPT = "nano-gpt"
     POE = "poe"
     CHUTES = "chutes"
+    ATLAS = "atlas"
     NEOSANTARA = "neosantara"
     PARASAIL = "parasail"
     XIAOMI_MIMO = "xiaomi_mimo"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -7957,6 +7957,15 @@
         "mode": "embedding",
         "output_cost_per_token": 0.0
     },
+    "atlas/atlas-tts": {
+        "input_cost_per_character": 0.0,
+        "litellm_provider": "atlas",
+        "mode": "audio_speech",
+        "supported_endpoints": [
+            "/v1/audio/speech"
+        ],
+        "source": "https://api.tts.runatlas.com"
+    },
     "azure/speech/azure-tts": {
         "input_cost_per_character": 1.5e-05,
         "litellm_provider": "azure",

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -193,6 +193,22 @@
         "a2a": false
       }
     },
+    "atlas": {
+      "display_name": "Atlas TTS (`atlas`)",
+      "endpoints": {
+        "chat_completions": false,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": true,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "aihubmix": {
       "display_name": "AIHubMix (`aihubmix`)",
       "url": "https://docs.litellm.ai/docs/providers/aihubmix",

--- a/tests/test_litellm/llms/openai_like/test_json_providers.py
+++ b/tests/test_litellm/llms/openai_like/test_json_providers.py
@@ -338,6 +338,85 @@ class TestDarkbloom:
             assert model_cost[model]["output_cost_per_token"] == output_cost
 
 
+class TestAtlas:
+    def test_atlas_json_config_exists(self):
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        atlas = JSONProviderRegistry.get("atlas")
+        assert atlas is not None
+        assert atlas.base_url == "https://api.tts.runatlas.com/v1"
+        assert atlas.api_key_env == "ATLAS_API_KEY"
+        assert atlas.api_base_env == "ATLAS_API_BASE"
+        assert "/v1/audio/speech" in atlas.supported_endpoints
+
+    def test_atlas_provider_resolution(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        with patch.dict(os.environ, {"ATLAS_API_KEY": "sk_test_key"}):
+            model, provider, api_key, api_base = get_llm_provider(
+                model="atlas/atlas-tts",
+                custom_llm_provider=None,
+                api_base=None,
+                api_key=None,
+            )
+
+        assert model == "atlas-tts"
+        assert provider == "atlas"
+        assert api_key == "sk_test_key"
+        assert api_base == "https://api.tts.runatlas.com/v1"
+
+    def test_atlas_registered_for_speech_routing(self):
+        from litellm import LlmProviders
+
+        assert "atlas" in litellm.openai_compatible_providers
+        assert LlmProviders("atlas") is LlmProviders.ATLAS
+
+    def test_atlas_speech_dispatch(self):
+        import httpx
+
+        mock_client = MagicMock()
+        mock_client.audio.speech.create.return_value.response = httpx.Response(
+            200,
+            content=b"RIFF-fake-wav-bytes",
+            request=httpx.Request("POST", "https://api.tts.runatlas.com/v1/audio/speech"),
+        )
+
+        with patch.dict(os.environ, {"ATLAS_API_KEY": "sk_test_key"}):
+            response = litellm.speech(
+                model="atlas/atlas-tts",
+                voice="dax",
+                input="Hello from Atlas.",
+                response_format="wav",
+                client=mock_client,
+            )
+
+        call_kwargs = mock_client.audio.speech.create.call_args.kwargs
+        assert call_kwargs["model"] == "atlas-tts"
+        assert call_kwargs["voice"] == "dax"
+        assert call_kwargs["input"] == "Hello from Atlas."
+        assert call_kwargs["response_format"] == "wav"
+        assert response.read() == b"RIFF-fake-wav-bytes"
+
+    def test_atlas_model_cost_map(self):
+        with open(
+            os.path.join(workspace_path, "model_prices_and_context_window.json")
+        ) as f:
+            model_cost = json.load(f)
+
+        assert "atlas/atlas-tts" in model_cost
+        assert model_cost["atlas/atlas-tts"]["litellm_provider"] == "atlas"
+        assert model_cost["atlas/atlas-tts"]["mode"] == "audio_speech"
+        assert model_cost["atlas/atlas-tts"]["supported_endpoints"] == ["/v1/audio/speech"]
+
+    def test_atlas_endpoints_support_documents_speech_only(self):
+        with open(os.path.join(workspace_path, "provider_endpoints_support.json")) as f:
+            support = json.load(f)
+
+        endpoints = support["providers"]["atlas"]["endpoints"]
+        assert endpoints["audio_speech"] is True
+        assert endpoints["chat_completions"] is False
+
+
 class TestPublicAIIntegration:
     """Integration tests for PublicAI provider"""
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Atlas TTS is an OpenAI-compatible speech provider that LiteLLM cannot reach today; callers have to bypass LiteLLM and hit it directly, losing routing, keys and spend tracking

How it solves it:

- registers `atlas` through the JSON provider mechanism in `litellm/llms/openai_like/providers.json`, declaring `/v1/audio/speech` as its only endpoint, so `litellm.speech(model="atlas/atlas-tts", voice="dax", ...)` and the proxy both work with no new Python module

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Local proxy on this branch, config being just the provider under test:

```yaml
model_list:
  - model_name: atlas-tts
    litellm_params:
      model: atlas/atlas-tts
      api_key: os.environ/ATLAS_API_KEY
```

```
$ export ATLAS_API_KEY=sk_live_...          # a real customer key, redacted
$ uv run python litellm/proxy/proxy_cli.py --config atlas.yaml

$ curl -s http://localhost:7519/v1/audio/speech \
    -H "Content-Type: application/json" \
    -d '{"model":"atlas-tts","input":"Hello from LiteLLM.","voice":"dax","response_format":"wav"}' \
    --output atlas.wav -w 'http=%{http_code} bytes=%{size_download} time=%{time_total}s\n'
http=200 bytes=57644 time=2.456718s

$ file atlas.wav
atlas.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 24000 Hz
```

The same model with a Hindi voice, since the upstream serves both English and Hindi:

```
$ curl -s http://localhost:7519/v1/audio/speech \
    -H "Content-Type: application/json" \
    -d '{"model":"atlas-tts","input":"नमस्ते! यह LiteLLM से आ रहा है।","voice":"maitri","response_format":"wav"}' \
    --output atlas_hi.wav -w 'http=%{http_code} bytes=%{size_download} time=%{time_total}s\n'
http=200 bytes=118828 time=1.140870s

$ file atlas_hi.wav
atlas_hi.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 24000 Hz
```

Both calls hit the real provider and returned playable audio; no mocks anywhere in the path

## Type

🆕 New Feature

## Changes

`atlas` is added to `providers.json` with `base_url` `https://api.tts.runatlas.com/v1`, `ATLAS_API_KEY` for auth and `ATLAS_API_BASE` for overrides, declaring `supported_endpoints: ["/v1/audio/speech"]`

Registration follows the pattern the existing JSON providers use: `atlas` in `openai_compatible_providers` and `openai_compatible_endpoints` in `constants.py`, which is the gate `litellm.speech()` checks before routing through the OpenAI SDK path; `LlmProviders.ATLAS` in `types/utils.py`; and the endpoint to provider mapping in `get_llm_provider_logic.py`

The provider serves speech only, so it is deliberately left out of `LITELLM_CHAT_PROVIDERS` and the text-completion list, and `provider_endpoints_support.json` documents it as `audio_speech` with everything else false

`atlas/atlas-tts` is added to both cost map files with `mode: audio_speech`. Cost is zero per character while the service is in private beta; the model segment after the prefix is passed through and ignored by the upstream, since the `voice` parameter is what selects the voice

Tests live in the existing `tests/test_litellm/llms/openai_like/test_json_providers.py` alongside the other JSON providers, as a `TestAtlas` class covering registry loading, provider resolution with the key read from the environment, the speech routing gate, a full `litellm.speech()` dispatch with an injected mock client asserting the prefix-stripped model and the voice, input and response_format that reach the SDK call, and consistency of the cost map and endpoint support entries

## QA runbook

1. `export ATLAS_API_KEY=<a customer key from the Atlas playground>`
2. write the config above to `atlas.yaml`
3. `uv run python litellm/proxy/proxy_cli.py --config atlas.yaml`
4. run either curl from the proof section; expect `http=200` and a RIFF WAVE file
5. without the key, expect the upstream's own 401 rather than a LiteLLM error, confirming the request is being proxied rather than short-circuited

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
