### PR TITLE
fix(ui): keep the session view open when selecting a log inside it

### DIFF
--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
@@ -403,6 +403,41 @@ describe("RequestLogsPanel", () => {
         expect(drawer()).toHaveAttribute("data-session-id", "sess-1");
       });
     });
+
+    it("clicking a multi-call session's row writes ?session_id= alongside ?log_id=", async () => {
+      const user = userEvent.setup();
+      respondWith([
+        logEntry({ request_id: "req-llm", call_type: "acompletion", session_id: "sess-1", session_total_count: 3 }),
+        logEntry({ request_id: "req-llm-2", call_type: "acompletion", session_id: "sess-1", session_total_count: 3 }),
+      ]);
+      renderWithProviders(<RequestLogsPanel {...defaultProps} />);
+
+      await waitFor(() => expect(row("req-llm")).not.toBeNull());
+      await user.click(row("req-llm") as HTMLElement);
+
+      const params = new URLSearchParams(window.location.search);
+      expect(params.get("session_id")).toBe("sess-1");
+      expect(params.get("log_id")).toBe("req-llm");
+      await waitFor(() => expect(drawer()).toHaveAttribute("data-session-id", "sess-1"));
+    });
+
+    it("selecting another log while a session view is open keeps the session open", async () => {
+      const user = userEvent.setup();
+      window.history.replaceState(null, "", "/logs/?log_id=req-llm");
+      respondWith([
+        logEntry({ request_id: "req-llm", call_type: "acompletion", session_id: "sess-1", session_total_count: 3 }),
+        logEntry({ request_id: "req-unenriched" }),
+      ]);
+      renderWithProviders(<RequestLogsPanel {...defaultProps} />);
+
+      await waitFor(() => expect(drawer()).toHaveAttribute("data-session-id", "sess-1"));
+
+      await user.click(screen.getByRole("button", { name: "select-next-log" }));
+
+      await waitFor(() => expect(drawer()).toHaveAttribute("data-log-id", "req-unenriched"));
+      expect(new URLSearchParams(window.location.search).get("session_id")).toBe("sess-1");
+      expect(drawer()).toHaveAttribute("data-session-id", "sess-1");
+    });
   });
 
   describe("live tail", () => {

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.tsx
@@ -235,9 +235,13 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
   const handleRowClick = useCallback(
     (log: LogEntry) => {
       setSelectedLog(log);
-      openLog(log.request_id);
+      if (log.session_id && (log.session_total_count || 1) > 1) {
+        openSession(log.session_id, log.request_id);
+      } else {
+        openLog(log.request_id);
+      }
     },
-    [openLog],
+    [openLog, openSession],
   );
 
   const handleSessionClick = useCallback(
@@ -253,9 +257,9 @@ export default function RequestLogsPanel({ accessToken, token, userRole, userID,
   const handleSelectLog = useCallback(
     (log: LogEntry) => {
       setSelectedLog(log);
-      selectLog(log.request_id);
+      selectLog(log.request_id, displaySessionId);
     },
-    [selectLog],
+    [selectLog, displaySessionId],
   );
 
   const handleKeyHashClick = useCallback((keyHash: string) => {

--- a/ui/litellm-dashboard/src/components/view_logs/logDetailRouting.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/logDetailRouting.ts
@@ -11,7 +11,7 @@ export interface LogDetailRouting {
   sessionId: string | null;
   openLog: (requestId: string) => void;
   openSession: (sessionId: string, requestId: string | null) => void;
-  selectLog: (requestId: string) => void;
+  selectLog: (requestId: string, sessionId?: string | null) => void;
   close: () => void;
 }
 
@@ -36,9 +36,12 @@ export function useLogDetailRouting(): LogDetailRouting {
     });
   }, []);
 
-  const selectLog = useCallback((requestId: string) => {
+  const selectLog = useCallback((requestId: string, sessionId?: string | null) => {
     navigateWithParams((params) => {
       params.set(LOG_ID_QUERY_PARAM, requestId);
+      if (sessionId) {
+        params.set(SESSION_ID_QUERY_PARAM, sessionId);
+      }
     }, "replace");
   }, []);
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Clicking a log inside an open session view collapsed the whole session list
- Session mode was derived from a row field the session endpoint does not return

How it solves it:

- Session row clicks write ?session_id= alongside ?log_id=
- Selecting a log inside a session view keeps ?session_id= in the URL

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Reproduced against a live proxy and the dashboard dev server with a real 9-request session (repeated /v1/chat/completions calls sharing one litellm_trace_id); the banner in each screenshot shows the live address-bar URL

Before (litellm_internal_staging): open a session by clicking its row in the logs table, then click any other log in the session's sidebar; the 9-request session list collapses to a single-log Trace view and the URL carries only ?log_id

![before: session collapses](https://raw.githubusercontent.com/BerriAI/litellm/assets_logs_session_fix_screenshots/logs-session-before.png)

After (662e70985e): the same flow keeps all 9 session logs listed while the main pane switches to the clicked log, and the URL carries ?session_id and ?log_id so the state also survives reload

![after: session stays open](https://raw.githubusercontent.com/BerriAI/litellm/assets_logs_session_fix_screenshots/logs-session-after.png)

## Type

🐛 Bug Fix

## Changes

The user flow that broke: logs table groups a session's calls into one row; clicking that row opened the drawer in session mode, but clicking any log inside the session's sidebar collapsed the drawer to a single-log view

Root cause: row clicks called openLog, which sets ?log_id and deletes ?session_id, so session mode survived only as a derived value from the clicked row's session_total_count. That field is enriched only by the main /spend/logs/ui list endpoint; the rows the drawer fetches from /spend/logs/session/ui do not have it, so selecting a sidebar log replaced the displayed log with an unenriched row and the derived session id became null

Fix: anchor session mode in the URL instead of deriving it. handleRowClick calls openSession for rows whose log belongs to a multi-call session, and selectLog now also writes ?session_id when the session view is active (still replace mode, so back closes the drawer in one step). The derived fallback remains only for direct ?log_id deep links, and the first in-session selection anchors it

Tests: two panel regression tests; clicking a session's row writes both params, and selecting an unenriched log while the session view is open keeps ?session_id and the session drawer. The second test fails on the unfixed code

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
