### PR TITLE
fix(interactions): add queued status and update openapi compliance tests

### DIFF
--- a/litellm/types/interactions/generated.py
+++ b/litellm/types/interactions/generated.py
@@ -173,6 +173,7 @@ class Status1(Enum):
     cancelled = "cancelled"
     incomplete = "incomplete"
     budget_exceeded = "budget_exceeded"
+    queued = "queued"
 
 
 class InteractionStatusUpdate(BaseModel):
@@ -341,6 +342,7 @@ class Status3(Enum):
     CANCELLED = "cancelled"
     INCOMPLETE = "incomplete"
     BUDGET_EXCEEDED = "budget_exceeded"
+    QUEUED = "queued"
 
 
 class ModelOption(RootModel[str]):

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -106,25 +106,35 @@ class TestRequestCompliance:
         assert "array" in input_types, "Input should support array"
 
     def test_content_schema_uses_discriminator(self, spec_dict):
-        """Verify Content uses type discriminator."""
+        """Verify Content is a oneOf over the content types, distinguishable by `type`.
+
+        Google's spec dropped the explicit OpenAPI `discriminator` keyword from
+        `Content` at some point after 2025-12-16; the schema is now a plain `oneOf`
+        with no `discriminator` object. LiteLLM's own Pydantic model
+        (`litellm.types.interactions.generated.Content`) still declares its own
+        `discriminator="type"` independently of this JSON Schema keyword, since
+        each content variant carries a distinguishing `type` literal - so this
+        check now verifies the oneOf shape directly rather than requiring the
+        (optional, and no longer present) `discriminator` keyword.
+        """
         content_schema = spec_dict["components"]["schemas"]["Content"]
 
-        assert "discriminator" in content_schema
-        assert content_schema["discriminator"]["propertyName"] == "type"
+        one_of = content_schema.get("oneOf", [])
+        assert one_of, "Content schema should be a oneOf"
 
-        # Check TextContent is an option (via mapping if present, or via oneOf refs)
-        mapping = content_schema["discriminator"].get("mapping")
-        if mapping:
-            assert "text" in mapping
-            print(f"Content type discriminator mapping: {list(mapping.keys())}")
-        else:
-            # Discriminator without explicit mapping — verify via oneOf
-            one_of = content_schema.get("oneOf", [])
-            ref_names = [opt["$ref"].split("/")[-1] for opt in one_of if "$ref" in opt]
-            assert (
-                "TextContent" in ref_names
-            ), f"TextContent not found in oneOf refs: {ref_names}"
-            print(f"Content type discriminator (no mapping), oneOf refs: {ref_names}")
+        if "discriminator" in content_schema:
+            assert content_schema["discriminator"]["propertyName"] == "type"
+            mapping = content_schema["discriminator"].get("mapping")
+            if mapping:
+                assert "text" in mapping
+                print(f"Content type discriminator mapping: {list(mapping.keys())}")
+                return
+
+        ref_names = [opt["$ref"].split("/")[-1] for opt in one_of if "$ref" in opt]
+        assert (
+            "TextContent" in ref_names
+        ), f"TextContent not found in oneOf refs: {ref_names}"
+        print(f"Content oneOf refs: {ref_names}")
 
     def test_text_content_schema(self, spec_dict):
         """Verify TextContent schema."""
@@ -182,7 +192,8 @@ class TestResponseCompliance:
         # `status` is an output-only field; validate against the response schema.
         schema = spec_dict["components"]["schemas"]["Interaction"]
         status_prop = schema["properties"]["status"]
-        # Google Interactions API uses lowercase status values (updated Feb 2026).
+        # Google Interactions API uses lowercase status values (updated Feb 2026;
+        # "queued" added after 2025-12-16 for interactions awaiting execution).
         # Keep this an exact match: this test intentionally breaks CI when
         # Google changes the live spec — that breakage is how we get notified
         # to review the change.
@@ -194,6 +205,7 @@ class TestResponseCompliance:
             "cancelled",
             "incomplete",
             "budget_exceeded",
+            "queued",
         ]
         assert status_prop["enum"] == expected_statuses
         print(f"✓ Status enum values: {expected_statuses}")

--- a/tests/test_litellm/interactions/test_openapi_compliance.py
+++ b/tests/test_litellm/interactions/test_openapi_compliance.py
@@ -134,7 +134,35 @@ class TestRequestCompliance:
         assert (
             "TextContent" in ref_names
         ), f"TextContent not found in oneOf refs: {ref_names}"
-        print(f"Content oneOf refs: {ref_names}")
+
+        # `discriminator="type"` on litellm's Pydantic `Content` RootModel only
+        # works if every variant schema requires a `type` field with a single
+        # literal value (`const`, or a one-element `enum`), and those literals
+        # are unique across variants. Verify that invariant directly against
+        # the spec's variant schemas, since the JSON Schema `discriminator`
+        # keyword that used to guarantee this is gone.
+        type_literals = []
+        for ref_name in ref_names:
+            variant_schema = spec_dict["components"]["schemas"][ref_name]
+            assert (
+                "type" in variant_schema.get("required", [])
+            ), f"{ref_name} does not require a 'type' field"
+
+            type_prop = variant_schema["properties"]["type"]
+            if "const" in type_prop:
+                literal = type_prop["const"]
+            elif len(type_prop.get("enum", [])) == 1:
+                literal = type_prop["enum"][0]
+            else:
+                raise AssertionError(
+                    f"{ref_name}.type is not a single literal value: {type_prop}"
+                )
+            type_literals.append(literal)
+
+        assert len(type_literals) == len(
+            set(type_literals)
+        ), f"Content variants do not have unique 'type' literals: {type_literals}"
+        print(f"Content oneOf refs: {ref_names}, type literals: {type_literals}")
 
     def test_text_content_schema(self, spec_dict):
         """Verify TextContent schema."""

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23304,7 +23304,7 @@ export interface components {
              * @description Default role assigned to new users created
              * @default internal_user_viewer
              */
-            user_role: ("internal_user" | "internal_user_viewer" | "proxy_admin" | "proxy_admin_viewer") | null;
+            user_role: ("proxy_admin" | "proxy_admin_viewer" | "internal_user" | "internal_user_viewer") | null;
         };
         /**
          * DefaultTeamSSOParams
@@ -25835,7 +25835,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */
@@ -33671,7 +33671,7 @@ export interface components {
                 [key: string]: unknown;
             } | null;
             /** Stream Timeout */
-            stream_timeout?: number | string | null;
+            stream_timeout?: string | number | null;
             /** Tag Regex */
             tag_regex?: string[] | null;
             /** Tags */


### PR DESCRIPTION
## Relevant issues

Fixes #35346

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Fetching Google's live Interactions API spec directly shows the drift that broke `tests/test_litellm/interactions/test_openapi_compliance.py`:

```
$ curl -s https://ai.google.dev/static/api/interactions.openapi.json | python3 -c "
import json, sys
spec = json.load(sys.stdin)
content = spec['components']['schemas']['Content']
print('Content has discriminator:', 'discriminator' in content)
status = spec['components']['schemas']['Interaction']['properties']['status']
print('status enum:', status.get('enum'))
"
Content has discriminator: False
status enum: ['in_progress', 'requires_action', 'completed', 'failed', 'cancelled', 'incomplete', 'budget_exceeded', 'queued']
```

Test run before this fix (on `litellm_oss_daily_2026_07_20`, unmodified):

```
$ uv run pytest tests/test_litellm/interactions/test_openapi_compliance.py -v
...
FAILED tests/test_litellm/interactions/test_openapi_compliance.py::TestRequestCompliance::test_content_schema_uses_discriminator
FAILED tests/test_litellm/interactions/test_openapi_compliance.py::TestResponseCompliance::test_status_enum_values
```

Test run after this fix:

```
$ uv run pytest tests/test_litellm/interactions/test_openapi_compliance.py -v
...
13 passed in 0.93s
```

## Type

🐛 Bug Fix

## Changes

Google's live Interactions API OpenAPI spec changed in two ways since `litellm/types/interactions/generated.py` was generated (2025-12-16): it added a `queued` status value to `Interaction.status`, and it dropped the `discriminator` keyword from the `Content` schema (now a plain `oneOf`).

This adds `queued` to the `Status1` and `Status3` enums in `litellm/types/interactions/generated.py` so LiteLLM's typed representation of the status field stays exhaustive with what Google's API can actually return. No other code depends on an exhaustive match over these enums today, so this is additive only.

Updates `test_content_schema_uses_discriminator` to verify the `Content` schema's `oneOf` shape directly instead of requiring the (optional, and no longer present) JSON Schema `discriminator` keyword; LiteLLM's own Pydantic `Content` model already declares its own `discriminator="type"` independently of that JSON Schema keyword; each content variant carries a distinguishing `type` literal, so this doesn't depend on Google's schema also declaring one. Also adds `"queued"` to the expected status list in `test_status_enum_values`.

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR