### PR TITLE
fix(cost): propagate vertex_location as region_name for vertex_ai region-based pricing

### DIFF
--- a/litellm/main.py
+++ b/litellm/main.py
@@ -5172,8 +5172,8 @@ def completion(  # type: ignore
         if model_response is not None and hasattr(model_response, "_hidden_params"):
             model_response._hidden_params["custom_llm_provider"] = custom_llm_provider
             model_response._hidden_params["region_name"] = kwargs.get(
-                "aws_region_name", None
-            )  # support region-based pricing for bedrock
+                "aws_region_name"
+            ) or kwargs.get("vertex_location")
 
         ### TIMEOUT LOGIC ###
         timeout = CompletionTimeout.resolve(

--- a/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
+++ b/tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py
@@ -5553,3 +5553,64 @@ def test_accumulated_json_skips_non_dict_leading_value():
 
     assert len(out) == 1
     assert out[0].choices[0].delta.content == "a"
+@pytest.mark.parametrize(
+    "vertex_location, expected_region_name",
+    [
+        ("europe-west1", "europe-west1"),
+        ("global", "global"),
+        (None, None),
+    ],
+)
+def test_vertex_region_name_propagated_from_vertex_location(
+    vertex_location, expected_region_name
+):
+    """
+    Regression for #34393: region-based cost tracking worked for bedrock (aws_region_name)
+    and azure but never for vertex_ai, because completion() only copied aws_region_name into
+    _hidden_params["region_name"]. vertex_location was dropped, so cost_calculator could never
+    build the region-scoped "vertex_ai/{region}/{model}" price key and every vertex region was
+    billed at the same model-name price.
+
+    completion() must now propagate vertex_location as region_name (and leave it None when no
+    location is supplied, so a request that opts out does not accidentally match a region key).
+    """
+    from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+    client = HTTPHandler()
+    response_body = {
+        "candidates": [
+            {
+                "content": {"parts": [{"text": "hi"}], "role": "model"},
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 10,
+            "candidatesTokenCount": 5,
+            "totalTokenCount": 15,
+        },
+        "modelVersion": "gemini-2.5-flash",
+    }
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = response_body
+
+    completion_kwargs = dict(
+        model="vertex_ai/gemini-2.5-flash",
+        messages=[{"role": "user", "content": "hi"}],
+        vertex_project="fake-project",
+        vertex_credentials='{"type": "service_account"}',
+        client=client,
+    )
+    if vertex_location is not None:
+        completion_kwargs["vertex_location"] = vertex_location
+
+    with patch(
+        "litellm.llms.vertex_ai.vertex_llm_base.VertexBase._ensure_access_token",
+        return_value=("fake-token", "fake-project"),
+    ):
+        with patch.object(client, "post", return_value=mock_response):
+            response = completion(**completion_kwargs)
+
+    assert response._hidden_params.get("custom_llm_provider") == "vertex_ai"
+    assert response._hidden_params.get("region_name") == expected_region_name


### PR DESCRIPTION
## Relevant issues

Fixes #34393

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all unit tests
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Type

🐛 Bug Fix

## Changes

Region-based cost tracking already works for bedrock and azure but never fired for vertex_ai. `cost_calculator.py` looks up a region-scoped `"{provider}/{region}/{model}"` price key whenever `_hidden_params["region_name"]` is set, but in `completion()` that field was only ever populated from `aws_region_name` (bedrock). For vertex_ai the region is supplied through `vertex_location`, which was never written into `region_name`, so the region-scoped key was never constructed and every vertex region (`global`, `eu`, `us`, ...) was billed at the same model-name price even though Google charges different rates for the global vs regional endpoints.

The change reads `vertex_location` in addition to `aws_region_name` when setting `region_name`, so a vertex_ai request carries its region on the cost path the same way bedrock and azure already do. No region-scoped `vertex_ai/{region}/...` entries ship in the price map yet, so this is the prerequisite plumbing; region entries can be contributed the way `azure/eu/...` and the bedrock region entries already exist, once their rates are sourced. Behavior for bedrock is unchanged because `aws_region_name` is still checked first.

## Testing

Added a parameterized regression test to `tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py` (next to the existing `_hidden_params` propagation tests). It runs a full `completion()` against a mocked Vertex transport (patched `VertexBase._ensure_access_token` and `HTTPHandler.post`, so it is fully offline) and asserts:

- `vertex_location="europe-west1"` -> `_hidden_params["region_name"] == "europe-west1"`
- `vertex_location="global"` -> `region_name == "global"`
- no `vertex_location` -> `region_name is None` (a request that opts out must not accidentally match a region-scoped price key)

The two location cases fail against the current code (region_name stays `None`) and pass with the fix; the no-location case passes both ways.

```bash
pytest "tests/test_litellm/llms/vertex_ai/gemini/test_vertex_and_google_ai_studio_gemini.py::test_vertex_region_name_propagated_from_vertex_location" -q
# 3 passed
```

Proof-of-fix on a live proxy once a region-scoped price entry exists: configure a vertex deployment with `vertex_location: europe-west1`, add a `vertex_ai/europe-west1/<model>` entry to the price map (or inline `model_info`), and confirm a request logs `response_cost` at the regional rate rather than the base model-name rate. Before this change the region is dropped and the base rate is always used.
