### PR TITLE
feat(s3): support SSE-KMS encryption params on both S3 logging paths

### DIFF
--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -172,33 +172,31 @@ class S3Logger:
             pass
 
 
+def _validated_sse_value(name: str, value: str | None) -> str | None:
+    if value is None or isinstance(value, str):
+        return value
+    verbose_logger.warning(
+        f"s3 logging: ignoring {name} because it has invalid type {type(value).__name__}; expected a string"
+    )
+    return None
+
+
 def resolve_sse_params(
     server_side_encryption: str | None,
     sse_kms_key_id: str | None,
 ) -> tuple[str | None, str | None]:
-    for name, value in (
-        ("s3_server_side_encryption", server_side_encryption),
-        ("s3_sse_kms_key_id", sse_kms_key_id),
-    ):
-        if value is not None and not isinstance(value, str):
-            verbose_logger.warning(
-                f"s3 logging: ignoring {name} because it has invalid type "
-                f"{type(value).__name__}; expected a string"
-            )
-            if name == "s3_server_side_encryption":
-                server_side_encryption = None
-            else:
-                sse_kms_key_id = None
-    algorithm = server_side_encryption or ("aws:kms" if sse_kms_key_id else None)
+    valid_sse = _validated_sse_value("s3_server_side_encryption", server_side_encryption)
+    valid_key_id = _validated_sse_value("s3_sse_kms_key_id", sse_kms_key_id)
+    algorithm = valid_sse or ("aws:kms" if valid_key_id else None)
     if algorithm is None:
         return None, None
-    if sse_kms_key_id and not algorithm.startswith("aws:kms"):
+    if valid_key_id and not algorithm.startswith("aws:kms"):
         verbose_logger.warning(
             f"s3 logging: ignoring s3_sse_kms_key_id because s3_server_side_encryption is {algorithm}; "
             "set it to aws:kms to encrypt with the KMS key"
         )
         return algorithm, None
-    return algorithm, sse_kms_key_id
+    return algorithm, valid_key_id
 
 
 def get_s3_object_key(

--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -176,6 +176,16 @@ def resolve_sse_params(
     server_side_encryption: str | None,
     sse_kms_key_id: str | None,
 ) -> tuple[str | None, str | None]:
+    for name, value in (
+        ("s3_server_side_encryption", server_side_encryption),
+        ("s3_sse_kms_key_id", sse_kms_key_id),
+    ):
+        if value is not None and not isinstance(value, str):
+            verbose_logger.warning(
+                f"s3 logging: ignoring SSE config because {name} has invalid type "
+                f"{type(value).__name__}; expected a string"
+            )
+            return None, None
     algorithm = server_side_encryption or ("aws:kms" if sse_kms_key_id else None)
     if algorithm is None:
         return None, None

--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -182,10 +182,13 @@ def resolve_sse_params(
     ):
         if value is not None and not isinstance(value, str):
             verbose_logger.warning(
-                f"s3 logging: ignoring SSE config because {name} has invalid type "
+                f"s3 logging: ignoring {name} because it has invalid type "
                 f"{type(value).__name__}; expected a string"
             )
-            return None, None
+            if name == "s3_server_side_encryption":
+                server_side_encryption = None
+            else:
+                sse_kms_key_id = None
     algorithm = server_side_encryption or ("aws:kms" if sse_kms_key_id else None)
     if algorithm is None:
         return None, None

--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -24,6 +24,8 @@ class S3Logger:
         s3_aws_secret_access_key=None,
         s3_aws_session_token=None,
         s3_config=None,
+        s3_server_side_encryption: str | None = None,
+        s3_sse_kms_key_id: str | None = None,
         **kwargs,
     ):
         import boto3
@@ -50,11 +52,16 @@ class S3Logger:
                 s3_aws_session_token = litellm.s3_callback_params.get("s3_aws_session_token")
                 s3_config = litellm.s3_callback_params.get("s3_config")
                 s3_path = litellm.s3_callback_params.get("s3_path")
+                s3_server_side_encryption = litellm.s3_callback_params.get("s3_server_side_encryption")
+                s3_sse_kms_key_id = litellm.s3_callback_params.get("s3_sse_kms_key_id")
                 # done reading litellm.s3_callback_params
                 s3_use_team_prefix = bool(litellm.s3_callback_params.get("s3_use_team_prefix", False))
             self.s3_use_team_prefix = s3_use_team_prefix
             self.bucket_name = s3_bucket_name
             self.s3_path = s3_path
+            self.s3_server_side_encryption, self.s3_sse_kms_key_id = resolve_sse_params(
+                s3_server_side_encryption, s3_sse_kms_key_id
+            )
             verbose_logger.debug(f"s3 logger using endpoint url {s3_endpoint_url}")
             # Create an S3 client with custom endpoint URL
             self.s3_client = boto3.client(
@@ -136,6 +143,15 @@ class S3Logger:
 
             print_verbose(f"\ns3 Logger - Logging payload = {payload_str}")
 
+            sse_params = {
+                key: value
+                for key, value in {
+                    "ServerSideEncryption": self.s3_server_side_encryption,
+                    "SSEKMSKeyId": self.s3_sse_kms_key_id,
+                }.items()
+                if value
+            }
+
             response = self.s3_client.put_object(
                 Bucket=self.bucket_name,
                 Key=s3_object_key,
@@ -144,6 +160,7 @@ class S3Logger:
                 ContentLanguage="en",
                 ContentDisposition=f'inline; filename="{s3_object_download_filename}"',
                 CacheControl="private, immutable, max-age=31536000, s-maxage=0",
+                **sse_params,
             )
 
             print_verbose(f"Response from s3:{str(response)}")
@@ -153,6 +170,22 @@ class S3Logger:
         except Exception as e:
             verbose_logger.exception(f"s3 Layer Error - {str(e)}")
             pass
+
+
+def resolve_sse_params(
+    server_side_encryption: str | None,
+    sse_kms_key_id: str | None,
+) -> tuple[str | None, str | None]:
+    algorithm = server_side_encryption or ("aws:kms" if sse_kms_key_id else None)
+    if algorithm is None:
+        return None, None
+    if sse_kms_key_id and not algorithm.startswith("aws:kms"):
+        verbose_logger.warning(
+            f"s3 logging: ignoring s3_sse_kms_key_id because s3_server_side_encryption is {algorithm}; "
+            "set it to aws:kms to encrypt with the KMS key"
+        )
+        return algorithm, None
+    return algorithm, sse_kms_key_id
 
 
 def get_s3_object_key(

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -8,13 +8,14 @@ NOTE 1: S3 does not provide a BATCH PUT API endpoint, so we create tasks to uplo
 
 import asyncio
 import time
+from collections.abc import Mapping
 from datetime import datetime
 from typing import List, Optional, cast
 
 import litellm
 from litellm._logging import print_verbose, verbose_logger
 from litellm.constants import DEFAULT_S3_BATCH_SIZE, DEFAULT_S3_FLUSH_INTERVAL_SECONDS
-from litellm.integrations.s3 import get_s3_object_key
+from litellm.integrations.s3 import get_s3_object_key, resolve_sse_params
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.litellm_core_utils.sensitive_data_masker import SensitiveDataMasker
 from litellm.llms.bedrock.base_aws_llm import BaseAWSLLM
@@ -55,6 +56,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         s3_use_key_prefix: bool = False,
         s3_use_virtual_hosted_style: bool = False,
         s3_server_side_encryption: Optional[str] = None,
+        s3_sse_kms_key_id: str | None = None,
         s3_callback_params_override: Optional[dict] = None,
         **kwargs,
     ):
@@ -94,6 +96,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 s3_use_key_prefix=s3_use_key_prefix,
                 s3_use_virtual_hosted_style=s3_use_virtual_hosted_style,
                 s3_server_side_encryption=s3_server_side_encryption,
+                s3_sse_kms_key_id=s3_sse_kms_key_id,
             )
             verbose_logger.debug(f"s3 logger using endpoint url {s3_endpoint_url}")
 
@@ -148,6 +151,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         s3_use_key_prefix: bool = False,
         s3_use_virtual_hosted_style: bool = False,
         s3_server_side_encryption: Optional[str] = None,
