### PR TITLE
fix(mcp): fence an outbound-token write against an overlapping invalidation

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_endpoint.py
+++ b/litellm/proxy/_experimental/mcp_server/outbound_credentials/token_endpoint.py
@@ -123,6 +123,23 @@ class TokenEndpointClient:
         return Ok(ExchangedToken(access_token=parsed.access_token, expires_in=parsed.expires_in))
 
 
+class _KeyGuard:
+    """The per-key single-flight lock plus the invalidation generation that lock protects.
+
+    Both live on one object so their lifetimes cannot diverge. `get_or_compute` binds the guard to
+    a local for its whole critical section, which keeps the weak map's entry alive for as long as
+    that compute could still write; an `invalidate` overlapping the compute therefore reaches the
+    very same object and its bump is guaranteed to be observed. Conversely a guard nobody holds is
+    collectible precisely because no write is outstanding for it to fence.
+    """
+
+    __slots__ = ("__weakref__", "generation", "lock")
+
+    def __init__(self) -> None:
+        self.lock = asyncio.Lock()
+        self.generation = 0
+
+
 class ExchangedTokenCache:
     """Memoizes the final token string per key, single-flighting concurrent misses on one lock."""
 
@@ -131,7 +148,7 @@ class ExchangedTokenCache:
             max_size_in_memory=MCP_TOKEN_EXCHANGE_CACHE_MAX_SIZE,
             default_ttl=MCP_OAUTH2_TOKEN_CACHE_DEFAULT_TTL,
         )
-        self._locks: weakref.WeakValueDictionary[str, asyncio.Lock] = weakref.WeakValueDictionary()
+        self._guards: weakref.WeakValueDictionary[str, _KeyGuard] = weakref.WeakValueDictionary()
 
     async def get_or_compute(
         self,
@@ -146,28 +163,50 @@ class ExchangedTokenCache:
         guaranteeing the token it gets back was minted for the *current* inputs: a stored entry
         whose fingerprint differs reads as a miss and is re-minted over. That keeps eviction
         addressable without the key having to encode the credential material it protects.
+
+        An `invalidate` landing while `compute` is in flight wins over that compute's write. The
+        token is still returned to the caller it was minted for, but it is not stored, so the next
+        resolution re-mints rather than serving a bearer that predates the invalidation for the
+        rest of its TTL.
         """
         cached = self._get(cache_key, fingerprint)
         if cached is not None:
             return Ok(cached)
-        async with self._lock(cache_key):
+        guard = self._guard(cache_key)
+        async with guard.lock:
             cached = self._get(cache_key, fingerprint)
             if cached is not None:
                 return Ok(cached)
+            generation = guard.generation
             match await compute():
                 case Ok(token):
-                    self._cache.set_cache(  # pyright: ignore[reportUnknownMemberType]  # InMemoryCache is untyped
-                        cache_key,
-                        (fingerprint, token.access_token),
-                        ttl=_cache_ttl_seconds(token.expires_in),
-                    )
+                    if guard.generation == generation:
+                        self._store(cache_key, fingerprint, token)
                     return Ok(token.access_token)
                 case Error(err):
                     return Error(err)
 
     def invalidate(self, cache_key: str) -> None:
-        """Evict one cached token so the next `get_or_compute` re-mints (e.g. after an upstream 401)."""
+        """Evict one cached token so the next `get_or_compute` re-mints (e.g. after an upstream 401).
+
+        Bumping the guard's generation is what makes the eviction stick against a compute already
+        awaiting the token endpoint: that compute snapshotted the old generation and so skips its
+        write. No guard means no compute is in flight, since an in-flight one pins its own.
+
+        Stays synchronous: callers invalidate from plain `def`s.
+        """
         self._cache.delete_cache(cache_key)  # pyright: ignore[reportUnknownMemberType]  # InMemoryCache is untyped
+        guard = self._guards.get(cache_key)
+        if guard is None:
+            return
+        guard.generation += 1
+
+    def _store(self, cache_key: str, fingerprint: str, token: ExchangedToken) -> None:
+        self._cache.set_cache(  # pyright: ignore[reportUnknownMemberType]  # InMemoryCache is untyped
+            cache_key,
+            (fingerprint, token.access_token),
+            ttl=_cache_ttl_seconds(token.expires_in),
+        )
 
     def _get(self, cache_key: str, fingerprint: str) -> str | None:
         """The stored token, or None when absent or minted for different inputs.
@@ -182,12 +221,12 @@ class ExchangedTokenCache:
             return None
         return token if stored_fingerprint == fingerprint else None
 
-    def _lock(self, cache_key: str) -> asyncio.Lock:
-        lock = self._locks.get(cache_key)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._locks[cache_key] = lock
-        return lock
+    def _guard(self, cache_key: str) -> _KeyGuard:
+        guard = self._guards.get(cache_key)
+        if guard is None:
+            guard = _KeyGuard()
+            self._guards[cache_key] = guard
+        return guard
 
 
 def _cache_ttl_seconds(expires_in: int | None) -> int:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_endpoint.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/outbound_credentials/test_token_endpoint.py
@@ -7,6 +7,7 @@ cache's hit/single-flight behavior. Each assertion fails under a real mutation o
 """
 
 import asyncio
+import gc
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -386,6 +387,110 @@ async def test_cache_invalidate_only_evicts_the_named_key():
 
     assert isinstance(kept, Ok) and kept.ok == "tok-1"
     assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_cache_invalidate_mid_compute_is_not_overwritten_by_that_compute():
+    """A bearer minted before an invalidation must never be served after it.
+
+    The compute is suspended at the token endpoint when the invalidation lands, so its write is
+    the one that would resurrect the evicted bearer for the rest of its TTL. The caller it was
+    minted for still gets it; the *cache* is what the invalidation is about.
+    """
+    cache = ExchangedTokenCache()
+    mint_started, release_mint = asyncio.Event(), asyncio.Event()
+
+    async def slow_mint():
+        mint_started.set()
+        await release_mint.wait()
+        return _ok_token("bearer-minted-before-invalidation")
+
+    async def re_mint():
+        return _ok_token("bearer-minted-after-invalidation")
+
+    in_flight = asyncio.create_task(cache.get_or_compute("slot", slow_mint, fingerprint="fp"))
+    await mint_started.wait()
+
+    assert not in_flight.done()
+    cache.invalidate("slot")
+    release_mint.set()
+
+    raced = await in_flight
+    assert isinstance(raced, Ok) and raced.ok == "bearer-minted-before-invalidation"
+
+    after = await cache.get_or_compute("slot", re_mint, fingerprint="fp")
+    assert isinstance(after, Ok) and after.ok == "bearer-minted-after-invalidation"
+
+
+@pytest.mark.asyncio
+async def test_cache_invalidate_mid_compute_survives_garbage_collection():
+    """The record of an invalidation must outlive a collection cycle taken mid-compute.
+
+    Per-key state is held weakly so idle keys do not accumulate. If the state a compute checks
+    before writing were collectible while that compute is suspended, the check would read as
+    "nothing was invalidated" and the stale write would land; the running compute has to pin it.
+    """
+    cache = ExchangedTokenCache()
+    mint_started, release_mint = asyncio.Event(), asyncio.Event()
+
+    async def slow_mint():
+        mint_started.set()
+        await release_mint.wait()
+        return _ok_token("bearer-minted-before-invalidation")
+
+    async def re_mint():
+        return _ok_token("bearer-minted-after-invalidation")
+
+    in_flight = asyncio.create_task(cache.get_or_compute("slot", slow_mint, fingerprint="fp"))
+    await mint_started.wait()
+
+    assert not in_flight.done()
+    cache.invalidate("slot")
+    gc.collect()
+    release_mint.set()
+    await in_flight
+
+    after = await cache.get_or_compute("slot", re_mint, fingerprint="fp")
+    assert isinstance(after, Ok) and after.ok == "bearer-minted-after-invalidation"
+
+
+@pytest.mark.asyncio
+async def test_cache_stores_a_compute_that_started_after_the_invalidation():
+    """Only the mint that predates the invalidation loses its write.
+
+    A caller queued behind the single-flight lock computes after the eviction, so its token is
+    fresh and must be cached; otherwise the fix would trade one stale bearer for re-minting on
+    every subsequent resolution.
+    """
+    cache = ExchangedTokenCache()
+    mint_started, release_mint = asyncio.Event(), asyncio.Event()
+
+    async def slow_mint():
+        mint_started.set()
+        await release_mint.wait()
+        return _ok_token("bearer-minted-before-invalidation")
+
+    async def re_mint():
+        return _ok_token("bearer-minted-after-invalidation")
+
+    async def must_not_run():
+        pytest.fail("the mint that followed the invalidation should have been cached")
+
+    in_flight = asyncio.create_task(cache.get_or_compute("slot", slow_mint, fingerprint="fp"))
+    await mint_started.wait()
+    queued = asyncio.create_task(cache.get_or_compute("slot", re_mint, fingerprint="fp"))
+    await asyncio.sleep(0)
+
+    assert not queued.done()
+    cache.invalidate("slot")
+    release_mint.set()
+
+    raced, fresh = await asyncio.gather(in_flight, queued)
+    assert isinstance(raced, Ok) and raced.ok == "bearer-minted-before-invalidation"
+    assert isinstance(fresh, Ok) and fresh.ok == "bearer-minted-after-invalidation"
+
+    served = await cache.get_or_compute("slot", must_not_run, fingerprint="fp")
+    assert isinstance(served, Ok) and served.ok == "bearer-minted-after-invalidation"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Invalidating an MCP outbound token mid-mint did not stick
- The in-flight mint overwrote the eviction right after it
- A 401'd bearer could be re-served for its whole TTL

How it solves it:

- Per-key generation counter, bumped by `invalidate()`
- The mint re-checks it before caching; on a mismatch it skips the write
- Generation lives on the single-flight lock object, so it outlives the mint

## Relevant issues

## Linear ticket

Resolves LIT-5058

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This one is a sub-second in-process race between two coroutines on the same event loop. A live proxy cannot be steered into that window on demand, and a capture that happened to miss it would prove nothing, so the honest proof is a deterministic repro of the exact interleaving rather than a staged curl transcript. The script below drives it directly: it starts a mint, waits until the mint is suspended at the token endpoint, invalidates, then lets the mint finish and asks the cache what the next resolution gets.

```python
import asyncio

from litellm.proxy._experimental.mcp_server.outbound_credentials.result import Ok
from litellm.proxy._experimental.mcp_server.outbound_credentials.token_endpoint import (
    ExchangedToken,
    ExchangedTokenCache,
)


async def main() -> None:
    cache = ExchangedTokenCache()
    started = asyncio.Event()

    async def slow_mint():
        started.set()
        await asyncio.sleep(0.2)
        return Ok(ExchangedToken(access_token="bearer-minted-before-invalidation", expires_in=3600))

    async def must_not_be_called():
        return Ok(ExchangedToken(access_token="bearer-minted-after-invalidation", expires_in=3600))

    in_flight = asyncio.create_task(cache.get_or_compute("slot", slow_mint, fingerprint="fp"))
    await started.wait()
    await asyncio.sleep(0.01)

    print("invalidate() runs while the mint is still awaiting the IdP")
    cache.invalidate("slot")
    returned_to_the_racing_caller = await in_flight
    print("racing caller got:            ", returned_to_the_racing_caller)

    next_resolution = await cache.get_or_compute("slot", must_not_be_called, fingerprint="fp")
    print("next resolution after invalidate:", next_resolution)

    if next_resolution == Ok("bearer-minted-before-invalidation"):
        print("\nBUG: a bearer minted BEFORE the invalidation is served AFTER it, for its full TTL")
    elif next_resolution == Ok("bearer-minted-after-invalidation"):
        print("\nOK: the invalidation held; the next resolution re-minted")
    else:
        print("\nUNEXPECTED:", next_resolution)


asyncio.run(main())
```

Before, at `c943d9a952`:

```
$ python repro.py
invalidate() runs while the mint is still awaiting the IdP
racing caller got:             Ok(ok='bearer-minted-before-invalidation')
next resolution after invalidate: Ok(ok='bearer-minted-before-invalidation')

BUG: a bearer minted BEFORE the invalidation is served AFTER it, for its full TTL
```

After, at `5ec24bd85d`:

```
$ python repro.py
invalidate() runs while the mint is still awaiting the IdP
racing caller got:             Ok(ok='bearer-minted-before-invalidation')
next resolution after invalidate: Ok(ok='bearer-minted-after-invalidation')

OK: the invalidation held; the next resolution re-minted
```

The three new tests were mutation-checked against the fix, each mutation applied by a script that refuses to run if its anchor is missing, so a silent no-op cannot be mistaken for a passing suite. Dropping the generation re-check (the original unfenced write) kills all three. Moving the generation into its own weakly-held box that the running mint does not pin, which is the plausible-looking fix that quietly does nothing, also kills all three. Snapshotting the generation before acquiring the lock instead of after kills only `test_cache_stores_a_compute_that_started_after_the_invalidation`, which is what keeps that test from being redundant with the other two.

## Type

🐛 Bug Fix

## Changes

`ExchangedTokenCache.get_or_compute` single-flights concurrent misses under a per-key lock, but `invalidate()` deleted outside that lock. A mint that was already awaiting the IdP when an invalidation ran wrote its result into the slot afterwards, so a bearer minted before the invalidation was served after it and stayed cached for its full TTL. That matters most on the upstream-401 retry in `_obo_call_tool_with_retry`, which gets exactly one invalidate-and-retry; if the stale write lands in that window the retry re-presents the bearer the server just rejected and the tool call fails.

The cache now keeps a per-key generation next to the lock. `invalidate()` bumps it, `get_or_compute` snapshots it inside the lock immediately before minting and compares before storing. On a mismatch the token is still returned to the caller it was minted for, since that caller may well still be able to use it, but it is not cached, so the next resolution re-mints.

Where the generation lives is the whole correctness argument. It sits on the same object as the single-flight lock, and `get_or_compute` binds that object to a local for its entire critical section. The map holding those objects is weak, so idle keys still fall away, but a mint in flight pins its own guard; an overlapping `invalidate()` therefore reaches the very same object and its bump cannot be missed. Storing the generation in a second weakly-held structure would look identical and be silently broken, because nothing would keep it alive across the await and the re-check would read a fresh zero. A guard nobody holds is collectible precisely because no write is outstanding for it to fence.

For the same reason the local binding is load-bearing and not a style choice. Writing `async with self._guard(cache_key).lock:` is the shorter and more natural form, and it reintroduces the bug: it retains only the lock and lets the guard temporary go, so the entry can be collected while the mint is still awaiting the IdP and the re-check then reads a fresh generation and stores anyway

`invalidate()` stays synchronous; the resolver calls it from a plain `def`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
