### PR TITLE
test(e2e): reset the database at the end of a suite run

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -14,20 +14,16 @@ shared fixtures build on it.
 """
 
 import functools
-import os
 from collections.abc import Iterator
 
 import pytest
 import requests
 
 from e2e_config import CONTROL_PLANE_BASE_URL, PROXY_BASE_URL
-from e2e_db import RESET_OPT_IN_ENV, reset_spend_logs, run_spend_log_cleanup
+from e2e_db import reset_database
 from junit_properties import attach_result_properties
 from lifecycle import ProxyClientProvider, ResourceManager
 from proxy_client import ProxyClient, build_proxy_client
-
-
-_E2E_TEST_RAN = pytest.StashKey[bool]()
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -99,29 +95,24 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
         pytest.fail(reason)
 
 
-def pytest_runtest_call(item: pytest.Item) -> None:
-    """Mark that an e2e test body actually ran (setup passed). Sessions that fail
-    setup never reach this hook, so the session-finish cleanup can use it as a
-    guard before truncating the spend-log DB. Tests under `tests/e2e/` without the
-    `e2e` marker (pure unit coverage for the harness itself) never hit the proxy,
-    so they must not arm the destructive DB truncate."""
-    if item.get_closest_marker("e2e") is None:
-        return
-    item.session.stash[_E2E_TEST_RAN] = True
+@pytest.fixture(scope="session", autouse=True)
+def reset_prisma_db_session(request: pytest.FixtureRequest) -> Iterator[None]:
+    """Reset the Prisma database once at the start of the test session.
 
+    `migrate reset` drops the schema and replays every migration, so the suite
+    starts from an empty DB at the migration head. Autouse and session-scoped, so it
+    runs once before the first test rather than per suite or per test.
 
