### PR TITLE
fix(router): remove stale wildcard deployments from pattern_router on upsert/delete

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8380,6 +8380,8 @@ class Router:
             public_model_name for _, public_model_name in self.team_model_to_deployment_indices
         )
 
+        self.pattern_router.remove_deployment(model_id)
+
         for team_id in list(self.team_pattern_routers.keys()):
             team_pattern_router = self.team_pattern_routers[team_id]
             team_pattern_router.remove_deployment(model_id)

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1707,6 +1707,51 @@ def test_get_model_access_groups_cache_invalidation_upsert_deployment():
     assert "updated-group" in result2
 
 
+def test_upsert_deployment_replaces_wildcard_pattern_router_entry():
+    from litellm.types.router import Deployment, LiteLLM_Params
+
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "anthropic/*",
+                "litellm_params": {"model": "anthropic/*", "api_key": "old-key"},
+                "model_info": {"id": "wildcard-deployment-id"},
+            },
+        ]
+    )
+
+    upserted = router.upsert_deployment(
+        Deployment(
+            model_name="anthropic/*",
+            litellm_params=LiteLLM_Params(model="anthropic/*", api_key="new-key"),
+            model_info={"id": "wildcard-deployment-id"},
+        )
+    )
+
+    assert upserted is not None
+    pattern_deployments = [
+        deployment for deployments in router.pattern_router.patterns.values() for deployment in deployments
+    ]
+    assert len(pattern_deployments) == 1
+    assert pattern_deployments[0]["litellm_params"]["api_key"] == "new-key"
+
+
+def test_delete_deployment_removes_wildcard_pattern_router_entry():
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "anthropic/*",
+                "litellm_params": {"model": "anthropic/*", "api_key": "old-key"},
+                "model_info": {"id": "wildcard-deployment-id"},
+            },
+        ]
+    )
+
+    router.delete_deployment(id="wildcard-deployment-id")
+
+    assert router.pattern_router.patterns == {}
+
+
 @pytest.mark.asyncio
 async def test_acompletion_streaming_iterator():
     """Test _acompletion_streaming_iterator for normal streaming and fallback behavior."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Editing a wildcard deployment leaves its old copy in the pattern router
- After an api_key rotation, wildcard traffic randomly uses the retired key
- Deleting a wildcard deployment keeps serving it via pattern routes

How it solves it:

- `_update_deployment_indices_after_removal` now cleans the main `pattern_router`
- Mirrors the existing `team_pattern_routers` cleanup; covers upsert and delete

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

We hit this in production on an internal proxy deployment: rotating the api_key of a DB-stored `anthropic/*` deployment left every pod with two pattern-router copies of the deployment (retired key and new key), so roughly half of all wildcard traffic kept failing with the old key's error until the pods were restarted

Reproduction against a live proxy (`STORE_MODEL_IN_DB=True`, real Anthropic API calls). Create a wildcard deployment with a deliberately invalid key, rotate it to a valid key via `/model/update`, then send 12 requests per endpoint with `num_retries: 0`

```bash
curl -s -X POST http://127.0.0.1:24817/model/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model_name":"anthropic/*","litellm_params":{"model":"anthropic/*","api_key":"sk-ant-api03-BAD-KEY-simulates-drained-org"},"model_info":{"id":"wildcard-demo"}}'

curl -s -X POST http://127.0.0.1:24817/model/update -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model_name":"anthropic/*","litellm_params":{"model":"anthropic/*","api_key":"os.environ/ANTHROPIC_API_KEY"},"model_info":{"id":"wildcard-demo"}}'

for i in $(seq 1 12); do curl -s -X POST http://127.0.0.1:24817/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"anthropic/claude-haiku-4-5","max_tokens":16,"num_retries":0,"messages":[{"role":"user","content":"Say ok"}]}' \
  | jq -r 'if .error then "FAIL" else "OK" end'; done | sort | uniq -c
# same loop against /v1/messages and /v1/responses
```

Before (f3f14cc0cf, pre-fix): every endpoint keeps flapping onto the retired key long after the rotation

```text
== /v1/chat/completions ==
   6 FAIL
   6 OK
== /v1/messages ==
   8 FAIL
   4 OK
== /v1/responses ==
   6 FAIL
   6 OK
```

Failures are all `litellm.AuthenticationError: AnthropicException - {"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}`, i.e. the pre-rotation key

After (captured at f58f364d1b; the branch was later rebuilt onto the staging base as eef10bf006 with an identical diff), identical sequence:

```text
== /v1/chat/completions ==
  12 OK
== /v1/messages ==
  12 OK
== /v1/responses ==
  12 OK
```

## Type

🐛 Bug Fix

## Changes

Wildcard deployments (`model_name` containing `*`) are registered twice: in `model_list` and as a serialized copy inside `PatternMatchRouter.patterns`. `Router.upsert_deployment` and `Router.delete_deployment` removed the `model_list` entry and cleaned the team pattern routers via `_update_deployment_indices_after_removal`, but never the main `pattern_router`, so the stale copy kept matching wildcard requests; after an upsert the pattern list held both the old and the new copy under the same deployment id and simple-shuffle alternated between them

The fix adds `self.pattern_router.remove_deployment(model_id)` to `_update_deployment_indices_after_removal`, right next to the existing team pattern router cleanup, which covers both the upsert and delete paths. Regression tests in `tests/test_litellm/test_router.py` assert that after an upsert exactly one pattern copy remains (carrying the new key) and that after a delete the pattern registry is empty; both fail on the pre-fix code

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
