### PR TITLE
fix(ui): let the per-user Internal Users edit form save sub-cent budgets

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/user_edit_view.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/user_edit_view.test.tsx
@@ -389,6 +389,24 @@ describe("UserEditView", () => {
     expect(callArgs.metadata).toEqual(MOCK_USER_DATA.user_info.metadata);
   });
 
+  it("should submit a sub-cent max budget the browser would veto under a 0.01 step", async () => {
+    const onSubmitMock = vi.fn();
+    renderWithProviders(<UserEditView {...defaultProps} onSubmit={onSubmitMock} />);
+
+    const budget: HTMLInputElement = await screen.findByRole("spinbutton");
+    await userEvent.clear(budget);
+    await userEvent.type(budget, "0.001");
+
+    // jsdom never blocks the submit itself, so assert the constraint the real browser
+    // enforces before onFinish ever runs
+    expect(budget.checkValidity()).toBe(true);
+
+    await userEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(onSubmitMock).toHaveBeenCalled());
+    expect(Number(onSubmitMock.mock.calls[0][0].max_budget)).toBe(0.001);
+  });
+
   it("should set max_budget to null when unlimited budget is checked on submit", async () => {
     const onSubmitMock = vi.fn();
     const userDataWithNullBudget = {

--- a/ui/litellm-dashboard/src/app/(dashboard)/users/_components/user_edit_view.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/users/_components/user_edit_view.tsx
@@ -96,7 +96,7 @@ export function UserEditView({
   };
 
   return (
-    <Form form={form} onFinish={handleSubmit} layout="vertical">
+    <Form form={form} onFinish={handleSubmit} layout="vertical" noValidate>
       {!isBulkEdit && (
         <Form.Item label="User ID" name="user_id">
           <TextInput disabled />
@@ -191,7 +191,7 @@ export function UserEditView({
           },
         ]}
       >
-        <NumericalInput step={0.01} precision={2} style={{ width: "100%" }} disabled={unlimitedBudget} />
+        <NumericalInput step="any" style={{ width: "100%" }} disabled={unlimitedBudget} />
       </Form.Item>
 
       <Form.Item label="Reset Budget" name="budget_duration">

--- a/ui/litellm-dashboard/src/components/shared/numerical_input.tsx
+++ b/ui/litellm-dashboard/src/components/shared/numerical_input.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { NumberInput } from "@tremor/react";
 
 interface NumericalInputProps {
-  step?: number;
+  step?: number | "any";
   style?: React.CSSProperties;
   placeholder?: string;
   min?: number;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Sub-cent budgets can't be saved on a single user
- Save Changes does nothing; no request, no error

How it solves it:

- Max Budget uses `step="any"` instead of `step={0.01}`
- The antd form opts out of native validation

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Same flow both times, against a live proxy with `STORE_MODEL_IN_DB=True`: Internal Users -> pick a user -> Details -> Edit Settings, type `0.001` into Max Budget (USD), press Save Changes

Before, at 7d97bbc3bb, the input reports `stepMismatch: true` with "Please enter a valid value. The two nearest valid values are 0.00011 and 0.01011", nothing is sent, and the detail view keeps showing the old budget. After, at 28c5b4cdbe, the same click saves

```bash
curl -s "http://localhost:4000/user/info?user_id=tiny-budget-repro" -H 'Authorization: Bearer sk-1234' | python3 -c "import json,sys; print(json.load(sys.stdin)['user_info']['max_budget'])"
```

```
before: 0.00011
after:  0.001
```

## Type

🐛 Bug Fix

## Changes

Follow-up to #35302, which fixed the three `useZodForm` forms and missed the antd one. `UserEditView` renders Max Budget through `NumericalInput` with `step={0.01}` inside an antd `Form` that never opted out of constraint validation, so the browser rejected any value with more than two decimals before `onFinish` ran. There was no application-level feedback: the mutation never fired and the read view kept rendering the previously loaded budget, which reads as the budget refusing to stick

The field now uses `step="any"` and the form carries `noValidate`, so antd's own rules are the only gate. The dead `precision={2}` goes too; that is an antd `InputNumber` prop, and `NumericalInput` renders a Tremor `NumberInput`, so it only ever reached the DOM as an unknown attribute

The regression test types a sub-cent budget, asserts the input passes `checkValidity()` (jsdom never blocks submission itself, so that assertion is what pins the real browser behavior) and asserts `onSubmit` receives `0.001`. It fails on the old `step={0.01}`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR