### PR TITLE
feat(ptu): surface PTU flat cost on the daily activity read path

### DIFF
--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException, status
 from typing_extensions import TypedDict
 
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import PTU_SENTINEL_API_KEY
 from litellm.proxy._types import CommonProxyErrors
 from litellm.proxy.utils import PrismaClient
 from litellm.repositories.table_repositories import DeletedVerificationTokenRepository
@@ -150,6 +151,7 @@ def update_metrics(existing_metrics: SpendMetrics, record: DailySpendRecord) -> 
     prompt_tokens: Final = record.prompt_tokens or 0
     completion_tokens: Final = record.completion_tokens or 0
     existing_metrics.spend += record.spend or 0.0
+    existing_metrics.flat_cost += getattr(record, "ptu_flat_cost", None) or 0.0
     existing_metrics.prompt_tokens += prompt_tokens
     existing_metrics.completion_tokens += completion_tokens
     existing_metrics.total_tokens += prompt_tokens + completion_tokens
@@ -208,30 +210,43 @@ def update_breakdown_metrics(
     entity_id_field: str | None = None,
     entity_metadata_field: Mapping[str, dict[str, object]] | None = None,
 ) -> BreakdownMetrics:
-    """Updates breakdown metrics for a single record using the existing update_metrics function"""
+    """Updates breakdown metrics for a single record using the existing update_metrics function.
+
+    PTU sentinel rows (api_key == PTU_SENTINEL_API_KEY) add their flat cost to every
+    parent bucket but never appear as an api_key row, and are kept out of the
+    per-request provider breakdown."""
+
+    is_ptu_sentinel: Final = record.api_key == PTU_SENTINEL_API_KEY
+
+    # A PTU sentinel row keys on the deployment id so a rename cannot move it, and carries
+    # the operator-facing name in model_group. The breakdown key is rendered directly as a
+    # label, so display the name; two deployments sharing one name merge here, which is
+    # what the write path used to do by collapsing them into a single row.
+    model_key: Final = (record.model_group or record.model) if is_ptu_sentinel else record.model
 
     # Update model breakdown
-    if record.model and record.model not in breakdown.models:
-        breakdown.models[record.model] = MetricWithMetadata(
+    if model_key and model_key not in breakdown.models:
+        breakdown.models[model_key] = MetricWithMetadata(
             metrics=SpendMetrics(),
-            metadata=model_metadata.get(record.model, {}),  # Add any model-specific metadata here
+            metadata=model_metadata.get(model_key, {}),  # Add any model-specific metadata here
         )
-    if record.model:
-        breakdown.models[record.model].metrics = update_metrics(breakdown.models[record.model].metrics, record)
+    if model_key:
+        breakdown.models[model_key].metrics = update_metrics(breakdown.models[model_key].metrics, record)
 
-        # Update API key breakdown for this model
-        if record.api_key not in breakdown.models[record.model].api_key_breakdown:
-            breakdown.models[record.model].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
-                metrics=SpendMetrics(),
-                metadata=KeyMetadata(
-                    key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
-                    team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
-                ),
+        if not is_ptu_sentinel:
+            # Update API key breakdown for this model
+            if record.api_key not in breakdown.models[model_key].api_key_breakdown:
+                breakdown.models[model_key].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
+                    metrics=SpendMetrics(),
+                    metadata=KeyMetadata(
+                        key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
+                        team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
+                    ),
+                )
+            breakdown.models[model_key].api_key_breakdown[record.api_key].metrics = update_metrics(
+                breakdown.models[model_key].api_key_breakdown[record.api_key].metrics,
+                record,
             )
-        breakdown.models[record.model].api_key_breakdown[record.api_key].metrics = update_metrics(
-            breakdown.models[record.model].api_key_breakdown[record.api_key].metrics,
-            record,
-        )
 
     # Update model group breakdown
     model_group_key: Final = record.model_group or record.model
@@ -245,19 +260,20 @@ def update_breakdown_metrics(
             breakdown.model_groups[model_group_key].metrics, record
         )
 
-        # Update API key breakdown for this model
-        if record.api_key not in breakdown.model_groups[model_group_key].api_key_breakdown:
-            breakdown.model_groups[model_group_key].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
-                metrics=SpendMetrics(),
-                metadata=KeyMetadata(
-                    key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
-                    team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
-                ),
+        if not is_ptu_sentinel:
+            # Update API key breakdown for this model
+            if record.api_key not in breakdown.model_groups[model_group_key].api_key_breakdown:
+                breakdown.model_groups[model_group_key].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
+                    metrics=SpendMetrics(),
+                    metadata=KeyMetadata(
+                        key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
+                        team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
+                    ),
+                )
+            breakdown.model_groups[model_group_key].api_key_breakdown[record.api_key].metrics = update_metrics(
+                breakdown.model_groups[model_group_key].api_key_breakdown[record.api_key].metrics,
+                record,
             )
-        breakdown.model_groups[model_group_key].api_key_breakdown[record.api_key].metrics = update_metrics(
-            breakdown.model_groups[model_group_key].api_key_breakdown[record.api_key].metrics,
-            record,
-        )
 
     if record.mcp_namespaced_tool_name:
         if record.mcp_namespaced_tool_name not in breakdown.mcp_servers:
@@ -288,28 +304,29 @@ def update_breakdown_metrics(
             record,
         )
 
-    # Update provider breakdown
-    provider: Final = record.custom_llm_provider or "unknown"
-    if provider not in breakdown.providers:
-        breakdown.providers[provider] = MetricWithMetadata(
-            metrics=SpendMetrics(),
-            metadata=provider_metadata.get(provider, {}),  # Add any provider-specific metadata here
-        )
-    breakdown.providers[provider].metrics = update_metrics(breakdown.providers[provider].metrics, record)
+    if not is_ptu_sentinel:
+        # Update provider breakdown
+        provider: Final = record.custom_llm_provider or "unknown"
+        if provider not in breakdown.providers:
+            breakdown.providers[provider] = MetricWithMetadata(
+                metrics=SpendMetrics(),
+                metadata=provider_metadata.get(provider, {}),  # Add any provider-specific metadata here
+            )
+        breakdown.providers[provider].metrics = update_metrics(breakdown.providers[provider].metrics, record)
 
-    # Update API key breakdown for this provider
-    if record.api_key not in breakdown.providers[provider].api_key_breakdown:
-        breakdown.providers[provider].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
-            metrics=SpendMetrics(),
-            metadata=KeyMetadata(
-                key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
-                team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
-            ),
+        # Update API key breakdown for this provider
+        if record.api_key not in breakdown.providers[provider].api_key_breakdown:
+            breakdown.providers[provider].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
+                metrics=SpendMetrics(),
+                metadata=KeyMetadata(
+                    key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
+                    team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
+                ),
+            )
+        breakdown.providers[provider].api_key_breakdown[record.api_key].metrics = update_metrics(
+            breakdown.providers[provider].api_key_breakdown[record.api_key].metrics,
+            record,
         )
-    breakdown.providers[provider].api_key_breakdown[record.api_key].metrics = update_metrics(
-        breakdown.providers[provider].api_key_breakdown[record.api_key].metrics,
-        record,
-    )
 
     # Update endpoint breakdown
     if record.endpoint:
@@ -336,16 +353,17 @@ def update_breakdown_metrics(
             record,
         )
 
-    # Update api key breakdown
-    if record.api_key not in breakdown.api_keys:
-        breakdown.api_keys[record.api_key] = KeyMetricWithMetadata(
-            metrics=SpendMetrics(),
-            metadata=KeyMetadata(
-                key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
-                team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
-            ),  # Add any api_key-specific metadata here
-        )
-    breakdown.api_keys[record.api_key].metrics = update_metrics(breakdown.api_keys[record.api_key].metrics, record)
+    if not is_ptu_sentinel:
+        # Update api key breakdown
+        if record.api_key not in breakdown.api_keys:
+            breakdown.api_keys[record.api_key] = KeyMetricWithMetadata(
+                metrics=SpendMetrics(),
+                metadata=KeyMetadata(
+                    key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
+                    team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
+                ),  # Add any api_key-specific metadata here
+            )
+        breakdown.api_keys[record.api_key].metrics = update_metrics(breakdown.api_keys[record.api_key].metrics, record)
 
     # Update entity-specific metrics if entity_id_field is provided
     if entity_id_field:
@@ -358,19 +376,20 @@ def update_breakdown_metrics(
             )
         breakdown.entities[entity_value].metrics = update_metrics(breakdown.entities[entity_value].metrics, record)
 
-        # Update API key breakdown for this entity
-        if record.api_key not in breakdown.entities[entity_value].api_key_breakdown:
-            breakdown.entities[entity_value].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
-                metrics=SpendMetrics(),
-                metadata=KeyMetadata(
-                    key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
-                    team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
-                ),
+        if not is_ptu_sentinel:
+            # Update API key breakdown for this entity
+            if record.api_key not in breakdown.entities[entity_value].api_key_breakdown:
+                breakdown.entities[entity_value].api_key_breakdown[record.api_key] = KeyMetricWithMetadata(
+                    metrics=SpendMetrics(),
+                    metadata=KeyMetadata(
+                        key_alias=api_key_metadata.get(record.api_key, {}).get("key_alias", None),
+                        team_id=api_key_metadata.get(record.api_key, {}).get("team_id", None),
+                    ),
+                )
+            breakdown.entities[entity_value].api_key_breakdown[record.api_key].metrics = update_metrics(
+                breakdown.entities[entity_value].api_key_breakdown[record.api_key].metrics,
+                record,
             )
-        breakdown.entities[entity_value].api_key_breakdown[record.api_key].metrics = update_metrics(
-            breakdown.entities[entity_value].api_key_breakdown[record.api_key].metrics,
-            record,
-        )
 
     return breakdown
 
