### PR TITLE
fix(tag-management): drop unsupported prisma select kwarg from key lookup

### DIFF
--- a/litellm/proxy/management_endpoints/tag_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tag_management_endpoints.py
@@ -96,7 +96,6 @@ class _VerificationTokenTableClient(Protocol):
     async def find_many(
         self,
         where: Mapping[str, object] | None = None,
-        select: Mapping[str, object] | None = None,
     ) -> "Sequence[PrismaVerificationToken]": ...
 
 
@@ -157,7 +156,6 @@ async def _get_internal_user_api_keys(
 
     key_records = await _table(VerificationTokenRepository(prisma_client)).find_many(
         where={"user_id": user_id},
-        select={"token": True},
     )
     user_api_keys.update(key_record.token for key_record in key_records if getattr(key_record, "token", None))
 

--- a/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
@@ -2,7 +2,8 @@ import inspect
 import json
 import os
 import sys
-from typing import Any, Dict, List, Optional
+from collections.abc import Sequence
+from typing import Optional
 
 import pytest
 from fastapi import HTTPException
@@ -13,7 +14,7 @@ sys.path.insert(
     0, os.path.abspath("../../../..")
 )  # Adds the parent directory to the system path
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import litellm
 from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
@@ -33,11 +34,11 @@ class FakeVerificationTokenTable:
     surfaces as an HTTP 500.
     """
 
-    def __init__(self, records: List[Any]):
-        self._records = records
-        self.calls: List[Dict[str, Any]] = []
+    def __init__(self, records: Sequence[Mock]):
+        self._records = tuple(records)
+        self.calls: list[dict[str, object]] = []
 
-    async def find_many(self, **kwargs: Any) -> List[Any]:
+    async def find_many(self, **kwargs: object) -> tuple[Mock, ...]:
         inspect.signature(LiteLLM_VerificationTokenActions.find_many).bind(
             self, **kwargs
         )

--- a/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tag_management_endpoints.py
@@ -1,11 +1,13 @@
+import inspect
 import json
 import os
 import sys
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
+from prisma.actions import LiteLLM_VerificationTokenActions
 
 sys.path.insert(
     0, os.path.abspath("../../../..")
@@ -19,6 +21,28 @@ from litellm.proxy.proxy_server import app
 from litellm.types.tag_management import TagDeleteRequest, TagInfoRequest, TagNewRequest
 
 client = TestClient(app)
+
+
+class FakeVerificationTokenTable:
+    """Stand-in for ``prisma_client.db.litellm_verificationtoken``.
+
+    ``AsyncMock`` swallows any keyword argument, so a plain mock cannot catch a
+    call that the generated prisma client would reject at runtime. This double
+    binds every call against the real ``find_many`` signature, so passing an
+    unsupported kwarg (e.g. ``select``) raises the same ``TypeError`` the proxy
+    surfaces as an HTTP 500.
+    """
+
+    def __init__(self, records: List[Any]):
+        self._records = records
+        self.calls: List[Dict[str, Any]] = []
+
+    async def find_many(self, **kwargs: Any) -> List[Any]:
+        inspect.signature(LiteLLM_VerificationTokenActions.find_many).bind(
+            self, **kwargs
+        )
+        self.calls.append(kwargs)
+        return self._records
 
 
 @pytest.mark.asyncio
@@ -380,6 +404,7 @@ async def test_list_tags_no_dynamic_tags():
         app.dependency_overrides.clear()
 
 
+@pytest.mark.asyncio
 async def test_internal_user_list_tags_only_returns_tags_used_by_their_keys():
     """
     Internal users can view tag usage, but the tag list must be scoped to tags
@@ -404,9 +429,8 @@ async def test_internal_user_list_tags_only_returns_tags_used_by_their_keys():
 
             owned_key_record = Mock()
             owned_key_record.token = "owned-key"
-            mock_db.litellm_verificationtoken.find_many = AsyncMock(
-                return_value=[owned_key_record]
-            )
+            fake_token_table = FakeVerificationTokenTable([owned_key_record])
+            mock_db.litellm_verificationtoken = fake_token_table
 
             mock_db.litellm_dailytagspend.group_by = AsyncMock(
                 return_value=[
@@ -446,10 +470,9 @@ async def test_internal_user_list_tags_only_returns_tags_used_by_their_keys():
                 "stored-owned-tag",
                 "dynamic-owned-tag",
             ]
-            mock_db.litellm_verificationtoken.find_many.assert_awaited_once_with(
-                where={"user_id": "internal-user-123"},
-                select={"token": True},
-            )
+            assert fake_token_table.calls == [
+                {"where": {"user_id": "internal-user-123"}}
+            ]
             mock_db.litellm_dailytagspend.group_by.assert_awaited_once_with(
                 by=["tag"],
                 where={
@@ -464,6 +487,54 @@ async def test_internal_user_list_tags_only_returns_tags_used_by_their_keys():
                 include={"litellm_budget_table": True},
             )
 
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_internal_user_list_tags_does_not_500_on_unsupported_prisma_kwarg():
+    """
+    Regression: /tag/list returned 500 for every internal user because the
+    non-admin branch looked up the caller's keys with
+    ``find_many(select={"token": True})``, and the generated prisma client has no
+    ``select`` kwarg. This reproduces the reported case exactly: a freshly created
+    internal user with no tag spend yet, which must get an empty 200 rather than
+    "LiteLLM_VerificationTokenActions.find_many() got an unexpected keyword
+    argument 'select'".
+    """
+    from unittest.mock import AsyncMock, Mock
+
+    from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+
+    mock_user_auth = UserAPIKeyAuth(
+        api_key="new-user-key",
+        user_id="brand-new-internal-user",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+    app.dependency_overrides[user_api_key_auth] = lambda: mock_user_auth
+
+    try:
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_db = Mock()
+            mock_prisma.db = mock_db
+
+            key_record = Mock()
+            key_record.token = "new-user-key"
+            fake_token_table = FakeVerificationTokenTable([key_record])
+            mock_db.litellm_verificationtoken = fake_token_table
+
+            mock_db.litellm_dailytagspend.group_by = AsyncMock(return_value=[])
+            mock_db.litellm_tagtable.find_many = AsyncMock(return_value=[])
+
+            response = client.get(
+                "/tag/list", headers={"Authorization": "Bearer new-user-key"}
+            )
+
+            assert response.status_code == 200, response.text
+            assert response.json() == []
+            assert fake_token_table.calls == [
+                {"where": {"user_id": "brand-new-internal-user"}}
+            ]
     finally:
         app.dependency_overrides.clear()
 
@@ -537,9 +608,8 @@ async def test_internal_user_tag_daily_activity_is_scoped_to_their_keys():
 
         owned_key_record = Mock()
         owned_key_record.token = "owned-key"
-        mock_db.litellm_verificationtoken.find_many = AsyncMock(
-            return_value=[owned_key_record]
-        )
+        fake_token_table = FakeVerificationTokenTable([owned_key_record])
+        mock_db.litellm_verificationtoken = fake_token_table
         mock_get_daily_activity.return_value = "daily-activity-response"
 
         result = await get_tag_daily_activity(
@@ -549,6 +619,7 @@ async def test_internal_user_tag_daily_activity_is_scoped_to_their_keys():
         )
 
         assert result == "daily-activity-response"
+        assert fake_token_table.calls == [{"where": {"user_id": "internal-user-123"}}]
         mock_get_daily_activity.assert_awaited_once()
         assert mock_get_daily_activity.await_args.kwargs["api_key"] == ["owned-key"]
 
@@ -583,9 +654,8 @@ async def test_internal_user_tag_daily_activity_rejects_unowned_api_key_filter()
 
         owned_key_record = Mock()
         owned_key_record.token = "owned-key"
-        mock_db.litellm_verificationtoken.find_many = AsyncMock(
-            return_value=[owned_key_record]
-        )
+        fake_token_table = FakeVerificationTokenTable([owned_key_record])
+        mock_db.litellm_verificationtoken = fake_token_table
         result = await get_tag_daily_activity(
             start_date="2025-01-01",
             end_date="2025-01-31",
@@ -593,6 +663,7 @@ async def test_internal_user_tag_daily_activity_rejects_unowned_api_key_filter()
             user_api_key_dict=mock_user_auth,
         )
 
+        assert fake_token_table.calls == [{"where": {"user_id": "internal-user-123"}}]
         assert result.results == []
         assert result.metadata.total_spend == 0
         assert result.metadata.total_api_requests == 0
@@ -626,7 +697,8 @@ async def test_internal_user_tag_daily_activity_scopes_to_current_key_without_us
     ):
         mock_db = Mock()
         mock_prisma.db = mock_db
-        mock_db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
+        fake_token_table = FakeVerificationTokenTable([])
+        mock_db.litellm_verificationtoken = fake_token_table
         mock_get_daily_activity.return_value = "daily-activity-response"
 
         result = await get_tag_daily_activity(
@@ -636,7 +708,7 @@ async def test_internal_user_tag_daily_activity_scopes_to_current_key_without_us
         )
 
         assert result == "daily-activity-response"
-        mock_db.litellm_verificationtoken.find_many.assert_not_awaited()
+        assert fake_token_table.calls == []
         mock_get_daily_activity.assert_awaited_once()
         assert mock_get_daily_activity.await_args.kwargs["api_key"] == [
             "current-owned-key"
@@ -669,7 +741,8 @@ async def test_internal_user_tag_daily_activity_without_any_scoped_keys_returns_
     ):
         mock_db = Mock()
         mock_prisma.db = mock_db
-        mock_db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
+        fake_token_table = FakeVerificationTokenTable([])
+        mock_db.litellm_verificationtoken = fake_token_table
 
         result = await get_tag_daily_activity(
             start_date="2025-01-01",
@@ -680,7 +753,7 @@ async def test_internal_user_tag_daily_activity_without_any_scoped_keys_returns_
         assert result.results == []
         assert result.metadata.total_spend == 0
         assert result.metadata.total_api_requests == 0
-        mock_db.litellm_verificationtoken.find_many.assert_not_awaited()
+        assert fake_token_table.calls == []
         mock_get_daily_activity.assert_not_awaited()
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/tag/list` returned 500 for every internal user
- Admin UI Tags page broken for all non-admins
- `/tag/daily/activity` failed the same way
- Prisma client has no `select` kwarg

How it solves it:

- Drop `select` from the key lookup
- Drop it from the table Protocol too
- Test double now binds the real signature

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Same live proxy and same internal-user key throughout; only the commit changes between the before and after runs

Setup, run once as proxy admin:

```bash
curl -s -X POST localhost:4001/user/new -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"user_role":"internal_user","max_budget":1000.0}'
```

```bash
curl -s -X POST localhost:4001/key/generate -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" -d '{"user_id":"cc1249bc-e1e3-4cf9-9ef1-54f12f4256bf"}'
```

### Before, at abb0e36ca5

```bash
curl -s -w "\nHTTP %{http_code}\n" localhost:4001/tag/list -H "Authorization: Bearer $INTERNAL_USER_KEY"
```

```
{"detail":"LiteLLM_VerificationTokenActions.find_many() got an unexpected keyword argument 'select'"}
HTTP 500
```

### After, at 35592323e2

Real spend first, so the list has something in it. Both calls hit live provider APIs and cost real money:

```bash
curl -s localhost:4001/v1/chat/completions -H "Authorization: Bearer $INTERNAL_USER_KEY" -H "Content-Type: application/json" -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"say hi in 3 words"}],"metadata":{"tags":["lit-tag-list-repro"]}}'
```

```
{"id":"chatcmpl-E7U9EsjEQZwYL4BWtHT1BXD9FTW6N","created":1785452892,"model":"gpt-4o-mini","object":"chat.completion","system_fingerprint":"fp_e7eb9f2bc2","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hello there, friend!","role":"assistant"}}]}
```

```bash
curl -s localhost:4001/v1/chat/completions -H "Authorization: Bearer $INTERNAL_USER_KEY" -H "Content-Type: application/json" -d '{"model":"claude-haiku-4-5","messages":[{"role":"user","content":"say hi in 3 words"}],"metadata":{"tags":["lit-tag-list-repro"]}}'
```

```
{"id":"chatcmpl-418bf530-750e-401f-b95d-079efdf6350f","created":1785452894,"model":"claude-haiku-4-5","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Hey, what's up!","role":"assistant"}}]}
```

Then the same request that used to 500:

```bash
curl -s -w "\nHTTP %{http_code}\n" localhost:4001/tag/list -H "Authorization: Bearer $INTERNAL_USER_KEY"
```

```
[{"name":"lit-tag-list-repro","description":"This is just a spend tag that was passed dynamically in a request. It does not control any LLM models.","models":null,"created_at":"2026-07-30T23:08:10.737Z","updated_at":"2026-07-30T23:08:10.737Z"}]
HTTP 200
```

`/tag/daily/activity` shares the same helper and was failing identically:

```bash
curl -s -w "\nHTTP %{http_code}\n" "localhost:4001/tag/daily/activity?start_date=2026-07-01&end_date=2026-07-30" -H "Authorization: Bearer $INTERNAL_USER_KEY"
```

```
{"results":[],"metadata":{"total_spend":0.0,"total_prompt_tokens":0,"total_completion_tokens":0,"total_tokens":0,"total_api_requests":0,"total_successful_requests":0,"total_failed_requests":0,"page":1,"total_pages":0,"has_more":false}}
HTTP 200
```

Scoping is unchanged, which is the part worth checking on a fix that touches an access-control path. The internal user still sees only their own tag while the admin sees every tag on the proxy:

```bash
curl -s localhost:4001/tag/list -H "Authorization: Bearer $LITELLM_MASTER_KEY" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))"
```

```
63
```

```bash
curl -s localhost:4001/tag/list -H "Authorization: Bearer $INTERNAL_USER_KEY" | python3 -c "import sys,json; print([t['name'] for t in json.load(sys.stdin)])"
```

```
['lit-tag-list-repro']
```

## Type

🐛 Bug Fix

## Changes

The non-admin branch of `/tag/list` scopes the response to tags produced by keys the caller owns, and it resolved that key set with `find_many(where=..., select={"token": True})`. prisma-client-py 0.11.0 accepts `take`, `skip`, `where`, `cursor`, `include`, `order` and `distinct` on `find_many`; there is no `select`. The call raised `TypeError`, the handler's blanket `except Exception` reraised it as a 500, and since the Admin UI calls `/tag/list` on load, the Tags page was broken for every non-admin user. `/tag/daily/activity` resolves the caller's keys through the same helper and was failing the same way. Present since #27315

The kwarg is dropped rather than translated. The generated client exposes no projection API at all, so there is nothing to map it onto, and a single user's key set is small enough that reading all columns is not worth working around. `select` also came off `_VerificationTokenTableClient`, the hand-rolled Protocol standing in for the prisma table, which had been advertising a parameter the real client does not have and was the reason basedpyright saw nothing wrong

No behavior changes beyond the 500. Which roles may call the endpoint, and how the response is scoped for each, are exactly as before

Worth a moment in review: the existing test asserted the call was made **with** `select={"token": True}`, against an `AsyncMock`, which accepts any keyword. That is why this shipped green and stayed green for two and a half months. The fix for that is in the test double rather than in another assertion. `FakeVerificationTokenTable.find_many` binds every call against `inspect.signature(LiteLLM_VerificationTokenActions.find_many)`, so an unsupported kwarg raises the same `TypeError` production raises. It derives from the installed client, so it cannot drift back into agreeing with a call the client would reject

Reverting the two source lines fails four tests in that file with the exact production message; restoring them passes all 25

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
