### PR TITLE
fix(terraform/team): add missing Importer to litellm_team resource

### DIFF
--- a/terraform/provider/litellm/resource_team.go
+++ b/terraform/provider/litellm/resource_team.go
@@ -26,6 +26,9 @@ func ResourceLiteLLMTeam() *schema.Resource {
 		Read:   resourceLiteLLMTeamRead,
 		Update: resourceLiteLLMTeamUpdate,
 		Delete: resourceLiteLLMTeamDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"team_alias": {

--- a/terraform/provider/litellm/resource_team_test.go
+++ b/terraform/provider/litellm/resource_team_test.go
@@ -1,6 +1,8 @@
 package litellm
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -10,9 +12,9 @@ import (
 // every import failed with "resource litellm_team doesn't support import".
 //
 // Teams are routinely created out-of-band (UI, /team/new scripts) and carry
-// spend history, budgets, and key associations, so import is the only safe way
-// to adopt one into Terraform - without it the sole alternative is letting
-// apply POST /team/new a duplicate.
+// spend history, budgets, and key associations, so import is the only way to
+// adopt one into Terraform - without it the sole alternative is letting apply
+// POST /team/new a duplicate.
 func TestResourceLiteLLMTeam_hasImporter(t *testing.T) {
 	r := ResourceLiteLLMTeam()
 
@@ -25,14 +27,67 @@ func TestResourceLiteLLMTeam_hasImporter(t *testing.T) {
 	}
 }
 
-// TestResourceLiteLLMTeam_importPopulatesFromID documents why passthrough
-// import is sufficient here: resourceLiteLLMTeamRead reconstructs every
-// schema field from the ID alone via GET /team/info, so no custom import
-// logic is required to produce complete state.
-func TestResourceLiteLLMTeam_importPopulatesFromID(t *testing.T) {
-	r := ResourceLiteLLMTeam()
+// TestResourceLiteLLMTeam_importReadsByTeamID asserts the behavior passthrough
+// import depends on: that Read, given only the ID the importer passes through,
+// looks the team up by that ID against /team/info and keeps it as the resource
+// ID. This is what makes import adopt the real team rather than creating a
+// duplicate.
+//
+// It deliberately does not assert on hydrated fields such as team_alias or
+// max_budget. /team/info nests those under a "team_info" key while
+// TeamResponse declares them at the top level, so they currently decode to
+// zero values - a pre-existing bug called out in the PR description and left
+// to a separate change.
+func TestResourceLiteLLMTeam_importReadsByTeamID(t *testing.T) {
+	const teamID = "d93eb581-d215-4332-aea9-fab87caf21de"
 
-	if r.Read == nil {
-		t.Fatal("litellm_team must set Read: passthrough import relies on it to populate state")
+	// Read also calls /team/permissions_list, so key the lookups by path
+	// rather than recording whichever request happened to arrive last.
+	queriedTeamID := map[string]string{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queriedTeamID[r.URL.Path] = r.URL.Query().Get("team_id")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"team_id":"` + teamID + `","team_info":{},"keys":[],"team_memberships":[]}`))
+	}))
+	defer srv.Close()
+
+	d := ResourceLiteLLMTeam().TestResourceData()
+	d.SetId(teamID)
+
+	if err := resourceLiteLLMTeamRead(d, NewClient(srv.URL, "test-key", true)); err != nil {
+		t.Fatalf("read after import: %v", err)
+	}
+
+	got, called := queriedTeamID[endpointTeamInfo]
+	if !called {
+		t.Fatalf("read did not call %s; called %v", endpointTeamInfo, queriedTeamID)
+	}
+	if got != teamID {
+		t.Errorf("looked up team_id %q, want %q", got, teamID)
+	}
+	if d.Id() != teamID {
+		t.Errorf("resource ID is %q after read, want %q - import must adopt the existing team", d.Id(), teamID)
+	}
+}
+
+// TestResourceLiteLLMTeam_importDropsMissingTeam covers the other half of the
+// contract: importing an ID that no longer exists must clear the ID rather
+// than leave a phantom resource in state.
+func TestResourceLiteLLMTeam_importDropsMissingTeam(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	d := ResourceLiteLLMTeam().TestResourceData()
+	d.SetId("does-not-exist")
+
+	if err := resourceLiteLLMTeamRead(d, NewClient(srv.URL, "test-key", true)); err != nil {
+		t.Fatalf("read of missing team should not error, got: %v", err)
+	}
+
+	if d.Id() != "" {
+		t.Errorf("resource ID is %q, want empty - a missing team must be dropped from state", d.Id())
 	}
 }

--- a/terraform/provider/litellm/resource_team_test.go
+++ b/terraform/provider/litellm/resource_team_test.go
@@ -1,0 +1,38 @@
+package litellm
+
+import (
+	"testing"
+)
+
+// TestResourceLiteLLMTeam_hasImporter guards the regression fixed alongside
+// this test: docs/resources/team.md documents `terraform import
+// litellm_team.<name> <team-id>`, but the resource did not set Importer, so
+// every import failed with "resource litellm_team doesn't support import".
+//
+// Teams are routinely created out-of-band (UI, /team/new scripts) and carry
+// spend history, budgets, and key associations, so import is the only safe way
+// to adopt one into Terraform - without it the sole alternative is letting
+// apply POST /team/new a duplicate.
+func TestResourceLiteLLMTeam_hasImporter(t *testing.T) {
+	r := ResourceLiteLLMTeam()
+
+	if r.Importer == nil {
+		t.Fatal("litellm_team must set Importer: import is documented in docs/resources/team.md")
+	}
+
+	if r.Importer.StateContext == nil {
+		t.Error("litellm_team Importer must set StateContext")
+	}
+}
+
+// TestResourceLiteLLMTeam_importPopulatesFromID documents why passthrough
+// import is sufficient here: resourceLiteLLMTeamRead reconstructs every
+// schema field from the ID alone via GET /team/info, so no custom import
+// logic is required to produce complete state.
+func TestResourceLiteLLMTeam_importPopulatesFromID(t *testing.T) {
+	r := ResourceLiteLLMTeam()
+
+	if r.Read == nil {
+		t.Fatal("litellm_team must set Read: passthrough import relies on it to populate state")
+	}
+}


### PR DESCRIPTION
## What

`docs/resources/team.md` documents team import:

```shell
terraform import litellm_team.engineering <team-id>
```

But `ResourceLiteLLMTeam()` never set `Importer` on its `schema.Resource`, and SDKv2 only wires up `ImportResourceState` when that field is present. Every documented import therefore fails:

```
Error: resource litellm_team doesn't support import
```

This adds the missing `Importer`, matching the passthrough pattern already used by `litellm_credential` and `litellm_key`.

## Why this matters

Teams are almost always created out-of-band before anyone adopts them into Terraform — via the UI, `/team/new` scripts, or a pre-Terraform workflow — and they accumulate spend history, budgets, and key associations that live only in the proxy's DB.

Without import there is no adoption path at all. The only alternative is to let `apply` `POST /team/new`, which creates a **duplicate** team with a fresh `team_id` while the real team keeps the spend history and the existing keys keep pointing at the old ID.

## The fix

```go
Importer: &schema.ResourceImporter{
    StateContext: schema.ImportStatePassthroughContext,
},
```

## Known limitation (pre-existing, not introduced here)

I want to be upfront that this makes import *possible*, not yet *complete*.

`resourceLiteLLMTeamRead` decodes `/team/info` straight into `TeamResponse`, which declares `team_alias`, `models`, `max_budget` etc. as top-level fields. But the endpoint nests them:

```python
class TeamInfoResponseObject(TypedDict):
    team_id: str
    team_info: TeamInfoResponseObjectTeamTable   # ← the team fields live here
    keys: List
    team_memberships: List[LiteLLM_TeamMembership]
```

So the decode silently succeeds and populates only `team_id`; every other field comes back as its zero value. (`TeamListResponseObject` is flat, so `/team/list` is unaffected — this is specific to `/team/info`.)

Practical effect on import: the resource is correctly adopted under its real `team_id`, which is the important part — no duplicate is created. But the imported state is empty, so the first `apply` writes the config values over whatever is in the proxy rather than showing a true diff. `team_member_permissions` is the exception; it's fetched separately via `/team/permissions_list` and populates correctly.

This affects ordinary refresh too, not just import, so it seemed like a separate concern rather than something to fold in here — especially since fixing it would surface real drift for existing users and deserves its own discussion. Happy to send it as a follow-up PR, or to roll it into this one if you'd rather they land together. Same for `litellm_organization`, which is missing `Importer` in the same way.

One caveat worth documenting for importers, which I hit in practice: because permissions *do* read correctly but the other fields don't, importing a team whose config omits `team_member_permissions` produces a diff that removes them, and `resourceLiteLLMTeamUpdate` posts that to `/team/permissions_update`. Anyone importing an existing team needs to mirror its current permissions in config first.

## Testing

`terraform/provider/litellm/resource_team_test.go` (new) asserts the resource declares an `Importer` with a `StateContext`, so this can't silently regress. I verified it genuinely catches the bug: reverting the one-line fix makes it fail with `litellm_team must set Importer`, restoring it passes.

It's a unit test rather than an acceptance test because the existing team/org acceptance tests go through `testAccPreCheck`, which requires a live proxy (`LITELLM_API_BASE` / `LITELLM_API_KEY`) and so can't guard this in CI.

Local checks against `terraform/provider/`:

- `go test ./...` — passes (incl. `tools/endpointaudit`)
- `go vet ./...` — clean
- `gofmt -l ./litellm/` — clean

## Verification against a real proxy

I built this branch and ran it against a production LiteLLM proxy with 16 pre-existing teams, using `dev_overrides` to substitute the patched provider.

Before the fix, all 16 imports failed immediately with `resource litellm_team doesn't support import`. After it, every team imported and resolved to `will be updated in-place` — **no `create` and no `destroy` on any team**, i.e. the real teams were adopted by `team_id` with their spend history and attached keys intact:

```
Plan: 16 to import, 2 to add, 18 to change, 1 to destroy.
```

(The non-team entries are unrelated pre-existing drift in that stack.)

## Notes

- Opened here rather than against `BerriAI/terraform-provider-litellm`, per that repo's README and this directory's README identifying `terraform/provider/` as the source of truth.
- CLA: signing at https://cla-assistant.io/BerriAI/litellm.
