### PR TITLE
fix(batches): prevent managed file fallbacks

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -263,8 +263,7 @@ async def create_batch(
                 )
 
             response = await llm_router.acreate_batch(
-                **_create_batch_data,
-                disable_fallbacks=True,
+                **{**_create_batch_data, "disable_fallbacks": True},
             )
             response.input_file_id = input_file_id
             response._hidden_params["unified_file_id"] = unified_file_id

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -262,7 +262,10 @@ async def create_batch(
                     detail={"error": "LLM Router not initialized. Ensure models added to proxy."},
                 )
 
-            response = await llm_router.acreate_batch(**_create_batch_data)
+            response = await llm_router.acreate_batch(
+                **_create_batch_data,
+                disable_fallbacks=True,
+            )
             response.input_file_id = input_file_id
             response._hidden_params["unified_file_id"] = unified_file_id
         else:

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -262,9 +262,8 @@ async def create_batch(
                     detail={"error": "LLM Router not initialized. Ensure models added to proxy."},
                 )
 
-            response = await llm_router.acreate_batch(
-                **{**_create_batch_data, "disable_fallbacks": True},
-            )
+            _create_batch_data.update(disable_fallbacks=True)  # pyright: ignore[reportCallIssue]  # router flag
+            response = await llm_router.acreate_batch(**_create_batch_data)
             response.input_file_id = input_file_id
             response._hidden_params["unified_file_id"] = unified_file_id
         else:

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -476,6 +476,7 @@ async def test_create__unified_file_id_single_model_disables_cross_model_fallbac
             "input_file_id": "litellm_proxy_unified_id",
             "endpoint": "/v1/chat/completions",
             "completion_window": "24h",
+            "disable_fallbacks": False,
         },
     )
     with (

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -469,7 +469,7 @@ async def test_create__fallback_body_custom_llm_provider(harness):
 
 
 @pytest.mark.asyncio
-async def test_create__unified_file_id_single_model(harness):
+async def test_create__unified_file_id_single_model_disables_cross_model_fallbacks(harness):
     set_body(
         harness,
         {
@@ -489,6 +489,7 @@ async def test_create__unified_file_id_single_model(harness):
     harness.litellm_acreate.assert_not_called()
     # model injected from the unified id, input_file_id restored, hidden param set
     assert harness.router_kwargs()["model"] == "gpt-4o-mini"
+    assert harness.router_kwargs()["disable_fallbacks"] is True
     assert resp.input_file_id == "litellm_proxy_unified_id"
     assert resp._hidden_params["unified_file_id"] == "unified-xyz"
 

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -6055,6 +6055,51 @@ def test_get_configured_token_limits_coerces_numeric_strings():
 
 
 @pytest.mark.asyncio
+async def test_acreate_batch_disable_fallbacks_surfaces_owning_provider_error():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "owning-model",
+                "litellm_params": {
+                    "model": "openai/gpt-4o-mini",
+                    "api_key": "sk-owning",
+                },
+            },
+            {
+                "model_name": "fallback-model",
+                "litellm_params": {
+                    "model": "azure/gpt-4o-mini",
+                    "api_key": "sk-fallback",
+                    "api_base": "https://fallback.openai.azure.com",
+                    "api_version": "2024-08-01-preview",
+                },
+            },
+        ],
+        fallbacks=[{"owning-model": ["fallback-model"]}],
+        num_retries=0,
+    )
+    owning_provider_error = litellm.BadRequestError(
+        message="completion_window must be one of: 24h",
+        model="openai/gpt-4o-mini",
+        llm_provider="openai",
+    )
+    mock_create = AsyncMock(side_effect=owning_provider_error)
+
+    with patch.object(router, "_acreate_batch", mock_create):
+        with pytest.raises(litellm.BadRequestError, match="24h"):
+            await router.acreate_batch(
+                model="owning-model",
+                input_file_id="file-owned-by-openai",
+                endpoint="/v1/chat/completions",
+                completion_window="5m",
+                disable_fallbacks=True,
+            )
+
+    mock_create.assert_awaited_once()
+    assert mock_create.call_args.kwargs["model"] == "owning-model"
+
+
+@pytest.mark.asyncio
 async def test_acreate_batch_request_bedrock_tags_override_deployment_tags():
     import httpx
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- An invalid managed batch create walks the model group's fallback
- The fallback can never serve it, since the input file is not the fallback provider's
- The caller waits out a pointless retry storm, and on older builds got the wrong provider's error

How it solves it:

