### PR TITLE
feat(ptu): configure provisioned-throughput flat cost on a model deployment

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260713010000_add_ptu_columns_to_daily_team_spend/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260713010000_add_ptu_columns_to_daily_team_spend/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "LiteLLM_DailyTeamSpend" ADD COLUMN IF NOT EXISTS "ptu_flat_cost" DOUBLE PRECISION NOT NULL DEFAULT 0.0;

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -30,7 +30,7 @@ model LiteLLM_BudgetTable {
   end_users LiteLLM_EndUserTable[] // multiple end-users can have the same budget
   tags LiteLLM_TagTable[] // multiple tags can have the same budget
   team_membership LiteLLM_TeamMembership[] // budgets of Users within a Team 
-  organization_membership LiteLLM_OrganizationMembership[] // budgets of Users within a Organization 
+  organization_membership LiteLLM_OrganizationMembership[] // budgets of Users within a Organization
 }
 
 // Models on proxy
@@ -893,6 +893,7 @@ model LiteLLM_DailyTeamSpend {
   api_requests        BigInt      @default(0)
   successful_requests BigInt      @default(0)
   failed_requests     BigInt      @default(0)
+  ptu_flat_cost       Float    @default(0.0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1718,3 +1718,9 @@ BROWSER_SECURITY_HEADERS: Final[frozenset[str]] = frozenset(
 )
 
 UNSAFE_PROXY_RESPONSE_HEADERS: Final[frozenset[str]] = HTTP_FRAMING_HEADERS | BROWSER_SECURITY_HEADERS
+
+# PTU reservation rollup writes rows to LiteLLM_DailyTeamSpend with this
+# sentinel api_key so PTU flat cost stays distinguishable from real per-request
+# spend under the table's composite unique constraint.
+PTU_SENTINEL_API_KEY: Final[str] = "__ptu_flat_cost__"
+PTU_ROLLUP_JOB_ID: Final[str] = "ptu_flat_cost_rollup_job"

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1716,3 +1716,9 @@ BROWSER_SECURITY_HEADERS: Final[frozenset[str]] = frozenset(
 )
 
 UNSAFE_PROXY_RESPONSE_HEADERS: Final[frozenset[str]] = HTTP_FRAMING_HEADERS | BROWSER_SECURITY_HEADERS
+
+# PTU reservation rollup writes rows to LiteLLM_DailyTeamSpend with this
+# sentinel api_key so PTU flat cost stays distinguishable from real per-request
+# spend under the table's composite unique constraint.
+PTU_SENTINEL_API_KEY: Final[str] = "__ptu_flat_cost__"
+PTU_ROLLUP_JOB_ID: Final[str] = "ptu_flat_cost_rollup_job"

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -15,6 +15,7 @@ import datetime
 import json
 from collections.abc import Awaitable, Mapping, Sequence
 from json import JSONDecodeError
+from types import MappingProxyType
 from typing import Final, Literal, Protocol, cast
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
@@ -79,6 +80,7 @@ from litellm.types.router import (
     SPECIAL_MODEL_INFO_PARAMS,
     Deployment,
     GenericLiteLLMParams,
+    ModelInfo,
     updateDeployment,
 )
 from litellm.utils import get_utc_datetime
@@ -233,6 +235,96 @@ def _raise_on_strategy_router_write_violation(
     )
 
 
+_PTU_MODEL_INFO_FIELDS: Final = ("ptu_count", "cost_per_ptu_per_hour", "ptu_effective_from", "ptu_effective_to")
+
+
+def _explicitly_cleared_ptu_fields(model_info: ModelInfo | None) -> frozenset[str]:
+    """The PTU fields a patch sends as an explicit null, which update_db_model drops."""
+    if model_info is None:
+        return frozenset()
+    return frozenset(
+        field
+        for field in _PTU_MODEL_INFO_FIELDS
+        if field in model_info.model_fields_set and getattr(model_info, field) is None
+    )
+
+
+def _merged_ptu_model_info(*, db_model: Deployment, patch_data: updateDeployment) -> Mapping[str, object]:
+    """The model_info a patch would store, which is the stored blob updated by the patch.
+
+    A PTU invariant holds over the deployment as it will exist, not over whichever subset
+    of fields a caller happened to send.
+    """
+    empty: Final[Mapping[str, object]] = MappingProxyType({})
+    stored: Final = db_model.model_info.model_dump(exclude_none=True) if db_model.model_info else empty
+    incoming: Final = patch_data.model_info.model_dump(exclude_none=True) if patch_data.model_info else empty
+    cleared: Final = _explicitly_cleared_ptu_fields(patch_data.model_info)
+    return MappingProxyType({k: v for k, v in {**stored, **incoming}.items() if k not in cleared})
+
+
+def _validate_ptu_model_info(model_info: Mapping[str, object]) -> None:
+    """Enforce the PTU cross-field invariant on the effective model_info.
+
+    ptu_count and cost_per_ptu_per_hour must be set together, and a team_id and a
+    ptu_effective_from are required when they are. The start is mandatory rather than
+    defaulted because flat cost accrues from it: inferring one would let a deployment
+    configured today be billed for days it did not exist. Per-field bounds (positive
+    count, non-negative rate) are enforced by ModelInfo itself.
+
+    Window ordering is checked before the count/rate gate. A patch that touches only one
+    end of the window carries no count or rate, and ModelInfo sees one field at a time, so
+    leaving it to either would let an inverted window reach the row; the next load then
+    fails to parse it and drops the deployment out of the router, where no further patch
+    can repair it because each one re-parses the stored value first.
+    """
+    effective_from: Final = _coerce_ptu_datetime(model_info.get("ptu_effective_from"))
+    effective_to: Final = _coerce_ptu_datetime(model_info.get("ptu_effective_to"))
+    if effective_from is not None and effective_to is not None and effective_to <= effective_from:
+        raise HTTPException(status_code=400, detail="ptu_effective_to must be after ptu_effective_from")
+
+    has_count: Final = model_info.get("ptu_count") is not None
+    has_rate: Final = model_info.get("cost_per_ptu_per_hour") is not None
+    if not has_count and not has_rate:
+        return
+    if has_count != has_rate:
+        raise HTTPException(status_code=400, detail="ptu_count and cost_per_ptu_per_hour must be set together")
+    if effective_from is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "ptu_effective_from is required when PTU fields are set. Flat cost accrues from that "
+                "instant, so without it the start would have to be inferred and a deployment configured "
+                "today could be billed for days it did not exist"
+            ),
+        )
+    if not model_info.get("team_id"):
+        raise HTTPException(
+            status_code=400, detail="team_id is required when PTU fields are set (one model maps to one team)"
+        )
+
+
+def _parse_ptu_datetime(value: object) -> datetime.datetime | None:
+    """``value`` as a datetime, parsing an ISO string, else None."""
+    if isinstance(value, datetime.datetime):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _coerce_ptu_datetime(value: object) -> datetime.datetime | None:
+    """Coerce a model_info effective-window value (datetime or ISO string) to UTC, else None."""
+    parsed: Final = _parse_ptu_datetime(value)
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed.astimezone(datetime.timezone.utc)
+
+
 def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> PrismaCompatibleUpdateDBModel:
     merged_model_name: Final = updated_patch.model_name or db_model.model_name
     merged_litellm_params: Final = db_model.litellm_params.model_dump(exclude_none=True)
@@ -270,6 +362,10 @@ def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> Pr
             if field in SPECIAL_MODEL_INFO_PARAMS and getattr(updated_patch.model_info, field) is None:
                 merged_model_info.pop(field, None)
                 merged_litellm_params.pop(field, None)
+        for field in _explicitly_cleared_ptu_fields(updated_patch.model_info):
+            merged_model_info.pop(field, None)
+
+    _validate_ptu_model_info(merged_model_info)
 
     # convert to prisma compatible format
 
@@ -715,6 +811,17 @@ async def _update_team_model_in_db(
         prisma_client=prisma_client,
         premium_user=premium_user,
     )
+
+    # Validated before any write, beside the premium check the create path already runs
+    # here. The team ACL is updated below and autocommits, so a validator that raises
+    # further down would leave the team mutated and the deployment row never written.
+    #
+    # The merged view is what gets stored, so that is what has to satisfy the invariants.
+    # Validating the patch alone rejected a partial edit of an already valid deployment:
+    # raising the rate on a configured model carries no ptu_effective_from, which the
+    # stored row supplies.
+    if patch_data.model_info is not None:
+        _validate_ptu_model_info(_merged_ptu_model_info(db_model=db_model, patch_data=patch_data))
 
     patch_team_id: Final = patch_data.model_info.team_id if patch_data.model_info else None
 
@@ -1424,6 +1531,8 @@ async def add_new_model(
 
         model_response: LiteLLM_ProxyModelTable | None = None
         # update DB
+        _validate_ptu_model_info(model_params.model_info.model_dump(exclude_none=True))
+
         if store_model_in_db is True:
             """
             - store model_list in db

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -15,6 +15,7 @@ import datetime
 import json
 from collections.abc import Mapping, Sequence
 from json import JSONDecodeError
+from types import MappingProxyType
 from typing import Any, Final, Literal, cast
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
@@ -165,6 +166,84 @@ def _raise_on_strategy_router_write_violation(
     )
 
 
+_PTU_MODEL_INFO_FIELDS: Final = ("ptu_count", "cost_per_ptu_per_hour", "ptu_effective_from", "ptu_effective_to")
+
+
+def _merged_ptu_model_info(*, db_model: Deployment, patch_data: updateDeployment) -> Mapping[str, object]:
+    """The model_info a patch would store, which is the stored blob updated by the patch.
+
+    A PTU invariant holds over the deployment as it will exist, not over whichever subset
+    of fields a caller happened to send.
+    """
+    empty: Final[Mapping[str, object]] = MappingProxyType({})
+    stored: Final = db_model.model_info.model_dump(exclude_none=True) if db_model.model_info else empty
+    incoming: Final = patch_data.model_info.model_dump(exclude_none=True) if patch_data.model_info else empty
+    return MappingProxyType({**stored, **incoming})
+
+
+def _validate_ptu_model_info(model_info: Mapping[str, object]) -> None:
+    """Enforce the PTU cross-field invariant on the effective model_info.
+
+    ptu_count and cost_per_ptu_per_hour must be set together, and a team_id and a
+    ptu_effective_from are required when they are. The start is mandatory rather than
+    defaulted because flat cost accrues from it: inferring one would let a deployment
+    configured today be billed for days it did not exist. Per-field bounds (positive
+    count, non-negative rate) are enforced by ModelInfo itself.
+
+    Window ordering is checked before the count/rate gate. A patch that touches only one
+    end of the window carries no count or rate, and ModelInfo sees one field at a time, so
+    leaving it to either would let an inverted window reach the row; the next load then
+    fails to parse it and drops the deployment out of the router, where no further patch
+    can repair it because each one re-parses the stored value first.
+    """
+    effective_from: Final = _coerce_ptu_datetime(model_info.get("ptu_effective_from"))
+    effective_to: Final = _coerce_ptu_datetime(model_info.get("ptu_effective_to"))
+    if effective_from is not None and effective_to is not None and effective_to <= effective_from:
+        raise HTTPException(status_code=400, detail="ptu_effective_to must be after ptu_effective_from")
+
+    has_count: Final = model_info.get("ptu_count") is not None
+    has_rate: Final = model_info.get("cost_per_ptu_per_hour") is not None
+    if not has_count and not has_rate:
+        return
+    if has_count != has_rate:
+        raise HTTPException(status_code=400, detail="ptu_count and cost_per_ptu_per_hour must be set together")
+    if effective_from is None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "ptu_effective_from is required when PTU fields are set. Flat cost accrues from that "
+                "instant, so without it the start would have to be inferred and a deployment configured "
+                "today could be billed for days it did not exist"
+            ),
+        )
+    if not model_info.get("team_id"):
+        raise HTTPException(
+            status_code=400, detail="team_id is required when PTU fields are set (one model maps to one team)"
+        )
+
+
+def _parse_ptu_datetime(value: object) -> datetime.datetime | None:
+    """``value`` as a datetime, parsing an ISO string, else None."""
+    if isinstance(value, datetime.datetime):
+        return value
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _coerce_ptu_datetime(value: object) -> datetime.datetime | None:
+    """Coerce a model_info effective-window value (datetime or ISO string) to UTC, else None."""
+    parsed: Final = _parse_ptu_datetime(value)
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed.astimezone(datetime.timezone.utc)
+
+
 def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> PrismaCompatibleUpdateDBModel:
     merged_deployment_dict: Final = DeploymentTypedDict(
         model_name=db_model.model_name,
@@ -209,6 +288,9 @@ def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> Pr
             if field in SPECIAL_MODEL_INFO_PARAMS and getattr(updated_patch.model_info, field) is None:
                 merged_deployment_dict["model_info"].pop(field, None)
                 merged_deployment_dict.get("litellm_params", {}).pop(field, None)
+        for field in _PTU_MODEL_INFO_FIELDS:
+            if field in updated_patch.model_info.model_fields_set and getattr(updated_patch.model_info, field) is None:
+                merged_deployment_dict["model_info"].pop(field, None)
 
     # convert to prisma compatible format
 
@@ -221,6 +303,7 @@ def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> Pr
 
     if "model_info" in merged_deployment_dict:
         model_info: Final = merged_deployment_dict["model_info"]
+        _validate_ptu_model_info(model_info)
         for key, value in model_info.items():
             if isinstance(value, datetime.datetime):
                 model_info[key] = value.isoformat()
@@ -658,6 +741,17 @@ async def _update_team_model_in_db(
         prisma_client=prisma_client,
         premium_user=premium_user,
     )
+
+    # Validated before any write, beside the premium check the create path already runs
+    # here. The team ACL is updated below and autocommits, so a validator that raises
+    # further down would leave the team mutated and the deployment row never written.
+    #
+    # The merged view is what gets stored, so that is what has to satisfy the invariants.
+    # Validating the patch alone rejected a partial edit of an already valid deployment:
+    # raising the rate on a configured model carries no ptu_effective_from, which the
+    # stored row supplies.
+    if patch_data.model_info is not None:
+        _validate_ptu_model_info(_merged_ptu_model_info(db_model=db_model, patch_data=patch_data))
 
     patch_team_id: Final = patch_data.model_info.team_id if patch_data.model_info else None
 
@@ -1366,6 +1460,8 @@ async def add_new_model(
 
         model_response: LiteLLM_ProxyModelTable | None = None
         # update DB
+        _validate_ptu_model_info(model_params.model_info.model_dump(exclude_none=True))
+
         if store_model_in_db is True:
             """
             - store model_list in db

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -30,7 +30,7 @@ model LiteLLM_BudgetTable {
   end_users LiteLLM_EndUserTable[] // multiple end-users can have the same budget
   tags LiteLLM_TagTable[] // multiple tags can have the same budget
   team_membership LiteLLM_TeamMembership[] // budgets of Users within a Team 
-  organization_membership LiteLLM_OrganizationMembership[] // budgets of Users within a Organization 
+  organization_membership LiteLLM_OrganizationMembership[] // budgets of Users within a Organization
 }
 
 // Models on proxy
@@ -893,6 +893,7 @@ model LiteLLM_DailyTeamSpend {
   api_requests        BigInt      @default(0)
   successful_requests BigInt      @default(0)
   failed_requests     BigInt      @default(0)
+  ptu_flat_cost       Float    @default(0.0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -122,6 +122,14 @@ class UpdateRouterConfig(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
 
+def _as_utc(value: datetime.datetime | None) -> datetime.datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
+
+
 class ModelInfo(BaseModel):
     id: str | None  # Allow id to be optional on input, but it will always be present as a str in the model instance
     db_model: bool = False  # used for proxy - to separate models which are stored in the db vs. config.
@@ -146,12 +154,29 @@ class ModelInfo(BaseModel):
     # admin-toggled pause flag; mirrors LiteLLM_ProxyModelTable.blocked
     blocked: bool | None = None
 
+    ptu_count: int | None = None
+    cost_per_ptu_per_hour: float | None = None
+    ptu_effective_from: datetime.datetime | None = None
+    ptu_effective_to: datetime.datetime | None = None
+
     def __init__(self, id: str | int | None = None, **params) -> None:
         if id is None:
             id = str(uuid.uuid4())  # Generate a UUID if id is None or not provided
         elif isinstance(id, int):
             id = str(id)
         super().__init__(id=id, **params)
+
+    @model_validator(mode="after")
+    def _validate_ptu_bounds(self) -> "ModelInfo":
+        if self.ptu_count is not None and self.ptu_count <= 0:
+            raise ValueError("ptu_count must be a positive integer")
+        if self.cost_per_ptu_per_hour is not None and self.cost_per_ptu_per_hour < 0:
+            raise ValueError("cost_per_ptu_per_hour must be non-negative")
+        start: Final = _as_utc(self.ptu_effective_from)
+        end: Final = _as_utc(self.ptu_effective_to)
+        if start is not None and end is not None and end <= start:
+            raise ValueError("ptu_effective_to must be after ptu_effective_from")
+        return self
 
     model_config = ConfigDict(extra="allow")
 

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -5,7 +5,7 @@ litellm.Router Types - includes RouterConfig, UpdateRouterConfig, ModelInfo etc
 import datetime
 import enum
 from dataclasses import dataclass
-from typing import Any, Final, Generic, Literal, TypeVar, get_type_hints
+from typing import Any, ClassVar, Final, Generic, Literal, TypeVar, get_type_hints
 
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -127,6 +127,14 @@ class UpdateRouterConfig(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
 
+def _as_utc(value: datetime.datetime | None) -> datetime.datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
+
+
 class ModelInfo(MirroredPricingParams):
     id: str | None  # Allow id to be optional on input, but it will always be present as a str in the model instance
     db_model: bool = False  # used for proxy - to separate models which are stored in the db vs. config.
@@ -151,12 +159,40 @@ class ModelInfo(MirroredPricingParams):
     # admin-toggled pause flag; mirrors LiteLLM_ProxyModelTable.blocked
     blocked: bool | None = None
 
+    # Bounds live on the model rather than litellm.constants: names there reach
+    # litellm/__init__ through several modules' star re-exports, and a Final rebound that
+    # way trips the basedpyright gate.
+    MAX_PTU_COUNT: ClassVar[int] = 1_000_000
+    MAX_COST_PER_PTU_PER_HOUR: ClassVar[float] = 1_000_000.0
+
+    ptu_count: int | None = None
+    cost_per_ptu_per_hour: float | None = None
+    ptu_effective_from: datetime.datetime | None = None
+    ptu_effective_to: datetime.datetime | None = None
+
     def __init__(self, id: str | int | None = None, **params) -> None:
         if id is None:
             id = str(uuid.uuid4())  # Generate a UUID if id is None or not provided
         elif isinstance(id, int):
             id = str(id)
         super().__init__(id=id, **params)
+
+    @model_validator(mode="after")
+    def _validate_ptu_bounds(self) -> "ModelInfo":
+        if self.ptu_count is not None and not 0 < self.ptu_count <= self.MAX_PTU_COUNT:
+            raise ValueError(f"ptu_count must be a positive integer no greater than {self.MAX_PTU_COUNT}")
+        if (
+            self.cost_per_ptu_per_hour is not None
+            and not 0 <= self.cost_per_ptu_per_hour <= self.MAX_COST_PER_PTU_PER_HOUR
+        ):
+            raise ValueError(
+                f"cost_per_ptu_per_hour must be a finite number between 0 and {self.MAX_COST_PER_PTU_PER_HOUR}"
+            )
+        start: Final = _as_utc(self.ptu_effective_from)
+        end: Final = _as_utc(self.ptu_effective_to)
+        if start is not None and end is not None and end <= start:
+            raise ValueError("ptu_effective_to must be after ptu_effective_from")
+        return self
 
     model_config = ConfigDict(extra="allow")
 

--- a/schema.prisma
+++ b/schema.prisma
@@ -30,7 +30,7 @@ model LiteLLM_BudgetTable {
   end_users LiteLLM_EndUserTable[] // multiple end-users can have the same budget
   tags LiteLLM_TagTable[] // multiple tags can have the same budget
   team_membership LiteLLM_TeamMembership[] // budgets of Users within a Team 
-  organization_membership LiteLLM_OrganizationMembership[] // budgets of Users within a Organization 
+  organization_membership LiteLLM_OrganizationMembership[] // budgets of Users within a Organization
 }
 
 // Models on proxy
@@ -893,6 +893,7 @@ model LiteLLM_DailyTeamSpend {
   api_requests        BigInt      @default(0)
   successful_requests BigInt      @default(0)
   failed_requests     BigInt      @default(0)
+  ptu_flat_cost       Float    @default(0.0)
   created_at          DateTime @default(now())
   updated_at          DateTime @updatedAt
 

--- a/tests/test_litellm/proxy/management_endpoints/test_ptu_model_settings.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ptu_model_settings.py
@@ -1,0 +1,290 @@
+import datetime
+import json
+
+"""Tests for PTU config on the model deployment (v1 model-settings design)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from litellm.proxy.management_endpoints.model_management_endpoints import (
+    _merged_ptu_model_info,
+    _validate_ptu_model_info,
+)
+from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo, updateDeployment
+
+
+def test_model_info_accepts_valid_ptu_fields():
+    info = ModelInfo(id="x", team_id="t", ptu_count=5, cost_per_ptu_per_hour=2.0)
+    assert info.ptu_count == 5
+    assert info.cost_per_ptu_per_hour == 2.0
+
+
+def test_model_info_rejects_non_positive_count():
+    with pytest.raises(ValueError):
+        ModelInfo(id="x", team_id="t", ptu_count=0, cost_per_ptu_per_hour=2.0)
+
+
+def test_model_info_rejects_negative_rate():
+    with pytest.raises(ValueError):
+        ModelInfo(id="x", team_id="t", ptu_count=5, cost_per_ptu_per_hour=-1.0)
+
+
+def test_model_info_allows_partial_delta_for_patch():
+    # A PATCH delta may carry only one field; bounds-only validation must not reject it.
+    info = ModelInfo(id="x", ptu_count=5)
+    assert info.ptu_count == 5
+    assert info.cost_per_ptu_per_hour is None
+
+
+def test_validate_helper_no_ptu_is_noop():
+    _validate_ptu_model_info({"team_id": "t"})
+
+
+def test_validate_helper_requires_both_fields():
+    with pytest.raises(HTTPException) as exc:
+        _validate_ptu_model_info({"team_id": "t", "ptu_count": 5})
+    assert exc.value.status_code == 400
+    assert "set together" in exc.value.detail
+
+
+def test_validate_helper_requires_team_id():
+    with pytest.raises(HTTPException) as exc:
+        _validate_ptu_model_info(
+            {"ptu_count": 5, "cost_per_ptu_per_hour": 2.0, "ptu_effective_from": "2026-08-01T00:00:00Z"}
+        )
+    assert exc.value.status_code == 400
+    assert "team_id" in exc.value.detail
+
+
+def test_validate_helper_requires_an_effective_start():
+    """Flat cost accrues from the start, so it cannot be inferred."""
+    with pytest.raises(HTTPException) as exc:
+        _validate_ptu_model_info({"team_id": "t", "ptu_count": 5, "cost_per_ptu_per_hour": 2.0})
+    assert exc.value.status_code == 400
+    assert "ptu_effective_from is required" in exc.value.detail
+
+
+def test_validate_helper_passes_full_config():
+    _validate_ptu_model_info(
+        {"team_id": "t", "ptu_count": 5, "cost_per_ptu_per_hour": 2.0, "ptu_effective_from": "2026-08-01T00:00:00Z"}
+    )
+
+
+def test_model_info_rejects_effective_to_before_from():
+    import datetime
+
+    with pytest.raises(ValueError):
+        ModelInfo(
+            id="x",
+            team_id="t",
+            ptu_count=5,
+            cost_per_ptu_per_hour=2.0,
+            ptu_effective_from=datetime.datetime(2026, 7, 30, tzinfo=datetime.timezone.utc),
+            ptu_effective_to=datetime.datetime(2026, 7, 29, tzinfo=datetime.timezone.utc),
+        )
+
+
+def test_model_info_accepts_valid_effective_window():
+    import datetime
+
+    info = ModelInfo(
+        id="x",
+        team_id="t",
+        ptu_count=5,
+        cost_per_ptu_per_hour=2.0,
+        ptu_effective_from=datetime.datetime(2026, 7, 30, tzinfo=datetime.timezone.utc),
+        ptu_effective_to=datetime.datetime(2026, 8, 30, tzinfo=datetime.timezone.utc),
+    )
+    assert info.ptu_effective_from is not None
+
+
+def test_model_info_compares_mixed_naive_and_aware_timestamps():
+    import datetime
+
+    info = ModelInfo(
+        id="x",
+        team_id="t",
+        ptu_count=5,
+        cost_per_ptu_per_hour=2.0,
+        ptu_effective_from=datetime.datetime(2026, 7, 30, 23, 0),
+        ptu_effective_to=datetime.datetime(2026, 7, 31, 0, 0, tzinfo=datetime.timezone.utc),
+    )
+    assert info.ptu_effective_to is not None
+
+    with pytest.raises(ValueError):
+        ModelInfo(
+            id="x",
+            team_id="t",
+            ptu_count=5,
+            cost_per_ptu_per_hour=2.0,
+            ptu_effective_from=datetime.datetime(2026, 7, 31, 2, 0),
+            ptu_effective_to=datetime.datetime(2026, 7, 31, 0, 0, tzinfo=datetime.timezone.utc),
+        )
+
+
+def test_validate_helper_rejects_effective_to_before_from():
+    with pytest.raises(HTTPException) as exc:
+        _validate_ptu_model_info(
+            {
+                "team_id": "t",
+                "ptu_count": 5,
+                "cost_per_ptu_per_hour": 2.0,
+                "ptu_effective_from": "2026-07-30T00:00:00Z",
+                "ptu_effective_to": "2026-07-29T00:00:00Z",
+            }
+        )
+    assert exc.value.status_code == 400
+    assert "ptu_effective_to" in exc.value.detail
+
+
+def test_validate_helper_accepts_valid_window_on_merged_info():
+    _validate_ptu_model_info(
+        {
+            "team_id": "t",
+            "ptu_count": 5,
+            "cost_per_ptu_per_hour": 2.0,
+            "ptu_effective_from": "2026-07-30T00:00:00Z",
+            "ptu_effective_to": "2026-08-30T00:00:00Z",
+        }
+    )
+
+
+def test_validate_helper_rejects_inverted_window_without_count_or_rate():
+    """A patch that touches only one end of the window merges to a model_info with no count
+    or rate. Returning early on that shape let an inverted window reach the row, and the next
+    load then failed to parse it and dropped the deployment out of the router."""
+    with pytest.raises(HTTPException) as exc:
+        _validate_ptu_model_info(
+            {
+                "team_id": "t",
+                "ptu_effective_from": "2026-08-02T00:00:00Z",
+                "ptu_effective_to": "2026-08-01T00:00:00Z",
+            }
+        )
+    assert exc.value.status_code == 400
+    assert "ptu_effective_to" in exc.value.detail
+
+
+def test_validate_helper_rejects_equal_window_bounds_without_count_or_rate():
+    with pytest.raises(HTTPException) as exc:
+        _validate_ptu_model_info(
+            {
+                "ptu_effective_from": "2026-08-01T00:00:00Z",
+                "ptu_effective_to": "2026-08-01T00:00:00Z",
+            }
+        )
+    assert exc.value.status_code == 400
+
+
+def test_validate_helper_accepts_ordered_window_without_count_or_rate():
+    """Window-only edits stay legal; only the ordering is enforced, and no team_id is
+    demanded while the deployment carries no priced PTU config."""
+    _validate_ptu_model_info(
+        {
+            "ptu_effective_from": "2026-08-01T00:00:00Z",
+            "ptu_effective_to": "2026-08-02T00:00:00Z",
+        }
+    )
+
+
+def test_validate_helper_accepts_a_single_open_ended_bound():
+    _validate_ptu_model_info({"ptu_effective_from": "2026-08-01T00:00:00Z"})
+    _validate_ptu_model_info({"ptu_effective_to": "2026-08-02T00:00:00Z"})
+
+
+class TestPartialPtuEditsUseTheMergedView:
+    """A PTU invariant holds over the deployment as it will exist, not over whichever
+    subset of fields a caller sent. Validating the patch alone rejected an ordinary edit."""
+
+    @staticmethod
+    def _configured():
+        return Deployment(
+            model_name="gpt-4o",
+            litellm_params=LiteLLM_Params(model="openai/gpt-4o"),
+            model_info=ModelInfo(
+                id="dep-0",
+                team_id="t",
+                ptu_count=10,
+                cost_per_ptu_per_hour=2.0,
+                ptu_effective_from=datetime.datetime(2026, 7, 1, tzinfo=datetime.timezone.utc),
+            ),
+        )
+
+    def test_raising_the_rate_on_a_configured_model_is_allowed(self):
+        """The patch carries no start; the stored row supplies it."""
+        merged = _merged_ptu_model_info(
+            db_model=self._configured(),
+            patch_data=updateDeployment(model_info=ModelInfo(id="dep-0", ptu_count=10, cost_per_ptu_per_hour=3.0)),
+        )
+        _validate_ptu_model_info(merged)
+        assert merged["cost_per_ptu_per_hour"] == 3.0
+        assert merged["ptu_effective_from"] is not None
+
+    def test_a_genuinely_startless_configuration_is_still_rejected(self):
+        """Merging must not become a way to smuggle PTU config in without a start."""
+        bare = Deployment(model_name="gpt-4o", litellm_params=LiteLLM_Params(model="openai/gpt-4o"))
+        merged = _merged_ptu_model_info(
+            db_model=bare,
+            patch_data=updateDeployment(
+                model_info=ModelInfo(id="dep-0", team_id="t", ptu_count=10, cost_per_ptu_per_hour=2.0)
+            ),
+        )
+        with pytest.raises(HTTPException) as exc:
+            _validate_ptu_model_info(merged)
+        assert "ptu_effective_from is required" in exc.value.detail
+
+    def test_the_patch_still_wins_over_the_stored_value(self):
+        merged = _merged_ptu_model_info(
+            db_model=self._configured(),
+            patch_data=updateDeployment(model_info=ModelInfo(id="dep-0", ptu_count=25)),
+        )
+        assert merged["ptu_count"] == 25
+
+
+class TestTeamModelUpdateValidatesBeforeWriting:
+    """Drives the endpoint path itself, not the helpers. The validator sits above the team
+    ACL write, which autocommits, so what it validates has to be right at that call site."""
+
+    @staticmethod
+    async def _run(db_model, patch_data, monkeypatch):
+        import litellm.proxy.management_endpoints.model_management_endpoints as mme
+
+        touched = []
+
+        async def _never(*args, **kwargs):
+            touched.append("team_write")
+
+        monkeypatch.setattr(mme, "_setup_new_team_model_assignment", _never)
+        monkeypatch.setattr(mme, "_update_existing_team_model_assignment", _never)
+        monkeypatch.setattr(mme.ModelManagementAuthChecks, "allow_team_model_action", AsyncMock(return_value=True))
+        result = await mme._update_team_model_in_db(
+            db_model=db_model,
+            patch_data=patch_data,
+            user_api_key_dict=MagicMock(),
+            prisma_client=MagicMock(),
+        )
+        return result, touched
+
+    @pytest.mark.asyncio
+    async def test_raising_the_rate_on_a_configured_model_reaches_the_write(self, monkeypatch):
+        """The patch carries no start. Validating it alone rejected this ordinary edit."""
+        db_model = TestPartialPtuEditsUseTheMergedView._configured()
+        patch = updateDeployment(model_info=ModelInfo(id="dep-0", team_id="t", ptu_count=10, cost_per_ptu_per_hour=3.0))
+
+        result, touched = await self._run(db_model, patch, monkeypatch)
+
+        assert touched == ["team_write"]
+        assert json.loads(result["model_info"])["cost_per_ptu_per_hour"] == 3.0
+
+    @pytest.mark.asyncio
+    async def test_a_startless_configuration_is_refused_before_the_team_write(self, monkeypatch):
+        """And the refusal still lands before anything is committed."""
+        bare = Deployment(model_name="gpt-4o", litellm_params=LiteLLM_Params(model="openai/gpt-4o"))
+        patch = updateDeployment(model_info=ModelInfo(id="dep-0", team_id="t", ptu_count=10, cost_per_ptu_per_hour=2.0))
+
+        with pytest.raises(HTTPException) as exc:
+            await self._run(bare, patch, monkeypatch)
+
+        assert "ptu_effective_from is required" in exc.value.detail

--- a/tests/test_litellm/proxy/management_endpoints/test_ptu_model_settings.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ptu_model_settings.py
@@ -1,0 +1,382 @@
+import datetime
+import json
+
+"""Tests for PTU config on the model deployment (v1 model-settings design)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from litellm.proxy.management_endpoints.model_management_endpoints import (
+    _merged_ptu_model_info,
+    _validate_ptu_model_info,
+)
+from litellm.types.router import Deployment, LiteLLM_Params, ModelInfo, updateDeployment
+
+
+def test_model_info_accepts_valid_ptu_fields():
+    info = ModelInfo(id="x", team_id="t", ptu_count=5, cost_per_ptu_per_hour=2.0)
+    assert info.ptu_count == 5
+    assert info.cost_per_ptu_per_hour == 2.0
+
+
+def test_model_info_rejects_non_positive_count():
+    with pytest.raises(ValueError):
+        ModelInfo(id="x", team_id="t", ptu_count=0, cost_per_ptu_per_hour=2.0)
+
+
+def test_model_info_rejects_negative_rate():
+    with pytest.raises(ValueError):
+        ModelInfo(id="x", team_id="t", ptu_count=5, cost_per_ptu_per_hour=-1.0)
+
+
+def test_model_info_rejects_a_count_beyond_the_cap():
+    """flat cost multiplies the count by a float, and an unbounded int overflows that
+    conversion, which aborted the rollup for every team rather than skipping one model."""
+    with pytest.raises(ValueError):
+        ModelInfo(id="x", team_id="t", ptu_count=10**400, cost_per_ptu_per_hour=2.0)
+
+
+def test_model_info_accepts_a_count_at_the_cap():
+    info = ModelInfo(id="x", team_id="t", ptu_count=ModelInfo.MAX_PTU_COUNT, cost_per_ptu_per_hour=2.0)
+    assert info.ptu_count == ModelInfo.MAX_PTU_COUNT
+
+
+@pytest.mark.parametrize("rate", [float("nan"), float("inf"), float("-inf")])
+def test_model_info_rejects_a_non_finite_rate(rate):
+    """NaN compares False against every bound, so a bare `< 0` check let it through and the
+    deployment then accrued a flat cost of nan."""
+    with pytest.raises(ValueError):
+        ModelInfo(id="x", team_id="t", ptu_count=5, cost_per_ptu_per_hour=rate)
+
+
+def test_model_info_rejects_a_rate_beyond_the_cap():
+    with pytest.raises(ValueError):
+        ModelInfo(id="x", team_id="t", ptu_count=5, cost_per_ptu_per_hour=ModelInfo.MAX_COST_PER_PTU_PER_HOUR * 2)
+
+
+def test_model_info_allows_partial_delta_for_patch():
+    # A PATCH delta may carry only one field; bounds-only validation must not reject it.
+    info = ModelInfo(id="x", ptu_count=5)
+    assert info.ptu_count == 5
+    assert info.cost_per_ptu_per_hour is None
+
+
+def test_validate_helper_no_ptu_is_noop():
+    _validate_ptu_model_info({"team_id": "t"})
+
+
+def test_validate_helper_requires_both_fields():
+    with pytest.raises(HTTPException) as exc:
+        _validate_ptu_model_info({"team_id": "t", "ptu_count": 5})
+    assert exc.value.status_code == 400
+    assert "set together" in exc.value.detail
+
+
+def test_validate_helper_requires_team_id():
+    with pytest.raises(HTTPException) as exc:
+        _validate_ptu_model_info(
+            {"ptu_count": 5, "cost_per_ptu_per_hour": 2.0, "ptu_effective_from": "2026-08-01T00:00:00Z"}
+        )
+    assert exc.value.status_code == 400
+    assert "team_id" in exc.value.detail
+
+
+def test_validate_helper_requires_an_effective_start():
+    """Flat cost accrues from the start, so it cannot be inferred."""
+    with pytest.raises(HTTPException) as exc:
+        _validate_ptu_model_info({"team_id": "t", "ptu_count": 5, "cost_per_ptu_per_hour": 2.0})
+    assert exc.value.status_code == 400
+    assert "ptu_effective_from is required" in exc.value.detail
+
+
+def test_validate_helper_passes_full_config():
+    _validate_ptu_model_info(
+        {"team_id": "t", "ptu_count": 5, "cost_per_ptu_per_hour": 2.0, "ptu_effective_from": "2026-08-01T00:00:00Z"}
+    )
+
+
+def test_model_info_rejects_effective_to_before_from():
+    import datetime
+
+    with pytest.raises(ValueError):
+        ModelInfo(
+            id="x",
+            team_id="t",
+            ptu_count=5,
+            cost_per_ptu_per_hour=2.0,
+            ptu_effective_from=datetime.datetime(2026, 7, 30, tzinfo=datetime.timezone.utc),
+            ptu_effective_to=datetime.datetime(2026, 7, 29, tzinfo=datetime.timezone.utc),
+        )
+
+
+def test_model_info_accepts_valid_effective_window():
+    import datetime
+
+    info = ModelInfo(
+        id="x",
+        team_id="t",
+        ptu_count=5,
+        cost_per_ptu_per_hour=2.0,
+        ptu_effective_from=datetime.datetime(2026, 7, 30, tzinfo=datetime.timezone.utc),
+        ptu_effective_to=datetime.datetime(2026, 8, 30, tzinfo=datetime.timezone.utc),
+    )
+    assert info.ptu_effective_from is not None
+
+
+def test_model_info_compares_mixed_naive_and_aware_timestamps():
+    import datetime
+
+    info = ModelInfo(
+        id="x",
+        team_id="t",
+        ptu_count=5,
+        cost_per_ptu_per_hour=2.0,
+        ptu_effective_from=datetime.datetime(2026, 7, 30, 23, 0),
+        ptu_effective_to=datetime.datetime(2026, 7, 31, 0, 0, tzinfo=datetime.timezone.utc),
+    )
+    assert info.ptu_effective_to is not None
+
+    with pytest.raises(ValueError):
+        ModelInfo(
+            id="x",
+            team_id="t",
+            ptu_count=5,
+            cost_per_ptu_per_hour=2.0,
+            ptu_effective_from=datetime.datetime(2026, 7, 31, 2, 0),
+            ptu_effective_to=datetime.datetime(2026, 7, 31, 0, 0, tzinfo=datetime.timezone.utc),
+        )
+
+
+def test_validate_helper_rejects_effective_to_before_from():
+    with pytest.raises(HTTPException) as exc:
+        _validate_ptu_model_info(
+            {
+                "team_id": "t",
+                "ptu_count": 5,
+                "cost_per_ptu_per_hour": 2.0,
+                "ptu_effective_from": "2026-07-30T00:00:00Z",
+                "ptu_effective_to": "2026-07-29T00:00:00Z",
+            }
+        )
+    assert exc.value.status_code == 400
+    assert "ptu_effective_to" in exc.value.detail
+
+
+def test_validate_helper_accepts_valid_window_on_merged_info():
+    _validate_ptu_model_info(
+        {
+            "team_id": "t",
+            "ptu_count": 5,
+            "cost_per_ptu_per_hour": 2.0,
+            "ptu_effective_from": "2026-07-30T00:00:00Z",
+            "ptu_effective_to": "2026-08-30T00:00:00Z",
+        }
+    )
+
+
+def test_validate_helper_rejects_inverted_window_without_count_or_rate():
+    """A patch that touches only one end of the window merges to a model_info with no count
+    or rate. Returning early on that shape let an inverted window reach the row, and the next
+    load then failed to parse it and dropped the deployment out of the router."""
+    with pytest.raises(HTTPException) as exc:
+        _validate_ptu_model_info(
+            {
+                "team_id": "t",
+                "ptu_effective_from": "2026-08-02T00:00:00Z",
+                "ptu_effective_to": "2026-08-01T00:00:00Z",
+            }
+        )
+    assert exc.value.status_code == 400
+    assert "ptu_effective_to" in exc.value.detail
+
+
+def test_validate_helper_rejects_equal_window_bounds_without_count_or_rate():
+    with pytest.raises(HTTPException) as exc:
+        _validate_ptu_model_info(
+            {
+                "ptu_effective_from": "2026-08-01T00:00:00Z",
+                "ptu_effective_to": "2026-08-01T00:00:00Z",
+            }
+        )
+    assert exc.value.status_code == 400
+
+
+def test_validate_helper_accepts_ordered_window_without_count_or_rate():
+    """Window-only edits stay legal; only the ordering is enforced, and no team_id is
+    demanded while the deployment carries no priced PTU config."""
+    _validate_ptu_model_info(
+        {
+            "ptu_effective_from": "2026-08-01T00:00:00Z",
+            "ptu_effective_to": "2026-08-02T00:00:00Z",
+        }
+    )
+
+
+def test_validate_helper_accepts_a_single_open_ended_bound():
+    _validate_ptu_model_info({"ptu_effective_from": "2026-08-01T00:00:00Z"})
+    _validate_ptu_model_info({"ptu_effective_to": "2026-08-02T00:00:00Z"})
+
+
+class TestPartialPtuEditsUseTheMergedView:
+    """A PTU invariant holds over the deployment as it will exist, not over whichever
+    subset of fields a caller sent. Validating the patch alone rejected an ordinary edit."""
+
+    @staticmethod
+    def _configured():
+        return Deployment(
+            model_name="gpt-4o",
+            litellm_params=LiteLLM_Params(model="openai/gpt-4o"),
+            model_info=ModelInfo(
+                id="dep-0",
+                team_id="t",
+                ptu_count=10,
+                cost_per_ptu_per_hour=2.0,
+                ptu_effective_from=datetime.datetime(2026, 7, 1, tzinfo=datetime.timezone.utc),
+            ),
+        )
+
+    def test_raising_the_rate_on_a_configured_model_is_allowed(self):
+        """The patch carries no start; the stored row supplies it."""
+        merged = _merged_ptu_model_info(
+            db_model=self._configured(),
+            patch_data=updateDeployment(model_info=ModelInfo(id="dep-0", ptu_count=10, cost_per_ptu_per_hour=3.0)),
+        )
+        _validate_ptu_model_info(merged)
+        assert merged["cost_per_ptu_per_hour"] == 3.0
+        assert merged["ptu_effective_from"] is not None
+
+    def test_a_genuinely_startless_configuration_is_still_rejected(self):
+        """Merging must not become a way to smuggle PTU config in without a start."""
+        bare = Deployment(model_name="gpt-4o", litellm_params=LiteLLM_Params(model="openai/gpt-4o"))
+        merged = _merged_ptu_model_info(
+            db_model=bare,
+            patch_data=updateDeployment(
+                model_info=ModelInfo(id="dep-0", team_id="t", ptu_count=10, cost_per_ptu_per_hour=2.0)
+            ),
+        )
+        with pytest.raises(HTTPException) as exc:
+            _validate_ptu_model_info(merged)
+        assert "ptu_effective_from is required" in exc.value.detail
+
+    def test_the_patch_still_wins_over_the_stored_value(self):
+        merged = _merged_ptu_model_info(
+            db_model=self._configured(),
+            patch_data=updateDeployment(model_info=ModelInfo(id="dep-0", ptu_count=25)),
+        )
+        assert merged["ptu_count"] == 25
+
+    def test_an_explicit_null_clears_the_stored_field(self):
+        """update_db_model drops a PTU field a patch sends as null, so the merged view has to
+        drop it too. Carrying the stored value forward validated a deployment that never
+        existed."""
+        merged = _merged_ptu_model_info(
+            db_model=self._configured(),
+            patch_data=updateDeployment(model_info=ModelInfo(id="dep-0", ptu_count=None)),
+        )
+        assert "ptu_count" not in merged
+
+    def test_clearing_one_half_of_the_pair_is_rejected(self):
+        """The write leaves a rate with no count. Merging on the stored count hid that."""
+        merged = _merged_ptu_model_info(
+            db_model=self._configured(),
+            patch_data=updateDeployment(model_info=ModelInfo(id="dep-0", ptu_count=None)),
+        )
+        with pytest.raises(HTTPException) as exc:
+            _validate_ptu_model_info(merged)
+        assert "must be set together" in exc.value.detail
+
+    def test_clearing_the_whole_pair_is_allowed(self):
+        """Turning PTU off on a deployment is a legitimate edit."""
+        merged = _merged_ptu_model_info(
+            db_model=self._configured(),
+            patch_data=updateDeployment(model_info=ModelInfo(id="dep-0", ptu_count=None, cost_per_ptu_per_hour=None)),
+        )
+        _validate_ptu_model_info(merged)
+        assert "ptu_count" not in merged
+        assert "cost_per_ptu_per_hour" not in merged
+
+    def test_an_omitted_field_is_not_a_clear(self):
+        """A partial edit that never mentions the count keeps it. Only an explicit null clears."""
+        merged = _merged_ptu_model_info(
+            db_model=self._configured(),
+            patch_data=updateDeployment(model_info=ModelInfo(id="dep-0", cost_per_ptu_per_hour=3.0)),
+        )
+        assert merged["ptu_count"] == 10
+
+
+class TestTeamModelUpdateValidatesBeforeWriting:
+    """Drives the endpoint path itself, not the helpers. The validator sits above the team
+    ACL write, which autocommits, so what it validates has to be right at that call site."""
+
+    @staticmethod
+    async def _run(db_model, patch_data, monkeypatch, touched=None):
+        import litellm.proxy.management_endpoints.model_management_endpoints as mme
+
+        touched = [] if touched is None else touched
+
+        async def _never(*args, **kwargs):
+            touched.append("team_write")
+
+        monkeypatch.setattr(mme, "_setup_new_team_model_assignment", _never)
+        monkeypatch.setattr(mme, "_update_existing_team_model_assignment", _never)
+        monkeypatch.setattr(mme.ModelManagementAuthChecks, "allow_team_model_action", AsyncMock(return_value=True))
+        result = await mme._update_team_model_in_db(
+            db_model=db_model,
+            patch_data=patch_data,
+            user_api_key_dict=MagicMock(),
+            prisma_client=MagicMock(),
+        )
+        return result, touched
+
+    @pytest.mark.asyncio
+    async def test_raising_the_rate_on_a_configured_model_reaches_the_write(self, monkeypatch):
+        """The patch carries no start. Validating it alone rejected this ordinary edit."""
+        db_model = TestPartialPtuEditsUseTheMergedView._configured()
+        patch = updateDeployment(model_info=ModelInfo(id="dep-0", team_id="t", ptu_count=10, cost_per_ptu_per_hour=3.0))
+
+        result, touched = await self._run(db_model, patch, monkeypatch)
+
+        assert touched == ["team_write"]
+        assert json.loads(result["model_info"])["cost_per_ptu_per_hour"] == 3.0
+
+    @pytest.mark.asyncio
+    async def test_a_startless_configuration_is_refused_before_the_team_write(self, monkeypatch):
+        """And the refusal still lands before anything is committed."""
+        bare = Deployment(model_name="gpt-4o", litellm_params=LiteLLM_Params(model="openai/gpt-4o"))
+        patch = updateDeployment(model_info=ModelInfo(id="dep-0", team_id="t", ptu_count=10, cost_per_ptu_per_hour=2.0))
+
+        with pytest.raises(HTTPException) as exc:
+            await self._run(bare, patch, monkeypatch)
+
+        assert "ptu_effective_from is required" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_clearing_half_the_pair_is_refused_before_the_team_write(self, monkeypatch):
+        """The write drops the nulled field, so validating against the stored one let a
+        deployment with a rate and no count commit."""
+        db_model = TestPartialPtuEditsUseTheMergedView._configured()
+        patch = updateDeployment(model_info=ModelInfo(id="dep-0", team_id="t", ptu_count=None))
+        touched = []
+
+        with pytest.raises(HTTPException) as exc:
+            await self._run(db_model, patch, monkeypatch, touched)
+
+        assert "must be set together" in exc.value.detail
+        assert touched == []
+
+    @pytest.mark.asyncio
+    async def test_clearing_the_whole_pair_reaches_the_write_and_stores_neither_field(self, monkeypatch):
+        """What the validator approved is what the write persists."""
+        db_model = TestPartialPtuEditsUseTheMergedView._configured()
+        patch = updateDeployment(
+            model_info=ModelInfo(id="dep-0", team_id="t", ptu_count=None, cost_per_ptu_per_hour=None)
+        )
+
+        result, touched = await self._run(db_model, patch, monkeypatch)
+
+        assert touched == ["team_write"]
+        stored = json.loads(result["model_info"])
+        assert "ptu_count" not in stored
+        assert "cost_per_ptu_per_hour" not in stored

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -35298,6 +35298,8 @@ export interface components {
             cache_creation_input_token_cost?: number | null;
             /** Cache Read Input Token Cost */
             cache_read_input_token_cost?: number | null;
+            /** Cost Per Ptu Per Hour */
+            cost_per_ptu_per_hour?: number | null;
             /** Created At */
             created_at?: string | null;
             /** Created By */
@@ -35317,6 +35319,12 @@ export interface components {
             output_cost_per_character?: number | null;
             /** Output Cost Per Token */
             output_cost_per_token?: number | null;
+            /** Ptu Count */
+            ptu_count?: number | null;
+            /** Ptu Effective From */
+            ptu_effective_from?: string | null;
+            /** Ptu Effective To */
+            ptu_effective_to?: string | null;
             /** Team Id */
             team_id?: string | null;
             /** Team Public Model Name */

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -35259,6 +35259,8 @@ export interface components {
             base_model?: string | null;
             /** Blocked */
             blocked?: boolean | null;
+            /** Cost Per Ptu Per Hour */
+            cost_per_ptu_per_hour?: number | null;
             /** Created At */
             created_at?: string | null;
             /** Created By */
@@ -35270,6 +35272,12 @@ export interface components {
             db_model: boolean;
             /** Id */
             id: string | null;
+            /** Ptu Count */
+            ptu_count?: number | null;
+            /** Ptu Effective From */
+            ptu_effective_from?: string | null;
+            /** Ptu Effective To */
+            ptu_effective_to?: string | null;
             /** Team Id */
             team_id?: string | null;
             /** Team Public Model Name */


### PR DESCRIPTION
## TLDR

Problem this solves:

- No way to attach provisioned-throughput cost inputs to a model
- Teams cannot see PTU flat cost alongside per-request spend

How it solves it:

- ModelInfo gains ptu_count, cost_per_ptu_per_hour, and an effective window
- model/new and model/{id}/update validate and store them; model/info returns them

## Relevant issues

## Linear ticket

Resolves LIT-4077

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Captured live against a proxy on this branch (commit 277f0963e1), real endpoints, no mocks.

Rebased onto litellm_internal_staging at f6587faef5 on 2026-08-06, which had moved 441 commits past the original branch point. The whole matrix below was re-run against the rebased head on a live proxy and a real Postgres, so nothing here is carried over from the pre-rebase run

The validation matrix, re-run on the rebased head

```
POST /model/new  ptu_count 10, no cost_per_ptu_per_hour
  -> 400 "ptu_count and cost_per_ptu_per_hour must be set together"

POST /model/new  ptu_count 2.5, cost_per_ptu_per_hour 2.0
  -> 422 "Input should be a valid integer, got a number with a fractional part"

POST /model/new  ptu_count 10, cost_per_ptu_per_hour -2.0
  -> 422 "Value error, cost_per_ptu_per_hour must be non-negative"

POST /model/new  ptu_count 10, cost_per_ptu_per_hour 2.0, no team_id
  -> 400 "team_id is required when PTU fields are set (one model maps to one team)"

POST /model/new  ptu_count 10, cost_per_ptu_per_hour 2.0, team_id set,
                 ptu_effective_from 2026-07-07T00:00:00Z
  -> HTTP 200

GET /model/info
  -> {'ptu_count': 10, 'cost_per_ptu_per_hour': 2.0,
      'ptu_effective_from': '2026-07-07T00:00:00+00:00', 'team_id': '71cb34c9-...'}
```

The stored window comes back as the same UTC wall clock it went in as

```
# 1. model/new with PTU config is persisted and returned
POST /model/new  model_info={team_id, ptu_count:5, cost_per_ptu_per_hour:2.0, ptu_effective_from:"2026-07-31T23:00:00Z"}
-> model_info: ptu_count=5 cost_per_ptu_per_hour=2.0 effective_from=2026-07-31T23:00:00Z

# 2. only one of the two PTU fields is rejected
POST /model/new  model_info={team_id, ptu_count:5}
-> HTTP 400 "ptu_count and cost_per_ptu_per_hour must be set together"

# 3. PTU fields without a team_id are rejected
POST /model/new  model_info={ptu_count:5, cost_per_ptu_per_hour:2.0}
-> HTTP 400 "team_id is required when PTU fields are set (one model maps to one team)"
```

### Screens

The four fields on the model form, and the cross-field invariant rejecting a half-set pair before it reaches the API:

![PTU fields on the model edit form](https://raw.githubusercontent.com/BerriAI/litellm/assets_ptu_flat_cost_screenshots/02-model-edit-fields.png)

![Clearing one of the pair is rejected on both fields](https://raw.githubusercontent.com/BerriAI/litellm/assets_ptu_flat_cost_screenshots/03-validation-pair.png)

Per-field bounds, rejected in the form rather than surfacing as a backend error:

![A fractional PTU count is rejected](https://raw.githubusercontent.com/BerriAI/litellm/assets_ptu_flat_cost_screenshots/04-validation-fractional.png)

![A negative PTU count is rejected](https://raw.githubusercontent.com/BerriAI/litellm/assets_ptu_flat_cost_screenshots/05-validation-negative.png)

This is the first of a stack. The daily rollup that writes ptu_flat_cost, the read path that surfaces it, and the UI land in follow-up PRs


### Live run 2026-08-08, commit c0ab5d2d5c

Fresh Postgres, migrations deployed from `litellm-proxy-extras`, real Gemini traffic, no mocks

```
POST /model/new   ptu_count 15, cost_per_ptu_per_hour 2.0, ptu_effective_from 2026-08-01   -> 200
POST /model/new   count without rate                                                        -> 400 must be set together
POST /model/new   pair without ptu_effective_from                                           -> 400 ptu_effective_from is required
POST /model/new   pair without team_id                                                      -> 400 team_id is required
POST /model/new   ptu_count 0                                                               -> 422 must be a positive integer
POST /model/new   cost_per_ptu_per_hour -1.0                                                -> 422 must be non-negative
POST /model/new   ptu_effective_to before ptu_effective_from                                -> 422 must be after
```

The merged-view fix, driven against a deployment storing count 15 / rate 3.0 / start 2026-08-01

```
PATCH  rate only, no start in the body      -> 200   stored rate 3.0, start preserved
PATCH  ptu_count: null (clears one half)    -> 400   must be set together
       stored after the refusal              = count 15, rate 3.0   unchanged
PATCH  count and rate both null             -> 200   both keys gone, PTU turned off
PATCH  reconfigure                          -> 200   count 15, rate 2.0 restored
```

Before this fix the half-clear passed validation on the stored count and committed the team write before `update_db_model`'s backstop rejected it


The same config as seen by an operator, on Models + Endpoints for the deployment created above

![Model Settings showing the stored PTU config](https://raw.githubusercontent.com/BerriAI/litellm/assets_ptu_flat_cost_screenshots/ptu-05-model-settings-read.png)

## Type

New Feature

## Changes

ModelInfo gains ptu_count, cost_per_ptu_per_hour, ptu_effective_from and ptu_effective_to. A model_validator enforces per-field bounds: a positive count, a non-negative rate, and effective_to strictly after effective_from. Bounds run at request-parse time on both model/new and model/{id}/update since both carry a ModelInfo

The cross-field invariant (count and rate set together, team_id required when either is set) is enforced by a helper applied to the effective model_info: on `POST /model/new` against the create payload, and on `PATCH /model/{model_id}/update` against the merged stored-plus-incoming model_info, so a partial patch that changes only one field validates the final state rather than the delta. Note the verb: `/model/{model_id}/update` is PATCH-only and answers POST with a 405, while the older `POST /model/update` is a different route that does not write model_info at all

The two invariant failures above answer 400 from the handler. The per-field bounds live on the ModelInfo validator instead, so they are reported at request-parse time as FastAPI's usual 422 rather than 400; both reject the request and persist nothing, but the status codes differ by design and the SDK/Router keep the bounds even when the endpoint is bypassed

The merged view mirrors what the write will store, including the clears. `update_db_model` drops a PTU field a patch sends as an explicit null, so carrying the stored value into validation approved a deployment that never forms: clearing a count while leaving a rate passed the pair check and then committed the team ACL write before the backstop validator inside `update_db_model` rejected it. Both paths now derive the cleared set from one helper, so they cannot drift again

LiteLLM_DailyTeamSpend gains a ptu_flat_cost column and a sentinel api_key constant, ready for the rollup PR; nothing writes them yet in this PR

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/35341" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Requires a DB migration and changes model deployment validation and spend schema; rollup/read paths are not in this PR, so misconfiguration is limited to rejected API payloads until follow-ups land.
> 
> **Overview**
> Adds **provisioned throughput (PTU)** settings on proxy model deployments so flat reservation cost can be configured per team-scoped model before a follow-up rollup writes spend.
> 
> **`ModelInfo`** now accepts `ptu_count`, `cost_per_ptu_per_hour`, and optional `ptu_effective_from` / `ptu_effective_to`, with bounds enforced at parse time (positive count, non-negative rate, effective window ordering). **`/model/new`** and **`/model/{id}/update`** (via merged `model_info` in `update_db_model`) call **`_validate_ptu_model_info`**: PTU count and hourly rate must be set together, and **`team_id`** is required when either is present.
> 
> **`LiteLLM_DailyTeamSpend`** gains **`ptu_flat_cost`** and **`ptu_source_model_id`** (migration + Prisma); **`PTU_SENTINEL_API_KEY`** and **`PTU_ROLLUP_JOB_ID`** are defined for future rollup rows—nothing writes these columns in this PR. Dashboard OpenAPI types include the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f46ef05c6ef91e460153162b17803fcb6ef62bd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->





