### PR TITLE
fix(proxy): preserve custom model_info registrations across model cost map reloads

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -123,7 +123,7 @@ from litellm.types.utils import (
     TokenCountResponse,
 )
 from litellm.utils import (
-    _invalidate_model_cost_lowercase_map,
+    install_model_cost_map,
     load_credentials_from_list,
 )
 
@@ -6461,12 +6461,8 @@ class ProxyConfig:
 
                 model_cost_map_url = litellm.model_cost_map_url
                 new_model_cost_map = get_model_cost_map(url=model_cost_map_url)
-                litellm.model_cost = new_model_cost_map
-                # Invalidate case-insensitive lookup map since model_cost was replaced
-                _invalidate_model_cost_lowercase_map()
-                # Repopulate provider model sets (e.g. litellm.anthropic_models) so that
-                # wildcard patterns like "anthropic/*" include any newly added models.
-                litellm.add_known_models(model_cost_map=new_model_cost_map)
+                fetched_models_count = len(new_model_cost_map) if new_model_cost_map else 0
+                install_model_cost_map(new_model_cost_map=new_model_cost_map)
 
                 # Update pod's in-memory last reload time
                 last_model_cost_map_reload = current_time.isoformat()
@@ -6496,9 +6492,7 @@ class ProxyConfig:
                 )
                 await invalidate_config_param("model_cost_map_reload_config")
 
-                verbose_proxy_logger.info(
-                    f"Model cost map reloaded successfully. Models count: {len(new_model_cost_map) if new_model_cost_map else 0}"
-                )
+                verbose_proxy_logger.info(f"Model cost map reloaded successfully. Models count: {fetched_models_count}")
 
         except Exception as e:
             verbose_proxy_logger.exception(f"Error in _check_and_reload_model_cost_map: {str(e)}")
