### PR TITLE
fix(auth): honor zero-cost model group aliases

### DIFF
--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -263,8 +263,9 @@ def _is_cost_explicitly_configured(model: str, llm_router: "Router") -> bool:
     fields. _get_model_info_helper() then defaults missing costs to 0.
     This function detects that scenario by checking the raw model_cost entry.
     """
+    resolved_model = llm_router._get_model_from_alias(model) or model
     for deployment in llm_router.model_list:
-        if deployment.get("model_name") != model:
+        if deployment.get("model_name") != resolved_model:
             continue
         model_id = deployment.get("model_info", {}).get("id")
         if model_id is None:

--- a/tests/proxy_unit_tests/test_zero_cost_model_budget_bypass.py
+++ b/tests/proxy_unit_tests/test_zero_cost_model_budget_bypass.py
@@ -108,6 +108,26 @@ class TestIsModelCostZero:
         )
         assert result is True
 
+    @pytest.mark.parametrize(
+        "alias_target",
+        [
+            "on-prem-model",
+            {"model": "on-prem-model", "hidden": False},
+        ],
+    )
+    def test_zero_cost_model_group_alias(
+        self, mock_router_with_zero_cost_model, alias_target
+    ):
+        mock_router_with_zero_cost_model.model_group_alias = {
+            "free-alias": alias_target
+        }
+
+        result = _is_model_cost_zero(
+            model="free-alias", llm_router=mock_router_with_zero_cost_model
+        )
+
+        assert result is True
+
     def test_paid_model_in_router(self, mock_router_with_zero_cost_model):
         """Test that a paid model is correctly identified as non-zero cost."""
         with patch("litellm.get_model_info") as mock_get_model_info:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Zero-cost models become blocked when called through aliases
- Explicit pricing validation searched under the alias name

How it solves it:

- Resolve aliases before inspecting deployment pricing metadata
- Keep conservative budget enforcement for unknown pricing

## Relevant issues

Fixes #35369

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proof was not run because reproducing an exceeded end-user budget requires a DB-backed proxy configuration

The local reproduction changed from `direct=True, alias=False` before the fix to both direct and aliased zero-cost lookups returning true at `136e09534a`

## Type

🐛 Bug Fix

## Changes

- Resolve string and object model-group aliases before deployment lookup
- Preserve the explicit zero-pricing safety check on the target deployment
- Cover both supported alias configuration formats
- 25 adjacent zero-cost and unmapped-pricing tests pass
- `make pre-commit` passes

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
