### PR TITLE
docs(pr-template): require e2e proof on all three LLM endpoints when applicable

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,6 +40,7 @@ If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slac
      The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
      For bug fixes: show reproduction before the fix and passing behavior after
      Include the commit hash each proof was captured at, for both the before and the after runs
+     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), include proof for every single one of them, not just one
      For new features: show the feature working end-to-end
      For UI changes: include before/after screenshots -->
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Changes spanning all three LLM endpoints often only get proven on one

How it solves it:

- Proof of Fix now requires proof on responses, chat completions, and messages

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Template-only change with no runtime behavior to prove; the added instruction line is visible in the diff

## Type

📖 Documentation

## Changes

Adds one line to the Screenshots / Proof of Fix comment block in .github/pull_request_template.md instructing authors to include e2e proof for every one of /v1/responses, /v1/chat/completions, and /v1/messages whenever the change applies to all three endpoints, rather than proving just one

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