+        s3_sse_kms_key_id: str | None = None,
         params_source: Optional[dict] = None,
     ):
         """
@@ -197,9 +201,19 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             bool(params.get("s3_use_virtual_hosted_style", False)) or s3_use_virtual_hosted_style
         )
 
-        self.s3_server_side_encryption = params.get("s3_server_side_encryption") or s3_server_side_encryption
+        self.s3_server_side_encryption, self.s3_sse_kms_key_id = resolve_sse_params(
+            params.get("s3_server_side_encryption") or s3_server_side_encryption,
+            params.get("s3_sse_kms_key_id") or s3_sse_kms_key_id,
+        )
 
         return
+
+    def _sse_headers(self) -> Mapping[str, str]:
+        candidates = {
+            "x-amz-server-side-encryption": self.s3_server_side_encryption,
+            "x-amz-server-side-encryption-aws-kms-key-id": self.s3_sse_kms_key_id,
+        }
+        return {key: value for key, value in candidates.items() if value}
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         await self._async_log_event_base(
@@ -335,11 +349,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 "Content-Language": "en",
                 "Content-Disposition": f'inline; filename="{batch_logging_element.s3_object_download_filename}"',
                 "Cache-Control": "private, immutable, max-age=31536000, s-maxage=0",
-                **(
-                    {"x-amz-server-side-encryption": self.s3_server_side_encryption}
-                    if self.s3_server_side_encryption
-                    else {}
-                ),
+                **self._sse_headers(),
             }
             req = requests.Request("PUT", url, data=json_string, headers=headers)
             prepped = req.prepare()
@@ -510,11 +520,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 "Content-Language": "en",
                 "Content-Disposition": f'inline; filename="{batch_logging_element.s3_object_download_filename}"',
                 "Cache-Control": "private, immutable, max-age=31536000, s-maxage=0",
-                **(
-                    {"x-amz-server-side-encryption": self.s3_server_side_encryption}
-                    if self.s3_server_side_encryption
-                    else {}
-                ),
+                **self._sse_headers(),
             }
             req = requests.Request("PUT", url, data=json_string, headers=headers)
             prepped = req.prepare()

--- a/tests/test_litellm/integrations/test_s3.py
+++ b/tests/test_litellm/integrations/test_s3.py
@@ -1,0 +1,121 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import litellm
+from litellm.integrations.s3 import S3Logger
+
+TEST_KMS_KEY_ARN = "arn:aws:kms:us-east-1:111122223333:key/test-key-id"
+
+
+def _standard_logging_payload() -> dict:
+    return {
+        "id": "chatcmpl-test-id",
+        "metadata": {"user_api_key_team_alias": None},
+    }
+
+
+def _log_event_kwargs() -> dict:
+    return {
+        "litellm_params": {"metadata": {}},
+        "standard_logging_object": _standard_logging_payload(),
+    }
+
+
+def _run_log_event(callback_params: dict) -> MagicMock:
+    original = litellm.s3_callback_params
+    litellm.s3_callback_params = callback_params
+    try:
+        with patch("boto3.client") as mock_boto3_client:
+            mock_s3_client = MagicMock()
+            mock_boto3_client.return_value = mock_s3_client
+            logger = S3Logger()
+            logger.log_event(
+                kwargs=_log_event_kwargs(),
+                response_obj={},
+                start_time=datetime(2026, 7, 30, 12, 0, 0),
+                end_time=datetime(2026, 7, 30, 12, 0, 1),
+                print_verbose=lambda *args, **kwargs: None,
+            )
+        return mock_s3_client
+    finally:
+        litellm.s3_callback_params = original
+
+
+def test_put_object_includes_sse_kms_params_when_configured():
+    """
+    When s3_server_side_encryption and s3_sse_kms_key_id are set in
+    s3_callback_params, put_object must receive ServerSideEncryption and
+    SSEKMSKeyId so objects land encrypted with the customer-managed key.
+    """
+    mock_s3_client = _run_log_event(
+        {
+            "s3_bucket_name": "test-bucket",
+            "s3_region_name": "us-east-1",
+            "s3_server_side_encryption": "aws:kms",
+            "s3_sse_kms_key_id": TEST_KMS_KEY_ARN,
+        }
+    )
+
+    put_object_kwargs = mock_s3_client.put_object.call_args.kwargs
+    assert put_object_kwargs["ServerSideEncryption"] == "aws:kms"
+    assert put_object_kwargs["SSEKMSKeyId"] == TEST_KMS_KEY_ARN
+
+
+def test_put_object_supports_sse_s3_without_key_id():
+    """SSE-S3 (AES256) needs only ServerSideEncryption, no key id."""
+    mock_s3_client = _run_log_event(
+        {
+            "s3_bucket_name": "test-bucket",
+            "s3_region_name": "us-east-1",
+            "s3_server_side_encryption": "AES256",
+        }
+    )
+
+    put_object_kwargs = mock_s3_client.put_object.call_args.kwargs
+    assert put_object_kwargs["ServerSideEncryption"] == "AES256"
+    assert "SSEKMSKeyId" not in put_object_kwargs
+
+
+def test_put_object_omits_sse_params_by_default():
+    """Without SSE config, put_object kwargs must stay unchanged."""
+    mock_s3_client = _run_log_event(
+        {
+            "s3_bucket_name": "test-bucket",
+            "s3_region_name": "us-east-1",
+        }
+    )
+
+    put_object_kwargs = mock_s3_client.put_object.call_args.kwargs
+    assert "ServerSideEncryption" not in put_object_kwargs
+    assert "SSEKMSKeyId" not in put_object_kwargs
+
+
+def test_put_object_infers_aws_kms_when_only_key_id_set():
+    """A key id without an algorithm must infer aws:kms instead of sending an invalid request."""
+    mock_s3_client = _run_log_event(
+        {
+            "s3_bucket_name": "test-bucket",
+            "s3_region_name": "us-east-1",
+            "s3_sse_kms_key_id": TEST_KMS_KEY_ARN,
+        }
+    )
+
+    put_object_kwargs = mock_s3_client.put_object.call_args.kwargs
+    assert put_object_kwargs["ServerSideEncryption"] == "aws:kms"
+    assert put_object_kwargs["SSEKMSKeyId"] == TEST_KMS_KEY_ARN
+
+
+def test_put_object_drops_key_id_when_algorithm_is_not_kms():
+    """AES256 plus a key id is invalid for S3; the key id must be dropped, not sent."""
+    mock_s3_client = _run_log_event(
+        {
+            "s3_bucket_name": "test-bucket",
+            "s3_region_name": "us-east-1",
+            "s3_server_side_encryption": "AES256",
+            "s3_sse_kms_key_id": TEST_KMS_KEY_ARN,
+        }
+    )
+
+    put_object_kwargs = mock_s3_client.put_object.call_args.kwargs
+    assert put_object_kwargs["ServerSideEncryption"] == "AES256"
+    assert "SSEKMSKeyId" not in put_object_kwargs

--- a/tests/test_litellm/integrations/test_s3.py
+++ b/tests/test_litellm/integrations/test_s3.py
@@ -121,8 +121,11 @@ def test_put_object_drops_key_id_when_algorithm_is_not_kms():
     assert "SSEKMSKeyId" not in put_object_kwargs
 
 
-def test_non_string_sse_config_is_ignored_not_crashing():
-    """YAML booleans or other non-strings in SSE config must not crash logger init."""
+def test_non_string_algorithm_is_dropped_and_valid_key_id_is_rescued():
+    """
+    A YAML boolean in s3_server_side_encryption must not crash logger init and
+    must not discard the valid key id; aws:kms is inferred from the key id.
+    """
     mock_s3_client = _run_log_event(
         {
             "s3_bucket_name": "test-bucket",
@@ -133,5 +136,21 @@ def test_non_string_sse_config_is_ignored_not_crashing():
     )
 
     put_object_kwargs = mock_s3_client.put_object.call_args.kwargs
-    assert "ServerSideEncryption" not in put_object_kwargs
+    assert put_object_kwargs["ServerSideEncryption"] == "aws:kms"
+    assert put_object_kwargs["SSEKMSKeyId"] == TEST_KMS_KEY_ARN
+
+
+def test_non_string_key_id_is_dropped_and_valid_algorithm_is_kept():
+    """A mistyped key id (unquoted YAML number) must not disable the valid algorithm."""
+    mock_s3_client = _run_log_event(
+        {
+            "s3_bucket_name": "test-bucket",
+            "s3_region_name": "us-east-1",
+            "s3_server_side_encryption": "aws:kms",
+            "s3_sse_kms_key_id": 12345,
+        }
+    )
+
+    put_object_kwargs = mock_s3_client.put_object.call_args.kwargs
+    assert put_object_kwargs["ServerSideEncryption"] == "aws:kms"
     assert "SSEKMSKeyId" not in put_object_kwargs

--- a/tests/test_litellm/integrations/test_s3.py
+++ b/tests/test_litellm/integrations/test_s3.py
@@ -119,3 +119,19 @@ def test_put_object_drops_key_id_when_algorithm_is_not_kms():
     put_object_kwargs = mock_s3_client.put_object.call_args.kwargs
     assert put_object_kwargs["ServerSideEncryption"] == "AES256"
     assert "SSEKMSKeyId" not in put_object_kwargs
+
+
+def test_non_string_sse_config_is_ignored_not_crashing():
+    """YAML booleans or other non-strings in SSE config must not crash logger init."""
+    mock_s3_client = _run_log_event(
+        {
+            "s3_bucket_name": "test-bucket",
+            "s3_region_name": "us-east-1",
+            "s3_server_side_encryption": True,
+            "s3_sse_kms_key_id": TEST_KMS_KEY_ARN,
+        }
+    )
+
+    put_object_kwargs = mock_s3_client.put_object.call_args.kwargs
+    assert "ServerSideEncryption" not in put_object_kwargs
+    assert "SSEKMSKeyId" not in put_object_kwargs

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1599,3 +1599,21 @@ def test_kms_key_id_dropped_when_algorithm_is_not_kms():
         assert logger.s3_sse_kms_key_id is None
     finally:
         litellm.s3_callback_params = original
+
+
+def test_non_string_sse_config_is_ignored_not_crashing():
+    """YAML booleans or other non-strings in SSE config must not crash logger init."""
+    import litellm
+
+    original = litellm.s3_callback_params
+    litellm.s3_callback_params = {
+        "s3_bucket_name": "from-global",
+        "s3_server_side_encryption": True,
+        "s3_sse_kms_key_id": "arn:aws:kms:us-east-1:111122223333:key/test-key-id",
+    }
+    try:
+        logger = S3Logger()
+        assert logger.s3_server_side_encryption is None
+        assert logger.s3_sse_kms_key_id is None
+    finally:
+        litellm.s3_callback_params = original

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1601,8 +1601,11 @@ def test_kms_key_id_dropped_when_algorithm_is_not_kms():
         litellm.s3_callback_params = original
 
 
-def test_non_string_sse_config_is_ignored_not_crashing():
-    """YAML booleans or other non-strings in SSE config must not crash logger init."""
+def test_non_string_algorithm_is_dropped_and_valid_key_id_is_rescued():
+    """
+    A YAML boolean in s3_server_side_encryption must not crash logger init and
+    must not discard the valid key id; aws:kms is inferred from the key id.
+    """
     import litellm
 
     original = litellm.s3_callback_params
@@ -1613,7 +1616,25 @@ def test_non_string_sse_config_is_ignored_not_crashing():
     }
     try:
         logger = S3Logger()
-        assert logger.s3_server_side_encryption is None
+        assert logger.s3_server_side_encryption == "aws:kms"
+        assert logger.s3_sse_kms_key_id == ("arn:aws:kms:us-east-1:111122223333:key/test-key-id")
+    finally:
+        litellm.s3_callback_params = original
+
+
+def test_non_string_key_id_is_dropped_and_valid_algorithm_is_kept():
+    """A mistyped key id (unquoted YAML number) must not disable the valid algorithm."""
+    import litellm
+
+    original = litellm.s3_callback_params
+    litellm.s3_callback_params = {
+        "s3_bucket_name": "from-global",
+        "s3_server_side_encryption": "aws:kms",
+        "s3_sse_kms_key_id": 12345,
+    }
+    try:
+        logger = S3Logger()
+        assert logger.s3_server_side_encryption == "aws:kms"
         assert logger.s3_sse_kms_key_id is None
     finally:
         litellm.s3_callback_params = original

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -1388,3 +1388,214 @@ def test_s3_server_side_encryption_read_from_callback_params():
         assert logger.s3_server_side_encryption == "aws:kms"
     finally:
         litellm.s3_callback_params = original
+
+
+@pytest.mark.asyncio
+async def test_async_upload_sets_sse_kms_key_id_header_when_configured():
+    """
+    When s3_sse_kms_key_id is set alongside aws:kms, the PUT must carry
+    x-amz-server-side-encryption-aws-kms-key-id so objects are encrypted
+    with the customer-managed KMS key instead of the bucket default.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.types.integrations.s3_v2 import s3BatchLoggingElement
+
+    logger = S3Logger(
+        s3_bucket_name="test-bucket",
+        s3_aws_access_key_id="test-key",
+        s3_aws_secret_access_key="test-secret",
+        s3_region_name="us-east-1",
+        s3_server_side_encryption="aws:kms",
+        s3_sse_kms_key_id="arn:aws:kms:us-east-1:111122223333:key/test-key-id",
+    )
+
+    test_element = s3BatchLoggingElement(
+        s3_object_key="2025-09-14/test-sse-kms.json",
+        payload={"test": "sse-kms"},
+        s3_object_download_filename="test-sse-kms.json",
+    )
+
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status = MagicMock()
+    logger.async_httpx_client = AsyncMock()
+    logger.async_httpx_client.put.return_value = response
+
+    await logger.async_upload_data_to_s3(test_element)
+
+    headers = logger.async_httpx_client.put.call_args.kwargs["headers"]
+    assert headers["x-amz-server-side-encryption"] == "aws:kms"
+    assert headers["x-amz-server-side-encryption-aws-kms-key-id"] == (
+        "arn:aws:kms:us-east-1:111122223333:key/test-key-id"
+    )
+
+
+def test_sync_upload_sets_sse_kms_key_id_header_when_configured():
+    """The sync upload path must carry the same SSE-KMS headers."""
+    from unittest.mock import MagicMock
+
+    from litellm.types.integrations.s3_v2 import s3BatchLoggingElement
+
+    logger = S3Logger(
+        s3_bucket_name="test-bucket",
+        s3_aws_access_key_id="test-key",
+        s3_aws_secret_access_key="test-secret",
+        s3_region_name="us-east-1",
+        s3_server_side_encryption="aws:kms",
+        s3_sse_kms_key_id="arn:aws:kms:us-east-1:111122223333:key/test-key-id",
+    )
+
+    test_element = s3BatchLoggingElement(
+        s3_object_key="2025-09-14/test-sync-sse-kms.json",
+        payload={"test": "sync-sse-kms"},
+        s3_object_download_filename="test-sync-sse-kms.json",
+    )
+
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status = MagicMock()
+    mock_sync_client = MagicMock()
+    mock_sync_client.put.return_value = response
+
+    with patch(
+        "litellm.integrations.s3_v2._get_httpx_client",
+        return_value=mock_sync_client,
+    ):
+        logger.upload_data_to_s3(test_element)
+
+    headers = mock_sync_client.put.call_args.kwargs["headers"]
+    assert headers["x-amz-server-side-encryption"] == "aws:kms"
+    assert headers["x-amz-server-side-encryption-aws-kms-key-id"] == (
+        "arn:aws:kms:us-east-1:111122223333:key/test-key-id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_upload_omits_kms_key_id_header_when_not_configured():
+    """SSE without a key id must not emit the KMS key id header."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.types.integrations.s3_v2 import s3BatchLoggingElement
+
+    logger = S3Logger(
+        s3_bucket_name="test-bucket",
+        s3_aws_access_key_id="test-key",
+        s3_aws_secret_access_key="test-secret",
+        s3_region_name="us-east-1",
+        s3_server_side_encryption="AES256",
+    )
+
+    test_element = s3BatchLoggingElement(
+        s3_object_key="2025-09-14/test-aes256.json",
+        payload={"test": "aes256"},
+        s3_object_download_filename="test-aes256.json",
+    )
+
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status = MagicMock()
+    logger.async_httpx_client = AsyncMock()
+    logger.async_httpx_client.put.return_value = response
+
+    await logger.async_upload_data_to_s3(test_element)
+
+    headers = logger.async_httpx_client.put.call_args.kwargs["headers"]
+    assert headers["x-amz-server-side-encryption"] == "AES256"
+    assert "x-amz-server-side-encryption-aws-kms-key-id" not in headers
+
+
+def test_s3_sse_kms_key_id_read_from_callback_params():
+    """s3_sse_kms_key_id can be configured via s3_callback_params."""
+    import litellm
+
+    original = litellm.s3_callback_params
+    litellm.s3_callback_params = {
+        "s3_bucket_name": "from-global",
+        "s3_server_side_encryption": "aws:kms",
+        "s3_sse_kms_key_id": "arn:aws:kms:us-east-1:111122223333:key/test-key-id",
+    }
+    try:
+        logger = S3Logger()
+        assert logger.s3_sse_kms_key_id == ("arn:aws:kms:us-east-1:111122223333:key/test-key-id")
+    finally:
+        litellm.s3_callback_params = original
+
+
+@pytest.mark.asyncio
+async def test_async_upload_infers_aws_kms_when_only_key_id_set():
+    """
+    Setting only s3_sse_kms_key_id must not produce an invalid request
+    (S3 rejects a key id without an algorithm); aws:kms is inferred.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.types.integrations.s3_v2 import s3BatchLoggingElement
+
+    logger = S3Logger(
+        s3_bucket_name="test-bucket",
+        s3_aws_access_key_id="test-key",
+        s3_aws_secret_access_key="test-secret",
+        s3_region_name="us-east-1",
+        s3_sse_kms_key_id="arn:aws:kms:us-east-1:111122223333:key/test-key-id",
+    )
+
+    test_element = s3BatchLoggingElement(
+        s3_object_key="2025-09-14/test-kms-only.json",
+        payload={"test": "kms-only"},
+        s3_object_download_filename="test-kms-only.json",
+    )
+
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status = MagicMock()
+    logger.async_httpx_client = AsyncMock()
+    logger.async_httpx_client.put.return_value = response
+
+    await logger.async_upload_data_to_s3(test_element)
+
+    headers = logger.async_httpx_client.put.call_args.kwargs["headers"]
+    assert headers["x-amz-server-side-encryption"] == "aws:kms"
+    assert headers["x-amz-server-side-encryption-aws-kms-key-id"] == (
+        "arn:aws:kms:us-east-1:111122223333:key/test-key-id"
+    )
+
+
+def test_s3_sse_kms_key_id_read_from_audit_override_params():
+    """The audit-log override path must honor s3_sse_kms_key_id too."""
+    import litellm
+
+    original = litellm.s3_callback_params
+    litellm.s3_callback_params = {"s3_bucket_name": "normal-logs-bucket"}
+    try:
+        logger = S3Logger(
+            s3_callback_params_override={
+                "s3_bucket_name": "audit-logs-bucket",
+                "s3_sse_kms_key_id": "arn:aws:kms:us-east-1:111122223333:key/audit-key-id",
+            }
+        )
+        assert logger.s3_bucket_name == "audit-logs-bucket"
+        assert logger.s3_sse_kms_key_id == ("arn:aws:kms:us-east-1:111122223333:key/audit-key-id")
+    finally:
+        litellm.s3_callback_params = original
+
+
+def test_kms_key_id_dropped_when_algorithm_is_not_kms():
+    """
+    AES256 plus a KMS key id is an invalid S3 combination; the key id must be
+    dropped at init so uploads keep working instead of silently 400ing.
+    """
+    import litellm
+
+    original = litellm.s3_callback_params
+    litellm.s3_callback_params = {
+        "s3_bucket_name": "from-global",
+        "s3_server_side_encryption": "AES256",
+        "s3_sse_kms_key_id": "arn:aws:kms:us-east-1:111122223333:key/test-key-id",
+    }
+    try:
+        logger = S3Logger()
+        assert logger.s3_server_side_encryption == "AES256"
+        assert logger.s3_sse_kms_key_id is None
+    finally:
+        litellm.s3_callback_params = original


### PR DESCRIPTION
## TLDR

Problem this solves:

- Enterprise AWS environments mandate customer-managed KMS keys (SSE-KMS) for S3 objects holding request logs. LiteLLM's S3 logging could not send a KMS key id on either logger path, so PutObject fails on buckets whose policy requires a specific key and customers cannot meet security policy natively (workaround today is SQS plus a self-managed S3 writer)
- The legacy `s3` callback additionally ignored `s3_server_side_encryption` entirely (it was only honored by `s3_v2`)

How it solves it:

- New `s3_callback_params` key `s3_sse_kms_key_id` (KMS key id or ARN), honored by both logger paths: `litellm/integrations/s3.py` passes `ServerSideEncryption` / `SSEKMSKeyId` to boto3 `put_object`, and `litellm/integrations/s3_v2.py` adds `x-amz-server-side-encryption` / `x-amz-server-side-encryption-aws-kms-key-id` to the signed PUT headers (both async and sync paths, via a shared `_sse_headers` helper); the headers are added before SigV4 signing so they are part of the canonical request
- A shared `resolve_sse_params` helper guards the invalid-combination footguns: setting only `s3_sse_kms_key_id` infers `aws:kms` (S3 rejects a key id without an algorithm with 400, which would silently drop every log since callback errors are swallowed), and setting a key id with a non-KMS algorithm (for example `AES256`) drops the key id with a startup warning instead of sending an invalid request; a non-string value (for example a YAML boolean or an unquoted numeric key id) invalidates only that field with a warning, so the valid sibling field still applies instead of encryption silently turning off; both salvage cases verified on a live proxy against real S3 (a boolean algorithm plus a valid key ARN still lands encrypted with the exact key via inference, and a numeric key id plus a valid aws:kms still lands encrypted with the default KMS key)
- SSE-S3 (`AES256`) works on both paths as a value of `s3_server_side_encryption`
- The audit-log S3 destination (`s3_audit_callback_params` override) inherits the new key automatically since it flows through the same `_init_s3_params`

## Relevant issues

Fixes #18179

## Linear ticket

Resolves LIT-4495

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Behavior changes

The legacy `s3` callback now honors `s3_server_side_encryption` (previously silently ignored; only `s3_v2` read it). Users of the legacy callback who already have that key set will start sending `ServerSideEncryption` on upgrade. If their configured value is valid and the logging principal has `kms:GenerateDataKey` on the key this is the intended behavior; if the value is stale or the principal lacks KMS permissions, uploads that previously succeeded unencrypted will start failing (errors are logged and, on `s3_v2`, counted in the callback failure metric). New IAM requirement when using SSE-KMS: the logging credentials need `kms:GenerateDataKey` (and `kms:Decrypt` for the `s3_v2` cold-storage read path) on the key

Not covered on purpose: the dashboard's s3 logging form is non-functional for every `s3_callback_params` field today (it writes env vars the loggers never read), so the new keys were deliberately not added to `callback_configs.json`; a rendered control that silently does nothing is worse than none for an encryption setting. Tracked in LIT-5021

## Screenshots / Proof of Fix

Real proxy (branch worktree), real Postgres, real Bedrock (`us.anthropic.claude-haiku-4-5-20251001-v1:0`), real S3 and KMS. The test bucket has a policy that denies PutObject unless the object is encrypted with `aws:kms` using one specific customer-managed key, which is exactly the enterprise setup the ticket describes:

```json
{"Sid": "DenyWrongKmsKey", "Effect": "Deny", "Principal": "*", "Action": "s3:PutObject",
 "Resource": "arn:aws:s3:::litellm-lit4495-sse-kms/*",
 "Condition": {"StringNotEquals": {"s3:x-amz-server-side-encryption-aws-kms-key-id": "arn:aws:kms:us-east-1:439158074652:key/c0f7281a-96b0-4700-b49e-405bef6861e9"}}}
```

Config used (s3_v2 leg; the legacy leg is identical with `success_callback: ["s3"]`):

```yaml
litellm_settings:
  success_callback: ["s3_v2"]
  s3_callback_params:
    s3_bucket_name: litellm-lit4495-sse-kms
    s3_region_name: us-east-1
    s3_server_side_encryption: aws:kms
    s3_sse_kms_key_id: arn:aws:kms:us-east-1:439158074652:key/c0f7281a-96b0-4700-b49e-405bef6861e9
```

Before (base `litellm_internal_staging`, same config): the chat call succeeds but every upload is rejected because the key id is never sent, so zero log objects land

```
$ curl -sS http://127.0.0.1:20495/v1/chat/completions -H "Authorization: Bearer sk-..." \
    -d '{"model":"bedrock-haiku","messages":[{"role":"user","content":"hi"}]}'   # 200 OK

proxy log (s3_v2): Error uploading to s3: Client error '403 Forbidden' for url
  'https://litellm-lit4495-sse-kms.s3.us-east-1.amazonaws.com/s3_v2-run/2026-07-30/time-16-29-25-...json'
proxy log (legacy s3): s3 Layer Error - An error occurred (AccessDenied) when calling the PutObject
  operation: ... explicit deny in a resource-based policy

$ aws s3api list-objects-v2 --bucket litellm-lit4495-sse-kms --prefix s3_v2-run/
  (empty)
```

After (this branch, same config, both callback variants):

```
$ aws s3api head-object --bucket litellm-lit4495-sse-kms \
    --key "s3_v2-run/2026-07-30/time-16-30-50-337172_chatcmpl-eb1297fa-....json" \
    --query '{SSE:ServerSideEncryption,KMSKey:SSEKMSKeyId}'
{
    "SSE": "aws:kms",
    "KMSKey": "arn:aws:kms:us-east-1:439158074652:key/c0f7281a-96b0-4700-b49e-405bef6861e9"
}

$ aws s3api head-object --bucket litellm-lit4495-sse-kms \
    --key "s3-run/2026-07-30/time-16-31-29-398163_chatcmpl-2453df0c-....json" \
    --query '{SSE:ServerSideEncryption,KMSKey:SSEKMSKeyId}'
{
    "SSE": "aws:kms",
    "KMSKey": "arn:aws:kms:us-east-1:439158074652:key/c0f7281a-96b0-4700-b49e-405bef6861e9"
}
```

Key-id-only config (no `s3_server_side_encryption` line at all) infers `aws:kms` and still lands past the deny policy:

```
$ aws s3api head-object --bucket litellm-lit4495-sse-kms \
    --key "v2-kmsonly/2026-07-30/time-16-38-15-...json" --query '{SSE:ServerSideEncryption,KMSKey:SSEKMSKeyId}'
{"SSE": "aws:kms", "KMSKey": "arn:aws:kms:us-east-1:439158074652:key/c0f7281a-...."}
```

No-SSE config against a normal bucket is unchanged (object lands with the bucket default `AES256`, no KMS headers sent). Algorithm-only config (`s3_server_side_encryption: aws:kms`, no key id) is also unchanged from the pre-PR behavior: the object lands encrypted with the AWS-managed default KMS key and no key id header is sent

### End-to-end evidence pass

Re-drove the flow after the PR was opened with a deliberately different order and shape than the verify runs (legacy callback first, key-id-only config on the legacy path, streaming requests instead of non-streaming). Outcome contract: every streamed chat completion produces exactly one object in the deny-policy bucket within the flush window, encrypted with `aws:kms` and the exact key ARN

```
$ curl .../v1/chat/completions -d '{"model":"bedrock-haiku","messages":[...],"stream":true}'   # legacy s3, key-id-only
data: {"id":"chatcmpl-1968b345-...","object":"chat.completion.chunk",...}

$ aws s3api head-object --bucket litellm-lit4495-sse-kms \
    --key "e2e-v1-kmsonly/2026-07-30/time-16-54-28-504213_chatcmpl-1968b345-....json" \
    --query '{SSE:ServerSideEncryption,KMSKey:SSEKMSKeyId}'
{"SSE": "aws:kms", "KMSKey": "arn:aws:kms:us-east-1:439158074652:key/c0f7281a-...."}

$ aws s3api head-object --bucket litellm-lit4495-sse-kms \
    --key "e2e-v2-explicit/2026-07-30/time-16-54-59-179932_chatcmpl-72a9f9d4-....json" \
    --query '{SSE:ServerSideEncryption,KMSKey:SSEKMSKeyId}'
{"SSE": "aws:kms", "KMSKey": "arn:aws:kms:us-east-1:439158074652:key/c0f7281a-...."}
```

Both passes match the contract with no timing or behavior divergence. Proxy dashboard (bundled UI on the same rig) showing the repro, verify, and e2e requests, all logged successfully:

![Request logs page](https://raw.githubusercontent.com/yucheng-berri/opentelemetry-python-contrib/assets-litellm-pr35291/lit4495-logs-page.png)

## Type

🆕 New Feature

## Changes

- `litellm/integrations/s3.py`: read `s3_server_side_encryption` and `s3_sse_kms_key_id` from `s3_callback_params`, pass `ServerSideEncryption` / `SSEKMSKeyId` to `put_object` only when set; new module-level `resolve_sse_params` helper shared with s3_v2. Constructor kwargs are honored only when `litellm.s3_callback_params` is unset, matching this logger's existing convention for every other param (when the global dict is set it fully defines the config); the shipped call sites construct `S3Logger()` bare, so the config dict is the supported surface
- `litellm/integrations/s3_v2.py`: new `s3_sse_kms_key_id` param through `__init__` and `_init_s3_params`; `_sse_headers` helper emits both SSE headers on the async and sync upload paths (replaces the previous inline algorithm-only splat)
- `tests/test_litellm/integrations/test_s3.py` (new mirror file for the legacy logger) and `tests/test_litellm/integrations/test_s3_v2.py`: positive, negative, inference, conflicting-config, callback-params and audit-override coverage; all new tests fail on base and pass with the change

## QA runbook

1. `docker run --rm -d --name qa-pg -p 5432:5432 -e POSTGRES_DB=litellm -e POSTGRES_USER=llmproxy -e POSTGRES_PASSWORD=dbpassword9090 postgres:16`
2. Create a bucket and a KMS key, and optionally attach the deny policy above with your key ARN
3. Start the proxy with the config above (`python litellm/proxy/proxy_cli.py --config <cfg> --detailed_debug`) and send one chat completion through any real model
4. Within ~10s (s3_v2 flush interval) run `aws s3api head-object` on the new object; `ServerSideEncryption` must be `aws:kms` and `SSEKMSKeyId` must be your key ARN
5. Repeat with `success_callback: ["s3"]` for the legacy path, with the `s3_server_side_encryption` line removed (key-id-only inference), and with no SSE keys at all (object gets the bucket default, `AES256`)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
