### PR TITLE
feat(budgets): add per-key/team/user rolling budget reset alignment

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260730000000_add_budget_reset_alignment/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260730000000_add_budget_reset_alignment/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "LiteLLM_VerificationToken" ADD COLUMN IF NOT EXISTS "budget_reset_alignment" TEXT;
+
+-- AlterTable
+ALTER TABLE "LiteLLM_DeletedVerificationToken" ADD COLUMN IF NOT EXISTS "budget_reset_alignment" TEXT;
+
+-- AlterTable
+ALTER TABLE "LiteLLM_TeamTable" ADD COLUMN IF NOT EXISTS "budget_reset_alignment" TEXT;
+
+-- AlterTable
+ALTER TABLE "LiteLLM_DeletedTeamTable" ADD COLUMN IF NOT EXISTS "budget_reset_alignment" TEXT;
+
+-- AlterTable
+ALTER TABLE "LiteLLM_UserTable" ADD COLUMN IF NOT EXISTS "budget_reset_alignment" TEXT;

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -131,7 +131,8 @@ model LiteLLM_TeamTable {
     max_parallel_requests Int?
     tpm_limit     BigInt?
     rpm_limit     BigInt?
-    budget_duration String? 
+    budget_duration String?
+    budget_reset_alignment String? // "calendar" (default) or "rolling"
     budget_reset_at DateTime?
     blocked Boolean @default(false)
     created_at    DateTime               @default(now()) @map("created_at")
@@ -202,6 +203,7 @@ model LiteLLM_DeletedTeamTable {
     tpm_limit               BigInt?
     rpm_limit               BigInt?
     budget_duration         String?
+    budget_reset_alignment  String?
     budget_reset_at         DateTime?
     blocked                 Boolean  @default(false)
     model_spend             Json     @default("{}")
@@ -249,7 +251,8 @@ model LiteLLM_UserTable {
     max_parallel_requests Int?
     tpm_limit     BigInt?
     rpm_limit     BigInt?
-    budget_duration String? 
+    budget_duration String?
+    budget_reset_alignment String? // "calendar" (default) or "rolling"
     budget_reset_at DateTime?
     allowed_cache_controls String[] @default([])
     policies         String[] @default([])
@@ -435,7 +438,8 @@ model LiteLLM_VerificationToken {
     tpm_limit     BigInt?
     rpm_limit     BigInt?
     max_budget Float?    
-    budget_duration String? 
+    budget_duration String?
+    budget_reset_alignment String? // "calendar" (default) or "rolling"
     budget_reset_at DateTime?
     allowed_cache_controls String[] @default([])
     allowed_routes   String[] @default([])
@@ -531,6 +535,7 @@ model LiteLLM_DeletedVerificationToken {
     rpm_limit               BigInt?
     max_budget              Float?
     budget_duration         String?
+    budget_reset_alignment  String?
     budget_reset_at         DateTime?
     allowed_cache_controls  String[] @default([])
     allowed_routes          String[] @default([])

--- a/litellm/litellm_core_utils/duration_parser.py
+++ b/litellm/litellm_core_utils/duration_parser.py
@@ -9,7 +9,8 @@ duration_in_seconds is used in diff parts of the code base, example
 import re
 import time as time_module
 from datetime import datetime, time, timedelta, timezone, tzinfo
-from typing import Final, Optional, Tuple
+from types import MappingProxyType
+from typing import Final, Mapping, Optional, Tuple
 from zoneinfo import ZoneInfo
 
 from litellm._logging import verbose_logger
@@ -20,6 +21,16 @@ _BUDGET_DURATION_WORD_ALIASES: Final[dict[str, str]] = {
     "weekly": "7d",
     "monthly": "30d",
 }
+
+_SECONDS_PER_UNIT: Final[Mapping[str, int]] = MappingProxyType(
+    {
+        "s": 1,
+        "m": 60,
+        "h": 3600,
+        "d": 86400,
+        "w": 604800,
+    }
+)
 
 
 def _normalize_duration(duration: str) -> str:
@@ -105,6 +116,70 @@ def duration_in_seconds(duration: str) -> int:
 
     else:
         raise ValueError(f"Unsupported duration unit, passed duration: {duration}")
+
+
+def _add_calendar_months(anchor: datetime, months: int) -> datetime:
+    """Add whole calendar months to `anchor`, keeping its time of day.
+
+    Clamps the day to the target month's length, so 31 Jan + 1mo lands on 28 Feb.
+    """
+    total_months = anchor.month - 1 + months
+    target_year = anchor.year + total_months // 12
+    target_month = total_months % 12 + 1
+    target_day = min(anchor.day, get_last_day_of_month(target_year, target_month))
+    return anchor.replace(year=target_year, month=target_month, day=target_day)
+
+
+def _advance_by_duration(anchor: datetime, value: int, unit: str) -> datetime:
+    if unit == "mo":
+        return _add_calendar_months(anchor, value)
+    return anchor + timedelta(seconds=value * _SECONDS_PER_UNIT[unit])
+
+
+def get_next_rolling_reset_time(
+    duration: str,
+    current_time: datetime,
+    timezone_str: str = "UTC",
+    previous_reset_at: datetime | None = None,
+) -> datetime:
+    """
+    Get the next reset time measured from the budget's own anchor rather than a
+    shared calendar boundary, keeping the anchor's time of day.
+
+    A "1mo" budget created at 14:37 on the 30th resets at 14:37 on the 30th of the
+    next month, where the calendar equivalent would reset at the start of the 1st.
+
+    Parameters:
+    - duration: Duration string (e.g. "30s", "30m", "30h", "30d", "1mo")
+    - current_time: Current datetime
+    - timezone_str: Timezone string (e.g. "UTC", "US/Eastern", "Asia/Kolkata")
+    - previous_reset_at: The reset time this budget is rolling over from. Anchoring
+      to it keeps the reset instant stable when the reset job runs late; without it
+      every late run would push the window further out, permanently.
+
+    Returns:
+    - Next reset time, always strictly after `current_time`
+    """
+    current_time, _ = _setup_timezone(current_time, timezone_str)
+
+    value, unit = _parse_duration(_normalize_duration(duration))
+    if value is None or unit is None or (unit != "mo" and unit not in _SECONDS_PER_UNIT):
+        return get_next_standardized_reset_time(
+            duration=duration,
+            current_time=current_time,
+            timezone_str=timezone_str,
+        )
+
+    if value == 0:
+        return current_time
+
+    if previous_reset_at is not None:
+        anchored, _ = _setup_timezone(previous_reset_at, timezone_str)
+        candidate = _advance_by_duration(anchored, value, unit)
+        if candidate > current_time:
+            return candidate
+
+    return _advance_by_duration(current_time, value, unit)
 
 
 def get_next_standardized_reset_time(

--- a/litellm/models/team.py
+++ b/litellm/models/team.py
@@ -13,6 +13,7 @@ from typing import List, Literal, Optional, Union
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from litellm.models.object_permission import LiteLLM_ObjectPermissionTable
+from litellm.types.budget import BudgetResetAlignment
 from litellm.types.llms.base import LiteLLMPydanticObjectBase
 
 
@@ -74,6 +75,7 @@ class TeamBase(LiteLLMPydanticObjectBase):
     max_budget: Optional[float] = None
     soft_budget: Optional[float] = None
     budget_duration: Optional[str] = None
+    budget_reset_alignment: BudgetResetAlignment | None = None
     budget_limits: Optional[List[BudgetLimitEntry]] = None
     models: list = []
     blocked: bool = False

--- a/litellm/models/user.py
+++ b/litellm/models/user.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Optional
 from pydantic import ConfigDict, Field, model_validator
 
 from litellm.models.object_permission import LiteLLM_ObjectPermissionTable
+from litellm.types.budget import BudgetResetAlignment
 from litellm.models.organization_membership import (
     LiteLLM_OrganizationMembershipTable,
 )
@@ -36,6 +37,7 @@ class LiteLLM_UserTable(LiteLLMPydanticObjectBase):
     tpm_limit: Optional[int] = None
     rpm_limit: Optional[int] = None
     budget_duration: Optional[str] = None
+    budget_reset_alignment: BudgetResetAlignment | None = None
     budget_reset_at: Optional[datetime] = None
     allowed_cache_controls: List[str] = []
     policies: List[str] = []

--- a/litellm/models/verification_token.py
+++ b/litellm/models/verification_token.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Optional, Union
 from pydantic import ConfigDict
 
 from litellm.models.object_permission import LiteLLM_ObjectPermissionTable
+from litellm.types.budget import BudgetResetAlignment
 from litellm.types.llms.base import LiteLLMPydanticObjectBase
 
 
@@ -33,6 +34,7 @@ class LiteLLM_VerificationToken(LiteLLMPydanticObjectBase):
     tpm_limit: Optional[int] = None
     rpm_limit: Optional[int] = None
     budget_duration: Optional[str] = None
+    budget_reset_alignment: BudgetResetAlignment | None = None
     budget_reset_at: Optional[datetime] = None
     allowed_cache_controls: Optional[list] = []
     allowed_routes: Optional[list] = []

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -20,6 +20,7 @@ from litellm.constants import MCP_STDIO_ALLOWED_COMMANDS
 from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
     validate_no_callback_env_reference,
 )
+from litellm.types.budget import BudgetResetAlignment
 from litellm.types.integrations.compression_interception import (
     CompressionSavingsMetadata,
 )
@@ -1045,6 +1046,7 @@ class GenerateRequestBase(LiteLLMPydanticObjectBase):
     rpm_limit: Optional[int] = None
 
     budget_duration: Optional[str] = None
+    budget_reset_alignment: BudgetResetAlignment | None = None
     budget_limits: Optional[List[BudgetLimitEntry]] = None  # multiple concurrent budget windows
     allowed_cache_controls: Optional[list] = []
     config: Optional[dict] = {}
@@ -1841,6 +1843,7 @@ class UpdateTeamRequest(LiteLLMPydanticObjectBase):
     models: Optional[list] = None
     blocked: Optional[bool] = None
     budget_duration: Optional[str] = None
+    budget_reset_alignment: BudgetResetAlignment | None = None
     tags: Optional[list] = None
     model_aliases: Optional[dict] = None
     guardrails: Optional[List[str]] = None

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -21,6 +21,7 @@ from litellm.proxy.common_utils.timezone_utils import (
 )
 from litellm.proxy.utils import PrismaClient, ProxyLogging
 from litellm.repositories.organization_repository import OrganizationRepository
+from litellm.types.budget import DEFAULT_BUDGET_RESET_ALIGNMENT
 from litellm.repositories.table_repositories import (
     EndUserRepository,
     TagRepository,
@@ -804,7 +805,10 @@ class ResetBudgetJob:
             item.spend = 0.0
             if hasattr(item, "budget_duration") and item.budget_duration is not None:
                 item.budget_reset_at = compute_budget_reset_at(
-                    budget_duration=item.budget_duration, settings=reset_settings
+                    budget_duration=item.budget_duration,
+                    settings=reset_settings,
+                    alignment=getattr(item, "budget_reset_alignment", None) or DEFAULT_BUDGET_RESET_ALIGNMENT,
+                    previous_reset_at=getattr(item, "budget_reset_at", None),
                 )
             return item
         except Exception as e:

--- a/litellm/proxy/common_utils/timezone_utils.py
+++ b/litellm/proxy/common_utils/timezone_utils.py
@@ -1,9 +1,14 @@
 from datetime import datetime, time, timezone
 
 from pydantic import BaseModel, ConfigDict
+from typing_extensions import assert_never
 
 import litellm
-from litellm.litellm_core_utils.duration_parser import get_next_standardized_reset_time
+from litellm.litellm_core_utils.duration_parser import (
+    get_next_rolling_reset_time,
+    get_next_standardized_reset_time,
+)
+from litellm.types.budget import DEFAULT_BUDGET_RESET_ALIGNMENT, BudgetResetAlignment
 
 
 class BudgetResetSettings(BaseModel):
@@ -61,20 +66,49 @@ def get_budget_reset_settings() -> BudgetResetSettings:
     )
 
 
-def compute_budget_reset_at(budget_duration: str, settings: BudgetResetSettings) -> datetime:
-    """Compute the next reset time for a budget duration using injected settings."""
-    return get_next_standardized_reset_time(
-        duration=budget_duration,
-        current_time=datetime.now(timezone.utc),
-        timezone_str=settings.timezone,
-        reset_time_of_day=settings.reset_time_of_day,
-    )
+def compute_budget_reset_at(
+    budget_duration: str,
+    settings: BudgetResetSettings,
+    alignment: BudgetResetAlignment = DEFAULT_BUDGET_RESET_ALIGNMENT,
+    previous_reset_at: datetime | None = None,
+) -> datetime:
+    """Compute the next reset time for a budget duration using injected settings.
+
+    `reset_time_of_day` is a calendar-alignment concept only; rolling budgets keep
+    the time of day of their own anchor, so it does not apply to them.
+    """
+    now = datetime.now(timezone.utc)
+    match alignment:
+        case "calendar":
+            return get_next_standardized_reset_time(
+                duration=budget_duration,
+                current_time=now,
+                timezone_str=settings.timezone,
+                reset_time_of_day=settings.reset_time_of_day,
+            )
+        case "rolling":
+            return get_next_rolling_reset_time(
+                duration=budget_duration,
+                current_time=now,
+                timezone_str=settings.timezone,
+                previous_reset_at=previous_reset_at,
+            )
+    assert_never(alignment)
 
 
-def get_budget_reset_time(budget_duration: str) -> datetime:
+def get_budget_reset_time(
+    budget_duration: str,
+    alignment: BudgetResetAlignment = DEFAULT_BUDGET_RESET_ALIGNMENT,
+    previous_reset_at: datetime | None = None,
+) -> datetime:
     """Get the budget reset time using the globally-configured timezone and reset time.
 
     Thin wrapper over `compute_budget_reset_at` for callers that don't yet receive
     `BudgetResetSettings` by injection (creation/update endpoints, startup backfill).
     """
-    return compute_budget_reset_at(budget_duration, get_budget_reset_settings())
+    return compute_budget_reset_at(
+        budget_duration,
+        get_budget_reset_settings(),
+        alignment=alignment,
+        previous_reset_at=previous_reset_at,
+    )

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -58,6 +58,7 @@ from litellm.repositories.user_repository import UserRepository
 from litellm.repositories.verification_token_repository import (
     VerificationTokenRepository,
 )
+from litellm.types.budget import DEFAULT_BUDGET_RESET_ALIGNMENT, BudgetResetAlignment
 from litellm.types.proxy.management_endpoints.common_daily_activity import (
     SpendAnalyticsPaginatedResponse,
 )
@@ -1084,7 +1085,11 @@ def _process_keys_for_user_info(
     return returned_keys
 
 
-def _update_internal_user_params(data_json: dict, data: UpdateUserRequest | UpdateUserRequestNoUserIDorEmail) -> dict:
+def _update_internal_user_params(
+    data_json: dict,
+    data: UpdateUserRequest | UpdateUserRequestNoUserIDorEmail,
+    existing_alignment: BudgetResetAlignment | None = None,
+) -> dict:
     non_default_values = {}
     fields_set = data.fields_set() if hasattr(data, "fields_set") else set()
 
@@ -1107,11 +1112,14 @@ def _update_internal_user_params(data_json: dict, data: UpdateUserRequest | Upda
     if data.user_role == LitellmUserRoles.INTERNAL_USER:
         is_internal_user = True
 
+    effective_alignment = data.budget_reset_alignment or existing_alignment or DEFAULT_BUDGET_RESET_ALIGNMENT
+
     if "budget_duration" in non_default_values:
         from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 
         non_default_values["budget_reset_at"] = get_budget_reset_time(
-            budget_duration=non_default_values["budget_duration"]
+            budget_duration=non_default_values["budget_duration"],
+            alignment=effective_alignment,
         )
 
     if "max_budget" not in non_default_values:
@@ -1126,7 +1134,8 @@ def _update_internal_user_params(data_json: dict, data: UpdateUserRequest | Upda
             from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 
             non_default_values["budget_reset_at"] = get_budget_reset_time(
-                budget_duration=non_default_values["budget_duration"]
+                budget_duration=non_default_values["budget_duration"],
+                alignment=effective_alignment,
             )
 
     return non_default_values
@@ -1231,10 +1240,6 @@ async def _update_single_user_helper(
         user_api_key_dict=user_api_key_dict,
     )
 
-    data_json: dict = user_request.model_dump(exclude_unset=True)
-    non_default_values = _update_internal_user_params(data_json=data_json, data=user_request)
-    _hash_password_in_dict(non_default_values)
-
     existing_user_row: BaseModel | None = None
     if user_request.user_id:
         existing_user_row = await UserRepository(prisma_client).table.find_first(
@@ -1249,6 +1254,14 @@ async def _update_single_user_helper(
 
     if existing_user_row is not None:
         existing_user_row = LiteLLM_UserTable.model_validate(existing_user_row.model_dump(exclude_none=True))
+
+    data_json: dict = user_request.model_dump(exclude_unset=True)
+    non_default_values = _update_internal_user_params(
+        data_json=data_json,
+        data=user_request,
+        existing_alignment=getattr(existing_user_row, "budget_reset_alignment", None),
+    )
+    _hash_password_in_dict(non_default_values)
 
     # Prevent budget self-escalation (GHSA-wvg4-6222-3q4r): non-admin callers
     # must not be able to raise their own budget/spend fields.

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -117,6 +117,7 @@ from litellm.repositories.verification_token_repository import (
 from litellm.router import Router
 from litellm.secret_managers.base_secret_manager import raise_if_unsafe_secret_name
 from litellm.secret_managers.main import get_secret
+from litellm.types.budget import DEFAULT_BUDGET_RESET_ALIGNMENT, BudgetResetAlignment
 from litellm.types.proxy.management_endpoints.key_management_endpoints import (
     BulkUpdateKeyRequest,
     BulkUpdateKeyResponse,
@@ -1922,6 +1923,11 @@ async def prepare_key_update_data(
             expires = datetime.now(timezone.utc) + timedelta(seconds=duration_s)
             non_default_values["expires"] = expires
 
+    requested_alignment = non_default_values.get("budget_reset_alignment")
+    effective_alignment = (
+        requested_alignment or existing_key_row.budget_reset_alignment or DEFAULT_BUDGET_RESET_ALIGNMENT
+    )
+
     if "budget_duration" in non_default_values:
         budget_duration = non_default_values.pop("budget_duration")
         if budget_duration is None:
@@ -1930,9 +1936,16 @@ async def prepare_key_update_data(
         elif isinstance(budget_duration, str) and len(budget_duration) > 0:
             from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 
-            key_reset_at = get_budget_reset_time(budget_duration=budget_duration)
+            key_reset_at = get_budget_reset_time(budget_duration=budget_duration, alignment=effective_alignment)
             non_default_values["budget_reset_at"] = key_reset_at
             non_default_values["budget_duration"] = budget_duration
+    elif requested_alignment is not None and existing_key_row.budget_duration is not None:
+        from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+
+        non_default_values["budget_reset_at"] = get_budget_reset_time(
+            budget_duration=existing_key_row.budget_duration,
+            alignment=effective_alignment,
+        )
 
     if "budget_limits" in non_default_values:
         raw_windows = non_default_values["budget_limits"]
@@ -3639,6 +3652,7 @@ async def generate_key_helper_fn(
     router_settings: Optional[dict] = None,
     access_group_ids: Optional[list] = None,
     budget_limits: Optional[list] = None,  # multiple concurrent budget windows
+    budget_reset_alignment: BudgetResetAlignment | None = None,
 ):
     from litellm.proxy.proxy_server import premium_user, prisma_client
 
@@ -3658,15 +3672,17 @@ async def generate_key_helper_fn(
         duration_seconds = duration_in_seconds(duration)
         expires = datetime.now(timezone.utc) + timedelta(seconds=duration_seconds)
 
+    reset_alignment = budget_reset_alignment or DEFAULT_BUDGET_RESET_ALIGNMENT
+
     if key_budget_duration is None:  # one-time budget
         key_reset_at = None
     else:
-        key_reset_at = get_budget_reset_time(budget_duration=key_budget_duration)
+        key_reset_at = get_budget_reset_time(budget_duration=key_budget_duration, alignment=reset_alignment)
 
     if budget_duration is None:  # one-time budget
         reset_at = None
     else:
-        reset_at = get_budget_reset_time(budget_duration=budget_duration)
+        reset_at = get_budget_reset_time(budget_duration=budget_duration, alignment=reset_alignment)
 
     # Initialize reset_at for each budget window
     budget_limits_json: Optional[str] = None
@@ -3734,6 +3750,7 @@ async def generate_key_helper_fn(
             "tpm_limit": tpm_limit,
             "rpm_limit": rpm_limit,
             "budget_duration": budget_duration,
+            "budget_reset_alignment": budget_reset_alignment,
             "budget_reset_at": reset_at,
             "allowed_cache_controls": allowed_cache_controls,
             "sso_user_id": sso_user_id,
@@ -3759,6 +3776,7 @@ async def generate_key_helper_fn(
             "tpm_limit": tpm_limit,
             "rpm_limit": rpm_limit,
             "budget_duration": key_budget_duration,
+            "budget_reset_alignment": budget_reset_alignment,
             "budget_reset_at": key_reset_at,
             "allowed_cache_controls": allowed_cache_controls,
             "permissions": permissions_json,

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -122,6 +122,7 @@ from litellm.repositories.verification_token_repository import (
     VerificationTokenRepository,
 )
 from litellm.router import Router
+from litellm.types.budget import DEFAULT_BUDGET_RESET_ALIGNMENT
 from litellm.types.proxy.management_endpoints.common_daily_activity import (
     SpendAnalyticsPaginatedResponse,
 )
@@ -1221,6 +1222,7 @@ async def new_team(
 
             complete_team_data.budget_reset_at = get_budget_reset_time(
                 budget_duration=complete_team_data.budget_duration,
+                alignment=complete_team_data.budget_reset_alignment or DEFAULT_BUDGET_RESET_ALIGNMENT,
             )
 
         # If budget_limits is set, initialize reset_at for each window
@@ -1824,7 +1826,7 @@ async def update_team(
             TeamMemberBudgetHandler.strip_system_managed_metadata_keys(updated_kv["metadata"])
 
         # Check budget_duration and budget_reset_at
-        _set_budget_reset_at(data, updated_kv)
+        _set_budget_reset_at(data, updated_kv, existing_team_row)
 
         _team_member_fields_in_request = {
             field
@@ -2026,15 +2028,33 @@ async def patch_team(
         raise handle_exception_on_proxy(e)
 
 
-def _set_budget_reset_at(data: UpdateTeamRequest, updated_kv: dict) -> None:
+def _set_budget_reset_at(
+    data: UpdateTeamRequest,
+    updated_kv: dict,
+    existing_team_row: LiteLLM_TeamTable | None = None,
+) -> None:
     """Set budget_reset_at in updated_kv if budget_duration is provided."""
+    existing_alignment = existing_team_row.budget_reset_alignment if existing_team_row is not None else None
+    effective_alignment = data.budget_reset_alignment or existing_alignment or DEFAULT_BUDGET_RESET_ALIGNMENT
+
     if data.budget_duration is not None:
         from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 
-        reset_at = get_budget_reset_time(budget_duration=data.budget_duration)
+        reset_at = get_budget_reset_time(budget_duration=data.budget_duration, alignment=effective_alignment)
         updated_kv["budget_reset_at"] = reset_at
     elif "budget_duration" in updated_kv and updated_kv["budget_duration"] is None:
         updated_kv["budget_reset_at"] = None
+    elif (
+        data.budget_reset_alignment is not None
+        and existing_team_row is not None
+        and existing_team_row.budget_duration is not None
+    ):
+        from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+
+        updated_kv["budget_reset_at"] = get_budget_reset_time(
+            budget_duration=existing_team_row.budget_duration,
+            alignment=effective_alignment,
+        )
 
     if data.budget_limits is not None and len(data.budget_limits) > 0:
         from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -131,7 +131,8 @@ model LiteLLM_TeamTable {
     max_parallel_requests Int?
     tpm_limit     BigInt?
     rpm_limit     BigInt?
-    budget_duration String? 
+    budget_duration String?
+    budget_reset_alignment String? // "calendar" (default) or "rolling"
     budget_reset_at DateTime?
     blocked Boolean @default(false)
     created_at    DateTime               @default(now()) @map("created_at")
@@ -202,6 +203,7 @@ model LiteLLM_DeletedTeamTable {
     tpm_limit               BigInt?
     rpm_limit               BigInt?
     budget_duration         String?
+    budget_reset_alignment  String?
     budget_reset_at         DateTime?
     blocked                 Boolean  @default(false)
     model_spend             Json     @default("{}")
@@ -249,7 +251,8 @@ model LiteLLM_UserTable {
     max_parallel_requests Int?
     tpm_limit     BigInt?
     rpm_limit     BigInt?
-    budget_duration String? 
+    budget_duration String?
+    budget_reset_alignment String? // "calendar" (default) or "rolling"
     budget_reset_at DateTime?
     allowed_cache_controls String[] @default([])
     policies         String[] @default([])
@@ -435,7 +438,8 @@ model LiteLLM_VerificationToken {
     tpm_limit     BigInt?
     rpm_limit     BigInt?
     max_budget Float?    
-    budget_duration String? 
+    budget_duration String?
+    budget_reset_alignment String? // "calendar" (default) or "rolling"
     budget_reset_at DateTime?
     allowed_cache_controls String[] @default([])
     allowed_routes   String[] @default([])
@@ -531,6 +535,7 @@ model LiteLLM_DeletedVerificationToken {
     rpm_limit               BigInt?
     max_budget              Float?
     budget_duration         String?
+    budget_reset_alignment  String?
     budget_reset_at         DateTime?
     allowed_cache_controls  String[] @default([])
     allowed_routes          String[] @default([])

--- a/litellm/types/budget.py
+++ b/litellm/types/budget.py
@@ -1,0 +1,21 @@
+"""Shared budget types.
+
+Kept outside `litellm.proxy._types` so `litellm_core_utils.duration_parser` can
+import it without pulling in the proxy package.
+"""
+
+from typing import Final, Literal
+
+BudgetResetAlignment = Literal["calendar", "rolling"]
+"""How a `budget_duration` is turned into the next `budget_reset_at`.
+
+"calendar" snaps to a shared boundary (start of day / Monday / 1st of the month),
+so every budget on the proxy resets at the same instant. "rolling" measures the
+duration from the budget's own anchor, keeping the original time of day.
+
+A `Literal` rather than a `str` Enum because these values are persisted to TEXT
+columns: `str(SomeStrEnum.MEMBER)` renders as "SomeStrEnum.MEMBER" on Python 3.11+,
+and `model_dump()` would hand Prisma an enum member instead of the value.
+"""
+
+DEFAULT_BUDGET_RESET_ALIGNMENT: Final[BudgetResetAlignment] = "calendar"

--- a/schema.prisma
+++ b/schema.prisma
@@ -131,7 +131,8 @@ model LiteLLM_TeamTable {
     max_parallel_requests Int?
     tpm_limit     BigInt?
     rpm_limit     BigInt?
-    budget_duration String? 
+    budget_duration String?
+    budget_reset_alignment String? // "calendar" (default) or "rolling"
     budget_reset_at DateTime?
     blocked Boolean @default(false)
     created_at    DateTime               @default(now()) @map("created_at")
@@ -202,6 +203,7 @@ model LiteLLM_DeletedTeamTable {
     tpm_limit               BigInt?
     rpm_limit               BigInt?
     budget_duration         String?
+    budget_reset_alignment  String?
     budget_reset_at         DateTime?
     blocked                 Boolean  @default(false)
     model_spend             Json     @default("{}")
@@ -249,7 +251,8 @@ model LiteLLM_UserTable {
     max_parallel_requests Int?
     tpm_limit     BigInt?
     rpm_limit     BigInt?
-    budget_duration String? 
+    budget_duration String?
+    budget_reset_alignment String? // "calendar" (default) or "rolling"
     budget_reset_at DateTime?
     allowed_cache_controls String[] @default([])
     policies         String[] @default([])
@@ -435,7 +438,8 @@ model LiteLLM_VerificationToken {
     tpm_limit     BigInt?
     rpm_limit     BigInt?
     max_budget Float?    
-    budget_duration String? 
+    budget_duration String?
+    budget_reset_alignment String? // "calendar" (default) or "rolling"
     budget_reset_at DateTime?
     allowed_cache_controls String[] @default([])
     allowed_routes   String[] @default([])
@@ -531,6 +535,7 @@ model LiteLLM_DeletedVerificationToken {
     rpm_limit               BigInt?
     max_budget              Float?
     budget_duration         String?
+    budget_reset_alignment  String?
     budget_reset_at         DateTime?
     allowed_cache_controls  String[] @default([])
     allowed_routes          String[] @default([])

--- a/tests/test_litellm/litellm_core_utils/test_duration_parser.py
+++ b/tests/test_litellm/litellm_core_utils/test_duration_parser.py
@@ -1,11 +1,12 @@
 import unittest
-from datetime import datetime, time, timezone
+from datetime import datetime, time, timedelta, timezone
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
 import litellm.litellm_core_utils.duration_parser as duration_parser
 from litellm.litellm_core_utils.duration_parser import (
     duration_in_seconds,
+    get_next_rolling_reset_time,
     get_next_standardized_reset_time,
 )
 
@@ -383,6 +384,161 @@ class TestWordFormBudgetDurations(unittest.TestCase):
         self.assertEqual(result, datetime(2023, 5, 16, 0, 0, 0, tzinfo=timezone.utc))
         mock_warning.assert_called_once()
         self.assertIn("garbage", mock_warning.call_args.args)
+
+
+class TestRollingResetTime(unittest.TestCase):
+    """Rolling resets measure the duration from the budget's own anchor and keep its
+    time of day, instead of snapping to a shared calendar boundary.
+    """
+
+    def test_rolling_month_lands_on_same_day_and_time_next_month(self):
+        base_time = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            get_next_rolling_reset_time("1mo", base_time, "UTC"),
+            datetime(2026, 8, 30, 14, 37, 0, tzinfo=timezone.utc),
+        )
+
+    def test_rolling_differs_from_calendar_for_month_durations(self):
+        """The whole point of the feature: 1mo and 30d must stop collapsing to the 1st."""
+        base_time = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        for duration in ("1mo", "30d"):
+            calendar = get_next_standardized_reset_time(duration, base_time, "UTC")
+            rolling = get_next_rolling_reset_time(duration, base_time, "UTC")
+            self.assertEqual(calendar, datetime(2026, 8, 1, 0, 0, 0, tzinfo=timezone.utc))
+            self.assertNotEqual(rolling, calendar)
+            self.assertEqual(rolling.hour, 14)
+            self.assertEqual(rolling.minute, 37)
+
+    def test_rolling_30d_is_exactly_30_days(self):
+        base_time = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            get_next_rolling_reset_time("30d", base_time, "UTC"),
+            datetime(2026, 8, 29, 14, 37, 0, tzinfo=timezone.utc),
+        )
+
+    def test_rolling_month_clamps_to_shorter_target_month(self):
+        base_time = datetime(2026, 1, 31, 9, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            get_next_rolling_reset_time("1mo", base_time, "UTC"),
+            datetime(2026, 2, 28, 9, 0, 0, tzinfo=timezone.utc),
+        )
+
+    def test_rolling_supports_multi_month_durations_that_calendar_rejects(self):
+        base_time = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        with self.assertRaises(ValueError):
+            get_next_standardized_reset_time("2mo", base_time, "UTC")
+        self.assertEqual(
+            get_next_rolling_reset_time("2mo", base_time, "UTC"),
+            datetime(2026, 9, 30, 14, 37, 0, tzinfo=timezone.utc),
+        )
+
+    def test_rolling_year_end_rollover(self):
+        base_time = datetime(2026, 12, 15, 9, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            get_next_rolling_reset_time("1mo", base_time, "UTC"),
+            datetime(2027, 1, 15, 9, 0, 0, tzinfo=timezone.utc),
+        )
+
+    def test_previous_anchor_absorbs_a_late_reset_job(self):
+        """A reset job that fires late must not push the window out permanently."""
+        previous_reset_at = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        ran_late = previous_reset_at + timedelta(minutes=3)
+        self.assertEqual(
+            get_next_rolling_reset_time("1mo", ran_late, "UTC", previous_reset_at=previous_reset_at),
+            datetime(2026, 8, 30, 14, 37, 0, tzinfo=timezone.utc),
+        )
+
+    def test_late_reset_job_does_not_accumulate_drift_over_many_periods(self):
+        """Twelve consecutive late runs must not move the reset's time of day at all.
+
+        Without anchoring on `previous_reset_at` each late run would add its own
+        lateness, so the window would creep later every single period.
+        """
+        anchor = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        previous_reset_at = anchor
+        for _ in range(12):
+            ran_late = previous_reset_at + timedelta(minutes=7)
+            previous_reset_at = get_next_rolling_reset_time(
+                "1mo", ran_late, "UTC", previous_reset_at=previous_reset_at
+            )
+        self.assertEqual(previous_reset_at.hour, anchor.hour)
+        self.assertEqual(previous_reset_at.minute, anchor.minute)
+        self.assertEqual(previous_reset_at.second, anchor.second)
+
+    def test_month_end_clamp_walks_the_day_backwards_and_never_forwards(self):
+        """A day-30 anchor is pulled back to 28 by February and stays there.
+
+        Inherent to anchoring on the previous reset: once clamped, the original
+        day-of-month is lost. Pinned here so the behavior is deliberate.
+        """
+        previous_reset_at = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        days = []
+        for _ in range(9):
+            previous_reset_at = get_next_rolling_reset_time(
+                "1mo", previous_reset_at, "UTC", previous_reset_at=previous_reset_at
+            )
+            days.append(previous_reset_at.day)
+
+        self.assertEqual(days, [30, 30, 30, 30, 30, 30, 28, 28, 28])
+        self.assertTrue(all(later <= earlier for earlier, later in zip(days, days[1:])))
+
+    def test_stale_anchor_jumps_past_now(self):
+        """After a long outage the next reset must be in the future, not the past."""
+        previous_reset_at = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 11, 2, 8, 0, 0, tzinfo=timezone.utc)
+        result = get_next_rolling_reset_time("1mo", now, "UTC", previous_reset_at=previous_reset_at)
+        self.assertGreater(result, now)
+        self.assertEqual(result, datetime(2026, 12, 2, 8, 0, 0, tzinfo=timezone.utc))
+
+    def test_result_is_always_strictly_after_now(self):
+        """An anchor exactly one period old must roll forward, never return now."""
+        previous_reset_at = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        now = datetime(2026, 8, 30, 14, 37, 0, tzinfo=timezone.utc)
+        result = get_next_rolling_reset_time("1mo", now, "UTC", previous_reset_at=previous_reset_at)
+        self.assertGreater(result, now)
+
+    def test_rolling_respects_timezone(self):
+        base_time = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        result = get_next_rolling_reset_time("1mo", base_time, "Asia/Kolkata")
+        self.assertEqual(result, datetime(2026, 8, 30, 14, 37, 0, tzinfo=timezone.utc))
+        self.assertEqual(result.astimezone(ZoneInfo("Asia/Kolkata")).hour, 20)
+
+    def test_naive_previous_anchor_is_treated_as_utc(self):
+        previous_reset_at = datetime(2026, 7, 30, 14, 37, 0)
+        ran_late = datetime(2026, 7, 30, 14, 40, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            get_next_rolling_reset_time("1mo", ran_late, "UTC", previous_reset_at=previous_reset_at),
+            datetime(2026, 8, 30, 14, 37, 0, tzinfo=timezone.utc),
+        )
+
+    def test_sub_day_durations_roll_from_now(self):
+        base_time = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            get_next_rolling_reset_time("12h", base_time, "UTC"),
+            datetime(2026, 7, 31, 2, 37, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            get_next_rolling_reset_time("30m", base_time, "UTC"),
+            datetime(2026, 7, 30, 15, 7, 0, tzinfo=timezone.utc),
+        )
+
+    def test_word_form_durations_are_normalized(self):
+        base_time = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            get_next_rolling_reset_time("monthly", base_time, "UTC"),
+            get_next_rolling_reset_time("30d", base_time, "UTC"),
+        )
+
+    def test_invalid_duration_falls_back_to_calendar_instead_of_raising(self):
+        base_time = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        self.assertEqual(
+            get_next_rolling_reset_time("garbage", base_time, "UTC"),
+            get_next_standardized_reset_time("garbage", base_time, "UTC"),
+        )
+
+    def test_zero_duration_expires_immediately(self):
+        base_time = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+        self.assertEqual(get_next_rolling_reset_time("0d", base_time, "UTC"), base_time)
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
+++ b/tests/test_litellm/proxy/common_utils/test_reset_budget_job.py
@@ -1817,3 +1817,84 @@ def test_get_data_reset_query_selects_null_budget_reset_at(table_name):
     )
 
     _asserts_null_reset_is_due(_extract_reset_where(find_many))
+
+
+def _make_key(*, budget_duration, budget_reset_at, token, alignment=None):
+    attrs = {
+        "spend": 100.0,
+        "budget_duration": budget_duration,
+        "budget_reset_at": budget_reset_at,
+        "id": token,
+        "token": token,
+    }
+    if alignment is not None:
+        attrs["budget_reset_alignment"] = alignment
+    return type("LiteLLM_VerificationToken", (), attrs)
+
+
+def test_reset_budget_for_key_without_alignment_stays_calendar_aligned(reset_budget_job, mock_prisma_client):
+    """Rows predating the column must keep the old behavior: 1mo snaps to the 1st."""
+    now = datetime.now(timezone.utc)
+    mock_prisma_client.data["key"] = [
+        _make_key(budget_duration="1mo", budget_reset_at=now, token="tok-no-alignment")
+    ]
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_keys())
+
+    write = [c for c in mock_prisma_client.db.batch_calls if c["table"] == "key"][0]
+    reset_at = write["data"]["budget_reset_at"].astimezone(timezone.utc)
+    assert reset_at.day == 1
+    assert reset_at.hour == 0
+
+
+def test_reset_budget_for_key_rolling_keeps_anchor_time_of_day(reset_budget_job, mock_prisma_client):
+    """A rolling key resets one calendar month after its own previous reset, same clock time."""
+    previous_reset_at = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+    mock_prisma_client.data["key"] = [
+        _make_key(
+            budget_duration="1mo",
+            budget_reset_at=previous_reset_at,
+            token="tok-rolling",
+            alignment="rolling",
+        )
+    ]
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_keys())
+
+    write = [c for c in mock_prisma_client.db.batch_calls if c["table"] == "key"][0]
+    reset_at = write["data"]["budget_reset_at"].astimezone(timezone.utc)
+    assert write["data"]["spend"] == 0
+    assert (reset_at.hour, reset_at.minute) == (14, 37)
+    assert reset_at.day == 30
+    assert reset_at > datetime.now(timezone.utc)
+
+
+def test_rolling_and_calendar_keys_reset_to_different_times_in_one_run(reset_budget_job, mock_prisma_client):
+    """Per-key alignment is honored per row, not proxy-wide."""
+    previous_reset_at = datetime(2026, 7, 30, 14, 37, 0, tzinfo=timezone.utc)
+    mock_prisma_client.data["key"] = [
+        _make_key(
+            budget_duration="1mo",
+            budget_reset_at=previous_reset_at,
+            token="tok-cal",
+            alignment="calendar",
+        ),
+        _make_key(
+            budget_duration="1mo",
+            budget_reset_at=previous_reset_at,
+            token="tok-roll",
+            alignment="rolling",
+        ),
+    ]
+
+    asyncio.run(reset_budget_job.reset_budget_for_litellm_keys())
+
+    written = {
+        c["where"]["token"]: c["data"]["budget_reset_at"].astimezone(timezone.utc)
+        for c in mock_prisma_client.db.batch_calls
+        if c["table"] == "key"
+    }
+    assert written["tok-cal"].day == 1
+    assert written["tok-cal"].hour == 0
+    assert (written["tok-roll"].hour, written["tok-roll"].minute) == (14, 37)
+    assert written["tok-cal"] != written["tok-roll"]

--- a/tests/test_litellm/proxy/common_utils/test_timezone_utils.py
+++ b/tests/test_litellm/proxy/common_utils/test_timezone_utils.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from datetime import datetime, time, timezone
+from datetime import datetime, time, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -180,3 +180,65 @@ def test_get_budget_reset_time_honors_global_budget_reset_time():
     finally:
         _restore_attr(litellm, "timezone", orig_tz)
         _restore_attr(litellm, "budget_reset_time", orig_rt)
+
+
+def test_compute_budget_reset_at_defaults_to_calendar_alignment():
+    """Existing deployments must keep snapping to the 1st when no alignment is set."""
+    settings = BudgetResetSettings(timezone="UTC")
+    reset_at = compute_budget_reset_at("1mo", settings)
+    assert reset_at.day == 1
+    assert reset_at.hour == 0
+    assert reset_at.minute == 0
+
+
+def test_compute_budget_reset_at_rolling_keeps_time_of_day():
+    settings = BudgetResetSettings(timezone="UTC")
+    before = datetime.now(timezone.utc)
+    reset_at = compute_budget_reset_at("1mo", settings, alignment="rolling")
+    after = datetime.now(timezone.utc)
+
+    assert reset_at > after
+    assert reset_at.hour == before.hour
+    assert reset_at.minute in (before.minute, after.minute)
+    assert reset_at.day != 1 or before.day == 1
+
+
+def test_rolling_ignores_reset_time_of_day():
+    """reset_time_of_day is a calendar-boundary concept; rolling keeps its own anchor."""
+    settings = BudgetResetSettings(timezone="UTC", reset_time_of_day=time(12, 0))
+    calendar_at = compute_budget_reset_at("1d", settings, alignment="calendar")
+    rolling_at = compute_budget_reset_at("1d", settings, alignment="rolling")
+
+    assert calendar_at.astimezone(timezone.utc).hour == 12
+    assert calendar_at.astimezone(timezone.utc).minute == 0
+    assert rolling_at.hour == datetime.now(timezone.utc).hour
+
+
+def test_compute_budget_reset_at_rolling_uses_previous_anchor():
+    settings = BudgetResetSettings(timezone="UTC")
+    previous_reset_at = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(seconds=5)
+    reset_at = compute_budget_reset_at(
+        "1mo", settings, alignment="rolling", previous_reset_at=previous_reset_at
+    )
+    assert reset_at.hour == previous_reset_at.hour
+    assert reset_at.minute == previous_reset_at.minute
+    assert reset_at.second == previous_reset_at.second
+
+
+def test_rolling_and_calendar_disagree_for_month_durations():
+    settings = BudgetResetSettings(timezone="UTC")
+    assert compute_budget_reset_at("1mo", settings, alignment="rolling") != compute_budget_reset_at(
+        "1mo", settings, alignment="calendar"
+    )
+
+
+def test_get_budget_reset_time_forwards_alignment():
+    orig_tz = getattr(litellm, "timezone", None)
+    try:
+        litellm.timezone = "UTC"
+        rolling = get_budget_reset_time(budget_duration="1mo", alignment="rolling")
+        calendar = get_budget_reset_time(budget_duration="1mo", alignment="calendar")
+        assert calendar.day == 1
+        assert rolling != calendar
+    finally:
+        _restore_attr(litellm, "timezone", orig_tz)

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -3702,3 +3702,54 @@ async def test_get_user_info_for_proxy_admin_validates_keys_and_teams():
     returned_key = result.keys[0]
     assert returned_key["team_id"] == "team-a"
     assert returned_key["models"] == []
+
+
+def test_update_internal_user_params_defaults_to_calendar_alignment():
+    """Users predating the column must keep snapping 1mo to the 1st."""
+    from litellm.proxy._types import UpdateUserRequest
+
+    data = UpdateUserRequest(user_id="u1", budget_duration="1mo")
+    result = _update_internal_user_params(data_json=data.model_dump(exclude_unset=True), data=data)
+
+    assert result["budget_reset_at"].day == 1
+    assert result["budget_reset_at"].hour == 0
+
+
+def test_update_internal_user_params_rolling_keeps_time_of_day():
+    from litellm.proxy._types import UpdateUserRequest
+
+    data = UpdateUserRequest(user_id="u1", budget_duration="1mo", budget_reset_alignment="rolling")
+    result = _update_internal_user_params(data_json=data.model_dump(exclude_unset=True), data=data)
+
+    now = datetime.now(timezone.utc)
+    assert result["budget_reset_at"].hour == now.hour
+    assert result["budget_reset_at"].day != 1 or now.day == 1
+    assert result["budget_reset_alignment"] == "rolling"
+
+
+def test_update_internal_user_params_duration_change_preserves_stored_alignment():
+    """Changing only budget_duration must not revert a rolling user to calendar."""
+    from litellm.proxy._types import UpdateUserRequest
+
+    data = UpdateUserRequest(user_id="u1", budget_duration="1mo")
+    result = _update_internal_user_params(
+        data_json=data.model_dump(exclude_unset=True),
+        data=data,
+        existing_alignment="rolling",
+    )
+
+    assert result["budget_reset_at"].hour == datetime.now(timezone.utc).hour
+
+
+def test_update_internal_user_params_request_alignment_beats_stored_alignment():
+    from litellm.proxy._types import UpdateUserRequest
+
+    data = UpdateUserRequest(user_id="u1", budget_duration="1mo", budget_reset_alignment="calendar")
+    result = _update_internal_user_params(
+        data_json=data.model_dump(exclude_unset=True),
+        data=data,
+        existing_alignment="rolling",
+    )
+
+    assert result["budget_reset_at"].day == 1
+    assert result["budget_reset_at"].hour == 0

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from datetime import datetime, timezone
 
 import litellm
 import pytest
@@ -15256,3 +15257,69 @@ async def test_rotate_master_key_rotates_sso_identity_assertions(
         prisma_client=mock_prisma_client,
         new_master_key="sk-new-master-key",
     )
+
+
+@pytest.mark.asyncio
+async def test_key_update_without_alignment_keeps_calendar_reset():
+    """A key that never set an alignment must keep snapping 1mo to the 1st."""
+    data = UpdateKeyRequest(key="sk-1", budget_duration="1mo")
+    existing_key = LiteLLM_VerificationToken(token="hashed", budget_duration="1mo")
+
+    result = await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    assert result["budget_reset_at"].day == 1
+    assert result["budget_reset_at"].hour == 0
+
+
+@pytest.mark.asyncio
+async def test_key_update_of_duration_only_preserves_stored_rolling_alignment():
+    """Changing budget_duration must not silently revert a rolling key to calendar."""
+    data = UpdateKeyRequest(key="sk-1", budget_duration="1mo")
+    existing_key = LiteLLM_VerificationToken(
+        token="hashed", budget_duration="1mo", budget_reset_alignment="rolling"
+    )
+
+    result = await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    reset_at = result["budget_reset_at"]
+    now = datetime.now(timezone.utc)
+    assert reset_at.day != 1 or now.day == 1
+    assert reset_at.hour == now.hour
+
+
+@pytest.mark.asyncio
+async def test_switching_alignment_alone_recomputes_reset_at():
+    """Flipping a key to rolling must take effect immediately, not one period later."""
+    data = UpdateKeyRequest(key="sk-1", budget_reset_alignment="rolling")
+    existing_key = LiteLLM_VerificationToken(
+        token="hashed", budget_duration="1mo", budget_reset_alignment="calendar"
+    )
+
+    result = await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    assert result["budget_reset_alignment"] == "rolling"
+    assert result["budget_reset_at"].hour == datetime.now(timezone.utc).hour
+
+
+@pytest.mark.asyncio
+async def test_switching_alignment_alone_is_noop_without_a_budget_duration():
+    """No budget_duration means no window to recompute; reset_at must stay absent."""
+    data = UpdateKeyRequest(key="sk-1", budget_reset_alignment="rolling")
+    existing_key = LiteLLM_VerificationToken(token="hashed", budget_duration=None)
+
+    result = await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    assert result["budget_reset_alignment"] == "rolling"
+    assert "budget_reset_at" not in result
+
+
+@pytest.mark.asyncio
+async def test_key_update_alignment_is_persisted_as_plain_string():
+    """The column is TEXT; an enum member would be written as its repr."""
+    data = UpdateKeyRequest(key="sk-1", budget_reset_alignment="rolling")
+    existing_key = LiteLLM_VerificationToken(token="hashed", budget_duration="1mo")
+
+    result = await prepare_key_update_data(data=data, existing_key_row=existing_key)
+
+    assert type(result["budget_reset_alignment"]) is str
+    assert result["budget_reset_alignment"] == "rolling"

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -10289,3 +10289,74 @@ async def test_list_available_teams_filters_joined_and_validates_rows(monkeypatc
     assert result[0].team_alias == "open team"
     find_many_kwargs = mock_prisma_client.db.litellm_teamtable.find_many.call_args.kwargs
     assert find_many_kwargs["where"] == {"team_id": {"in": ["team-open"]}}
+
+
+def test_set_budget_reset_at_defaults_to_calendar_for_teams_without_alignment():
+    """Teams predating the column must keep snapping 1mo to the 1st."""
+    from litellm.proxy._types import UpdateTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import _set_budget_reset_at
+
+    data = UpdateTeamRequest(team_id="t", budget_duration="1mo")
+    updated_kv: dict = {"team_id": "t", "budget_duration": "1mo"}
+
+    _set_budget_reset_at(data, updated_kv)
+
+    assert updated_kv["budget_reset_at"].day == 1
+    assert updated_kv["budget_reset_at"].hour == 0
+
+
+def test_set_budget_reset_at_rolling_keeps_time_of_day():
+    from litellm.proxy._types import UpdateTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import _set_budget_reset_at
+
+    data = UpdateTeamRequest(team_id="t", budget_duration="1mo", budget_reset_alignment="rolling")
+    updated_kv: dict = {"team_id": "t", "budget_duration": "1mo"}
+
+    _set_budget_reset_at(data, updated_kv)
+
+    now = datetime.now(timezone.utc)
+    assert updated_kv["budget_reset_at"].hour == now.hour
+    assert updated_kv["budget_reset_at"].day != 1 or now.day == 1
+
+
+def test_set_budget_reset_at_duration_change_preserves_stored_team_alignment():
+    """Changing only budget_duration must not revert a rolling team to calendar."""
+    from litellm.models.team import LiteLLM_TeamTable
+    from litellm.proxy._types import UpdateTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import _set_budget_reset_at
+
+    existing = LiteLLM_TeamTable(team_id="t", budget_duration="1mo", budget_reset_alignment="rolling")
+    data = UpdateTeamRequest(team_id="t", budget_duration="1mo")
+    updated_kv: dict = {"team_id": "t", "budget_duration": "1mo"}
+
+    _set_budget_reset_at(data, updated_kv, existing)
+
+    assert updated_kv["budget_reset_at"].hour == datetime.now(timezone.utc).hour
+
+
+def test_set_budget_reset_at_alignment_switch_alone_recomputes_from_existing_duration():
+    from litellm.models.team import LiteLLM_TeamTable
+    from litellm.proxy._types import UpdateTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import _set_budget_reset_at
+
+    existing = LiteLLM_TeamTable(team_id="t", budget_duration="1mo", budget_reset_alignment="calendar")
+    data = UpdateTeamRequest(team_id="t", budget_reset_alignment="rolling")
+    updated_kv: dict = {"team_id": "t"}
+
+    _set_budget_reset_at(data, updated_kv, existing)
+
+    assert updated_kv["budget_reset_at"].hour == datetime.now(timezone.utc).hour
+
+
+def test_set_budget_reset_at_alignment_switch_is_noop_without_stored_duration():
+    from litellm.models.team import LiteLLM_TeamTable
+    from litellm.proxy._types import UpdateTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import _set_budget_reset_at
+
+    existing = LiteLLM_TeamTable(team_id="t", budget_duration=None)
+    data = UpdateTeamRequest(team_id="t", budget_reset_alignment="rolling")
+    updated_kv: dict = {"team_id": "t"}
+
+    _set_budget_reset_at(data, updated_kv, existing)
+
+    assert "budget_reset_at" not in updated_kv

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23505,7 +23505,7 @@ export interface components {
              * @description Default role assigned to new users created
              * @default internal_user_viewer
              */
-            user_role: ("internal_user" | "internal_user_viewer" | "proxy_admin" | "proxy_admin_viewer") | null;
+            user_role: ("proxy_admin" | "proxy_admin_viewer" | "internal_user" | "internal_user_viewer") | null;
         };
         /**
          * DefaultTeamSSOParams
@@ -24084,6 +24084,8 @@ export interface components {
             budget_id?: string | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /**
              * Config
              * @default {}
@@ -24234,6 +24236,8 @@ export interface components {
             budget_id?: string | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /**
              * Config
              * @default {}
@@ -25102,6 +25106,8 @@ export interface components {
             budget_duration?: string | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /** Budget Reset At */
             budget_reset_at?: string | null;
             /** Created At */
@@ -25234,6 +25240,8 @@ export interface components {
             budget_limits?: {
                 [key: string]: unknown;
             }[] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /** Budget Reset At */
             budget_reset_at?: string | null;
             /**
@@ -26046,7 +26054,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */
@@ -26295,6 +26303,8 @@ export interface components {
             budget_duration?: string | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /** Budget Reset At */
             budget_reset_at?: string | null;
             /** Created At */
@@ -26426,6 +26436,8 @@ export interface components {
             allowed_cache_controls: string[];
             /** Budget Duration */
             budget_duration?: string | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /** Budget Reset At */
             budget_reset_at?: string | null;
             /** Created At */
@@ -26514,6 +26526,8 @@ export interface components {
             allowed_cache_controls: string[];
             /** Budget Duration */
             budget_duration?: string | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /** Budget Reset At */
             budget_reset_at?: string | null;
             /** Created At */
@@ -26636,6 +26650,8 @@ export interface components {
             budget_limits?: {
                 [key: string]: unknown;
             }[] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /** Budget Reset At */
             budget_reset_at?: string | null;
             /**
@@ -28324,6 +28340,8 @@ export interface components {
             budget_duration?: string | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /** Default Team Member Models */
             default_team_member_models?: string[] | null;
             /** Disable Global Guardrails */
@@ -28450,6 +28468,8 @@ export interface components {
             } | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /**
              * Config
              * @default {}
@@ -28594,6 +28614,8 @@ export interface components {
             budget_id?: string | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /**
              * Config
              * @default {}
@@ -29076,6 +29098,8 @@ export interface components {
             budget_duration?: string | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /** Default Team Member Models */
             default_team_member_models?: string[] | null;
             /** Disable Global Guardrails */
@@ -30379,6 +30403,8 @@ export interface components {
             budget_id?: string | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /**
              * Config
              * @default {}
@@ -31490,6 +31516,8 @@ export interface components {
             budget_duration?: string | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /** Budget Reset At */
             budget_reset_at?: string | null;
             /** Created At */
@@ -31600,6 +31628,8 @@ export interface components {
             budget_duration?: string | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /** Budget Reset At */
             budget_reset_at?: string | null;
             /** Created At */
@@ -32447,6 +32477,8 @@ export interface components {
             budget_id?: string | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /**
              * Config
              * @default {}
@@ -32809,6 +32841,8 @@ export interface components {
             budget_duration?: string | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /** Default Team Member Models */
             default_team_member_models?: string[] | null;
             /** Disable Global Guardrails */
@@ -32920,6 +32954,8 @@ export interface components {
             } | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /**
              * Config
              * @default {}
@@ -33026,6 +33062,8 @@ export interface components {
             } | null;
             /** Budget Limits */
             budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /**
              * Config
              * @default {}
@@ -33268,6 +33306,8 @@ export interface components {
             budget_limits?: {
                 [key: string]: unknown;
             }[] | null;
+            /** Budget Reset Alignment */
+            budget_reset_alignment?: ("calendar" | "rolling") | null;
             /** Budget Reset At */
             budget_reset_at?: string | null;
             /**
@@ -34136,7 +34176,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */


### PR DESCRIPTION
## TLDR

Problem this solves:

- `1mo` and `30d` behave identically; both reset on the 1st
- No way to reset one month from now, same time of day
- Late reset jobs would push every new window later

How it solves it:

- New nullable `budget_reset_alignment` on keys, teams, users
- `"rolling"` measures from the budget's own anchor
- NULL reads as `"calendar"`, so existing behavior is unchanged

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Draft: live-proxy proof is still to be captured and will be posted here before review is requested

The commands it will be captured with, against a proxy started as `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver`:

```bash
# rolling: budget_reset_at should be one month out, at the current time of day
curl -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"budget_duration":"1mo","budget_reset_alignment":"rolling","max_budget":5}'

# calendar (the unchanged default): budget_reset_at should be the 1st at 00:00
curl -X POST http://localhost:4000/key/generate \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"budget_duration":"1mo","max_budget":5}'

# flipping an existing key to rolling takes effect immediately
curl -X POST http://localhost:4000/key/update \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"key":"<key from the calendar request>","budget_reset_alignment":"rolling"}'

# then spend against the rolling key with a real model and confirm the cap holds
curl -X POST http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer <rolling key>" -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.1","messages":[{"role":"user","content":"hi"}]}'
```

## Type

🆕 New Feature

## Changes

Every write to `budget_reset_at` funnels through `get_budget_reset_time`, which calls `get_next_standardized_reset_time`. That function snaps to a shared calendar boundary and drops the time of day for every unit, so `1mo` and `30d` both mean "the start of the 1st of next month" and neither can express "one month from now, at the same time of day". There was no setting to change this

This adds a nullable `budget_reset_alignment` column to `LiteLLM_VerificationToken`, `LiteLLM_TeamTable` and `LiteLLM_UserTable`, plus the two audit tables that mirror them. A NULL reads as `"calendar"`, so existing rows, existing configs and the default for new rows all keep today's behavior exactly. Setting a row to `"rolling"` measures the duration from that budget's own anchor instead: a `1mo` budget created at 14:37 on the 30th next resets at 14:37 on the 30th of the following month, and `30d` becomes a real 30 days. Alignment is resolved per row, so a rolling team and a calendar team reset to different instants in the same job run

`compute_budget_reset_at` dispatches on the alignment and the new `get_next_rolling_reset_time` does the arithmetic. `reset_time_of_day` stays a calendar concept; a rolling budget keeps the time of day of its anchor, so it does not apply

Rolling resets anchor on the previous `budget_reset_at` rather than on the moment the reset job happens to run. Anchoring on "now" would fold the cron's lateness into every new window, so a job that is consistently a few minutes late would walk the reset time later and later without bound. A stale anchor, after an outage longer than one period, falls forward from now so the next reset is always in the future

Month arithmetic clamps to the target month's length, so a day-31 anchor lands on 28 February. Once clamped, the original day-of-month cannot be recovered from the previous reset alone, so that walk is pinned by a test rather than left to chance

Alignment is typed as a `Literal` rather than a `str` Enum because the value is persisted to a TEXT column. On Python 3.11+ `str(SomeStrEnum.MEMBER)` renders as `"SomeStrEnum.MEMBER"`, and `model_dump()` would hand Prisma an enum member instead of its value; the floor here is 3.10, so `enum.StrEnum` is not available either

Updating only `budget_duration` on a row that already has an alignment keeps that alignment, and setting only the alignment recomputes `budget_reset_at` right away instead of one period later. For `/user/update` this needed the existing user row to be fetched before the update params are prepared; nothing between the two reads the prepared values, so the fetch moved up rather than the preparation moving down

Two related things stay calendar-only and out of scope: `LiteLLM_BudgetTable`, which backs shared budget objects for end-users and team members, and the `budget_limits` JSON windows on keys and teams. Both can follow without a schema change to what is here

Tests cover the rolling arithmetic and its edges (month-end clamp, year rollover, multi-month durations that the calendar path rejects, sub-day units, invalid durations falling back instead of raising), the drift behavior over twelve consecutive late runs, per-row alignment in a single reset job run, and the create and update resolution order for keys, teams and users

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
