### PR TITLE
fix(rate-limit): enforce token limits when the pre-call increment is zero

### DIFF
--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -1341,7 +1341,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             else:
                 limit_value = rate_limit.get("tokens_per_unit")
                 inc_amount = int(increment_amounts.get("tokens", 0) or 0)
-            if limit_value is None:
+            if limit_value is None or inc_amount < 0:
                 continue
             counter_key = self.create_rate_limit_keys(descriptor_key, descriptor_value, rlt)
             # Counter-key TTL and window_size are conceptually distinct

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -148,7 +148,13 @@ for i = 1, descriptor_count do
         current_counter = tonumber(redis.call('GET', counter_key) or 0)
     end
 
-    if current_counter + increment > limit then
+    local blocked
+    if increment > 0 then
+        blocked = current_counter + increment > limit
+    else
+        blocked = current_counter >= limit
+    end
+    if blocked then
         return { 1, i, current_counter, limit }
     end
 
@@ -1534,7 +1540,12 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                     or 0
                 )
             )
-            if current_counter + meta["increment"] > meta["current_limit"]:
+            over_limit = (
+                current_counter + meta["increment"] > meta["current_limit"]
+                if meta["increment"] > 0
+                else current_counter >= meta["current_limit"]
+            )
+            if over_limit:
                 return RateLimitResponse(
                     overall_code="OVER_LIMIT",
                     statuses=[
@@ -1596,7 +1607,16 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         shared primitive.
         """
         tpm_descriptors: List[RateLimitDescriptor] = [
-            d for d in descriptors if (d.get("rate_limit") or {}).get("tokens_per_unit") is not None
+            RateLimitDescriptor(
+                key=d["key"],
+                value=d["value"],
+                rate_limit=RateLimitDescriptorRateLimitObject(
+                    tokens_per_unit=(d.get("rate_limit") or {}).get("tokens_per_unit"),
+                    window_size=(d.get("rate_limit") or {}).get("window_size"),
+                ),
+            )
+            for d in descriptors
+            if (d.get("rate_limit") or {}).get("tokens_per_unit") is not None
         ]
         if not tpm_descriptors:
             return RateLimitResponse(overall_code="OK", statuses=[])

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -1341,7 +1341,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             else:
                 limit_value = rate_limit.get("tokens_per_unit")
                 inc_amount = int(increment_amounts.get("tokens", 0) or 0)
-            if limit_value is None or inc_amount <= 0:
+            if limit_value is None:
                 continue
             counter_key = self.create_rate_limit_keys(descriptor_key, descriptor_value, rlt)
             # Counter-key TTL and window_size are conceptually distinct

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -43,6 +43,7 @@ class KeyLoggingCallback(BaseModel):
 
 class KeyMetadata(BaseModel):
     logging: list[KeyLoggingCallback] | None = None
+    priority: str | None = None
 
 
 class ObjectPermission(BaseModel):
@@ -97,6 +98,7 @@ class LiteLLMBudgetTable(BaseModel):
 
 class KeyInfo(BaseModel):
     key_alias: str | None = None
+    metadata: KeyMetadata | None = None
     models: list[str] = []
     tpm_limit: int | None = None
     rpm_limit: int | None = None
@@ -694,6 +696,7 @@ class LiteLLMParamsBody(BaseModel):
     complexity_router_config: dict[str, object] | None = None
     mock_response: str | None = None
     timeout: float | None = None
+    tpm: int | None = None
 
 
 ModelMode = Literal["batch", "realtime", "image_generation"]

--- a/tests/e2e/quota_management/ratelimit/test_dynamic_rate_limit_priority_e2e.py
+++ b/tests/e2e/quota_management/ratelimit/test_dynamic_rate_limit_priority_e2e.py
@@ -1,0 +1,242 @@
+"""Live e2e: the v3 dynamic rate limiter's saturation-aware priority reservation.
+
+Covers quota_management.ratelimit.priority_generous / priority_strict: with
+`dynamic_rate_limiter_v3` enabled, a model's TPM capacity is split into priority
+reservations, but a reservation is only enforced once the model is saturated.
+
+- Generous mode (recorded usage below the saturation threshold): a key whose
+  priority reserves 25% of capacity keeps serving past its reservation,
+  borrowing the idle capacity (priority_generous.picks_under_tpm)
+- Strict mode (recorded usage at/over the threshold): the over-reservation key
+  is blocked with the priority-flavored 429 while a key of a different priority,
+  still inside its own reservation, is served (priority_strict.picks_under_tpm)
+
+The proxy under test must run with this config (and LITELLM_LICENSE set, since
+priority reservation is a premium feature):
+
+    litellm_settings:
+      callbacks: ["dynamic_rate_limiter_v3"]
+      priority_reservation:
+        prod: 0.5
+        dev: 0.25
+      priority_reservation_settings:
+        saturation_threshold: 0.5
+        saturation_check_cache_ttl: 1
+
+The constants below mirror those values; if the proxy runs different ones the
+tests fail with a message naming the required config rather than skipping.
+
+The limiter counts a request against the model-wide window pre-call, but tokens
+only land on the counters after each response completes (there is no pre-call
+token reservation at the model level), so recorded saturation always trails the
+traffic that produced it. The tests therefore drive spend by summing each
+body's usage.total_tokens (the counter can never be ahead of that sum) and poll
+for the strict-mode block instead of expecting it on an exact call. Each test
+creates its own /model/new deployment so its 60s rate-limit window and counters
+are isolated from concurrent runs.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import pytest
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from e2e_config import unique_marker
+from e2e_http import StreamingResponse, require_successful_call
+from lifecycle import ResourceManager
+from models import KeyGenerateBody, KeyMetadata, LiteLLMParamsBody
+from quota_client import QuotaClient
+
+pytestmark = pytest.mark.e2e
+
+BACKEND = "anthropic/claude-haiku-4-5-20251001"
+MODEL_TPM = 400
+DEV_PRIORITY = "dev"
+PROD_PRIORITY = "prod"
+DEV_RESERVED_TOKENS = int(MODEL_TPM * 0.25)
+SATURATION_TOKENS = int(MODEL_TPM * 0.5)
+CHAT_MAX_TOKENS = 16
+WINDOW_SECONDS = 60
+WINDOW_MARGIN_SECONDS = 10
+STRICT_POLL_SPEND_CEILING = int(MODEL_TPM * 0.7)
+
+REQUIRED_CONFIG_HINT = (
+    "the proxy must run litellm_settings.callbacks=['dynamic_rate_limiter_v3'] with "
+    "priority_reservation {prod: 0.5, dev: 0.25} and priority_reservation_settings "
+    "{saturation_threshold: 0.5, saturation_check_cache_ttl: 1}; see this module's docstring"
+)
+
+
+class _ChatUsage(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    total_tokens: int
+
+
+class _ChatBodyWithUsage(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    usage: _ChatUsage
+
+
+def _total_tokens(outcome: StreamingResponse) -> int:
+    try:
+        return _ChatBodyWithUsage.model_validate_json(outcome.body).usage.total_tokens
+    except ValidationError:
+        pytest.fail(f"successful chat body must report usage.total_tokens, got: {outcome.body[:300]}")
+
+
+@dataclass(frozen=True, slots=True)
+class _Fixture:
+    model: str
+    dev_key: str
+    prod_key: str
+
+
+def _dynamic_limited_model(client: QuotaClient, resources: ResourceManager, label: str) -> _Fixture:
+    model = f"e2e-dynpri-{label}-{unique_marker()}"
+    model_id = client.proxy.create_model(
+        model,
+        LiteLLMParamsBody(model=BACKEND, api_key="os.environ/ANTHROPIC_API_KEY", tpm=MODEL_TPM),
+    )
+    resources.defer(lambda: client.proxy.delete_model(model_id))
+
+    def _priority_key(priority: str) -> str:
+        key = client.proxy.generate_key(
+            KeyGenerateBody(
+                models=[model],
+                metadata=KeyMetadata(priority=priority),
+                key_alias=f"e2e-dynpri-{label}-{priority}-{unique_marker()}",
+            )
+        )
+        resources.defer(lambda: client.proxy.delete_key(key))
+        return key
+
+    return _Fixture(model=model, dev_key=_priority_key(DEV_PRIORITY), prod_key=_priority_key(PROD_PRIORITY))
+
+
+def _chat(client: QuotaClient, key: str, model: str) -> StreamingResponse:
+    return client.chat(key, model, f"reply with one word {unique_marker()}", max_tokens=CHAT_MAX_TOKENS)
+
+
+@dataclass(frozen=True, slots=True)
+class _FirstOk:
+    sent_at: float
+    response: StreamingResponse
+
+
+def _first_ok(client: QuotaClient, key: str, model: str) -> _FirstOk:
+    """First successful call on a fresh key opens the model's rate-limit window;
+    `sent_at` (captured before the winning send) is a lower bound on the window
+    start. A fresh key may briefly 401 until the auth cache picks it up, so
+    retry 401s to a deadline; a 401 never reaches the limiter, so only the
+    successful call consumes budget."""
+    deadline = time.monotonic() + client.proxy.poll_timeout
+    while True:
+        sent_at = time.monotonic()
+        outcome = _chat(client, key, model)
+        if outcome.ok:
+            return _FirstOk(sent_at=sent_at, response=outcome)
+        if outcome.status_code != 401 or time.monotonic() >= deadline:
+            require_successful_call(outcome)
+        time.sleep(client.proxy.poll_interval)
+
+
+def _window_guard(first: _FirstOk, spent: int) -> None:
+    assert time.monotonic() < first.sent_at + WINDOW_SECONDS - WINDOW_MARGIN_SECONDS, (
+        f"only {spent} tokens of spend landed before the {WINDOW_SECONDS}s rate-limit window could "
+        "roll; this test needs every call inside one window"
+    )
+
+
+class TestDynamicRateLimitPriority:
+    @pytest.mark.covers(
+        "quota_management.ratelimit.priority_generous.picks_under_tpm",
+        exercised_on=["chat_completions"],
+    )
+    def test_generous_mode_lets_priority_borrow_past_reservation(
+        self, client: QuotaClient, resources: ResourceManager
+    ) -> None:
+        fixture = _dynamic_limited_model(client, resources, "generous")
+
+        info = client.proxy.key_info(fixture.dev_key)
+        assert info.metadata is not None and info.metadata.priority == DEV_PRIORITY, (
+            f"/key/info must echo the key's priority metadata, got {info.metadata}"
+        )
+
+        first = _first_ok(client, fixture.dev_key, fixture.model)
+        spent = _total_tokens(first.response)
+        while spent <= DEV_RESERVED_TOKENS:
+            _window_guard(first, spent)
+            assert spent < SATURATION_TOKENS, (
+                f"spend reached the saturation threshold ({spent} of {SATURATION_TOKENS}) before "
+                f"crossing the dev reservation ({DEV_RESERVED_TOKENS}); shrink per-call spend to "
+                "keep the borrowing claim observable"
+            )
+            outcome = _chat(client, fixture.dev_key, fixture.model)
+            assert outcome.status_code != 429, (
+                f"dev key was blocked at {spent} recorded tokens, under the saturation threshold "
+                f"({SATURATION_TOKENS} of {MODEL_TPM}); generous mode must let it borrow past its "
+                f"{DEV_RESERVED_TOKENS}-token reservation. If the limiter is missing entirely, "
+                f"{REQUIRED_CONFIG_HINT}. 429 body: {outcome.body[:300]}"
+            )
+            require_successful_call(outcome)
+            spent += _total_tokens(outcome)
+
+        assert spent > DEV_RESERVED_TOKENS
+
+    @pytest.mark.covers(
+        "quota_management.ratelimit.priority_strict.picks_under_tpm",
+        exercised_on=["chat_completions"],
+    )
+    def test_strict_mode_blocks_saturated_priority_but_serves_the_other(
+        self, client: QuotaClient, resources: ResourceManager
+    ) -> None:
+        fixture = _dynamic_limited_model(client, resources, "strict")
+
+        prod_warmup = _first_ok(client, fixture.prod_key, fixture.model)
+        first = _first_ok(client, fixture.dev_key, fixture.model)
+        prod_spent = _total_tokens(prod_warmup.response)
+        dev_spent = _total_tokens(first.response)
+
+        while prod_spent + dev_spent < SATURATION_TOKENS:
+            _window_guard(prod_warmup, prod_spent + dev_spent)
+            outcome = _chat(client, fixture.dev_key, fixture.model)
+            assert outcome.status_code != 429, (
+                f"dev key was blocked at {prod_spent + dev_spent} recorded tokens, before the "
+                f"saturation threshold ({SATURATION_TOKENS} of {MODEL_TPM}); strict enforcement "
+                f"must not engage early. 429 body: {outcome.body[:300]}"
+            )
+            require_successful_call(outcome)
+            dev_spent += _total_tokens(outcome)
+
+        while True:
+            _window_guard(prod_warmup, prod_spent + dev_spent)
+            assert prod_spent + dev_spent < STRICT_POLL_SPEND_CEILING, (
+                f"dev key was still served at {prod_spent + dev_spent} tokens, past the saturation "
+                f"threshold ({SATURATION_TOKENS}) and {DEV_RESERVED_TOKENS}-token dev reservation; "
+                f"strict priority enforcement never engaged. Check that {REQUIRED_CONFIG_HINT}"
+            )
+            outcome = _chat(client, fixture.dev_key, fixture.model)
+            if outcome.status_code == 429:
+                assert "Priority-based rate limit exceeded" in outcome.body, (
+                    f"the saturated dev key must get the priority-flavored 429, got: {outcome.body[:300]}"
+                )
+                assert outcome.headers.get("x-litellm-priority") == DEV_PRIORITY, (
+                    f"the 429 must attribute the blocked priority, headers: "
+                    f"{ {k: v for k, v in outcome.headers.items() if 'litellm' in k} }"
+                )
+                break
+            require_successful_call(outcome)
+            dev_spent += _total_tokens(outcome)
+
+        prod_outcome = _chat(client, fixture.prod_key, fixture.model)
+        require_successful_call(prod_outcome)
+        prod_spent += _total_tokens(prod_outcome)
+        assert prod_spent < int(MODEL_TPM * 0.5), (
+            f"the prod fairness claim needs prod spend ({prod_spent}) inside its reservation "
+            f"({int(MODEL_TPM * 0.5)}); shrink per-call spend"
+        )

--- a/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_dynamic_rate_limiter_v3.py
@@ -1771,3 +1771,95 @@ async def test_priority_429_includes_model_name_and_configured_limits():
     assert "Priority: prod" in error_msg, error_msg
     assert "Rate limit type: tokens" in error_msg, error_msg
     assert "Model saturation:" in error_msg, error_msg
+
+
+@pytest.mark.asyncio
+async def test_tpm_only_model_enforces_priority_and_model_capacity():
+    """Regression: a model configured with ONLY tpm (no rpm) must still be
+    rate limited.
+
+    The atomic check-and-increment path used to drop any counter whose
+    pre-call increment was zero. Token increments are always zero pre-call
+    (usage lands on the counters post-call), so on a TPM-only model the
+    limiter evaluated no counters at all: no model-wide cap, no priority
+    reservation, in either mode. This test drives the real pre-call ->
+    log-success -> pre-call flow with no limiter internals mocked.
+    """
+    from fastapi import HTTPException
+
+    from litellm.types.utils import ModelResponse, Usage
+
+    os.environ["LITELLM_LICENSE"] = "test-license-key"
+    litellm.priority_reservation = {"dev": 0.25, "prod": 0.5}
+
+    dual_cache = DualCache()
+    handler = DynamicRateLimitHandler(internal_usage_cache=dual_cache)
+
+    model = "tpm-only-model"
+    llm_router = Router(
+        model_list=[
+            {
+                "model_name": model,
+                "litellm_params": {
+                    "model": "gpt-3.5-turbo",
+                    "api_key": "test-key",
+                    "api_base": "test-base",
+                    "tpm": 400,
+                },
+            }
+        ]
+    )
+    handler.update_variables(llm_router=llm_router)
+
+    dev_user = UserAPIKeyAuth()
+    dev_user.metadata = {"priority": "dev"}
+    prod_user = UserAPIKeyAuth()
+    prod_user.metadata = {"priority": "prod"}
+
+    async def record_usage(priority: str, total_tokens: int) -> None:
+        await handler.async_log_success_event(
+            kwargs={
+                "standard_logging_object": {
+                    "metadata": {"user_api_key_auth_metadata": {"priority": priority}},
+                },
+                "litellm_params": {"metadata": {"model_group": model}},
+            },
+            response_obj=ModelResponse(
+                model=model,
+                usage=Usage(prompt_tokens=0, completion_tokens=total_tokens, total_tokens=total_tokens),
+            ),
+            start_time=None,
+            end_time=None,
+        )
+
+    assert (
+        await handler.async_pre_call_hook(
+            user_api_key_dict=dev_user, cache=dual_cache, data={"model": model}, call_type="completion"
+        )
+        is None
+    )
+
+    await record_usage("dev", 250)
+
+    with pytest.raises(HTTPException) as dev_blocked:
+        await handler.async_pre_call_hook(
+            user_api_key_dict=dev_user, cache=dual_cache, data={"model": model}, call_type="completion"
+        )
+    assert dev_blocked.value.status_code == 429
+    assert "Priority-based rate limit exceeded" in dev_blocked.value.detail["error"]
+
+    assert (
+        await handler.async_pre_call_hook(
+            user_api_key_dict=prod_user, cache=dual_cache, data={"model": model}, call_type="completion"
+        )
+        is None
+    )
+
+    await record_usage("prod", 200)
+
+    with pytest.raises(HTTPException) as capacity_blocked:
+        await handler.async_pre_call_hook(
+            user_api_key_dict=prod_user, cache=dual_cache, data={"model": model}, call_type="completion"
+        )
+    assert capacity_blocked.value.status_code == 429
+    assert "Model capacity reached" in capacity_blocked.value.detail["error"]

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -5035,17 +5035,20 @@ async def test_atomic_check_with_zero_increment_still_enforces_token_limit():
     await handler.async_increment_tokens_with_ttl_preservation(
         pipeline_operations=[
             RedisPipelineIncrementOperation(
-                key=counter_key, increment_value=150, ttl=60
+                key=counter_key, increment_value=100, ttl=60
             )
         ],
     )
 
-    over_limit = await handler.atomic_check_and_increment_by_n(
+    at_limit = await handler.atomic_check_and_increment_by_n(
         descriptors=[descriptor],
         increments=[zero_token_increment],
     )
-    assert over_limit["overall_code"] == "OVER_LIMIT"
-    blocked = over_limit["statuses"][0]
+    assert at_limit["overall_code"] == "OVER_LIMIT", (
+        "a check-only pass must block once recorded usage reaches the limit, "
+        "matching RPM's >= semantics; > would leak one extra request"
+    )
+    blocked = at_limit["statuses"][0]
     assert blocked["rate_limit_type"] == "tokens"
     assert blocked["current_limit"] == 100
 
@@ -5053,7 +5056,7 @@ async def test_atomic_check_with_zero_increment_still_enforces_token_limit():
         await handler.internal_usage_cache.async_get_cache(
             key=counter_key, litellm_parent_otel_span=None, local_only=True
         )
-        == 150
+        == 100
     )
 
     negative_increment: Dict[str, int] = {"requests": -1, "tokens": -50}
@@ -5067,5 +5070,33 @@ async def test_atomic_check_with_zero_increment_still_enforces_token_limit():
         await handler.internal_usage_cache.async_get_cache(
             key=counter_key, litellm_parent_otel_span=None, local_only=True
         )
-        == 150
+        == 100
     )
+
+
+@pytest.mark.asyncio
+async def test_reserve_tpm_tokens_never_evaluates_the_requests_dimension():
+    """The reservation path deliberately leaves RPM to the separate
+    should_rate_limit pass. Now that zero-increment counters are checked
+    instead of skipped, reserve_tpm_tokens must strip requests_per_unit from
+    its descriptors or an exhausted RPM budget would double-enforce here."""
+    from litellm.proxy.hooks.parallel_request_limiter_v3 import RateLimitDescriptor
+
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(DualCache())
+    )
+    descriptor = RateLimitDescriptor(
+        key="api_key",
+        value="reserve-test-key",
+        rate_limit={"requests_per_unit": 0, "tokens_per_unit": 1000, "window_size": 60},
+    )
+
+    response = await handler.reserve_tpm_tokens(
+        descriptors=[descriptor],
+        estimated_tokens=10,
+    )
+    assert response["overall_code"] == "OK", (
+        "an exhausted requests budget (limit 0) must not block the token "
+        f"reservation pass, got: {response}"
+    )
+    assert [s["rate_limit_type"] for s in response["statuses"]] == ["tokens"]

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -4998,3 +4998,60 @@ async def test_split_usage_still_respects_the_configured_limit_type(monkeypatch)
     token_operations = [op for op in captured_operations if op["key"].endswith(":tokens")]
     assert token_operations
     assert all(op["increment_value"] == 7 for op in token_operations)
+
+
+@pytest.mark.asyncio
+async def test_atomic_check_with_zero_increment_still_enforces_token_limit():
+    """Regression: a zero token increment must still CHECK the token limit.
+
+    The dynamic rate limiter calls atomic_check_and_increment_by_n with
+    {"requests": 1, "tokens": 0} because tokens land on the counter post-call.
+    The payload builder used to skip any counter whose increment was <= 0, so a
+    TPM-only descriptor produced zero counters to evaluate and the call
+    returned OK with empty statuses; TPM limits were never enforced at all.
+    """
+    from litellm.proxy.hooks.parallel_request_limiter_v3 import RateLimitDescriptor
+
+    handler = _PROXY_MaxParallelRequestsHandler(
+        internal_usage_cache=InternalUsageCache(DualCache())
+    )
+    descriptor = RateLimitDescriptor(
+        key="model_saturation_check",
+        value="tpm-only-model",
+        rate_limit={"tokens_per_unit": 100, "window_size": 60},
+    )
+    zero_token_increment: Dict[str, int] = {"requests": 1, "tokens": 0}
+
+    under_limit = await handler.atomic_check_and_increment_by_n(
+        descriptors=[descriptor],
+        increments=[zero_token_increment],
+    )
+    assert under_limit["overall_code"] == "OK"
+    assert [s["rate_limit_type"] for s in under_limit["statuses"]] == ["tokens"]
+
+    counter_key = handler.create_rate_limit_keys(
+        "model_saturation_check", "tpm-only-model", "tokens"
+    )
+    await handler.async_increment_tokens_with_ttl_preservation(
+        pipeline_operations=[
+            RedisPipelineIncrementOperation(
+                key=counter_key, increment_value=150, ttl=60
+            )
+        ],
+    )
+
+    over_limit = await handler.atomic_check_and_increment_by_n(
+        descriptors=[descriptor],
+        increments=[zero_token_increment],
+    )
+    assert over_limit["overall_code"] == "OVER_LIMIT"
+    blocked = over_limit["statuses"][0]
+    assert blocked["rate_limit_type"] == "tokens"
+    assert blocked["current_limit"] == 100
+
+    assert (
+        await handler.internal_usage_cache.async_get_cache(
+            key=counter_key, litellm_parent_otel_span=None, local_only=True
+        )
+        == 150
+    )

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -5055,3 +5055,17 @@ async def test_atomic_check_with_zero_increment_still_enforces_token_limit():
         )
         == 150
     )
+
+    negative_increment: Dict[str, int] = {"requests": -1, "tokens": -50}
+    refund_attempt = await handler.atomic_check_and_increment_by_n(
+        descriptors=[descriptor],
+        increments=[negative_increment],
+    )
+    assert refund_attempt["overall_code"] == "OK"
+    assert refund_attempt["statuses"] == []
+    assert (
+        await handler.internal_usage_cache.async_get_cache(
+            key=counter_key, litellm_parent_otel_span=None, local_only=True
+        )
+        == 150
+    )


### PR DESCRIPTION
## TLDR

Problem this solves:

- TPM-only models were never rate limited by the v3 dynamic rate limiter
- Model-wide TPM cap and priority reservations both silently skipped
- Customers testing reserved quota saw teams blow past model capacity

How it solves it:

- Zero-increment token counters now run as a pure limit check
- Restores the pre-regression semantics of the read-only check phase

## Relevant issues

## Linear ticket

Resolves LIT-4800

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs against a live local proxy (`litellm --config <config> --port 4010`) with this config, hitting the real Anthropic API:

```yaml
litellm_settings:
  callbacks: ["dynamic_rate_limiter_v3"]
  priority_reservation:
    prod: 0.5
    dev: 0.25
  priority_reservation_settings:
    saturation_threshold: 0.5
    saturation_check_cache_ttl: 1
general_settings:
  master_key: sk-1234
  store_model_in_db: true
```

