### PR TITLE
ci: retry Codecov uploads and stop failing jobs on OIDC token flakes

### DIFF
--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -159,11 +159,10 @@ jobs:
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           use_oidc: true
-          directory: simulated-first-attempt-outage
-          disable_search: true
+          directory: coverage-reports
           root_dir: ${{ github.workspace }}
           flags: ${{ inputs.artifact-name }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
       - name: Upload to Codecov (retry)
         if: steps.codecov-upload.outcome == 'failure'

--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -154,8 +154,20 @@ jobs:
           merge-multiple: true
 
       - name: Upload to Codecov
-        env:
-          ACTIONS_ID_TOKEN_REQUEST_URL: http://127.0.0.1:9/simulated-oidc-broker-outage
+        id: codecov-upload
+        continue-on-error: true
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        with:
+          use_oidc: true
+          directory: simulated-first-attempt-outage
+          disable_search: true
+          root_dir: ${{ github.workspace }}
+          flags: ${{ inputs.artifact-name }}
+          fail_ci_if_error: true
+
+      - name: Upload to Codecov (retry)
+        if: steps.codecov-upload.outcome == 'failure'
+        continue-on-error: true
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           use_oidc: true

--- a/.github/workflows/_test-unit-base.yml
+++ b/.github/workflows/_test-unit-base.yml
@@ -154,6 +154,8 @@ jobs:
           merge-multiple: true
 
       - name: Upload to Codecov
+        env:
+          ACTIONS_ID_TOKEN_REQUEST_URL: http://127.0.0.1:9/simulated-oidc-broker-outage
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           use_oidc: true


### PR DESCRIPTION
## TLDR

Problem this solves:

- A transient GitHub OIDC timeout turned CI red on PR #35186
- codecov-action fetches its ID token once, with no retry
- `fail_ci_if_error: false` does not cover that internal step

How it solves it:

- Retries the Codecov upload once if the first attempt fails
- Marks both attempts `continue-on-error` so uploads stay best-effort

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

No unit tests because the change is workflow YAML only; the sabotage leg below is the test, exercised on this PR's own CI

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The organic failure this fixes: [job 90803402008](https://github.com/BerriAI/litellm/actions/runs/30521030624/job/90803402008) on PR #35186. GitHub's OIDC broker answered `Request timeout` once, codecov-action's internal "Get OIDC token" step threw, and the whole `proxy-runtime / Upload coverage to Codecov` job went red on a PR that only touched batch cost code. That log is the before-fix evidence; the broker outage itself cannot be simulated on demand (see note below), so the legs prove each half of the fix deterministically on this PR's own CI

| Leg | Commit | First attempt | Result |
| --- | --- | --- | --- |
| Before fix, baseline | 3741be3529 | normal | [upload jobs green](https://github.com/BerriAI/litellm/actions/runs/30568143085/job/90960287876) |
| After fix, forced first-attempt failure | 1e5dc5bf78 | fails | [retry uploads, job green](https://github.com/BerriAI/litellm/actions/runs/30571294498/job/90970883858) |
| After fix, final head | 325c426d89 | normal | [green, retry skipped](https://github.com/BerriAI/litellm/actions/runs/30572169018/job/90974521389) |

In the forced-failure leg the first attempt points `directory` at a nonexistent path with `fail_ci_if_error: true`, so its uploader exits 1; the log then shows the retry step minting a fresh OIDC token, uploading the real coverage, and the job finishing green. On the final head all 20 upload jobs ran green with step conclusions `Upload to Codecov: success, Upload to Codecov (retry): skipped`, including `proxy-runtime`, the shard that flaked in the original incident

Simulation note: commit 3741be3529 originally tried to fake the broker outage by overriding `ACTIONS_ID_TOKEN_REQUEST_URL` in step `env`, but the runner injects the real value into every action process after merging user env, so the override is inert ([log](https://github.com/BerriAI/litellm/actions/runs/30568143085/job/90960287876) shows the poisoned value in the env listing while the token fetch succeeds). That run therefore serves as the baseline leg

## Type

🚄 Infrastructure

## Changes

`_test-unit-base.yml` upload-coverage job only. The existing `Upload to Codecov` step gains an `id` and `continue-on-error: true`, and an identical `Upload to Codecov (retry)` step runs only when the first attempt fails. Rationale: codecov-action v5 fetches the OIDC token in an internal `actions/github-script` step with no error handling, `@actions/core` only retries 502/503/504 responses, and `fail_ci_if_error` only guards the uploader step after it, so a single broker hiccup failed the whole job. The job was already declared best-effort via `fail_ci_if_error: false`; this makes that intent hold for the token fetch too, while the retry keeps coverage flowing on transient blips

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
