### PR TITLE
feat(ui): show which log rows are the auto-router's own classifier calls

### DIFF
--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -11,6 +11,7 @@ from typing import (
     Literal,
     Mapping,
     NamedTuple,
+    Sequence,
     Union,
 )
 
@@ -2025,19 +2026,7 @@ async def ui_view_spend_logs(
 
         data = await prisma_client.db.query_raw(sql_query, *sql_params)
 
-        # query_raw returns the JSONB `metadata` column as a string (the Prisma
-        # serialiser bypasses the model-layer JSON hydration we get on the ORM
-        # path). The UI reads `metadata.status` / `metadata.error_information`
-        # as object fields, so failure rows looked like successes (#29674).
-        # Re-hydrate to dict here.
-        for row in data:
-            if isinstance(row, dict):
-                md = row.get("metadata")
-                if isinstance(md, str):
-                    try:
-                        row["metadata"] = json.loads(md)
-                    except (ValueError, TypeError):
-                        row["metadata"] = {}
+        _hydrate_spend_log_metadata(data)
 
         # Calculate total pages
         total_pages = (total_records + page_size - 1) // page_size
@@ -2076,6 +2065,27 @@ def _spend_log_field_has_content(value: Union[str, list, dict] | None) -> bool:
     if isinstance(value, (list, dict)):
         return len(value) > 0
     return True
+
+
+def _hydrate_spend_log_metadata(rows: Sequence[Any]) -> None:
+    """Re-hydrate the JSONB ``metadata`` column returned by ``query_raw`` as a string.
+
+    The Prisma serialiser bypasses the model-layer JSON hydration we get on the ORM
+    path, while the UI reads ``metadata.status`` / ``metadata.error_information`` /
+    ``metadata.internal_call_origin`` as object fields. Property access on a string
+    is silently undefined, so failure rows looked like successes (#29674). Every
+    ``query_raw`` reader of this column goes through here so a new one cannot
+    reintroduce that.
+    """
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        md = row.get("metadata")
+        if isinstance(md, str):
+            try:
+                row["metadata"] = json.loads(md)
+            except (ValueError, TypeError):
+                row["metadata"] = {}
 
 
 def _cold_storage_object_key_from_metadata(
@@ -3361,6 +3371,7 @@ async def ui_view_session_spend_logs(
             LIMIT $2 OFFSET $3
         """
         result = await prisma_client.db.query_raw(sql_query, session_id, page_size, skip, *scope_params)
+        _hydrate_spend_log_metadata(result)
 
         total_pages = (total_records + page_size - 1) // page_size
 

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_management_endpoints.py
@@ -1583,6 +1583,47 @@ async def test_ui_view_session_spend_logs_pagination(client, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_ui_view_session_spend_logs_rehydrates_metadata_jsonb_text(client, monkeypatch):
+    """The session sidebar reads metadata fields as object properties, so this endpoint
+    must re-hydrate the JSONB column that query_raw hands back as a string, exactly as
+    /spend/logs/ui does (#29674). Property access on a string is silently undefined,
+    so a row's origin, status and error information all read as absent without this.
+    """
+    raw_row = {
+        "request_id": "req-classifier-1",
+        "session_id": "session-123",
+        "startTime": "2024-01-01T00:00:00Z",
+        "metadata": json.dumps({"internal_call_origin": "autorouter_classifier", "status": "success"}),
+    }
+
+    class MockDB:
+        async def count(self, *args, **kwargs):
+            return 1
+
+        async def query_raw(self, sql_query, session_id, page_size, skip, *scope_params):
+            return [dict(raw_row)]
+
+    class MockPrismaClient:
+        def __init__(self):
+            self.db = MockDB()
+            self.db.litellm_spendlogs = self.db
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MockPrismaClient())
+    app.dependency_overrides[ps.user_api_key_auth] = lambda: UserAPIKeyAuth(
+        user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin_user"
+    )
+
+    try:
+        response = client.get("/spend/logs/session/ui", params={"session_id": "session-123"})
+        assert response.status_code == 200
+        row = response.json()["data"][0]
+        assert isinstance(row["metadata"], dict)
+        assert row["metadata"]["internal_call_origin"] == "autorouter_classifier"
+    finally:
+        app.dependency_overrides.pop(ps.user_api_key_auth, None)
+
+
+@pytest.mark.asyncio
 async def test_ui_view_session_spend_logs_scopes_non_admin_to_own_logs(client, monkeypatch):
     own_log = {
         "id": "log1",

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/ClassifyTag.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/ClassifyTag.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ClassifyTag } from "./ClassifyTag";
+
+describe("ClassifyTag", () => {
+  it("renders for an auto-router classifier row", () => {
+    render(<ClassifyTag origin="autorouter_classifier" />);
+    expect(screen.getByText("Classify")).toBeInTheDocument();
+  });
+
+  it("renders nothing for ordinary traffic, which is what makes the tag meaningful", () => {
+    const { container } = render(<ClassifyTag origin={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for an unrecognized origin rather than labelling it as a classifier call", () => {
+    const { container } = render(<ClassifyTag origin="something_else" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/ClassifyTag.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/ClassifyTag.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/cva.config";
+
+export const AUTOROUTER_CLASSIFIER_ORIGIN = "autorouter_classifier";
+
+export function ClassifyTag({ origin, className }: { origin?: string | null; className?: string }) {
+  if (origin !== AUTOROUTER_CLASSIFIER_ORIGIN) return null;
+  return (
+    <Badge
+      variant="secondary"
+      title="Tier classification call made by the auto-router, not a request the caller sent"
+      className={cn("px-2 py-0 text-[10px] font-normal", className)}
+    >
+      Classify
+    </Badge>
+  );
+}

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/DrawerHeader.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/DrawerHeader.tsx
@@ -3,6 +3,7 @@ import { CloseOutlined, UpOutlined, DownOutlined } from "@ant-design/icons";
 import moment from "moment";
 import { LogEntry } from "../columns";
 import { AutoRouterTag } from "@/components/shared/table_cells";
+import { ClassifyTag } from "./ClassifyTag";
 import { getProviderLogoAndName } from "../../provider_info_helpers";
 import {
   DRAWER_HEADER_PADDING,
@@ -59,6 +60,7 @@ export function DrawerHeader({
       <ModelProviderSection
         model={log.model}
         modelGroup={log.model_group}
+        internalCallOrigin={log.metadata?.internal_call_origin}
         providerLogo={providerInfo?.logo}
         providerName={providerInfo?.displayName}
       />
@@ -83,11 +85,13 @@ export function DrawerHeader({
 function ModelProviderSection({
   model,
   modelGroup,
+  internalCallOrigin,
   providerLogo,
   providerName,
 }: {
   model: string;
   modelGroup?: string;
+  internalCallOrigin?: string | null;
   providerLogo?: string;
   providerName?: string;
 }) {
@@ -114,6 +118,7 @@ function ModelProviderSection({
           </Text>
         )}
         <AutoRouterTag modelGroup={modelGroup} />
+        <ClassifyTag origin={internalCallOrigin} />
       </Space>
     </Space>
   );

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/LogDetailsDrawer.tsx
@@ -6,6 +6,7 @@ import { LogEntry } from "../columns";
 import { AutoRouterIcon, useIsAutoRoutedModelGroup } from "@/components/shared/table_cells";
 import { AGENT_CALL_TYPES, MCP_CALL_TYPES } from "../constants";
 import { getEventDisplayName } from "../utils";
+import { ClassifyTag } from "./ClassifyTag";
 import { DrawerHeader } from "./DrawerHeader";
 import { useKeyboardNavigation } from "./useKeyboardNavigation";
 import { LogDetailContent, GuardrailJumpLink } from "./LogDetailContent";
@@ -78,6 +79,7 @@ function TraceEventRow({ row, isSelected, onClick }: TraceEventRowProps) {
         <span className="text-xs font-medium text-slate-900 truncate">
           {getEventDisplayName(row.call_type, row.model)}
         </span>
+        <ClassifyTag origin={row.metadata?.internal_call_origin} className="ml-auto" />
       </div>
       <div className="text-[10px] text-slate-500 mt-0 flex items-center gap-1.5 font-mono">
         <span>{durationValue}s</span>


### PR DESCRIPTION
## TLDR

Problem this solves:

- Classifier calls sit in the session trace looking like caller traffic
- Nothing in the sidebar says the auto-router made that call

How it solves it:

- Small "Classify" pill on the trace row, and in the drawer header
- Reads the `internal_call_origin` the backend PR records

## Relevant issues

- Stacked on #35300, which records `internal_call_origin` on classifier spend log rows
- Adds the pill to the session trace sidebar and the opened request's header
- Existing icons and the Logs table Type column are deliberately untouched

## Linear ticket

Resolves LIT-5014

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

This is a UI change on top of #35300, so the steps to see it are below and the screenshots follow once they are captured
<img width="1600" height="1200" alt="image" src="https://github.com/user-attachments/assets/eac4c178-4f4e-49d2-a8d4-d7c33542482b" />



Run a proxy with an auto-router whose classifier is an LLM, using a config shaped like this:

```yaml
model_list:
  - model_name: gw-opus
    litellm_params:
      model: anthropic/us.anthropic.claude-opus-4-8
  - model_name: smart-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        classifier_type: llm
        classifier_llm_config:
          model: gw-opus
        tiers: {SIMPLE: gw-opus, MEDIUM: gw-opus, COMPLEX: gw-opus, REASONING: gw-opus}
```

1. Send an auto-routed request so the classifier runs, tagging it with a session you can find again

```bash
curl -s -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" \
  -d '{"model":"smart-router","messages":[{"role":"user","content":"Write a haiku about routing"}],"max_tokens":40,"litellm_session_id":"SESS-CHAT"}'
```

2. Send an ordinary request to the same model group, so there is an unlabelled row to compare against

```bash
curl -s -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $KEY" \
  -d '{"model":"gw-opus","messages":[{"role":"user","content":"say hello"}],"max_tokens":10,"litellm_session_id":"SESS-ORDINARY"}'
```

3. Open http://localhost:4000/ui/?page=logs, click the `smart-router` row from step 1, and look at the session sidebar on the left. Two rows share the session: the routed completion, and the classifier call carrying a "Classify" pill

4. Click the classifier row itself and confirm the same pill appears in the drawer header next to the model name

5. Open the row from step 2 and confirm no pill appears anywhere, which is the check that the pill means something

## Type

🆕 New Feature

## Changes

- `ClassifyTag` renders a shadcn `Badge` in the `secondary` variant with a leading dot, no bespoke palette
- Rendered on the session trace row in `LogDetailsDrawer` and beside `AutoRouterTag` in the drawer header
- Reads `metadata.internal_call_origin`, the field #35300 records, so the UI presence-checks a fact rather than inferring one
- The trace row icons are unchanged; the Logs table Type column is untouched

### Things a reviewer will ask about

Why the tag is gated on an exact match rather than on the field being present: an origin this build does not recognize is not necessarily a classifier call, and labelling it as one would be a false claim on a spend row. Unknown values render nothing

Why this is not in the Logs table Type column: that column answers what kind of API call a row is, and these rows really are ordinary completions. Where the row came from is a different question, so it belongs where a reader is already inspecting one request

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only labeling plus a localized spend-logs serialization fix; no auth, billing, or routing behavior changes.
> 
> **Overview**
> Adds a **Classify** badge in the logs UI when a spend row is an auto-router tier-classification call (`metadata.internal_call_origin === autorouter_classifier`), not caller traffic. The pill appears on session trace rows in `LogDetailsDrawer` and next to the model name in the drawer header; unknown or missing origins render nothing.
> 
> On the proxy, inline JSONB `metadata` re-hydration after `query_raw` is moved into **`_hydrate_spend_log_metadata`**, used by `/spend/logs/ui` and now **`/spend/logs/session/ui`** so session sidebar rows expose nested metadata (including `internal_call_origin`) instead of a raw string.
> 
> Tests cover session UI metadata hydration and `ClassifyTag` rendering rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9695e022ae75b023b1214d995b278db7d451148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->