### PR TITLE
fix(tests): patch unified_guardrail translation cache directly, not the loader

### DIFF
--- a/tests/test_litellm/proxy/conftest.py
+++ b/tests/test_litellm/proxy/conftest.py
@@ -72,6 +72,27 @@ def _isolate_proxy_module_globals():
 
 
 @pytest.fixture(autouse=True)
+def _isolate_unified_guardrail_translation_cache():
+    """
+    Reset UnifiedLLMGuardrails' lazily-populated translation registry cache
+    before and after each test.
+
+    The cache is a module-level global gated by an ``is None`` check in 4
+    hook methods; once any test exercises a hook for real, the global stays
+    populated for the rest of the xdist worker's lifetime, silently
+    bypassing any later test's attempt to inject a translation mapping via
+    the loader function instead of the global itself.
+    """
+    import litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail as ug
+
+    ug.endpoint_guardrail_translation_mappings = None
+    try:
+        yield
+    finally:
+        ug.endpoint_guardrail_translation_mappings = None
+
+
+@pytest.fixture(autouse=True)
 def _reset_graceful_shutdown_state():
     """Graceful shutdown state is process-scoped; keep it from leaking between tests."""
     from litellm.proxy.shutdown.graceful_shutdown_manager import (

--- a/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_post_call_guardrails.py
+++ b/tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_post_call_guardrails.py
@@ -294,19 +294,23 @@ class TestUnifiedGuardrailCallTypeResolution:
 
         response_body = {"candidates": [{"content": {"parts": [{"text": "hello"}]}}]}
 
-        with patch(
-            "litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail.load_guardrail_translation_mappings"
-        ) as mock_load:
-            mock_handler_instance = AsyncMock()
-            mock_handler_instance.process_output_response = AsyncMock(
-                return_value=response_body
-            )
-            mock_handler_class = MagicMock(return_value=mock_handler_instance)
+        import litellm.proxy.guardrails.guardrail_hooks.unified_guardrail.unified_guardrail as ug
+        from litellm.types.utils import CallTypes
 
-            from litellm.types.utils import CallTypes
+        mock_handler_instance = AsyncMock()
+        mock_handler_instance.process_output_response = AsyncMock(
+            return_value=response_body
+        )
+        mock_handler_class = MagicMock(return_value=mock_handler_instance)
 
-            mock_load.return_value = {CallTypes.pass_through: mock_handler_class}
-
+        # endpoint_guardrail_translation_mappings is a module global cached
+        # across tests; patch it directly rather than the loader, which is
+        # only consulted while the cache is still None.
+        with patch.object(
+            ug,
+            "endpoint_guardrail_translation_mappings",
+            {CallTypes.pass_through: mock_handler_class},
+        ):
             result = await unified.async_post_call_success_hook(
                 data=data,
                 user_api_key_dict=user_api_key_dict,


### PR DESCRIPTION
## TLDR

Problem this solves:

- test_pass_through_call_type_resolved_from_logging_obj is flaky: it fails depending on xdist test ordering
- root cause is a module-level cache in unified_guardrail.py that the test's mock silently bypasses once populated by any other test in the same worker

How it solves it:

- patch the endpoint_guardrail_translation_mappings module global directly instead of the loader function it gates, matching the pattern test_blocked_response_usage.py already uses
- add an autouse fixture that resets the cache before and after every test under tests/test_litellm/proxy, so no test can poison or be poisoned by it

## Relevant issues

- test_pass_through_call_type_resolved_from_logging_obj fails nondeterministically in CI depending on which worker/order it runs in
- root cause: unified_guardrail.py:66 endpoint_guardrail_translation_mappings is a bare module global, lazily populated once per process by 4 hook methods and never reset between tests

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is a test-isolation-only fix; production code is untouched. The proof is reproducing the flake deterministically and showing the fix eliminates it, since the failure is inherently about test process state rather than something observable on a running proxy.

Repro (unfixed code): populate the module global the same way a real, unmocked hook call does (exactly what test_proxy_logging_hook_detection.py::test_unified_guardrail_iterator_accepts_explicit_guardrail does in the same CI job), then run the original test body.

```
$ uv run --no-sync python repro_flake.py
FAIL: original test body (patches the loader) raised: Expected process_output_response to have been awaited once. Awaited 0 times.
```

Verify (fixed code): same poisoning, but running the fixed test body (patches the module global directly).

```
$ uv run --no-sync python verify_fix.py
PASS: fixed test body (patches the module global) succeeded
```

Full proxy-infra CI job scope run locally with the same xdist config as CI (2 workers, loadscope, 2 reruns):

```
$ pytest -n 2 --dist=loadscope --reruns 2 --reruns-delay 1 \
    tests/test_litellm/proxy/db tests/test_litellm/proxy/middleware \
    tests/test_litellm/proxy/spend_tracking tests/test_litellm/proxy/pass_through_endpoints \
    tests/test_litellm/proxy/_experimental tests/test_litellm/proxy/experimental \
    tests/test_litellm/proxy/common_utils tests/test_litellm/proxy/logging_endpoints \
    tests/test_litellm/proxy/test_*.py
5691 passed, 42 rerun in 67.98s
```
(21 unrelated failures in test_semantic_tool_filter.py, due to a missing optional `semantic_router` dependency in this local environment, excluded)

## Type

✅ Test

## Changes

- `tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_post_call_guardrails.py`: patch the module global directly instead of the loader function
- `tests/test_litellm/proxy/conftest.py`: add an autouse fixture resetting `unified_guardrail.endpoint_guardrail_translation_mappings` before and after each test

## QA runbook

Run the target test in the same process as a real (unmocked) UnifiedLLMGuardrails hook call, in either order, and confirm both pass deterministically:

```
pytest tests/test_litellm/proxy/test_proxy_logging_hook_detection.py::test_unified_guardrail_iterator_accepts_explicit_guardrail \
       tests/test_litellm/proxy/pass_through_endpoints/test_passthrough_post_call_guardrails.py::TestUnifiedGuardrailCallTypeResolution::test_pass_through_call_type_resolved_from_logging_obj
```

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR