### PR TITLE
fix(ui): clear the shared ID-JAG leg-1 columns on an auth type switch

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.test.tsx
@@ -432,6 +432,86 @@ describe("MCPServerEdit (auth type switch)", () => {
     expect(payload.registration_url).toBeNull();
   });
 
+  it("preserves the shared leg-1 endpoint and audience when switching token exchange to ID-JAG", async () => {
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({
+      ...interactiveOAuthServer,
+      auth_type: "oauth2_id_jag",
+    });
+
+    render(
+      <MCPServerEdit
+        mcpServer={{
+          ...interactiveOAuthServer,
+          auth_type: "oauth2_token_exchange",
+          token_exchange_endpoint: "https://idp.example.com/oauth2/token",
+          audience: "api://existing-resource",
+          subject_token_type: "urn:ietf:params:oauth:token-type:saml2",
+        }}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await selectAntOption("Authentication", "ID-JAG (Okta Cross App Access)");
+
+    const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
+    await act(async () => {
+      fireEvent.click(saveButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(networking.updateMCPServer).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+    expect(payload.auth_type).toBe("oauth2_id_jag");
+    expect(payload.token_exchange_endpoint).toBe("https://idp.example.com/oauth2/token");
+    expect(payload.audience).toBe("api://existing-resource");
+    expect(payload.subject_token_type).toBe("urn:ietf:params:oauth:token-type:saml2");
+  });
+
+  it("clears the shared leg-1 endpoint and audience when switching ID-JAG to an auth type that uses neither", async () => {
+    vi.mocked(networking.updateMCPServer).mockResolvedValue({
+      ...interactiveOAuthServer,
+      auth_type: "none",
+    });
+
+    render(
+      <MCPServerEdit
+        mcpServer={{
+          ...interactiveOAuthServer,
+          auth_type: "oauth2_id_jag",
+          token_exchange_endpoint: "https://idp.example.com/oauth2/token",
+          audience: "api://existing-resource",
+          subject_token_type: "urn:ietf:params:oauth:token-type:saml2",
+        }}
+        accessToken="access-token"
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        availableAccessGroups={[]}
+      />,
+    );
+
+    await selectAntOption("Authentication", "None");
+
+    const saveButtons = screen.getAllByRole("button", { name: "Save Changes" });
+    await act(async () => {
+      fireEvent.click(saveButtons[0]);
+    });
+
+    await waitFor(() => {
+      expect(networking.updateMCPServer).toHaveBeenCalledTimes(1);
+    });
+
+    const [, payload] = vi.mocked(networking.updateMCPServer).mock.calls[0];
+    expect(payload.auth_type).toBe("none");
+    expect(payload.token_exchange_endpoint).toBeNull();
+    expect(payload.audience).toBeNull();
+    expect(payload.subject_token_type).toBeNull();
+  });
+
   it("keeps oauth2 endpoint overrides when the auth type is unchanged", async () => {
     vi.mocked(networking.updateMCPServer).mockResolvedValue({ ...interactiveOAuthServer });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_server_edit.tsx
@@ -70,6 +70,7 @@ const AUTH_TYPES_REQUIRING_CREDENTIALS = [
   AUTH_TYPE.TRUE_PASSTHROUGH,
   AUTH_TYPE.OAUTH_DELEGATE,
 ];
+const AUTH_TYPES_SHARING_TOKEN_EXCHANGE_COLUMNS = [AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE, AUTH_TYPE.OAUTH2_ID_JAG];
 export const EDIT_OAUTH_UI_STATE_KEY = "litellm-mcp-oauth-edit-state";
 
 const MCPServerEdit: React.FC<MCPServerEditProps> = ({
@@ -858,9 +859,13 @@ const MCPServerEdit: React.FC<MCPServerEditProps> = ({
         ...(mcpServer.auth_type === AUTH_TYPE.OAUTH2 && restValues.auth_type !== AUTH_TYPE.OAUTH2
           ? { issuer: null, authorization_url: null, token_url: null, registration_url: null }
           : {}),
+        ...(AUTH_TYPES_SHARING_TOKEN_EXCHANGE_COLUMNS.includes(mcpServer.auth_type ?? "") &&
+        !AUTH_TYPES_SHARING_TOKEN_EXCHANGE_COLUMNS.includes(restValues.auth_type ?? "")
+          ? { token_exchange_endpoint: null, audience: null, subject_token_type: null }
+          : {}),
         ...(mcpServer.auth_type === AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE &&
         restValues.auth_type !== AUTH_TYPE.OAUTH2_TOKEN_EXCHANGE
-          ? { token_exchange_endpoint: null, audience: null, subject_token_type: null, token_exchange_profile: null }
+          ? { token_exchange_profile: null }
           : {}),
         server_id: mcpServer.server_id,
         mcp_info: {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Converting an ID-JAG server to another auth type left a stale `token_exchange_endpoint` and `audience` on the record
- Switching OAuth token exchange to ID-JAG wiped the leg-1 values the new mode was about to reuse, and the save path then refused the server as half-configured

How it solves it:

- The three shared columns clear when a server leaves the token-exchange/ID-JAG pair, not when it leaves one member of it
- The token-exchange-only clearing narrows to `token_exchange_profile`, the one field that mode alone owns

## Relevant issues

Follow-up to #35147, which landed the ID-JAG auth type without this. Supersedes #34038, which carried an earlier form of the fix alongside a duplicate of the ID-JAG form that #35147 has since replaced

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PRs scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If youre seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

## Type

🐛 Bug Fix

## Changes

`AUTH_TYPES_SHARING_TOKEN_EXCHANGE_COLUMNS` names the two auth types that persist leg 1 in the same columns, and the save path keys the clearing off membership of that set. Leaving the set nulls `token_exchange_endpoint`, `audience` and `subject_token_type`; moving between its members leaves them alone

`subject_token_type` belongs in the shared set because the ID-JAG form exposes it and `_id_jag_subject_token_type` reads it, honoring a configured non-default value verbatim. Clearing it on an OBO to ID-JAG switch silently discarded a deliberately configured assertion type

## QA runbook

1. Edit an MCP server whose auth type is ID-JAG, switch it to None, save, and confirm the stored record no longer carries the old `token_exchange_endpoint`, `audience` or `subject_token_type`
2. Edit a server whose auth type is OAuth Token Exchange with a non-default `subject_token_type`, switch it to ID-JAG, save, and confirm all three values survive and the server is accepted rather than refused as half-configured

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR