### PR TITLE
fix(proxy): honor callback-transformed exceptions on remaining LLM routes

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -9289,10 +9289,20 @@ async def completion(
             _response.choices[0].text = e.message
             return _response
     except Exception as e:
-        await proxy_logging_obj.post_call_failure_hook(
+        transformed_exception = await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
+        # Use transformed exception if callback returned one, otherwise use original
+        if transformed_exception is not None:
+            e = transformed_exception
         verbose_proxy_logger.exception("litellm.proxy.proxy_server.completion(): Exception occured - {}".format(str(e)))
+        if isinstance(e, HTTPException):
+            raise ProxyException(
+                message=getattr(e, "message", str(e.detail)),
+                type=getattr(e, "type", "None"),
+                param=getattr(e, "param", "None"),
+                code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
+            )
         error_msg = f"{str(e)}"
         raise ProxyException(
             message=getattr(e, "message", error_msg),
@@ -9528,15 +9538,18 @@ async def moderations(
 
         return response
     except Exception as e:
-        await proxy_logging_obj.post_call_failure_hook(
+        transformed_exception = await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
+        # Use transformed exception if callback returned one, otherwise use original
+        if transformed_exception is not None:
+            e = transformed_exception
         verbose_proxy_logger.exception(
             "litellm.proxy.proxy_server.moderations(): Exception occured - {}".format(str(e))
         )
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "message", str(e)),
+                message=getattr(e, "message", str(e.detail)),
                 type=getattr(e, "type", "None"),
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
@@ -9674,11 +9687,14 @@ async def audio_speech(
         )
 
     except Exception as e:
-        await proxy_logging_obj.post_call_failure_hook(
+        transformed_exception = await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict,
             original_exception=e,
             request_data=data,
         )
+        # Use transformed exception if callback returned one, otherwise use original
+        if transformed_exception is not None:
+            e = transformed_exception
         verbose_proxy_logger.error("litellm.proxy.proxy_server.audio_speech(): Exception occured - {}".format(str(e)))
         verbose_proxy_logger.debug(traceback.format_exc())
         raise e
@@ -9818,9 +9834,12 @@ async def audio_transcriptions(
 
         return response
     except Exception as e:
-        await proxy_logging_obj.post_call_failure_hook(
+        transformed_exception = await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
+        # Use transformed exception if callback returned one, otherwise use original
+        if transformed_exception is not None:
+            e = transformed_exception
         verbose_proxy_logger.exception(
             "litellm.proxy.proxy_server.audio_transcription(): Exception occured - {}".format(str(e))
         )

--- a/tests/test_litellm/proxy/hooks/test_post_call_failure_hook_integration.py
+++ b/tests/test_litellm/proxy/hooks/test_post_call_failure_hook_integration.py
@@ -147,3 +147,40 @@ async def test_failure_hook_handles_exceptions_gracefully():
         # Should return None (original exception will be used)
         assert result is None
         assert logger.called is True
+
+
+@pytest.mark.asyncio
+async def test_route_surfaces_transformed_exception_to_client():
+    """
+    Test that a proxy route actually sends the transformed error to the client.
+
+    The hook contract is only useful end-to-end: `/chat/completions` honours it via
+    `_handle_llm_api_exception`, but several routes awaited the hook and dropped its
+    return value, so the callback's message never reached the caller.
+    """
+    from fastapi import Response
+
+    from litellm.proxy import proxy_server
+    from litellm.proxy._types import ProxyException
+
+    transformer = ErrorTransformerLogger()
+
+    class FailingRequest:
+        """Blows up on the first thing the route does, landing us in `except`."""
+
+        headers: dict = {}
+
+        async def body(self):
+            raise RuntimeError("technical detail the user should never see")
+
+    with patch("litellm.callbacks", [transformer]):
+        with pytest.raises(ProxyException) as exc_info:
+            await proxy_server.moderations(
+                request=FailingRequest(),  # type: ignore[arg-type]
+                fastapi_response=Response(),
+                user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            )
+
+    assert transformer.called is True
+    assert exc_info.value.message == "User-friendly error: Your request could not be processed."
+    assert exc_info.value.code == "400"


### PR DESCRIPTION
## Title

fix(proxy): honor callback-transformed exceptions on remaining LLM routes

## Relevant issues

None filed — found while building a callback that rewrites proxy error messages for end users.

## Problem

`ProxyLogging.post_call_failure_hook` documents its contract as:

> Callbacks can return or raise HTTPException to transform error responses sent to clients.

`/chat/completions` honors this through `_handle_llm_api_exception`, and so does the auth path in `auth_exception_handler.py`. But several routes `await` the hook and drop its return value:

```python
await proxy_logging_obj.post_call_failure_hook(
    user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
)
```

so on those routes the callback runs, returns its `HTTPException`, and the caller still receives the raw upstream error. The behaviour therefore depends on which endpoint you hit, which is hard to discover — the docstring makes no such distinction.

## Changes

Applies the two-line pattern already used in `common_request_processing.py` and `auth_exception_handler.py`:

```python
transformed_exception = await proxy_logging_obj.post_call_failure_hook(...)
# Use transformed exception if callback returned one, otherwise use original
if transformed_exception is not None:
    e = transformed_exception
```

to `/completions`, `/moderations`, `/audio/speech` and `/audio/transcriptions`.

Two related touch-ups, without which the transformed message still would not arrive intact:

- `/completions` had no `isinstance(e, HTTPException)` branch, unlike its siblings, so the transformed error surfaced as `"400: <detail>"`;
- `/moderations` built that message from `str(e)` instead of `str(e.detail)`, with the same effect.

**Deliberately out of scope:** the `ModifyResponseException` / `RejectedRequestError` branches return successful (guardrail) responses rather than errors; assistants endpoints and the streaming generators shape responses differently and are left for a separate change.

## Testing

Added `test_route_surfaces_transformed_exception_to_client` to the existing `tests/test_litellm/proxy/hooks/test_post_call_failure_hook_integration.py` — it drives a real route and asserts the client-facing `ProxyException` carries the callback's message and status code. The existing tests in that file only covered `ProxyLogging.post_call_failure_hook` itself, which is why the gap went unnoticed.

```
4 passed
```

Verified the test is meaningful: with the `proxy_server.py` change reverted it fails, the raw `RuntimeError` propagating to the caller.

`ruff check` and `ruff format --check` clean on the changed files.

## Type

🐛 Bug Fix

## Checklist

- [x] Scope kept to one problem
- [x] Test added, and confirmed to fail without the fix
- [x] `ruff check` / `ruff format --check` pass on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)