### Before (code identical to base 8ccbc3e735 for this path; fix reverted in the working tree)

A model with `tpm: 400` and a `dev` key whose priority reserves 25% (100 tokens). 28 calls in one window, every single one served; the proxy's own saturation log shows the model past 100% of its TPM with the dev key still being admitted

```
$ curl -s http://localhost:4010/model/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model_name": "haiku-tpm-before", "litellm_params": {"model": "anthropic/claude-haiku-4-5-20251001", "api_key": "os.environ/ANTHROPIC_API_KEY", "tpm": 400}}'
$ DEV_KEY=$(curl -s http://localhost:4010/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"models": ["haiku-tpm-before"], "metadata": {"priority": "dev"}}' | jq -r .key)
$ for i in $(seq 1 28); do curl -s -o /dev/null -w "dev call $i -> HTTP %{http_code}\n" http://localhost:4010/v1/chat/completions \
    -H "Authorization: Bearer $DEV_KEY" -H "Content-Type: application/json" \
    -d '{"model": "haiku-tpm-before", "messages": [{"role": "user", "content": "reply with one word"}], "max_tokens": 16}'; done
dev call 1 -> HTTP 200
...
dev call 28 -> HTTP 200        # all 28 are 200, zero 429s
```

Proxy log at the same moment:

