### PR TITLE
test(e2e): skip the throughput SLO load test pending LIT-5054

### DIFF
--- a/tests/e2e/load/test_chat_completions_throughput_e2e.py
+++ b/tests/e2e/load/test_chat_completions_throughput_e2e.py
@@ -16,6 +16,17 @@ pytestmark = [pytest.mark.e2e, pytest.mark.load]
 
 
 class TestChatCompletionsThroughput:
+    @pytest.mark.skip(
+        reason=(
+            "LIT-5054: the SLO measures how many gateway replicas happen to be warm, not the "
+            "request path. Clearing the floor needs roughly 5-7 replicas at ~10-14 RPS each, "
+            "stage idles at one, and reactive HPA scale-up lands minutes into a ~3 minute "
+            "test. It has failed both assertions on consecutive days: 93.3% errors at an "
+            "inflated 264 RPS (closed-loop RPS rises when requests fail fast, and those "
+            "requests never reached a pod), then 16.7 RPS with zero failures. Unskip once the "
+            "assertion is independent of fleet size."
+        )
+    )
     @pytest.mark.covers("reliability.perf.throughput.under_slo")
     def test_sustains_throughput_slo_under_load(self, client: LoadClient, load_key: str) -> None:
         result = run_chat_load(


### PR DESCRIPTION
## TLDR

High level flow for the user:

- Nothing changes for users; test-only
- The throughput test stops failing on stage replica count

High level flow on a technical level:

- SLO needs ~5-7 warm gateway replicas; stage idles at one
- Failed both its assertions on consecutive days
- Skip it; its coverage cell returns to the gap list

## Relevant issues

## Linear ticket

Refs LIT-5054

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR adds no product behavior, so there is nothing to curl a green result out of; what needs proving is that the assertion is gated on stage capacity rather than on the proxy. Evidence spans two consecutive stage runs, in which the test failed each of its two assertions in turn

**2026-07-30 12:42 UTC**, the error-ratio assertion:

```
E  AssertionError: 43675/46826 requests failed (93.3% > 1.0% allowed);
   throughput of 264.1 RPS is not a clean read under this error rate
```

Those failures never reached a proxy. Over the load window the gateway pods logged 3,170 `/chat/completions` requests while the test reported 3,151 successes, a match within 19 lines, and there is no 429, 5xx, budget error or "no healthy deployment" line anywhere in either namespace. Only `litellm-gateway-5645668d45-xthvk` was serving; its three ReplicaSet siblings did not accept a request until 13:54:02Z or later, after the measurement window had effectively closed. Served volume on the one live pod ran 287/356/404/421/382/405 per 30s, about 10-14 RPS, against 264 RPS offered

**2026-07-31 12:47 UTC**, the RPS floor, with clean traffic:

```
E  AssertionError: sustained 16.7 RPS over 180.0s with 100 users, below the 50.0 RPS SLO;
   the proxy request path regressed under load
E  assert 16.68544577900492 >= 50.0
E   +  where 16.68544577900492 = LoadResult(requests=2975, failures=0, requests_per_second=16.68544577900492).requests_per_second
```

Zero failures out of 2,975 requests

The 264 RPS in the first message is an artifact rather than throughput. `tests/e2e/load/locustfile.py` uses `FastHttpUser` with `wait_time = constant(0)`, so the harness is closed-loop and RPS is users divided by mean latency; when requests fail in milliseconds instead of completing in seconds, apparent RPS climbs. Clean runs of this test sit at 16-46 RPS, so a high number here is the signature of the failure, not evidence against it

The arithmetic behind the skip: `LOAD_USERS=200` and `LOAD_MIN_RPS=90` (`tests/e2e/e2e_config.py:86-90`; the rust namespace runs a 100-user / 50 RPS variant) against ~10-14 RPS per pod means the floor needs roughly 5-7 warm replicas. Stage idles at one and scales reactively, and the scale-down confirms the shape: `l9ff9` and `ztsm7` logged `INFO: Shutting down` at 14:00:15Z and `xthvk` at 14:05:15Z once load stopped

Over roughly 38 hours in the `litellm` namespace the test went 3 pass / 5 fail, and three of those five failed the RPS floor with essentially zero errors (46.1, 16.5 and 23.0 RPS), which is the same capacity story wearing a different assertion. The parallel `litellm-rust` namespace failed all five of its recent runs

After this PR, at commit `475a6449ce`:

```
$ cd tests/e2e && python -m pytest load/test_chat_completions_throughput_e2e.py -q -rs -k throughput_slo
s                                                                        [100%]
SKIPPED [1] load/test_chat_completions_throughput_e2e.py:19: LIT-5054: the SLO measures how many gateway replicas happen to be warm ...
1 skipped in 0.01s
```

The coverage collector hands the cell back rather than counting it covered:

```
$ cd tests/e2e && PYTHONPATH=. python -m coverage_registry.collector
... cell(s) are claimed only by skipped tests, so they count as uncovered (unskip the test or drop the marker):
  reliability.perf.throughput.under_slo
```

`make lint-e2e-basedpyright` reports `0 errors, 0 warnings, 0 notes`

## Type

✅ Test

## Changes

Adds a `pytest.mark.skip` to `test_sustains_throughput_slo_under_load` with a reason naming LIT-5054 and explaining that the SLO is gated on warm replica count rather than on the request path. No product code changes, no config changes, and no other test is touched

The `@pytest.mark.covers` marker and the registry row are left in place deliberately. The collector resolves skip state with pytest's own evaluator and counts a cell as covered only when a test that would actually run declares it, so skipping already returns `reliability.perf.throughput.under_slo` to the gap list; deleting the row would shrink the denominator and hide the gap instead of showing it

Worth stating plainly, because the skip should not be read as "nothing to see here": this is the only e2e test that drives the proxy under concurrency, so while it is skipped there is no throughput signal at all, and `reliability_performance` was already the second-weakest module at 30.8% coverage. LIT-5054 also carries a second question the skip should not bury, namely that 16.7 RPS with zero errors at 100 users implies roughly 6 seconds per request, which needs confirming as real upstream latency rather than assumed

## QA runbook

- tests/e2e/load/test_chat_completions_throughput_e2e.py::TestChatCompletionsThroughput::test_sustains_throughput_slo_under_load - currently skipped; when unskipped it proves the proxy sustains a throughput floor under sustained concurrent chat traffic without shedding requests
  - [ ] Runs Locust against the proxy base URL with a dedicated load key, driving `LOAD_USERS` closed-loop users at `LOAD_SPAWN_RATE` for `LOAD_DURATION_SECONDS`, with zero think time so the offered rate is bounded only by how fast the proxy answers
  - [ ] Asserts at least one request completed, which separates "the proxy was unreachable or the model unservable" from a genuine slow result before either of the two quality assertions runs
  - [ ] Asserts the failure ratio stays within `LOAD_MAX_FAILURE_RATIO`, because a throughput number measured under heavy errors is not a meaningful read; this is the assertion that fired on 2026-07-30
  - [ ] Asserts sustained requests per second meets `LOAD_MIN_RPS`, which is the actual SLO under test; this is the assertion that fired on 2026-07-31 and the one whose dependence on warm replica count is the reason for the skip
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
