### PR TITLE
fix(proxy): request stream usage upstream by default and strip it from client streams

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -258,7 +258,7 @@ def _litellm_model_supports_stream_options(litellm_model: str) -> bool:
     return supported_params is not None and "stream_options" in supported_params
 
 
-def _deployment_litellm_model(deployment: Mapping[str, object]) -> Optional[str]:
+def _deployment_litellm_model(deployment: Mapping[str, object]) -> str | None:
     litellm_params = deployment.get("litellm_params")
     if isinstance(litellm_params, Mapping):
         litellm_model = litellm_params.get("model")
@@ -269,11 +269,12 @@ def _deployment_litellm_model(deployment: Mapping[str, object]) -> Optional[str]
 
 def _model_deployments_support_stream_options(
     model: object,
-    llm_router: Optional[Router],
+    llm_router: Router | None,
+    team_id: str | None,
 ) -> bool:
     if not isinstance(model, str):
         return False
-    deployments = llm_router.get_model_list(model_name=model) if llm_router is not None else None
+    deployments = llm_router.get_model_list(model_name=model, team_id=team_id) if llm_router is not None else None
     deployment_models = tuple(
         litellm_model
         for deployment in deployments or ()
@@ -1309,6 +1310,7 @@ class ProxyBaseLLMRequestProcessing:
                 supports_stream_options=lambda: _model_deployments_support_stream_options(
                     model=self.data.get("model"),
                     llm_router=llm_router,
+                    team_id=user_api_key_dict.team_id,
                 ),
             )
         )

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -5,6 +5,7 @@ import math
 import time
 import traceback
 from datetime import datetime
+from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -39,6 +40,9 @@ from litellm.constants import (
 )
 from litellm.integrations.custom_guardrail import CustomGuardrail
 from litellm.litellm_core_utils.dd_tracing import NullTracer, tracer
