### PR TITLE
fix(ui): let the internal user and org forms save sub-cent budgets

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/default-user-settings/DefaultUserSettingsForm.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/default-user-settings/DefaultUserSettingsForm.test.tsx
@@ -149,6 +149,34 @@ describe("DefaultUserSettingsForm", () => {
     expect(updateSettings).toHaveBeenCalledWith({ ...SAVED_BODY, max_budget: 250 });
   });
 
+  it("saves a sub-cent budget the browser would veto under a 0.01 step", async () => {
+    const user = userEvent.setup();
+    const { updateSettings } = renderForm();
+
+    await enterEditMode(user);
+    const budget: HTMLInputElement = await screen.findByLabelText("Max Budget (USD)");
+    await user.clear(budget);
+    await user.type(budget, "0.001");
+
+    const teamBudget: HTMLInputElement = screen.getByLabelText("Max Budget in Team (USD)");
+    await user.clear(teamBudget);
+    await user.type(teamBudget, "0.002");
+
+    // jsdom never blocks the submit itself, so assert the constraint the real browser
+    // enforces before handleSubmit ever runs
+    expect(budget.checkValidity()).toBe(true);
+    expect(teamBudget.checkValidity()).toBe(true);
+
+    await user.click(await saveButton());
+
+    await waitFor(() => expect(updateSettings).toHaveBeenCalledTimes(1));
+    expect(updateSettings).toHaveBeenCalledWith({
+      ...SAVED_BODY,
+      max_budget: 0.001,
+      teams: [{ team_id: "team-alpha", max_budget_in_team: 0.002, user_role: "user" }],
+    });
+  });
+
   it("clears an emptied budget with null", async () => {
     const user = userEvent.setup();
     const { updateSettings } = renderForm();

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/default-user-settings/DefaultUserSettingsForm.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/default-user-settings/DefaultUserSettingsForm.tsx
@@ -133,7 +133,7 @@ const TeamsField = ({ control }: { control: SettingsControl }) => {
 
             <FormField control={control} name={`teams.${index}.max_budget_in_team`} label="Max Budget in Team (USD)">
               {({ ref, ...budgetField }) => (
-                <Input {...budgetField} ref={ref} type="number" step={0.01} min={0} placeholder="Optional" />
+                <Input {...budgetField} ref={ref} type="number" step="any" min={0} placeholder="Optional" />
               )}
             </FormField>
 
@@ -249,7 +249,7 @@ const SettingsForm = ({ initialValues, roleOptions, updateSettings, onCancel, on
   const onSubmit = form.handleSubmit((values) => mutation.mutate(values));
 
   return (
-    <form onSubmit={onSubmit}>
+    <form onSubmit={onSubmit} noValidate>
       <FieldGroup>
         <FormField
           control={form.control}
@@ -286,7 +286,7 @@ const SettingsForm = ({ initialValues, roleOptions, updateSettings, onCancel, on
           label="Max Budget (USD)"
           description="Default maximum budget for new users"
         >
-          {({ ref, ...field }) => <Input {...field} ref={ref} type="number" step={0.01} min={0} />}
+          {({ ref, ...field }) => <Input {...field} ref={ref} type="number" step="any" min={0} />}
         </FormField>
 
         <FormField

--- a/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.test.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.test.tsx
@@ -84,6 +84,28 @@ describe("OrgCreateDialog", () => {
     await waitFor(() => expect(screen.queryByLabelText("Organization Name")).not.toBeInTheDocument());
   });
 
+  it("creates with a sub-cent max budget the browser would veto under a 0.01 step", async () => {
+    const user = userEvent.setup();
+    const { createOrganization } = renderDialog();
+
+    await user.type(screen.getByLabelText("Organization Name"), "new-org");
+    const budget: HTMLInputElement = screen.getByLabelText("Max Budget (USD)");
+    await user.type(budget, "0.001");
+
+    // jsdom never blocks the submit itself, so assert the constraint the real browser
+    // enforces before handleSubmit ever runs
+    expect(budget.checkValidity()).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: "Create Organization" }));
+
+    await waitFor(() => expect(createOrganization).toHaveBeenCalledTimes(1));
+    expect(createOrganization.mock.calls[0][0]).toStrictEqual({
+      organization_alias: "new-org",
+      models: [],
+      max_budget: 0.001,
+    });
+  });
+
   it("maps selectors and limits into the create body", async () => {
     const user = userEvent.setup();
     const { createOrganization } = renderDialog();

--- a/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-create/OrgCreateDialog.tsx
@@ -79,7 +79,7 @@ export const OrgCreateDialog = ({
           <DialogTitle>Create Organization</DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={onSubmit}>
+        <form onSubmit={onSubmit} noValidate>
           <FieldGroup>
             <FormField control={form.control} name="organization_alias" label="Organization Name">
               {({ ref, ...field }) => <Input {...field} ref={ref} />}
@@ -97,7 +97,7 @@ export const OrgCreateDialog = ({
             </FormField>
 
             <FormField control={form.control} name="max_budget" label="Max Budget (USD)">
-              {({ ref, ...field }) => <Input {...field} ref={ref} type="number" step={0.01} min={0} />}
+              {({ ref, ...field }) => <Input {...field} ref={ref} type="number" step="any" min={0} />}
             </FormField>
 
             <FormField control={form.control} name="budget_duration" label="Reset Budget">

--- a/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.test.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.test.tsx
@@ -113,6 +113,24 @@ describe("OrgSettingsForm", () => {
     expect(patchOrganization).toHaveBeenCalledWith("org-1", { organization_alias: "acme-2" });
   });
 
+  it("saves a sub-cent max budget the browser would veto under a 0.01 step", async () => {
+    const user = userEvent.setup();
+    const { patchOrganization } = renderForm();
+
+    const budget: HTMLInputElement = screen.getByLabelText("Max Budget (USD)");
+    await user.clear(budget);
+    await user.type(budget, "0.001");
+
+    // jsdom never blocks the submit itself, so assert the constraint the real browser
+    // enforces before handleSubmit ever runs
+    expect(budget.checkValidity()).toBe(true);
+
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(patchOrganization).toHaveBeenCalledTimes(1));
+    expect(patchOrganization).toHaveBeenCalledWith("org-1", { max_budget: 0.001 });
+  });
+
   it("sends null when a limit is cleared", async () => {
     const user = userEvent.setup();
     const { patchOrganization } = renderForm();

--- a/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.tsx
+++ b/ui/litellm-dashboard/src/components/organization/org-settings/OrgSettingsForm.tsx
@@ -78,7 +78,7 @@ export const OrgSettingsForm = ({
   });
 
   return (
-    <form onSubmit={onSubmit}>
+    <form onSubmit={onSubmit} noValidate>
       <FieldGroup>
         <FormField control={form.control} name="organization_alias" label="Organization Name">
           {({ ref, ...field }) => <Input {...field} ref={ref} />}
@@ -96,7 +96,7 @@ export const OrgSettingsForm = ({
         </FormField>
 
         <FormField control={form.control} name="max_budget" label="Max Budget (USD)">
-          {({ ref, ...field }) => <Input {...field} ref={ref} type="number" step={0.01} min={0} />}
+          {({ ref, ...field }) => <Input {...field} ref={ref} type="number" step="any" min={0} />}
         </FormField>
 
         <FormField control={form.control} name="budget_duration" label="Reset Budget">


### PR DESCRIPTION
## TLDR

Problem this solves:

- A sub-cent max budget could not be saved from the UI
- Browser step check vetoed the submit, silently
- Read view kept showing the stale value

How it solves it:

- Money inputs use `step="any"` instead of `step={0.01}`
- The react-hook-form forms opt out of native validation
- zod stays the only validator on submit

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs go through Internal Users -> Default User Settings -> Edit Settings, type `0.001` into Max Budget (USD), press Save Changes, against a live proxy with `STORE_MODEL_IN_DB=True`

Before, captured at 8ccbc3e735: Chrome refuses the submit with "Please enter a valid value. The two nearest valid values are 0 and 0.01", the PATCH never leaves the page, and the read view still says "Not set"

<!-- BEFORE_SCREENSHOTS -->

After, captured at 9dbf530d6e: the same input saves and the read view shows `0.001`

<!-- AFTER_SCREENSHOTS -->

Server state confirms it, before and after the same click:

```bash
curl -s http://localhost:4000/get/internal_user_settings -H 'Authorization: Bearer sk-1234' | python3 -c "import json,sys; print(json.load(sys.stdin)['values'])"
```

```
before: {'user_role': 'internal_user', 'max_budget': None, 'budget_duration': '30d', 'models': None, 'teams': None}
after:  {'user_role': 'internal_user', 'max_budget': 0.001, 'budget_duration': '30d', 'models': None, 'teams': None}
```

The per-user form is the same story. On a user sitting at `max_budget` 0.00011, typing `0.001` and pressing Save Changes at 9dbf530d6e leaves the input reading `stepMismatch: true` with "Please enter a valid value. The two nearest valid values are 0.00011 and 0.01011", and the server never moves:

```bash
curl -s "http://localhost:4000/user/info?user_id=tiny-budget-repro" -H 'Authorization: Bearer sk-1234' | python3 -c "import json,sys; print(json.load(sys.stdin)['user_info']['max_budget'])"
```

```
before: 0.00011
after:  0.001
```

## Type

🐛 Bug Fix

## Changes

`DefaultUserSettingsForm`, `OrgSettingsForm` and `OrgCreateDialog` are the three forms built on `useZodForm`, and `UserEditView` is the antd form behind Edit Settings on a single internal user. All four had the same defect: a money `<input type="number">` with `step={0.01}` inside a `<form>` that still ran the browser's constraint validation. The browser checks `step` before the submit handler runs, so a sub-cent amount was rejected by the DOM with a native bubble and zero application-level feedback; the mutation never fired, the form stayed dirty and the read view kept rendering the previously loaded value. The zod schemas already accepted any non-negative number, so nothing but the DOM disagreed

Both halves are now fixed: money fields declare `step="any"` so arbitrary precision is legal, and each form carries `noValidate` so validation lives in zod (or antd's own rules) alone and a stray `min`, `step` or `pattern` attribute can never silently swallow a submit again. Integer-only fields (TPM/RPM) keep `step={1}`. `UserEditView` also drops a dead `precision={2}`, which is an antd `InputNumber` prop that `NumericalInput` never forwarded anywhere except the DOM

Each form gets a regression test that types a sub-cent budget, asserts the input passes `checkValidity()` (jsdom never blocks submission itself, so that assertion is what actually pins the browser behavior) and asserts the save payload carries `0.001` rather than nothing. All four fail on the old `step={0.01}`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
