### PR TITLE
fix(redis): stop an unreachable Redis from blocking every request

### DIFF
--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -61,23 +61,51 @@ def _get_redis_kwargs():
     return available_args
 
 
-def _get_redis_url_kwargs(client=None):
+def _init_arg_names(cls: type) -> frozenset[str]:
+    """Every ``__init__`` parameter accepted anywhere in a class's MRO.
+
+    Keyword-only parameters are included, and the MRO is walked because redis-py splits a
+    connection's parameters between ``AbstractConnection`` and its concrete subclasses.
+    """
+    return frozenset(
+        name
+        for klass in inspect.getmro(cls)
+        if klass is not object
+        for spec in (inspect.getfullargspec(klass.__init__),)
+        for name in spec.args + spec.kwonlyargs
+    )
+
+
+def _get_redis_url_kwargs(client: Optional[type] = None) -> tuple[str, ...]:
+    """Connection kwargs that redis-py forwards from ``from_url`` down to the connection.
+
+    ``from_url`` is declared as ``(cls, url, **kwargs)``, so introspecting it yields no
+    connection kwargs at all. What it really does is hand its kwargs to the connection
+    class, so that class's signature is the allowlist.
+
+    Taking the client's signature instead would be wrong in both directions: it omits
+    nothing useful, but it admits client-only parameters such as
+    ``single_connection_client`` and ``auto_close_connection_pool``, plus the ``ssl_*``
+    family that only ``SSLConnection`` accepts. Those reach ``AbstractConnection`` and
+    raise ``TypeError`` the first time a connection is created. TLS on a url config is
+    selected by the ``rediss://`` scheme, which picks ``SSLConnection`` on its own.
+    """
     if client is None:
-        client = redis.Redis.from_url
-    arg_spec = inspect.getfullargspec(redis.Redis.from_url)
+        client = redis.Redis
+    connection_cls = async_redis.Connection if client is async_redis.Redis else redis.Connection
+
+    exclude_args = frozenset(
+        {
+            "self",
+            "connection_pool",
+            "retry",
+        }
+    )
 
     # Only allow primitive arguments
-    exclude_args = {
-        "self",
-        "connection_pool",
-        "retry",
-    }
+    include_args = ("url", "max_connections")
 
-    include_args = ["url"]
-
-    available_args = [x for x in arg_spec.args if x not in exclude_args] + include_args
-
-    return available_args
+    return tuple(x for x in _init_arg_names(connection_cls) if x not in exclude_args) + include_args
 
 
 def _get_redis_cluster_kwargs(client=None):
@@ -614,7 +642,7 @@ def get_redis_async_client(
     if "url" in redis_kwargs and redis_kwargs["url"] is not None:
         if connection_pool is not None:
             return async_redis.Redis(connection_pool=connection_pool)
-        args = _get_redis_url_kwargs(client=async_redis.Redis.from_url)
+        args = _get_redis_url_kwargs(client=async_redis.Redis)
         url_kwargs = {}
         for arg in redis_kwargs:
             if arg in args:
@@ -662,10 +690,10 @@ def get_redis_connection_pool(
         return None
 
     if "url" in redis_kwargs and redis_kwargs["url"] is not None:
-        pool_kwargs = {
-            "timeout": REDIS_CONNECTION_POOL_TIMEOUT,
-            "url": redis_kwargs["url"],
-        }
+        allowed_args = _get_redis_url_kwargs(client=async_redis.Redis)
+        pool_kwargs = {k: v for k, v in redis_kwargs.items() if k in allowed_args and k != "max_connections"}
+        pool_kwargs["timeout"] = REDIS_CONNECTION_POOL_TIMEOUT
+        pool_kwargs["url"] = redis_kwargs["url"]
         if "max_connections" in redis_kwargs:
             try:
                 pool_kwargs["max_connections"] = int(redis_kwargs["max_connections"])

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -17,7 +17,8 @@ import json
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union, cast
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, TypeVar, Union, cast
 
 import litellm
 from litellm._logging import print_verbose, verbose_logger
@@ -168,24 +169,97 @@ class RedisCircuitBreaker:
         self._state = self.CLOSED
 
 
+_RedisCallResult = TypeVar("_RedisCallResult")
+
+
+_swallowed_redis_failures: ContextVar[int] = ContextVar("litellm_swallowed_redis_failures", default=0)
+
+
+@functools.lru_cache(maxsize=1)
+def _redis_health_error_types() -> tuple[type, ...]:
+    """Exception types that mean the Redis backend itself is unhealthy.
+
+    Command and data errors say nothing about connectivity: an INCR against a non-numeric
+    value or an undecodable cached entry is a request problem, and counting those would let
+    a caller trip the shared breaker on demand, dropping rate limiting to per-process
+    counters that spreading traffic across replicas can outrun.
+
+    Imported lazily because this module is reachable from a base ``import litellm`` while
+    redis is not a base dependency.
+    """
+    from redis.exceptions import BusyLoadingError, ClusterDownError
+    from redis.exceptions import ConnectionError as RedisConnectionError
+    from redis.exceptions import TimeoutError as RedisTimeoutError
+
+    return (RedisConnectionError, RedisTimeoutError, BusyLoadingError, ClusterDownError, OSError, asyncio.TimeoutError)
+
+
+def _is_redis_health_failure(exc: BaseException) -> bool:
+    """True when ``exc`` indicates Redis is unreachable rather than the request being bad."""
+    try:
+        return isinstance(exc, _redis_health_error_types())
+    except ImportError:
+        return True
+
+
+def _record_swallowed_redis_failure(breaker: RedisCircuitBreaker, exc: BaseException) -> None:
+    """Record a Redis failure that the calling method is about to swallow.
+
+    The marker is a ContextVar rather than a counter on the breaker because breakers are
+    shared by every concurrent caller. A plain shared counter cannot tell "my call failed"
+    from "some other in-flight call failed", so a success overlapping someone else's
+    failure would be discarded and a Redis that is answering would still be evicted.
+    asyncio gives each task its own copy of the context, so this is per-call.
+    """
+    if not _is_redis_health_failure(exc):
+        return
+    breaker.record_failure()
+    _swallowed_redis_failures.set(_swallowed_redis_failures.get() + 1)
+
+
+async def _run_under_circuit_breaker(
+    breaker: RedisCircuitBreaker,
+    name: str,
+    call: Callable[[], Awaitable[_RedisCallResult]],
+) -> _RedisCallResult:
+    """Run one Redis coroutine under a circuit breaker.
+
+    Shared by the method decorator and the Lua script executor so both feed the same
+    health signal. Success is recorded only when nothing failed while ``call`` ran,
+    because several Redis methods catch their own connection errors and return a default.
+    """
+    if breaker.is_open():
+        raise Exception(f"Redis circuit breaker is open — skipping {name}")
+    swallowed_before = _swallowed_redis_failures.get()
+    try:
+        result = await call()
+    except Exception as e:
+        if _is_redis_health_failure(e):
+            breaker.record_failure()
+        raise
+    if _swallowed_redis_failures.get() == swallowed_before:
+        breaker.record_success()
+    return result
+
+
 def _redis_circuit_breaker_guard(method):  # type: ignore
     """
     Decorator for RedisCache async methods.
     Checks the circuit breaker before each call; records success/failure after.
     Does not apply to ping/disconnect/test_connection (health/teardown must always run).
+
+    A returning method is not proof of a healthy Redis: several methods catch their own
+    connection errors and return a default so callers degrade rather than fail. Counting
+    those as successes reset the failure streak on every request, so the breaker could
+    never open and Redis was never taken out of the pool. Success is therefore recorded
+    only when no failure was registered while the method ran.
     """
 
     @functools.wraps(method)
     async def wrapper(self, *args, **kwargs):  # type: ignore
-        if self._circuit_breaker.is_open():
-            raise Exception(f"Redis circuit breaker is open — skipping {method.__name__}")
-        try:
-            result = await method(self, *args, **kwargs)
-            self._circuit_breaker.record_success()
-            return result
-        except Exception:
-            self._circuit_breaker.record_failure()
-            raise
+        return await _run_under_circuit_breaker(
+            self._circuit_breaker, method.__name__, lambda: method(self, *args, **kwargs)
+        )
 
     return wrapper
 
@@ -551,13 +625,16 @@ class RedisCache(BaseCache):
         )
 
         async def run_script(keys: Sequence[str], args: Sequence[Any], client: Any = None) -> Any:
-            executor: Optional[Callable[..., Awaitable[Any]]] = litellm.in_memory_llm_clients_cache.get_cache(
-                key=script_cache_key
-            )
-            if executor is None:
-                executor = self._register_script_for_current_loop(script)
-                litellm.in_memory_llm_clients_cache.set_cache(key=script_cache_key, value=executor)
-            return await executor(keys=keys, args=args, client=client)
+            async def execute() -> object:
+                executor: Optional[Callable[..., Awaitable[Any]]] = litellm.in_memory_llm_clients_cache.get_cache(
+                    key=script_cache_key
+                )
+                if executor is None:
+                    executor = self._register_script_for_current_loop(script)
+                    litellm.in_memory_llm_clients_cache.set_cache(key=script_cache_key, value=executor)
+                return await executor(keys=keys, args=args, client=client)
+
+            return await _run_under_circuit_breaker(self._circuit_breaker, "run_script", execute)
 
         return run_script
 
@@ -674,6 +751,7 @@ class RedisCache(BaseCache):
                 str(e),
                 value,
             )
