### PR TITLE
test(pricing): cover gpt-5.6 cache-cost plumbing and bedrock_mantle responses billing

### DIFF
--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -710,6 +710,49 @@ def test_generic_cost_per_token_gpt56_flex_above_272k(
 
 
 @pytest.mark.parametrize(
+    "service_tier,prompt_tokens,input_rate,cache_write_rate,cache_read_rate",
+    [
+        (None, 100000, 2e-6, 2.5e-6, 2e-7),
+        ("flex", 100000, 1e-6, 1.25e-6, 1e-7),
+        ("priority", 100000, 4e-6, 5e-6, 4e-7),
+        (None, 300000, 4e-6, 5e-6, 4e-7),
+        ("flex", 300000, 2e-6, 2.5e-6, 2e-7),
+    ],
+)
+def test_generic_cost_per_token_gpt56_terra_cache_costs_by_tier_and_context(
+    service_tier, prompt_tokens, input_rate, cache_write_rate, cache_read_rate
+):
+    os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    cached_tokens = 50000
+    cache_write_tokens = 40000
+    text_tokens = prompt_tokens - cached_tokens - cache_write_tokens
+    usage = Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=100,
+        total_tokens=prompt_tokens + 100,
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            cached_tokens=cached_tokens, cache_write_tokens=cache_write_tokens
+        ),
+    )
+
+    prompt_cost, _ = generic_cost_per_token(
+        model="gpt-5.6-terra",
+        usage=usage,
+        custom_llm_provider="openai",
+        service_tier=service_tier,
+    )
+
+    expected_prompt_cost = (
+        text_tokens * input_rate
+        + cached_tokens * cache_read_rate
+        + cache_write_tokens * cache_write_rate
+    )
+    assert prompt_cost == pytest.approx(expected_prompt_cost)
+
+
+@pytest.mark.parametrize(
     "model,input_cost,output_cost,cache_read_cost",
     [
         ("azure/gpt-5.6", 5e-6, 3e-5, 5e-7),

--- a/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
+++ b/tests/test_litellm/llms/bedrock_mantle/test_bedrock_mantle_responses_transformation.py
@@ -1534,6 +1534,39 @@ class TestBedrockMantleResponsesPricing:
         assert info["output_cost_per_token"] == pytest.approx(output_cost)
         assert info["max_input_tokens"] == 272000
 
+    @pytest.mark.parametrize(
+        "model, input_cost, output_cost",
+        [
+            ("openai.gpt-5.6-sol", 5.5e-06, 3.3e-05),
+            ("openai.gpt-5.6-terra", 2.2e-06, 1.32e-05),
+            ("openai.gpt-5.6-luna", 2.2e-07, 1.32e-06),
+        ],
+    )
+    def test_gpt_5_6_responses_call_cost(self, local_cost_map, model, input_cost, output_cost):
+        from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
+
+        input_tokens = 100000
+        output_tokens = 10000
+        response = ResponsesAPIResponse(
+            id="resp-1",
+            created_at=1700000000,
+            model=model,
+            output=[],
+            usage=ResponseAPIUsage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=input_tokens + output_tokens,
+            ),
+        )
+
+        cost = litellm.completion_cost(
+            completion_response=response,
+            model=f"bedrock_mantle/{model}",
+            custom_llm_provider="bedrock_mantle",
+        )
+
+        assert cost == pytest.approx(input_tokens * input_cost + output_tokens * output_cost)
+
     def test_models_registered(self, local_cost_map):
         assert "bedrock_mantle/openai.gpt-5.5" in litellm.bedrock_mantle_models
         assert "bedrock_mantle/openai.gpt-5.4" in litellm.bedrock_mantle_models


### PR DESCRIPTION
## TLDR

Problem this solves:

- Follow-up to #35270, closing the two QA-runbook gaps that kept its last checkboxes unchecked
- The cache-cost fields wired through `get_model_info` there (`cache_creation_input_token_cost_flex`/`_priority`, and the `*_above_272k_tokens_flex` cache variants) had no billing test; re-dropping them from the explicit kwargs list passed the whole suite
- No test exercised a `/v1/responses` call against a `bedrock_mantle` gpt-5.6 deployment end to end through the cost calculator

How it solves it:

- `test_generic_cost_per_token_gpt56_terra_cache_costs_by_tier_and_context` bills a request with cache-read and cache-write tokens across five (service tier, context size) combinations and asserts the exact prompt cost. Mutation-verified: reverting the cache wiring in `litellm/utils.py` fails the flex, priority, and flex-long-context rows
- `test_gpt_5_6_responses_call_cost` runs a `ResponsesAPIResponse` for all three bedrock_mantle gpt-5.6 models through `litellm.completion_cost` and asserts the exact spend at the corrected rates

The standard above-272k cache-write row passes even without the explicit wiring because `_get_model_info_helper` has a regex passthrough for keys ending in `_above_<n>k_tokens`; tier-suffixed keys do not match it, which is exactly why the explicit wiring needs its own coverage.

The remaining wired-but-untested fields (`cache_*_above_272k_tokens_priority`) have no data in the cost map because OpenAI publishes no long-context column for the Fast tier, so there is no billing behavior to lock down.

## Relevant issues

Follow-up to #35270

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Type

🧪 Tests

## Changes

Test-only; no runtime code changes.