```
17:16:49 - LiteLLM Proxy:DEBUG: Model haiku-tpm-before overall saturation: 103.0%
17:16:49 - LiteLLM Proxy:DEBUG: [Dynamic Rate Limiter] Model=haiku-tpm-before, Saturation=103.0%, Threshold=50.0%, Priority=dev
```

### After (d640ace6d8)

Same scenario. The dev key borrows idle capacity while the model is under the 50% saturation threshold (14 calls served), then gets the priority 429 once saturated past its reservation, while a fresh `prod` key is still served

```
$ for i in $(seq 1 14); do curl -s -o /dev/null -w "dev call $i -> HTTP %{http_code}\n" http://localhost:4010/v1/chat/completions \
    -H "Authorization: Bearer $DEV_KEY" -H "Content-Type: application/json" \
    -d '{"model": "haiku-tpm-demo", "messages": [{"role": "user", "content": "reply with one word"}], "max_tokens": 16}'; done
dev call 1 -> HTTP 200
...
dev call 14 -> HTTP 200

$ curl -s http://localhost:4010/v1/chat/completions -H "Authorization: Bearer $DEV_KEY" -H "Content-Type: application/json" \
    -d '{"model": "haiku-tpm-demo", "messages": [{"role": "user", "content": "reply with one word"}], "max_tokens": 16}'
{"error":{"message":"Priority-based rate limit exceeded. Model: haiku-tpm-demo, Priority: dev, Rate limit type: tokens, Model TPM: 400, Model RPM: not configured, Remaining: 0, Model saturation: 52.8%","type":"throttling_error","param":null,"code":"429",...}}

$ curl -s -o /dev/null -w "prod call -> HTTP %{http_code}\n" http://localhost:4010/v1/chat/completions \
    -H "Authorization: Bearer $PROD_KEY" -H "Content-Type: application/json" \
    -d '{"model": "haiku-tpm-demo", "messages": [{"role": "user", "content": "reply with one word"}], "max_tokens": 16}'
prod call -> HTTP 200
```