+            _record_swallowed_redis_failure(self._circuit_breaker, e)
 
     async def _pipeline_helper(
         self,
@@ -758,6 +836,7 @@ class RedisCache(BaseCache):
                 str(e),
                 cache_value,
             )
+            _record_swallowed_redis_failure(self._circuit_breaker, e)
 
     async def _set_cache_sadd_helper(
         self,
@@ -842,6 +921,7 @@ class RedisCache(BaseCache):
                 str(e),
                 value,
             )
+            _record_swallowed_redis_failure(self._circuit_breaker, e)
 
     @_redis_circuit_breaker_guard
     async def batch_cache_write(self, key, value, **kwargs):
@@ -1106,6 +1186,7 @@ class RedisCache(BaseCache):
                 )
             )
             print_verbose(f"litellm.caching.caching: async get() - Got exception from REDIS: {str(e)}")
+            _record_swallowed_redis_failure(self._circuit_breaker, e)
 
     @_redis_circuit_breaker_guard
     async def async_batch_get_cache(
@@ -1177,6 +1258,7 @@ class RedisCache(BaseCache):
                 )
             )
             verbose_logger.error(f"Error occurred in async batch get cache - {str(e)}")
+            _record_swallowed_redis_failure(self._circuit_breaker, e)
             return key_value_dict
 
     def sync_ping(self) -> bool:
@@ -1432,6 +1514,7 @@ class RedisCache(BaseCache):
             return ttl
         except Exception as e:
             verbose_logger.debug(f"Redis TTL Error: {e}")
+            _record_swallowed_redis_failure(self._circuit_breaker, e)
             return None
 
     @_redis_circuit_breaker_guard

--- a/tests/test_litellm/caching/test_redis_cache.py
+++ b/tests/test_litellm/caching/test_redis_cache.py
@@ -59,9 +59,24 @@ def test_delete_cache_applies_namespace(namespace, monkeypatch, redis_no_ping):
 
 
 @pytest.mark.asyncio
