### PR TITLE
chore: bump litellm 1.95.0 -> 1.96.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm"
-version = "1.95.0"
+version = "1.96.0"
 description = "Library to easily interface with LLM API providers"
 readme = "README.md"
 requires-python = ">=3.10, <3.15"
@@ -302,7 +302,7 @@ members = ["enterprise", "litellm-proxy-extras"]
 profile = "black"
 
 [tool.commitizen]
-version = "1.95.0"
+version = "1.96.0"
 version_files = [
     "pyproject.toml:^version",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-24T16:43:28.506903Z"
+exclude-newer = "2026-07-27T18:40:42.08538Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4116,7 +4116,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.95.0"
+version = "1.96.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## TLDR

Problem this solves:

- The 1.95.0 line already shipped `v1.95.0-rc.1`
- Promoting staging now opens the next minor line
- Staging still carries 1.95.0, same as main

How it solves it:

- MINOR bump litellm 1.95.0 -> 1.96.0
- Refresh uv.lock against the bumped version

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

No runtime behavior changes here, so there is nothing to demonstrate against a live proxy; this is purely a version-number and lockfile change ahead of the staging -> main promotion

litellm follows the cleaner-release scheme where each weekly stable takes the MINOR and PATCH is reserved for hotfixes, so the first release of a new line gets a MINOR bump. The 1.95.0 line has graduated past dev builds: alongside `v1.95.0-dev.1` and `v1.95.0-dev.2` it carries `v1.95.0-rc.1`, published 2026-07-30, which means this promotion opens 1.96.0

Neither subpackage is bumped. `enterprise/` and `litellm-proxy-extras/` are byte-identical between `origin/main` and `origin/litellm_internal_staging`, so they stay at 0.1.52 and 0.4.81

`uv lock` reported only the root editable package as updated, and the lock diff is limited to that one version line plus the rolling `exclude-newer` timestamp; no third-party dependency version moved

## Type

🚄 Infrastructure

## Changes

The root `pyproject.toml` gets its `[project]` and `[tool.commitizen]` versions bumped, and `uv.lock` is re-resolved

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