+from litellm.litellm_core_utils.get_supported_openai_params import (
+    get_supported_openai_params,
+)
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.litellm_core_utils.llm_response_utils.get_headers import (
     get_response_headers,
@@ -245,25 +249,64 @@ async def _cancel_pending_gather_tasks(tasks: list["asyncio.Task[Any]"]) -> None
             pass
 
 
+@lru_cache(maxsize=512)
+def _litellm_model_supports_stream_options(litellm_model: str) -> bool:
+    try:
+        supported_params = get_supported_openai_params(model=litellm_model)
+    except Exception:  # noqa: BLE001  # unmapped or malformed model strings must disable injection, not fail the request
+        return False
+    return supported_params is not None and "stream_options" in supported_params
+
+
+def _deployment_litellm_model(deployment: Mapping[str, object]) -> Optional[str]:
+    litellm_params = deployment.get("litellm_params")
+    if isinstance(litellm_params, Mapping):
+        litellm_model = litellm_params.get("model")
+    else:
+        litellm_model = getattr(litellm_params, "model", None)
+    return litellm_model if isinstance(litellm_model, str) else None
+
+
+def _model_deployments_support_stream_options(
+    model: object,
+    llm_router: Optional[Router],
+) -> bool:
+    if not isinstance(model, str):
+        return False
+    deployments = llm_router.get_model_list(model_name=model) if llm_router is not None else None
+    deployment_models = tuple(
+        litellm_model
+        for deployment in deployments or ()
+        for litellm_model in (_deployment_litellm_model(deployment),)
+        if litellm_model is not None
+    )
+    candidate_models = deployment_models if deployment_models else (model,)
+    return all(_litellm_model_supports_stream_options(m) for m in candidate_models)
+
+
 def _stream_usage_tracking_updates(
     data: Mapping[str, object],
     general_settings: Mapping[str, object],
     route_type: str,
+    supports_stream_options: Callable[[], bool],
 ) -> Mapping[str, object]:
+    scrub = {"_litellm_strip_stream_usage": False} if "_litellm_strip_stream_usage" in data else {}
     if data.get("stream", False) is not True:
-        return {}
+        return scrub
     always_include = general_settings.get("always_include_stream_usage")
     stream_options = data.get("stream_options")
     if always_include is True:
         if "stream_options" not in data:
-            return {"stream_options": {"include_usage": True}}
+            return {**scrub, "stream_options": {"include_usage": True}}
         if isinstance(stream_options, dict) and "include_usage" not in stream_options:
-            return {"stream_options": {**stream_options, "include_usage": True}}
-        return {}
+            return {**scrub, "stream_options": {**stream_options, "include_usage": True}}
+        return scrub
     if always_include is False or route_type != "acompletion":
-        return {}
+        return scrub
     if isinstance(stream_options, dict) and stream_options.get("include_usage") is True:
-        return {}
+        return scrub
+    if not supports_stream_options():
+        return scrub
     merged_stream_options = {**stream_options} if isinstance(stream_options, dict) else {}
     return {
         "stream_options": {**merged_stream_options, "include_usage": True},
@@ -1264,6 +1307,10 @@ class ProxyBaseLLMRequestProcessing:
                 data=self.data,
                 general_settings=general_settings,
                 route_type=route_type,
+                supports_stream_options=lambda: _model_deployments_support_stream_options(
+                    model=self.data.get("model"),
+                    llm_router=llm_router,
+                ),
             )
         )
         ### CALL HOOKS ### - modify/reject incoming data before calling the model

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -12,6 +12,7 @@ from typing import (
     Callable,
     Dict,
     Literal,
+    Mapping,
     Optional,
     Tuple,
     Union,
@@ -242,6 +243,32 @@ async def _cancel_pending_gather_tasks(tasks: list["asyncio.Task[Any]"]) -> None
             await task
         except (asyncio.CancelledError, Exception):  # noqa: BLE001
             pass
+
+
+def _stream_usage_tracking_updates(
+    data: Mapping[str, object],
+    general_settings: Mapping[str, object],
+    route_type: str,
+) -> Mapping[str, object]:
+    if data.get("stream", False) is not True:
+        return {}
+    always_include = general_settings.get("always_include_stream_usage")
+    stream_options = data.get("stream_options")
+    if always_include is True:
+        if "stream_options" not in data:
+            return {"stream_options": {"include_usage": True}}
+        if isinstance(stream_options, dict) and "include_usage" not in stream_options:
+            return {"stream_options": {**stream_options, "include_usage": True}}
+        return {}
+    if always_include is False or route_type != "acompletion":
+        return {}
+    if isinstance(stream_options, dict) and stream_options.get("include_usage") is True:
+        return {}
+    merged_stream_options = {**stream_options} if isinstance(stream_options, dict) else {}
+    return {
+        "stream_options": {**merged_stream_options, "include_usage": True},
+        "_litellm_strip_stream_usage": True,
+    }
 
 
 def _serialize_http_exception_detail(
@@ -1232,17 +1259,13 @@ class ProxyBaseLLMRequestProcessing:
         )
 
         ### AUTO STREAM USAGE TRACKING ###
-        # If always_include_stream_usage is enabled and this is a streaming request
-        # automatically add stream_options={'include_usage': True} if not already set
-        if (
-            general_settings.get("always_include_stream_usage", False) is True
-            and self.data.get("stream", False) is True
-        ):
-            # Only set if stream_options is not already provided by the client
-            if "stream_options" not in self.data:
-                self.data["stream_options"] = {"include_usage": True}
-            elif isinstance(self.data["stream_options"], dict) and "include_usage" not in self.data["stream_options"]:
-                self.data["stream_options"]["include_usage"] = True
+        self.data.update(
+            _stream_usage_tracking_updates(
+                data=self.data,
+                general_settings=general_settings,
+                route_type=route_type,
+            )
+        )
         ### CALL HOOKS ### - modify/reject incoming data before calling the model
 
         ## LOGGING OBJECT ## - initialize logging object for logging success/failure events for call

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -277,8 +277,7 @@ def _model_deployments_support_stream_options(
     deployment_models = tuple(
         litellm_model
         for deployment in deployments or ()
-        for litellm_model in (_deployment_litellm_model(deployment),)
-        if litellm_model is not None
+        if (litellm_model := _deployment_litellm_model(deployment)) is not None
     )
     candidate_models = deployment_models if deployment_models else (model,)
     return all(_litellm_model_supports_stream_options(m) for m in candidate_models)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -13500,6 +13500,7 @@ async def async_queue_request(
     data = {}
     try:
         data = await request.json()  # type: ignore
+        data.pop("_litellm_strip_stream_usage", None)
 
         # Include original request and headers in the data
         data["proxy_server_request"] = {

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -119,6 +119,7 @@ from litellm.router_utils.add_retry_fallback_headers import (
 from litellm.types.utils import (
     ModelResponse,
     ModelResponseStream,
+    StreamingChoices,
     TextCompletionResponse,
     TokenCountResponse,
 )
@@ -7368,6 +7369,25 @@ def _serialize_streaming_chunk(chunk: BaseModel) -> Union[str, bytes]:
     return chunk.model_dump_json(exclude_none=True, exclude_unset=True)
 
 
+def _is_injected_stream_usage_artifact(chunk: object) -> bool:
+    if not isinstance(chunk, ModelResponseStream):
+        return False
+    if chunk.provider_specific_fields is not None:
+        return False
+    return all(_is_empty_streaming_choice(choice) for choice in chunk.choices or [])
+
+
+def _is_empty_streaming_choice(choice: StreamingChoices) -> bool:
+    if choice.finish_reason is not None:
+        return False
+    if getattr(choice, "logprobs", None) is not None:
+        return False
+    delta = getattr(choice, "delta", None)
+    if delta is None:
+        return True
+    return all(value is None for value in delta.model_dump().values())
+
+
 async def _apply_streaming_chunk_hooks(
     *,
     chunk: Any,
@@ -7447,6 +7467,7 @@ async def async_data_generator(
         needs_iterator_wrap = proxy_logging_obj.needs_iterator_wrap()
         needs_per_chunk_hook = proxy_logging_obj.needs_per_chunk_streaming_hook()
         is_raw_sse_stream = bool(request_data.get("_litellm_raw_sse_stream"))
+        strip_stream_usage = bool(request_data.get("_litellm_strip_stream_usage"))
         raw_sse_buffer = ""
 
         if needs_iterator_wrap:
@@ -7497,6 +7518,15 @@ async def async_data_generator(
                 fallback_was_attempted=fallback_was_attempted,
                 fallback_model_from_metadata=fallback_model_from_metadata,
             )
+
+            if strip_stream_usage and _is_injected_stream_usage_artifact(chunk):
+                if pending_fallback_event:
+                    yield _format_fallback_metadata_sse_event(
+                        fallback_model=fallback_model_from_metadata,
+                        fallback_errors=fallback_errors,
+                    )
+                    fallback_metadata_event_sent = True
+                continue
 
             raw_passthrough = False
             if isinstance(chunk, BaseModel):

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3296,6 +3296,7 @@ all_litellm_params = (
         "model_file_id_mapping",
         "litellm_logging_obj",
         "litellm_call_id",
+        "_litellm_strip_stream_usage",
         "use_client",
         "id",
         "fallbacks",

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1,7 +1,7 @@
 import asyncio
 import copy
 import datetime
-from typing import AsyncGenerator, Optional
+from typing import AsyncGenerator, Callable, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -5113,10 +5113,22 @@ class TestStreamingClientDisconnectBilling:
         proxy_logging_obj._arelease_max_parallel_requests_on_disconnect.assert_awaited_once()
 
 
-def _apply_stream_usage_tracking(data: dict, general_settings: dict, route_type: str) -> None:
+def _apply_stream_usage_tracking(
+    data: dict,
+    general_settings: dict,
+    route_type: str,
+    supports_stream_options: Callable[[], bool] = lambda: True,
+) -> None:
     from litellm.proxy.common_request_processing import _stream_usage_tracking_updates
 
-    data.update(_stream_usage_tracking_updates(data=data, general_settings=general_settings, route_type=route_type))
+    data.update(
+        _stream_usage_tracking_updates(
+            data=data,
+            general_settings=general_settings,
+            route_type=route_type,
+            supports_stream_options=supports_stream_options,
+        )
+    )
 
 
 class TestApplyStreamUsageTracking:
@@ -5203,3 +5215,125 @@ class TestApplyStreamUsageTracking:
 
         assert "stream_options" not in data
         assert "_litellm_strip_stream_usage" not in data
+
+    def test_default_skips_injection_when_provider_lacks_stream_options_support(self):
+        data = {"stream": True, "model": "bytez-model"}
+
+        _apply_stream_usage_tracking(
+            data=data,
+            general_settings={},
+            route_type="acompletion",
+            supports_stream_options=lambda: False,
+        )
+
+        assert "stream_options" not in data
+        assert "_litellm_strip_stream_usage" not in data
+
+    def test_client_supplied_strip_marker_is_neutralized(self):
+        data = {
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "_litellm_strip_stream_usage": True,
+        }
+
+        _apply_stream_usage_tracking(data=data, general_settings={}, route_type="acompletion")
+
+        assert data["_litellm_strip_stream_usage"] is False
+        assert data["stream_options"] == {"include_usage": True}
+
+    def test_client_supplied_strip_marker_is_neutralized_with_flag_true(self):
+        data = {
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "_litellm_strip_stream_usage": True,
+        }
+
+        _apply_stream_usage_tracking(
+            data=data,
+            general_settings={"always_include_stream_usage": True},
+            route_type="acompletion",
+        )
+
+        assert data["_litellm_strip_stream_usage"] is False
+
+    def test_client_supplied_strip_marker_is_neutralized_on_non_streaming_request(self):
+        data = {"_litellm_strip_stream_usage": True}
+
+        _apply_stream_usage_tracking(data=data, general_settings={}, route_type="acompletion")
+
+        assert data["_litellm_strip_stream_usage"] is False
+
+
+class TestModelDeploymentsSupportStreamOptions:
+    def _support(self, model, llm_router=None) -> bool:
+        from litellm.proxy.common_request_processing import (
+            _model_deployments_support_stream_options,
+        )
+
+        return _model_deployments_support_stream_options(model=model, llm_router=llm_router)
+
+    def test_openai_compatible_deployment_supports_stream_options(self):
+        router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "azure-nano",
+                    "litellm_params": {
+                        "model": "azure/gpt-5.4-nano",
+                        "api_key": "fake",
+                        "api_base": "https://example.openai.azure.com",
+                    },
+                }
+            ]
+        )
+
+        assert self._support("azure-nano", router) is True
+
+    def test_deployment_on_provider_rejecting_stream_options_is_not_injected(self):
+        router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "tiny",
+                    "litellm_params": {"model": "bytez/openai-community/gpt2", "api_key": "fake"},
+                }
+            ]
+        )
+
+        assert self._support("tiny", router) is False
+
+    def test_mixed_provider_model_group_is_not_injected(self):
+        router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "mixed",
+                    "litellm_params": {"model": "openai/gpt-4o", "api_key": "fake"},
+                },
+                {
+                    "model_name": "mixed",
+                    "litellm_params": {"model": "oci/cohere.command-r-plus", "api_key": "fake"},
+                },
+            ]
+        )
+
+        assert self._support("mixed", router) is False
+
+    def test_wildcard_route_resolves_provider_support(self):
+        router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "openai/*",
+                    "litellm_params": {"model": "openai/*", "api_key": "fake"},
+                }
+            ]
+        )
+
+        assert self._support("openai/gpt-4o", router) is True
+
+    def test_provider_prefixed_model_without_router_is_resolved_directly(self):
+        assert self._support("openai/gpt-4o", None) is True
+        assert self._support("bytez/openai-community/gpt2", None) is False
+
+    def test_unmapped_model_name_is_not_injected(self):
+        assert self._support("some-unmapped-public-alias", None) is False
+
+    def test_non_string_model_is_not_injected(self):
+        assert self._support(None, None) is False

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5111,3 +5111,95 @@ class TestStreamingClientDisconnectBilling:
         )
 
         proxy_logging_obj._arelease_max_parallel_requests_on_disconnect.assert_awaited_once()