-async def test_redis_client_init_with_socket_timeout(monkeypatch, redis_no_ping):
-    monkeypatch.setenv("REDIS_HOST", "my-fake-host")
-    redis_cache = RedisCache(socket_timeout=1.0)
+@pytest.mark.parametrize(
+    "redis_config",
+    [
+        pytest.param({"host": "my-fake-host"}, id="host_port"),
+        pytest.param({"url": "redis://my-fake-host:6379"}, id="url"),
+    ],
+)
+async def test_redis_client_init_with_socket_timeout(monkeypatch, redis_no_ping, redis_config):
+    """socket_timeout has to reach the connection however Redis was configured.
+
+    A url config used to drop every connection kwarg, so redis-py was left with
+    socket_timeout (and socket_connect_timeout, which falls back to it) unset. A
+    Redis host that drops packets instead of refusing them then blocks each caller
+    indefinitely, and the circuit breaker never trips because no call ever returns.
+    """
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_HOST", raising=False)
+    redis_cache = RedisCache(socket_timeout=1.0, **redis_config)
     assert redis_cache.redis_kwargs["socket_timeout"] == 1.0
     client = redis_cache.init_async_client()
     assert client is not None
@@ -428,3 +443,168 @@ def test_delete_cache_namespaces_key(namespace, expected, monkeypatch, redis_no_
     redis_cache.redis_client = mock_client
     redis_cache.delete_cache(key="k")
     mock_client.delete.assert_called_once_with(expected)
+
+
+def _closed_port() -> int:
+    """A port with nothing listening, so Redis calls fail fast and deterministically."""
+    import socket
+
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "call_method",
+    [
+        pytest.param(lambda c: c.async_get_cache("lit4930"), id="async_get_cache"),
+        pytest.param(lambda c: c.async_batch_get_cache(["lit4930"]), id="async_batch_get_cache"),
+        pytest.param(lambda c: c.async_set_cache("lit4930", "v"), id="async_set_cache"),
+        pytest.param(lambda c: c.async_get_ttl("lit4930"), id="async_get_ttl"),
+    ],
+)
+async def test_circuit_breaker_opens_when_method_swallows_redis_failure(redis_no_ping, call_method):
+    """A guarded method that swallows its own Redis error must still count as a failure.
+
+    These methods catch connection errors and return a default so callers degrade instead
+    of failing, which is correct. But that returns cleanly through the circuit breaker
+    guard, and counting it as a success reset the failure streak on every call, so the
+    breaker could never open. An unreachable Redis then stayed in the pool and every
+    request kept paying the full socket timeout on it.
+    """
+    from litellm.constants import REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD
+
+    cache = RedisCache(host="127.0.0.1", port=_closed_port(), socket_timeout=0.5)
+
+    for _ in range(REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD):
+        await call_method(cache)
+
+    with pytest.raises(Exception, match="circuit breaker is open"):
+        await call_method(cache)
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_success_still_resets_the_failure_streak(redis_no_ping):
+    """A reachable Redis must keep the breaker closed, however many earlier calls failed.
+
+    The guard now records success only when nothing failed while the method ran, so this
+    pins the other half of that contract: a call that genuinely reaches Redis has to clear
+    the streak, or a healthy Redis would eventually be evicted from the pool.
+    """
+    from litellm.constants import REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD
+
+    cache = RedisCache(host="127.0.0.1", port=_closed_port(), socket_timeout=0.5)
+
+    for _ in range(REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD - 1):
+        await cache.async_get_cache("lit4930")
+    assert cache._circuit_breaker.is_open() is False
+
+    reachable_redis = AsyncMock()
+    reachable_redis.get.return_value = None
+    with patch.object(cache, "init_async_client", return_value=reachable_redis):
+        await cache.async_get_cache("lit4930")
+
+    for _ in range(REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD - 1):
+        await cache.async_get_cache("lit4930")
+
+    assert cache._circuit_breaker.is_open() is False, "one success must clear the streak"
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_covers_lua_script_execution(redis_no_ping):
+    """Lua script execution must feed the breaker like every other Redis call.
+
+    The v3 rate limiter issues all of its Redis traffic through async_register_script, so
+    leaving that path unguarded meant the coordination calls during an outage never
+    counted toward taking Redis out of the pool and kept paying a full socket timeout
+    each, which is the traffic the outage hurts most.
+    """
+    from litellm.constants import REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD
+
+    cache = RedisCache(host="127.0.0.1", port=_closed_port(), socket_timeout=0.5)
+    run_script = cache.async_register_script("return 1")
+
+    for _ in range(REDIS_CIRCUIT_BREAKER_FAILURE_THRESHOLD):
+        with pytest.raises(Exception):
+            await run_script(keys=["lit4930"], args=[1])
+
+    with pytest.raises(Exception, match="circuit breaker is open"):
+        await run_script(keys=["lit4930"], args=[1])
+
+
+@pytest.mark.asyncio
+async def test_concurrent_success_is_not_cancelled_by_another_calls_failure():
+    """One caller's failure must not discard a different caller's success.
+
+    A breaker is shared by every concurrent caller, so tracking "did this call fail" on the
+    breaker itself cannot tell my failure from someone else's. A Redis that is still
+    answering would then be evicted from the pool by unrelated in-flight failures, which is
+    the opposite of the outage this guard exists to handle.
+    """
+    from redis.exceptions import ConnectionError as RedisConnectionError
+
+    from litellm.caching.redis_cache import (
+        RedisCircuitBreaker,
+        _record_swallowed_redis_failure,
+        _run_under_circuit_breaker,
+    )
+
+    breaker = RedisCircuitBreaker(failure_threshold=3, recovery_timeout=60)
+
+    # The failure has to land after both calls are already in flight, which is the only
+    # ordering where a shared counter confuses the two. Failing before the healthy call
+    # starts would leave its snapshot correct and prove nothing.
+    async def swallows_a_failure():
+        await asyncio.sleep(0.02)
+        _record_swallowed_redis_failure(breaker, RedisConnectionError("redis unreachable"))
+        return None
+
+    async def succeeds_while_the_other_fails():
+        await asyncio.sleep(0.05)
+        return "ok"
+
+    rounds = breaker.failure_threshold + 1
+    for _ in range(rounds):
+        await asyncio.gather(
+            _run_under_circuit_breaker(breaker, "failing", swallows_a_failure),
+            _run_under_circuit_breaker(breaker, "healthy", succeeds_while_the_other_fails),
+        )
+
+    assert breaker._failure_count < breaker.failure_threshold, "the healthy call must clear the streak"
+    assert breaker.is_open() is False, "a Redis answering every round must stay in the pool"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error, opens_breaker",
+    [
+        pytest.param("ConnectionError", True, id="connection_refused_is_unhealthy"),
+        pytest.param("TimeoutError", True, id="timeout_is_unhealthy"),
+        pytest.param("BusyLoadingError", True, id="loading_is_unhealthy"),
+        pytest.param("ResponseError", False, id="wrong_type_command_is_not"),
+        pytest.param("DataError", False, id="bad_data_is_not"),
+    ],
+)
+async def test_only_connectivity_failures_open_the_breaker(error, opens_breaker):
+    """Command and data errors must not count against Redis health.
+
+    They say nothing about connectivity, and a caller able to provoke them (an INCR against
+    a non-numeric value, say) could otherwise trip the shared breaker on demand and drop
+    rate limiting to per-process counters, which spreading traffic across replicas outruns.
+    """
+    import redis.exceptions
+
+    from litellm.caching.redis_cache import RedisCircuitBreaker, _run_under_circuit_breaker
+
+    breaker = RedisCircuitBreaker(failure_threshold=3, recovery_timeout=60)
+    raised = getattr(redis.exceptions, error)("boom")
+
+    async def failing_call():
+        raise raised
+
+    for _ in range(breaker.failure_threshold + 1):
+        with pytest.raises(Exception):
+            await _run_under_circuit_breaker(breaker, "op", failing_call)
+
+    assert breaker.is_open() is opens_breaker