- Disable cross-model fallbacks for unified managed input files
- Preserve retries within the owning model group
- The owning provider's own validation error reaches the caller immediately

## User Flow

Before: a rejected batch takes about five seconds to come back, because the gateway tries a provider that cannot possibly serve it

1. POST https://litellm-domain/v1/files with the batch JSONL (multipart: purpose=batch, target_model_names=my-gpt) returns 200 with a long scrambled file id
2. POST https://litellm-domain/v1/batches with {"input_file_id": "<that id>", "endpoint": "/v1/chat/completions", "completion_window": "5m", "metadata": {"repro": "35359"}} hangs for about five seconds
3. The call finally returns 400 saying `Invalid value: '5m'. Supported values are: '24h'.`, so the answer is right but the wait was spent retrying the Azure group, which does not hold the input file
4. On a gateway older than the managed-file ownership checks, that same call instead returned the Azure group's error, naming a quota problem rather than the invalid window

After: the same rejected batch comes back immediately with the same message

1. POST https://litellm-domain/v1/files with the batch JSONL (multipart: purpose=batch, target_model_names=my-gpt) returns 200 with a long scrambled file id
2. POST https://litellm-domain/v1/batches with {"input_file_id": "<that id>", "endpoint": "/v1/chat/completions", "completion_window": "5m", "metadata": {"repro": "35359"}} returns in about a fifth of a second
3. The call returns 400 saying `Invalid value: '5m'. Supported values are: '24h'.`, from the provider that owns the file, with no other provider contacted
4. A valid create is unaffected: the same request with "completion_window": "24h" returns 200 with a batch id and status "validating", created against the same provider that owns the input file

## Relevant issues

Related to #35359, which stays open: this covers the managed unified-file path only, and the load-balanced batch path is still unpinned

## Linear ticket

Resolves LIT-5194

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxies against real OpenAI and real Azure batch APIs, one per build, each on its own fresh postgres database. Before runs at `aae06a5fd1` (staging, fix absent, `grep disable_fallbacks litellm/proxy/batches_endpoints/endpoints.py` returns nothing). After runs at `070126a138` , this PR's head `efb5f74173` merged into staging `41d8cddfd7`, which merges clean. Config is the issue's, with a real OpenAI batch model and a real Azure GlobalBatch deployment:

```yaml
model_list:
  - model_name: my-gpt
    litellm_params:
      model: openai/gpt-5.4-nano
      api_key: os.environ/OPENAI_API_KEY
    model_info:
      id: my-gpt_unified-1
  - model_name: my-azure-gpt
    litellm_params:
      model: azure/gpt-5.4-mini-batch
      api_base: os.environ/AZURE_FOUNDRY_API_BASE
      api_key: os.environ/AZURE_FOUNDRY_API_KEY
      api_version: "2025-04-01-preview"
    model_info:
      id: my-azure-gpt_unified-1
router_settings:
  fallbacks: [{"my-gpt": ["my-azure-gpt"]}]
litellm_settings:
  enable_preview_features: true
```

The Azure group was verified usable on its own before anything else, by creating a real batch straight against Azure outside LiteLLM (`batch_464d4d48-5327-4bb6-bfc6-b2dc32d8ada0`), so nothing below is an artifact of a dead deployment.

The request carries `metadata`, which matters. Without it the proxy plants a null `metadata` on the batch data, the fallback handler does `kwargs.setdefault("metadata", {}).update(...)`, `setdefault` hands back the existing `None`, and the fallback dies on `AttributeError` before it selects a deployment. That accidental short-circuit hides the behavior under test, so the discriminating request is the one an ordinary caller sends with batch metadata attached.

Same steps on both proxies:

```
$ curl -sS -X POST http://127.0.0.1:<port>/v1/files -H "Authorization: Bearer sk-1234" \
    -F purpose=batch -F target_model_names=my-gpt -F file=@batch_input.jsonl
{"id":"bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07dW5pZmllZF9pZCxmYWIwODA1OS0...","status":"uploaded",...}

$ curl -sS -i -X POST http://127.0.0.1:<port>/v1/batches -H "Authorization: Bearer sk-1234" \
    -H "Content-Type: application/json" \
    -d '{"input_file_id":"<unified id>","endpoint":"/v1/chat/completions","completion_window":"5m","metadata":{"repro":"35359"}}'
HTTP/1.1 400 Bad Request

{"error":{"message":"Error code: 400 - {'error': {'message': \"Invalid value: '5m'. Supported values are: '24h'.\", 'type': 'invalid_request_error', 'param': 'completion_window', 'code': 'invalid_value'}}","type":"internal_server_error","param":"completion_window","code":"400"}}
```

