### PR TITLE
feat(search): add Aliyun IQS search provider (UnifiedSearch)

### DIFF
--- a/litellm/llms/aliyun_iqs/search/__init__.py
+++ b/litellm/llms/aliyun_iqs/search/__init__.py
@@ -1,0 +1,7 @@
+"""
+Aliyun IQS Search API module.
+"""
+
+from litellm.llms.aliyun_iqs.search.transformation import AliyunIQSSearchConfig
+
+__all__ = ["AliyunIQSSearchConfig"]

--- a/litellm/llms/aliyun_iqs/search/__init__.py
+++ b/litellm/llms/aliyun_iqs/search/__init__.py
@@ -4,4 +4,4 @@ Aliyun IQS Search API module.
 
 from litellm.llms.aliyun_iqs.search.transformation import AliyunIQSSearchConfig
 
-__all__ = ["AliyunIQSSearchConfig"]
+__all__ = ["AliyunIQSSearchConfig"]  # mutable-ok: module export list

--- a/litellm/llms/aliyun_iqs/search/transformation.py
+++ b/litellm/llms/aliyun_iqs/search/transformation.py
@@ -5,7 +5,7 @@ Aliyun IQS (Information Query Service) UnifiedSearch API Reference:
 https://help.aliyun.com/zh/document_detail/2883041.html
 """
 
-from typing import Dict, List, Optional, TypedDict, Union
+from typing import Optional, TypedDict, Union
 
 import httpx
 
@@ -45,11 +45,11 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
 
     def validate_environment(
         self,
-        headers: Dict,
+        headers: dict,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         **kwargs,
-    ) -> Dict:
+    ) -> dict:
         """
         Validate environment and return headers.
         """
@@ -70,7 +70,7 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
         self,
         api_base: Optional[str],
         optional_params: dict,
-        data: Optional[Union[Dict, List[Dict]]] = None,
+        data: Optional[Union[dict, list[dict]]] = None,
         **kwargs,
     ) -> str:
         """
@@ -86,10 +86,10 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
 
     def transform_search_request(
         self,
-        query: Union[str, List[str]],
+        query: Union[str, list[str]],
         optional_params: dict,
         **kwargs,
-    ) -> Dict:
+    ) -> dict:
         """
         Transform Search request to Aliyun IQS UnifiedSearch API format.
 

--- a/litellm/llms/aliyun_iqs/search/transformation.py
+++ b/litellm/llms/aliyun_iqs/search/transformation.py
@@ -1,0 +1,178 @@
+"""
+Calls Aliyun IQS UnifiedSearch endpoint to search the web.
+
+Aliyun IQS (Information Query Service) UnifiedSearch API Reference:
+https://help.aliyun.com/zh/document_detail/2883041.html
+"""
+
+from typing import Dict, List, Optional, TypedDict, Union
+
+import httpx
+
+from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
+from litellm.llms.base_llm.search.transformation import (
+    BaseSearchConfig,
+    SearchResponse,
+    SearchResult,
+)
+from litellm.secret_managers.main import get_secret_str
+
+
+class _AliyunIQSSearchRequestRequired(TypedDict):
+    """Required fields for Aliyun IQS UnifiedSearch API request."""
+
+    query: str  # Required - search query (1-500 chars)
+
+
+class AliyunIQSSearchRequest(_AliyunIQSSearchRequestRequired, total=False):
+    """
+    Aliyun IQS UnifiedSearch API request format.
+    Based on: https://help.aliyun.com/zh/document_detail/2883041.html
+    """
+
+    engineType: str  # Optional - Generic (default) / GenericAdvanced / LiteAdvanced / Deep
+    timeRange: str  # Optional - OneDay / OneWeek / OneMonth / OneYear / NoLimit (default)
+    category: str  # Optional - industry category (finance, law, medical, ...)
+    advancedParams: dict  # Optional - numResults (1-50), start/endPublishedDate, ...
+
+
+class AliyunIQSSearchConfig(BaseSearchConfig):
+    ALIYUN_IQS_API_BASE = "https://cloud-iqs.aliyuncs.com"
+
+    @staticmethod
+    def ui_friendly_name() -> str:
+        return "Aliyun IQS"
+
+    def validate_environment(
+        self,
+        headers: Dict,
+        api_key: Optional[str] = None,
+        api_base: Optional[str] = None,
+        **kwargs,
+    ) -> Dict:
+        """
+        Validate environment and return headers.
+        """
+        api_key = self.resolve_server_api_key(
+            caller_api_key=api_key,
+            caller_api_base=api_base,
+            key_env_vars=("ALIYUN_IQS_API_KEY",),
+            base_env_var="ALIYUN_IQS_API_BASE",
+            default_api_base=self.ALIYUN_IQS_API_BASE,
+        )
+        if not api_key:
+            raise ValueError(
+                "ALIYUN_IQS_API_KEY is not set. Set `ALIYUN_IQS_API_KEY` environment variable."
+            )
+        headers["Authorization"] = f"Bearer {api_key}"
+        headers["Content-Type"] = "application/json"
+        return headers
+
+    def get_complete_url(
+        self,
+        api_base: Optional[str],
+        optional_params: dict,
+        data: Optional[Union[Dict, List[Dict]]] = None,
+        **kwargs,
+    ) -> str:
+        """
+        Get complete URL for Search endpoint.
+        """
+        api_base = (
+            api_base
+            or get_secret_str("ALIYUN_IQS_API_BASE")
+            or self.ALIYUN_IQS_API_BASE
+        )
+
+        # Append "/search/unified" to the api base if it's not already there
+        if not api_base.endswith("/search/unified"):
+            api_base = f"{api_base}/search/unified"
+
+        return api_base
+
+    def transform_search_request(
+        self,
+        query: Union[str, List[str]],
+        optional_params: dict,
+        **kwargs,
+    ) -> Dict:
+        """
+        Transform Search request to Aliyun IQS UnifiedSearch API format.
+
+        Args:
+            query: Search query (string or list of strings). IQS only supports single string queries.
+            optional_params: Optional parameters for the request
+                - max_results: Maximum number of search results (1-50) -> maps to advancedParams.numResults
+                - engineType: Search engine type (default 'Generic')
+                - timeRange: Time range filter ('OneDay', 'OneWeek', 'OneMonth', 'OneYear', 'NoLimit')
+                - category: Industry category ('finance', 'law', 'medical', ...)
+
+        Returns:
+            Dict with typed request data following AliyunIQSSearchRequest spec
+        """
+        if isinstance(query, list):
+            # IQS only supports single string queries
+            query = " ".join(query)
+
+        request_data: AliyunIQSSearchRequest = {
+            "query": query,
+            "engineType": optional_params.get("engineType", "Generic"),
+        }
+
+        # Transform Perplexity unified spec parameters to IQS format
+        if "max_results" in optional_params:
+            request_data["advancedParams"] = {
+                "numResults": optional_params["max_results"],
+            }
+
+        # Convert to dict before dynamic key assignments
+        result_data = dict(request_data)
+
+        # pass through all other parameters as-is
+        for param, value in optional_params.items():
+            if param not in self.get_supported_perplexity_optional_params() and param not in result_data:
+                result_data[param] = value
+
+        return result_data
+
+    def transform_search_response(
+        self,
+        raw_response: httpx.Response,
+        logging_obj: LiteLLMLoggingObj,
+        **kwargs,
+    ) -> SearchResponse:
+        """
+        Transform Aliyun IQS UnifiedSearch API response to LiteLLM unified SearchResponse format.
+
+        IQS → LiteLLM mappings:
+        - pageItems[].title → SearchResult.title
+        - pageItems[].link → SearchResult.url
+        - pageItems[].snippet (fallback: summary) → SearchResult.snippet
+        - pageItems[].publishedTime → SearchResult.date
+        - No last_updated field in IQS response (set to None)
+
+        Args:
+            raw_response: Raw httpx response from IQS
+            logging_obj: Logging object for tracking
+
+        Returns:
+            SearchResponse with standardized format
+        """
+        response_json = raw_response.json()
+
+        # Transform pageItems to SearchResult objects
+        results = []
+        for item in response_json.get("pageItems", []):
+            search_result = SearchResult(
+                title=item.get("title", ""),
+                url=item.get("link", ""),
+                snippet=item.get("snippet") or item.get("summary") or "",
+                date=item.get("publishedTime"),
+                last_updated=None,  # IQS doesn't provide last_updated in response
+            )
+            results.append(search_result)
+
+        return SearchResponse(
+            results=results,
+            object="search",
+        )

--- a/litellm/llms/aliyun_iqs/search/transformation.py
+++ b/litellm/llms/aliyun_iqs/search/transformation.py
@@ -33,7 +33,9 @@ class AliyunIQSSearchRequest(_AliyunIQSSearchRequestRequired, total=False):
     engineType: str  # Optional - Generic (default) / GenericAdvanced / LiteAdvanced / Deep
     timeRange: str  # Optional - OneDay / OneWeek / OneMonth / OneYear / NoLimit (default)
     category: str  # Optional - industry category (finance, law, medical, ...)
-    advancedParams: dict  # Optional - numResults (1-50), start/endPublishedDate, ...
+    advancedParams: (
+        dict  # mutable-ok: nested API payload object; Optional - numResults (1-50), start/endPublishedDate, ...
+    )
 
 
 class AliyunIQSSearchConfig(BaseSearchConfig):
@@ -45,11 +47,11 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
 
     def validate_environment(
         self,
-        headers: dict,
+        headers: dict,  # mutable-ok: overrides BaseSearchConfig dict-shaped interface
         api_key: str | None = None,
         api_base: str | None = None,
         **kwargs,
-    ) -> dict:
+    ) -> dict:  # mutable-ok: overrides BaseSearchConfig dict-shaped interface
         """
         Validate environment and return headers.
         """
@@ -69,8 +71,8 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
     def get_complete_url(
         self,
         api_base: str | None,
-        optional_params: dict,
-        data: dict | list[dict] = None,
+        optional_params: dict,  # mutable-ok: overrides BaseSearchConfig dict-shaped interface
+        data: dict | list[dict] = None,  # mutable-ok: overrides BaseSearchConfig dict-shaped interface
         **kwargs,
     ) -> str:
         """
@@ -86,10 +88,10 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
 
     def transform_search_request(
         self,
-        query: str | list[str],
-        optional_params: dict,
+        query: str | list[str],  # mutable-ok: overrides BaseSearchConfig dict-shaped interface
+        optional_params: dict,  # mutable-ok: overrides BaseSearchConfig dict-shaped interface
         **kwargs,
-    ) -> dict:
+    ) -> dict:  # mutable-ok: returns httpx json payload dict
         """
         Transform Search request to Aliyun IQS UnifiedSearch API format.
 
@@ -108,19 +110,19 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
             # IQS only supports single string queries
             query = " ".join(query)
 
-        request_data: AliyunIQSSearchRequest = {
+        request_data: AliyunIQSSearchRequest = {  # mutable-ok: request payload built once, serialized by httpx json=
             "query": query,
             "engineType": optional_params.get("engineType", "Generic"),
         }
 
         # Transform Perplexity unified spec parameters to IQS format
         if "max_results" in optional_params:
-            request_data["advancedParams"] = {
+            request_data["advancedParams"] = {  # mutable-ok: nested payload dict
                 "numResults": optional_params["max_results"],
             }
 
         # Convert to dict before dynamic key assignments
-        result_data = dict(request_data)
+        result_data = dict(request_data)  # mutable-ok: payload passed to httpx json= requires a real dict
 
         # pass through all other parameters as-is
         for param, value in optional_params.items():
@@ -155,8 +157,8 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
         response_json = raw_response.json()
 
         # Transform pageItems to SearchResult objects
-        results = []
-        for item in response_json.get("pageItems", []):
+        results = []  # mutable-ok: collected into pydantic SearchResponse(results=...)
+        for item in response_json.get("pageItems") or ():
             search_result = SearchResult(
                 title=item.get("title", ""),
                 url=item.get("link", ""),

--- a/litellm/llms/aliyun_iqs/search/transformation.py
+++ b/litellm/llms/aliyun_iqs/search/transformation.py
@@ -61,9 +61,7 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
             default_api_base=self.ALIYUN_IQS_API_BASE,
         )
         if not api_key:
-            raise ValueError(
-                "ALIYUN_IQS_API_KEY is not set. Set `ALIYUN_IQS_API_KEY` environment variable."
-            )
+            raise ValueError("ALIYUN_IQS_API_KEY is not set. Set `ALIYUN_IQS_API_KEY` environment variable.")
         headers["Authorization"] = f"Bearer {api_key}"
         headers["Content-Type"] = "application/json"
         return headers
@@ -78,11 +76,7 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
         """
         Get complete URL for Search endpoint.
         """
-        api_base = (
-            api_base
-            or get_secret_str("ALIYUN_IQS_API_BASE")
-            or self.ALIYUN_IQS_API_BASE
-        )
+        api_base = api_base or get_secret_str("ALIYUN_IQS_API_BASE") or self.ALIYUN_IQS_API_BASE
 
         # Append "/search/unified" to the api base if it's not already there
         if not api_base.endswith("/search/unified"):

--- a/litellm/llms/aliyun_iqs/search/transformation.py
+++ b/litellm/llms/aliyun_iqs/search/transformation.py
@@ -5,7 +5,7 @@ Aliyun IQS (Information Query Service) UnifiedSearch API Reference:
 https://help.aliyun.com/zh/document_detail/2883041.html
 """
 