New e2e suite against the same live proxy at d640ace6d8:

```
$ LITELLM_PROXY_URL=http://localhost:4010 uv run pytest tests/e2e/quota_management/ratelimit/test_dynamic_rate_limit_priority_e2e.py -v
tests/e2e/quota_management/ratelimit/test_dynamic_rate_limit_priority_e2e.py::TestDynamicRateLimitPriority::test_generous_mode_lets_priority_borrow_past_reservation PASSED
tests/e2e/quota_management/ratelimit/test_dynamic_rate_limit_priority_e2e.py::TestDynamicRateLimitPriority::test_strict_mode_blocks_saturated_priority_but_serves_the_other PASSED
============================== 2 passed in 16.71s ==============================
```

### Live QA: the reported two-team reserved-quota scenario, before vs after

This reproduces the scenario from LIT-4800's originating report: two teams share one model, each team reserved a 50% floor, team A demanding more than full capacity every minute while team B asks for 50% or 40% of it. Run against a live proxy on this branch with `priority_reservation: {team_a: 0.5, team_b: 0.5}` and `saturation_threshold: 0.5`; the model is `tpm: 1000` so a single completion is not the whole budget. Each minute runs as its own fresh 60s window; traffic is paced curl loops (team A one request per second, team B paced to its requested rate), tallying `usage.total_tokens` on 200s and classifying 429 bodies. These supplementary rows use `mock_response` deployments so every call is a deterministic 30 tokens and the runs cost nothing; the rate-limiter path (pre-call atomic check, post-call token accounting) is identical to the real-API proof above, which remains the primary evidence