@@ -15669,12 +15663,8 @@ async def reload_model_cost_map(
 
         model_cost_map_url = litellm.model_cost_map_url
         new_model_cost_map = get_model_cost_map(url=model_cost_map_url)
-        litellm.model_cost = new_model_cost_map
-        # Invalidate case-insensitive lookup map since model_cost was replaced
-        _invalidate_model_cost_lowercase_map()
-        # Repopulate provider model sets (e.g. litellm.anthropic_models) so that
-        # wildcard patterns like "anthropic/*" include any newly added models.
-        litellm.add_known_models(model_cost_map=new_model_cost_map)
+        fetched_models_count = len(new_model_cost_map) if new_model_cost_map else 0
+        install_model_cost_map(new_model_cost_map=new_model_cost_map)
 
         # Update pod's in-memory last reload time
         global last_model_cost_map_reload
@@ -15701,7 +15691,7 @@ async def reload_model_cost_map(
         )
         await invalidate_config_param("model_cost_map_reload_config")
 
-        models_count = len(new_model_cost_map) if new_model_cost_map else 0
+        models_count = fetched_models_count
         verbose_proxy_logger.info(f"Model cost map reloaded successfully in current pod. Models count: {models_count}")
 
         return {

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10223,8 +10223,8 @@ class Router:
                 base_model = _model_info.get("base_model", None)
                 if base_model is None:
                     base_model = _litellm_params.get("base_model", None)
-                model_info = self.get_router_model_info(deployment=deployment, received_model_name=model)
                 _deployment_model = base_model or _litellm_params.get("model", None)
+                model_info = self.get_router_model_info(deployment=deployment, received_model_name=model)
 
                 max_input_tokens = model_info.get("max_input_tokens") if isinstance(model_info, dict) else None
                 if isinstance(max_input_tokens, int) and has_countable_input:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2674,6 +2674,26 @@ def _get_builtin_model_info_for_registration(model: str) -> Optional[ModelInfo]:
     return None
 
 
+_custom_model_cost_registrations: dict[str, dict] = {}  # mutable-ok: registry replayed after cost map reloads
+
+
+def install_model_cost_map(new_model_cost_map: dict) -> None:  # mutable-ok: map becomes litellm.model_cost
+    """
+    Replace ``litellm.model_cost`` with a freshly fetched cost map, then restore
+    every custom entry previously added via ``register_model`` (deployment-level
+    ``model_info`` from the router, user pricing overrides, etc.).
+
+    Without the re-registration step, a cost map reload silently wipes custom
+    model metadata: ``/model_group/info`` loses token limits and pre-call checks
+    fail with "LLM Provider NOT provided" for models not in the built-in map.
+    """
+    litellm.model_cost = new_model_cost_map
+    _invalidate_model_cost_lowercase_map()
+    litellm.add_known_models(model_cost_map=new_model_cost_map)
+    if _custom_model_cost_registrations:
+        register_model(model_cost=dict(_custom_model_cost_registrations))
+
+
 def register_model(model_cost: Union[str, dict]):
     """
     Register new / Override existing models (and their pricing) to specific providers.
@@ -2708,6 +2728,7 @@ def register_model(model_cost: Union[str, dict]):
         ## get model info ##
         provider = value.get("litellm_provider", "")
         _key_str = str(key)
+        _custom_model_cost_registrations[_key_str] = dict(value)
         if provider in _skip_get_model_info_providers or any(
             _key_str.startswith(f"{p}/") for p in _skip_get_model_info_providers
         ):

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -6398,3 +6398,101 @@ def test_model_info_is_active_for_environment_matrix(monkeypatch):
     monkeypatch.delenv("LITELLM_ENVIRONMENT")
     with pytest.raises(ValueError, match="LITELLM_ENVIRONMENT"):
         model_info_is_active_for_environment(model_info={"supported_environments": ["production"]})
+
+
+def test_model_group_info_survives_model_cost_map_reload():
+    """Regression: a model cost map reload (scheduled or via /reload/model_cost_map)
+    replaced litellm.model_cost wholesale, wiping the model_info entries the router
+    registered for custom models at startup. /model_group/info then returned
+    max_input_tokens=None / max_output_tokens=None for those model groups even
+    though the values were set in the config."""
+    import uuid
+
+    from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+    from litellm.utils import (
+        _custom_model_cost_registrations,
+        _invalidate_model_cost_lowercase_map,
+        install_model_cost_map,
+    )
+
+    backend_model = f"dashscope/reload-survival-{uuid.uuid4().hex[:12]}"
+    original_model_cost = litellm.model_cost
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "reload-survival-alias",
+                "litellm_params": {
+                    "model": backend_model,
+                    "api_base": "https://custom-gateway.example.com/v1",
+                    "api_key": "fake-key",
+                },
+                "model_info": {"max_input_tokens": 1048576, "max_output_tokens": 8192},
+            }
+        ],
+    )
+    deployment_id = router.model_list[0]["model_info"]["id"]
+    try:
+        install_model_cost_map(GetModelCostMap.load_local_model_cost_map())
+
+        info = router.get_model_group_info("reload-survival-alias")
+        assert info is not None
+        assert info.max_input_tokens == 1048576
+        assert info.max_output_tokens == 8192
+    finally:
+        for key in (backend_model, deployment_id):
+            _custom_model_cost_registrations.pop(key, None)
+            original_model_cost.pop(key, None)
+        litellm.model_cost = original_model_cost
+        _invalidate_model_cost_lowercase_map()
+
+
+def test_pre_call_checks_do_not_raise_for_unmapped_custom_model():
+    """Regression: with enable_pre_call_checks=True, a deployment whose backend model
+    was missing from litellm.model_cost (e.g. after a cost map reload wiped the
+    router's registrations) made _pre_call_checks resolve the provider from the
+    model group alias, raising BadRequestError('LLM Provider NOT provided') for
+    every request to that alias."""
+    import uuid
+
+    from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+    from litellm.utils import (
+        _custom_model_cost_registrations,
+        _invalidate_model_cost_lowercase_map,
+    )
+
+    backend_model = f"hosted_vllm/precall-unmapped-{uuid.uuid4().hex[:12]}"
+    original_model_cost = litellm.model_cost
+    original_drop_params = litellm.drop_params
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "precall-unmapped-alias",
+                "litellm_params": {
+                    "model": backend_model,
+                    "api_base": "https://my-vllm.example.com/v1",
+                    "api_key": "none",
+                },
+            }
+        ],
+        enable_pre_call_checks=True,
+    )
+    deployment_id = router.model_list[0]["model_info"]["id"]
+    try:
+        litellm.drop_params = False
+        litellm.model_cost = GetModelCostMap.load_local_model_cost_map()
+        _invalidate_model_cost_lowercase_map()
+
+        returned = router._pre_call_checks(
+            model="precall-unmapped-alias",
+            healthy_deployments=list(router.model_list),
+            messages=[{"role": "user", "content": "hello"}],
+            request_kwargs={},
+        )
+        assert len(returned) == 1
+    finally:
+        litellm.drop_params = original_drop_params
+        for key in (backend_model, deployment_id):
+            _custom_model_cost_registrations.pop(key, None)
+            original_model_cost.pop(key, None)
+        litellm.model_cost = original_model_cost
+        _invalidate_model_cost_lowercase_map()

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -5007,3 +5007,46 @@ async def test_builtin_string_callback_registers_when_subclass_already_active(
     )
 
     assert any(type(cb) is S3Logger for cb in litellm._async_success_callback)
+
+
+def test_install_model_cost_map_preserves_custom_registrations():
+    """Regression: the proxy's model cost map reload replaced litellm.model_cost
+    wholesale, discarding every entry added via register_model (router deployment
+    model_info, user pricing overrides). install_model_cost_map must re-apply
+    those registrations on top of the freshly fetched map."""
+    import uuid
+
+    from litellm.litellm_core_utils.get_model_cost_map import GetModelCostMap
+    from litellm.utils import (
+        _custom_model_cost_registrations,
+        _invalidate_model_cost_lowercase_map,
+        install_model_cost_map,
+    )
+
+    test_model = f"dashscope/install-map-test-{uuid.uuid4().hex[:12]}"
+    original_model_cost = litellm.model_cost
+    try:
+        litellm.register_model(
+            {
+                test_model: {
+                    "max_input_tokens": 1048576,
+                    "max_output_tokens": 8192,
+                    "litellm_provider": "dashscope",
+                    "mode": "chat",
+                }
+            }
+        )
+        assert litellm.model_cost[test_model]["max_input_tokens"] == 1048576
+
+        install_model_cost_map(GetModelCostMap.load_local_model_cost_map())
+
+        assert litellm.model_cost[test_model]["max_input_tokens"] == 1048576
+        model_info = litellm.get_model_info(test_model)
+        assert model_info["max_input_tokens"] == 1048576
+        assert model_info["max_output_tokens"] == 8192
+        assert model_info["litellm_provider"] == "dashscope"
+    finally:
+        _custom_model_cost_registrations.pop(test_model, None)
+        original_model_cost.pop(test_model, None)
+        litellm.model_cost = original_model_cost
+        _invalidate_model_cost_lowercase_map()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Model cost map reloads wiped custom model_info registered from config
- /model_group/info then returned null token limits for those models
- With enable_pre_call_checks, alias requests failed with "LLM Provider NOT provided"

How it solves it:

- Record register_model entries and replay them after every cost map reload
- Pre-call checks resolve the provider from the deployment model, not the alias

## Relevant issues

## Linear ticket

Resolves LIT-4675

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs use the customer's config shape: a custom dashscope model that is not in the built-in cost map, `max_input_tokens`/`max_output_tokens` set under `model_info`, `enable_pre_call_checks: true`, and a `model_name: "*"` wildcard entry. `deepseek-v4-pro` is a real model served by dashscope-intl and requests hit the real dashscope API

Before, at commit c56e657097 (proxy on localhost:4010, models load correctly at startup, then one cost map reload wipes them):

```
$ curl -s "http://localhost:4010/model_group/info?model_group=deepseek-v4-pro" -H "Authorization: Bearer sk-1234"
            "model_group": "deepseek-v4-pro",
            "max_input_tokens": 1048576.0,
            "max_output_tokens": 8192.0,

$ curl -s -X POST http://localhost:4010/reload/model_cost_map -H "Authorization: Bearer sk-1234"
{"message":"Price data reloaded successfully! 2983 models updated.","status":"success","models_count":2983,"timestamp":"2026-07-30T21:05:55.987247"}

$ curl -s "http://localhost:4010/model_group/info?model_group=deepseek-v4-pro" -H "Authorization: Bearer sk-1234"
            "model_group": "deepseek-v4-pro",
            "max_input_tokens": null,
            "max_output_tokens": null,
```

This matches what users hit in production whenever a scheduled price data reload is configured: on a fresh pod the first scheduler tick has no previous reload time recorded, so the wipe happens within seconds of startup and the proxy looks permanently broken even right after a restart

After, at commit bcbc17cdec (same config, same sequence):

```
$ curl -s "http://localhost:4010/model_group/info?model_group=deepseek-v4-pro" -H "Authorization: Bearer sk-1234"
deepseek-v4-pro ['dashscope'] 1048576.0 8192.0

$ curl -s -X POST http://localhost:4010/reload/model_cost_map -H "Authorization: Bearer sk-1234"
{"message":"Price data reloaded successfully! 3010 models updated.","status":"success","models_count":3010,"timestamp":"2026-07-30T21:06:25.752482"}

$ curl -s "http://localhost:4010/model_group/info?model_group=deepseek-v4-pro" -H "Authorization: Bearer sk-1234"
deepseek-v4-pro ['dashscope'] 1048576.0 8192.0

$ curl -s "http://localhost:4010/model_group/info?model_group=glm-5.1" -H "Authorization: Bearer sk-1234"
glm-5.1 ['dashscope'] 131072.0 16384.0
```

And a real completion through the alias after the reload, with pre-call checks on (this is the request that previously failed with "LLM Provider NOT provided"):

```
$ curl -s http://localhost:4010/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "deepseek-v4-pro", "messages": [{"role": "user", "content": "Say hi in exactly three words."}]}'
{
    "id": "chatcmpl-5502e58b-035e-980a-8b06-aa1c5631bd9e",
    "model": "deepseek-v4-pro",
    "choices": [{"finish_reason": "stop", "message": {"content": "Hi, how are?", "role": "assistant"}}],
    "usage": {"completion_tokens": 186, "prompt_tokens": 11, "total_tokens": 197}
}
```

## Type

🐛 Bug Fix

## Changes

`Router._create_deployment` registers each deployment's `model_info` into `litellm.model_cost` via `register_model`, under both the deployment id and the shared `{provider}/{model}` key. That registration is what `/model_group/info` and `get_router_model_info` read token limits and provider metadata from for models that are not in the built-in cost map

The proxy's price data reload (`_check_and_reload_model_cost_map`, which runs on the scheduled interval configured in the UI, and the manual `/reload/model_cost_map` endpoint) replaced `litellm.model_cost` wholesale with the freshly fetched map and cleared the model info LRU caches. Every custom registration was silently discarded. `/model_group/info` then reported `max_input_tokens`/`max_output_tokens` as null for those model groups (the Model Hub shows "- / -"), and with `enable_pre_call_checks: true` every request to such an alias failed: `get_router_model_info` raised "model isn't mapped", the per-deployment model variable was left unset, and the invalid-params check then called `get_llm_provider` with the model group alias, raising `BadRequestError: LLM Provider NOT provided`. Since a scheduled reload fires within seconds of pod startup (no previous reload time is recorded in a fresh pod), this looked like a permanent failure that survives restarts. `/v1/models` kept showing the limits because it reads deployment `model_info` directly, which made the symptom especially confusing

Three changes:

1. `register_model` now records every registration in a module-level registry, and the new `litellm.utils.install_model_cost_map` replaces the map, invalidates the caches, repopulates known models, and replays the registry on top of the fresh map. Both proxy reload sites now go through it. Reported model counts are captured from the fetched map before the replay so they keep reflecting upstream price data
2. `Router._pre_call_checks` now derives the per-deployment model name before calling `get_router_model_info`, so a deployment whose backend model is missing from the cost map no longer makes provider resolution fall back to the model group alias and fail the whole request
3. Regression tests for all three: registry replay through `install_model_cost_map`, `get_model_group_info` token limits surviving a reload, and `_pre_call_checks` not raising for an unmapped custom model. Each fails without its fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

