### PR TITLE
fix(proxy): resolve team model_aliases on Files/Batches model-pinned routing

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -189,6 +189,7 @@ async def create_batch(
                 llm_router=llm_router,
                 model_id=model_from_file_id,
                 operation_context="batch creation (file created with model)",
+                team_id=user_api_key_dict.team_id,
             )
 
             original_file_id = get_original_file_id(input_file_id)
@@ -278,6 +279,7 @@ async def create_batch(
                     llm_router=llm_router,
                     model_id=model_param,
                     operation_context="batch creation",
+                    team_id=user_api_key_dict.team_id,
                 )
 
                 prepare_data_with_credentials(
@@ -483,6 +485,7 @@ async def retrieve_batch(
                 llm_router=llm_router,
                 model_id=model_from_id,
                 operation_context="batch retrieval (batch created with model)",
+                team_id=user_api_key_dict.team_id,
             )
 
             original_batch_id = get_original_file_id(batch_id)
@@ -689,6 +692,7 @@ async def list_batches(
                 llm_router=llm_router,
                 model_id=model_param,
                 operation_context="batch listing",
+                team_id=user_api_key_dict.team_id,
             )
 
             data.update(credentials)
@@ -870,6 +874,7 @@ async def cancel_batch(
                 llm_router=llm_router,
                 model_id=model_from_id,
                 operation_context="batch cancellation (batch created with model)",
+                team_id=user_api_key_dict.team_id,
             )
 
             original_batch_id = get_original_file_id(batch_id)

--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -174,7 +174,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
 
         return None
 
-    def _resolve_batch_provider(self, batch_model: Optional[str]) -> Optional[str]:
+    def _resolve_batch_provider(self, batch_model: Optional[str], team_id: Optional[str] = None) -> Optional[str]:
         """Resolve the provider from the deployment that serves ``batch_model``.
 
         The provider is read from trusted router credentials rather than the
@@ -197,6 +197,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 llm_router=llm_router,
                 model_id=batch_model,
                 operation_context="batch input file read (rate limiting)",
+                team_id=team_id,
             )
         except HTTPException:
             return None
@@ -259,7 +260,9 @@ class _PROXY_BatchRateLimiter(CustomLogger):
 
         skip_providers = general_settings.get("skip_batch_input_file_rate_limiting_for_providers") or []
         if skip_providers:
-            batch_provider = self._resolve_batch_provider(self._get_batch_routing_model(data))
+            batch_provider = self._resolve_batch_provider(
+                self._get_batch_routing_model(data), team_id=user_api_key_dict.team_id
+            )
             if batch_provider and batch_provider in skip_providers:
                 verbose_proxy_logger.debug(f"Skipping batch input file processing for provider={batch_provider}")
                 return True, None
@@ -327,6 +330,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         file_id: str,
         custom_llm_provider: str,
         data: Dict,
+        team_id: Optional[str] = None,
     ) -> Tuple[str, Dict[str, Any]]:
         """
         Map proxy-facing file IDs to provider file IDs and credentials.
@@ -354,6 +358,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                         llm_router=llm_router,
                         model_id=model_from_file_id,
                         operation_context="batch input file read (rate limiting)",
+                        team_id=team_id,
                     )
                     fetch_kwargs.update(_extract_file_access_credentials(credentials))
                     fetch_kwargs["model"] = model_from_file_id
@@ -371,6 +376,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                     llm_router=llm_router,
                     model_id=request_model,
                     operation_context="batch input file read (rate limiting)",
+                    team_id=team_id,
                 )
                 fetch_kwargs.update(_extract_file_access_credentials(credentials))
                 fetch_kwargs["model"] = request_model
@@ -528,6 +534,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                     file_id=file_id,
                     custom_llm_provider=custom_llm_provider,
                     data=data or {},