--- a/tests/test_litellm/test_redis.py
+++ b/tests/test_litellm/test_redis.py
@@ -737,3 +737,111 @@ def test_connection_pool_env_redis_ssl_false_uses_plain_connection(monkeypatch):
     assert pool is not None
     assert pool.connection_class is async_redis.Connection
     assert "ssl" not in pool.connection_kwargs
+
+
+@pytest.mark.parametrize(
+    "redis_config",
+    [
+        pytest.param({"host": "redis-host", "port": 6379}, id="host_port"),
+        pytest.param({"url": "redis://redis-host:6379"}, id="url"),
+    ],
+)
+def test_connection_pool_keeps_socket_timeout(redis_config, monkeypatch):
+    """The async pool must carry socket_timeout however Redis was configured.
+
+    The url branch used to rebuild pool kwargs from scratch as {timeout, url,
+    max_connections}, dropping socket_timeout. redis-py then leaves both
+    socket_timeout and socket_connect_timeout (which falls back to it) unset, so a
+    Redis host that drops packets rather than refusing them blocks every caller
+    indefinitely instead of failing fast.
+    """
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_HOST", raising=False)
+    monkeypatch.delenv("REDIS_CLUSTER_NODES", raising=False)
+
+    pool = get_redis_connection_pool(socket_timeout=5.0, **redis_config)
+
+    assert pool is not None
+    assert pool.connection_kwargs.get("socket_timeout") == 5.0
+
+
+@pytest.mark.parametrize(
+    "redis_config",
+    [
+        pytest.param({"host": "redis-host", "port": 6379}, id="host_port"),
+        pytest.param({"url": "redis://redis-host:6379"}, id="url"),
+    ],
+)
+def test_sync_client_keeps_socket_timeout(redis_config, monkeypatch):
+    """The sync client is built during RedisCache.__init__ and blocks the caller.
+
+    Without socket_timeout it stalls for the OS TCP timeout against an unreachable
+    host, so merely constructing the cache stops the process.
+    """
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_HOST", raising=False)
+    monkeypatch.delenv("REDIS_CLUSTER_NODES", raising=False)
+
+    client = get_redis_client(socket_timeout=5.0, **redis_config)
+
+    assert client.connection_pool.connection_kwargs.get("socket_timeout") == 5.0
+
+
+@pytest.mark.parametrize(
+    "redis_config",
+    [
+        pytest.param({"host": "redis-host", "port": 6379}, id="host_port"),
+        pytest.param({"url": "redis://redis-host:6379"}, id="url"),
+    ],
+)
+def test_async_client_keeps_socket_timeout(redis_config, monkeypatch):
+    """Same invariant for the async client built without an injected pool."""
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_HOST", raising=False)
+    monkeypatch.delenv("REDIS_CLUSTER_NODES", raising=False)
+
+    client = get_redis_async_client(socket_timeout=5.0, **redis_config)
+
+    assert client.connection_pool.connection_kwargs.get("socket_timeout") == 5.0
+
+
+def test_url_config_does_not_forward_ssl_kwarg(monkeypatch):
+    """ssl stays consumed rather than forwarded on the url path.
+
+    TLS is selected by the rediss:// scheme there; handing ssl=True to a redis://
+    url yields a plain Connection that rejects the kwarg when it first connects.
+    """
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_HOST", raising=False)
+    monkeypatch.delenv("REDIS_CLUSTER_NODES", raising=False)
+
+    client = get_redis_client(url="redis://redis-host:6379", ssl=True)
+
+    assert "ssl" not in client.connection_pool.connection_kwargs
+
+
+@pytest.mark.parametrize(
+    "client_only_kwarg",
+    [
+        pytest.param({"single_connection_client": True}, id="single_connection_client"),
+        pytest.param({"auto_close_connection_pool": True}, id="auto_close_connection_pool"),
+        pytest.param({"ssl_ca_certs": "/tmp/ca.pem"}, id="ssl_ca_certs"),
+        pytest.param({"ssl": True}, id="ssl"),
+    ],
+)
+def test_url_config_drops_kwargs_the_connection_cannot_accept(client_only_kwarg, monkeypatch):
+    """Only kwargs the connection accepts may be forwarded on the url path.
+
+    from_url hands its kwargs down to the connection class, so client-level settings and
+    the SSLConnection-only ssl_* family raise TypeError the first time a connection is
+    created. TLS on a url config comes from the rediss:// scheme instead.
+    """
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("REDIS_HOST", raising=False)
+    monkeypatch.delenv("REDIS_CLUSTER_NODES", raising=False)
+
+    pool = get_redis_connection_pool(url="redis://redis-host:6379", socket_timeout=5.0, **client_only_kwarg)
+
+    assert pool is not None
+    pool.make_connection()
+    assert pool.connection_kwargs.get("socket_timeout") == 5.0


### PR DESCRIPTION
## TLDR

Problem this solves:

- A url-configured Redis silently dropped every connection kwarg
- No socket_timeout, so an unreachable Redis blocked callers forever
- The Redis circuit breaker could never open, so Redis was never dropped
- Result: proxy stayed liveness-healthy while every request hung

How it solves it:

- Allowlist the kwargs the connection actually accepts, not the client's
- Count a swallowed Redis error as a failure, not a success
- Put Lua script execution behind the same circuit breaker

## Relevant issues

## Linear ticket

Resolves LIT-4930

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on a real Postgres, calling the real OpenAI API. Redis is a real server that gets frozen mid-flight with `docker pause`, which is what a server under maintenance looks like from the client's side: the TCP connection stays open and nothing ever replies. Stopping the container instead would be a much weaker test, since a refused connection fails instantly and none of this code is exercised.

Config used for both runs (proxy-level cache and coordination Redis both on a url, which is the shape that was broken):

```yaml
litellm_settings:
  cache: true
  cache_params:
    type: redis
    url: os.environ/LIT4930_REDIS_URL
router_settings:
  redis_url: os.environ/LIT4930_REDIS_URL
```

**Before, at `4d54324515`.** Requests are sent with an rpm-limited key so the coordination path is live. Redis is healthy for the first two, then paused:

```
--- redis HEALTHY (unfixed) ---
  request 1: http=200 total=1.631369s
  request 2: http=200 total=1.149407s
--- redis PAUSED at 12:30:22 ---
  request 1: TIMED OUT after 60s (client gave up; server never answered)
  request 2: TIMED OUT after 60s (client gave up; server never answered)
  request 3: TIMED OUT after 60s (client gave up; server never answered)
```

The proxy never answers again. What makes this hard to catch in production is that it still looks alive:

```
$ curl -s -o /dev/null -w 'http=%{http_code} in %{time_total}s\n' http://127.0.0.1:4930/health/liveliness
http=200 in 0.001210s
```

A load balancer keeps the pod in rotation, and every inference request hangs.

Starting a proxy while Redis is already unreachable was equally fatal, because `RedisCache.__init__` makes a synchronous call with the same missing timeout:

```
$ # unfixed, redis blackholed
t+0s   liveliness=000
...
t+141s liveliness=000        <- never came up
```

**After, at `196ae5ddd6`.** Same config, same script, same paused Redis:

```
--- redis HEALTHY (fixed) ---
  request 1: http=200 total=1.873846s
  request 2: http=200 total=1.488952s
--- redis PAUSED at 14:07:45 ---
  request 1: http=200 total=11.091554s
  request 2: http=200 total=11.020037s
  request 3: http=200 total=1.345299s
  request 4: http=200 total=1.232392s
  request 5: http=200 total=1.275938s
  request 6: http=200 total=1.301726s
  request 7: http=200 total=6.520788s
```

