### PR TITLE
fix(responses): pass plain-string tool output through unchanged in chat->responses bridge

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -267,15 +267,16 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                         }
                     )
             elif role == "tool":
-                # Convert tool message to function call output format
-                # The Responses API expects 'output' to be a list with input_text/input_image types
-                # Using list format for consistency across text and multimodal content
-                tool_output: list[dict[str, Any]]
+                # Convert tool message to function call output format.
+                # Per the Responses API spec, function_call_output.output is a plain
+                # string for text results; only multimodal (list) content is wrapped
+                # into input_text/input_image items.
+                tool_output: Union[str, list[dict[str, Any]]]
                 if content is None:
-                    tool_output = []
+                    tool_output = ""
                 elif isinstance(content, str):
-                    # Convert string to list with input_text
-                    tool_output = [{"type": "input_text", "text": content}]
+                    # Keep plain string as-is to match the Responses API spec
+                    tool_output = content
                 elif isinstance(content, list):
                     # Transform list content to Responses API format
                     tool_output = self._convert_content_to_responses_format(
@@ -283,14 +284,14 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                         "user",  # Use "user" role to get input_* types
                     )
                 else:
-                    # Fallback: convert unexpected types to input_text
-                    tool_output = [{"type": "input_text", "text": str(content)}]
+                    # Fallback: coerce unexpected types to string
+                    tool_output = str(content)
                 if tool_call_id in custom_tool_call_ids:
                     input_items.append(
                         ResponseCustomToolCallOutputParam(
                             type="custom_tool_call_output",
                             call_id=tool_call_id,
-                            output=content if isinstance(content, str) else tool_output,
+                            output=tool_output,
                         )
                     )
                 else:

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -242,15 +242,16 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                         }
                     )
             elif role == "tool":
-                # Convert tool message to function call output format
-                # The Responses API expects 'output' to be a list with input_text/input_image types
-                # Using list format for consistency across text and multimodal content
-                tool_output: List[Dict[str, Any]]
+                # Convert tool message to function call output format.
+                # Per the Responses API spec, function_call_output.output is a plain
+                # string for text results; only multimodal (list) content is wrapped
+                # into input_text/input_image items.
+                tool_output: Union[str, List[Dict[str, Any]]]
                 if content is None:
-                    tool_output = []
+                    tool_output = ""
                 elif isinstance(content, str):
-                    # Convert string to list with input_text
-                    tool_output = [{"type": "input_text", "text": content}]
+                    # Keep plain string as-is to match the Responses API spec
+                    tool_output = content
                 elif isinstance(content, list):
                     # Transform list content to Responses API format
                     tool_output = self._convert_content_to_responses_format(
@@ -258,8 +259,8 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                         "user",  # Use "user" role to get input_* types
                     )
                 else:
-                    # Fallback: convert unexpected types to input_text
-                    tool_output = [{"type": "input_text", "text": str(content)}]
+                    # Fallback: coerce unexpected types to string
+                    tool_output = str(content)
                 input_items.append(
                     {
                         "type": "function_call_output",

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -147,17 +147,17 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_imag
 
 def test_convert_chat_completion_messages_to_responses_api_tool_result_with_text():
     """
-    Test that tool messages with text content are correctly transformed to Responses API format.
+    Test that tool messages with plain-string content are passed through unchanged.
 
-    This is a regression test for the issue where tool results were being transformed
-    with type='output_text' instead of type='input_text', which caused OpenAI's Responses API
-    to reject the request with "Invalid value: 'output_text'".
+    This is a regression test for issue #34978. Per the Responses API spec,
+    function_call_output.output is a plain string for text results. Wrapping plain
+    strings into a list of input_text items broke strict Responses API backends.
 
     Chat Completion format:
         {"role": "tool", "tool_call_id": "call_abc123", "content": "15 degrees"}
 
-    Responses API format should use input_text, not output_text:
-        {"type": "function_call_output", "call_id": "call_abc123", "output": [{"type": "input_text", "text": "15 degrees"}]}
+    Responses API format should keep the string as-is:
+        {"type": "function_call_output", "call_id": "call_abc123", "output": "15 degrees"}
     """
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
         LiteLLMResponsesTransformationHandler,
@@ -206,22 +206,15 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_text
     ), "function_call_output not found in response"
     assert function_call_output["call_id"] == "call_abc123"
 
-    # Check that the output is correctly transformed to use input_text, not output_text
+    # Plain-string tool output should remain a plain string, not a list
     output = function_call_output["output"]
-    assert isinstance(output, list), "output should be a list"
-    assert len(output) == 1, "output should have one item"
-
-    text_item = output[0]
-    # Should be transformed to use input_text for tool results in Responses API format
+    assert isinstance(output, str), "plain-string output should stay a string"
     assert (
-        text_item["type"] == "input_text"
-    ), f"Expected type 'input_text' for tool result, got '{text_item.get('type')}'"
-    assert (
-        text_item["text"] == "15 degrees"
-    ), f"Expected text '15 degrees', got '{text_item.get('text')}'"
+        output == "15 degrees"
+    ), f"Expected output '15 degrees', got '{output}'"
 
     print(
-        "✓ Tool result with text correctly transformed to use input_text for Responses API format"
+        "✓ Plain-string tool result passed through unchanged for Responses API format"
     )
 
 
@@ -1294,16 +1287,14 @@ def test_text_plus_tool_calls_sequence():
 
 def test_tool_message_output_uses_input_text_not_output_text():
     """
-    Test that tool message content uses input_text type, not output_text.
+    Test that a plain-string tool message is passed through as a string.
 
-    This is a regression test for a bug where tool results were transformed to:
-        {"type": "function_call_output", "output": [{"type": "output_text", "text": "..."}]}
+    This is a regression test for issue #34978. Per the Responses API spec,
+    function_call_output.output is a plain string for text results:
+        {"type": "function_call_output", "output": "..."}
 
-    But the Responses API expects input_text for tool results:
-        {"type": "function_call_output", "output": [{"type": "input_text", "text": "..."}]}
-
-    The incorrect format caused OpenAI to reject with:
-        "Invalid value: 'output_text'. Supported values are: 'input_text', 'input_image', and 'input_file'."
+    (Previously the string was wrapped into a list of input_text items, which broke
+    strict Responses API backends.)
     """
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
         LiteLLMResponsesTransformationHandler,
@@ -1346,16 +1337,12 @@ def test_tool_message_output_uses_input_text_not_output_text():
     assert function_call_output is not None, "function_call_output not found"
     assert function_call_output["call_id"] == "call_abc123"
 
-    # The output should be a list with input_text type
+    # Plain-string tool output should remain a plain string
     output = function_call_output["output"]
-    assert isinstance(output, list), f"output should be a list, got {type(output)}"
-    assert len(output) == 1
-    assert (
-        output[0]["type"] == "input_text"
-    ), f"Expected input_text, got {output[0].get('type')}"
-    assert output[0]["text"] == '{"temperature": 15, "condition": "sunny"}'
+    assert isinstance(output, str), f"output should be a string, got {type(output)}"
+    assert output == '{"temperature": 15, "condition": "sunny"}'
 
-    print("✓ Tool message output correctly uses input_text type")
+    print("✓ Plain-string tool message output preserved as a string")
 
 
 def test_multiple_tool_calls_in_single_choice():

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -218,6 +218,98 @@ def test_convert_chat_completion_messages_to_responses_api_tool_result_with_text
     )
 
 
