### PR TITLE
fix(router): register custom tiered-pricing keys for arbitrary thresholds

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -321,6 +321,9 @@ class RoutingArgs(enum.Enum):
     ttl = 60  # 1min (RPM/TPM expire key)
 
 
+CUSTOM_TIER_PRICING_KEY_PATTERN = re.compile(r"_above_\d+k?_tokens$")
+
+
 class Router:
     model_names: set = set()
     cache_responses: Optional[bool] = False
@@ -7500,6 +7503,25 @@ class Router:
                 if backend_value is not None:
                     model_info[field] = backend_value
 
+    @staticmethod
+    def _extra_custom_pricing_fields(litellm_params: LiteLLM_Params) -> Dict[str, Any]:
+        """Custom tiered-pricing keys the user set on ``litellm_params`` that are not declared
+        on ``CustomPricingLiteLLMParams`` (e.g. ``input_cost_per_token_above_32k_tokens``).
+
+        The runtime cost calculator resolves any ``_above_<N>_tokens`` key generically, so a
+        user can configure an arbitrary threshold, but the fixed ``CustomPricingLiteLLMParams``
+        field list only carries a handful of declared thresholds. Without propagating the rest,
+        the router drops them at registration and requests in that tier bill at the base rate.
+        The shared backend key stays clean because ``shared_backend_model_info`` only keeps
+        cost-map schema fields, so these arbitrary keys never leak onto it.
+        """
+        extra = litellm_params.model_extra or {}
+        return {
+            key: value
+            for key, value in extra.items()
+            if value is not None and CUSTOM_TIER_PRICING_KEY_PATTERN.search(key)
+        }
+
     def _create_deployment(
         self,
         deployment_info: dict,
@@ -7527,6 +7549,9 @@ class Router:
             for field in CustomPricingLiteLLMParams.model_fields.keys():
                 if deployment.litellm_params.get(field) is not None:
                     _model_info[field] = deployment.litellm_params[field]
+            _model_info.update(
+                Router._extra_custom_pricing_fields(deployment.litellm_params)
+            )
 
             if _model_info.get("input_cost_per_token") is not None:
                 Router._inherit_builtin_cache_pricing(
@@ -8277,6 +8302,9 @@ class Router:
             field_value = deployment.litellm_params.get(field)
             if field_value is not None:
                 _model_info_dict[field] = field_value
+        _model_info_dict.update(
+            Router._extra_custom_pricing_fields(deployment.litellm_params)
+        )
 
         if _model_info_dict.get("input_cost_per_token") is not None:
             Router._inherit_builtin_cache_pricing(

--- a/tests/test_litellm/test_router_model_cost_isolation.py
+++ b/tests/test_litellm/test_router_model_cost_isolation.py
@@ -944,3 +944,81 @@ def test_wildcard_zero_cost_request_does_not_poison_named_deployment_pricing():
         assert named_cost == pytest.approx(10 * builtin_input_cost)
     finally:
         _restore_model_cost_entries(model_keys)
+def test_custom_arbitrary_tier_pricing_registered_under_deployment_model_id():
+    """
+    Regression for #34378: a Router/UI deployment configuring an arbitrary custom
+    tiered-pricing key on litellm_params (e.g. input_cost_per_token_above_32k_tokens,
+    a threshold not declared on CustomPricingLiteLLMParams) must survive registration
+    and land in the deployment's model_id cost-map entry, so requests above the
+    threshold are billed at the tier rate rather than the base rate.
+    """
+    backend_model = "vertex_ai/gemini-2.5-flash"
+
+    Router(
+        model_list=[
+            {
+                "model_name": "custom-32k-tier-model",
+                "litellm_params": {
+                    "model": backend_model,
+                    "api_key": "fake-key-tier-1",
+                    "input_cost_per_token": 0.0000004,
+                    "output_cost_per_token": 0.0000012,
+                    "input_cost_per_token_above_32k_tokens": 0.0000008,
+                    "output_cost_per_token_above_32k_tokens": 0.0000024,
+                    "cache_read_input_token_cost_above_32k_tokens": 0.0000001,
+                },
+                "model_info": {"id": "deployment-custom-32k"},
+            },
+        ],
+    )
+
+    entry = litellm.model_cost.get("deployment-custom-32k")
+    assert entry is not None, "Deployment should be registered by model_id"
+    assert entry["input_cost_per_token_above_32k_tokens"] == 0.0000008
+    assert entry["output_cost_per_token_above_32k_tokens"] == 0.0000024
+    assert entry["cache_read_input_token_cost_above_32k_tokens"] == 0.0000001
+
+
+def test_custom_arbitrary_tier_pricing_does_not_pollute_shared_backend_key():
+    """
+    Regression for #34378 combined with the shared-key isolation guarantee: an
+    arbitrary custom tier key set on one deployment must not leak onto the shared
+    backend model key, so a sibling deployment on the same backend keeps built-in
+    pricing (mirrors the existing declared-field isolation tests).
+    """
+    backend_model = "vertex_ai/gemini-2.5-flash"
+
+    router = Router(
+        model_list=[
+            {
+                "model_name": "tiered-custom-model",
+                "litellm_params": {
+                    "model": backend_model,
+                    "api_key": "fake-key-tier-2",
+                    "input_cost_per_token": 0.0000004,
+                    "output_cost_per_token": 0.0000012,
+                    "input_cost_per_token_above_32k_tokens": 0.0000008,
+                },
+                "model_info": {"id": "deployment-tiered-custom"},
+            },
+            {
+                "model_name": "sibling-builtin-model",
+                "litellm_params": {
+                    "model": backend_model,
+                    "api_key": "fake-key-tier-3",
+                },
+                "model_info": {"id": "deployment-sibling-builtin"},
+            },
+        ],
+    )
+
+    shared_entry = litellm.model_cost.get(backend_model, {})
+    assert (
+        "input_cost_per_token_above_32k_tokens" not in shared_entry
+    ), "Custom tier key must not pollute the shared backend model key"
+
+    info_custom = router.get_deployment_model_info(
+        model_id="deployment-tiered-custom", model_name=backend_model
+    )
+    assert info_custom is not None
+    assert info_custom["input_cost_per_token_above_32k_tokens"] == 0.0000008


### PR DESCRIPTION
## Relevant issues

Fixes #34378

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Router custom-pricing registration copied only the fields declared on `CustomPricingLiteLLMParams` into the per-deployment cost map (`litellm/router.py`, both the `_create_deployment` and the dynamic add-deployment paths). A DB/UI deployment that configures a tiered-pricing key on an arbitrary threshold, for example `input_cost_per_token_above_32k_tokens`, therefore had that key silently dropped at registration; it never reached `model_map_information.model_map_value` and was never applied during cost calculation, so a request in the 32k-128k range billed at the base `input_cost_per_token`. Declared thresholds such as `above_128k` worked only because they happen to be present on `CustomPricingLiteLLMParams`.

The runtime cost calculator already handles arbitrary thresholds: `litellm/litellm_core_utils/llm_cost_calc/utils.py` builds the tiered key from a regex on the threshold value, so any `_above_<N>_tokens` key is resolved generically. The only gap was the router refusing to propagate undeclared thresholds. This adds a small helper, `Router._extra_custom_pricing_fields`, that returns every `_above_<N>_tokens` key the user set on `litellm_params` (via `model_extra`, since `LiteLLM_Params` allows extra fields), and applies it at both custom-pricing registration sites right after the declared-field copy loop. The shared-backend-key strip is widened by exactly the same key set, so a custom tier configured on one deployment still cannot pollute a sibling deployment that shares the same backend model.

Declaring a fixed handful of extra thresholds on `CustomPricingLiteLLMParams` was the alternative, but it stays whack-a-mole; a user who picks `above_64k` would hit the same bug. Matching the runtime calculator's generic handling is the durable fix, and it keeps the two classes from having to stay in lockstep for every future threshold.

## Testing

Added two regression tests to `tests/test_litellm/test_router_model_cost_isolation.py` (the file that already owns the custom-pricing / shared-key-isolation behavior):

- `test_custom_arbitrary_tier_pricing_registered_under_deployment_model_id` configures `input_cost_per_token_above_32k_tokens` / `output_cost_per_token_above_32k_tokens` / `cache_read_input_token_cost_above_32k_tokens` on a deployment and asserts all three land in that deployment's `model_id` entry in `litellm.model_cost`
- `test_custom_arbitrary_tier_pricing_does_not_pollute_shared_backend_key` asserts the arbitrary tier key does not leak onto the shared backend model key while the owning deployment still keeps it

Both fail against the current code (the `_above_32k_tokens` keys are dropped, so the assertions see them missing) and pass with the fix. The full file is green locally (13 passed):

```bash
pytest tests/test_litellm/test_router_model_cost_isolation.py -q
```

Proof-of-fix on a live proxy: configure a deployment with a custom 32k tier through the config and confirm a >32k-token request is billed at the tier rate.

```yaml
model_list:
  - model_name: gpt-4o-custom-tier
    litellm_params:
      model: openai/gpt-4o
      api_key: os.environ/OPENAI_API_KEY
      input_cost_per_token: 0.0000004
      output_cost_per_token: 0.0000012
      input_cost_per_token_above_32k_tokens: 0.0000008
      output_cost_per_token_above_32k_tokens: 0.0000024
```

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug 2>&1 | tee litellm.log
# then send a request whose prompt exceeds 32k tokens and check response_cost in the logs;
# before this change the prompt bills at 4e-7/token, after it bills at 8e-7/token above 32k
```
