### PR TITLE
fix(bedrock): raise BadRequestError for malformed tool call arguments

### DIFF
--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -3761,8 +3761,18 @@ def _convert_to_bedrock_tool_call_invoke(
                         _parts_list.append(cache_point_block)
         return _parts_list
     except Exception as e:
-        raise Exception(
-            "Unable to convert openai tool calls={} to bedrock tool calls. Received error={}".format(tool_calls, str(e))
+        # A malformed tool call is invalid client input, not a transient
+        # provider/network failure. Raising a bare Exception here would be
+        # mapped to APIConnectionError (500) by exception_type(), which the
+        # router treats as retryable — so a deterministic, pre-network failure
+        # would be retried through the whole fallback chain instead of being
+        # returned to the caller as a 400.
+        raise litellm.BadRequestError(
+            message="Unable to convert openai tool calls={} to bedrock tool calls. Received error={}".format(
+                tool_calls, str(e)
+            ),
+            model=model or "",
+            llm_provider="bedrock",
         )
 
 

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_litellm_core_utils_prompt_templates_factory.py
@@ -2396,6 +2396,36 @@ def test_bedrock_tool_call_invoke_multiple_normal_tools():
     assert result[1]["toolUse"]["toolUseId"] == "call_2"
 
 
+def test_bedrock_tool_call_invoke_truncated_arguments_raises_bad_request():
+    """
+    Truncated tool call arguments are invalid client input, so they must raise a
+    non-retryable BadRequestError (400) rather than a bare Exception.
+
+    A bare Exception is mapped to APIConnectionError (500) by exception_type(),
+    which litellm._should_retry() treats as retryable. Because this failure
+    happens during request transformation — before any network I/O — retrying it
+    can never succeed, so the router would walk the retry/fallback chain against
+    a deterministic failure.
+    """
+    tool_calls = [
+        {
+            "id": "tooluse_MAh2QLVjBRkvi5QJkLQ08V",
+            "type": "function",
+            "function": {
+                "name": "replace_note_content",
+                # Truncated JSON: no closing brace.
+                "arguments": '{"note_id": "999af35c-4061-4ece-8581-7d43fc988ba4", "title": "WG-example"',
+            },
+        }
+    ]
+
+    with pytest.raises(litellm.BadRequestError) as exc_info:
+        _convert_to_bedrock_tool_call_invoke(tool_calls, model="anthropic.claude-3-sonnet-20240229-v1:0")
+
+    assert exc_info.value.status_code == 400
+    assert litellm._should_retry(exc_info.value.status_code) is False
+
+
 # ========================================================================
 # Tool result deduplication tests (Case D in sanitize_messages_for_tool_calling)
 # ========================================================================


### PR DESCRIPTION
## TLDR

Problem this solves:

- Malformed tool call arguments raise a bare `Exception`, mapped to a retryable 500
- A deterministic, pre-network input error is retried through the whole fallback chain
- Callers get `APIConnectionError` instead of a 400 identifying their bad input

How it solves it:

- Raise `litellm.BadRequestError` (400), which the router does not retry
- Matches the `BadRequestError` pattern already used elsewhere in this module

## Relevant issues

Addresses the transformation half of #35303 (Defect 1).

That issue reports three separate defects; this PR deliberately fixes only the first, since it is
the one that makes the others reachable from this path. The router-side items (fallback cycle
detection and per-attempt log/callback amplification) are left for separate PRs to keep this diff
isolated.

## Linear ticket

<!-- external contributor -->

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

> **End-to-end proof against live Bedrock is in [this comment](https://github.com/BerriAI/litellm/pull/35374#issuecomment-5144339941)**, real Converse calls, before/after at both commit hashes. Headline: the same malformed request takes **447.64 s at ~98% CPU before** the fix (18 retry attempts) and **0.34 s after** (not retried).

### What is wrong

`_convert_to_bedrock_tool_call_invoke` wraps its body in `try/except Exception` and re-raises a
**bare** `Exception`. `exception_type()` has no mapping for a bare `Exception`, so it falls through
to its catch-all and returns `APIConnectionError` (500), a class `litellm._should_retry()` treats
as retryable.

The failure happens inside `_async_transform_request()`, i.e. **before any network I/O**. It is
deterministic: the same input fails the same way every time, so no number of retries can succeed.
The router nonetheless walks its retry and fallback chain against it.

### Reproduction

`arguments` is a truncated JSON string, a partially-streamed tool call that a client replayed back
into its message history. This is the payload from #35303 with the closing brace missing:

```python
import litellm
from litellm.litellm_core_utils.prompt_templates.factory import _convert_to_bedrock_tool_call_invoke

TRUNCATED = '{"note_id": "999af35c-4061-4ece-8581-7d43fc988ba4", "title": "WG-example"'
tool_calls = [{
    "id": "tooluse_MAh2QLVjBRkvi5QJkLQ08V",
    "type": "function",
    "function": {"name": "replace_note_content", "arguments": TRUNCATED},
}]
try:
    _convert_to_bedrock_tool_call_invoke(tool_calls, model="anthropic.claude-3-sonnet-20240229-v1:0")
except BaseException as e:
    status = getattr(e, "status_code", None)
    print(f"exception     : {type(e).__module__}.{type(e).__name__}")
    print(f"status_code   : {status}")
    if status is None:
        from litellm.litellm_core_utils.exception_mapping_utils import exception_type
        try:
            exception_type(model="anthropic.claude-3-sonnet-20240229-v1:0",
                           original_exception=e, custom_llm_provider="bedrock")
        except BaseException as m:
            ms = getattr(m, "status_code", None)
            print(f"  -> mapped to: {type(m).__name__} status={ms} _should_retry={litellm._should_retry(ms)}")
    else:
        print(f"_should_retry : {litellm._should_retry(status)}")
```

**Before**, on base commit `3c2264cf`:

```
exception     : builtins.Exception
status_code   : None
  -> mapped to: APIConnectionError status=500 _should_retry=True
```

**After**, on `d8bc227d` (this branch):

```
exception     : litellm.exceptions.BadRequestError
status_code   : 400
_should_retry : False
```

### Why the 400 survives to the caller

`exception_type()` early-returns any exception already in `litellm.LITELLM_EXCEPTION_TYPES`
unchanged, and `utils.py` does `raise exception_type(...)`. So the `BadRequestError` is not
re-wrapped: the caller receives a 400 and the retry path is closed.

### Tests

`test_bedrock_tool_call_invoke_truncated_arguments_raises_bad_request` asserts the raised type is
`BadRequestError`, its `status_code` is 400, and `_should_retry(400)` is `False`. It fails on the
unpatched base and passes with the fix:

```
# fix reverted, test only
1 failed, 86 deselected

# with fix, whole file
86 passed, 1 failed
```

The one remaining failure is `test_bedrock_converse_messages_pt_document_various_formats`
(`ValueError: No supported extensions for MIME type: text/markdown`). It fails identically on a
clean checkout of the base commit, so it is pre-existing and unrelated.

Wider run, `tests/test_litellm/litellm_core_utils/`: **1214 passed, 16 failed**. All 16 are in
`test_streaming_handler.py`, `test_health_check_helpers.py`, `test_litellm_logging.py` and
`test_realtime_streaming.py`, none of which this PR touches, and all reproducible on the unmodified
base.

### Note on a related site, deliberately not changed here

`convert_to_gemini_tool_call_invoke` has the identical pattern (`raise Exception("Unable to
convert openai tool calls={} to gemini tool calls...")`) and is therefore retryable in the same
way. I left it out to keep this diff to one provider and one problem. Happy to send a follow-up if
you would like it fixed the same way.

Separately, both messages pass `.format(...)` placeholders that end up in a log line as literal
`{}` (Defect 3 in #35303). That is a logging concern rather than a control-flow one, so it is also
out of scope here.

## Type

🐛 Bug Fix

