### PR TITLE
fix(tool-management): drop unsupported prisma select kwarg from team lookup

### DIFF
--- a/litellm/proxy/management_endpoints/tool_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tool_management_endpoints.py
@@ -478,10 +478,7 @@ async def _resolve_team_id_to_object_permission_id(
     if not team_id or not team_id.strip():
         return None
     team_id_clean = team_id.strip()
-    row = await TeamRepository(prisma_client).table.find_unique(
-        where={"team_id": team_id_clean},
-        select={"object_permission_id": True},
-    )
+    row = await TeamRepository(prisma_client).table.find_unique(where={"team_id": team_id_clean})
     if row is None:
         return None
     op_id = getattr(row, "object_permission_id", None)
@@ -497,10 +494,7 @@ async def _resolve_team_id_to_object_permission_id(
     )
     if updated_count == 0:
         await ObjectPermissionRepository(prisma_client).table.delete(where={"object_permission_id": new_id})
-        row = await TeamRepository(prisma_client).table.find_unique(
-            where={"team_id": team_id_clean},
-            select={"object_permission_id": True},
-        )
+        row = await TeamRepository(prisma_client).table.find_unique(where={"team_id": team_id_clean})
         return getattr(row, "object_permission_id", None) if row else None
     return new_id
 

--- a/tests/test_litellm/proxy/management_endpoints/test_tool_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tool_management_endpoints.py
@@ -7,15 +7,17 @@ and litellm.proxy.proxy_server.prisma_client) because the endpoint code
 imports these inside function bodies to avoid circular imports.
 """
 
+import inspect
 import os
 import sys
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from prisma.actions import LiteLLM_TeamTableActions
 
 sys.path.insert(0, os.path.abspath("../../.."))
 
@@ -72,6 +74,47 @@ def _rollup_row(date: str, tool_name: str, spend: float, request_count: int, tot
 
 def _group_row(tool_name: str, spend: float, request_count: int, total_tokens: int) -> dict:
     return {"tool_name": tool_name, "_sum": {"spend": spend, "total_tokens": total_tokens, "request_count": request_count}}
+
+
+class FakeTeamTable:
+    """Stand-in for ``prisma_client.db.litellm_teamtable``.
+
+    ``AsyncMock`` accepts any keyword argument, so a plain mock cannot catch a call
+    the generated prisma client would reject at runtime. This double binds every
+    call against the real action signature, so an unsupported kwarg (e.g. ``select``)
+    raises the same ``TypeError`` the proxy surfaces as an HTTP 500.
+    """
+
+    def __init__(self, rows: list, updated_count: int = 1):
+        self._rows = list(rows)
+        self._updated_count = updated_count
+        self.find_unique_calls: list = []
+        self.update_many_calls: list = []
+
+    async def find_unique(self, **kwargs: Any) -> Any:
+        inspect.signature(LiteLLM_TeamTableActions.find_unique).bind(self, **kwargs)
+        index = len(self.find_unique_calls)
+        self.find_unique_calls.append(kwargs)
+        return self._rows[index] if index < len(self._rows) else None
+
+    async def update_many(self, **kwargs: Any) -> int:
+        inspect.signature(LiteLLM_TeamTableActions.update_many).bind(self, **kwargs)
+        self.update_many_calls.append(kwargs)
+        return self._updated_count
+
+
+def _team_row(object_permission_id: Optional[str]) -> MagicMock:
+    row = MagicMock()
+    row.object_permission_id = object_permission_id
+    return row
+
+
+def _team_policy_prisma(team_table: FakeTeamTable) -> MagicMock:
+    prisma = MagicMock()
+    prisma.db.litellm_teamtable = team_table
+    prisma.db.litellm_objectpermissiontable.create = AsyncMock()
+    prisma.db.litellm_objectpermissiontable.delete = AsyncMock()
+    return prisma
 
 
 def _rollup_prisma(group_rows: list, daily_rows: list | None = None) -> MagicMock:
@@ -160,6 +203,72 @@ class TestToolManagementEndpoints:
         body = resp.json()
         assert body["input_policy"] == "blocked"
         assert body["updated"] is True
+
+    @patch(
+        "litellm.proxy.db.tool_registry_writer.add_tool_to_object_permission_blocked",
+        new_callable=AsyncMock,
+    )
+    def test_update_tool_policy_for_team_does_not_500_on_unsupported_prisma_kwarg(self, mock_block):
+        """
+        Regression: POST /v1/tool/policy with a team_id returned 500 with
+        "LiteLLM_TeamTableActions.find_unique() got an unexpected keyword argument
+        'select'". The team lookup passed select={"object_permission_id": True}, and
+        the generated prisma client has no select kwarg, so the call raised TypeError
+        that the handler turned into a 500.
+        """
+        mock_block.return_value = True
+        team_table = FakeTeamTable([_team_row("existing-op-id")])
+
+        with patch("litellm.proxy.proxy_server.prisma_client", _team_policy_prisma(team_table)), patch(
+            "litellm.proxy.db.tool_registry_writer.get_tool_policy_registry"
+        ) as mock_registry:
+            mock_registry.return_value.is_initialized.return_value = False
+            resp = self.client.post(
+                "/v1/tool/policy",
+                json={"tool_name": "my_tool", "input_policy": "blocked", "team_id": "team-123"},
+            )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["team_id"] == "team-123"
+        assert team_table.find_unique_calls == [{"where": {"team_id": "team-123"}}]
+        mock_block.assert_awaited_once_with(
+            prisma_client=mock_block.await_args.kwargs["prisma_client"],
+            object_permission_id="existing-op-id",
+            tool_name="my_tool",
+        )
+
+    @patch(
+        "litellm.proxy.db.tool_registry_writer.add_tool_to_object_permission_blocked",
+        new_callable=AsyncMock,
+    )
+    def test_update_tool_policy_for_team_reresolves_when_permission_race_is_lost(self, mock_block):
+        """
+        Same regression on the second team lookup: when the team has no object
+        permission yet and a concurrent writer wins the update_many (0 rows updated),
+        the handler re-reads the team to pick up the winner's id. That fallback read
+        passed the same unsupported select kwarg.
+        """
+        mock_block.return_value = True
+        team_table = FakeTeamTable(
+            [_team_row(None), _team_row("winner-op-id")],
+            updated_count=0,
+        )
+
+        with patch("litellm.proxy.proxy_server.prisma_client", _team_policy_prisma(team_table)), patch(
+            "litellm.proxy.db.tool_registry_writer.get_tool_policy_registry"
+        ) as mock_registry:
+            mock_registry.return_value.is_initialized.return_value = False
+            resp = self.client.post(
+                "/v1/tool/policy",
+                json={"tool_name": "my_tool", "input_policy": "blocked", "team_id": "team-123"},
+            )
+
+        assert resp.status_code == 200, resp.text
+        assert team_table.find_unique_calls == [
+            {"where": {"team_id": "team-123"}},
+            {"where": {"team_id": "team-123"}},
+        ]
+        assert mock_block.await_args.kwargs["object_permission_id"] == "winner-op-id"
 
     @patch("litellm.proxy.proxy_server.prisma_client", None)
     def test_list_tools_no_db_returns_500(self):

--- a/tests/test_litellm/proxy/management_endpoints/test_tool_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_tool_management_endpoints.py
@@ -10,8 +10,9 @@ imports these inside function bodies to avoid circular imports.
 import inspect
 import os
 import sys
+from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -85,19 +86,19 @@ class FakeTeamTable:
     raises the same ``TypeError`` the proxy surfaces as an HTTP 500.
     """
 