+
+
+def _apply_stream_usage_tracking(data: dict, general_settings: dict, route_type: str) -> None:
+    from litellm.proxy.common_request_processing import _stream_usage_tracking_updates
+
+    data.update(_stream_usage_tracking_updates(data=data, general_settings=general_settings, route_type=route_type))
+
+
+class TestApplyStreamUsageTracking:
+    def test_default_injects_usage_and_marks_strip_for_chat_completions(self):
+        data = {"stream": True, "model": "gpt-5.4-nano"}
+
+        _apply_stream_usage_tracking(data=data, general_settings={}, route_type="acompletion")
+
+        assert data["stream_options"] == {"include_usage": True}
+        assert data["_litellm_strip_stream_usage"] is True
+
+    def test_default_preserves_other_client_stream_options_keys(self):
+        data = {"stream": True, "stream_options": {"include_obfuscation": True}}
+
+        _apply_stream_usage_tracking(data=data, general_settings={}, route_type="acompletion")
+
+        assert data["stream_options"] == {"include_obfuscation": True, "include_usage": True}
+        assert data["_litellm_strip_stream_usage"] is True
+
+    def test_client_requested_usage_is_left_untouched_and_not_stripped(self):
+        data = {"stream": True, "stream_options": {"include_usage": True}}
+
+        _apply_stream_usage_tracking(data=data, general_settings={}, route_type="acompletion")
+
+        assert data["stream_options"] == {"include_usage": True}
+        assert "_litellm_strip_stream_usage" not in data
+
+    def test_client_include_usage_false_is_overridden_and_stripped(self):
+        data = {"stream": True, "stream_options": {"include_usage": False}}
+
+        _apply_stream_usage_tracking(data=data, general_settings={}, route_type="acompletion")
+
+        assert data["stream_options"]["include_usage"] is True
+        assert data["_litellm_strip_stream_usage"] is True
+
+    def test_explicit_false_flag_disables_injection_entirely(self):
+        data = {"stream": True}
+
+        _apply_stream_usage_tracking(
+            data=data,
+            general_settings={"always_include_stream_usage": False},
+            route_type="acompletion",
+        )
+
+        assert "stream_options" not in data
+        assert "_litellm_strip_stream_usage" not in data
+
+    def test_flag_true_injects_without_strip_marker(self):
+        data = {"stream": True}
+
+        _apply_stream_usage_tracking(
+            data=data,
+            general_settings={"always_include_stream_usage": True},
+            route_type="acompletion",
+        )
+
+        assert data["stream_options"] == {"include_usage": True}
+        assert "_litellm_strip_stream_usage" not in data
+
+    def test_flag_true_respects_client_explicit_include_usage_false(self):
+        data = {"stream": True, "stream_options": {"include_usage": False}}
+
+        _apply_stream_usage_tracking(
+            data=data,
+            general_settings={"always_include_stream_usage": True},
+            route_type="acompletion",
+        )
+
+        assert data["stream_options"] == {"include_usage": False}
+        assert "_litellm_strip_stream_usage" not in data
+
+    def test_default_does_not_touch_non_chat_completion_routes(self):
+        data = {"stream": True}
+
+        _apply_stream_usage_tracking(data=data, general_settings={}, route_type="anthropic_messages")
+
+        assert "stream_options" not in data
+        assert "_litellm_strip_stream_usage" not in data
+
+    def test_non_streaming_request_is_untouched(self):
+        data = {"model": "gpt-5.4-nano"}
+
+        _apply_stream_usage_tracking(data=data, general_settings={}, route_type="acompletion")
+
+        assert "stream_options" not in data
+        assert "_litellm_strip_stream_usage" not in data

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -5265,12 +5265,12 @@ class TestApplyStreamUsageTracking:
 
 
 class TestModelDeploymentsSupportStreamOptions:
-    def _support(self, model, llm_router=None) -> bool:
+    def _support(self, model, llm_router=None, team_id=None) -> bool:
         from litellm.proxy.common_request_processing import (
             _model_deployments_support_stream_options,
         )
 
-        return _model_deployments_support_stream_options(model=model, llm_router=llm_router)
+        return _model_deployments_support_stream_options(model=model, llm_router=llm_router, team_id=team_id)
 
     def test_openai_compatible_deployment_supports_stream_options(self):
         router = litellm.Router(
@@ -5334,6 +5334,23 @@ class TestModelDeploymentsSupportStreamOptions:
 
     def test_unmapped_model_name_is_not_injected(self):
         assert self._support("some-unmapped-public-alias", None) is False
+
+    def test_team_alias_model_resolves_with_team_id(self):
+        router = litellm.Router(
+            model_list=[
+                {
+                    "model_name": "model_name_team-1_8b6a0b3f",
+                    "litellm_params": {"model": "azure/gpt-5.4-nano", "api_key": "fake"},
+                    "model_info": {
+                        "team_id": "team-1",
+                        "team_public_model_name": "team-gpt",
+                    },
+                }
+            ]
+        )
+
+        assert self._support("team-gpt", router, team_id="team-1") is True
+        assert self._support("team-gpt", router, team_id=None) is False
 
     def test_non_string_model_is_not_injected(self):
         assert self._support(None, None) is False

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -10572,3 +10572,109 @@ async def test_startup_survives_database_read_failure_for_coordination_redis():
         )
 
     assert result is None
