### PR TITLE
fix(ui) Make sure that team list loading always includes the user ID for non-admin users

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.test.ts
@@ -895,4 +895,26 @@ describe("useAllTeams", () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
   });
+
+  it("includes user_id in /v2/team/list for non-admin users", async () => {
+    mockUseAuthorized.mockReturnValue({
+      accessToken: "test-access-token",
+      userId: "non-admin-user-id",
+      userRole: "app_user",
+      token: "test-token",
+      userEmail: "test@example.com",
+      premiumUser: false,
+      disabledPersonalKeyCreation: null,
+      showSSOBanner: false,
+    });
+    fetchMock.mockResolvedValue(pageResponse(mockTeams, 1, 1));
+
+    const { result } = renderHook(() => useAllTeams(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const firstUrl = fetchMock.mock.calls[0][0] as string;
+    expect(firstUrl).toContain("user_id=non-admin-user-id");
+  });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/teams/useTeams.ts
@@ -114,24 +114,41 @@ export const useTeams = (): UseQueryResult<Team[]> => {
 
 const ALL_TEAMS_PAGE_SIZE = 100;
 
-const fetchAllTeamsPaged = async (accessToken: string): Promise<Team[]> => {
-  const firstPage: TeamsResponse = await teamListCall(accessToken, 1, ALL_TEAMS_PAGE_SIZE);
+const fetchAllTeamsPaged = async (
+  accessToken: string,
+  userId: string | null,
+  userRole: string | null,
+): Promise<Team[]> => {
+  const isAdmin = userRole === "Admin" || userRole === "Admin Viewer";
+  const firstPage: TeamsResponse = await teamListCall(accessToken, 1, ALL_TEAMS_PAGE_SIZE, {
+    userID: isAdmin ? undefined : userId,
+  });
   const totalPages = firstPage.total_pages ?? 1;
   if (totalPages <= 1) return firstPage.teams;
 
   const remainingPages: TeamsResponse[] = await Promise.all(
-    Array.from({ length: totalPages - 1 }, (_, i) => teamListCall(accessToken, i + 2, ALL_TEAMS_PAGE_SIZE)),
+    Array.from({ length: totalPages - 1 }, (_, i) =>
+      teamListCall(accessToken, i + 2, ALL_TEAMS_PAGE_SIZE, {
+        userID: isAdmin ? undefined : userId,
+      }),
+    ),
   );
   return [firstPage, ...remainingPages].flatMap((page) => page.teams);
 };
 
 export const useAllTeams = (): UseQueryResult<Team[]> => {
-  const { accessToken } = useAuthorized();
+  const { accessToken, userId, userRole } = useAuthorized();
   return useQuery<Team[]>({
     queryKey: teamKeys.list({
-      filters: { scope: "all", pageSize: ALL_TEAMS_PAGE_SIZE, accessToken: accessToken ?? "" },
+      filters: {
+        scope: "all",
+        pageSize: ALL_TEAMS_PAGE_SIZE,
+        accessToken: accessToken ?? "",
+        userId: userId ?? "",
+        userRole: userRole ?? "",
+      },
     }),
-    queryFn: async () => await fetchAllTeamsPaged(accessToken!),
+    queryFn: async () => await fetchAllTeamsPaged(accessToken!, userId, userRole),
     enabled: Boolean(accessToken),
     staleTime: 30000,
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/add_attachment_form.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/add_attachment_form.test.tsx
@@ -18,8 +18,9 @@ vi.mock("./impact_preview_alert", () => ({
     React.createElement("div", { "data-testid": "impact-preview" }, `${impactResult.affected_keys_count} keys`),
 }));
 
+const mockUseAuthorized = vi.fn();
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
-  default: () => ({ userId: "admin-user-id", userRole: "Admin", accessToken: "test-token" }),
+  default: () => mockUseAuthorized(),
 }));
 
 const makePolicy = (overrides: Partial<Policy> = {}): Policy => ({
@@ -51,6 +52,7 @@ const teamListResult = (aliases: string[]) =>
 describe("AddAttachmentForm", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseAuthorized.mockReturnValue({ userId: "admin-user-id", userRole: "Admin", accessToken: "test-token" });
     vi.mocked(networking.teamListCall).mockResolvedValue([]);
     vi.mocked(networking.keyListCall).mockResolvedValue({ keys: [] });
     vi.mocked(networking.modelAvailableCall).mockResolvedValue({ data: [] });
@@ -79,6 +81,13 @@ describe("AddAttachmentForm", () => {
     renderWithProviders(<AddAttachmentForm {...defaultProps} />);
     await waitFor(() => expect(networking.teamListCall).toHaveBeenCalled());
     expect(networking.teamListCall).toHaveBeenCalledWith("test-token", null, null);
+  });
+
+  it("passes userId for non-admin callers", async () => {
+    mockUseAuthorized.mockReturnValue({ userId: "member-1", userRole: "internal_user", accessToken: "test-token" });
+    renderWithProviders(<AddAttachmentForm {...defaultProps} />);
+    await waitFor(() => expect(networking.teamListCall).toHaveBeenCalled());
+    expect(networking.teamListCall).toHaveBeenCalledWith("test-token", null, "member-1");
   });
 
   it("should not fetch teams, keys, or models when accessToken is null", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/add_attachment_form.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/policies/_components/add_attachment_form.tsx
@@ -56,7 +56,8 @@ const AddAttachmentForm: React.FC<AddAttachmentFormProps> = ({
     setIsLoadingTeams(true);
     setTeamsLoaded(false);
     try {
-      const teamsResponse = await teamListCall(accessToken, null, null);
+      const isAdmin = userRole === "Admin" || userRole === "Admin Viewer";
+      const teamsResponse = await teamListCall(accessToken, null, isAdmin ? null : userId || null);
       const teamsArray = Array.isArray(teamsResponse) ? teamsResponse : teamsResponse?.data || [];
       const teamAliases = teamsArray.map((t: any) => t.team_alias).filter(Boolean);
       setAvailableTeams(teamAliases);

--- a/ui/litellm-dashboard/src/components/ToolDetail.tsx
+++ b/ui/litellm-dashboard/src/components/ToolDetail.tsx
@@ -30,6 +30,7 @@ import {
   type ToolPolicyOverrideRow,
 } from "@/components/networking";
 import type { Team } from "@/components/key_team_helpers/key_list";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 
 interface ToolDetailProps {
   toolName: string;
@@ -60,6 +61,7 @@ function getDefaultLogsDateRange(): { start: string; end: string } {
 }
 
 export function ToolDetail({ toolName, onBack, accessToken }: ToolDetailProps) {
+  const { userId, userRole } = useAuthorized();
   const queryClient = useQueryClient();
   const [overrideSaving, setOverrideSaving] = useState(false);
   const [inputPolicySaving, setInputPolicySaving] = useState(false);
@@ -88,8 +90,11 @@ export function ToolDetail({ toolName, onBack, accessToken }: ToolDetailProps) {
   });
 
   const { data: teamsData } = useQuery({
-    queryKey: ["teams-list-tool-detail"],
-    queryFn: () => teamListCall(accessToken!, null, null),
+    queryKey: ["teams-list-tool-detail", userId ?? "", userRole ?? ""],
+    queryFn: () => {
+      const isAdmin = userRole === "Admin" || userRole === "Admin Viewer";
+      return teamListCall(accessToken!, null, isAdmin ? null : userId || null);
+    },
     enabled: !!accessToken,
   });
 

--- a/ui/litellm-dashboard/src/components/key_team_helpers/filter_helpers.ts
+++ b/ui/litellm-dashboard/src/components/key_team_helpers/filter_helpers.ts
@@ -116,16 +116,22 @@ export const fetchTeamFilterOptions = async (
  * @param organizationId Optional organization ID to filter teams
  * @returns Array of all teams
  */
-export const fetchAllTeams = async (accessToken: string | null, organizationId?: string | null): Promise<Team[]> => {
+export const fetchAllTeams = async (
+  accessToken: string | null,
+  organizationId?: string | null,
+  userId?: string | null,
+  userRole?: string | null,
+): Promise<Team[]> => {
   if (!accessToken) return [];
 
   try {
+    const isAdmin = userRole === "Admin" || userRole === "Admin Viewer";
     let allTeams: Team[] = [];
     let currentPage = 1;
     let hasMorePages = true;
 
     while (hasMorePages) {
-      const response = await teamListCall(accessToken, organizationId || null, null);
+      const response = await teamListCall(accessToken, organizationId || null, isAdmin ? null : userId || null);
 
       // Add teams from this page
       allTeams = [...allTeams, ...response];

--- a/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/log_filter_logic.tsx
@@ -195,10 +195,10 @@ export function useLogFilterLogic({
   };
 
   const allTeamsQueryOptions: UseQueryOptions<Team[], Error> = {
-    queryKey: ["allTeamsForLogFilters", accessToken],
+    queryKey: ["allTeamsForLogFilters", accessToken, userID ?? "", userRole ?? ""],
     queryFn: async () => {
       if (!accessToken) return [];
-      const teamsData = await fetchAllTeams(accessToken);
+      const teamsData = await fetchAllTeams(accessToken, undefined, userID, userRole);
       return teamsData || [];
     },
     enabled: !!accessToken,


### PR DESCRIPTION
Make sure that team list loading always includes the user ID for non-admin users so that the list populates correctly. This allows the key list to correctly render budgets. It likely also changes other parts of the interface that were previously not getting team lists. Fixes #35404

Problem this solves:

- The UI doesn't properly populate the team list for non-admin users in all cases, so things like the key list don't have information about team budgets

How it solves it:

- Ensure that any time we invoke teamListCall, we include the userID for non-admin users.
- 
## Relevant issues

Fixes #35404

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ x] I have added meaningful tests
- [ x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before:
<img width="1478" height="785" alt="Screenshot 2026-07-31 at 2 34 44 PM" src="https://github.com/user-attachments/assets/63155726-4044-4b71-b29a-be8435fd7684" />

After:
<img width="1466" height="702" alt="Screenshot 2026-07-31 at 3 21 01 PM" src="https://github.com/user-attachments/assets/8826c9a7-5e6e-4789-a50d-af7c89892063" />


## Type

🐛 Bug Fix


## Changes


### Final Attestation

- [ x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
