### PR TITLE
chore(release): backport #35271 to rc/1.95.0

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2455,16 +2455,6 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
             "is active as a reminder that hard enforcement is relaxed."
         ),
     )
-    skip_user_budget_on_team_key: bool | None = Field(
-        None,
-        description=(
-            "If True, restores the legacy behavior where a user's personal "
-            "max_budget is NOT enforced when their key belongs to a team; only "
-            "the team (and team-member) budgets apply. Defaults to False, meaning "
-            "the user's personal max_budget is always enforced regardless of "
-            "whether the key belongs to a team (see GitHub issue #12905)."
-        ),
-    )
     user_url_validation: Optional[bool] = Field(
         None,
         description=(

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -632,31 +632,28 @@ async def common_checks(
             )
 
         async def _user_max_budget_check() -> None:
-            if user_object is None or user_object.max_budget is None:
-                return
-            skip_for_team = (
-                general_settings.get("skip_user_budget_on_team_key") is True
-                and team_object is not None
-                and team_object.team_id is not None
-            )
-            if skip_for_team:
-                return
-            from litellm.proxy.proxy_server import get_current_spend
+            # 4.1 personal budget, if personal key
+            if (
+                (team_object is None or team_object.team_id is None)
+                and user_object is not None
+                and user_object.max_budget is not None
+            ):
+                from litellm.proxy.proxy_server import get_current_spend
 
-            user_budget = user_object.max_budget
-            user_spend = await get_current_spend(
-                counter_key=f"spend:user:{user_object.user_id}",
-                fallback_spend=user_object.spend or 0.0,
-                max_budget=user_budget,
-            )
-            if math.isfinite(user_budget) and user_spend >= user_budget:
-                raise litellm.BudgetExceededError(
-                    current_cost=user_spend,
+                user_budget = user_object.max_budget
+                user_spend = await get_current_spend(
+                    counter_key=f"spend:user:{user_object.user_id}",
+                    fallback_spend=user_object.spend or 0.0,
                     max_budget=user_budget,
-                    message=f"ExceededBudget: User={user_object.user_id} over budget. Spend={user_spend}, Budget={user_budget}",
-                    entity_type=Litellm_EntityType.USER.value,
-                    entity_id=user_object.user_id,
                 )
+                if math.isfinite(user_budget) and user_spend >= user_budget:
+                    raise litellm.BudgetExceededError(
+                        current_cost=user_spend,
+                        max_budget=user_budget,
+                        message=f"ExceededBudget: User={user_object.user_id} over budget. Spend={user_spend}, Budget={user_budget}",
+                        entity_type=Litellm_EntityType.USER.value,
+                        entity_id=user_object.user_id,
+                    )
 
         # Each scope reads a distinct counter key with no cross-scope ordering
         # dependency, so the per-scope Redis-first reads run concurrently instead

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -2461,7 +2461,6 @@ async def _reserve_budget_after_common_checks(
         proxy_logging_obj=proxy_logging_obj,
         end_user_id=end_user_id,
         end_user_object=end_user_object,
-        skip_user_budget_on_team_key=general_settings.get("skip_user_budget_on_team_key") is True,
         fail_closed_budget_enforcement=general_settings.get("fail_closed_budget_enforcement") is True,
     )
 

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -15169,7 +15169,6 @@ async def get_config_list(
         "forward_client_headers_to_llm_api": {"type": "Boolean"},
         "mcp_required_fields": {"type": "List"},
         "cancel_on_disconnect": {"type": "Boolean"},
-        "skip_user_budget_on_team_key": {"type": "Boolean"},
         "disable_auto_add_proxy_admin_to_teams": {"type": "Boolean"},
     }
 

--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -155,7 +155,6 @@ async def reserve_budget_for_request(
     proxy_logging_obj: ProxyLogging,
     end_user_id: Optional[str] = None,
     end_user_object: Optional[Any] = None,
-    skip_user_budget_on_team_key: bool = False,
     fail_closed_budget_enforcement: bool = False,
 ) -> Optional[dict]:
     if valid_token is None or not RouteChecks.is_llm_api_route(route=route):
@@ -175,7 +174,6 @@ async def reserve_budget_for_request(
         proxy_logging_obj=proxy_logging_obj,
         end_user_id=end_user_id,
         end_user_object=end_user_object,
-        skip_user_budget_on_team_key=skip_user_budget_on_team_key,
     )
     if not counters:
         return None
@@ -333,7 +331,6 @@ async def _get_budget_counters(
     proxy_logging_obj: ProxyLogging,
     end_user_id: Optional[str] = None,
     end_user_object: Optional[Any] = None,
-    skip_user_budget_on_team_key: bool = False,
 ) -> List[_BudgetCounter]:
     counters: List[_BudgetCounter] = []
 
@@ -382,9 +379,8 @@ async def _get_budget_counters(
             )
         )
 
-    is_team_key = team_object is not None and team_object.team_id is not None
     if (
-        not (is_team_key and skip_user_budget_on_team_key)
+        (team_object is None or team_object.team_id is None)
         and user_object is not None
         and user_object.user_id is not None
         and user_object.max_budget is not None

--- a/tests/proxy_unit_tests/test_user_api_key_auth.py
+++ b/tests/proxy_unit_tests/test_user_api_key_auth.py
@@ -219,8 +219,8 @@ async def test_aaauser_personal_budgets(key_ownership):
     """
     Set a personal budget on a user
 
-    User budget is enforced regardless of key ownership (personal or team).
-    Both cases should raise BudgetExceededError when the user is over budget.
+    - have it only apply when key belongs to user -> raises BudgetExceededError
+    - if key belongs to team, have key respect team budget -> allows call to go through
     """
     import asyncio
     import time
@@ -278,9 +278,12 @@ async def test_aaauser_personal_budgets(key_ownership):
         == valid_token
     )
 
-    with pytest.raises(ProxyException) as exc_info:
+    if key_ownership == "user_key":
+        with pytest.raises(ProxyException) as exc_info:
+            await user_api_key_auth(request=request, api_key="Bearer " + user_key)
+        assert exc_info.value.type == ProxyErrorTypes.budget_exceeded
+    else:
         await user_api_key_auth(request=request, api_key="Bearer " + user_key)
-    assert exc_info.value.type == ProxyErrorTypes.budget_exceeded
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -4683,66 +4683,26 @@ async def test_common_checks_personal_user_budget_blocks_in_gather():
 
 
 @pytest.mark.asyncio
-async def test_user_budget_enforced_on_team_key():
-    """User budget must be enforced even when the key belongs to a team.
+async def test_common_checks_personal_user_budget_skipped_for_team_key():
+    """A user's personal max_budget does not apply to a team-scoped key.
 
-    Previously _user_max_budget_check skipped enforcement for team keys,
-    letting a user with a $100 personal budget spend unlimited through a
-    team key. This regression test ensures that is no longer the case.
+    Team keys are governed by the team (and team-member) budgets only; the key
+    owner's personal budget is deliberately out of scope. This asserts the read
+    path lets a team key through even when the user is far over their personal
+    budget, and fails if personal enforcement is reintroduced for team keys.
     """
     from fastapi import Request
 
     from litellm.proxy.auth.auth_checks import common_checks
 
     user = LiteLLM_UserTable(user_id="u1", spend=0.0, max_budget=100.0)
-    team = LiteLLM_TeamTable(team_id="t1", max_budget=2100.0)
+    team = LiteLLM_TeamTable(team_id="t1", spend=0.0, max_budget=1000.0)
     token = UserAPIKeyAuth(token="k1", user_id="u1", team_id="t1")
 
     async def _spend_by_counter(counter_key, fallback_spend, max_budget=None, **kwargs):
         return 999.0 if counter_key == "spend:user:u1" else 0.0
 
-    async def _no_membership(*a, **kw):
-        return None
-
-    with patch("litellm.proxy.proxy_server.prisma_client", None), patch(
-        "litellm.proxy.proxy_server.get_current_spend", _spend_by_counter
-    ), patch("litellm.proxy.auth.auth_checks.get_team_membership", _no_membership):
-        with pytest.raises(litellm.BudgetExceededError) as over:
-            await common_checks(
-                request_body={"messages": [{"role": "user", "content": "hi"}]},
-                team_object=team,
-                user_object=user,
-                end_user_object=None,
-                global_proxy_spend=None,
-                general_settings={},
-                route="/chat/completions",
-                llm_router=None,
-                proxy_logging_obj=MagicMock(),
-                valid_token=token,
-                request=MagicMock(spec=Request),
-            )
-    assert "User=u1" in str(over.value)
-
-
-@pytest.mark.asyncio
-async def test_skip_user_budget_on_team_key_flag_restores_old_behavior():
-    """Setting skip_user_budget_on_team_key=True skips user budget for team keys.
-
-    This is the opt-in escape hatch that restores the legacy behavior where
-    user budgets were not enforced when the key belonged to a team.
-    """
-    from fastapi import Request
-
-    from litellm.proxy.auth.auth_checks import common_checks
-
-    user = LiteLLM_UserTable(user_id="u1", spend=0.0, max_budget=100.0)
-    team = LiteLLM_TeamTable(team_id="t1", max_budget=2100.0)
-    token = UserAPIKeyAuth(token="k1", user_id="u1", team_id="t1")
-
-    async def _spend_by_counter(counter_key, fallback_spend, max_budget=None, **kwargs):
-        return 999.0 if counter_key == "spend:user:u1" else 0.0
-
-    async def _no_membership(*a, **kw):
+    async def _no_membership(*args, **kwargs):
         return None
 
     with patch("litellm.proxy.proxy_server.prisma_client", None), patch(
@@ -4754,7 +4714,7 @@ async def test_skip_user_budget_on_team_key_flag_restores_old_behavior():
             user_object=user,
             end_user_object=None,
             global_proxy_spend=None,
-            general_settings={"skip_user_budget_on_team_key": True},
+            general_settings={},
             route="/chat/completions",
             llm_router=None,
             proxy_logging_obj=MagicMock(),

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -611,12 +611,12 @@ async def test_should_reserve_team_member_and_org_budget_counters(spend_counter_
 
 
 @pytest.mark.asyncio
-async def test_should_reserve_user_budget_counter_for_team_key(spend_counter_state):
-    """A user's personal budget must be reserved even when the key belongs to a team.
+async def test_should_not_reserve_user_budget_counter_for_team_key(spend_counter_state):
+    """The reservation path mirrors the read path: no personal user counter for a team key.
 
-    Regression for GitHub issue #12905: previously the reservation path skipped the
-    user spend counter whenever the key had a team, so a team key could overshoot the
-    user's personal max_budget under concurrency.
+    A team-scoped key reserves against the key and team counters only, so the key
+    owner's personal max_budget never gates a team request. Fails if the user
+    counter is reserved for team keys again.
     """
     counter_cache, key_cache = spend_counter_state
     proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
@@ -645,44 +645,7 @@ async def test_should_reserve_user_budget_counter_for_team_key(spend_counter_sta
             proxy_logging_obj=proxy_logging_obj,
         )
 
-    assert counter_cache.in_memory_cache.get_cache(key="spend:user:user-on-team") == pytest.approx(0.3)
-
-    await release_budget_reservation(reservation)
-
-
-@pytest.mark.asyncio
-async def test_should_skip_user_budget_counter_for_team_key_when_flag_set(spend_counter_state):
-    """skip_user_budget_on_team_key=True restores the legacy behavior where a user's
-    personal budget is not reserved for a team key."""
-    counter_cache, key_cache = spend_counter_state
-    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
-    valid_token = UserAPIKeyAuth(
-        token="key-user-on-team-skip",
-        spend=0.0,
-        user_id="user-on-team-skip",
-        team_id="team-no-budget-skip",
-    )
-    team_object = LiteLLM_TeamTable(team_id="team-no-budget-skip", spend=0.0, max_budget=None)
-    user_object = LiteLLM_UserTable(user_id="user-on-team-skip", spend=0.0, max_budget=5.0)
-
-    with patch(
-        "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
-        return_value=0.3,
-    ):
-        reservation = await reserve_budget_for_request(
-            request_body=_request_body(),
-            route="/chat/completions",
-            llm_router=None,
-            valid_token=valid_token,
-            team_object=team_object,
-            user_object=user_object,
-            prisma_client=None,
-            user_api_key_cache=key_cache,
-            proxy_logging_obj=proxy_logging_obj,
-            skip_user_budget_on_team_key=True,
-        )
-
-    assert counter_cache.in_memory_cache.get_cache(key="spend:user:user-on-team-skip") is None
+    assert counter_cache.in_memory_cache.get_cache(key="spend:user:user-on-team") is None
 
     await release_budget_reservation(reservation)
 

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -9201,38 +9201,6 @@ def test_get_config_list_includes_cancel_on_disconnect(monkeypatch):
         app.dependency_overrides.clear()
 
 
-def test_get_config_list_includes_skip_user_budget_on_team_key(monkeypatch):
-    """Related to #12905: the opt-out flag must be discoverable via /config/list so
-    it renders as a Boolean toggle on the Admin UI General Settings table. This
-    requires both the ConfigGeneralSettings field and the allowed_args entry."""
-    import types
-    from unittest.mock import AsyncMock, MagicMock
-
-    from fastapi.testclient import TestClient
-
-    import litellm.proxy.proxy_server as ps
-    from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
-    from litellm.proxy.proxy_server import app
-
-    mock_prisma = MagicMock()
-    mock_config_table = MagicMock()
-    mock_config_table.find_first = AsyncMock(return_value=None)
-    mock_prisma.db = types.SimpleNamespace(litellm_config=mock_config_table)
-    monkeypatch.setattr(ps, "prisma_client", mock_prisma)
-    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
-        user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
-    )
-    try:
-        client = TestClient(app)
-        resp = client.get("/config/list", params={"config_type": "general_settings"})
-        assert resp.status_code == 200, resp.text
-        fields = {item["field_name"]: item for item in resp.json()}
-        assert "skip_user_budget_on_team_key" in fields
-        assert fields["skip_user_budget_on_team_key"]["field_type"] == "Boolean"
-    finally:
-        app.dependency_overrides.clear()
-
-
 def test_get_config_list_includes_budget_exceeded_throttle_percentage(monkeypatch):
     """The throttle fraction is a litellm_settings scalar surfaced on the General
     Settings table as a Float field so it sits with the other global limits; it

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22794,11 +22794,6 @@ export interface components {
              */
             reject_clientside_metadata_tags?: boolean | null;
             /**
-             * Skip User Budget On Team Key
-             * @description If True, restores the legacy behavior where a user's personal max_budget is NOT enforced when their key belongs to a team; only the team (and team-member) budgets apply. Defaults to False, meaning the user's personal max_budget is always enforced regardless of whether the key belongs to a team (see GitHub issue #12905).
-             */
-            skip_user_budget_on_team_key?: boolean | null;
-            /**
              * Store Model In Db
              * @description If True, models and config are stored in and loaded from the database. Default is False.
              */


### PR DESCRIPTION
## TLDR

Problem this solves:

- rc/1.95.0 enforces a user's personal budget on their team keys
- An over-budget user is locked out of the Admin UI
- The opt-out flag is dead weight once the behavior is gone

How it solves it:

- Backports #35271, which reverted #32005
- A team key is governed by team and team-member budgets only
- No version bump; the rc line pins pyproject at 1.95.0

## Relevant issues

Backports #35271 onto `rc/1.95.0`. #32005 made a user's personal `max_budget` apply to team-scoped keys and shipped `skip_user_budget_on_team_key` as the opt-out. That flipped the default for every deployment on this line, so keys that had been serving started returning `429 ExceededBudget` once the owner's personal spend crossed their own cap, with plenty of team budget left. #35271 reverted it on staging; this brings the same revert to the rc line

The sharpest symptom is the Admin UI. A dashboard login mints a virtual key scoped to the `litellm-dashboard` pseudo-team, so on this line an over-budget internal user is refused on the management routes the dashboard calls on load and cannot reach the page that would raise their own limit. The proof below reproduces that lockout and its removal against a live proxy

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## What is included

- #35271 `revert(proxy)!: stop enforcing user budget on team keys`, cherry-picked from `6f1625d23bb1649394ad59c6a98c31633a1ba924` on `litellm_internal_staging`

That is the whole branch: one commit, no bump, no lock refresh. The rc line pins `pyproject` at `1.95.0` for its entire dev and rc phase, which `v1.95.0-dev.1`, `v1.95.0-dev.2` and `v1.95.0-rc.1` all confirm by carrying that same version, so a backport onto this line does not move it. `v1.95.0` itself is not published on DockerHub, so nothing has shipped under the GA version either

## Adaptation notes

None; the pick is VERBATIM. `git patch-id --stable` returns `de2054cb5cf74874ac58b70edffbe1a6179bf317` for both the staging commit and the picked commit, and `git range-diff` shows the `(cherry picked from commit ...)` footer as the only difference

Worth noting because the same pick was ADAPTED on `stable/1.94.x` in #35277, where the removed `skip_user_budget_on_team_key` sat beside `fail_closed_budget_enforcement` from #34429, which that line does not carry. `rc/1.95.0` does carry #34429, so the adjacency resolves on its own and no hand resolution was needed

## Known noise on this line

Five failures are present on the untouched tip `16fa6fa15e` and are unrelated to this pick, so the results below are deltas rather than absolutes:

```
tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py::TestAggregateGatewayDcrChallenge::test_challenge_inserts_server_root_path
tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py::TestAggregateGatewayDcrChallenge::test_challenge_invalid_token_on_failed_bearer
tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py::TestAggregateGatewayDcrChallenge::test_challenge_on_anonymous_aggregate_mcp
tests/test_litellm/proxy/test_proxy_server.py::test_general_settings_ui_fields_are_db_overridable
tests/test_litellm/proxy/test_proxy_server.py::test_max_ui_session_budget_default_is_one_dollar
```

The two `test_proxy_server.py` failures both concern `max_ui_session_budget`, not the flag this pick removes

## Screenshots / Proof of Fix

One proxy, one Postgres, one config, two builds. The only thing that changes between the runs is the source tree. Both runs use the same over-budget internal user, driven over their cap by real paid OpenAI calls, and the same dashboard session token shape a UI login mints

Setup, on the before build:

```
$ curl -s -X POST $PROXY/user/new -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
    -d '{"user_id":"bp35271","user_email":"bp35271@example.com","user_role":"internal_user","max_budget":0.0005}'

$ curl -s -X POST $PROXY/v1/chat/completions -H "Authorization: Bearer $PERSONAL_KEY" -H 'Content-Type: application/json' \
    -d '{"model":"gpt-4o","messages":[{"role":"user","content":"Write 150 words about why release branches exist."}],"max_tokens":250}'
usage: 209 tokens

$ curl -s "$PROXY/user/info?user_id=bp35271" -H "Authorization: Bearer sk-1234"
spend: 0.0020175  max_budget: 0.0005  OVER BUDGET: True
```

The dashboard token is minted by an actual form login, and it is team-scoped exactly as the UI mints it:

```
$ curl -s -c cookies.txt -X POST $PROXY/login -H 'Content-Type: application/x-www-form-urlencoded' \
    --data-urlencode "username=bp35271@example.com" --data-urlencode "password=..."

$ curl -s "$PROXY/key/info?key=$UI_SESSION_KEY" -H "Authorization: Bearer sk-1234"
team_id: litellm-dashboard | user_id: bp35271
```

### Before, at commit `16fa6fa15e` (the untouched rc/1.95.0 tip)

Seventeen management routes the dashboard calls on load, with that session token:

```
/key/list                429  ExceededBudget=1
/organization/list       429  ExceededBudget=1
/team/list               429  ExceededBudget=1
/v2/key/info             405  ExceededBudget=0
/user/available_roles    429  ExceededBudget=1
/policies/list           429  ExceededBudget=1
/prompts/list            429  ExceededBudget=1
/v1/agents               429  ExceededBudget=1
/v2/guardrails/list      429  ExceededBudget=1
/model/info              200  ExceededBudget=0
/global/spend/logs       429  ExceededBudget=1
/sso/get/ui_settings     429  ExceededBudget=1
/get/config/callbacks    429  ExceededBudget=1
/vector_store/list       429  ExceededBudget=1
/mcp-rest/tools/list     429  ExceededBudget=1
/team/available          429  ExceededBudget=1
/callback/list           404  ExceededBudget=0

429s: 14/17   ExceededBudget bodies: 14/17
```

Fourteen of seventeen are refused with `ExceededBudget`, so the dashboard renders skeletons and the user cannot reach the page that would raise their limit. `/model/info` answers 200 because model discovery is already exempted; the 405 and 404 are a method and a missing route, not budget

### After, at commit `8b92b36573` (this branch)

Same proxy, same database, same user, same token shape, rebuilt from the picked tree:

```
/key/list                200  ExceededBudget=0
/organization/list       200  ExceededBudget=0
/team/list               401  ExceededBudget=0
/v2/key/info             405  ExceededBudget=0
/user/available_roles    200  ExceededBudget=0
/policies/list           401  ExceededBudget=0
/prompts/list            401  ExceededBudget=0
/v1/agents               200  ExceededBudget=0
/v2/guardrails/list      200  ExceededBudget=0
/model/info              200  ExceededBudget=0
/global/spend/logs       401  ExceededBudget=0
/sso/get/ui_settings     200  ExceededBudget=0
/get/config/callbacks    401  ExceededBudget=0
/vector_store/list       200  ExceededBudget=0
/mcp-rest/tools/list     200  ExceededBudget=0
/team/available          200  ExceededBudget=0
/callback/list           404  ExceededBudget=0

429s: 0/17   ExceededBudget bodies: 0/17
```

The five 401s are ordinary role checks rather than leftover budget refusals, which a control run pins down. Repeating the identical sweep on the same build with a second internal user who has no budget at all returns the same status code on every one of the seventeen routes:

```
/key/list                over-budget=200  healthy=200  MATCH
/organization/list       over-budget=200  healthy=200  MATCH
/team/list               over-budget=401  healthy=401  MATCH
/v2/key/info             over-budget=405  healthy=405  MATCH
/user/available_roles    over-budget=200  healthy=200  MATCH
/policies/list           over-budget=401  healthy=401  MATCH
/prompts/list            over-budget=401  healthy=401  MATCH
/v1/agents               over-budget=200  healthy=200  MATCH
/v2/guardrails/list      over-budget=200  healthy=200  MATCH
/model/info              over-budget=200  healthy=200  MATCH
/global/spend/logs       over-budget=401  healthy=401  MATCH
/sso/get/ui_settings     over-budget=200  healthy=200  MATCH
/get/config/callbacks    over-budget=401  healthy=401  MATCH
/vector_store/list       over-budget=200  healthy=200  MATCH
/mcp-rest/tools/list     over-budget=200  healthy=200  MATCH
/team/available          over-budget=200  healthy=200  MATCH
/callback/list           over-budget=404  healthy=404  MATCH
```

`$ curl -s "$PROXY/team/list" -H "Authorization: Bearer $UI_SESSION_KEY"` on the after build returns `{"detail":{"error":"Only admin users can query all teams/other teams. Your user role=internal_user"}}`, which is the role check speaking

### Personal budgets are still enforced

This is the half that proves the revert narrows enforcement to the team boundary instead of switching personal budgets off. The same user's personal key, which carries no team, is refused identically on both builds:

```
before, 16fa6fa15e
/v1/chat/completions     429  ExceededBudget: User=bp35271 over budget. Spend=0.0020175, Budget=0.0005
/key/list                429  ExceededBudget: User=bp35271 over budget. Spend=0.0020175, Budget=0.0005

after, 8b92b36573
/v1/chat/completions     429  ExceededBudget: User=bp35271 over budget. Spend=0.0020175, Budget=0.0005
/key/list                429  ExceededBudget: User=bp35271 over budget. Spend=0.0020175, Budget=0.0005
```

### Determinism, and the two added tests are red before they are green

Baseline on the untouched tip `16fa6fa15e`, over the nineteen test files that touch the pick or reference the symbols it changes:

```
5 failed, 1927 passed, 65 warnings in 396.22s
```

Post-pick, same nineteen files, same flags:

```
5 failed, 1924 passed, 65 warnings in 398.14s
```

The failure sets are identical, so there are zero new failures. The passing count drops by exactly three because the pick removes five tests that asserted the old behavior and its flag, and adds two that assert the restored direction:

```
removed: test_user_budget_enforced_on_team_key
         test_skip_user_budget_on_team_key_flag_restores_old_behavior
         test_should_reserve_user_budget_counter_for_team_key
         test_should_skip_user_budget_counter_for_team_key_when_flag_set
         test_get_config_list_includes_skip_user_budget_on_team_key
added:   test_common_checks_personal_user_budget_skipped_for_team_key
         test_should_not_reserve_user_budget_counter_for_team_key
```

Both added tests were confirmed red before green on this line rather than merely collected. Restoring the pre-revert `auth_checks.py` and `budget_reservation.py` while keeping the new tests makes both fail, and with the exact semantics being reverted:

```
E  litellm.exceptions.BudgetExceededError: ExceededBudget: User=u1 over budget. Spend=999.0, Budget=100.0
E  AssertionError: assert 0.3 is None
   +  where 0.3 = get_cache(key='spend:user:user-on-team')
2 failed
```

Restoring the picked source makes both pass. That is what establishes the pick delivers its claim on this line rather than only applying cleanly

Deep verification (gauntlet and scanner re-check) in progress; this body will be updated with the evidence

## Type

🐛 Bug Fix

## Changes

A team-scoped key is governed by the team and team-member budgets. The owner's personal `max_budget` applies to their personal keys

Both enforcement points move together, which is what made #32005 a behavior change rather than a read-time quirk. `_user_max_budget_check` in `common_checks` is the read-time gate, and `_get_budget_counters` decides which spend counters a request optimistically reserves against; reverting only one would leave a team key that passes the read check but still reserves against the personal counter

The `skip_user_budget_on_team_key` flag existed only to switch the new behavior off, so it goes with the behavior rather than lingering as a no-op: the `ConfigGeneralSettings` field, the `/config/list` `allowed_args` entry that rendered it as an Admin UI toggle, and the argument threaded through `reserve_budget_for_request` and `_get_budget_counters`. A tree-wide grep confirms no reference to it survives anywhere on the branch

`schema.d.ts` carries the matching 5-line removal from the pick. It is a generated types file rather than production UI source, so no Next.js rebuild is required and the branch commits no `_experimental/out/` artifacts

The single commit is a `-x` cherry-pick whose source is reachable from `litellm_internal_staging`. No merge commits, and grype reports no new advisory on this line's lock

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