-def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    """Once the whole e2e session is done (all suites), optionally truncate the
-    spend logs so the DB doesn't accumulate test rows. The truncate is destructive
-    and irreversible, so it runs only when the operator explicitly opts in
-    (`E2E_RESET_SPEND_LOGS=1`) and an e2e test body actually ran; otherwise a
-    `DATABASE_URL` pointing at a shared or staging instance is left untouched.
-    Best-effort: a cleanup failure (no DB reachable) must not fail the run."""
-    run_spend_log_cleanup(
-        opt_in=os.environ.get(RESET_OPT_IN_ENV),
-        e2e_test_ran=session.stash.get(_E2E_TEST_RAN, False),
-        truncate=reset_spend_logs,
-    )
+    Skipped when the session collected no `e2e`-marked test: the harness's own unit
+    coverage (this file's siblings) never touches a database, and dropping the schema
+    to run it would wipe whatever `DATABASE_URL` points at for no reason.
+
+    Fails the session if the reset fails: every downstream test would otherwise run
+    against a half-dropped schema and report confusing unrelated errors.
+    """
+    if any(item.get_closest_marker("e2e") is not None for item in request.session.items):
+        reset_database()
+    yield
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e/e2e_db.py
+++ b/tests/e2e/e2e_db.py
@@ -1,56 +1,115 @@
-"""Shared, destructive DB helpers for the e2e harness.
+"""Destructive DB reset for the e2e harness.
 
 Kept at the top level next to e2e_config and lifecycle so every suite imports it
 by name (`from e2e_db import ...`); no suite reaches into another's directory by
 mutating sys.path.
 
-reset_spend_logs truncates LiteLLM_SpendLogs and cannot be undone, so the
-session-finish cleanup routes through run_spend_log_cleanup, which fires the
-truncate only on an explicit operator opt-in. "An e2e test ran" is necessary but
-never sufficient: a DATABASE_URL pointing at a shared or staging instance must
-not be wiped by a routine local run that merely exercised a test.
+reset_database drops the schema and replays every migration, so it removes spend
+logs, keys, teams, users and orgs and leaves the DB at the migration head.
 """
 
 import os
-from collections.abc import Callable
+from pathlib import Path
 
-RESET_OPT_IN_ENV = "E2E_RESET_SPEND_LOGS"
+from pydantic import TypeAdapter
+
+LOCAL_DATABASE_URL = "postgresql://llmproxy:dbpassword9090@localhost:5432/litellm"
+
+# The schema whose sibling `migrations/` holds the real history the proxy deploys
+# (litellm/proxy/schema.prisma has no migrations dir, so resetting against it would
+# drop the schema with nothing to replay). Absolute, because pytest's working
+# directory is not the repo root.
+SCHEMA_PATH = Path(__file__).resolve().parents[2] / "litellm-proxy-extras" / "litellm_proxy_extras" / "schema.prisma"
 
 
-def run_spend_log_cleanup(
-    *, opt_in: str | None, e2e_test_ran: bool, truncate: Callable[[], None]
-) -> bool:
-    """Invoke `truncate` iff the destructive spend-log reset is both opted into
-    and warranted, returning whether the truncate was attempted.
+def resolve_database_url() -> str:
+    """The connection string to reset, mirroring how the proxy builds its own.
 
-    The truncate fires only when the opt-in value is exactly "1" AND an e2e test
-    body actually ran. Any other opt-in value (unset, "0", "true", "") leaves the
-    DB untouched, so the destructive path is never armed by the env var's mere
-    presence or by a test run on its own. Best-effort: a truncate failure is
-    swallowed so cleanup never fails the session, so the returned bool reports
-    that the reset was attempted, not that the DB call succeeded.
+    On RDS with IAM auth there is no durable `DATABASE_URL` for the prisma CLI to
+    read: the proxy assembles one at startup from `DATABASE_HOST`/`PORT`/`USER`/
+    `NAME` plus a short-lived IAM token (see proxy_cli.py's "GET DB TOKEN FOR IAM
+    AUTH"), and that token rotates roughly every 12 minutes. A reset that relied on
+    the CLI picking `DATABASE_URL` out of the environment would abort on stage with
+    "environment variable not found", or silently hit the local-docker default.
+
+    Precedence, most specific first:
+      1. An explicit `DATABASE_URL` (local docker, Neon, a tunnel).
+      2. RDS parts + a freshly minted IAM token, when `IAM_TOKEN_DB_AUTH` is on.
+      3. RDS parts + `DATABASE_PASSWORD`, for password auth.
+      4. The local docker default.
     """
-    if opt_in != "1" or not e2e_test_ran:
-        return False
-    try:
-        truncate()
-    except Exception as exc:  # noqa: BLE001 - cleanup is best-effort
-        print(f"spend-log cleanup best-effort failed: {exc}")
-    return True
+    explicit_url = os.environ.get("DATABASE_URL")
+    if explicit_url:
+        return explicit_url
+
+    db_host = os.environ.get("DATABASE_HOST")
+    db_user = os.environ.get("DATABASE_USER") or os.environ.get("DATABASE_USERNAME")
+    db_name = os.environ.get("DATABASE_NAME")
+    if not (db_host and db_user and db_name):
+        return LOCAL_DATABASE_URL
+
+    db_port = os.environ.get("DATABASE_PORT", "5432")
+    secret = _resolve_database_secret(db_host=db_host, db_port=db_port, db_user=db_user)
+    url = f"postgresql://{db_user}:{secret}@{db_host}:{db_port}/{db_name}"
+    db_schema = os.environ.get("DATABASE_SCHEMA")
+    return f"{url}?schema={db_schema}" if db_schema else url
 
 
-def reset_spend_logs() -> None:
-    """Truncate LiteLLM_SpendLogs for a clean slate. No proxy endpoint deletes
-    spend logs (/global/spend/reset keeps them), so go to the DB directly. Uses
-    DATABASE_URL (default: the local docker postgres on its mapped host port; the
-    in-container `@db` host isn't resolvable from the host, so default to
-    localhost).
+def _resolve_database_secret(*, db_host: str, db_port: str, db_user: str) -> str:
+    """An IAM auth token when IAM auth is enabled, else `DATABASE_PASSWORD`.
+
+    The token is minted per call and URL-encoded by `generate_iam_auth_token`; it is
+    valid for ~15 minutes, which is ample for one reset but is why it must never be
+    cached across a session.
     """
-    import psycopg
-
-    url = os.environ.get(
-        "DATABASE_URL",
-        "postgresql://llmproxy:dbpassword9090@localhost:5432/litellm",
+    iam_enabled = (os.environ.get("IAM_TOKEN_DB_AUTH") or "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
     )
-    with psycopg.connect(url) as conn:
-        _ = conn.execute('TRUNCATE TABLE "LiteLLM_SpendLogs"')
+    if not iam_enabled:
+        return os.environ.get("DATABASE_PASSWORD", "")
+
+    # Reuse the proxy's own minting path so the token matches what the gateway
+    # presents. It is untyped (boto has no stub for generate_db_auth_token), so
+    # validate the result instead of trusting it: an empty or non-string token
+    # would be spliced into the URL and surface as an opaque auth failure.
+    from litellm.proxy.auth.rds_iam_token import (  # noqa: PLC0415 - boto import is expensive
+        generate_iam_auth_token,  # pyright: ignore[reportUnknownVariableType]  # untyped helper; result validated below
+    )
+
+    token = TypeAdapter(str).validate_python(
+        generate_iam_auth_token(  # pyright: ignore[reportUnknownArgumentType]  # untyped helper
+            db_host=db_host, db_port=db_port, db_user=db_user
+        )
+    )
+    if not token:
+        raise RuntimeError("RDS IAM auth token came back empty; cannot reach the database")
+    return token
+
+
+def reset_database() -> None:
+    """`prisma migrate reset --force --skip-seed`: drop the schema, replay migrations.
+
+    Runs through prisma's bundled Python CLI rather than `npx prisma`, so the reset
+    does not depend on node being on PATH in the e2e runner image. `--skip-seed`
+    keeps it from running a seed script; each suite's fixtures create what they need.
+
+    `DATABASE_URL` is injected from resolve_database_url because the CLI cannot
+    assemble an RDS/IAM connection string itself, and `--schema` is explicit and
+    absolute because the repo carries three schema.prisma files and the CLI resolves
+    a relative path against the working directory.
+    """
+    from prisma.cli import prisma as prisma_cli  # noqa: PLC0415
+
+    if not SCHEMA_PATH.is_file():
+        raise RuntimeError(f"prisma schema not found at {SCHEMA_PATH}")
+
+    exit_code = prisma_cli.run(
+        ["migrate", "reset", "--force", "--skip-seed", "--schema", str(SCHEMA_PATH)],
+        check=False,
+        env={"DATABASE_URL": resolve_database_url()},
+    )
+    if exit_code != 0:
+        raise RuntimeError(f"Prisma reset failed with exit code {exit_code}")
+    print(f"database reset: replayed migrations from {SCHEMA_PATH}")

--- a/tests/e2e/test_e2e_db.py
+++ b/tests/e2e/test_e2e_db.py
@@ -1,0 +1,128 @@
+"""Coverage for e2e_db's connection resolution.
+
+Harness-only (no `e2e` marker): these never touch a proxy or a database.
+
+RDS with IAM auth has no durable DATABASE_URL: the proxy assembles one at startup
+from the DATABASE_* parts plus a token that rotates every ~12 minutes. A reset that
+only read DATABASE_URL silently fell back to the local-docker default, so it was a
+no-op against RDS and a hazard locally, which is what this resolver exists to fix.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from e2e_db import LOCAL_DATABASE_URL, resolve_database_url
+
+
+DB_ENV_VARS = (
+    "DATABASE_URL",
+    "DATABASE_HOST",
+    "DATABASE_PORT",
+    "DATABASE_USER",
+    "DATABASE_USERNAME",
+    "DATABASE_NAME",
+    "DATABASE_PASSWORD",
+    "DATABASE_SCHEMA",
+    "IAM_TOKEN_DB_AUTH",
+)
+
+
+@pytest.fixture
+def clean_db_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop every DB var so a developer's real `.env` (which points at a shared
+    instance) cannot decide what these assert."""
+    for name in DB_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_explicit_database_url_wins(clean_db_env: None, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql://u:p@explicit:5432/db")
+    monkeypatch.setenv("DATABASE_HOST", "ignored.example.com")
+    assert resolve_database_url() == "postgresql://u:p@explicit:5432/db"
+
+
+def test_falls_back_to_local_when_nothing_is_configured(clean_db_env: None) -> None:
+    assert resolve_database_url() == LOCAL_DATABASE_URL
+
+
+@pytest.mark.parametrize("missing", ["DATABASE_HOST", "DATABASE_USER", "DATABASE_NAME"])
+def test_incomplete_rds_parts_fall_back_rather_than_building_a_broken_url(
+    clean_db_env: None, monkeypatch: pytest.MonkeyPatch, missing: str
+) -> None:
+    """A half-configured environment must not produce a URL with "None" in it."""
+    parts = {
+        "DATABASE_HOST": "rds.example.com",
+        "DATABASE_USER": "litellm",
+        "DATABASE_NAME": "litellm",
+    }
+    del parts[missing]
+    for name, value in parts.items():
+        monkeypatch.setenv(name, value)
+    assert resolve_database_url() == LOCAL_DATABASE_URL
+
+
+def test_builds_url_from_rds_parts_with_password(
+    clean_db_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_HOST", "rds.example.com")
+    monkeypatch.setenv("DATABASE_USER", "litellm")
+    monkeypatch.setenv("DATABASE_NAME", "litellm")
+    monkeypatch.setenv("DATABASE_PASSWORD", "pw")
+    assert resolve_database_url() == "postgresql://litellm:pw@rds.example.com:5432/litellm"
+
+
+def test_honors_database_schema_and_port(
+    clean_db_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("DATABASE_HOST", "rds.example.com")
+    monkeypatch.setenv("DATABASE_USER", "litellm")
+    monkeypatch.setenv("DATABASE_NAME", "litellm")
+    monkeypatch.setenv("DATABASE_PASSWORD", "pw")
+    monkeypatch.setenv("DATABASE_PORT", "6543")
+    monkeypatch.setenv("DATABASE_SCHEMA", "public")
+    assert (
+        resolve_database_url()
+        == "postgresql://litellm:pw@rds.example.com:6543/litellm?schema=public"
+    )
+
+
+def test_mints_an_iam_token_when_iam_auth_is_enabled(
+    clean_db_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The RDS/IAM case this whole resolver exists for: no DATABASE_URL, no
+    password, credentials come from a freshly minted token."""
+    seen: dict[str, str] = {}
+
+    def fake_token(db_host: str, db_port: str, db_user: str) -> str:
+        seen.update(host=db_host, port=db_port, user=db_user)
+        return "TOKEN%2FENCODED"
+
+    monkeypatch.setattr("litellm.proxy.auth.rds_iam_token.generate_iam_auth_token", fake_token)
+    monkeypatch.setenv("DATABASE_HOST", "rds.example.com")
+    monkeypatch.setenv("DATABASE_USER", "litellm")
+    monkeypatch.setenv("DATABASE_NAME", "litellm")
+    monkeypatch.setenv("IAM_TOKEN_DB_AUTH", "true")
+
+    assert (
+        resolve_database_url()
+        == "postgresql://litellm:TOKEN%2FENCODED@rds.example.com:5432/litellm"
+    )
+    assert seen == {"host": "rds.example.com", "port": "5432", "user": "litellm"}
+
+
+def test_password_is_used_when_iam_auth_is_off(
+    clean_db_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """IAM_TOKEN_DB_AUTH left unset (or "false") must not attempt to reach AWS."""
+
+    def explode(**_kwargs: object) -> str:
+        raise AssertionError("must not mint an IAM token when IAM auth is disabled")
+
+    monkeypatch.setattr("litellm.proxy.auth.rds_iam_token.generate_iam_auth_token", explode)
+    monkeypatch.setenv("DATABASE_HOST", "rds.example.com")
+    monkeypatch.setenv("DATABASE_USER", "litellm")
+    monkeypatch.setenv("DATABASE_NAME", "litellm")
+    monkeypatch.setenv("DATABASE_PASSWORD", "pw")
+    monkeypatch.setenv("IAM_TOKEN_DB_AUTH", "false")
+    assert resolve_database_url() == "postgresql://litellm:pw@rds.example.com:5432/litellm"


### PR DESCRIPTION
The e2e suites share a long-lived proxy, so anything a test creates persists unless deleted. The per-test `resources` teardown covers what a test registers, but a crash before defer() or a silently failed cleanup leaks rows, and spend logs accumulate with no delete route at all.

Adds reset_database: one TRUNCATE ... RESTART IDENTITY CASCADE over every LiteLLM_* table, driven through prisma. Gated behind E2E_RESET_DATABASE=1 plus "an e2e test actually ran", matching the existing spend-log guard, so a routine local run against a shared DATABASE_URL cannot wipe it. Runs at session finish so the run's own rows stay readable while tests execute; the spend suites poll /spend/logs mid-run.

Deliberately not `prisma migrate reset`. That drops and recreates the schema, but the chart's migrations pod is a pre-install/pre-upgrade Helm hook running `migrate deploy`, so it fires on a release, not per suite run. With the suite on its own 6-hourly cron, a dropped schema would leave the next run pointing at an empty database and the gateway assumes the schema exists at startup. TRUNCATE leaves the tables and _prisma_migrations intact, so the DB stays at the migration head and the chart keeps owning migrations.

reset_spend_logs and reset_database both resolve the connection through resolve_database_url, which assembles the URL from DATABASE_HOST/PORT/USER/NAME plus a freshly minted IAM token when IAM_TOKEN_DB_AUTH is set. On RDS with IAM auth there is no durable DATABASE_URL (the proxy builds one at startup from a token that rotates every ~12 minutes), so reading DATABASE_URL alone silently fell back to the local-docker default: a no-op against RDS, and a hazard locally.

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- <blah>
- ...

How it solves it:

- <blah>
- ...

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), include proof for every single one of them, not just one
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