+                    team_id=user_api_key_dict.team_id if user_api_key_dict is not None else None,
                 )
                 # For non-managed files, use the standard litellm.afile_content
                 file_content = await litellm.afile_content(

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -259,6 +259,7 @@ def get_credentials_for_model(
     llm_router,  # Router instance
     model_id: str,
     operation_context: str = "file operation",
+    team_id: Optional[str] = None,
 ):
     """
     Retrieve API credentials for a model from the LLM Router.
@@ -267,6 +268,10 @@ def get_credentials_for_model(
         llm_router: LiteLLM Router instance
         model_id: Model name or deployment ID
         operation_context: Description for error messages (e.g., "file upload", "batch creation")
+        team_id: Optional team id of the caller. Passed through to
+            ``Router.get_deployment_credentials_with_provider`` so a team's
+            ``model_aliases`` resolve on this (model-pinned) path the same way
+            they already do on ``/v1/chat/completions``.
 
     Returns:
         Dictionary with credentials (api_key, api_base, custom_llm_provider, etc.)
@@ -282,7 +287,7 @@ def get_credentials_for_model(
             detail={"error": "Router not initialized. Cannot use model-based routing."},
         )
 
-    credentials = llm_router.get_deployment_credentials_with_provider(model_id=model_id)
+    credentials = llm_router.get_deployment_credentials_with_provider(model_id=model_id, team_id=team_id)
 
     if credentials is None:
         raise HTTPException(
@@ -466,6 +471,7 @@ def handle_model_based_routing(
     llm_router,  # Router instance
     data: dict,
     check_file_id_encoding: bool = True,
+    team_id: Optional[str] = None,
 ) -> tuple[bool, Optional[str], Optional[str], Optional[dict]]:
     """
     Orchestrate model-based credential routing for file operations.
@@ -476,6 +482,9 @@ def handle_model_based_routing(
         llm_router: LiteLLM Router instance
         data: Request data dictionary
         check_file_id_encoding: Whether to check for embedded model in file_id
+        team_id: Optional team id of the caller, forwarded to
+            ``get_credentials_for_model`` so team ``model_aliases`` resolve
+            here the same way they do on ``/v1/chat/completions``.
 
     Returns:
         Tuple of (should_use_model_routing, model_used, original_file_id, credentials)
@@ -499,6 +508,7 @@ def handle_model_based_routing(
             llm_router=llm_router,
             model_id=model_from_id,
             operation_context=f"file operation (file created with model '{model_from_id}')",
+            team_id=team_id,
         )
         original_file_id = get_original_file_id(file_id)
         return True, model_from_id, original_file_id, credentials
@@ -509,6 +519,7 @@ def handle_model_based_routing(
             llm_router=llm_router,
             model_id=model_from_param,
             operation_context="file operation",
+            team_id=team_id,
         )
         return True, model_from_param, None, credentials
 

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -189,6 +189,7 @@ async def route_create_file(
             llm_router=llm_router,
             model_id=model,
             operation_context="file upload",
+            team_id=user_api_key_dict.team_id,
         )
 
         # Merge credentials into the request
@@ -739,6 +740,7 @@ async def get_file_content(
                 llm_router=llm_router,
                 data=data,
                 check_file_id_encoding=True,
+                team_id=user_api_key_dict.team_id,
             )
 
             if not should_route:
@@ -949,6 +951,7 @@ async def get_file(
             llm_router=llm_router,
             data=data,
             check_file_id_encoding=True,
+            team_id=user_api_key_dict.team_id,
         )
 
         if should_route:
@@ -1147,6 +1150,7 @@ async def delete_file(
             llm_router=llm_router,
             data=data,
             check_file_id_encoding=True,
+            team_id=user_api_key_dict.team_id,
         )
 
         if should_route and credentials is not None:
@@ -1332,6 +1336,7 @@ async def list_files(
             llm_router=llm_router,
             data=data,
             check_file_id_encoding=False,
+            team_id=user_api_key_dict.team_id,
         )
 
         if should_route and credentials is not None:
@@ -1361,6 +1366,7 @@ async def list_files(
                 llm_router=llm_router,
                 model_id=target_model_names_list[0],
                 operation_context="file list",
+                team_id=user_api_key_dict.team_id,
             )
             prepare_data_with_credentials(data=data, credentials=credentials)
             response = await litellm.afile_list(

--- a/litellm/proxy/vector_store_files_endpoints/endpoints.py
+++ b/litellm/proxy/vector_store_files_endpoints/endpoints.py
@@ -35,6 +35,7 @@ def _update_request_data_with_managed_file_id(
     file_id: str,
     request: Request,
     llm_router: Optional["Router"] = None,
+    team_id: Optional[str] = None,
 ) -> tuple[Dict, Optional[str]]:
     """
     Update request data with model routing information from managed file ID.
@@ -53,6 +54,8 @@ def _update_request_data_with_managed_file_id(
         file_id: File ID (can be managed/encoded or regular)
         request: FastAPI request object
         llm_router: LiteLLM router for credential lookup (required for managed files)
+        team_id: Optional team id of the caller, so a team's model_aliases
+            resolve on this routing path too
 
     Returns:
         Tuple of (updated request data, original_managed_file_id)
@@ -100,7 +103,9 @@ def _update_request_data_with_managed_file_id(
 
                 # Get credentials for the model
                 if llm_router:
-                    credentials = llm_router.get_deployment_credentials_with_provider(model_id=routing_model)
+                    credentials = llm_router.get_deployment_credentials_with_provider(
+                        model_id=routing_model, team_id=team_id
+                    )
                     if credentials:
                         prepare_data_with_credentials(
                             data=data,
@@ -132,6 +137,7 @@ def _update_request_data_with_managed_file_id(
         llm_router=llm_router,
         data=data,
         check_file_id_encoding=True,
+        team_id=team_id,
     )
 
     if should_route:
@@ -261,6 +267,7 @@ async def _update_request_data_with_model_routing_hint(
             llm_router=llm_router,
             data=data,
             check_file_id_encoding=False,
+            team_id=caller_team_id,
         )
 
     if should_route and credentials is not None:
@@ -502,7 +509,11 @@ async def vector_store_file_create(
     original_managed_file_id = None
     if "file_id" in data:
         data, original_managed_file_id = _update_request_data_with_managed_file_id(
-            data=data, file_id=data["file_id"], request=request, llm_router=llm_router
+            data=data,
+            file_id=data["file_id"],
+            request=request,
+            llm_router=llm_router,
+            team_id=user_api_key_dict.team_id,
         )
 
     # Then handle managed vector store IDs
@@ -700,7 +711,11 @@ async def vector_store_file_retrieve(
 
     # Handle managed file IDs first
     data, original_managed_file_id = _update_request_data_with_managed_file_id(
-        data=data, file_id=file_id, request=request, llm_router=llm_router
+        data=data,
+        file_id=file_id,
+        request=request,
+        llm_router=llm_router,
+        team_id=user_api_key_dict.team_id,
     )
 
     # Then handle managed vector store IDs
@@ -802,7 +817,11 @@ async def vector_store_file_content(
 
     # Handle managed file IDs first
     data, original_managed_file_id = _update_request_data_with_managed_file_id(
-        data=data, file_id=file_id, request=request, llm_router=llm_router
+        data=data,
+        file_id=file_id,
+        request=request,
+        llm_router=llm_router,
+        team_id=user_api_key_dict.team_id,
     )
 
     # Then handle managed vector store IDs
@@ -904,7 +923,11 @@ async def vector_store_file_update(
 
     # Handle managed file IDs first
     data, original_managed_file_id = _update_request_data_with_managed_file_id(
-        data=data, file_id=file_id, request=request, llm_router=llm_router
+        data=data,
+        file_id=file_id,
+        request=request,
+        llm_router=llm_router,
+        team_id=user_api_key_dict.team_id,
     )
 
     # Then handle managed vector store IDs
@@ -1006,7 +1029,11 @@ async def vector_store_file_delete(
 
     # Handle managed file IDs first
     data, original_managed_file_id = _update_request_data_with_managed_file_id(
-        data=data, file_id=file_id, request=request, llm_router=llm_router
+        data=data,
+        file_id=file_id,
+        request=request,
+        llm_router=llm_router,
+        team_id=user_api_key_dict.team_id,
     )
 
     # Then handle managed vector store IDs

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -146,7 +146,7 @@ class Harness:
         return dict(self.router_acreate.call_args.kwargs)
 
 
-def _creds_lookup(*, model_id: str) -> Dict[str, str]:
+def _creds_lookup(*, model_id: str, team_id: Optional[str] = None) -> Dict[str, str]:
     # KeyError on an unknown/hardcoded model_id - the bug cannot hide.
     return dict(CREDS[model_id])
 
@@ -259,7 +259,7 @@ async def test_create__model_encoded_file_id(harness):
     harness.router_acreate.assert_not_called()
 
     # 2. CREDENTIALS - resolved for the model decoded FROM the file id.
-    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", team_id=None)
 
     # 3. SEAM PAYLOAD - exact, whole dict. A new forwarded key breaks this.
     assert harness.acreate_kwargs() == {
@@ -315,7 +315,7 @@ async def test_create__model_encoded_file_id__resolver_gets_decoded_model(harnes
 
     await call_create(harness)
 
-    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", team_id=None)
 
 
 # =========================================================================== #
@@ -339,7 +339,7 @@ async def test_create__model_from_body(harness):
 
     assert harness.litellm_acreate.call_count == 1
     harness.router_acreate.assert_not_called()
-    harness.creds_resolver.assert_called_once_with(model_id="vertex-model")
+    harness.creds_resolver.assert_called_once_with(model_id="vertex-model", team_id=None)
     payload = harness.acreate_kwargs()
     assert payload["custom_llm_provider"] == "vertex_ai"
     assert payload["input_file_id"] == "file-plain"
@@ -359,7 +359,7 @@ async def test_create__model_from_header(harness):
 
     await call_create(harness, headers={"x-litellm-model": "vertex-model"})
 
-    harness.creds_resolver.assert_called_once_with(model_id="vertex-model")
+    harness.creds_resolver.assert_called_once_with(model_id="vertex-model", team_id=None)
     harness.router_acreate.assert_not_called()
 
 
@@ -376,7 +376,7 @@ async def test_create__model_from_query(harness):
 
     await call_create(harness, query={"model": "vertex-model"})
 
-    harness.creds_resolver.assert_called_once_with(model_id="vertex-model")
+    harness.creds_resolver.assert_called_once_with(model_id="vertex-model", team_id=None)
     harness.router_acreate.assert_not_called()
 
 
@@ -399,7 +399,7 @@ async def test_create__body_model_beats_header_and_query(harness):
         query={"model": "vertex-model"},
     )
 
-    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", team_id=None)
 
 
 # =========================================================================== #
@@ -707,7 +707,7 @@ async def test_create__model_encoded_beats_unified(harness):
 
     assert harness.litellm_acreate.call_count == 1
     harness.router_acreate.assert_not_called()
-    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", team_id=None)
 
 
 # =========================================================================== #
@@ -753,7 +753,7 @@ async def test_create__model_encoded_beats_loadbalancing(harness):
 
     assert harness.litellm_acreate.call_count == 1
     harness.router_acreate.assert_not_called()
-    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", team_id=None)
 
 
 # =========================================================================== #
@@ -1064,7 +1064,7 @@ async def test_retrieve__model_encoded_id(retrieve_harness):
     retrieve_harness.router_aretrieve.assert_not_called()
 
     # 2. CREDENTIALS - resolved for the model decoded FROM the batch id.
-    retrieve_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    retrieve_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", team_id=None)
 
     # 3. SEAM PAYLOAD - exact, whole dict forwarded to the provider call.
     #    Note `model` is the DECODED model, not the deployment from creds: the
@@ -1122,7 +1122,7 @@ async def test_retrieve__model_encoded_beats_loadbalancing(retrieve_harness):
 
     assert retrieve_harness.litellm_aretrieve.call_count == 1
     retrieve_harness.router_aretrieve.assert_not_called()
-    retrieve_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    retrieve_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", team_id=None)
 
 
 # --------------------------------------------------------------------------- #
@@ -1538,7 +1538,7 @@ async def test_list__model_from_body_routes_and_encodes(list_harness):
 
     assert list_harness.litellm_alist.call_count == 1
     list_harness.router_alist.assert_not_called()
-    list_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    list_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", team_id=None)
     assert resp.data[0].id == encode_file_id_with_model("batch-1", "azure/gpt-4o", id_type="batch")
     assert resp.data[1].id == encode_file_id_with_model("batch-2", "azure/gpt-4o", id_type="batch")
 
@@ -1828,7 +1828,7 @@ async def test_cancel__model_encoded_id(cancel_harness):
     cancel_harness.router_acancel.assert_not_called()
 
     # CREDENTIALS - resolved for the model decoded from the batch id.
-    cancel_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    cancel_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", team_id=None)
 
     # SEAM PAYLOAD - exact dict. NOTE current behavior: `model` is the
     # DEPLOYMENT name from creds, NOT the decoded model (cancel, unlike
@@ -1866,7 +1866,7 @@ async def test_cancel__model_encoded_beats_unified(cancel_harness):
 
     assert cancel_harness.litellm_acancel.call_count == 1
     cancel_harness.router_acancel.assert_not_called()
-    cancel_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    cancel_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", team_id=None)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
+++ b/tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py
@@ -3051,3 +3051,87 @@ def test_list_files_key_allowed_openai_model_still_resolves_team_credentials(
         mocker, monkeypatch, _team_openai_plus_global_anthropic_router(), ["team-gpt"]
     )
     assert captured_kwargs.get("api_key") == "team-openai-key"
+
+
+def test_create_file_model_param_resolves_team_public_model_name(
+    mocker: MockerFixture, monkeypatch
+):
+    """
+    Regression: POST /v1/files with x-litellm-model set to a team's public model
+    name (the identifier team model_aliases/model_alias_map rewrite requests to,
+    e.g. "my-alias" -> "team-a-openai-deployment") must resolve that
+    team-scoped deployment's credentials on this model-pinned path, the
+    same way it already resolves on /v1/chat/completions. Before this fix,
+    get_credentials_for_model() never received team_id, so
+    Router.get_deployment_credentials_with_provider() could only match global
+    deployments and this 400'd with "Model '<alias>' not found in model_list."
+    """
+    import litellm.proxy.proxy_server as ps
+    from litellm.proxy._types import LitellmUserRoles
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "team-a-openai-deployment",
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "api_key": "team-a-openai-key",
+                },
+                "model_info": {
+                    "id": "team-a-openai-deployment",
+                    "team_id": "team-a",
+                    "team_public_model_name": "my-alias",
+                },
+            },
+        ]
+    )
+
+    proxy_logging_obj = setup_proxy_logging_object(monkeypatch, router)
+    monkeypatch.setattr("litellm.proxy.proxy_server.master_key", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", None)
+    monkeypatch.setattr("litellm.proxy.proxy_server.llm_router", router)
+    proxy_logging_obj.update_request_status = mocker.AsyncMock()
+    proxy_logging_obj.post_call_success_hook = mocker.AsyncMock(return_value=None)
+    proxy_logging_obj.post_call_failure_hook = mocker.AsyncMock()
+
+    captured_kwargs: dict = {}
+
+    async def _mock_acreate_file(**kwargs):
+        captured_kwargs.update(kwargs)
+        return OpenAIFileObject(
+            id="file-team-alias-123",
+            object="file",
+            bytes=2,
+            created_at=1234567890,
+            filename="batch.jsonl",
+            purpose="batch",
+            status="uploaded",
+        )
+
+    monkeypatch.setattr(litellm, "acreate_file", _mock_acreate_file)
+
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        api_key="test-key",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="test-user",
+        team_id="team-a",
+        team_models=["my-alias"],
+    )
+
+    try:
+        response = client.post(
+            "/v1/files",
+            files={"file": ("batch.jsonl", b"{}", "application/jsonl")},
+            data={"purpose": "batch"},
+            headers={
+                "Authorization": "Bearer test-key",
+                "x-litellm-model": "my-alias",
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+    assert response.status_code == 200, response.text
+    assert captured_kwargs.get("api_key") == "team-a-openai-key"
+    assert captured_kwargs.get("custom_llm_provider") == "openai"
+    proxy_logging_obj.post_call_failure_hook.assert_not_called()

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -177,7 +177,7 @@ async def test_vector_store_file_list_resolves_credentials_from_model_query_para
     assert result["model"] == "openai/gpt-4o-mini"
     assert "custom_llm_provider" not in result
     llm_router.get_deployment_credentials_with_provider.assert_called_once_with(
-        model_id="team-openai"
+        model_id="team-openai", team_id=None
     )
 
 

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_tenant_guard.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_tenant_guard.py
@@ -138,7 +138,7 @@ async def test_vector_store_file_list_resolves_managed_vector_store_before_team_
 
     llm_router = MagicMock()
 
-    def get_credentials(model_id):
+    def get_credentials(model_id, team_id=None):
         return {
             "api_key": f"sk-{model_id}",
             "api_base": "https://api.openai.com/v1",
@@ -171,7 +171,7 @@ async def test_vector_store_file_list_resolves_managed_vector_store_before_team_
     assert captured_data["api_key"] == "sk-managed-deployment"
     assert captured_data["model"] == "openai/managed-deployment"
     llm_router.get_deployment_credentials_with_provider.assert_called_once_with(
-        model_id="managed-deployment"
+        model_id="managed-deployment", team_id=None
     )
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Team `model_aliases` don't resolve on model-pinned Files/Batches routing
- `/v1/files` and `/v1/batches` 400 with an alias that works on `/v1/chat/completions`
- Caller has no way to use a team alias via `x-litellm-model`/`model` there

How it solves it:

- Thread `team_id` into `get_credentials_for_model()` and `handle_model_based_routing()`
- Pass `user_api_key_dict.team_id` at every call site in files/batches endpoints
- Mirrors the pattern `get_team_provider_credentials()` already uses for provider-only calls

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests) — ran the two relevant pytest files locally (see below); have not run the full CI suite
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

I don't have a live proxy + real provider credentials to run this fully e2e per the template's guidance, so this proof is a pytest repro against the real code paths (only the true I/O boundaries the existing test file already mocks are mocked: `litellm.acreate_file` and proxy logging — the router, credential resolution, and request routing all run for real). This reproduces the exact production error message reported against a real deployment via the new test `test_create_file_model_param_resolves_team_public_model_name`; happy to run a live e2e if a maintainer points me at a suitable harness/fixture for this endpoint:

```
POST /v1/files  (purpose=batch, header "x-litellm-model: my-alias")
caller's team_id="team-a", team's deployment: team_public_model_name="my-alias" -> real openai deployment with api_key="team-a-openai-key"
```

**Before fix** (this test run against the pre-fix code, same commit tree minus this diff):

```
fastapi.exceptions.HTTPException: 400: {'error': "Model 'my-alias' not found in model_list. Please check your config.yaml."}
FAILED tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py::test_create_file_model_param_resolves_team_public_model_name
```

**After fix:**

```
tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py::test_create_file_model_param_resolves_team_public_model_name PASSED
```

captured `acreate_file` kwargs show the team deployment's real credentials were resolved: `api_key="team-a-openai-key"`, `custom_llm_provider="openai"` — the same alias that already worked on `/v1/chat/completions` for this team now also works on `/v1/files`.

Full existing suites also pass with no regressions:

```
tests/test_litellm/proxy/openai_files_endpoint/test_files_endpoint.py: 45 passed, 2 skipped
tests/test_litellm/proxy/batches_endpoints/test_endpoints.py: 83 passed, 2 xfailed
tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py: 89 passed (combined with test_vector_store_tenant_guard.py)
```

(A few pre-existing mocks of `Router.get_deployment_credentials_with_provider` in the batches and vector-store test files needed a `team_id` kwarg added to their signature/assertions, since the real method already accepts it — no behavior assertions changed beyond that.)

## Type

🐛 Bug Fix

## Changes

- `litellm/proxy/openai_files_endpoints/common_utils.py`: `get_credentials_for_model()` and `handle_model_based_routing()` now accept `team_id` and forward it to `Router.get_deployment_credentials_with_provider()`.
- `litellm/proxy/openai_files_endpoints/files_endpoints.py`: pass `team_id=user_api_key_dict.team_id` at every `get_credentials_for_model`/`handle_model_based_routing` call site (`route_create_file`, `get_file_content`, `get_file`, `delete_file`, `list_files`).
- `litellm/proxy/batches_endpoints/endpoints.py`: same, at every `get_credentials_for_model` call site (`create_batch`, `retrieve_batch`, `list_batches`, `cancel_batch`).
- `litellm/proxy/vector_store_files_endpoints/endpoints.py`: same, at `_update_request_data_with_managed_file_id`'s and `_update_request_data_with_model_routing_hint`'s `handle_model_based_routing`/direct router calls.
- `litellm/proxy/hooks/batch_rate_limiter.py`: same, at `_resolve_batch_provider`'s and `_resolve_batch_input_file_fetch_params`'s `get_credentials_for_model` calls.
- Tests: new regression test for the files model-pinned path; existing batches/vector-store endpoint test mocks and assertions updated for the new `team_id` kwarg.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