Every request is answered. The first two pay the socket timeout while the failures accumulate, then the breaker opens and latency returns to the healthy baseline of roughly one second with Redis skipped entirely:

```
Redis circuit breaker OPENED after 5 consecutive failures — fast-failing Redis calls for 60s
```

Request 7 is a breaker half-opening after their 60s recovery window and sending a probe through. That is the intended design, and it is why the outage numbers are uneven rather than flat: each cache holds its own breaker, so during a sustained outage most requests are served from memory at roughly a second while an occasional probe pays one timeout to find out whether Redis is back.

Unpausing Redis puts it back in the pool on the next probe, so the degradation is not sticky:

```
--- redis RECOVERED ---
  request 1: http=200 total=1.332444s
  request 2: http=200 total=2.076628s
```

Startup with Redis already unreachable now completes instead of hanging:

```
$ # fixed, redis blackholed
t+25s  liveliness=200
```

The isolated mechanism, measured against a blackholed host (`10.255.255.1`, packets dropped) so the two config styles can be compared directly:

```
BEFORE (4d54324515)                     AFTER (196ae5ddd6)
 host/port  construct 10.02s            host/port  construct 10.03s
            get       5.00s                        get       5.00s
 url        construct >30s BLOCKED      url        construct 10.02s
            (killed after 5 min)                   get       5.00s
```

Note on behaviour during an outage: rate limiting falls back to per-worker in-memory counters, so limits fail open rather than rejecting traffic. That is the existing behaviour of the v3 limiter's fallbacks, not something this PR changes, but it is worth stating explicitly since this PR is what makes that fallback actually reachable. For the same reason only connectivity failures feed the breaker; counting command and data errors would let a caller provoke that fallback on demand.

## Type

🐛 Bug Fix

## Changes

Two independent defects had to line up for a Redis outage to take the proxy down rather than degrade it.

**Connection kwargs were dropped on url configs.** `_get_redis_url_kwargs` built its allowlist from `inspect.getfullargspec(redis.Redis.from_url)`. `from_url` is declared `(cls, url, **kwargs)`, so the argspec carries no connection kwargs at all and the function returned `['cls', 'url', 'url']`. Everything was stripped, `socket_timeout` included, and `socket_connect_timeout` falls back to `socket_timeout`, so both ended up `None` and redis-py blocked until the OS gave up. `get_redis_connection_pool` lost the same kwargs by a different route, rebuilding its pool kwargs from scratch as `{timeout, url, max_connections}`. Host/port configs were unaffected, which is why this survived so long.

The allowlist now comes from the connection class that redis-py ultimately hands those kwargs to, walking the MRO because redis-py splits them between `AbstractConnection` and its subclasses. Taking the client's signature instead would look reasonable and be wrong: it admits client-only settings such as `single_connection_client` and `auto_close_connection_pool`, plus the `ssl_*` family that only `SSLConnection` accepts, and all of those reach `AbstractConnection` and raise `TypeError` on first connect. TLS on a url config comes from the `rediss://` scheme, which selects `SSLConnection` on its own.

**The circuit breaker could not open.** `_redis_circuit_breaker_guard` inferred health from the method returning. But `async_get_cache`, `async_batch_get_cache`, `async_set_cache`, `async_set_cache_pipeline`, `async_set_cache_sadd` and `async_get_ttl` all catch their own connection errors and return a default so callers degrade instead of failing, which is correct behaviour that happens to be indistinguishable from success at the decorator boundary. Every failed call therefore reset the failure streak, the threshold was never reached, and an unreachable Redis stayed in the pool with every request paying a full timeout on it. Measured directly: six consecutive failing calls left `failure_count=0, state=closed`.

Those methods now record the failure, and success is recorded only when nothing failed while the method ran. Separately, Lua execution bypassed the breaker entirely, which mattered most because the v3 rate limiter issues all of its Redis traffic that way; the guard is now a small module-level helper shared by the decorator and the script executor.

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
