### PR TITLE
fix(guardrails): serve config guardrails from list and info endpoints without a DB and make their ids stable

### DIFF
--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -73,6 +73,7 @@ def _get_guardrails_list_response(
         )
         guardrail_configs.append(
             GuardrailInfoResponse(
+                guardrail_id=guardrail.get("guardrail_id"),
                 guardrail_name=guardrail.get("guardrail_name"),
                 litellm_params=masked_params,
                 guardrail_info=guardrail.get("guardrail_info"),
@@ -178,13 +179,14 @@ async def list_guardrails_v2(
     from litellm.proxy.guardrails.guardrail_registry import IN_MEMORY_GUARDRAIL_HANDLER
     from litellm.proxy.proxy_server import prisma_client
 
-    if prisma_client is None:
-        raise HTTPException(status_code=500, detail="Prisma client not initialized")
-
     is_admin = user_api_key_dict.user_role == LitellmUserRoles.PROXY_ADMIN
 
     try:
-        guardrails = await GUARDRAIL_REGISTRY.get_all_guardrails_from_db(prisma_client=prisma_client)
+        guardrails = (
+            await GUARDRAIL_REGISTRY.get_all_guardrails_from_db(prisma_client=prisma_client)
+            if prisma_client is not None
+            else []
+        )
 
         excluded_guardrail_ids: set = set()
         if not is_admin:
@@ -1228,13 +1230,12 @@ async def get_guardrail_info(guardrail_id: str):
     from litellm.proxy.proxy_server import prisma_client
     from litellm.types.guardrails import GUARDRAIL_DEFINITION_LOCATION
 
-    if prisma_client is None:
-        raise HTTPException(status_code=500, detail="Prisma client not initialized")
-
     try:
         guardrail_definition_location: GUARDRAIL_DEFINITION_LOCATION = GUARDRAIL_DEFINITION_LOCATION.DB
-        result = await GUARDRAIL_REGISTRY.get_guardrail_by_id_from_db(
-            guardrail_id=guardrail_id, prisma_client=prisma_client
+        result = (
+            await GUARDRAIL_REGISTRY.get_guardrail_by_id_from_db(guardrail_id=guardrail_id, prisma_client=prisma_client)
+            if prisma_client is not None
+            else None
         )
         if result is None:
             in_memory = IN_MEMORY_GUARDRAIL_HANDLER.get_guardrail_by_id(guardrail_id=guardrail_id)

--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -3,6 +3,7 @@
 import importlib
 import os
 from datetime import datetime, timezone
+from itertools import chain, count
 from typing import Any, Dict, List, Literal, Optional, Set, Type, cast
 
 from pydantic import ValidationError
@@ -64,6 +65,8 @@ guardrail_initializer_registry = {
     SupportedGuardrailIntegrations.GRAYSWAN.value: initialize_grayswan,
     SupportedGuardrailIntegrations.LLM_AS_A_JUDGE.value: initialize_llm_as_a_judge,
 }
+
+CONFIG_GUARDRAIL_ID_NAMESPACE = uuid.UUID("625f63f4-935a-50e5-98b5-fbe77babc74a")
 
 guardrail_class_registry: Dict[str, Type[CustomGuardrail]] = {
     SupportedGuardrailIntegrations.BEDROCK.value: BedrockGuardrail,
@@ -407,6 +410,11 @@ class InMemoryGuardrailHandler:
         and never deleted by reconciliation.
         """
 
+    def _stable_guardrail_id(self, guardrail_name: str) -> str:
+        seeds = chain((guardrail_name,), (f"{guardrail_name}:{occurrence}" for occurrence in count(1)))
+        candidate_ids = (str(uuid.uuid5(CONFIG_GUARDRAIL_ID_NAMESPACE, seed.encode("utf-8"))) for seed in seeds)
+        return next(candidate_id for candidate_id in candidate_ids if candidate_id not in self.IN_MEMORY_GUARDRAILS)
+
     def initialize_guardrail(
         self,
         guardrail: Guardrail,
@@ -419,7 +427,7 @@ class InMemoryGuardrailHandler:
 
         Returns a Guardrail object if the guardrail is initialized successfully
         """
-        guardrail_id = guardrail.get("guardrail_id") or str(uuid.uuid4())
+        guardrail_id = guardrail.get("guardrail_id") or self._stable_guardrail_id(guardrail["guardrail_name"])
         guardrail["guardrail_id"] = guardrail_id
         if guardrail_id in self.IN_MEMORY_GUARDRAILS:
             verbose_proxy_logger.debug("guardrail_id already exists in IN_MEMORY_GUARDRAILS")

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_endpoints.py
@@ -400,6 +400,114 @@ async def test_get_guardrail_info_not_found(
     assert "not found" in str(exc_info.value.detail)
 
 
+@pytest.mark.asyncio
+async def test_list_guardrails_v2_without_prisma_returns_config_guardrails(
+    mocker, mock_in_memory_handler
+):
+    """
+    A proxy without a DB must still list config-defined guardrails instead of
+    raising 500 'Prisma client not initialized'.
+    """
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", None)
+    mocker.patch(
+        "litellm.proxy.guardrails.guardrail_registry.IN_MEMORY_GUARDRAIL_HANDLER",
+        mock_in_memory_handler,
+    )
+
+    response = await list_guardrails_v2(user_api_key_dict=MOCK_ADMIN_USER)
+
+    assert len(response.guardrails) == 1
+    config_guardrail = response.guardrails[0]
+    assert config_guardrail.guardrail_id == "test-config-guardrail"
+    assert config_guardrail.guardrail_name == "Test Config Guardrail"
+    assert config_guardrail.guardrail_definition_location == "config"
+
+
+@pytest.mark.asyncio
+async def test_list_guardrails_v2_without_prisma_non_admin_sees_unrestricted_config_guardrails(
+    mocker, mock_in_memory_handler
+):
+    """
+    A non-admin caller on a no-DB proxy must see config guardrails that carry
+    no team_id restriction; the team lookup must not blow up without a DB.
+    """
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", None)
+    mocker.patch(
+        "litellm.proxy.guardrails.guardrail_registry.IN_MEMORY_GUARDRAIL_HANDLER",
+        mock_in_memory_handler,
+    )
+
+    non_admin_auth = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER, user_id="internal-user-1"
+    )
+    response = await list_guardrails_v2(user_api_key_dict=non_admin_auth)
+
+    assert [g.guardrail_id for g in response.guardrails] == ["test-config-guardrail"]
+
+
+@pytest.mark.asyncio
+async def test_get_guardrail_info_without_prisma_returns_config_guardrail(
+    mocker, mock_in_memory_handler
+):
+    """
+    The info endpoint must serve config-defined guardrails from the in-memory
+    registry when no DB is attached instead of raising 500.
+    """
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", None)
+    mocker.patch(
+        "litellm.proxy.guardrails.guardrail_registry.IN_MEMORY_GUARDRAIL_HANDLER",
+        mock_in_memory_handler,
+    )
+
+    response = await get_guardrail_info("test-config-guardrail")
+
+    assert response.guardrail_id == "test-config-guardrail"
+    assert response.guardrail_name == "Test Config Guardrail"
+    assert response.guardrail_definition_location == "config"
+
+
+@pytest.mark.asyncio
+async def test_get_guardrail_info_without_prisma_404s_unknown_id(
+    mocker, mock_in_memory_handler
+):
+    mocker.patch("litellm.proxy.proxy_server.prisma_client", None)
+    mocker.patch(
+        "litellm.proxy.guardrails.guardrail_registry.IN_MEMORY_GUARDRAIL_HANDLER",
+        mock_in_memory_handler,
+    )
+    mock_in_memory_handler.get_guardrail_by_id.return_value = None
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_guardrail_info("non-existent-guardrail")
+
+    assert exc_info.value.status_code == 404
+
+
+def test_get_guardrails_list_response_includes_guardrail_id():
+    """
+    The v1 list response is the UI's fallback when v2 fails; without ids every
+    row click requests /guardrails/undefined/info.
+    """
+    from litellm.proxy.guardrails.guardrail_endpoints import (
+        _get_guardrails_list_response,
+    )
+
+    response = _get_guardrails_list_response(
+        [
+            {
+                "guardrail_id": "stable-config-id",
+                "guardrail_name": "tooling",
+                "litellm_params": {
+                    "guardrail": "litellm_content_filter",
+                    "mode": "pre_call",
+                },
+            }
+        ]
+    )
+
+    assert response.guardrails[0].guardrail_id == "stable-config-id"
+
+
 def test_get_provider_specific_params():
     """Test getting provider-specific parameters"""
     from litellm.proxy.guardrails.guardrail_endpoints import _get_fields_from_model

--- a/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
+++ b/tests/test_litellm/proxy/guardrails/test_guardrail_registry.py
@@ -72,6 +72,95 @@ def test_initialize_guardrail_run_in_parallel_preserves_constructor_default(conf
         registry_module.guardrail_initializer_registry.pop("parallel_default_test", None)
 
 
+def _register_noop_initializer(guardrail_type: str):
+    from litellm.proxy.guardrails import guardrail_registry as registry_module
+
+    def _initializer(litellm_params, guardrail):
+        return CustomGuardrail(
+            guardrail_name=guardrail["guardrail_name"],
+            event_hook=GuardrailEventHooks.pre_call,
+            default_on=False,
+        )
+
+    registry_module.guardrail_initializer_registry[guardrail_type] = _initializer
+    return registry_module
+
+
+def _config_guardrail(name: str, guardrail_type: str, guardrail_id=None) -> dict:
+    guardrail = {
+        "guardrail_name": name,
+        "litellm_params": {"guardrail": guardrail_type, "mode": "pre_call"},
+    }
+    if guardrail_id is not None:
+        guardrail["guardrail_id"] = guardrail_id
+    return guardrail
+
+
+def test_config_guardrail_id_is_stable_across_boots():
+    """
+    Config guardrails used to get a fresh uuid4 per process, so ids from a
+    previous boot (or another replica) 404'd on /guardrails/{id}/info even
+    though the guardrail was alive.
+    """
+    registry_module = _register_noop_initializer("stable_id_test")
+    try:
+        first_boot = InMemoryGuardrailHandler().initialize_guardrail(
+            guardrail=_config_guardrail("tooling", "stable_id_test")
+        )
+        second_boot = InMemoryGuardrailHandler().initialize_guardrail(
+            guardrail=_config_guardrail("tooling", "stable_id_test")
+        )
+
+        assert first_boot["guardrail_id"] == second_boot["guardrail_id"]
+    finally:
+        registry_module.guardrail_initializer_registry.pop("stable_id_test", None)
+
+
+def test_explicit_config_guardrail_id_wins_over_derived_id():
+    registry_module = _register_noop_initializer("explicit_id_test")
+    try:
+        result = InMemoryGuardrailHandler().initialize_guardrail(
+            guardrail=_config_guardrail(
+                "tooling", "explicit_id_test", guardrail_id="my-explicit-id"
+            )
+        )
+
+        assert result["guardrail_id"] == "my-explicit-id"
+    finally:
+        registry_module.guardrail_initializer_registry.pop("explicit_id_test", None)
+
+
+def test_duplicate_config_guardrail_names_get_distinct_stable_ids():
+    """
+    Duplicate guardrail_name entries are legitimate (load balancing across
+    deployments); each occurrence must keep its own id, stable across boots.
+    """
+    registry_module = _register_noop_initializer("dup_name_test")
+    try:
+        handler = InMemoryGuardrailHandler()
+        first = handler.initialize_guardrail(
+            guardrail=_config_guardrail("dup", "dup_name_test")
+        )
+        second = handler.initialize_guardrail(
+            guardrail=_config_guardrail("dup", "dup_name_test")
+        )
+
+        rebooted_handler = InMemoryGuardrailHandler()
+        rebooted_first = rebooted_handler.initialize_guardrail(
+            guardrail=_config_guardrail("dup", "dup_name_test")
+        )
+        rebooted_second = rebooted_handler.initialize_guardrail(
+            guardrail=_config_guardrail("dup", "dup_name_test")
+        )
+
+        assert first["guardrail_id"] != second["guardrail_id"]
+        assert first["guardrail_id"] == rebooted_first["guardrail_id"]
+        assert second["guardrail_id"] == rebooted_second["guardrail_id"]
+        assert len(handler.IN_MEMORY_GUARDRAILS) == 2
+    finally:
+        registry_module.guardrail_initializer_registry.pop("dup_name_test", None)
+
+
 def test_update_in_memory_guardrail():
     handler = InMemoryGuardrailHandler()
     handler.guardrail_id_to_custom_guardrail["123"] = CustomGuardrail(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Config guardrails show "Guardrail not found" in the Admin UI
- No-DB proxies: v2 list and info raise 500 before the config fallback
- v1 list (the UI fallback) never returns guardrail_id
- Config guardrail ids are random per boot, so restarts and replicas 404

How it solves it:

- List and info consult the in-memory registry even without prisma
- v1 list response now carries guardrail_id
- Config guardrail ids are uuid5(name), stable across boots and replicas

## Relevant issues

Fixes #35256

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All legs use this config (guardrail defined only in config.yaml, no explicit guardrail_id, which is the normal case):

```yaml
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY
guardrails:
  - guardrail_name: "tooling"
    litellm_params:
      guardrail: litellm_content_filter
      mode: pre_call
      default_on: false
      blocked_words:
        - keyword: "FORBIDDENWORD"
          action: BLOCK
general_settings:
  master_key: sk-1234
```

The no-DB legs boot the proxy through a wrapper that strips DATABASE_URL after dotenv loads (the repo .env would otherwise attach a DB):

```python
import os, sys, dotenv
_orig = dotenv.load_dotenv
def _no_db(*a, **k):
    r = _orig(*a, **k)
    os.environ.pop("DATABASE_URL", None)
    return r
dotenv.load_dotenv = _no_db
os.environ.pop("DATABASE_URL", None)
from litellm.proxy.proxy_cli import run_server
run_server(["--config", sys.argv[1], "--port", sys.argv[2], "--detailed_debug"], standalone_mode=True)
```

### Before (base ae242fdd06, no DB, port 51377)

```bash
$ curl -s -w "\nHTTP %{http_code}\n" http://localhost:51377/v2/guardrails/list -H "Authorization: Bearer sk-1234"
{"detail":"Prisma client not initialized"}
HTTP 500

$ curl -s http://localhost:51377/guardrails/list -H "Authorization: Bearer sk-1234" | jq '[.guardrails[] | {guardrail_name, guardrail_id}]'
[{"guardrail_name": "tooling", "guardrail_id": null}]

$ curl -s -w "\nHTTP %{http_code}\n" http://localhost:51377/guardrails/undefined/info -H "Authorization: Bearer sk-1234"
{"detail":"Prisma client not initialized"}
HTTP 500

$ curl -s -w "\nHTTP %{http_code}\n" http://localhost:51377/guardrails/25b2bc3f-de3c-4d08-bdef-f840b1c8a518/info -H "Authorization: Bearer sk-1234"
{"detail":"Prisma client not initialized"}
HTTP 500
```

`/guardrails/undefined/info` is the exact request the UI ends up making: v2 500s, the UI falls back to the v1 list, its rows have no id, and the row click fetches id `undefined`. The live in-memory id is unobtainable by any API consumer pre-fix, and the 500 fires before any lookup, so it is identical for every id

### After (this PR's head 5ae1f1530c, no DB, port 51919, boot 1)

```bash
$ curl -s -w "\nHTTP %{http_code}\n" http://localhost:51919/v2/guardrails/list -H "Authorization: Bearer sk-1234"
{"guardrails":[{"guardrail_id":"d6ec73d0-a2d4-5280-b172-7659aca68334","guardrail_name":"tooling", ... "guardrail_definition_location":"config"}]}
HTTP 200

$ curl -s http://localhost:51919/guardrails/list -H "Authorization: Bearer sk-1234" | jq '[.guardrails[] | {guardrail_name, guardrail_id}]'
[{"guardrail_name": "tooling", "guardrail_id": "d6ec73d0-a2d4-5280-b172-7659aca68334"}]

$ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:51919/guardrails/d6ec73d0-a2d4-5280-b172-7659aca68334/info -H "Authorization: Bearer sk-1234"
HTTP 200

$ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:51919/guardrails/d6ec73d0-a2d4-5280-b172-7659aca68334 -H "Authorization: Bearer sk-1234"
HTTP 200

$ curl -s -w "\nHTTP %{http_code}\n" http://localhost:51919/guardrails/25b2bc3f-de3c-4d08-bdef-f840b1c8a518/info -H "Authorization: Bearer sk-1234"
{"detail":"Guardrail with ID 25b2bc3f-de3c-4d08-bdef-f840b1c8a518 not found"}
HTTP 404
```

### After, restart stability (same head, no DB, port 51919, boot 2)

```bash
$ curl -s http://localhost:51919/v2/guardrails/list -H "Authorization: Bearer sk-1234" | jq '[.guardrails[] | {guardrail_name, guardrail_id}]'
[{"guardrail_name": "tooling", "guardrail_id": "d6ec73d0-a2d4-5280-b172-7659aca68334"}]

$ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:51919/guardrails/d6ec73d0-a2d4-5280-b172-7659aca68334/info -H "Authorization: Bearer sk-1234"
HTTP 200
```

The id is byte-identical across boots, and the pre-restart id keeps resolving after the restart

### After, with-DB sanity (same head, DATABASE_URL set, Postgres on localhost:5432, port 52466)

```bash
$ curl -s -X POST http://localhost:52466/guardrails -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"guardrail": {"guardrail_name": "db-guard", "litellm_params": {"guardrail": "litellm_content_filter", "mode": "pre_call", "default_on": false, "blocked_words": [{"keyword": "DBWORD", "action": "BLOCK"}]}}}' | jq '{guardrail_id, guardrail_name}'
{"guardrail_id": "a83a46cd-e409-443c-97d6-697ba53be9b5", "guardrail_name": "db-guard"}

$ curl -s http://localhost:52466/v2/guardrails/list -H "Authorization: Bearer sk-1234" | jq '[.guardrails[] | {guardrail_name, guardrail_id, guardrail_definition_location}]'
[
  {"guardrail_name": "db-guard", "guardrail_id": "a83a46cd-e409-443c-97d6-697ba53be9b5", "guardrail_definition_location": "db"},
  {"guardrail_name": "tooling", "guardrail_id": "d6ec73d0-a2d4-5280-b172-7659aca68334", "guardrail_definition_location": "config"}
]

$ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:52466/guardrails/a83a46cd-e409-443c-97d6-697ba53be9b5/info -H "Authorization: Bearer sk-1234"
HTTP 200

$ curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:52466/guardrails/d6ec73d0-a2d4-5280-b172-7659aca68334/info -H "Authorization: Bearer sk-1234"
HTTP 200
```

DB-defined guardrails keep their DB-generated ids and the list shape is unchanged; the config guardrail carries the same stable id with and without a DB

| Leg | Route | Before ae242fdd06 | After 5ae1f1530c |
|---|---|---|---|
| No DB | GET /v2/guardrails/list | FAIL, 500 | PASS, 200 |
| No DB | GET /guardrails/list ids | FAIL, null | PASS, id set |
| No DB | GET /guardrails/{id}/info | FAIL, 500 | PASS, 200 |
| No DB | GET /guardrails/{id} | FAIL, 500 | PASS, 200 |
| No DB | info, unknown id | FAIL, 500 | PASS, 404 |
| No DB | id across restarts | FAIL, changes | PASS, identical |
| With DB | v2 list, db + config | PASS | PASS |
| With DB | info, both sources | PASS | PASS |

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/guardrails/guardrail_endpoints.py`: `/v2/guardrails/list` and `GET /guardrails/{id}` plus `/guardrails/{id}/info` no longer raise 500 when prisma is not initialized; they treat the DB as empty and serve the in-memory config guardrails that both endpoints already knew how to merge. The info endpoint 404s only when neither source has the id. `_get_guardrails_list_response` (the v1 list the UI falls back to) now includes `guardrail_id`; the ids are present on the config dicts because `initialize_guardrail` writes them back at startup

`litellm/proxy/guardrails/guardrail_registry.py`: a config guardrail without an explicit `guardrail_id` now gets `uuid5(CONFIG_GUARDRAIL_ID_NAMESPACE, guardrail_name)` instead of a fresh `uuid4` per process, so the id survives restarts and matches across replicas. An explicit `guardrail_id` in yaml still wins

Safety analysis for the deterministic id:

Duplicate `guardrail_name` entries in config are legitimate today (load balancing across guardrail deployments with the same name, see `_populate_router_guardrail_list`). A plain name hash would make the second occurrence collide with the first and silently skip its initialization, so on collision the derivation walks deterministic seeds (`name`, `name:1`, `name:2`, ...) until a free id is found. Occurrences keep distinct ids that are stable across boots as long as the config keeps its order, and since the entries share a name a reorder only swaps ids between interchangeable deployments

Consumers audited: `usage_tracking.py` aggregates daily usage by guardrail_id, so stable ids stop the per-restart fragmentation of usage rows for config guardrails (rows written under old random ids stay under those ids, a one-time discontinuity). `_init_guardrails_in_db`, `sync_guardrail_from_db`, and `reconcile_db_guardrails` only handle ids read from DB rows, which are DB-generated uuid4 values, and reconciliation never touches config-sourced entries, so there is no interaction with derived ids beyond a cryptographically negligible uuid collision. The mutation endpoints (PUT, PATCH, DELETE on /guardrails/{id}) check DB existence first and keep 404ing for config ids exactly as before. The `source="db"` callers of `initialize_guardrail` always pass ids from DB rows, so the derived-id path is effectively config-only. No blocker found

## QA runbook

1. Save the config from the proof section as `config.yaml` and the no-DB wrapper as `no_db_proxy.py`
2. Pick a random free high port, e.g. `lsof -nP -iTCP:51919 -sTCP:LISTEN` must print nothing
3. Boot without a DB: `python no_db_proxy.py config.yaml 51919`
4. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:51919/v2/guardrails/list -H "Authorization: Bearer sk-1234"` and expect HTTP 200 listing `tooling` with a `guardrail_id` and `guardrail_definition_location` `config`
5. `curl -s http://localhost:51919/guardrails/list -H "Authorization: Bearer sk-1234" | jq '.guardrails[].guardrail_id'` and expect the same id, not null
6. `curl -s -w "\nHTTP %{http_code}\n" http://localhost:51919/guardrails/<that id>/info -H "Authorization: Bearer sk-1234"` and expect HTTP 200
7. Restart the proxy, rerun steps 4 and 6, and expect the identical id and HTTP 200 for the pre-restart id
8. Boot normally with `DATABASE_URL` set (`python litellm/proxy/proxy_cli.py --config config.yaml --port 52466`), rerun step 4, and expect DB guardrails listed as `db` alongside the config guardrail with the same id as the no-DB boots
9. In the Admin UI guardrails page, click the `tooling` row and expect its info panel instead of "Guardrail not found"

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deterministic config guardrail IDs change identity across upgrades (one-time usage/analytics discontinuity) and duplicate-name ordering affects which occurrence gets which id; read-path behavior for no-DB proxies is otherwise low risk.
> 
> **Overview**
> Fixes Admin UI **"Guardrail not found"** and **500s on proxies without a database** by making list/info endpoints work when Prisma is unset, and by returning stable IDs for config-defined guardrails.
> 
> **No-DB / read APIs:** `GET /v2/guardrails/list` and `GET /guardrails/{id}/info` (and `GET /guardrails/{id}`) no longer fail with *Prisma client not initialized*. They treat the DB as empty and still merge **config** guardrails from the in-memory registry. Unknown IDs return **404** instead of **500**. The v1 `GET /guardrails/list` helper now includes **`guardrail_id`** so UI fallback rows don’t request `/guardrails/undefined/info`.
> 
> **Stable config IDs:** Config guardrails without an explicit `guardrail_id` get a deterministic **`uuid5`** from `guardrail_name` (with `name:1`, `name:2`, … for duplicate names) instead of a new **`uuid4` per process**, so IDs survive restarts and match across replicas. Explicit YAML `guardrail_id` still wins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae1f1530c4d529af6a313db67de47142339963b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->