-from typing import Optional, TypedDict, Union
+from typing import TypedDict
 
 import httpx
 
@@ -46,8 +46,8 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
     def validate_environment(
         self,
         headers: dict,
-        api_key: Optional[str] = None,
-        api_base: Optional[str] = None,
+        api_key: str | None = None,
+        api_base: str | None = None,
         **kwargs,
     ) -> dict:
         """
@@ -68,9 +68,9 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
 
     def get_complete_url(
         self,
-        api_base: Optional[str],
+        api_base: str | None,
         optional_params: dict,
-        data: Optional[Union[dict, list[dict]]] = None,
+        data: dict | list[dict] = None,
         **kwargs,
     ) -> str:
         """
@@ -86,7 +86,7 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
 
     def transform_search_request(
         self,
-        query: Union[str, list[str]],
+        query: str | list[str],
         optional_params: dict,
         **kwargs,
     ) -> dict:

--- a/litellm/llms/aliyun_iqs/search/transformation.py
+++ b/litellm/llms/aliyun_iqs/search/transformation.py
@@ -78,7 +78,7 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
         """
         Get complete URL for Search endpoint.
         """
-        api_base = api_base or get_secret_str("ALIYUN_IQS_API_BASE") or self.ALIYUN_IQS_API_BASE
+        api_base = (api_base or get_secret_str("ALIYUN_IQS_API_BASE") or self.ALIYUN_IQS_API_BASE).rstrip("/")
 
         # Append "/search/unified" to the api base if it's not already there
         if not api_base.endswith("/search/unified"):
@@ -117,7 +117,12 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
 
         # Transform Perplexity unified spec parameters to IQS format
         if "max_results" in optional_params:
+            # merge with caller-supplied advancedParams instead of replacing,
+            # so native filters (date ranges, ...) survive
             request_data["advancedParams"] = {  # mutable-ok: nested payload dict
+                **optional_params.get(
+                    "advancedParams", {}
+                ),  # mutable-ok: empty default, immediately spread into payload
                 "numResults": optional_params["max_results"],
             }
 
@@ -155,6 +160,11 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
             SearchResponse with standardized format
         """
         response_json = raw_response.json()
+
+        # 200-with-error-body guard: IQS business errors (errorCode/errorMessage)
+        # must not masquerade as "zero results" — non-2xx already raises upstream
+        if "pageItems" not in response_json and ("errorCode" in response_json or "errorMessage" in response_json):
+            raise ValueError(f"Aliyun IQS error response: {response_json}")
 
         # Transform pageItems to SearchResult objects
         results = []  # mutable-ok: collected into pydantic SearchResponse(results=...)

--- a/litellm/llms/aliyun_iqs/search/transformation.py
+++ b/litellm/llms/aliyun_iqs/search/transformation.py
@@ -5,6 +5,7 @@ Aliyun IQS (Information Query Service) UnifiedSearch API Reference:
 https://help.aliyun.com/zh/document_detail/2883041.html
 """
 
+from types import MappingProxyType
 from typing import TypedDict
 
 import httpx
@@ -120,9 +121,7 @@ class AliyunIQSSearchConfig(BaseSearchConfig):
             # merge with caller-supplied advancedParams instead of replacing,
             # so native filters (date ranges, ...) survive
             request_data["advancedParams"] = {  # mutable-ok: nested payload dict
-                **optional_params.get(
-                    "advancedParams", {}
-                ),  # mutable-ok: empty default, immediately spread into payload
+                **optional_params.get("advancedParams", MappingProxyType({})),
                 "numResults": optional_params["max_results"],
             }
 

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3640,6 +3640,7 @@ class SearchProviders(str, Enum):
     YOU_COM = "you_com"
     APISERPENT = "apiserpent"
     TINYFISH = "tinyfish"
+    ALIYUN_IQS = "aliyun_iqs"
 
 
 # Create a set of all search provider values for quick lookup

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -8881,6 +8881,9 @@ class ProviderConfigManager:
         """
         Get Search configuration for a given provider.
         """
+        from litellm.llms.aliyun_iqs.search.transformation import (
+            AliyunIQSSearchConfig,
+        )
         from litellm.llms.apiserpent.search.transformation import (
             APISerpentSearchConfig,
         )
@@ -8921,6 +8924,7 @@ class ProviderConfigManager:
             SearchProviders.YOU_COM: YouComSearchConfig,
             SearchProviders.APISERPENT: APISerpentSearchConfig,
             SearchProviders.TINYFISH: TinyfishSearchConfig,
+            SearchProviders.ALIYUN_IQS: AliyunIQSSearchConfig,
         }
         config_class = PROVIDER_TO_CONFIG_MAP.get(provider, None)
         if config_class is None:

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -120,6 +120,13 @@
         "interactions": true
       }
     },
