### PR TITLE
fix(batches): bound the batch rate limiter's input-file read

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1356,6 +1356,13 @@ BASE_MCP_ROUTE = "/mcp"
 BATCH_STATUS_POLL_INTERVAL_SECONDS = int(os.getenv("BATCH_STATUS_POLL_INTERVAL_SECONDS", 3600))  # 1 hour
 BATCH_STATUS_POLL_MAX_ATTEMPTS = int(os.getenv("BATCH_STATUS_POLL_MAX_ATTEMPTS", 24))  # for 24 hours
 
+# Deadline for the batch rate limiter's input-file read. The read happens inline
+# in POST /v1/batches, so it must resolve well within a client's read timeout;
+# unbounded, the OpenAI SDK default (600s, max_retries=2) applies and a stalled
+# Files API holds the request open indefinitely. Override per-deployment with
+# general_settings.batch_input_file_read_timeout.
+DEFAULT_BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS = float(os.getenv("BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS", 10))
+
 HEALTH_CHECK_TIMEOUT_SECONDS = int(os.getenv("HEALTH_CHECK_TIMEOUT_SECONDS", 60))  # 60 seconds
 _background_health_check_max_tokens_env = os.getenv("BACKGROUND_HEALTH_CHECK_MAX_TOKENS")
 try:

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1359,9 +1359,9 @@ BATCH_STATUS_POLL_MAX_ATTEMPTS = int(os.getenv("BATCH_STATUS_POLL_MAX_ATTEMPTS",
 # Deadline for the batch rate limiter's input-file read. The read happens inline
 # in POST /v1/batches, so it must resolve well within a client's read timeout;
 # unbounded, the OpenAI SDK default (600s, max_retries=2) applies and a stalled
-# Files API holds the request open indefinitely. Override per-deployment with
+# Files API holds the request open indefinitely. Override with
 # general_settings.batch_input_file_read_timeout.
-DEFAULT_BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS = float(os.getenv("BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS", 10))
+DEFAULT_BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS = 10.0
 
 HEALTH_CHECK_TIMEOUT_SECONDS = int(os.getenv("HEALTH_CHECK_TIMEOUT_SECONDS", 60))  # 60 seconds
 _background_health_check_max_tokens_env = os.getenv("BACKGROUND_HEALTH_CHECK_MAX_TOKENS")

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2408,6 +2408,10 @@ class ConfigGeneralSettings(LiteLLMPydanticObjectBase):
         None,
         description="By default, the user calling /team/new is automatically added to the new team as a team admin. If True, proxy admins are no longer auto-added; members explicitly listed in members_with_roles are unaffected. Default is False.",
     )
+    batch_input_file_read_timeout: Optional[float] = Field(
+        None,
+        description="Seconds the batch rate limiter may spend reading a batch input file to count tokens (default 10). The read runs inline in POST /v1/batches, so this must stay well inside client read timeouts. On timeout, keys whose model allowlist must be validated against the file are rejected; keys with unrestricted model access are admitted without rate limiting.",
+    )
     maximum_spend_logs_retention_period: Optional[str] = Field(
         None,
         description="Maximum retention period for spend logs (e.g., '7d' for 7 days). Logs older than this will be deleted.",

--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -376,6 +376,12 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         Model-embedded IDs (``file-<base64>``) are not unified managed-file IDs;
         without decoding them, ``afile_content`` is called with the encoded ID
         and the upstream provider returns 404.
+
+        The returned kwargs may carry a ``timeout`` from the deployment's
+        credentials (one of ``_extract_file_access_credentials``' keys). Callers
+        that need their own deadline must set it on the result rather than passing
+        it alongside ``**fetch_kwargs``, which would raise TypeError for a
+        duplicate kwarg.
         """
         from litellm.proxy.openai_files_endpoints.common_utils import (
             decode_model_from_file_id,
@@ -574,7 +580,12 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                     custom_llm_provider=custom_llm_provider,
                     data=data or {},
                 )
-                # For non-managed files, use the standard litellm.afile_content.
+                # Set on the resolved kwargs, not passed as a separate keyword:
+                # they may already carry the deployment's own `timeout`, and
+                # passing both raises TypeError for a duplicate kwarg. This
+                # read's budget wins on purpose; a deployment timeout is sized
+                # for serving traffic, not for a read that blocks POST /v1/batches.
+                fetch_kwargs["timeout"] = timeout_seconds
                 # `timeout` reaches file_content's TIMEOUT LOGIC via
                 # GenericLiteLLMParams, capping the upstream HTTP request itself
                 # rather than only the await, so an abandoned read stops
@@ -582,7 +593,6 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 fetch = litellm.afile_content(
                     file_id=provider_file_id,
                     user_api_key_dict=user_api_key_dict,
-                    timeout=timeout_seconds,
                     **fetch_kwargs,
                 )
 

--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -33,10 +33,12 @@ from typing import (
 from fastapi import HTTPException
 from pydantic import BaseModel
 
+import asyncio
 import json
 
 import litellm
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import DEFAULT_BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS
 from litellm.batches.batch_utils import (
     _count_entry_tokens,
     _estimate_batch_entry_tokens,
@@ -94,6 +96,24 @@ class BatchFileUsage(BaseModel):
 
     total_tokens: int
     request_count: int
+
+
+class BatchInputFileReadTimeout(Exception):
+    """The batch input-file read exceeded its deadline.
+
+    Distinct from a generic failure because the read serves two purposes and the
+    two have opposite safe defaults: it counts tokens for rate limiting (where
+    admitting the batch unmetered is tolerable) and it validates every
+    ``body.model`` in the JSONL against the caller's allowlist (where admitting
+    the batch unchecked is a privilege escalation). Carrying its own type lets
+    ``async_pre_call_hook`` fail closed only for keys that need the allowlist
+    check, instead of the blanket fail-open its generic handler applies.
+    """
+
+    def __init__(self, file_id: str, timeout_seconds: float) -> None:
+        self.file_id = file_id
+        self.timeout_seconds = timeout_seconds
+        super().__init__(f"Timed out after {timeout_seconds}s reading batch input file {file_id}")
 
 
 class _PROXY_BatchRateLimiter(CustomLogger):
@@ -291,6 +311,28 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 "skip_batch_input_file_rate_limiting_for_providers or "
                 "disable_batch_input_file_rate_limiting instead."
             )
+
+    @staticmethod
+    def _batch_input_file_read_timeout() -> float:
+        """Seconds the input-file read may take before it is abandoned.
+
+        Falls back to the default when the operator's value is missing or not a
+        positive number: a zero/negative deadline would make wait_for expire
+        immediately and reject every batch from a restricted key.
+        """
+        from litellm.proxy.proxy_server import general_settings
+
+        configured = general_settings.get("batch_input_file_read_timeout")
+        if isinstance(configured, bool) or not isinstance(configured, (int, float)):
+            return DEFAULT_BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS
+        if configured <= 0:
+            verbose_proxy_logger.warning(
+                "Ignoring general_settings.batch_input_file_read_timeout=%s: must be > 0. Using %ss.",
+                configured,
+                DEFAULT_BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS,
+            )
+            return DEFAULT_BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS
+        return float(configured)
 
     @staticmethod
     def _key_requires_batch_model_access_check(
@@ -518,8 +560,11 @@ class _PROXY_BatchRateLimiter(CustomLogger):
             # For managed files the unified file id encodes the proxy model
             # alias(es) the file was uploaded for; auth validates against those.
             target_model_names = get_models_from_unified_file_id(is_managed_file) if is_managed_file else []
+            # Resolved before the coroutine is built so a failure here can never
+            # leave an un-awaited coroutine behind.
+            timeout_seconds = self._batch_input_file_read_timeout()
             if is_managed_file and user_api_key_dict is not None:
-                file_content = await self._fetch_managed_file_content(
+                fetch = self._fetch_managed_file_content(
                     file_id=file_id,
                     user_api_key_dict=user_api_key_dict,
                 )
@@ -529,12 +574,30 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                     custom_llm_provider=custom_llm_provider,
                     data=data or {},
                 )
-                # For non-managed files, use the standard litellm.afile_content
-                file_content = await litellm.afile_content(
+                # For non-managed files, use the standard litellm.afile_content.
+                # `timeout` reaches file_content's TIMEOUT LOGIC via
+                # GenericLiteLLMParams, capping the upstream HTTP request itself
+                # rather than only the await, so an abandoned read stops
+                # occupying its executor thread too.
+                fetch = litellm.afile_content(
                     file_id=provider_file_id,
                     user_api_key_dict=user_api_key_dict,
+                    timeout=timeout_seconds,
                     **fetch_kwargs,
                 )
+
+            # Bound the read: it runs inline in POST /v1/batches, so unbounded the
+            # SDK default (600s x 3 attempts) outlives every client timeout and the
+            # request just hangs (LIT-5027).
+            #
+            # wait_for is what guarantees the handler stops waiting, and it is the
+            # only bound the managed-files path has (that hook takes no timeout
+            # argument), so an abandoned managed read may hold its executor thread
+            # until the SDK's own timeout fires.
+            try:
+                file_content = await asyncio.wait_for(fetch, timeout=timeout_seconds)
+            except asyncio.TimeoutError as exc:
+                raise BatchInputFileReadTimeout(file_id=file_id, timeout_seconds=timeout_seconds) from exc
 
             file_content_bytes = getattr(file_content, "content", None)
             if not isinstance(file_content_bytes, bytes):
@@ -603,6 +666,10 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 verbose_proxy_logger.error(
                     f"Batch input file rejected for {file_id}: status={e.status_code} detail={e.detail}"
                 )
+            raise
+        except BatchInputFileReadTimeout:
+            # The caller decides the policy (reject vs admit unmetered) and logs
+            # accordingly; a generic error line here would just duplicate it.
             raise
         except Exception as e:
             verbose_proxy_logger.error(f"Error counting input file usage for {file_id}: {str(e)}")
@@ -854,6 +921,38 @@ class _PROXY_BatchRateLimiter(CustomLogger):
         except HTTPException:
             # Re-raise HTTP exceptions (rate limit exceeded)
             raise
+        except BatchInputFileReadTimeout as e:
+            # The read is both the token count and the JSONL model-allowlist
+            # check, so the two cases diverge. A key restricted to a subset of
+            # models cannot be admitted without validating the file: doing so
+            # would grant exactly the bypass _should_skip_batch_input_file_processing
+            # refuses to allow via operator config. An unrestricted key has only
+            # rate-limit accuracy at stake, so it is admitted unmetered, matching
+            # the generic fail-open below.
+            if self._key_requires_batch_model_access_check(user_api_key_dict):
+                verbose_proxy_logger.error(
+                    "Rejecting batch: could not read input file %s within %ss to validate "
+                    "the models it references against the key's allowlist.",
+                    e.file_id,
+                    e.timeout_seconds,
+                )
+                raise ProxyException(
+                    message=(
+                        f"Could not read the batch input file within {e.timeout_seconds}s to "
+                        "validate the models it references. Retry, or contact your proxy admin "
+                        "if the files API is degraded."
+                    ),
+                    type=ProxyErrorTypes.internal_server_error,
+                    param="input_file_id",
+                    code=504,
+                ) from e
+            verbose_proxy_logger.warning(
+                "Batch admitted without rate limiting: reading input file %s timed out after %ss. "
+                "Its tokens and requests are not counted against this key's limits.",
+                e.file_id,
+                e.timeout_seconds,
+            )
+            return data
         except Exception as e:
             verbose_proxy_logger.error(f"Error in batch rate limiting: {str(e)}", exc_info=True)
             # Don't block the request if rate limiting fails

--- a/tests/e2e/batches/test_batches_e2e.py
+++ b/tests/e2e/batches/test_batches_e2e.py
@@ -397,16 +397,6 @@ def unattributed_rows(rows: list[SpendLogRow]) -> list[SpendLogRow]:
     return [row for row in rows if not row.api_key]
 
 
-@pytest.mark.skip(
-    reason=(
-        "LIT-5027: the path under test hangs. The batch rate limiter reads the input file "
-        "to count tokens by awaiting litellm.afile_content with no timeout, so a slow Files "
-        "API holds POST /v1/batches open past any client deadline (63.6s observed on stage "
-        "against a 60s read timeout). The unattributed-spend-row contract below is never "
-        "reached, so the test reports a timeout rather than the behavior it guards. Unskip "
-        "once the fetch is bounded."
-    )
-)
 def test_rate_limited_batch_create_leaves_no_unattributed_spend_row(
     client: BatchClient, resources: ResourceManager, batch_deployments: None
 ) -> None:

--- a/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
+++ b/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
@@ -1906,3 +1906,57 @@ async def test_read_deadline_is_passed_to_the_upstream_file_fetch():
         )
 
     assert captured.get("timeout") == 3.5, "read deadline never reached the upstream fetch"
+
+
+@pytest.mark.asyncio
+async def test_read_deadline_overrides_a_deployment_configured_timeout():
+    """`timeout` is one of _extract_file_access_credentials' credential keys, so a
+    deployment's litellm_params can already put it in fetch_kwargs. Passing the
+    limiter's deadline as a separate keyword alongside **fetch_kwargs then raises
+    TypeError for a duplicate kwarg, turning the hang into a 500. The limiter's
+    budget must win: a deployment timeout is sized for serving traffic, not for an
+    inline pre-call hook."""
+    captured: dict = {}
+
+    async def _capture(*args, **kwargs):
+        captured.update(kwargs)
+        return MagicMock(content=b'{"body": {"model": "gpt-4o-mini", "messages": []}}\n')
+
+    rate_limiter = _make_rate_limiter()
+    user = UserAPIKeyAuth(api_key="sk", models=["*"])
+
+    # A deployment whose credentials carry their own `timeout`, which is what
+    # _extract_file_access_credentials merges into fetch_kwargs. Driven through the
+    # real resolver so the merge itself is under test, not a stubbed return value.
+    router = MagicMock(
+        model_list=[
+            {
+                "model_name": "gpt-4o-mini",
+                "litellm_params": {
+                    "model": "gpt-4o-mini",
+                    "api_key": "sk-deployment",
+                    "timeout": 600,
+                    "custom_llm_provider": "openai",
+                },
+            }
+        ]
+    )
+
+    with (
+        patch("litellm.afile_content", new=_capture),
+        patch(
+            "litellm.proxy.openai_files_endpoints.common_utils.get_credentials_for_model",
+            return_value={"api_key": "sk-deployment", "timeout": 600, "custom_llm_provider": "openai"},
+        ),
+        patch("litellm.proxy.proxy_server.llm_router", router),
+        patch("litellm.proxy.proxy_server.general_settings", {"batch_input_file_read_timeout": 4.0}),
+    ):
+        usage = await rate_limiter.count_input_file_usage(
+            file_id="file-plain",
+            custom_llm_provider="openai",
+            user_api_key_dict=user,
+            data={"model": "gpt-4o-mini"},
+        )
+
+    assert usage.request_count == 1
+    assert captured.get("timeout") == 4.0, "deployment timeout must not override the limiter's deadline"

--- a/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
+++ b/tests/test_litellm/proxy/hooks/test_batch_file_validation.py
@@ -7,12 +7,14 @@ VERIA-39 regression tests:
   models the caller is not authorized to use.
 """
 
+import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
 
-from litellm.proxy._types import LitellmUserRoles, UserAPIKeyAuth
+from litellm.proxy._types import LitellmUserRoles, ProxyException, UserAPIKeyAuth
 
 
 def _models(file_content_as_dict):
@@ -1671,3 +1673,236 @@ async def test_count_input_file_usage_collects_models_after_malformed_line():
             )
 
     assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# LIT-5027: the input-file read must be bounded
+#
+# The read runs inline in POST /v1/batches and served two purposes with opposite
+# safe defaults: counting tokens for rate limiting, and validating every
+# body.model in the JSONL against the caller's allowlist. Unbounded, a stalled
+# Files API held the request open past any client deadline (63.6s observed on
+# stage against a 60s read timeout).
+#
+# These use a genuinely slow fetch against a short deadline rather than faking
+# asyncio.TimeoutError, so they fail if wait_for is removed and the await goes
+# back to being unbounded.
+# ---------------------------------------------------------------------------
+
+
+def _slow_fetch(delay: float = 10.0):
+    """A file read that outlives the test-scale deadline (0.05s) by 200x.
+
+    Paired with `@pytest.mark.timeout` on each test so that removing the bound
+    surfaces as a fast failure rather than a hung CI job: unbounded, the await
+    runs the full `delay` and pytest-timeout kills it well before that.
+    """
+
+    async def _fetch(*args, **kwargs):
+        await asyncio.sleep(delay)
+        raise AssertionError("slow fetch should have been abandoned, not awaited to completion")
+
+    return _fetch
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.asyncio
+async def test_input_file_read_is_abandoned_at_the_deadline():
+    """The read must not outlive its budget. Without the bound this awaits the
+    full 30s sleep (in prod, the SDK's 600s x 3) instead of giving up."""
+    from litellm.proxy.hooks.batch_rate_limiter import BatchInputFileReadTimeout
+
+    rate_limiter = _make_rate_limiter()
+    user = UserAPIKeyAuth(api_key="sk", models=["*"])
+
+    with (
+        patch("litellm.afile_content", new=_slow_fetch()),
+        patch("litellm.proxy.proxy_server.general_settings", {"batch_input_file_read_timeout": 0.05}),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+    ):
+        started = time.monotonic()
+        with pytest.raises(BatchInputFileReadTimeout) as exc:
+            await rate_limiter.count_input_file_usage(
+                file_id="file-slow",
+                custom_llm_provider="openai",
+                user_api_key_dict=user,
+            )
+        elapsed = time.monotonic() - started
+
+    assert elapsed < 5, f"read was not abandoned at its deadline (took {elapsed:.2f}s)"
+    assert exc.value.file_id == "file-slow"
+    assert exc.value.timeout_seconds == 0.05
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.asyncio
+async def test_managed_file_read_is_also_bounded():
+    """Managed files take a different code path (the managed-files hook, which
+    accepts no timeout kwarg), so it needs the same bound."""
+    from litellm.proxy.hooks.batch_rate_limiter import BatchInputFileReadTimeout
+
+    rate_limiter = _make_rate_limiter()
+    user = UserAPIKeyAuth(api_key="sk", models=["*"])
+
+    with (
+        patch.object(rate_limiter, "_fetch_managed_file_content", new=_slow_fetch()),
+        patch(
+            "litellm.proxy.openai_files_endpoints.common_utils._is_base64_encoded_unified_file_id",
+            return_value="litellm_proxy/gpt-4o-mini",
+        ),
+        patch(
+            "litellm.proxy.openai_files_endpoints.common_utils.get_models_from_unified_file_id",
+            return_value=["gpt-4o-mini"],
+        ),
+        patch("litellm.proxy.proxy_server.general_settings", {"batch_input_file_read_timeout": 0.05}),
+    ):
+        started = time.monotonic()
+        with pytest.raises(BatchInputFileReadTimeout):
+            await rate_limiter.count_input_file_usage(
+                file_id="file-managed-slow",
+                custom_llm_provider="openai",
+                user_api_key_dict=user,
+            )
+        elapsed = time.monotonic() - started
+
+    assert elapsed < 5, f"managed-file read was not abandoned at its deadline (took {elapsed:.2f}s)"
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.asyncio
+async def test_timeout_rejects_batch_when_key_has_a_model_allowlist():
+    """A restricted key's batch cannot be admitted on timeout: the file read is
+    the only thing that validates the models inside the JSONL, so admitting it
+    unchecked would let the caller run models outside its allowlist under the
+    proxy's shared credentials."""
+    rate_limiter = _make_rate_limiter()
+    rate_limiter.parallel_request_limiter._create_rate_limit_descriptors.return_value = [
+        {"rate_limit": {"requests_per_unit": 5}}
+    ]
+    user = UserAPIKeyAuth(api_key="sk-restricted", models=["gpt-4o-mini"])
+
+    with (
+        patch("litellm.afile_content", new=_slow_fetch()),
+        patch("litellm.proxy.proxy_server.general_settings", {"batch_input_file_read_timeout": 0.05}),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+    ):
+        with pytest.raises(ProxyException) as exc:
+            await rate_limiter.async_pre_call_hook(
+                user_api_key_dict=user,
+                cache=MagicMock(),
+                data={"input_file_id": "file-slow", "model": "gpt-4o-mini"},
+                call_type="acreate_batch",
+            )
+
+    assert exc.value.code == "504"
+    assert "validate the models" in exc.value.message
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.asyncio
+async def test_timeout_admits_batch_when_key_has_unrestricted_model_access():
+    """With no allowlist to enforce, only rate-limit accuracy is at stake, so a
+    degraded Files API must not turn batch creation into an outage."""
+    rate_limiter = _make_rate_limiter()
+    rate_limiter.parallel_request_limiter._create_rate_limit_descriptors.return_value = [
+        {"rate_limit": {"requests_per_unit": 5}}
+    ]
+    rate_limiter._check_and_increment_batch_counters = AsyncMock()
+    user = UserAPIKeyAuth(api_key="sk-open", models=["*"])
+    data = {"input_file_id": "file-slow", "model": "gpt-4o-mini"}
+
+    with (
+        patch("litellm.afile_content", new=_slow_fetch()),
+        patch("litellm.proxy.proxy_server.general_settings", {"batch_input_file_read_timeout": 0.05}),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+    ):
+        result = await rate_limiter.async_pre_call_hook(
+            user_api_key_dict=user,
+            cache=MagicMock(),
+            data=data,
+            call_type="acreate_batch",
+        )
+
+    assert result is data
+    # Admitted unmetered: no counters were reserved, and no token count was
+    # stamped for the completion-side reconciliation to read.
+    rate_limiter._check_and_increment_batch_counters.assert_not_awaited()
+    assert "_batch_token_count" not in data
+
+
+@pytest.mark.timeout(30)
+@pytest.mark.asyncio
+async def test_access_group_key_is_rejected_on_timeout():
+    """Access-group keys carry no literal model list but still require the JSONL
+    check (_key_requires_batch_model_access_check returns True), so they must
+    fail closed alongside allowlisted keys."""
+    rate_limiter = _make_rate_limiter()
+    rate_limiter.parallel_request_limiter._create_rate_limit_descriptors.return_value = [
+        {"rate_limit": {"requests_per_unit": 5}}
+    ]
+    user = UserAPIKeyAuth(api_key="sk-group", models=[], access_group_ids=["grp-1"])
+
+    with (
+        patch("litellm.afile_content", new=_slow_fetch()),
+        patch("litellm.proxy.proxy_server.general_settings", {"batch_input_file_read_timeout": 0.05}),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+    ):
+        with pytest.raises(ProxyException) as exc:
+            await rate_limiter.async_pre_call_hook(
+                user_api_key_dict=user,
+                cache=MagicMock(),
+                data={"input_file_id": "file-slow", "model": "gpt-4o-mini"},
+                call_type="acreate_batch",
+            )
+
+    assert exc.value.code == "504"
+
+
+def test_read_timeout_defaults_and_rejects_unusable_values():
+    """A zero/negative or non-numeric deadline must fall back to the default; a
+    0s budget would expire instantly and reject every restricted key's batch."""
+    from litellm.constants import DEFAULT_BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS
+
+    rate_limiter = _make_rate_limiter()
+    resolve = rate_limiter._batch_input_file_read_timeout
+
+    for settings, expected in (
+        ({}, DEFAULT_BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS),
+        ({"batch_input_file_read_timeout": 0}, DEFAULT_BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS),
+        ({"batch_input_file_read_timeout": -5}, DEFAULT_BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS),
+        ({"batch_input_file_read_timeout": "20"}, DEFAULT_BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS),
+        ({"batch_input_file_read_timeout": True}, DEFAULT_BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS),
+        ({"batch_input_file_read_timeout": 45}, 45.0),
+        ({"batch_input_file_read_timeout": 2.5}, 2.5),
+    ):
+        with patch("litellm.proxy.proxy_server.general_settings", settings):
+            assert resolve() == expected, f"unexpected deadline for {settings}"
+
+
+@pytest.mark.asyncio
+async def test_read_deadline_is_passed_to_the_upstream_file_fetch():
+    """wait_for alone only abandons the await; afile_content runs the sync client
+    in an executor thread that a cancelled await does not interrupt. The same
+    deadline must therefore reach afile_content so the HTTP request is capped and
+    the thread is released."""
+    captured: dict = {}
+
+    async def _capture(*args, **kwargs):
+        captured.update(kwargs)
+        return MagicMock(content=b'{"body": {"model": "gpt-4o-mini", "messages": []}}\n')
+
+    rate_limiter = _make_rate_limiter()
+    user = UserAPIKeyAuth(api_key="sk", models=["*"])
+
+    with (
+        patch("litellm.afile_content", new=_capture),
+        patch("litellm.proxy.proxy_server.general_settings", {"batch_input_file_read_timeout": 3.5}),
+        patch("litellm.proxy.proxy_server.llm_router", None),
+    ):
+        await rate_limiter.count_input_file_usage(
+            file_id="file-plain",
+            custom_llm_provider="openai",
+            user_api_key_dict=user,
+        )
+
+    assert captured.get("timeout") == 3.5, "read deadline never reached the upstream fetch"

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -22705,6 +22705,11 @@ export interface components {
              */
             background_health_checks?: boolean | null;
             /**
+             * Batch Input File Read Timeout
+             * @description Seconds the batch rate limiter may spend reading a batch input file to count tokens (default 10). The read runs inline in POST /v1/batches, so this must stay well inside client read timeouts. On timeout, keys whose model allowlist must be validated against the file are rejected; keys with unrestricted model access are admitted without rate limiting.
+             */
+            batch_input_file_read_timeout?: number | null;
+            /**
              * Cancel On Disconnect
              * @description cancel the in-flight upstream LLM request (non-streaming) when the client disconnects, freeing backend capacity (e.g. a vLLM GPU slot); the request is logged as a 499 failure
              */


### PR DESCRIPTION
## TLDR

Problem this solves:

- `POST /v1/batches` could hang indefinitely
- The batch rate limiter read the input file with no deadline
- A stalled Files API outlived every client timeout

How it solves it:

- Bound the read; default 10s, configurable
- Restricted keys fail closed, unrestricted keys admitted unmetered
- Unskips the e2e test this hang was blocking

## Relevant issues

## Linear ticket

Resolves LIT-5027

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Pending; I will attach the live-proxy runs against a proxy built from this branch. The reproduction needs a Files API that stalls on read, so the before/after is captured by pointing a deployment at a file host that holds the connection open, then re-running the same batch create with the fix in place

## Type

🐛 Bug Fix

## Changes

`BatchRateLimiter.async_pre_call_hook` runs synchronously in the request path. When the calling key has applicable rpm/tpm limits, it read the batch input file to count tokens and awaited that read with no deadline, so the OpenAI SDK default applied: 600s with `max_retries=2`. A slow or stalled Files API therefore held `POST /v1/batches` open far past any reasonable client timeout. On stage a read took 63.6s against a client whose read timeout was 60s, so the client gave up first and the eventual 404 (the client's teardown had already deleted the file) read as the cause rather than the consequence

The read is now bounded. Both fetch paths go through one `asyncio.wait_for`, since the managed-files hook accepts no timeout argument of its own

The failure policy splits, because the read does double duty. It counts tokens for rate limiting, and it validates every `body.model` in the JSONL against the caller's model allowlist. Those two have opposite safe defaults on timeout. A key restricted to a subset of models is rejected with a 504: admitting its batch without reading the file would grant exactly the bypass that `_should_skip_batch_input_file_processing` already refuses to allow through operator config, letting a caller run models outside its allowlist under the proxy's shared credentials by making the read slow. A key with unrestricted model access has only rate-limit accuracy at stake, so its batch is admitted unmetered with a warning, matching the fail-open the generic handler already applied; a degraded Files API does not turn batch creation into an outage

The deadline is also passed to `afile_content`, not just to `wait_for`. `afile_content` runs the sync client via `run_in_executor`, and cancelling that await does not interrupt a thread already in the pool, so bounding only the await would free the request handler while leaking the worker until the SDK's own timeout fired. The managed-files path takes no timeout argument, so there `wait_for` is the only bound and an abandoned read may still hold its thread; that is called out in a comment rather than papered over

Two smaller things fall out. The hang was invisible in logs because the hook emitted nothing between entry and failure, and the eventual error was swallowed by the "don't block the request if rate limiting fails" handler, so neither the caller nor the operator learned the limiter had failed. Both timeout branches now log. The rejection raises `ProxyException` rather than `HTTPException` so it maps to the same OpenAI error shape as the proxy's other refusals

I checked the rest of the pre-call hooks for the same unbounded-await shape, as the ticket asked. `batch_rate_limiter.py` is the only hook that reads files

New setting: `general_settings.batch_input_file_read_timeout`, default 10s, also settable per-deployment via `BATCH_INPUT_FILE_READ_TIMEOUT_SECONDS`. Non-positive and non-numeric values fall back to the default, since a 0s budget would expire instantly and reject every restricted key's batch

## QA runbook

- tests/e2e/batches/test_batches_e2e.py::test_rate_limited_batch_create_leaves_no_unattributed_spend_row - creating a batch on a rate-limited key runs the input-file read and leaves no spend row the proxy could not attribute to a key. This test is unskipped here; it was skipped in #35301 because the path under test hung
  - [ ] Generate a key with limits but no model restriction, so the file-read path fires while the batch itself is not blocked: `curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"models": [], "tpm_limit": 1000000, "rpm_limit": 1000, "user_id": "e2e-batch-rl-manual"}'`
  - [ ] Note the current unattributed rows so the assertion is a delta, not an absolute: `curl -s "http://localhost:4000/spend/logs/v2?start_date=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)&end_date=$(date -u -v+1H +%Y-%m-%dT%H:%M:%SZ)" -H "Authorization: Bearer sk-1234" | jq '[.data[] | select(.api_key == "" or .api_key == null)] | length'`
  - [ ] Upload a batch JSONL with `purpose=batch` using the key from step 1, then `POST /v1/batches` with the returned `input_file_id` and expect 200 within a few seconds rather than a client-side read timeout
  - [ ] Re-run the step 2 query and expect the count unchanged: every row the batch produced carries the calling key
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