Before, with the fix reverted in the working tree (limiter code identical to base 8ccbc3e735); nothing is ever blocked, the model serves 156% of its TPM to a lone team and 213% under contention:

```
A alone (wants 100%+):      team_a served 1560 of 1000 TPM, 52 ok, 0x 429
A wants 100%+, B wants 50%: team_a served 1590, 53 ok, 0x 429
                            team_b served  540, 18 ok, 0x 429   (2130 total on a 1000 TPM model)
```

After, at 334805990c; every minute row measured:

| Minute | A demand | B demand | A served | B served | A 429s | B 429s |
|---|---|---|---|---|---|---|
| 1 | 100%+ | | 510 | | 36 priority | |
| 2 | 100%+ | 50% | 510 | 510 | 28 priority, 6 capacity | 1 capacity |
| 3 | 100%+ | | 510 | | 36 priority | |
| 4 | 100%+ | 40% | 510 | 420 | 35 priority | 0 |
| 5 | 100%+ | | 510 | | 34 priority | |

Total served per contended minute is capped at ~102% of the model TPM (the 2% is one in-flight 30-token call per team, expected from post-call token accounting); minute 2 splits 50/50 and in minute 4 team B gets its full 40% with zero 429s. A team alone serves its reservation plus one call, not full capacity, because model-wide saturation crosses the 50% threshold and strict mode engages against the lone team's own usage; capacity borrowing above `max(reservation, saturation_threshold)` is not reachable by design. Raising the threshold trades floor protection for borrowing, measured at `saturation_threshold: 0.8` on the same branch:

```
A alone (wants 100%+):      team_a served 810 (borrows to the 80% threshold)
A wants 100%+, B wants 50%: team_a served 600, team_b served 420
                            (A's generous-mode grab is not clawed back; B also hits the model cap)
```

## Type

🐛 Bug Fix
✅ Test

## Changes

`_build_descriptor_atomic_payload` in `parallel_request_limiter_v3.py` skipped any counter whose pre-call increment was `<= 0`. The dynamic rate limiter always passes `{"requests": 1, "tokens": 0}` pre-call because token usage lands on the counters only after the response completes, so on a model configured with only `tpm` (no `rpm`) both descriptors produced zero counters to evaluate and every atomic check returned `OK` with empty statuses. The model-wide TPM cap and the priority reservations were never enforced, in either generous or strict mode. This regressed in dd57ae6691 when the pre-call flow moved from the read-only `should_rate_limit` check (which evaluated token limits without an increment) to the atomic check-and-increment path

The fix keeps zero-increment counters in the payload so they act as a pure check, and per the constraints in LIT-4800 a check-only counter blocks at `current >= limit` (matching RPM's semantics; plain `>` would let a pool sitting exactly at its reservation admit one extra request) while incrementing counters keep `current + increment > limit`. Both the Redis Lua and in-memory paths implement the same rule, and a zero increment is a no-op write so counters stay accurate. Negative increments stay excluded (per review) so malformed input cannot decrement counters; the primitive test asserts they neither check nor mutate. `reserve_tpm_tokens` now rebuilds its descriptors with only `tokens_per_unit`, keeping the requests dimension out of the reservation pass, which deliberately leaves RPM to the separate `should_rate_limit` check; `test_reserve_tpm_tokens_never_evaluates_the_requests_dimension` pins that

Tests added:

- `test_atomic_check_with_zero_increment_still_enforces_token_limit` (primitive level): a TPM-only descriptor with a zero token increment must be checked, and the pure check must not mutate the counter. Fails on the pre-fix code
- `test_tpm_only_model_enforces_priority_and_model_capacity` (hook level): drives the real pre-call, log-success, pre-call flow with no limiter internals mocked, asserting both the priority 429 and the model-capacity 429 on a TPM-only model. The existing unit tests all configured `rpm` or mocked `atomic_check_and_increment_by_n`, which is how this escaped
- `test_dynamic_rate_limit_priority_e2e.py`: live e2e covering the previously uncovered `quota_management.ratelimit.priority_generous.picks_under_tpm` and `priority_strict.picks_under_tpm` registry rows
- `tests/e2e/models.py`: adds `KeyMetadata.priority`, `KeyInfo.metadata`, and `LiteLLMParamsBody.tpm` typed fields the new e2e test needs

## QA runbook

Environment prerequisites: a live proxy started with the config shown in the proof section, `LITELLM_LICENSE`, `DATABASE_URL`, and `ANTHROPIC_API_KEY` set. Each test creates its own model via `/model/new` so counters and the 60s window are isolated; a full manual pass must finish inside one window

- tests/e2e/quota_management/ratelimit/test_dynamic_rate_limit_priority_e2e.py::TestDynamicRateLimitPriority::test_generous_mode_lets_priority_borrow_past_reservation - a key whose priority reserves 25% of a 400 TPM model keeps serving past 100 tokens while the model is under 50% saturation
  - [ ] POST /model/new with the master key: `{"model_name": "qa-dynpri", "litellm_params": {"model": "anthropic/claude-haiku-4-5-20251001", "api_key": "os.environ/ANTHROPIC_API_KEY", "tpm": 400}}`
  - [ ] POST /key/generate: `{"models": ["qa-dynpri"], "metadata": {"priority": "dev"}}`
  - [ ] GET /key/info for that key and expect metadata.priority == "dev"
  - [ ] Send /v1/chat/completions calls (max_tokens 16, short prompt) with the dev key, summing usage.total_tokens, until the sum passes 100
  - [ ] Expect every call to return 200 (no 429) even though the dev reservation is 100 tokens
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
- tests/e2e/quota_management/ratelimit/test_dynamic_rate_limit_priority_e2e.py::TestDynamicRateLimitPriority::test_strict_mode_blocks_saturated_priority_but_serves_the_other - once the model passes 50% saturation the over-reservation dev key gets the priority 429 while a prod key inside its reservation is still served
  - [ ] Create a fresh model and a dev key and a prod key as above
  - [ ] Send one prod call (warmup), then dev calls until combined usage.total_tokens passes 200
  - [ ] Keep sending dev calls and expect a 429 whose body contains "Priority-based rate limit exceeded" and whose x-litellm-priority header is "dev", before combined spend reaches 280
  - [ ] Immediately send a prod call and expect 200
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