@@ -599,6 +618,14 @@ def _build_aggregated_sql_query(
     # total_successful_requests metadata they feed) once the admin UI reads SGR
     # only from LiteLLM_DailyGatewayRequests. The remaining spend, token and
     # api_requests rollups are still served from here.
+    #
+    # Only LiteLLM_DailyTeamSpend carries ptu_flat_cost; other daily tables emit a
+    # constant zero so the SpendMetrics.flat_cost response shape stays uniform.
+    ptu_flat_cost_select: Final = (
+        "SUM(ptu_flat_cost)::float AS ptu_flat_cost"
+        if table_name == "litellm_dailyteamspend"
+        else "0::float AS ptu_flat_cost"
+    )
     sql_query: Final = f"""
         SELECT
             date,
@@ -612,6 +639,7 @@ def _build_aggregated_sql_query(
                      custom_llm_provider, mcp_namespaced_tool_name,
                      endpoint) AS group_level,
             SUM(spend)::float AS spend,
+            {ptu_flat_cost_select},
             SUM(prompt_tokens)::bigint AS prompt_tokens,
             SUM(completion_tokens)::bigint AS completion_tokens,
             SUM(cache_read_input_tokens)::bigint AS cache_read_input_tokens,
@@ -707,7 +735,9 @@ async def _aggregate_spend_records(
     The per-row loop is offloaded to a worker thread via asyncio.to_thread so
     a large result set doesn't peg the event loop.
     """
-    api_keys: Final[set[str]] = {record.api_key for record in records if record.api_key}
+    api_keys: Final[set[str]] = {
+        record.api_key for record in records if record.api_key and record.api_key != PTU_SENTINEL_API_KEY
+    }
 
     api_key_metadata: dict[str, _KeyMetadataDict] = {}
     if api_keys:
@@ -754,6 +784,7 @@ def _record_to_spend_metrics(record: _GroupingSetsRow) -> SpendMetrics:
     completion_tokens: Final = record.completion_tokens or 0
     return SpendMetrics(
         spend=record.spend or 0.0,
+        flat_cost=getattr(record, "ptu_flat_cost", None) or 0.0,
         prompt_tokens=prompt_tokens,
         completion_tokens=completion_tokens,
         total_tokens=prompt_tokens + completion_tokens,
@@ -820,6 +851,7 @@ def _aggregate_grouping_sets_records_sync(
     for record in records:
         level = record.group_level
         metrics = _record_to_spend_metrics(record)
+        is_ptu_sentinel = record.api_key == PTU_SENTINEL_API_KEY
 
         if level == _GROUP_GRAND_TOTAL:
             total_metrics = metrics
@@ -832,7 +864,7 @@ def _aggregate_grouping_sets_records_sync(
         breakdown = ensure_date(record.date)["breakdown"]
 
         if level == _GROUP_DATE_API_KEY:
-            if record.api_key:
+            if record.api_key and not is_ptu_sentinel:
                 breakdown.api_keys[record.api_key] = KeyMetricWithMetadata(
                     metrics=metrics,
                     metadata=_key_metadata(api_key_metadata, record.api_key),
@@ -841,13 +873,13 @@ def _aggregate_grouping_sets_records_sync(
             if record.model:
                 assign_metric_with_metadata(breakdown.models, record.model, metrics)
         elif level == _GROUP_DATE_MODEL_API_KEY:
-            if record.model and record.api_key:
+            if record.model and record.api_key and not is_ptu_sentinel:
                 assign_api_key_breakdown(breakdown.models, record.model, record.api_key, metrics)
         elif level == _GROUP_DATE_MODEL_GROUP:
             if record.model_group:
                 assign_metric_with_metadata(breakdown.model_groups, record.model_group, metrics)
         elif level == _GROUP_DATE_MODEL_GROUP_API_KEY:
-            if record.model_group and record.api_key:
+            if record.model_group and record.api_key and not is_ptu_sentinel:
                 assign_api_key_breakdown(
                     breakdown.model_groups,
                     record.model_group,
@@ -855,10 +887,17 @@ def _aggregate_grouping_sets_records_sync(
                     metrics,
                 )
         elif level == _GROUP_DATE_PROVIDER:
+            # Only PTU sentinel rows carry ptu_flat_cost and they have no provider, so at
+            # this level the sentinel's cost would land under "unknown". Withholding the
+            # flat cost matches the per-row path, which skips sentinel rows outright. The
+            # bucket itself is still assigned unconditionally: a legacy row predating the
+            # api_requests column backfills to all zeroes, and skipping those would drop a
+            # provider the base build reported.
+            provider_metrics = metrics.model_copy(update={"flat_cost": 0.0})  # mutable-ok: pydantic update payload
             provider = record.custom_llm_provider or "unknown"
-            assign_metric_with_metadata(breakdown.providers, provider, metrics)
+            assign_metric_with_metadata(breakdown.providers, provider, provider_metrics)
         elif level == _GROUP_DATE_PROVIDER_API_KEY:
-            if record.api_key:
+            if record.api_key and not is_ptu_sentinel:
                 provider = record.custom_llm_provider or "unknown"
                 assign_api_key_breakdown(breakdown.providers, provider, record.api_key, metrics)
         elif level == _GROUP_DATE_MCP:
@@ -898,7 +937,7 @@ async def _aggregate_grouping_sets_records(
     records: Sequence[_GroupingSetsRow],
 ) -> _AggregatedSpendData:
     """Async wrapper: fetch api_key_metadata, then dispatch on a worker thread."""
-    api_keys: Final[set[str]] = {r.api_key for r in records if r.api_key}
+    api_keys: Final[set[str]] = {r.api_key for r in records if r.api_key and r.api_key != PTU_SENTINEL_API_KEY}
 
     api_key_metadata: dict[str, _KeyMetadataDict] = {}
     if api_keys:
@@ -1008,6 +1047,7 @@ async def get_daily_activity(
             results=aggregated["results"],
             metadata=DailySpendMetadata(
                 total_spend=metadata_metrics.spend,
+                total_flat_cost=metadata_metrics.flat_cost,
                 total_prompt_tokens=metadata_metrics.prompt_tokens,
                 total_completion_tokens=metadata_metrics.completion_tokens,
                 total_tokens=metadata_metrics.total_tokens,
@@ -1098,6 +1138,7 @@ async def get_daily_activity_aggregated(
             results=aggregated["results"],
             metadata=DailySpendMetadata(
                 total_spend=aggregated["totals"].spend,
+                total_flat_cost=aggregated["totals"].flat_cost,
                 total_prompt_tokens=aggregated["totals"].prompt_tokens,
                 total_completion_tokens=aggregated["totals"].completion_tokens,
                 total_tokens=aggregated["totals"].total_tokens,

--- a/litellm/types/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/types/proxy/management_endpoints/common_daily_activity.py
@@ -18,6 +18,7 @@ class GroupByDimension(str, Enum):
 
 class SpendMetrics(BaseModel):
     spend: float = Field(default=0.0)
+    flat_cost: float = Field(default=0.0)
     prompt_tokens: int = Field(default=0)
     completion_tokens: int = Field(default=0)
     cache_read_input_tokens: int = Field(default=0)
@@ -75,6 +76,7 @@ class DailySpendData(BaseModel):
 
 class DailySpendMetadata(BaseModel):
     total_spend: float = Field(default=0.0)
+    total_flat_cost: float = Field(default=0.0)
     total_prompt_tokens: int = Field(default=0)
     total_completion_tokens: int = Field(default=0)
     total_tokens: int = Field(default=0)

--- a/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
@@ -7,9 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../../../..")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../../../.."))  # Adds the parent directory to the system path
 
 from litellm.proxy.management_endpoints.common_daily_activity import (
     _adjust_dates_for_timezone,
@@ -108,8 +106,7 @@ async def test_get_daily_activity_order_has_id_tiebreaker():
     mock_table.find_many.assert_called_once()
     order = mock_table.find_many.call_args[1]["order"]
     assert order == [{"date": "desc"}, {"id": "asc"}], (
-        f"order must include the id tiebreaker after date for stable offset "
-        f"pagination (see #30164); got {order!r}"
+        f"order must include the id tiebreaker after date for stable offset pagination (see #30164); got {order!r}"
     )
 
 
@@ -301,9 +298,7 @@ async def test_get_api_key_metadata_returns_active_key_metadata():
     mock_active_key.key_alias = "my-active-key"
     mock_active_key.team_id = "team-abc"
 
-    mock_prisma.db.litellm_verificationtoken.find_many = AsyncMock(
-        return_value=[mock_active_key]
-    )
+    mock_prisma.db.litellm_verificationtoken.find_many = AsyncMock(return_value=[mock_active_key])
 
     result = await get_api_key_metadata(
         prisma_client=mock_prisma,
@@ -329,9 +324,7 @@ async def test_get_api_key_metadata_falls_back_to_deleted_keys():
     mock_deleted_key.key_alias = "toto-test-2"
     mock_deleted_key.team_id = "team-xyz"
 
-    mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(
-        return_value=[mock_deleted_key]
-    )
+    mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(return_value=[mock_deleted_key])
 
     result = await get_api_key_metadata(
         prisma_client=mock_prisma,
@@ -360,9 +353,7 @@ async def test_get_api_key_metadata_mixed_active_and_deleted_keys():
     mock_active_key.key_alias = "active-alias"
     mock_active_key.team_id = "team-active"
 
-    mock_prisma.db.litellm_verificationtoken.find_many = AsyncMock(
-        return_value=[mock_active_key]
-    )
+    mock_prisma.db.litellm_verificationtoken.find_many = AsyncMock(return_value=[mock_active_key])
 
     # One deleted key found
     mock_deleted_key = MagicMock()
@@ -370,9 +361,7 @@ async def test_get_api_key_metadata_mixed_active_and_deleted_keys():
     mock_deleted_key.key_alias = "deleted-alias"
     mock_deleted_key.team_id = "team-deleted"
 
-    mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(
-        return_value=[mock_deleted_key]
-    )
+    mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(return_value=[mock_deleted_key])
 
     result = await get_api_key_metadata(
         prisma_client=mock_prisma,
@@ -397,13 +386,9 @@ async def test_get_api_key_metadata_deleted_table_not_queried_when_all_keys_foun
     mock_active_key.key_alias = "alias-1"
     mock_active_key.team_id = "team-1"
 
-    mock_prisma.db.litellm_verificationtoken.find_many = AsyncMock(
-        return_value=[mock_active_key]
-    )
+    mock_prisma.db.litellm_verificationtoken.find_many = AsyncMock(return_value=[mock_active_key])
     mock_prisma.db.litellm_deletedverificationtoken = MagicMock()
-    mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(
-        return_value=[]
-    )
+    mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(return_value=[])
 
     result = await get_api_key_metadata(
         prisma_client=mock_prisma,
@@ -425,9 +410,7 @@ async def test_get_api_key_metadata_deleted_table_error_handled_gracefully():
     mock_prisma.db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
 
     # Deleted table raises an error (e.g., table doesn't exist in older schema)
-    mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(
-        side_effect=Exception("Table not found")
-    )
+    mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(side_effect=Exception("Table not found"))
 
     result = await get_api_key_metadata(
         prisma_client=mock_prisma,
@@ -458,9 +441,7 @@ async def test_get_api_key_metadata_regenerated_key_uses_most_recent_deleted_rec
     mock_deleted_2.team_id = "older-team"
 
     # Ordered by deleted_at desc, so first record is the most recent
-    mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(
-        return_value=[mock_deleted_1, mock_deleted_2]
-    )
+    mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(return_value=[mock_deleted_1, mock_deleted_2])
 
     result = await get_api_key_metadata(
         prisma_client=mock_prisma,
@@ -633,9 +614,7 @@ async def test_aggregated_activity_preserves_metadata_for_deleted_keys():
     mock_deleted_key.team_id = "69cd4b77-b095-4489-8c46-4f2f31d840a2"
 
     mock_prisma.db.litellm_deletedverificationtoken = MagicMock()
-    mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(
-        return_value=[mock_deleted_key]
-    )
+    mock_prisma.db.litellm_deletedverificationtoken.find_many = AsyncMock(return_value=[mock_deleted_key])
 
     result = await get_daily_activity_aggregated(
         prisma_client=mock_prisma,
@@ -754,15 +733,9 @@ async def test_model_groups_breakdown_keys_by_public_name_with_model_fallback():
     mock_prisma.db = MagicMock()
 
     records = [
-        _daily_user_spend_record(
-            user_id="u1", api_key="key-1", spend=7.0, model="gpt-5.2", model_group="gpt-5.2-eu"
-        ),
-        _daily_user_spend_record(
-            user_id="u1", api_key="key-1", spend=3.0, model="gpt-5.2", model_group=None
-        ),
-        _daily_user_spend_record(
-            user_id="u1", api_key="key-1", spend=2.0, model="claude-x", model_group=""
-        ),
+        _daily_user_spend_record(user_id="u1", api_key="key-1", spend=7.0, model="gpt-5.2", model_group="gpt-5.2-eu"),
+        _daily_user_spend_record(user_id="u1", api_key="key-1", spend=3.0, model="gpt-5.2", model_group=None),
+        _daily_user_spend_record(user_id="u1", api_key="key-1", spend=2.0, model="claude-x", model_group=""),
     ]
 
     mock_table = MagicMock()
@@ -829,9 +802,7 @@ class TestAdjustDatesForTimezone:
         ],
     )
     def test_returns_input_dates_unchanged_for_any_offset(self, offset_minutes):
-        start, end = _adjust_dates_for_timezone(
-            "2026-05-29", "2026-05-29", offset_minutes
-        )
+        start, end = _adjust_dates_for_timezone("2026-05-29", "2026-05-29", offset_minutes)
         assert start == "2026-05-29"
         assert end == "2026-05-29"
 
@@ -859,9 +830,7 @@ class TestAdjustDatesForTimezone:
         exceeded the multi-day total by ~50% over a 5-day IST window.
         """
         days = ["2026-05-29", "2026-05-30", "2026-05-31", "2026-06-01", "2026-06-02"]
-        single_day_ranges = [
-            _adjust_dates_for_timezone(d, d, offset_minutes) for d in days
-        ]
+        single_day_ranges = [_adjust_dates_for_timezone(d, d, offset_minutes) for d in days]
         multi_day_range = _adjust_dates_for_timezone(days[0], days[-1], offset_minutes)
 
         per_day_starts = [r[0] for r in single_day_ranges]
@@ -894,9 +863,7 @@ class TestAdjustDatesForTimezoneLiveEnd:
         assert (start, end) == ("2026-07-06", "2026-08-06")
 
     def test_without_opt_in_live_range_keeps_pass_through(self):
-        start, end = _adjust_dates_for_timezone(
-            "2026-07-06", "2026-08-05", 420, utc_now=self.PT_EVENING_UTC
-        )
+        start, end = _adjust_dates_for_timezone("2026-07-06", "2026-08-05", 420, utc_now=self.PT_EVENING_UTC)
         assert (start, end) == ("2026-07-06", "2026-08-05")
 
     def test_pt_historical_range_is_untouched(self):
@@ -1173,3 +1140,348 @@ class TestEverySavingsDriverSurvivesTheReadPath:
             assert f"total_{driver}" in DailySpendMetadata.model_fields, (
                 f"total_{driver} is missing, so the range summary omits the driver"
             )
+
+
+def _spend_record(api_key, *, model="gpt-4o-mini-ptu", spend=0.0, ptu_flat_cost=0.0):
+    return SimpleNamespace(
+        api_key=api_key,
+        model=model,
+        model_group=None,
+        mcp_namespaced_tool_name=None,
+        custom_llm_provider="openai",
+        endpoint=None,
+        spend=spend,
+        prompt_tokens=0,
+        completion_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+        compression_saved_tokens=0,
+        compression_savings_spend=0,
+        prompt_caching_savings_spend=0,
+        autorouter_savings_spend=0,
+        total_tokens=0,
+        api_requests=0,
+        successful_requests=0,
+        failed_requests=0,
+        ptu_flat_cost=ptu_flat_cost,
+    )
+
+
+def test_update_metrics_accumulates_ptu_flat_cost():
+    metrics = update_metrics(SpendMetrics(), _spend_record("real-key", spend=1.0, ptu_flat_cost=240.0))
+    assert metrics.flat_cost == 240.0
+    assert metrics.spend == 1.0
+
+
+def test_ptu_sentinel_excluded_from_key_breakdown_but_flat_cost_aggregates():
+    from litellm.constants import PTU_SENTINEL_API_KEY
+    from litellm.proxy.management_endpoints.common_daily_activity import update_breakdown_metrics
+    from litellm.types.proxy.management_endpoints.common_daily_activity import BreakdownMetrics
+
+    breakdown = BreakdownMetrics()
+    update_breakdown_metrics(breakdown, _spend_record("real-key", spend=5.0, ptu_flat_cost=0.0), {}, {}, {})
+    update_breakdown_metrics(breakdown, _spend_record(PTU_SENTINEL_API_KEY, spend=0.0, ptu_flat_cost=240.0), {}, {}, {})
+
+    model_bucket = breakdown.models["gpt-4o-mini-ptu"]
+    # flat cost aggregates into the parent model metrics
+    assert model_bucket.metrics.flat_cost == 240.0
+    assert model_bucket.metrics.spend == 5.0
+    # the sentinel never appears as an api_key row; only the real key does
+    assert PTU_SENTINEL_API_KEY not in model_bucket.api_key_breakdown
+    assert "real-key" in model_bucket.api_key_breakdown
+
+
+def _grouping_row(
+    group_level,
+    *,
+    api_key=None,
+    model=None,
+    model_group=None,
+    custom_llm_provider="openai",
+    mcp_namespaced_tool_name=None,
+    endpoint=None,
+    spend=0.0,
+    ptu_flat_cost=0.0,
+):
+    from litellm.proxy.management_endpoints.common_daily_activity import _GroupingSetsRow
+
+    return _GroupingSetsRow(
+        date="2024-01-01",
+        api_key=api_key,
+        model=model,
+        model_group=model_group,
+        custom_llm_provider=custom_llm_provider,
+        mcp_namespaced_tool_name=mcp_namespaced_tool_name,
+        endpoint=endpoint,
+        group_level=group_level,
+        spend=spend,
+        ptu_flat_cost=ptu_flat_cost,
+        prompt_tokens=0,
+        completion_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+        compression_saved_tokens=0,
+        compression_savings_spend=0.0,
+        prompt_caching_savings_spend=0.0,
+        autorouter_savings_spend=0.0,
+        api_requests=0,
+        successful_requests=0,
+        failed_requests=0,
+    )
+
+
+def test_grouping_sets_dispatcher_excludes_ptu_sentinel_from_key_breakdowns():
+    """The GROUPING SETS path must mirror the per-row path: the flat-cost sentinel
+    aggregates into the date/model/total metrics but never surfaces as an api_key."""
+    from litellm.constants import PTU_SENTINEL_API_KEY
+    from litellm.proxy.management_endpoints.common_daily_activity import (
+        _GROUP_DATE_API_KEY,
+        _GROUP_DATE_MODEL,
+        _GROUP_DATE_MODEL_API_KEY,
+        _GROUP_GRAND_TOTAL,
+        _aggregate_grouping_sets_records_sync,
+    )
+
+    records = [
+        _grouping_row(_GROUP_DATE_API_KEY, api_key="real-key", spend=5.0),
+        _grouping_row(_GROUP_DATE_API_KEY, api_key=PTU_SENTINEL_API_KEY, ptu_flat_cost=240.0),
+        _grouping_row(_GROUP_DATE_MODEL, model="gpt-4o-mini-ptu", spend=5.0, ptu_flat_cost=240.0),
+        _grouping_row(_GROUP_DATE_MODEL_API_KEY, model="gpt-4o-mini-ptu", api_key="real-key", spend=5.0),
+        _grouping_row(
+            _GROUP_DATE_MODEL_API_KEY, model="gpt-4o-mini-ptu", api_key=PTU_SENTINEL_API_KEY, ptu_flat_cost=240.0
+        ),
+        _grouping_row(_GROUP_GRAND_TOTAL, spend=5.0, ptu_flat_cost=240.0),
+    ]
+
+    aggregated = _aggregate_grouping_sets_records_sync(records=records, api_key_metadata={})
+
+    assert aggregated["totals"].flat_cost == 240.0
+    day = aggregated["results"][0]
+    assert PTU_SENTINEL_API_KEY not in day.breakdown.api_keys
+    assert "real-key" in day.breakdown.api_keys
+
+    model_bucket = day.breakdown.models["gpt-4o-mini-ptu"]
+    assert model_bucket.metrics.flat_cost == 240.0
+    assert model_bucket.metrics.spend == 5.0
+    assert PTU_SENTINEL_API_KEY not in model_bucket.api_key_breakdown
+    assert "real-key" in model_bucket.api_key_breakdown
+
+
+def test_grouping_sets_dispatcher_populates_every_breakdown_level():
+    """Every GROUPING SETS level lands in its bucket, and the flat-cost sentinel
+    is kept out of the model_group and provider api_key sub-breakdowns too."""
+    from litellm.constants import PTU_SENTINEL_API_KEY
+    from litellm.proxy.management_endpoints.common_daily_activity import (
+        _GROUP_DATE_ENDPOINT,
+        _GROUP_DATE_ENDPOINT_API_KEY,
+        _GROUP_DATE_MCP,
+        _GROUP_DATE_MCP_API_KEY,
+        _GROUP_DATE_MODEL_GROUP,
+        _GROUP_DATE_MODEL_GROUP_API_KEY,
+        _GROUP_DATE_PROVIDER,
+        _GROUP_DATE_PROVIDER_API_KEY,
+        _aggregate_grouping_sets_records_sync,
+    )
+
+    records = [
+        _grouping_row(_GROUP_DATE_MODEL_GROUP, model_group="grp", spend=4.0, ptu_flat_cost=240.0),
+        _grouping_row(_GROUP_DATE_MODEL_GROUP_API_KEY, model_group="grp", api_key="real-key", spend=4.0),
+        _grouping_row(
+            _GROUP_DATE_MODEL_GROUP_API_KEY, model_group="grp", api_key=PTU_SENTINEL_API_KEY, ptu_flat_cost=240.0
+        ),
+        _grouping_row(_GROUP_DATE_PROVIDER, custom_llm_provider="azure", spend=4.0),
+        _grouping_row(_GROUP_DATE_PROVIDER_API_KEY, custom_llm_provider="azure", api_key="real-key", spend=4.0),
+        _grouping_row(
+            _GROUP_DATE_PROVIDER_API_KEY,
+            custom_llm_provider="azure",
+            api_key=PTU_SENTINEL_API_KEY,
+            ptu_flat_cost=240.0,
+        ),
+        _grouping_row(_GROUP_DATE_MCP, mcp_namespaced_tool_name="srv/tool", spend=2.0),
+        _grouping_row(_GROUP_DATE_MCP_API_KEY, mcp_namespaced_tool_name="srv/tool", api_key="real-key", spend=2.0),
+        _grouping_row(_GROUP_DATE_ENDPOINT, endpoint="/v1/chat/completions", spend=3.0),
+        _grouping_row(_GROUP_DATE_ENDPOINT_API_KEY, endpoint="/v1/chat/completions", api_key="real-key", spend=3.0),
+    ]
+
+    aggregated = _aggregate_grouping_sets_records_sync(records=records, api_key_metadata={})
+    day = aggregated["results"][0]
+
+    group_bucket = day.breakdown.model_groups["grp"]
+    assert group_bucket.metrics.flat_cost == 240.0
+    assert PTU_SENTINEL_API_KEY not in group_bucket.api_key_breakdown
+    assert "real-key" in group_bucket.api_key_breakdown
+
+    provider_bucket = day.breakdown.providers["azure"]
+    assert PTU_SENTINEL_API_KEY not in provider_bucket.api_key_breakdown
+    assert "real-key" in provider_bucket.api_key_breakdown
+
+    assert "real-key" in day.breakdown.mcp_servers["srv/tool"].api_key_breakdown
+    assert "real-key" in day.breakdown.endpoints["/v1/chat/completions"].api_key_breakdown
+
+
+def test_grouping_sets_dispatcher_keeps_ptu_flat_cost_out_of_the_provider_breakdown():
+    """Sentinel rows carry no provider, so their flat cost must not surface under the
+    "unknown" provider - the per-row path skips them for exactly the same reason."""
+    from litellm.proxy.management_endpoints.common_daily_activity import (
+        _GROUP_DATE_PROVIDER,
+        _aggregate_grouping_sets_records_sync,
+    )
+
+    records = [
+        _grouping_row(_GROUP_DATE_PROVIDER, custom_llm_provider="azure", spend=4.0),
+        # the sentinel's own provider-level row: empty provider, flat cost only
+        _grouping_row(_GROUP_DATE_PROVIDER, custom_llm_provider="", ptu_flat_cost=240.0),
+    ]
+
+    aggregated = _aggregate_grouping_sets_records_sync(records=records, api_key_metadata={})
+    providers = aggregated["results"][0].breakdown.providers
+
+    # the bucket is still reported (a legacy all-zero row must not vanish); only the
+    # flat cost is withheld, so no provider is credited with PTU capacity cost
+    assert providers["azure"].metrics.spend == 4.0
+    assert sum(bucket.metrics.flat_cost for bucket in providers.values()) == 0.0
+
+
+def test_grouping_sets_dispatcher_keeps_a_real_provider_row_that_shares_the_sentinel_shape():
+    """A request row whose provider is empty still gets its "unknown" bucket - only the
+    flat cost is withheld, so provider attribution of real spend is unchanged."""
+    from litellm.proxy.management_endpoints.common_daily_activity import (
+        _GROUP_DATE_PROVIDER,
+        _aggregate_grouping_sets_records_sync,
+    )
+
+    records = [_grouping_row(_GROUP_DATE_PROVIDER, custom_llm_provider="", spend=4.0, ptu_flat_cost=240.0)]
+
+    aggregated = _aggregate_grouping_sets_records_sync(records=records, api_key_metadata={})
+    unknown = aggregated["results"][0].breakdown.providers["unknown"]
+
+    assert unknown.metrics.spend == 4.0
+    assert unknown.metrics.flat_cost == 0.0
+
+
+def test_update_breakdown_metrics_covers_mcp_endpoint_and_entity():
+    """A full request record fans out into the mcp, endpoint, provider and entity
+    breakdowns, while the flat-cost sentinel stays out of the entity api_key sub-map."""
+    from litellm.constants import PTU_SENTINEL_API_KEY
+    from litellm.proxy.management_endpoints.common_daily_activity import update_breakdown_metrics
+    from litellm.types.proxy.management_endpoints.common_daily_activity import BreakdownMetrics
+
+    breakdown = BreakdownMetrics()
+    record = SimpleNamespace(
+        api_key="real-key",
+        model="gpt-4o-mini-ptu",
+        model_group="grp",
+        mcp_namespaced_tool_name="srv/tool",
+        custom_llm_provider="azure",
+        endpoint="/v1/chat/completions",
+        spend=5.0,
+        prompt_tokens=0,
+        completion_tokens=0,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=0,
+        compression_saved_tokens=0,
+        compression_savings_spend=0,
+        prompt_caching_savings_spend=0,
+        autorouter_savings_spend=0,
+        total_tokens=0,
+        api_requests=0,
+        successful_requests=0,
+        failed_requests=0,
+        ptu_flat_cost=0.0,
+        team_id="team-1",
+    )
+    update_breakdown_metrics(breakdown, record, {}, {}, {}, entity_id_field="team_id")
+
+    assert "srv/tool" in breakdown.mcp_servers
+    assert "real-key" in breakdown.mcp_servers["srv/tool"].api_key_breakdown
+    assert "/v1/chat/completions" in breakdown.endpoints
+    assert "azure" in breakdown.providers
+    assert "team-1" in breakdown.entities
+    assert "real-key" in breakdown.entities["team-1"].api_key_breakdown
+
+    sentinel = SimpleNamespace(**{**record.__dict__, "api_key": PTU_SENTINEL_API_KEY, "ptu_flat_cost": 240.0})
+    update_breakdown_metrics(breakdown, sentinel, {}, {}, {}, entity_id_field="team_id")
+    assert PTU_SENTINEL_API_KEY not in breakdown.entities["team-1"].api_key_breakdown
+    assert breakdown.entities["team-1"].metrics.flat_cost == 240.0
+
+
+def test_grouping_sets_dispatcher_keeps_an_all_zero_legacy_provider_bucket():
+    """LiteLLM_DailyTeamSpend predates its api_requests column; the migration that added it
+    backfilled NOT NULL DEFAULT 0, so a legacy keyless row is all zeroes. Dropping those
+    would silently remove a provider the base build reported."""
+    from litellm.proxy.management_endpoints.common_daily_activity import (
+        _GROUP_DATE_PROVIDER,
+        _aggregate_grouping_sets_records_sync,
+    )
+
+    records = [
+        _grouping_row(_GROUP_DATE_PROVIDER, custom_llm_provider="ollama"),  # spend/tokens/requests all 0
+        _grouping_row(_GROUP_DATE_PROVIDER, custom_llm_provider="openai", spend=0.25),
+    ]
+
+    providers = _aggregate_grouping_sets_records_sync(records=records, api_key_metadata={})["results"][
+        0
+    ].breakdown.providers
+
+    assert set(providers) == {"ollama", "openai"}
+    assert providers["ollama"].metrics.spend == 0.0
+    assert providers["ollama"].metrics.flat_cost == 0.0
+
+
+class TestSentinelRowsDisplayTheirModelName:
+    """A sentinel row keys on the deployment id so a rename cannot move it. The usage views
+    render the breakdown key directly as a label, so the read path has to show the name."""
+
+    @staticmethod
+    def _breakdown(records):
+        from litellm.proxy.management_endpoints.common_daily_activity import update_breakdown_metrics
+        from litellm.types.proxy.management_endpoints.common_daily_activity import BreakdownMetrics
+
+        breakdown = BreakdownMetrics()
+        for record in records:
+            update_breakdown_metrics(breakdown, record, {}, {}, {})
+        return breakdown
+
+    @staticmethod
+    def _sentinel(*, model_id, model_group, flat_cost=480.0):
+        from litellm.constants import PTU_SENTINEL_API_KEY
+
+        record = _spend_record(PTU_SENTINEL_API_KEY, model=model_id, spend=0.0, ptu_flat_cost=flat_cost)
+        record.model_group = model_group
+        return record
+
+    def test_models_breakdown_keys_a_sentinel_row_on_its_public_name(self):
+        models = self._breakdown([self._sentinel(model_id="dep-1", model_group="gpt-4o-ptu")]).models
+
+        assert "gpt-4o-ptu" in models, f"the UI would label this row a UUID: {list(models)}"
+        assert "dep-1" not in models
+        assert models["gpt-4o-ptu"].metrics.flat_cost == pytest.approx(480.0)
+
+    def test_two_deployments_sharing_a_name_merge_under_it(self):
+        """The write path stopped collapsing them, so the read path has to."""
+        models = self._breakdown(
+            [
+                self._sentinel(model_id="dep-a", model_group="gpt-4o-ptu", flat_cost=240.0),
+                self._sentinel(model_id="dep-b", model_group="gpt-4o-ptu", flat_cost=120.0),
+            ]
+        ).models
+
+        assert list(models) == ["gpt-4o-ptu"]
+        assert models["gpt-4o-ptu"].metrics.flat_cost == pytest.approx(360.0)
+
+    def test_a_request_row_still_keys_on_its_model(self):
+        """Scoped to sentinel rows: a request row keys on model as it always has, even
+        though it also carries a model_group."""
+        record = _spend_record("real-key", model="gemini/gemini-2.5-flash", spend=1.25)
+        record.model_group = "gemini-live"
+
+        models = self._breakdown([record]).models
+
+        assert "gemini/gemini-2.5-flash" in models
+        assert "gemini-live" not in models
+
+    def test_a_sentinel_row_without_a_model_group_falls_back_to_the_id(self):
+        """Never drop the charge: an unexpected row with no display name still reports."""
+        models = self._breakdown([self._sentinel(model_id="dep-1", model_group=None)]).models
+
+        assert models["dep-1"].metrics.flat_cost == pytest.approx(480.0)

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -24218,6 +24218,11 @@ export interface components {
              */
             total_failed_requests: number;
             /**
+             * Total Flat Cost
+             * @default 0
+             */
+            total_flat_cost: number;
+            /**
              * Total Pages
              * @default 1
              */
@@ -32471,6 +32476,11 @@ export interface components {
              * @default 0
              */
             failed_requests: number;
+            /**
+             * Flat Cost
+             * @default 0
+             */
+            flat_cost: number;
             /**
              * Prompt Caching Savings Spend
              * @default 0

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -24253,6 +24253,11 @@ export interface components {
              */
             total_failed_requests: number;
             /**
+             * Total Flat Cost
+             * @default 0
+             */
+            total_flat_cost: number;
+            /**
              * Total Pages
              * @default 1
              */
@@ -32512,6 +32517,11 @@ export interface components {
              * @default 0
              */
             failed_requests: number;
+            /**
+             * Flat Cost
+             * @default 0
+             */
+            flat_cost: number;
             /**
              * Prompt Caching Savings Spend
              * @default 0


### PR DESCRIPTION
## TLDR

Problem this solves:

- The flat cost the rollup writes is not visible anywhere yet
- Sentinel rollup rows must not pollute the per-key or per-provider breakdowns

How it solves it:

- Aggregate ptu_flat_cost into SpendMetrics.flat_cost and total_flat_cost
- Sentinel rows add to parent totals only, never appear as a key

## Relevant issues

## Linear ticket

Resolves LIT-4077

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Captured live against a proxy on this branch (commit 7ead5b8f75), real DB, no mocks.

Rebased onto litellm_internal_staging at f6587faef5 on 2026-08-06, which had moved 441 commits past the original branch point. The whole matrix below was re-run against the rebased head on a live proxy and a real Postgres, so nothing here is carried over from the pre-rebase run

With flat-cost rows and real request rows both present, the response separates them rather than mixing them. Three chat completions went to Gemini 2.5 Flash through a team-scoped key, alongside a 30-day PTU window

```
GET /team/daily/activity?start_date=2026-07-07&end_date=2026-08-06&page_size=1000
  total_spend        : 0.0056465
  total_flat_cost    : 14880.0
  total_api_requests : 3
  total_tokens       : 2285

  sentinel in api_key breakdown : False
  providers seen                : ['gemini']
```

The request totals count only the three real calls, so the sentinel rows contribute their flat cost and nothing else. They also stay out of the api_key breakdown, and the provider breakdown holds only the provider that actually served traffic, with no bucket invented for the sentinel's empty provider

 The rollup PR wrote a sentinel row of ptu_flat_cost 10 for a team (5 PTU, 2.0/hour, effective from 23:00 so one active hour). With this read path the amount now surfaces on the team daily activity response

```
GET /team/daily/activity?team_ids=<pr2-proof team>&start_date=2026-07-31&end_date=2026-07-31
-> metadata.total_flat_cost = 10.00
```

Before this PR the same call returned total_flat_cost 0 because the read path did not read the column. This is the third of a stack; the UI that renders it lands in a follow-up PR


### Live run 2026-08-08, commit 8704e3820f

Ten sentinel rows worth $6,260.00 in `LiteLLM_DailyTeamSpend`, plus one real Gemini request so request spend and flat cost are both present

```
GET /team/daily/activity?start_date=2026-08-01&end_date=2026-08-08&page_size=1000

metadata.total_flat_cost   6260.0        matches the DB sum exactly
metadata.total_spend       0.000062      the real request, kept separate

per day   2026-08-01  720.0
          2026-08-05  720.0
          2026-08-06  740.0   = 720 + 20, two deployments
          2026-08-07  1200.0  = 720 + 480
          2026-08-08  720.0

breakdown.models          {"ptu-prod-renamed": 720.0}   display name, not the deployment UUID
breakdown.api_keys        the __ptu_flat_cost__ sentinel does not appear
```

`page_size=1000` matters: the endpoint paginates and the totals are per page, so a bare curl under-reports and reads as a rollup bug. The dashboard passes 1000 and sums pages itself

## Type

New Feature

## Changes

update_metrics accumulates ptu_flat_cost into SpendMetrics.flat_cost, and _record_to_spend_metrics reads it on the aggregated path; _build_aggregated_sql_query selects SUM(ptu_flat_cost) only for litellm_dailyteamspend and a constant zero otherwise, so every daily table returns the same shape. DailySpendMetadata gains total_flat_cost, populated from the aggregated totals

update_breakdown_metrics guards every api_key sub-breakdown and the top-level api_keys map with the sentinel check, so the __ptu_flat_cost__ row contributes to parent metrics but never becomes a key row; the provider breakdown is skipped entirely for sentinel rows since flat cost is not per-provider request spend. The GROUPING SETS dispatcher applies the same rules: sentinel rows stay out of every api_key sub-breakdown, and because the sentinel has no provider its flat cost is withheld from the provider parent rather than landing under "unknown". The provider bucket itself is still emitted unconditionally, matching the base build: a row predating the api_requests column backfills to all zeroes, and suppressing those would drop a provider the previous build reported

### Screens

Flat cost reaching a team's response and rendering alongside request spend, with the sentinel absent from the key breakdown:

![Team usage showing flat cost from the read path](https://raw.githubusercontent.com/BerriAI/litellm/assets_ptu_flat_cost_screenshots/07-team-usage-tiles.png)

Same build, tag usage: the shared response still carries the field at 0.0 and the view renders neither tile, so a non-team consumer sees no change:

![Tag usage keeps five tiles and one series](https://raw.githubusercontent.com/BerriAI/litellm/assets_ptu_flat_cost_screenshots/09-tag-usage-regression.png)

### Sentinel rows display their model name

The row keys on the deployment id so a rename cannot move it, and the per-model breakdown
is rendered directly as a label by the Usage page and the daily_with_models export, so the
read path keys a sentinel row on model_group. Two deployments sharing a public name merge
under it, which is the collapse the write path used to do by summing them into one row.
Request rows are untouched. Verified through a four-pod proxy, where the breakdown labels
came back as ptu-a and ptu-renamed rather than UUIDs

## Behavior changes

flat_cost and total_flat_cost are added to the shared SpendMetrics and DailySpendMetadata, so every daily activity endpoint returns them, defaulting to 0.0 where no PTU cost exists. This mirrors how compression_saved_tokens and prompt_caching_savings_spend were added to the same models in #33810; the fields are additive and no existing value or status code changes. The per-request api_keys sets used to seed key metadata exclude the sentinel string as well

On the aggregated GROUPING SETS path a team whose only rows for a day are PTU sentinels can now show an `unknown` provider bucket with flat_cost 0, spend 0 and 0 requests. The sentinel carries no provider, and by the time the provider grouping set is aggregated the api_key column has been grouped away, so a sentinel row cannot be told apart from a genuine row that simply has no provider. Suppressing the bucket by checking for request activity was tried and reverted: rows predating the api_requests column backfill to all zeroes, so that check silently dropped provider buckets the previous build reported. An empty bucket is the lesser cost, and no flat cost is ever credited to a provider on either path. The per-row path skips sentinel rows outright and so shows no such bucket; the two paths differ only in this empty entry

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/35391" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes billing/analytics response semantics and breakdown rules for sentinel rows; incorrect handling could misreport spend or leak fake API keys in breakdowns on some aggregation paths.
> 
> **Overview**
> Daily spend analytics now expose **PTU flat cost** alongside token spend: `SpendMetrics` gains **`flat_cost`**, and response metadata includes **`total_flat_cost`**.
> 
> The read path pulls **`ptu_flat_cost`** from **`LiteLLM_DailyTeamSpend`** (other daily tables return zero so the shape stays consistent). Aggregation maps that into **`flat_cost`** on totals and per-date metrics.
> 
> Rows keyed with **`PTU_SENTINEL_API_KEY`** (`__ptu_flat_cost__`) still roll their flat cost into parent buckets (e.g. model totals) but are **excluded** from per-api-key breakdowns, the top-level api_keys map, and provider breakdown; metadata lookups also skip the sentinel string. Dashboard OpenAPI types pick up the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f888e3cd40d7012053de3ab4122f594128c25c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->