Both builds return that same body. The difference is what the gateway did before answering. Before, it ran the cross-group fallback and burned five seconds on a group that cannot serve the request:

```
before  openai.BadRequestError: Error code: 400 - {'error': {'message': "Invalid value: '5m'. Supported values are: '24h'.", ...}}
before  router.py:6240 - Trying to fallback b/w models
before  fallback_event_handlers.py:130 - Falling back to model_group = my-azure-gpt
before  router.py:10739 - cooldown deployments: []
before  handle_error.py:77 - get_available_deployment for model: my-azure-gpt, No deployment available
before  litellm.types.router.RouterRateLimitError: No deployments available for selected model ... Passed model=my-azure-gpt
```

After, the same request produces none of that:

```
after   Trying to fallback           => 0
after   Falling back to model_group  => 0
after   my-azure-gpt                 => 0
after   AttributeError               => 0
```

`AttributeError => 0` is the part that rules out the boring reading. The fallback did not merely crash early on the null-metadata path, it was never attempted, because the create is pinned to the owning provider before the fallback handler is reached.

Timing of that identical request, which is what the end user actually feels:

```
before  http=400 total=4.895397s
after   http=400 total=0.219s 0.194s 0.180s 0.188s 0.183s   (five consecutive runs, median 0.188s)
```

That is a 26x cut in time to error, and the after median lands on top of the 0.184s floor the before leg measured for the variant where the fallback never runs at all.

Two controls. First, fallbacks are demonstrably live on the fixed build: a plain provider 400 on the ordinary chat path (`temperature: 99` against `my-gpt`) on the same proxy still logs `Trying to fallback b/w models` and `Falling back to model_group = my-azure-gpt`, so only the managed batch create is pinned. Second, ordinary managed batch creation still works on both builds: the same request with `"completion_window": "24h"` returns 200 with `x-litellm-model-id: my-gpt_unified-1` and `x-litellm-model-api-base: https://api.openai.com`, creating real OpenAI batches (`batch_6a74bd9a842c8190976ae062fdfeccab` before, `batch_6a74bd7f6ea08190900bc3998b8f0847` after). OpenAI's own API confirms the after batch in `validating` against input file `file-5tMf13PmRwQmJZCFzvV9oC`, exactly the file the proxy uploaded in step 1, so the batch was created under the credentials that own the input file.

| Leg | Commit | Fallback attempted | Caller's error | Time |
|---|---|---|---|---|
| Before | aae06a5fd1 | yes, to my-azure-gpt | OpenAI's `24h` | 4.895s |
| After | 070126a138 | no | OpenAI's `24h` | 0.188s |

What this run does not show, stated plainly, because it changes how the fix should be read. The issue's headline symptom, the caller receiving the Azure group's error, no longer reproduces on current staging. Two managed-files guards that post-date the reported v1.89.1 now stop the fallback after it has been entered: `async_filter_deployments` in `base_managed_resource.py` narrows candidates to the deployments that own the input file, and `create_batch` rejects any managed batch input with more than one target model, so the fallback group is always empty and the router re-raises the original error. Uploading the file to both groups to defeat the first guard just trips the second (`{"error": "Expected 1 model, got 2"}`). Across every case in this run, zero requests reached Azure and no Azure batch was created. So on today's code the fix removes a fallback that is already incapable of landing anywhere, and what it buys is the latency above plus an explicit guarantee at the call site in place of two incidental ones.

## Type

🐛 Bug Fix

## Changes

`create_batch` handles managed unified input files by resolving the file's single target model and calling `llm_router.acreate_batch`. The router's default behavior is to walk the configured model-group fallbacks on error, which is wrong for this call: batch and file resources belong to the provider that created them, so no other model group can serve a create bound to this input file, and a provider's own validation error is exactly what the caller needs to see. Passing `disable_fallbacks=True` for this branch pins the create to the owning group while leaving `num_retries` inside that group untouched.

Regression tests: `test_create__unified_file_id_single_model_disables_cross_model_fallbacks` asserts the endpoint overrides a caller-supplied `disable_fallbacks: False` and reaches the router with the flag on, and `test_acreate_batch_disable_fallbacks_surfaces_owning_provider_error` builds a two-group router with a real fallback configured and asserts the owning provider's `24h` error propagates with the fallback provider never invoked.

Scope note: the flag is passed in the managed unified-file branch only. The `enable_loadbalancing_on_batch_endpoints` branch above it still calls `llm_router.acreate_batch` without it.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
