### PR TITLE
fix(proxy): align team member add with existing user provisioning rules

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import math
 import traceback
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Annotated, Any, Dict, List, Mapping, Optional, Tuple, Union, cast
 
@@ -2426,6 +2427,123 @@ def _emit_team_members_metric(team: LiteLLM_TeamTable) -> None:
         verbose_proxy_logger.debug("Prometheus: failed to emit team members metric: %s", str(e))
 
 
+async def _resolve_existing_member_user_ids(
+    members: Sequence[Member],
+    prisma_client: PrismaClient,
+) -> frozenset[str]:
+    """Return the caller-supplied user_ids that already have a user row."""
+    user_repository = UserRepository(prisma_client)
+    found = await asyncio.gather(
+        *(user_repository.find_by_id(member.user_id) for member in members if member.user_id is not None)
+    )
+    return frozenset(user.user_id for user in found if user is not None and user.user_id is not None)
+
+
+def _pre_existing_user_ids(
+    members: Sequence[Member],
+    caller_supplied_user_ids: frozenset[str],
+    existing_user_ids: frozenset[str],
+) -> frozenset[str]:
+    """Return the user_ids that already had a user row before this request.
+
+    Combines the caller-supplied ids that resolved to a user with the ids
+    ``_validate_and_populate_member_user_info`` filled in, which it only does
+    from a matched user row. Deriving it that way keeps this in step with the
+    email matching that resolution performs, rather than repeating it here.
+    """
+    populated_user_ids = frozenset(
+        member.user_id
+        for member in members
+        if member.user_id is not None and member.user_id not in caller_supplied_user_ids
+    )
+    return existing_user_ids | populated_user_ids
+
+
+def _validate_member_user_id_provisioning(
+    members: Sequence[Member],
+    existing_user_ids: frozenset[str],
+    user_api_key_dict: UserAPIKeyAuth,
+) -> None:
+    """Restrict adding a caller-chosen user_id that has no user row yet to proxy admins.
+
+    Team and org admins keep the ability to add users that already exist and to
+    invite new ones by user_email, where the user_id is allocated server-side.
+    """
+    if user_api_key_dict.user_role in (
+        LitellmUserRoles.PROXY_ADMIN,
+        LitellmUserRoles.PROXY_ADMIN.value,
+    ):
+        return
+
+    unknown_user_ids = tuple(
+        member.user_id for member in members if member.user_id is not None and member.user_id not in existing_user_ids
+    )
+    if not unknown_user_ids:
+        return
+
+    raise HTTPException(
+        status_code=403,
+        detail={  # mutable-ok: HTTPException detail must be a plain mapping to keep this route's {"error": ...} response shape
+            "error": (
+                "Only proxy admins can add a user_id that does not exist yet: {}. "
+                "Add the member by user_email to invite a new user, or ask a proxy admin "
+                "to create the user first.".format(", ".join(unknown_user_ids))
+            )
+        },
+    )
+
+
+def _members_audit_value(members: Sequence[Member]) -> str:
+    """Serialize a team's member list for an audit-log value.
+
+    The audit-log columns hold a JSON object, so the member list is nested
+    under a key rather than serialized as a top-level array.
+    """
+    return safe_dumps(
+        {  # mutable-ok: the audit-log JSON column rejects a top-level array, so this value must be an object
+            "members_with_roles": tuple(member.model_dump() for member in members)
+        }
+    )
+
+
+async def _create_team_member_add_audit_logs(
+    team_id: str,
+    updated_users: Sequence[LiteLLM_UserTable],
+    existing_user_ids: frozenset[str],
+    before_members: Sequence[Member],
+    after_members: Sequence[Member],
+    user_api_key_dict: UserAPIKeyAuth,
+    litellm_proxy_admin_name: str,
+) -> None:
+    """Record the membership change, and any user row it created, in the audit log."""
+    from litellm.proxy.management_helpers.audit_logs import create_object_audit_log
+
+    for user in updated_users:
+        if user.user_id is None or user.user_id in existing_user_ids:
+            continue
+        await create_object_audit_log(
+            object_id=user.user_id,
+            action="created",
+            litellm_changed_by=None,
+            user_api_key_dict=user_api_key_dict,
+            litellm_proxy_admin_name=litellm_proxy_admin_name,
+            table_name=LitellmTableNames.USER_TABLE_NAME,
+            before_value=None,
+            after_value=safe_dumps(user.model_dump(exclude_none=True)),
+        )
+
+    await create_object_audit_log(
+        object_id=team_id,
+        action="updated",
+        litellm_changed_by=None,
+        user_api_key_dict=user_api_key_dict,
+        litellm_proxy_admin_name=litellm_proxy_admin_name,
+        table_name=LitellmTableNames.TEAM_TABLE_NAME,
+        before_value=_members_audit_value(before_members),
+        after_value=_members_audit_value(after_members),
+    )
+
+
 async def _validate_and_populate_member_user_info(
     member: Member,
     prisma_client: PrismaClient,
@@ -2606,6 +2724,19 @@ async def team_member_add(
         data=data,
     )
 
+    requested_members = tuple(data.member) if isinstance(data.member, list) else (data.member,)
+    caller_supplied_user_ids = frozenset(member.user_id for member in requested_members if member.user_id is not None)
+    existing_user_ids = await _resolve_existing_member_user_ids(
+        members=requested_members,
+        prisma_client=prisma_client,
+    )
+    _validate_member_user_id_provisioning(
+        members=requested_members,
+        existing_user_ids=existing_user_ids,
+        user_api_key_dict=user_api_key_dict,
+    )
+    members_before_add = tuple(complete_team_data.members_with_roles)
+
     # Validate and populate user_email/user_id for members before processing
     if isinstance(data.member, Member):
         await _validate_and_populate_member_user_info(
@@ -2618,6 +2749,12 @@ async def team_member_add(
                 member=m,
                 prisma_client=prisma_client,
             )
+
+    pre_existing_user_ids = _pre_existing_user_ids(
+        members=requested_members,
+        caller_supplied_user_ids=caller_supplied_user_ids,
+        existing_user_ids=existing_user_ids,
+    )
 
     (
         updated_team,
@@ -2636,6 +2773,16 @@ async def team_member_add(
         raise HTTPException(status_code=404, detail={"error": f"Team with id {data.team_id} not found"})
 
     _emit_team_members_metric(complete_team_data)
+
+    await _create_team_member_add_audit_logs(
+        team_id=data.team_id,
+        updated_users=updated_users,
+        existing_user_ids=pre_existing_user_ids,
+        before_members=members_before_add,
+        after_members=tuple(complete_team_data.members_with_roles),
+        user_api_key_dict=user_api_key_dict,
+        litellm_proxy_admin_name=litellm_proxy_admin_name,
+    )
 
     return TeamAddMemberResponse.model_validate(
         {

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2431,12 +2431,23 @@ async def _resolve_existing_member_user_ids(
     members: Sequence[Member],
     prisma_client: PrismaClient,
 ) -> frozenset[str]:
-    """Return the caller-supplied user_ids that already have a user row."""
-    user_repository = UserRepository(prisma_client)
-    found = await asyncio.gather(
-        *(user_repository.find_by_id(member.user_id) for member in members if member.user_id is not None)
+    """Return the caller-supplied user_ids that already have a user row.
+
+    Resolved with a single query so the number of members in the request does
+    not translate into that many concurrent connections.
+    """
+    requested_user_ids = frozenset(member.user_id for member in members if member.user_id is not None)
+    if not requested_user_ids:
+        return frozenset()
+
+    found = await UserRepository(prisma_client).table.find_many(
+        where={  # mutable-ok: Prisma query filters are dict-shaped
+            "user_id": {  # mutable-ok: Prisma query filters are dict-shaped
+                "in": sorted(requested_user_ids)
+            }
+        }
     )
-    return frozenset(user.user_id for user in found if user is not None and user.user_id is not None)
+    return frozenset(user.user_id for user in found or () if user.user_id is not None)
 
 
 def _pre_existing_user_ids(
@@ -2457,6 +2468,9 @@ def _pre_existing_user_ids(
         if member.user_id is not None and member.user_id not in caller_supplied_user_ids
     )
     return existing_user_ids | populated_user_ids
+
+
+_MAX_REPORTED_UNKNOWN_USER_IDS = 10
 
 
 def _validate_member_user_id_provisioning(
@@ -2481,13 +2495,15 @@ def _validate_member_user_id_provisioning(
     if not unknown_user_ids:
         return
 
+    listed = ", ".join(unknown_user_ids[:_MAX_REPORTED_UNKNOWN_USER_IDS])
+    remaining = len(unknown_user_ids) - _MAX_REPORTED_UNKNOWN_USER_IDS
     raise HTTPException(
         status_code=403,
         detail={  # mutable-ok: HTTPException detail must be a plain mapping to keep this route's {"error": ...} response shape
             "error": (
-                "Only proxy admins can add a user_id that does not exist yet: {}. "
+                "Only proxy admins can add a user_id that does not exist yet: {}{}. "
                 "Add the member by user_email to invite a new user, or ask a proxy admin "
-                "to create the user first.".format(", ".join(unknown_user_ids))
+                "to create the user first.".format(listed, " and {} more".format(remaining) if remaining > 0 else "")
             )
         },
     )
@@ -2515,13 +2531,15 @@ async def _create_team_member_add_audit_logs(
     user_api_key_dict: UserAPIKeyAuth,
     litellm_proxy_admin_name: str,
 ) -> None:
-    """Record the membership change, and any user row it created, in the audit log."""
+    """Record the membership change, and any user row it created, in the audit log.
+
+    The entries are written concurrently so a request adding many members does
+    not pay for them one after another.
+    """
     from litellm.proxy.management_helpers.audit_logs import create_object_audit_log
 
-    for user in updated_users:
-        if user.user_id is None or user.user_id in existing_user_ids:
-            continue
-        await create_object_audit_log(
+    created_user_entries = tuple(
+        create_object_audit_log(
             object_id=user.user_id,
             action="created",
             litellm_changed_by=None,
@@ -2531,8 +2549,11 @@ async def _create_team_member_add_audit_logs(
             before_value=None,
             after_value=safe_dumps(user.model_dump(exclude_none=True)),
         )
+        for user in updated_users
+        if user.user_id is not None and user.user_id not in existing_user_ids
+    )
 
-    await create_object_audit_log(
+    membership_entry = create_object_audit_log(
         object_id=team_id,
         action="updated",
         litellm_changed_by=None,
@@ -2542,6 +2563,8 @@ async def _create_team_member_add_audit_logs(
         before_value=_members_audit_value(before_members),
         after_value=_members_audit_value(after_members),
     )
+
+    await asyncio.gather(*created_user_entries, membership_entry)
 
 
 async def _validate_and_populate_member_user_info(

--- a/tests/proxy_unit_tests/test_proxy_server.py
+++ b/tests/proxy_unit_tests/test_proxy_server.py
@@ -1475,7 +1475,7 @@ async def test_create_team_member_add_team_admin(
                     user_api_key_dict=valid_token,
                 )
             except HTTPException as e:
-                if user_role == "user":
+                if user_role == "user" or new_member_method == "user_id":
                     assert e.status_code == 403
                     return
                 else:

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -10338,3 +10338,239 @@ async def test_list_available_teams_filters_joined_and_validates_rows(monkeypatc
     assert result[0].team_alias == "open team"
     find_many_kwargs = mock_prisma_client.db.litellm_teamtable.find_many.call_args.kwargs
     assert find_many_kwargs["where"] == {"team_id": {"in": ["team-open"]}}
+
+
+def _provisioning_caller(role: LitellmUserRoles) -> UserAPIKeyAuth:
+    return UserAPIKeyAuth(user_id="caller-1", user_role=role)
+
+
+def test_validate_member_user_id_provisioning_allows_proxy_admin():
+    """Proxy admins may add a user_id that has no user row yet."""
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _validate_member_user_id_provisioning,
+    )
+
+    _validate_member_user_id_provisioning(
+        members=[Member(user_id="brand-new", role="user")],
+        existing_user_ids=frozenset(),
+        user_api_key_dict=_provisioning_caller(LitellmUserRoles.PROXY_ADMIN),
+    )
+
+
+def test_validate_member_user_id_provisioning_rejects_unknown_user_id_for_non_proxy_admin():
+    """A non-proxy-admin cannot add a user_id that has no user row yet."""
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _validate_member_user_id_provisioning,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_member_user_id_provisioning(
+            members=[Member(user_id="brand-new", role="user")],
+            existing_user_ids=frozenset(),
+            user_api_key_dict=_provisioning_caller(LitellmUserRoles.INTERNAL_USER),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert "brand-new" in str(exc_info.value.detail)
+
+
+def test_validate_member_user_id_provisioning_allows_existing_user_id_for_non_proxy_admin():
+    """A non-proxy-admin may still add a user that already exists."""
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _validate_member_user_id_provisioning,
+    )
+
+    _validate_member_user_id_provisioning(
+        members=[Member(user_id="already-here", role="user")],
+        existing_user_ids=frozenset({"already-here"}),
+        user_api_key_dict=_provisioning_caller(LitellmUserRoles.INTERNAL_USER),
+    )
+
+
+def test_validate_member_user_id_provisioning_allows_email_only_member_for_non_proxy_admin():
+    """Inviting by user_email stays open to non-proxy-admins; the user_id is server-allocated."""
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _validate_member_user_id_provisioning,
+    )
+
+    _validate_member_user_id_provisioning(
+        members=[Member(user_email="invitee@example.com", role="user")],
+        existing_user_ids=frozenset(),
+        user_api_key_dict=_provisioning_caller(LitellmUserRoles.INTERNAL_USER),
+    )
+
+
+def test_validate_member_user_id_provisioning_rejects_unknown_user_id_paired_with_email():
+    """Supplying a user_email alongside an unknown user_id does not lift the restriction."""
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _validate_member_user_id_provisioning,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_member_user_id_provisioning(
+            members=[Member(user_id="chosen-id", user_email="invitee@example.com", role="user")],
+            existing_user_ids=frozenset(),
+            user_api_key_dict=_provisioning_caller(LitellmUserRoles.INTERNAL_USER),
+        )
+
+    assert exc_info.value.status_code == 403
+
+
+def test_validate_member_user_id_provisioning_reports_every_unknown_member():
+    """A bulk add names each unknown user_id rather than only the first."""
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _validate_member_user_id_provisioning,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_member_user_id_provisioning(
+            members=[
+                Member(user_id="known", role="user"),
+                Member(user_id="unknown-a", role="user"),
+                Member(user_id="unknown-b", role="user"),
+            ],
+            existing_user_ids=frozenset({"known"}),
+            user_api_key_dict=_provisioning_caller(LitellmUserRoles.INTERNAL_USER),
+        )
+
+    detail = str(exc_info.value.detail)
+    assert "unknown-a" in detail
+    assert "unknown-b" in detail
+
+
+@pytest.mark.asyncio
+async def test_resolve_existing_member_user_ids_matches_caller_supplied_user_ids():
+    """Only caller-supplied user_ids are looked up; unknown ones resolve to nothing."""
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _resolve_existing_member_user_ids,
+    )
+
+    prisma_client = MagicMock()
+
+    async def find_by_id(user_id):
+        if user_id == "by-id":
+            return LiteLLM_UserTable(user_id="by-id", max_budget=None, spend=0.0, user_email=None, models=[])
+        return None
+
+    with patch("litellm.proxy.management_endpoints.team_endpoints.UserRepository") as repo:
+        repo.return_value.find_by_id = AsyncMock(side_effect=find_by_id)
+
+        resolved = await _resolve_existing_member_user_ids(
+            members=[
+                Member(user_id="by-id", role="user"),
+                Member(user_id="missing", role="user"),
+                Member(user_email="someone@example.com", role="user"),
+            ],
+            prisma_client=prisma_client,
+        )
+
+    assert resolved == frozenset({"by-id"})
+
+
+def test_pre_existing_user_ids_counts_ids_filled_in_by_member_resolution():
+    """An id the member-resolution step filled in came from a matched row, so it pre-existed.
+
+    This is what keeps a case-variant email invite of an existing user from being
+    recorded as a newly created user.
+    """
+    from litellm.proxy.management_endpoints.team_endpoints import _pre_existing_user_ids
+
+    # member arrived email-only; resolution matched an existing row and filled in the id
+    resolved_member = Member(user_id="matched-existing", user_email="Someone@Example.com", role="user")
+
+    assert _pre_existing_user_ids(
+        members=[resolved_member],
+        caller_supplied_user_ids=frozenset(),
+        existing_user_ids=frozenset(),
+    ) == frozenset({"matched-existing"})
+
+
+def test_pre_existing_user_ids_excludes_caller_supplied_ids_that_do_not_exist():
+    """A caller-supplied id that resolved to nothing is genuinely new, so it stays out."""
+    from litellm.proxy.management_endpoints.team_endpoints import _pre_existing_user_ids
+
+    assert _pre_existing_user_ids(
+        members=[Member(user_id="brand-new", role="user"), Member(user_id="already-here", role="user")],
+        caller_supplied_user_ids=frozenset({"brand-new", "already-here"}),
+        existing_user_ids=frozenset({"already-here"}),
+    ) == frozenset({"already-here"})
+
+
+def test_members_audit_value_serializes_to_a_json_object():
+    """The audit-log columns hold a JSON object; a top-level array is rejected by the DB."""
+    from litellm.proxy.management_endpoints.team_endpoints import _members_audit_value
+
+    payload = json.loads(_members_audit_value([Member(user_id="u1", role="admin"), Member(user_id="u2", role="user")]))
+
+    assert isinstance(payload, dict)
+    assert [m["user_id"] for m in payload["members_with_roles"]] == ["u1", "u2"]
+
+
+@pytest.mark.asyncio
+async def test_team_member_add_audits_a_user_created_from_a_list_payload(monkeypatch):
+    """A user created by a list payload must still be reported as newly created.
+
+    For a list payload the member-list reconciliation back-fills the caller's own
+    Member objects with the ids of users this request just created. The set of
+    pre-existing ids therefore has to be captured before that runs, otherwise a
+    freshly created user looks like it was already there and no creation is recorded.
+    """
+    from litellm.proxy._types import TeamMemberAddRequest
+    from litellm.proxy.management_endpoints.team_endpoints import team_member_add
+
+    team_id = "team-list-audit"
+    created_user_id = "generated-uuid-for-new-invitee"
+    member = Member(user_email="invitee@example.com", role="user")
+
+    mock_prisma_client = AsyncMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+    monkeypatch.setattr("litellm.proxy.proxy_server.premium_user", True)
+    monkeypatch.setattr("litellm.proxy.proxy_server.litellm_proxy_admin_name", "default_user_id")
+
+    team_row = LiteLLM_TeamTable(team_id=team_id, members_with_roles=[])
+    created_user = LiteLLM_UserTable(
+        user_id=created_user_id, user_email="invitee@example.com", max_budget=None, spend=0.0, models=[]
+    )
+    updated_team = MagicMock()
+    updated_team.model_dump.return_value = {"team_id": team_id, "members_with_roles": []}
+
+    async def fake_add_team_members_to_team(**kwargs):
+        # mirrors _update_team_members_list: the list branch mutates the caller's Member in place
+        member.user_id = created_user_id
+        return updated_team, [created_user], []
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints.get_team_object",
+            new_callable=AsyncMock,
+            return_value=team_row,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._validate_team_member_add_permissions",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._validate_and_populate_member_user_info",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._resolve_existing_member_user_ids",
+            new_callable=AsyncMock,
+            return_value=frozenset(),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._add_team_members_to_team",
+            side_effect=fake_add_team_members_to_team,
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._create_team_member_add_audit_logs",
+            new_callable=AsyncMock,
+        ) as mock_audit,
+    ):
+        await team_member_add(
+            data=TeamMemberAddRequest(team_id=team_id, member=[member]),
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin-1"),
+        )
+
+    mock_audit.assert_called_once()
+    assert created_user_id not in mock_audit.call_args.kwargs["existing_user_ids"]

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -10440,20 +10440,18 @@ def test_validate_member_user_id_provisioning_reports_every_unknown_member():
 
 @pytest.mark.asyncio
 async def test_resolve_existing_member_user_ids_matches_caller_supplied_user_ids():
-    """Only caller-supplied user_ids are looked up; unknown ones resolve to nothing."""
+    """Caller-supplied user_ids resolve in one query; unknown ones resolve to nothing."""
     from litellm.proxy.management_endpoints.team_endpoints import (
         _resolve_existing_member_user_ids,
     )
 
     prisma_client = MagicMock()
-
-    async def find_by_id(user_id):
-        if user_id == "by-id":
-            return LiteLLM_UserTable(user_id="by-id", max_budget=None, spend=0.0, user_email=None, models=[])
-        return None
+    find_many = AsyncMock(
+        return_value=[LiteLLM_UserTable(user_id="by-id", max_budget=None, spend=0.0, user_email=None, models=[])]
+    )
 
     with patch("litellm.proxy.management_endpoints.team_endpoints.UserRepository") as repo:
-        repo.return_value.find_by_id = AsyncMock(side_effect=find_by_id)
+        repo.return_value.table.find_many = find_many
 
         resolved = await _resolve_existing_member_user_ids(
             members=[
@@ -10465,6 +10463,28 @@ async def test_resolve_existing_member_user_ids_matches_caller_supplied_user_ids
         )
 
     assert resolved == frozenset({"by-id"})
+    # one round-trip, and email-only members contribute no id to look up
+    find_many.assert_awaited_once()
+    assert find_many.await_args.kwargs["where"] == {"user_id": {"in": ["by-id", "missing"]}}
+
+
+@pytest.mark.asyncio
+async def test_resolve_existing_member_user_ids_skips_the_query_when_no_user_ids():
+    """An all-email payload must not hit the database at all."""
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _resolve_existing_member_user_ids,
+    )
+
+    with patch("litellm.proxy.management_endpoints.team_endpoints.UserRepository") as repo:
+        repo.return_value.table.find_many = AsyncMock()
+
+        resolved = await _resolve_existing_member_user_ids(
+            members=[Member(user_email="a@example.com", role="user")],
+            prisma_client=MagicMock(),
+        )
+
+    assert resolved == frozenset()
+    repo.return_value.table.find_many.assert_not_awaited()
 
 
 def test_pre_existing_user_ids_counts_ids_filled_in_by_member_resolution():
@@ -10574,3 +10594,26 @@ async def test_team_member_add_audits_a_user_created_from_a_list_payload(monkeyp
 
     mock_audit.assert_called_once()
     assert created_user_id not in mock_audit.call_args.kwargs["existing_user_ids"]
+
+
+def test_validate_member_user_id_provisioning_caps_the_ids_it_echoes_back():
+    """A large member list must not echo every id back in the error body."""
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        _MAX_REPORTED_UNKNOWN_USER_IDS,
+        _validate_member_user_id_provisioning,
+    )
+
+    members = [Member(user_id=f"u{i}", role="user") for i in range(500)]
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_member_user_id_provisioning(
+            members=members,
+            existing_user_ids=frozenset(),
+            user_api_key_dict=_provisioning_caller(LitellmUserRoles.INTERNAL_USER),
+        )
+
+    detail = str(exc_info.value.detail)
+    assert "u0" in detail
+    assert f"u{_MAX_REPORTED_UNKNOWN_USER_IDS}" not in detail
+    assert f"and {500 - _MAX_REPORTED_UNKNOWN_USER_IDS} more" in detail
+    assert len(detail) < 1000

--- a/ui/litellm-dashboard/src/components/common_components/user_search_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/user_search_modal.test.tsx
@@ -65,4 +65,14 @@ describe("UserSearchModal", () => {
 
     expect(userFilterUICall).not.toHaveBeenCalled();
   });
+
+  it("tells the user that only existing accounts can be selected", () => {
+    renderModal();
+
+    const notice = screen.getByRole("alert");
+    expect(notice).toHaveTextContent(/users that already exist/i);
+    expect(notice).toHaveTextContent(/ask a proxy admin to create their account first/i);
+    // info, not warning: a warning here would read as an error state on an empty form
+    expect(notice.className).toMatch(/ant-alert-info/);
+  });
 });

--- a/ui/litellm-dashboard/src/components/common_components/user_search_modal.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/user_search_modal.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Modal, Form, Button, Select, Tooltip } from "antd";
+import { Modal, Form, Button, Select, Tooltip, Alert } from "antd";
 import { UserAddOutlined } from "@ant-design/icons";
 import { useDebouncedCallback } from "@tanstack/react-pacer/debouncer";
 import { userFilterUICall } from "@/components/networking";
@@ -140,6 +140,14 @@ const UserSearchModal: React.FC<UserSearchModalProps> = ({
           role: defaultRole,
         }}
       >
+        <Alert
+          type="info"
+          showIcon
+          className="mb-4"
+          message="Search selects from users that already exist. To add someone new, ask a proxy admin to create their account first."
+          data-testid="member-existing-users-notice"
+        />
+
         <Form.Item label="Email" name="user_email" className="mb-4">
           <Select
             showSearch


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/team/member_add` created user rows for non-proxy-admins
- Creating users directly is proxy-admin-only, so the two disagreed
- `/team/member_add` wrote no audit log at all

How it solves it:

- Only proxy admins may add an unused `user_id`
- Email invites unchanged; the `user_id` is allocated server-side
- Membership changes and created users now hit the audit log

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Run against a live proxy on `localhost:4001`. The caller is a team admin whose proxy-level role is
`internal_user`; `sk-1234` is the master key. Setup for both runs: create a team, create the
`internal_user`, make them a team admin of that team

**Before, at `f2cfa86713`** (base of this branch). The team admin picks an arbitrary `user_id` and
the proxy creates a fully-roled user for it

```bash
curl -sX POST "$BASE/team/member_add" -H "Authorization: Bearer $TEAM_ADMIN_KEY" \
  -H 'Content-Type: application/json' \
  -d '{"team_id":"proof-1785553306","member":{"user_id":"injected-proof-1785553306","role":"user"}}'
```

```
HTTP 200
members_with_roles: [{"user_id": "default_user_id", "user_email": null, "role": "admin"},
                     {"user_id": "ta-proof-1785553306", "user_email": null, "role": "admin"},
                     {"user_id": "injected-proof-1785553306", "user_email": null, "role": "user"}]
```

```bash
curl -s "$BASE/user/info?user_id=injected-proof-1785553306" -H "Authorization: Bearer sk-1234"
```

```
HTTP 200
user_role: internal_user | user_email: None
```

**After, at `e8e2e07ef6`** (this branch). Same request, same caller

```bash
curl -sX POST "$BASE/team/member_add" -H "Authorization: Bearer $TEAM_ADMIN_KEY" \
  -H 'Content-Type: application/json' \
  -d '{"team_id":"proof-1785553336","member":{"user_id":"injected-proof-1785553336","role":"user"}}'
```

```
HTTP 403
{"detail": {"error": "Only proxy admins can add a user_id that does not exist yet: injected-proof-1785553336. Add the member by user_email to invite a new user, or ask a proxy admin to create the user first."}}
```

```bash
curl -s "$BASE/user/info?user_id=injected-proof-1785553336" -H "Authorization: Bearer sk-1234"
```

```
HTTP 404
{"error": {"message": "User injected-proof-1785553336 not found", ... "code": "404"}}
```

**Flows that stay open, also at `e8e2e07ef6`**

```bash
# team admin invites a brand-new user by email
curl -sX POST "$BASE/team/member_add" -H "Authorization: Bearer $TEAM_ADMIN_KEY" \
  -H 'Content-Type: application/json' \
  -d '{"team_id":"'"$TEAM"'","member":{"user_email":"newhire@example.com","role":"user"}}'   # HTTP 200

# team admin adds a user that already exists
curl -sX POST "$BASE/team/member_add" -H "Authorization: Bearer $TEAM_ADMIN_KEY" \
  -H 'Content-Type: application/json' \
  -d '{"team_id":"'"$TEAM"'","member":{"user_id":"exists-1","role":"user"}}'                 # HTTP 200

# proxy admin pre-provisions a brand-new user_id
curl -sX POST "$BASE/team/member_add" -H "Authorization: Bearer sk-1234" \
  -H 'Content-Type: application/json' \
  -d '{"team_id":"'"$TEAM"'","member":{"user_id":"preprov-1","role":"user"}}'                # HTTP 200
```

**Audit log, at `e8e2e07ef6`** (needs `litellm_settings.store_audit_logs: true` and a license). A
team admin invites a new user by email; before this change `/audit` returned nothing for either the
membership change or the created user

```bash
curl -s "$BASE/audit?object_id=$TEAM_ID&page_size=100" -H "Authorization: Bearer sk-1234"
# LiteLLM_TeamTable / updated, with members_with_roles before and after

curl -s "$BASE/audit?object_id=$NEW_USER_ID&page_size=100" -H "Authorization: Bearer sk-1234"
# LiteLLM_UserTable / created
```

## Type

🐛 Bug Fix

## Changes

`_validate_member_user_id_provisioning` rejects a `user_id` with no user row when the caller is not
a proxy admin, so choosing the identifier for a new account lines up with the restriction that
already applies to creating one directly. Team and org admins keep both of the paths they actually
use day to day: adding someone who already exists, and inviting someone new by `user_email`, where
the `user_id` is generated server-side rather than supplied by the caller

`_create_team_member_add_audit_logs` records the membership change on the team and a creation entry
for any user row the request adds, which brings this endpoint in line with `/team/update`,
`/user/new` and `/key/*`. The set of ids that already existed is captured before the members are
added, because the list-payload branch of `_update_team_members_list` back-fills the caller's own
`Member` objects with ids of users the same request just created; reading it afterwards would
classify a new user as pre-existing and skip its entry

Worth flagging for review: this is a behavior change for anyone pre-provisioning by a caller-chosen
`user_id` as a team or org admin rather than by `user_email`, who now gets a 403. The internal
callers were checked and are unaffected, since `map_user_to_teams`, `create_team_member_add_task`
and `_add_user_to_team` either pass a proxy-admin identity or run after the user row exists

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
