### PR TITLE
fix(proxy): preserve budget_limits window reset_at when editing max_budget

### DIFF
--- a/litellm/models/verification_token.py
+++ b/litellm/models/verification_token.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from pydantic import ConfigDict
 
 from litellm.models.object_permission import LiteLLM_ObjectPermissionTable
+from litellm.models.team import BudgetLimitEntry
 from litellm.types.llms.base import LiteLLMPydanticObjectBase
 
 
@@ -59,7 +60,7 @@ class LiteLLM_VerificationToken(LiteLLMPydanticObjectBase):
     last_rotation_at: datetime | None = None
     key_rotation_at: datetime | None = None
     router_settings: dict | None = None
-    budget_limits: list[dict] | None = None
+    budget_limits: list[BudgetLimitEntry] | None = None
     model_config = ConfigDict(protected_namespaces=())
 
 

--- a/litellm/proxy/common_utils/budget_limits.py
+++ b/litellm/proxy/common_utils/budget_limits.py
@@ -1,0 +1,88 @@
+"""Shared resolution of ``budget_limits`` windows for keys and teams.
+
+Each ``budget_limits`` entry carries a server-managed ``reset_at`` that anchors
+its spend window (``window_start = reset_at - budget_duration``; see
+``budget_reservation.get_budget_window_start``). Spend for a window is never
+persisted as a running total; it is re-derived from ``LiteLLM_SpendLogs`` since
+``window_start``, so moving ``reset_at`` moves the window and, on a cold spend
+counter, the spend it enforces.
+
+On update we therefore preserve ``reset_at`` for any window whose
+``budget_duration`` already exists on the entity, so editing ``max_budget``
+alone does not restart the window. Only genuinely new durations get a fresh
+reset boundary. On create there is nothing to preserve, so every window is
+initialized fresh.
+"""
+
+import json
+from datetime import datetime
+from typing import Mapping, Sequence
+
+from pydantic import TypeAdapter
+
+from litellm.models.team import BudgetLimitEntry
+from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+
+BudgetLimitWindow = BudgetLimitEntry | Mapping[str, object]
+# Existing windows can arrive parsed (key rows, validated team models) or as the
+# raw JSON string a prisma ``Json?`` column returns from ``find_unique`` (which
+# is ``null`` when the field was cleared).
+ExistingBudgetLimits = str | Sequence[BudgetLimitWindow] | None
+
+_EXISTING_WINDOWS_ADAPTER: TypeAdapter[list[BudgetLimitEntry] | None] = TypeAdapter(list[BudgetLimitEntry] | None)
+
+
+def _to_entry(window: BudgetLimitWindow) -> BudgetLimitEntry:
+    if isinstance(window, BudgetLimitEntry):
+        return window
+    return BudgetLimitEntry.model_validate(window)
+
+
+def _iter_existing(existing: ExistingBudgetLimits) -> Sequence[BudgetLimitEntry]:
+    if existing is None:
+        return ()
+    if isinstance(existing, str):
+        return _EXISTING_WINDOWS_ADAPTER.validate_json(existing) or ()
+    return [_to_entry(window) for window in existing]
+
+
+def _existing_reset_at_by_duration(existing: ExistingBudgetLimits) -> Mapping[str, datetime]:
+    return {entry.budget_duration: entry.reset_at for entry in _iter_existing(existing) if entry.reset_at is not None}
+
+
+def _resolve_window(window: BudgetLimitWindow, preserved: Mapping[str, datetime]) -> BudgetLimitEntry:
+    entry = _to_entry(window)
+    reset_at = preserved.get(entry.budget_duration) or get_budget_reset_time(budget_duration=entry.budget_duration)
+    return entry.model_copy(update={"reset_at": reset_at})
+
+
+def resolve_budget_limit_windows(
+    incoming: Sequence[BudgetLimitWindow],
+    existing: ExistingBudgetLimits = None,
+) -> tuple[BudgetLimitEntry, ...]:
+    """Return the windows to persist, each with ``reset_at`` resolved.
+
+    A window whose ``budget_duration`` matches one in ``existing`` keeps that
+    window's ``reset_at``; every other window is initialized to a fresh reset
+    boundary. Any client-supplied ``reset_at`` on ``incoming`` is ignored, since
+    the field is server-managed.
+    """
+    preserved = _existing_reset_at_by_duration(existing)
+    return tuple(_resolve_window(window, preserved) for window in incoming)
+
+
+def _to_stored_dict(window: BudgetLimitEntry) -> dict[str, object]:
+    return {
+        "budget_duration": window.budget_duration,
+        "max_budget": window.max_budget,
+        "reset_at": window.reset_at.isoformat() if window.reset_at is not None else None,
+    }
+
+
+def serialize_budget_limit_windows(windows: Sequence[BudgetLimitEntry]) -> str:
+    """Serialize resolved windows to the JSON string stored in the DB column.
+
+    ``reset_at`` is emitted with ``datetime.isoformat`` (``+00:00`` offset) to
+    match the format written by the create paths and existing rows.
+    """
+    return json.dumps([_to_stored_dict(window) for window in windows])

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2000,14 +2000,16 @@ async def prepare_key_update_data(
     if "budget_limits" in non_default_values:
         raw_windows: Final = non_default_values["budget_limits"]
         if raw_windows:
-            from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+            from litellm.proxy.common_utils.budget_limits import (
+                resolve_budget_limit_windows,
+                serialize_budget_limit_windows,
+            )
 
-            initialized_windows: Final = []
-            for window in raw_windows:
-                w = window if isinstance(window, dict) else window.model_dump()
-                w["reset_at"] = get_budget_reset_time(budget_duration=w["budget_duration"]).isoformat()
-                initialized_windows.append(w)
-            non_default_values["budget_limits"] = json.dumps(initialized_windows)
+            windows = resolve_budget_limit_windows(
+                incoming=raw_windows,
+                existing=existing_key_row.budget_limits,
+            )
+            non_default_values["budget_limits"] = serialize_budget_limit_windows(windows)
         else:
             # [] / None clears the field; prisma-client-py has no DbNull
             # sentinel for Json? columns, so store the JSON literal null

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1863,9 +1863,11 @@ async def update_team(
                 detail={"error": f"Team not found, passed team_id={data.team_id}"},
             )
 
+        existing_team = LiteLLM_TeamTable.model_validate(existing_team_row.model_dump())
+
         # Verify caller has access to manage this team
         await _verify_team_access(
-            team_obj=LiteLLM_TeamTable.model_validate(existing_team_row.model_dump()),
+            team_obj=existing_team,
             user_api_key_dict=user_api_key_dict,
         )
 
@@ -1994,7 +1996,7 @@ async def update_team(
             )
 
         # Check budget_duration and budget_reset_at
-        _set_budget_reset_at(data, updated_kv)
+        _set_budget_reset_at(data, updated_kv, existing_team)
 
         _team_member_fields_in_request: Final = {
             field
@@ -2196,8 +2198,17 @@ async def patch_team(
         raise handle_exception_on_proxy(e)
 
 
-def _set_budget_reset_at(data: UpdateTeamRequest, updated_kv: dict) -> None:
-    """Set budget_reset_at in updated_kv if budget_duration is provided."""
+def _set_budget_reset_at(
+    data: UpdateTeamRequest,
+    updated_kv: dict,
+    existing_team_row: LiteLLM_TeamTable,
+) -> None:
+    """Set budget_reset_at in updated_kv if budget_duration is provided.
+
+    For ``budget_limits``, windows whose ``budget_duration`` already exists on
+    the team keep their current ``reset_at`` so editing ``max_budget`` alone
+    does not restart the window (and therefore does not disturb its spend).
+    """
     if data.budget_duration is not None:
         from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
 
@@ -2207,14 +2218,16 @@ def _set_budget_reset_at(data: UpdateTeamRequest, updated_kv: dict) -> None:
         updated_kv["budget_reset_at"] = None
 
     if data.budget_limits is not None and len(data.budget_limits) > 0:
-        from litellm.proxy.common_utils.timezone_utils import get_budget_reset_time
+        from litellm.proxy.common_utils.budget_limits import (
+            resolve_budget_limit_windows,
+            serialize_budget_limit_windows,
+        )
 
-        initialized_windows: Final = []
-        for window in data.budget_limits:
-            w = window if isinstance(window, dict) else window.model_dump()
-            w["reset_at"] = get_budget_reset_time(budget_duration=w["budget_duration"]).isoformat()
-            initialized_windows.append(w)
-        updated_kv["budget_limits"] = json.dumps(initialized_windows)
+        windows = resolve_budget_limit_windows(
+            incoming=data.budget_limits,
+            existing=existing_team_row.budget_limits,
+        )
+        updated_kv["budget_limits"] = serialize_budget_limit_windows(windows)
 
 
 async def handle_update_object_permission(data_json: dict, existing_team_row: LiteLLM_TeamTable) -> dict:

--- a/tests/test_litellm/proxy/common_utils/test_budget_limits.py
+++ b/tests/test_litellm/proxy/common_utils/test_budget_limits.py
@@ -1,0 +1,93 @@
+from datetime import datetime, timezone
+
+from litellm.models.team import BudgetLimitEntry
+from litellm.proxy.common_utils.budget_limits import (
+    resolve_budget_limit_windows,
+    serialize_budget_limit_windows,
+)
+
+EXISTING_RESET_AT = datetime(2027, 1, 1, tzinfo=timezone.utc)
+
+
+def test_resolve_preserves_reset_at_for_unchanged_duration():
+    existing = [
+        BudgetLimitEntry(budget_duration="365d", max_budget=100.0, reset_at=EXISTING_RESET_AT),
+    ]
+    incoming = [BudgetLimitEntry(budget_duration="365d", max_budget=250.0)]
+
+    resolved = resolve_budget_limit_windows(incoming=incoming, existing=existing)
+
+    assert len(resolved) == 1
+    assert resolved[0].max_budget == 250.0
+    assert resolved[0].reset_at == EXISTING_RESET_AT
+
+
+def test_resolve_initializes_fresh_reset_at_for_new_duration():
+    existing = [
+        BudgetLimitEntry(budget_duration="365d", max_budget=100.0, reset_at=EXISTING_RESET_AT),
+    ]
+    incoming = [
+        BudgetLimitEntry(budget_duration="365d", max_budget=100.0),
+        BudgetLimitEntry(budget_duration="30d", max_budget=20.0),
+    ]
+
+    resolved = {w.budget_duration: w for w in resolve_budget_limit_windows(incoming=incoming, existing=existing)}
+
+    assert resolved["365d"].reset_at == EXISTING_RESET_AT
+    assert resolved["30d"].reset_at is not None
+    assert resolved["30d"].reset_at != EXISTING_RESET_AT
+
+
+def test_resolve_on_create_initializes_all_windows():
+    incoming = [BudgetLimitEntry(budget_duration="30d", max_budget=20.0)]
+
+    resolved = resolve_budget_limit_windows(incoming=incoming)
+
+    assert resolved[0].reset_at is not None
+
+
+def test_resolve_ignores_client_supplied_reset_at_on_new_window():
+    bogus = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    incoming = [BudgetLimitEntry(budget_duration="30d", max_budget=20.0, reset_at=bogus)]
+
+    resolved = resolve_budget_limit_windows(incoming=incoming)
+
+    assert resolved[0].reset_at != bogus
+
+
+def test_resolve_accepts_dict_windows():
+    existing = [{"budget_duration": "365d", "max_budget": 100.0, "reset_at": EXISTING_RESET_AT.isoformat()}]
+    incoming = [{"budget_duration": "365d", "max_budget": 250.0}]
+
+    resolved = resolve_budget_limit_windows(incoming=incoming, existing=existing)
+
+    assert resolved[0].max_budget == 250.0
+    assert resolved[0].reset_at == EXISTING_RESET_AT
+
+
+def test_resolve_accepts_existing_json_string():
+    """A raw prisma ``Json?`` column can arrive as a JSON string; it must still
+    have its reset_at preserved for an unchanged duration."""
+    import json
+
+    existing = json.dumps([{"budget_duration": "365d", "max_budget": 100.0, "reset_at": EXISTING_RESET_AT.isoformat()}])
+    incoming = [{"budget_duration": "365d", "max_budget": 250.0}]
+
+    resolved = resolve_budget_limit_windows(incoming=incoming, existing=existing)
+
+    assert resolved[0].max_budget == 250.0
+    assert resolved[0].reset_at == EXISTING_RESET_AT
+
+
+def test_serialize_produces_iso_reset_at():
+    windows = resolve_budget_limit_windows(
+        incoming=[BudgetLimitEntry(budget_duration="365d", max_budget=100.0, reset_at=EXISTING_RESET_AT)],
+        existing=[BudgetLimitEntry(budget_duration="365d", max_budget=100.0, reset_at=EXISTING_RESET_AT)],
+    )
+
+    import json
+
+    stored = json.loads(serialize_budget_limit_windows(windows))
+    assert stored[0]["reset_at"] == EXISTING_RESET_AT.isoformat()
+    assert stored[0]["budget_duration"] == "365d"
+    assert stored[0]["max_budget"] == 100.0

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -2010,6 +2010,48 @@ async def test_prepare_key_update_data_budget_limits_serializes_windows():
 
 
 @pytest.mark.asyncio
+async def test_prepare_key_update_data_budget_limits_preserves_reset_at():
+    """
+    Editing a key's budget_limits window max_budget must keep the existing
+    window's reset_at (so its spend window is not restarted), while a new
+    duration is initialized fresh.
+    """
+    from datetime import datetime, timezone
+
+    from litellm.proxy._types import UpdateKeyRequest
+    from litellm.proxy.management_endpoints.key_management_endpoints import (
+        prepare_key_update_data,
+    )
+
+    existing_reset_at = datetime(2027, 1, 1, tzinfo=timezone.utc).isoformat()
+    existing_key = LiteLLM_VerificationToken(
+        token="test-token",
+        key_alias="test-key",
+        models=["gpt-3.5-turbo"],
+        user_id="test-user",
+        team_id=None,
+        metadata={},
+        budget_limits=[{"budget_duration": "365d", "max_budget": 100.0, "reset_at": existing_reset_at}],
+    )
+
+    update_request = UpdateKeyRequest(
+        key="test-token",
+        budget_limits=[
+            {"budget_duration": "365d", "max_budget": 250.0},
+            {"budget_duration": "1d", "max_budget": 5.0},
+        ],
+    )
+
+    result = await prepare_key_update_data(data=update_request, existing_key_row=existing_key)
+
+    stored = {w["budget_duration"]: w for w in json.loads(result["budget_limits"])}
+    assert stored["365d"]["max_budget"] == 250.0
+    assert stored["365d"]["reset_at"] == existing_reset_at
+    assert stored["1d"]["reset_at"] is not None
+    assert stored["1d"]["reset_at"] != existing_reset_at
+
+
+@pytest.mark.asyncio
 async def test_prepare_key_update_data_disable_global_guardrails_false_no_premium(
     monkeypatch,
 ):

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -9303,7 +9303,7 @@ def test_set_budget_reset_at_clears_when_budget_duration_null():
     data = UpdateTeamRequest(team_id="test-team", budget_duration=None)
     updated_kv = {"team_id": "test-team", "budget_duration": None}
 
-    _set_budget_reset_at(data, updated_kv)
+    _set_budget_reset_at(data, updated_kv, LiteLLM_TeamTable(team_id="test-team"))
 
     assert "budget_reset_at" in updated_kv
     assert updated_kv["budget_reset_at"] is None
@@ -9320,7 +9320,7 @@ def test_set_budget_reset_at_noop_when_budget_duration_not_sent():
     data = UpdateTeamRequest(team_id="test-team")
     updated_kv = {"team_id": "test-team"}
 
-    _set_budget_reset_at(data, updated_kv)
+    _set_budget_reset_at(data, updated_kv, LiteLLM_TeamTable(team_id="test-team"))
 
     assert "budget_reset_at" not in updated_kv
 
@@ -9336,10 +9336,149 @@ def test_set_budget_reset_at_sets_value_when_budget_duration_provided():
     data = UpdateTeamRequest(team_id="test-team", budget_duration="30d")
     updated_kv = {"team_id": "test-team", "budget_duration": "30d"}
 
-    _set_budget_reset_at(data, updated_kv)
+    _set_budget_reset_at(data, updated_kv, LiteLLM_TeamTable(team_id="test-team"))
 
     assert "budget_reset_at" in updated_kv
     assert updated_kv["budget_reset_at"] is not None
+
+
+def test_set_budget_reset_at_preserves_reset_at_for_unchanged_duration():
+    """
+    Editing a budget_limits window's max_budget must NOT restart the window:
+    a window whose budget_duration already exists on the team keeps its
+    existing reset_at, and only the max_budget changes.
+    """
+    from litellm.proxy._types import UpdateTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import _set_budget_reset_at
+
+    existing_reset_at = datetime(2027, 1, 1, tzinfo=timezone.utc).isoformat()
+    existing_team_row = LiteLLM_TeamTable(
+        team_id="test-team",
+        budget_limits=[{"budget_duration": "365d", "max_budget": 100.0, "reset_at": existing_reset_at}],
+    )
+    data = UpdateTeamRequest(
+        team_id="test-team",
+        budget_limits=[{"budget_duration": "365d", "max_budget": 250.0}],
+    )
+    updated_kv = {"team_id": "test-team"}
+
+    _set_budget_reset_at(data, updated_kv, existing_team_row)
+
+    stored = json.loads(updated_kv["budget_limits"])
+    assert len(stored) == 1
+    assert stored[0]["max_budget"] == 250.0
+    assert stored[0]["reset_at"] == existing_reset_at
+
+
+def test_set_budget_reset_at_initializes_new_duration_window():
+    """
+    A budget_limits window with a duration not present on the team gets a fresh
+    reset_at while any unchanged-duration window keeps its existing reset_at.
+    """
+    from litellm.proxy._types import UpdateTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import _set_budget_reset_at
+
+    existing_reset_at = datetime(2027, 1, 1, tzinfo=timezone.utc).isoformat()
+    existing_team_row = LiteLLM_TeamTable(
+        team_id="test-team",
+        budget_limits=[{"budget_duration": "365d", "max_budget": 100.0, "reset_at": existing_reset_at}],
+    )
+    data = UpdateTeamRequest(
+        team_id="test-team",
+        budget_limits=[
+            {"budget_duration": "365d", "max_budget": 100.0},
+            {"budget_duration": "30d", "max_budget": 20.0},
+        ],
+    )
+    updated_kv = {"team_id": "test-team"}
+
+    _set_budget_reset_at(data, updated_kv, existing_team_row)
+
+    stored = {w["budget_duration"]: w for w in json.loads(updated_kv["budget_limits"])}
+    assert stored["365d"]["reset_at"] == existing_reset_at
+    assert stored["30d"]["reset_at"] is not None
+    assert stored["30d"]["reset_at"] != existing_reset_at
+
+
+def test_set_budget_reset_at_ignores_client_supplied_reset_at():
+    """
+    reset_at is server-managed. A client-sent reset_at on a brand-new duration
+    is discarded in favor of a freshly computed boundary.
+    """
+    from litellm.proxy._types import UpdateTeamRequest
+    from litellm.proxy.management_endpoints.team_endpoints import _set_budget_reset_at
+
+    bogus = datetime(2000, 1, 1, tzinfo=timezone.utc).isoformat()
+    data = UpdateTeamRequest(
+        team_id="test-team",
+        budget_limits=[{"budget_duration": "30d", "max_budget": 20.0, "reset_at": bogus}],
+    )
+    updated_kv = {"team_id": "test-team"}
+
+    _set_budget_reset_at(data, updated_kv, LiteLLM_TeamTable(team_id="test-team"))
+
+    stored = json.loads(updated_kv["budget_limits"])
+    assert stored[0]["reset_at"] != bogus
+
+
+@pytest.mark.asyncio
+async def test_update_team_endpoint_preserves_budget_limits_reset_at():
+    """
+    End-to-end through the /team/update endpoint: editing a budget_limits
+    window's max_budget must persist the existing window's reset_at unchanged,
+    so the spend window is not restarted. Exercises the update_team wiring that
+    reads the existing team row and routes it through _set_budget_reset_at.
+    """
+    from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+    from fastapi import Request
+
+    from litellm.proxy._types import LitellmUserRoles, UpdateTeamRequest, UserAPIKeyAuth
+    from litellm.proxy.management_endpoints.team_endpoints import update_team
+
+    existing_reset_at = datetime(2099, 1, 1, tzinfo=timezone.utc).isoformat()
+    mock_request = Mock(spec=Request)
+    mock_user_api_key_dict = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="test_user_id")
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client,
+        patch("litellm.proxy.proxy_server.llm_router"),
+        patch("litellm.proxy.proxy_server.user_api_key_cache"),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj"),
+        patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"),
+        patch("litellm.proxy.management_endpoints.team_endpoints._cache_team_object"),
+    ):
+        mock_existing_team = MagicMock()
+        mock_existing_team.model_dump.return_value = {
+            "team_id": "test_team_id",
+            "team_alias": "test_team",
+            "budget_limits": [
+                {"budget_duration": "365d", "max_budget": 100.0, "reset_at": existing_reset_at}
+            ],
+            "metadata": {},
+        }
+        mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=mock_existing_team)
+
+        mock_updated_team = MagicMock()
+        mock_updated_team.team_id = "test_team_id"
+        mock_updated_team.model_dump.return_value = {"team_id": "test_team_id"}
+        mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=mock_updated_team)
+        mock_prisma_client.jsonify_team_object = MagicMock(side_effect=lambda db_data: db_data)
+
+        await update_team(
+            data=UpdateTeamRequest(
+                team_id="test_team_id",
+                budget_limits=[{"budget_duration": "365d", "max_budget": 200.0}],
+            ),
+            http_request=mock_request,
+            user_api_key_dict=mock_user_api_key_dict,
+        )
+
+        assert mock_prisma_client.db.litellm_teamtable.update.called
+        update_data = mock_prisma_client.db.litellm_teamtable.update.call_args[1]["data"]
+        stored = json.loads(update_data["budget_limits"])
+        assert stored[0]["max_budget"] == 200.0
+        assert stored[0]["reset_at"] == existing_reset_at
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/repositories/test_repositories.py
+++ b/tests/test_litellm/repositories/test_repositories.py
@@ -1643,7 +1643,7 @@ class TestVerificationTokenRepositoryExtended:
             "spend": 5.0,
             "organization_id": "org-9",
             "budget_id": "budget-9",
-            "budget_limits": [{"model": "gpt-4", "budget": 1.0}],
+            "budget_limits": [{"budget_duration": "1d", "max_budget": 1.0}],
         }
 
         class MockTx:
@@ -1742,7 +1742,7 @@ class TestVerificationTokenRepositoryExtended:
             "model_spend": '{"gpt-4": 10.0}',
             "model_max_budget": '{"gpt-4": 100.0}',
             "router_settings": '{"timeout": 30}',
-            "budget_limits": '[{"limit": 50}]',
+            "budget_limits": '[{"budget_duration": "1d", "max_budget": 50.0}]',
             "litellm_budget_table": '{"budget_id": "b1"}',
         }
         token = await repo.find_by_id("sk-json")

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -26117,9 +26117,7 @@ export interface components {
             /** Budget Id */
             budget_id?: string | null;
             /** Budget Limits */
-            budget_limits?: {
-                [key: string]: unknown;
-            }[] | null;
+            budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
             /** Budget Reset At */
             budget_reset_at?: string | null;
             /**
@@ -27545,9 +27543,7 @@ export interface components {
             /** Budget Id */
             budget_id?: string | null;
             /** Budget Limits */
-            budget_limits?: {
-                [key: string]: unknown;
-            }[] | null;
+            budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
             /** Budget Reset At */
             budget_reset_at?: string | null;
             /**
@@ -34614,9 +34610,7 @@ export interface components {
             /** Budget Id */
             budget_id?: string | null;
             /** Budget Limits */
-            budget_limits?: {
-                [key: string]: unknown;
-            }[] | null;
+            budget_limits?: components["schemas"]["BudgetLimitEntry"][] | null;
             /** Budget Reset At */
             budget_reset_at?: string | null;
             /**


### PR DESCRIPTION
Problem this solves:
Updating a team or key budget_limits array rewrote reset_at to now + budget_duration for every window on every update, which moved each window_start (reset_at - budget_duration) and restarted the spend window. Editing one window's max_budget silently rescheduled all windows, and because window spend is re-derived from spend logs since window_start, a cold spend counter would then read the accumulated spend back as ~0

How it solves it:
Resolve incoming windows through a shared helper that preserves the existing reset_at for any window whose budget_duration already exists on the entity, and only initializes a fresh boundary for genuinely new durations. Client-supplied reset_at stays ignored since the field is server-managed. Both the team update path and the key update path go through the same helper

Also type LiteLLM_VerificationToken.budget_limits as List[BudgetLimitEntry] instead of List[dict] to match the team model, which lets the update path pass the existing windows in fully typed

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)


## Screenshots / Proof of Fix

Flow on the local environment

1. Create a team with budget_limit
<img width="1513" height="179" alt="Screenshot 2026-07-31 at 13 09 59" src="https://github.com/user-attachments/assets/53fd3de4-ce54-469e-b17d-fdd67321b930" />

2. Create a key belonging to the team
<img width="1511" height="278" alt="Screenshot 2026-07-31 at 13 33 38" src="https://github.com/user-attachments/assets/7485e3a2-dc23-4372-867c-c0f2995f1b67" />

3. Sample prompt to OpenAI
<img width="1516" height="141" alt="Screenshot 2026-07-31 at 13 38 22" src="https://github.com/user-attachments/assets/8e2a6935-ed4d-47e1-8dcc-d6ebfd553472" />

4. Proof the limit exists 
<img width="1512" height="243" alt="Screenshot 2026-07-31 at 13 41 56" src="https://github.com/user-attachments/assets/b94a25df-7d87-4c9a-af03-be410e2b7425" />

5. Changing manually `reset_at` in db to proof that it won't be modified, thanks to the new code
<img width="876" height="627" alt="Screenshot 2026-07-31 at 13 50 11" src="https://github.com/user-attachments/assets/c165ca3f-6ddc-406a-8b31-95d4296a6863" />

6. Updating max_budget in budget_limits arr without loosing reset_at
<img width="1519" height="201" alt="Screenshot 2026-07-31 at 13 51 13" src="https://github.com/user-attachments/assets/ec6de449-4ae3-4f9c-9fde-407fd9f261e5" />

## Type

🐛 Bug Fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