-    def __init__(self, rows: list, updated_count: int = 1):
-        self._rows = list(rows)
+    def __init__(self, rows: Sequence[MagicMock], updated_count: int = 1):
+        self._rows = tuple(rows)
         self._updated_count = updated_count
-        self.find_unique_calls: list = []
-        self.update_many_calls: list = []
+        self.find_unique_calls: list[dict[str, object]] = []
+        self.update_many_calls: list[dict[str, object]] = []
 
-    async def find_unique(self, **kwargs: Any) -> Any:
+    async def find_unique(self, **kwargs: object) -> Optional[MagicMock]:
         inspect.signature(LiteLLM_TeamTableActions.find_unique).bind(self, **kwargs)
         index = len(self.find_unique_calls)
         self.find_unique_calls.append(kwargs)
         return self._rows[index] if index < len(self._rows) else None
 
-    async def update_many(self, **kwargs: Any) -> int:
+    async def update_many(self, **kwargs: object) -> int:
         inspect.signature(LiteLLM_TeamTableActions.update_many).bind(self, **kwargs)
         self.update_many_calls.append(kwargs)
         return self._updated_count


### PR DESCRIPTION
## TLDR

Problem this solves:

- `POST /v1/tool/policy` 500s whenever a `team_id` is sent
- Per-team tool blocking is completely unreachable
- Prisma 0.11.0 has no `select` kwarg on `find_unique`

How it solves it:

- Drops the `select` kwarg from both team lookups
- Test double now binds calls against the real prisma signature

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs are against a live proxy on `localhost:4001` backed by a real Postgres

Setup, run once against either commit:

```bash
curl -sS -X POST http://localhost:4001/team/new \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"team_alias":"tool-policy-repro-team"}'
```

That returned `team_id=b2d51515-c38d-4faa-8ae6-ec52637797b7`, used below

### Before, at 8e287652c6 (base, without this PR)

```bash
curl -sS -w '\nHTTP %{http_code}\n' -X POST http://localhost:4001/v1/tool/policy \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"tool_name":"my_tool","input_policy":"blocked","team_id":"b2d51515-c38d-4faa-8ae6-ec52637797b7"}'
```

```
{"detail":"LiteLLM_TeamTableActions.find_unique() got an unexpected keyword argument 'select'"}
HTTP 500
```

### After, at 8c759f0616 (this PR)

Four calls, covering both lookup paths plus the unblock and not-found cases

```bash
TEAM=b2d51515-c38d-4faa-8ae6-ec52637797b7

echo "### 1. block my_tool for the team (team has no object permission yet)"
curl -sS -w '\nHTTP %{http_code}\n' -X POST http://localhost:4001/v1/tool/policy \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d "{\"tool_name\":\"my_tool\",\"input_policy\":\"blocked\",\"team_id\":\"$TEAM\"}"

echo "### 2. block a second tool (team now HAS an object permission)"
curl -sS -w '\nHTTP %{http_code}\n' -X POST http://localhost:4001/v1/tool/policy \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d "{\"tool_name\":\"other_tool\",\"input_policy\":\"blocked\",\"team_id\":\"$TEAM\"}"

echo "### 3. unblock my_tool for the team"
curl -sS -w '\nHTTP %{http_code}\n' -X POST http://localhost:4001/v1/tool/policy \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d "{\"tool_name\":\"my_tool\",\"input_policy\":\"untrusted\",\"team_id\":\"$TEAM\"}"

echo "### 4. unknown team still 404s"
curl -sS -w '\nHTTP %{http_code}\n' -X POST http://localhost:4001/v1/tool/policy \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" -H "Content-Type: application/json" \
  -d '{"tool_name":"my_tool","input_policy":"blocked","team_id":"no-such-team"}'
```

```
### 1. block my_tool for the team (team has no object permission yet)
{"tool_name":"my_tool","input_policy":"blocked","output_policy":null,"updated":true,"team_id":"b2d51515-c38d-4faa-8ae6-ec52637797b7","key_hash":null}
HTTP 200

### 2. block a second tool (team now HAS an object permission)
{"tool_name":"other_tool","input_policy":"blocked","output_policy":null,"updated":true,"team_id":"b2d51515-c38d-4faa-8ae6-ec52637797b7","key_hash":null}
HTTP 200

### 3. unblock my_tool for the team
{"tool_name":"my_tool","input_policy":"untrusted","output_policy":null,"updated":true,"team_id":"b2d51515-c38d-4faa-8ae6-ec52637797b7","key_hash":null}
HTTP 200

### 4. unknown team still 404s
{"detail":"Key or team not found for the given identifier"}
HTTP 404
```

The 200s are not empty acknowledgements; the writes landed in the DB. After the three calls above, `my_tool` was blocked then unblocked and `other_tool` stayed blocked

```bash
curl -sS "http://localhost:4001/team/info?team_id=b2d51515-c38d-4faa-8ae6-ec52637797b7" \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" | jq '.team_info.object_permission'
```

```
{
  "object_permission_id": "37bb10b0-482f-4ec2-9d5e-c37a99aba259",
  "mcp_servers": [],
  "mcp_access_groups": [],
  "mcp_tool_permissions": null,
  "vector_stores": [],
  "agents": [],
  "agent_access_groups": [],
  "models": [],
  "mcp_toolsets": [],
  "blocked_tools": [
    "other_tool"
  ],
  "search_tools": [],
  "mcp_tool_search_enabled": null
}
```

## Type

🐛 Bug Fix

## Changes

`_resolve_team_id_to_object_permission_id` read the team row with `select={"object_permission_id": True}`. prisma-client-py 0.11.0 does not accept a `select` kwarg on `find_unique`; its signature is `(self, where, include)`. The kwarg went straight to the generated client, raised `TypeError`, and the handler's catch-all turned that into a 500. Both reads were affected: the initial lookup and the fallback re-read taken when a concurrent writer wins the `update_many` race, so there was no path through the team branch that worked

The kwarg is dropped rather than replaced. The generated client has no projection API, and this is a single-row primary-key lookup where selecting all columns costs nothing worth working around

The reason this shipped green is the existing tests stubbed the team table with an `AsyncMock`, which accepts any keyword and so cannot reproduce a call the real client rejects. The new `FakeTeamTable` double binds every `find_unique` and `update_many` call against the real generated-action signature, so an unsupported kwarg raises the same `TypeError` production does. Both new tests fail on base with the exact 500 message quoted above and pass with the fix

Same class of bug as the `/tag/list` 500, which is a separate PR against a different endpoint

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