+    "aliyun_iqs": {
+      "display_name": "Aliyun IQS (`aliyun_iqs`)",
+      "url": "https://help.aliyun.com/zh/document_detail/2883041.html",
+      "endpoints": {
+        "search": true
+      }
+    },
     "amazon_nova": {
       "display_name": "Amazon Nova (`amazon_nova`)",
       "url": "https://docs.litellm.ai/docs/providers/amazon_nova",

--- a/tests/search_tests/test_aliyun_iqs_search.py
+++ b/tests/search_tests/test_aliyun_iqs_search.py
@@ -98,3 +98,44 @@ class TestAliyunIQSSearch:
             # Verify second result falls back to summary when snippet is empty
             second_result = response.results[1]
             assert second_result.snippet == "Summary fallback for result 2"
+
+
+class TestAliyunIQSSearchTransformations:
+    """Unit tests for AliyunIQSSearchConfig transformations (no network)."""
+
+    def setup_method(self):
+        from litellm.llms.aliyun_iqs.search.transformation import AliyunIQSSearchConfig
+        self.config = AliyunIQSSearchConfig()
+
+    def test_transform_search_request_list_query_and_max_results(self):
+        data = self.config.transform_search_request(
+            query=["latest", "AI", "news"],
+            optional_params={"max_results": 10, "engineType": "GenericAdvanced", "timeRange": "OneWeek"},
+        )
+        assert data["query"] == "latest AI news"
+        assert data["engineType"] == "GenericAdvanced"
+        assert data["advancedParams"] == {"numResults": 10}
+        assert data["timeRange"] == "OneWeek"
+
+    def test_get_complete_url_appends_path(self):
+        assert (
+            self.config.get_complete_url(api_base=None, optional_params={})
+            == "https://cloud-iqs.aliyuncs.com/search/unified"
+        )
+        assert (
+            self.config.get_complete_url(api_base="https://cloud-iqs.aliyuncs.com/search/unified", optional_params={})
+            == "https://cloud-iqs.aliyuncs.com/search/unified"
+        )
+
+    def test_validate_environment_missing_key_raises(self, monkeypatch):
+        import pytest as _pytest
+        monkeypatch.delenv("ALIYUN_IQS_API_KEY", raising=False)
+        with _pytest.raises(ValueError, match="ALIYUN_IQS_API_KEY"):
+            self.config.validate_environment(headers={})
+
+    def test_transform_search_response_empty(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"requestId": "r1"}
+        response = self.config.transform_search_response(raw_response=mock_resp, logging_obj=None)
+        assert response.results == []
+        assert response.object == "search"

--- a/tests/search_tests/test_aliyun_iqs_search.py
+++ b/tests/search_tests/test_aliyun_iqs_search.py
@@ -1,0 +1,100 @@
+"""
+Tests for Aliyun IQS UnifiedSearch API integration.
+"""
+
+import os
+import sys
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+sys.path.insert(0, os.path.abspath("../.."))
+
+import litellm
+
+
+class TestAliyunIQSSearch:
+    """
+    Tests for Aliyun IQS UnifiedSearch functionality with mocked network responses.
+    """
+
+    @pytest.mark.asyncio
+    async def test_aliyun_iqs_search_request_payload(self):
+        """
+        Test that validates the IQS search request payload structure without making real API calls.
+        """
+        # Set environment variable for API key
+        os.environ["ALIYUN_IQS_API_KEY"] = "test-api-key"
+
+        # Create a mock response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "requestId": "test-request-id",
+            "pageItems": [
+                {
+                    "title": "Test Result 1",
+                    "link": "https://example.com/1",
+                    "snippet": "This is a test snippet for result 1",
+                    "publishedTime": "2026-07-01",
+                },
+                {
+                    "title": "Test Result 2",
+                    "link": "https://example.com/2",
+                    "snippet": "",
+                    "summary": "Summary fallback for result 2",
+                },
+            ],
+        }
+
+        # Mock the httpx AsyncClient post method
+        with patch(
+            "litellm.llms.custom_httpx.http_handler.AsyncHTTPHandler.post",
+            new_callable=AsyncMock,
+        ) as mock_post:
+            mock_post.return_value = mock_response
+
+            # Make the search call
+            response = await litellm.asearch(
+                query="latest developments in AI",
+                search_provider="aliyun_iqs",
+                max_results=5,
+            )
+
+            # Verify the post method was called once
+            assert mock_post.call_count == 1
+
+            # Get the actual call arguments
+            call_args = mock_post.call_args
+
+            # Verify URL
+            assert call_args.kwargs["url"] == "https://cloud-iqs.aliyuncs.com/search/unified"
+
+            # Verify headers contain Authorization
+            headers = call_args.kwargs.get("headers", {})
+            assert "Authorization" in headers
+            assert headers["Authorization"] == "Bearer test-api-key"
+            assert headers["Content-Type"] == "application/json"
+
+            # Verify request payload
+            json_data = call_args.kwargs.get("json")
+            assert json_data is not None
+            assert json_data["query"] == "latest developments in AI"
+            assert json_data["engineType"] == "Generic"
+            assert json_data["advancedParams"] == {"numResults": 5}
+
+            # Verify response structure
+            assert hasattr(response, "results")
+            assert hasattr(response, "object")
+            assert response.object == "search"
+            assert len(response.results) == 2
+
+            # Verify first result
+            first_result = response.results[0]
+            assert first_result.title == "Test Result 1"
+            assert first_result.url == "https://example.com/1"
+            assert first_result.snippet == "This is a test snippet for result 1"
+            assert first_result.date == "2026-07-01"
+
+            # Verify second result falls back to summary when snippet is empty
+            second_result = response.results[1]
+            assert second_result.snippet == "Summary fallback for result 2"

--- a/tests/search_tests/test_aliyun_iqs_search.py
+++ b/tests/search_tests/test_aliyun_iqs_search.py
@@ -105,6 +105,7 @@ class TestAliyunIQSSearchTransformations:
 
     def setup_method(self):
         from litellm.llms.aliyun_iqs.search.transformation import AliyunIQSSearchConfig
+
         self.config = AliyunIQSSearchConfig()
 
     def test_transform_search_request_list_query_and_max_results(self):
@@ -129,6 +130,7 @@ class TestAliyunIQSSearchTransformations:
 
     def test_validate_environment_missing_key_raises(self, monkeypatch):
         import pytest as _pytest
+
         monkeypatch.delenv("ALIYUN_IQS_API_KEY", raising=False)
         with _pytest.raises(ValueError, match="ALIYUN_IQS_API_KEY"):
             self.config.validate_environment(headers={})
@@ -139,3 +141,33 @@ class TestAliyunIQSSearchTransformations:
         response = self.config.transform_search_response(raw_response=mock_resp, logging_obj=None)
         assert response.results == []
         assert response.object == "search"
+
+    def test_max_results_merges_native_advanced_params(self):
+        data = self.config.transform_search_request(
+            query="q",
+            optional_params={
+                "max_results": 5,
+                "advancedParams": {"startPublishedDate": "2026-01-01"},
+            },
+        )
+        assert data["advancedParams"] == {
+            "startPublishedDate": "2026-01-01",
+            "numResults": 5,
+        }
+
+    def test_get_complete_url_normalizes_trailing_slash(self):
+        assert (
+            self.config.get_complete_url(api_base="https://cloud-iqs.aliyuncs.com/", optional_params={})
+            == "https://cloud-iqs.aliyuncs.com/search/unified"
+        )
+
+    def test_error_body_raises_instead_of_empty_results(self):
+        import pytest as _pytest
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "errorCode": "Retrieval.TestUserPeriodExpired",
+            "errorMessage": "The test period has expired",
+        }
+        with _pytest.raises(ValueError, match="TestUserPeriodExpired"):
+            self.config.transform_search_response(raw_response=mock_resp, logging_obj=None)


### PR DESCRIPTION
## Summary

Adds [Aliyun IQS (Information Query Service)](https://help.aliyun.com/zh/document_detail/2883041.html) **UnifiedSearch** as a new search provider, following the same pattern as the existing providers (tavily, brave, etc.):

- `litellm/llms/aliyun_iqs/search/transformation.py` — `POST https://cloud-iqs.aliyuncs.com/search/unified`, `Authorization: Bearer` auth, `engineType=Generic` by default (overridable via optional params)
- Response mapping: `pageItems[].title/link/snippet/publishedTime` → `SearchResult.title/url/snippet/date` (falls back to `summary` when `snippet` is empty)
- Registered in `SearchProviders` enum + `ProviderConfigManager.get_provider_search_config`
- Server-managed credential: `ALIYUN_IQS_API_KEY` env var (via `resolve_server_api_key`, trusted-host guard included)

IQS is an open-domain search engine for agents from Alibaba Cloud — a useful option for users running in Aliyun regions (low latency from cn-beijing, domestic-Chinese web coverage, billed in CNY).

## Test plan

- Added `tests/search_tests/test_aliyun_iqs_search.py` (mocked httpx; asserts URL, Bearer header, payload shape incl. `advancedParams.numResults` mapping, and response mapping) — passes
- Also running in production through `websearch_interception` → `litellm.asearch(search_provider="aliyun_iqs")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)