+def test_convert_chat_completion_messages_to_responses_api_tool_result_with_none_content():
+    """
+    A tool message with ``content=None`` should produce an empty-string output.
+
+    Regression test for issue #34978: ``function_call_output.output`` must be a
+    string per the Responses API spec, so a null tool result normalizes to "".
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_none",
+                    "type": "function",
+                    "function": {"name": "noop", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_none",
+            "content": None,
+        },
+    ]
+
+    response, _ = handler.convert_chat_completion_messages_to_responses_api(messages)
+
+    function_call_output = next(
+        (item for item in response if item.get("type") == "function_call_output"),
+        None,
+    )
+    assert function_call_output is not None, "function_call_output not found"
+    assert function_call_output["call_id"] == "call_none"
+
+    output = function_call_output["output"]
+    assert isinstance(output, str), "None content should normalize to a string"
+    assert output == "", f"Expected empty string, got '{output}'"
+
+
+def test_convert_chat_completion_messages_to_responses_api_tool_result_with_non_string_content():
+    """
+    A tool message with a non-str/non-list content should be coerced to a string.
+
+    Regression test for issue #34978: unexpected scalar types must still yield a
+    string ``output`` rather than a list wrapper.
+    """
+    from litellm.completion_extras.litellm_responses_transformation.transformation import (
+        LiteLLMResponsesTransformationHandler,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_num",
+                    "type": "function",
+                    "function": {"name": "count", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_num",
+            "content": 42,
+        },
+    ]
+
+    response, _ = handler.convert_chat_completion_messages_to_responses_api(messages)
+
+    function_call_output = next(
+        (item for item in response if item.get("type") == "function_call_output"),
+        None,
+    )
+    assert function_call_output is not None, "function_call_output not found"
+    assert function_call_output["call_id"] == "call_num"
+
+    output = function_call_output["output"]
+    assert isinstance(output, str), "non-string content should be coerced to a string"
+    assert output == "42", f"Expected '42', got '{output}'"
+
+
 def test_openai_responses_chunk_parser_reasoning_summary():
     from litellm.completion_extras.litellm_responses_transformation.transformation import (
         OpenAiResponsesToChatCompletionStreamIterator,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Chat→Responses bridge wrapped plain-string tool output in a list
- Strict Responses API backends reject the list form and 400

How it solves it:

- Pass plain strings through as-is; only wrap list (multimodal) content
- Keeps the #17507 multimodal fix; restores spec-compliant string output

## Relevant issues

Fixes #34978

## Linear ticket

<!-- external contributor: none -->

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

`convert_chat_completion_messages_to_responses_api` in
`litellm/completion_extras/litellm_responses_transformation/transformation.py`
unconditionally wrapped every tool message's content into a list of
`input_text` items, even for plain strings. The OpenAI Responses API documents
`function_call_output.output` as a plain string, so strict backends reject the
list form with `400 Input should be a valid string`.

Before (produced for a plain-string tool result):

```json
{"type": "function_call_output", "call_id": "call_1",
 "output": [{"type": "input_text", "text": "{\"result\": \"...\"}"}]}
```

After:

```json
{"type": "function_call_output", "call_id": "call_1",
 "output": "{\"result\": \"...\"}"}
```

List (multimodal) tool content is still transformed to
`input_text`/`input_image` items, preserving the #17507 / #17762 behavior.

> Note: I do not have access to a strict Responses gateway to capture a live
> e2e run, so proof here is at the transformation/unit-test level. Maintainers
> with a strict backend can confirm the plain-text tool-result path now sends a
> string.

## Type

🐛 Bug Fix

## Changes

- `transformation.py`: for `role == "tool"`, pass plain `str` content through
  unchanged, map `None` to `""`, transform `list` content to Responses format,
  and coerce other types with `str()`.
- Updated the two regression tests that asserted the old list-wrapping behavior
  to expect the spec-compliant string output.

## QA runbook

The two updated tests are pure unit tests (no live proxy required):

- `tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py::test_convert_chat_completion_messages_to_responses_api_tool_result_with_text`
  — a plain-string tool result stays a string in `function_call_output.output`.
  - [ ] Run the test and confirm `output == "15 degrees"` and `isinstance(output, str)`.
  - [ ] Sanity check: the multimodal test (`..._tool_result_with_image`) still asserts a list of `input_image` items, so multimodal handling is unchanged.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