+
+
+def _stream_usage_test_chunks():
+    from litellm.types.utils import Delta, ModelResponseStream, StreamingChoices, Usage
+
+    content_chunk = ModelResponseStream(
+        model="gpt-5.4-nano",
+        choices=[StreamingChoices(delta=Delta(content="pong"))],
+    )
+    finish_chunk = ModelResponseStream(
+        model="gpt-5.4-nano",
+        choices=[StreamingChoices(finish_reason="stop")],
+    )
+    usage_chunk = ModelResponseStream(model="gpt-5.4-nano", choices=[])
+    usage_chunk.usage = Usage(prompt_tokens=50, completion_tokens=188, total_tokens=238)
+    return content_chunk, finish_chunk, usage_chunk
+
+
+def _stream_usage_generator_chunks():
+    from litellm.types.utils import ModelResponseStream
+
+    content_chunk, finish_chunk, usage_chunk = _stream_usage_test_chunks()
+    prompt_filter_chunk = ModelResponseStream(model="gpt-5.4-nano", choices=[])
+    return prompt_filter_chunk, content_chunk, finish_chunk, usage_chunk
+
+
+def test_is_injected_stream_usage_artifact():
+    from litellm.proxy.proxy_server import _is_injected_stream_usage_artifact
+    from litellm.types.utils import ModelResponseStream, Usage
+
+    content_chunk, finish_chunk, empty_choices_usage_chunk = _stream_usage_test_chunks()
+    assert _is_injected_stream_usage_artifact(empty_choices_usage_chunk) is True
+
+    synthetic_final_chunk = ModelResponseStream(model="gpt-5.4-nano")
+    synthetic_final_chunk.usage = Usage(prompt_tokens=50, completion_tokens=188, total_tokens=238)
+    assert _is_injected_stream_usage_artifact(synthetic_final_chunk) is True
+
+    azure_prompt_filter_chunk = ModelResponseStream(model="gpt-5.4-nano", choices=[])
+    assert _is_injected_stream_usage_artifact(azure_prompt_filter_chunk) is True
+
+    assert _is_injected_stream_usage_artifact(content_chunk) is False
+    assert _is_injected_stream_usage_artifact(finish_chunk) is False
+
+    content_chunk_with_usage, finish_chunk_with_usage, _ = _stream_usage_test_chunks()
+    content_chunk_with_usage.usage = Usage(prompt_tokens=50, completion_tokens=188, total_tokens=238)
+    finish_chunk_with_usage.usage = Usage(prompt_tokens=50, completion_tokens=188, total_tokens=238)
+    assert _is_injected_stream_usage_artifact(content_chunk_with_usage) is False
+    assert _is_injected_stream_usage_artifact(finish_chunk_with_usage) is False
+
+    assert _is_injected_stream_usage_artifact({"usage": {"prompt_tokens": 1}}) is False
+
+
+async def _collect_async_data_generator_frames(request_data: dict) -> list:
+    from litellm.proxy.proxy_server import async_data_generator
+    from litellm.proxy.utils import ProxyLogging
+
+    chunks = _stream_usage_generator_chunks()
+
+    class MockStream:
+        def __aiter__(self):
+            return self._stream()
+
+        async def _stream(self):
+            for chunk in chunks:
+                yield chunk
+
+        async def aclose(self):
+            pass
+
+    mock_proxy_logging_obj = MagicMock(spec=ProxyLogging)
+    mock_proxy_logging_obj.needs_iterator_wrap.return_value = False
+    mock_proxy_logging_obj.needs_per_chunk_streaming_hook.return_value = False
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock()
+
+    with patch("litellm.proxy.proxy_server.proxy_logging_obj", mock_proxy_logging_obj):
+        with patch.object(proxy_server_module.ProxyLogging, "_fire_deferred_stream_logging"):
+            return [
+                frame.decode("utf-8") if isinstance(frame, bytes) else frame
+                async for frame in async_data_generator(
+                    MockStream(), MagicMock(spec=UserAPIKeyAuth), request_data
+                )
+            ]
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_strips_injected_usage_chunk():
+    frames = await _collect_async_data_generator_frames(
+        {"model": "gpt-5.4-nano", "_litellm_strip_stream_usage": True}
+    )
+
+    data_frames = [frame for frame in frames if frame.startswith("data: {")]
+    assert len(data_frames) == 2
+    assert any("pong" in frame for frame in data_frames)
+    assert any("finish_reason" in frame for frame in data_frames)
+    assert not any('"usage"' in frame for frame in data_frames)
+    assert frames[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_async_data_generator_forwards_usage_chunk_without_strip_marker():
+    frames = await _collect_async_data_generator_frames({"model": "gpt-5.4-nano"})
+
+    data_frames = [frame for frame in frames if frame.startswith("data: {")]
+    assert len(data_frames) == 4
+    assert any('"usage"' in frame and '"completion_tokens":188' in frame.replace(" ", "") for frame in data_frames)
+    assert frames[-1] == "data: [DONE]\n\n"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streams without `stream_options.include_usage` get tiktoken-estimated usage
- Hidden reasoning tokens are invisible to tiktoken, so SpendLogs undercounts output massively
- On reasoning models the gap reaches 90%+ of billed output tokens

How it solves it:

- Proxy injects `include_usage` upstream on `/v1/chat/completions` streams
- Injection only happens when every deployment behind the requested model declares `stream_options` in its supported OpenAI params, so providers that reject the param (Bytez, OCI) or that stream usage natively (Anthropic, Gemini, Bedrock) are left untouched
- Injection artifacts are stripped, so client-visible SSE stays byte-identical
- The internal strip marker is neutralized when it arrives in a client request body, so clients cannot suppress a usage chunk they asked for
- `always_include_stream_usage: false` remains a kill switch, `true` keeps forwarding usage

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs hit a live proxy backed by real Azure OpenAI and Anthropic APIs, with SpendLogs in Postgres. Before runs were captured at `abd239f903` (current litellm_internal_staging), after runs at this PR's head `c0de87d08d`. Config mirrors an affected deployment, with no `always_include_stream_usage` set:

```yaml
model_list:
  - model_name: azure-nano
    litellm_params:
      model: "azure/gpt-5.4-nano"
      api_base: os.environ/AZURE_API_BASE
      api_key: os.environ/AZURE_API_KEY
      api_version: "2025-04-01-preview"
  - model_name: anthropic-fable
    litellm_params:
      model: "anthropic/claude-fable-5"
      api_key: os.environ/ANTHROPIC_API_KEY
general_settings:
  store_model_in_db: True
```

The client request never sends `stream_options`:

```bash
curl -s -N http://localhost:47211/v1/chat/completions \
  -H "Authorization: Bearer sk-..." -H 'Content-Type: application/json' \
  -d '{"model":"azure-nano","messages":[{"role":"user","content":"What is 47*53 minus 19? Reply with just the number."}],"stream":true,"reasoning_effort":"medium"}'
```

SpendLogs rows across the QA matrix (`psql -d llnl_fix_qa -c 'SELECT model, prompt_tokens, completion_tokens, spend FROM "LiteLLM_SpendLogs" ORDER BY "startTime"'`):

| leg | commit | config | pt | ct | spend |
|---|---|---|---|---|---|
| azure pong | before | default | 12 | 1 | $0.00000365 |
| azure pong | after | default | 11 | 5 | $0.00000845 |
| azure reasoning | before | flag false | 23 | 2 | $0.00000710 |
| azure reasoning | after | default | 22 | 40 | $0.00005440 |
| anthropic pong | before | default | 16 | 4 | $0.00036000 |
| anthropic pong | after | default | 16 | 4 | $0.00036000 |

The before rows are tiktoken estimates: the reasoning request produced a 2-token visible answer ("2472") while Azure billed 40 output tokens, so 38 reasoning tokens and 87% of the spend were silently dropped. The after rows match provider-billed usage exactly. Anthropic streams usage natively and its route is untouched by this PR (the support gate skips it entirely), so its numbers were correct before and stay identical

Client-visible SSE frames for the same azure request, before vs after, both with zero usage frames and identical shapes (verified with `diff` over the captured streams):

```
{"choices":[{"d":{"role":"assistant","content":""},"fr":null}],"usage":false}
{"choices":[{"d":{"content":"pong"},"fr":null}],"usage":false}
{"choices":[{"d":{},"fr":"stop"}],"usage":false}
IDENTICAL
```

Clients that do opt in still get the usage chunk, at both commits:

```bash
curl -s -N ... -d '{"model":"azure-nano","messages":[...],"stream":true,"stream_options":{"include_usage":true}}'
# final frame: {"choices":[...],"usage":{"prompt_tokens":11,"completion_tokens":5,...}}
```

`always_include_stream_usage: true` still forwards the usage chunk to clients that never asked (existing behavior, verified live), and an explicit `false` disables the upstream injection entirely, reproducing the old estimated row (23 pt, 2 ct) for deployments whose OpenAI-compatible backend rejects `stream_options`

Providers whose param map rejects `stream_options` are skipped by the support gate instead of erroring. With a Bytez model in the same config (fake key, so the request dies at the provider's door either way), streaming at `43efd02d35` failed before ever reaching Bytez:

```
{"error":{"message":"litellm.APIConnectionError: param `stream_options` is not supported on Bytez ..."}}
```

while at `c0de87d08d` the identical request passes param mapping and reaches the real Bytez API:

```
{"error":{"message":"litellm.APIConnectionError: BytezException - {\"error\":\"Unauthorized\"} ..."}}
```

Team-scoped models resolve through the gate too. With a team model created via `/team/new` + `/model/new` (internal name `model_name_{team_id}_{uuid}`, public alias `team-gpt`) and streamed through a team key, the reasoning request at `0732122536` logged the tiktoken estimate (23 pt, 2 ct, $0.00000710) because the gate resolved the alias without `team_id` and skipped injection; at `c0de87d08d` the identical request logs provider-billed usage (22 pt, 38 ct, $0.00005190) with client-visible frames unchanged

## Type

🐛 Bug Fix

## Changes

`_stream_usage_tracking_updates` in `common_request_processing.py` replaces the old flag-gated injection block. With `always_include_stream_usage` unset it injects `stream_options.include_usage: true` into `/v1/chat/completions` streams (merging with any client-sent `stream_options`) and marks the request with an internal `_litellm_strip_stream_usage` key; `true` keeps the exact previous inject-and-forward semantics, and `false` now opts out of injection entirely. The route scoping matters because other streaming surfaces (Anthropic `/v1/messages`, Google `generateContent`) already receive provider usage without asking and their generators do not strip

Default injection is additionally gated on provider support: `_model_deployments_support_stream_options` resolves the requested model through the router (deployments, aliases, and wildcards via `get_model_list`) and only allows injection when every backing deployment lists `stream_options` in `get_supported_openai_params`. `stream_options` is exempt from the generic `UnsupportedParamsError` check, so the only providers that can break are ones whose `map_openai_params` explicitly raises (Bytez, OCI); those, and providers that stream usage natively and never needed the flag (Anthropic, Gemini, Bedrock), now keep their exact pre-PR behavior. The gate resolves with the request's `team_id`, since team-scoped models store an internal `model_name_{team_id}_{uuid}` name and are only reachable through their `team_public_model_name` when the team is known. Unresolvable models conservatively skip injection, falling back to today's estimates rather than risking a provider error

`_litellm_strip_stream_usage` is internal, so a value arriving in the client request body is neutralized: `_stream_usage_tracking_updates` overwrites any inbound value (only the proxy's own injection path can set it to true), and the experimental `/queue/chat/completions` endpoint, which bypasses that pre-call logic, pops it from the parsed body. A client can no longer plant the marker to make the proxy swallow a usage chunk it explicitly requested

`async_data_generator` in `proxy_server.py` drops injection artifacts when the marker is set: chunks whose choices are all empty (no delta content, finish_reason, or logprobs) and that carry no `provider_specific_fields`. That covers both the provider's final usage chunk and the empty prompt-filter chunk Azure only emits when `include_usage` is on, which live testing showed would otherwise leak. Chunks with real payload are never touched, even when a provider attaches usage to them

`_litellm_strip_stream_usage` is registered in `all_litellm_params` so `get_non_default_completion_params` treats it as LiteLLM-internal instead of sweeping it into the provider request body

Tests pin the tri-state config semantics, the artifact predicate against real chunk shapes (synthetic usage chunk, empty-choices usage chunk, prompt-filter chunk, content and finish chunks with usage attached), and the generator end to end: with the marker the usage chunk disappears from client SSE, without it the chunk is forwarded. The support gate is covered against real Router instances (Azure deployment, Bytez deployment, mixed-provider model group, wildcard route, unmapped alias, and a team-alias model that only resolves when `team_id` is passed), and the marker neutralization against client-planted values on the default, flag-true, and non-streaming paths

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default proxy streaming request/response path and spend-logging inputs for chat completions, but provider support gating and conservative skip behavior limit breakage; extensive tests cover injection, stripping, and router/team resolution.
> 
> **Overview**
> **Default `/v1/chat/completions` streaming** now asks the provider for real usage by injecting `stream_options.include_usage` when `always_include_stream_usage` is unset, while keeping the client stream unchanged by marking the request with internal `_litellm_strip_stream_usage` and dropping empty usage-only SSE chunks in `async_data_generator`.
> 
> Injection is scoped to **`acompletion`** and gated on **router-resolved deployments** (including team aliases): every backing model must advertise `stream_options` in `get_supported_openai_params`, so providers that reject the param or already stream usage natively are skipped. **`always_include_stream_usage: true`** still injects and forwards usage; **`false`** disables injection entirely.
> 
> Client-supplied `_litellm_strip_stream_usage` is **neutralized** on the normal pre-call path and **stripped** on the queued chat-completions endpoint; the flag is registered in **`all_litellm_params`** so it is not forwarded upstream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0de87d08d4bee0069280071a0fb1854bdd0a646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->