### PR TITLE
feat(router): log the selection probability for adaptive routing decisions

### DIFF
--- a/litellm/router_strategy/adaptive_router/adaptive_router.py
+++ b/litellm/router_strategy/adaptive_router/adaptive_router.py
@@ -17,14 +17,18 @@ import asyncio
 import time
 from collections import OrderedDict
 from dataclasses import asdict, dataclass
-from typing import Any, Union, cast
+from typing import Any, Optional, Union, cast
 
 from litellm._logging import verbose_router_logger
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     get_last_user_message,
 )
-from litellm.types.utils import StandardLoggingRoutingDecision
+from litellm.types.utils import (
+    StandardLoggingRoutingDecision,
+    StandardLoggingRoutingExploration,
+)
 from litellm.router_strategy.adaptive_router.bandit import (
+    estimate_propensity,
     BanditCell,
     apply_delta,
     initial_cell,
@@ -178,7 +182,9 @@ class AdaptiveRouter:
 
         request_type = classify_prompt(user_text)
         min_quality_tier = self._extract_min_quality_tier(request_kwargs)
-        chosen_model = await self.pick_model(request_type=request_type, min_quality_tier=min_quality_tier)
+        chosen_model, propensity, candidate_set = await self.pick_model_with_propensity(
+            request_type=request_type, min_quality_tier=min_quality_tier
+        )
         verbose_router_logger.debug(
             "AdaptiveRouter[%s]: classified=%s -> chose %s",
             self.router_name,
@@ -197,14 +203,38 @@ class AdaptiveRouter:
         return PreRoutingHookResponse(
             model=chosen_model,
             messages=messages,
-            routing_decision=StandardLoggingRoutingDecision(
-                router_model_name=self.router_name,
-                router_type="adaptive",
-                routed_model=chosen_model,
-                cause="bandit",
-                request_type=request_type.value,
+            routing_decision=self._routing_decision(
+                chosen_model=chosen_model,
+                request_type=request_type,
+                propensity=propensity,
+                candidate_set=candidate_set,
             ),
         )
+
+    def _routing_decision(
+        self,
+        *,
+        chosen_model: str,
+        request_type: RequestType,
+        propensity: Optional[float],
+        candidate_set: tuple[str, ...],
+    ) -> StandardLoggingRoutingDecision:
+        """Build the spend-log record for one bandit decision."""
+        decision = StandardLoggingRoutingDecision(
+            router_model_name=self.router_name,
+            router_type="adaptive",
+            routed_model=chosen_model,
+            cause="bandit",
+            request_type=request_type.value,
+            candidate_set=candidate_set,
+        )
+        if propensity is not None:
+            decision["propensity"] = propensity
+            decision["exploration"] = StandardLoggingRoutingExploration(
+                strategy="thompson",
+                n_samples=self.config.propensity_samples,
+            )
+        return decision
 
     # ---- Pick model ------------------------------------------------------
 
@@ -226,6 +256,33 @@ class AdaptiveRouter:
             quality_weight=self.config.weights.quality,
             cost_weight=self.config.weights.cost,
         )
+
+    async def pick_model_with_propensity(
+        self,
+        request_type: RequestType,
+        min_quality_tier: int | None = None,
+    ) -> tuple[str, Optional[float], tuple[str, ...]]:
+        """Pick a model and report how likely that pick was.
+
+        Returns (model, propensity, candidate_set). Selection still goes through
+        `pick_model`, unchanged; this only measures the choice it made. The
+        propensity is None unless `propensity_samples` is configured, while the
+        candidate set is always returned -- a logged decision is only
+        interpretable against the options that were actually available.
+        """
+        chosen = await self.pick_model(request_type=request_type, min_quality_tier=min_quality_tier)
+        eligible = self._eligible_models(min_quality_tier)
+        if not eligible:
+            return chosen, None, ()
+        propensity = estimate_propensity(
+            {m: self._cells[(request_type, m)] for m in eligible},
+            {m: self.model_to_cost.get(m, 0.0) for m in eligible},
+            chosen,
+            quality_weight=self.config.weights.quality,
+            cost_weight=self.config.weights.cost,
+            propensity_samples=self.config.propensity_samples,
+        )
+        return chosen, propensity, tuple(eligible)
 
     async def get_state_snapshot(self) -> dict[str, Any]:
         """In-memory snapshot for the introspection endpoint. Cheap; no DB hit."""

--- a/litellm/router_strategy/adaptive_router/bandit.py
+++ b/litellm/router_strategy/adaptive_router/bandit.py
@@ -12,7 +12,7 @@ Hot path: thompson_sample() — pure function, no I/O.
 
 import random
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from litellm.router_strategy.adaptive_router.config import (
     BASE_TIER_WEIGHT,
@@ -109,6 +109,27 @@ def score(
     return quality_weight * quality_sample + cost_weight * cost_score
 
 
+def _draw_once(
+    cells: Dict[str, BanditCell],
+    model_costs: Dict[str, float],
+    all_costs: List[float],
+    quality_weight: float,
+    cost_weight: float,
+    rng: Optional[random.Random],
+) -> str:
+    """One joint Thompson draw: sample every arm, score, return the argmax."""
+    best_model: Optional[str] = None
+    best_score = float("-inf")
+    for model, cell in cells.items():
+        q = thompson_sample(cell, rng=rng)
+        s = score(q, model_costs[model], all_costs, quality_weight, cost_weight)
+        if s > best_score:
+            best_score = s
+            best_model = model
+    assert best_model is not None
+    return best_model
+
+
 def pick_best(
     cells: Dict[str, BanditCell],
     model_costs: Dict[str, float],
@@ -125,13 +146,55 @@ def pick_best(
     if not cells:
         raise ValueError("pick_best called with no models")
     all_costs = list(model_costs.values())
-    best_model: Optional[str] = None
-    best_score = float("-inf")
-    for model, cell in cells.items():
-        q = thompson_sample(cell, rng=rng)
-        s = score(q, model_costs[model], all_costs, quality_weight, cost_weight)
-        if s > best_score:
-            best_score = s
-            best_model = model
-    assert best_model is not None
-    return best_model
+    return _draw_once(cells, model_costs, all_costs, quality_weight, cost_weight, rng)
+
+
+def estimate_propensity(
+    cells: Dict[str, BanditCell],
+    model_costs: Dict[str, float],
+    chosen: str,
+    quality_weight: float = DEFAULT_QUALITY_WEIGHT,
+    cost_weight: float = DEFAULT_COST_WEIGHT,
+    rng: Optional[random.Random] = None,
+    propensity_samples: int = 0,
+) -> Optional[float]:
+    """
+    Estimate P(`chosen` is picked) in the current posterior state.
+
+    Returns None when propensity_samples == 0, which is the default and costs
+    nothing.
+
+    Why estimate rather than compute: a model wins when its scored Beta draw
+    beats every other model's. For more than two models that has no closed
+    form, so P(chosen) has to be measured while the posteriors are in hand or
+    it cannot be recovered at all. A randomized routing decision logged without
+    it is data no off-policy estimator can use.
+
+    The already-made choice counts as one observation, which guarantees the
+    result is >= 1/(propensity_samples + 1). A zero would be self-contradictory
+    -- the model demonstrably was picked -- and would become an infinite
+    importance weight downstream. The cost is an upward bias of order
+    1/propensity_samples, far below the Monte Carlo noise it displaces.
+
+    Hot path: propensity_samples * len(cells) betavariate draws, all of it
+    skipped at the default.
+    """
+    if propensity_samples < 0:
+        raise ValueError(f"propensity_samples must be >= 0, got {propensity_samples}")
+    # Checked before anything else: at the default this function does no work
+    # and must not be able to fail, whatever state the caller is in.
+    if propensity_samples == 0:
+        return None
+    if not cells:
+        raise ValueError("estimate_propensity called with no models")
+    if len(cells) == 1:
+        # Nothing was chosen between, so the probability is exactly 1 and
+        # sampling would only add error.
+        return 1.0
+
+    all_costs = list(model_costs.values())
+    wins = 1  # the decision that was actually made
+    for _ in range(propensity_samples):
+        if _draw_once(cells, model_costs, all_costs, quality_weight, cost_weight, rng) == chosen:
+            wins += 1
+    return wins / (propensity_samples + 1)

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -925,6 +925,10 @@ class AdaptiveRouterWeights(BaseModel):
 class AdaptiveRouterConfig(BaseModel):
     available_models: List[str]
     weights: AdaptiveRouterWeights = Field(default_factory=AdaptiveRouterWeights)
+    # Monte Carlo replicates used to estimate P(chosen | posteriors) for the
+    # spend log. 0 disables the estimate and costs nothing, which is the
+    # default so no existing deployment pays for a field it does not read.
+    propensity_samples: int = Field(default=0, ge=0, le=4096)
 
 
 class AdaptiveRouterPreferences(BaseModel):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -2703,6 +2703,19 @@ RoutingDecisionCause = Literal[
 ]
 
 
+class StandardLoggingRoutingExploration(TypedDict, total=False):
+    """How a randomized router drew this request, when it randomized at all.
+
+    ``strategy`` is "none" for deterministic routers, whose propensity is 1.0.
+    ``n_samples`` is present only for estimated propensities and reports their
+    precision, so a consumer can tell an exact probability from a Monte Carlo
+    one.
+    """
+
+    strategy: Literal["none", "thompson", "epsilon_greedy"]
+    n_samples: int
+
+
 class StandardLoggingRoutingDecision(TypedDict, total=False):
     """Per-request provenance for a pre-routing strategy (auto-router) decision."""
 
@@ -2719,6 +2732,9 @@ class StandardLoggingRoutingDecision(TypedDict, total=False):
     classifier_model: str
     escalated: bool
     tier_boundaries: StandardLoggingRoutingDecisionTierBoundaries
+    candidate_set: tuple[str, ...]
+    propensity: float
+    exploration: StandardLoggingRoutingExploration
 
 
 # Fields whose values quote the caller's prompt. Dropped when an operator turns message
@@ -2738,6 +2754,9 @@ DERIVED_ROUTING_DECISION_FIELDS: FrozenSet[str] = frozenset(
         "classifier_model",
         "escalated",
         "tier_boundaries",
+        "candidate_set",
+        "propensity",
+        "exploration",
     }
 )
 

--- a/tests/test_litellm/router_strategy/adaptive_router/test_propensity.py
+++ b/tests/test_litellm/router_strategy/adaptive_router/test_propensity.py
@@ -1,0 +1,182 @@
+"""Tests for the selection probability the adaptive router records.
+
+A propensity is a claim: "this model gets chosen this often, in this state." The
+tests that matter here check the claim against what the sampler actually does,
+because a propensity that does not predict selection frequency is worse than no
+propensity at all -- it makes a log look analyzable when it is not.
+"""
+
+import random
+
+import pytest
+
+from litellm.router_strategy.adaptive_router.bandit import (
+    BanditCell,
+    estimate_propensity,
+    pick_best,
+)
+
+CELLS = {
+    "cheap": BanditCell(alpha=5.0, beta=5.0),
+    "mid": BanditCell(alpha=6.0, beta=4.0),
+    "premium": BanditCell(alpha=7.0, beta=3.0),
+}
+COSTS = {"cheap": 0.0005, "mid": 0.003, "premium": 0.02}
+
+
+def _empirical(n: int, seed: int = 0) -> dict:
+    """Selection frequency over n independent picks."""
+    rng = random.Random(seed)
+    counts = {model: 0 for model in CELLS}
+    for _ in range(n):
+        counts[pick_best(CELLS, COSTS, rng=rng)] += 1
+    return {model: count / n for model, count in counts.items()}
+
+
+def _estimated(n_samples: int, draws: int, seed: int = 1) -> dict:
+    """Average logged propensity per model over many decisions."""
+    rng = random.Random(seed)
+    totals = {model: 0.0 for model in CELLS}
+    counts = {model: 0 for model in CELLS}
+    for _ in range(draws):
+        model = pick_best(CELLS, COSTS, rng=rng)
+        propensity = estimate_propensity(
+            CELLS, COSTS, model, rng=rng, propensity_samples=n_samples
+        )
+        totals[model] += propensity
+        counts[model] += 1
+    return {
+        model: (totals[model] / counts[model] if counts[model] else 0.0) for model in CELLS
+    }
+
+
+class TestPropensityIsHonest:
+    """The logged number has to describe the sampler that produced it."""
+
+    def test_matches_empirical_selection_frequency(self):
+        # The whole claim, checked directly. Off-policy evaluation divides by
+        # this number, so a systematic error here biases every downstream
+        # estimate without any symptom.
+        empirical = _empirical(20_000)
+        estimated = _estimated(n_samples=256, draws=4_000)
+        for model in CELLS:
+            assert estimated[model] == pytest.approx(empirical[model], abs=0.05), (
+                f"{model}: logged propensity {estimated[model]:.3f} does not match "
+                f"realized selection frequency {empirical[model]:.3f}"
+            )
+
+    def test_propensities_across_models_sum_to_one(self):
+        # Each model's propensity is P(it wins); over all models that is a
+        # distribution.
+        rng = random.Random(7)
+        seen = {}
+        for _ in range(3_000):
+            model = pick_best(CELLS, COSTS, rng=rng)
+            propensity = estimate_propensity(
+                CELLS, COSTS, model, rng=rng, propensity_samples=256
+            )
+            seen.setdefault(model, []).append(propensity)
+        total = sum(sum(v) / len(v) for v in seen.values())
+        assert total == pytest.approx(1.0, abs=0.1)
+
+    def test_never_returns_zero(self):
+        # The model demonstrably was chosen, so a zero would be
+        # self-contradictory -- and an infinite importance weight downstream.
+        skewed = {"a": BanditCell(1.0, 40.0), "b": BanditCell(40.0, 1.0)}
+        costs = {"a": 0.001, "b": 0.001}
+        rng = random.Random(3)
+        for _ in range(500):
+            model = pick_best(skewed, costs, rng=rng)
+            propensity = estimate_propensity(
+                skewed, costs, model, rng=rng, propensity_samples=8
+            )
+            assert propensity >= 1.0 / 9
+
+
+class TestNoRegression:
+    """Existing behaviour is untouched unless a deployment opts in."""
+
+    def test_default_costs_nothing_and_returns_nothing(self):
+        # Selection is untouched and no extra draws happen at the default.
+        assert estimate_propensity(CELLS, COSTS, "mid") is None
+
+    def test_pick_best_signature_is_unchanged(self):
+        # Existing callers and their mocks must keep working.
+        assert pick_best(CELLS, COSTS, rng=random.Random(0)) in CELLS
+
+    def test_seeded_runs_are_reproducible(self):
+        first = estimate_propensity(
+            CELLS, COSTS, "mid", rng=random.Random(5), propensity_samples=32
+        )
+        second = estimate_propensity(
+            CELLS, COSTS, "mid", rng=random.Random(5), propensity_samples=32
+        )
+        assert first == second
+
+    def test_single_model_is_certain_without_sampling(self):
+        assert (
+            estimate_propensity(
+                {"only": BanditCell(1.0, 1.0)}, {"only": 0.01}, "only", propensity_samples=64
+            )
+            == 1.0
+        )
+
+    def test_rejects_empty_and_negative_inputs(self):
+        with pytest.raises(ValueError):
+            estimate_propensity({}, {}, "a", propensity_samples=8)
+        with pytest.raises(ValueError):
+            estimate_propensity(CELLS, COSTS, "mid", propensity_samples=-1)
+
+
+class TestRoutingDecision:
+    """What lands in the spend log."""
+
+    def _router(self, propensity_samples: int):
+        from litellm.router_strategy.adaptive_router.adaptive_router import AdaptiveRouter
+        from litellm.types.router import (
+            AdaptiveRouterConfig,
+            AdaptiveRouterPreferences,
+            RequestType,
+        )
+
+        tiers = {"cheap": 1, "mid": 2, "premium": 3}
+        return AdaptiveRouter(
+            router_name="adaptive-test",
+            config=AdaptiveRouterConfig(
+                available_models=list(CELLS),
+                propensity_samples=propensity_samples,
+            ),
+            model_to_prefs={
+                model: AdaptiveRouterPreferences(
+                    quality_tier=tier, strengths=[RequestType.GENERAL]
+                )
+                for model, tier in tiers.items()
+            },
+            model_to_cost=dict(COSTS),
+        )
+
+    @pytest.mark.asyncio
+    async def test_records_candidate_set_even_when_not_sampling(self):
+        from litellm.types.router import RequestType
+
+        router = self._router(propensity_samples=0)
+        model, propensity, candidates = await router.pick_model_with_propensity(
+            RequestType.GENERAL
+        )
+        assert model in candidates
+        # The candidate set is free and always logged: a decision is only
+        # interpretable against the options that existed.
+        assert set(candidates) == set(CELLS)
+        assert propensity is None
+
+    @pytest.mark.asyncio
+    async def test_records_propensity_when_enabled(self):
+        from litellm.types.router import RequestType
+
+        router = self._router(propensity_samples=64)
+        model, propensity, candidates = await router.pick_model_with_propensity(
+            RequestType.GENERAL
+        )
+        assert model in candidates
+        assert propensity is not None
+        assert 0.0 < propensity <= 1.0


### PR DESCRIPTION
`StandardLoggingRoutingDecision` records which model the adaptive router picked and the score behind it, but not the probability it was picked with, and that probability cannot be recovered once the request is logged. This adds it.

A model wins when its scored Beta draw beats every other model's. For more than two models that comparison has no closed form, so `P(chosen)` has to be measured while the posteriors are in hand or not at all. The adaptive router is already a randomized policy, so it is already perturbing production traffic. Without the selection probability, none of that randomization buys any inference. With it, the same spend logs answer what a different routing table would have cost and scored, estimated from traffic that already happened.

## Fields

```python
candidate_set: tuple[str, ...]                  # models the sampler could have chosen
propensity: float                               # P(routed_model | posteriors) at decision time
exploration: StandardLoggingRoutingExploration  # {"strategy": ..., "n_samples": ...}
```

`exploration` matters as much as `propensity`. It lets a consumer tell an exact probability from a Monte Carlo one. It also reserves `strategy="none"` for the deterministic routers, whose propensity is exactly 1.0; this PR wires up the adaptive router only, since it is the one that randomizes.

## Behavior

`bandit.estimate_propensity()` measures a choice that has already been made, so `pick_best` keeps its signature and `pick_model` still does exactly one draw. Selection is untouched.

The estimate is off by default, at `AdaptiveRouterConfig.propensity_samples = 0`. The zero-sample path returns before every other check in the function, so at the default it cannot raise whatever state the caller is in.

The already-made decision counts as one observation, which puts a floor of `1/(n+1)` under the result. A zero would be self-contradictory, since the model demonstrably was picked, and downstream it becomes an infinite importance weight. The price is an upward bias of order `1/n`, well under the Monte Carlo noise it displaces.

`candidate_set` is recorded unconditionally. It costs nothing, and a propensity is not interpretable without the set it was drawn from.

Both fields land in `DERIVED_ROUTING_DECISION_FIELDS`, so a row keeps them when an operator turns message logging off. They aggregate the prompt without reproducing any of it.

## Cost

Median per decision, four models, Apple M-series:

| `propensity_samples` | per decision | added |
| --- | --- | --- |
| 0 (default) | 3.2 us | 0.0 us |
| 32 | 102.7 us | 99.4 us |
| 128 | 404.1 us | 400.9 us |

## Tests

Ten new tests in `tests/test_litellm/router_strategy/adaptive_router/test_propensity.py`. The load-bearing one checks that the estimate tracks the empirical selection frequency of the sampler it claims to describe, because a propensity that does not is worse than logging nothing. The rest cover the sum-to-one property across models, the never-zero floor, the free default path, `pick_best` reproducibility under a seed, the single-model short circuit, and that both fields reach the routing decision.

## Base

Stacked on #35016, whose `StandardLoggingRoutingDecision` these fields extend. Rebased onto its current head. If the schema is going to carry routing provenance, the selection probability is the one field that cannot be added later from stored data, which is why this is worth deciding before that PR merges rather than after.
