### PR TITLE
perf(caching): skip cache bookkeeping when caching is disabled

### DIFF
--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -19,6 +19,7 @@ import datetime
 import inspect
 import time
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Generator, Mapping
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Final, Optional, TypeVar
 
 from pydantic import BaseModel
@@ -1033,6 +1034,9 @@ class LLMCachingHandler:
         Sync internal method to add the result to the cache
         """
 
+        if litellm.cache is None:
+            return
+
         new_kwargs: Final = kwargs.copy()
         new_kwargs.update(
             convert_args_to_kwargs(
@@ -1040,8 +1044,6 @@ class LLMCachingHandler:
                 args,
             )
         )
-        if litellm.cache is None:
-            return
 
         if self._should_store_result_in_cache(original_function=self.original_function, kwargs=new_kwargs):
             litellm.cache.add_cache(result, **new_kwargs)
@@ -1215,22 +1217,16 @@ class LLMCachingHandler:
         )
 
 
+@lru_cache(maxsize=1024)
+def _positional_param_names(original_function: Callable) -> tuple[str, ...]:
+    return tuple(inspect.signature(original_function).parameters)
+
+
 def convert_args_to_kwargs(
     original_function: Callable,
     args: tuple[object, ...] | None = None,
 ) -> dict[str, object]:
-    # Get the signature of the original function
-    signature: Final = inspect.signature(original_function)
+    if not args:
+        return {}
 
-    # Get parameter names in the order they appear in the original function
-    param_names: Final = list(signature.parameters.keys())
-
-    # Create a mapping of positional arguments to parameter names
-    args_to_kwargs: Final = {}
-    if args:
-        for index, arg in enumerate(args):
-            if index < len(param_names):
-                param_name = param_names[index]
-                args_to_kwargs[param_name] = arg
-
-    return args_to_kwargs
+    return dict(zip(_positional_param_names(original_function), args))

--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -18,6 +18,7 @@ import asyncio
 import datetime
 import inspect
 import time
+from functools import lru_cache
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -1015,6 +1016,8 @@ class LLMCachingHandler:
         """
         Sync internal method to add the result to the cache
         """
+        if litellm.cache is None:
+            return
 
         new_kwargs = kwargs.copy()
         new_kwargs.update(
@@ -1023,8 +1026,6 @@ class LLMCachingHandler:
                 args,
             )
         )
-        if litellm.cache is None:
-            return
 
         if self._should_store_result_in_cache(original_function=self.original_function, kwargs=new_kwargs):
             litellm.cache.add_cache(result, **new_kwargs)
@@ -1178,22 +1179,16 @@ class LLMCachingHandler:
         )
 
 
+@lru_cache(maxsize=1024)
+def _positional_param_names(original_function: Callable) -> tuple[str, ...]:
+    return tuple(inspect.signature(original_function).parameters.keys())
+
+
 def convert_args_to_kwargs(
     original_function: Callable,
     args: Optional[Tuple[Any, ...]] = None,
 ) -> Dict[str, Any]:
-    # Get the signature of the original function
-    signature = inspect.signature(original_function)
+    if not args:
+        return {}
 
-    # Get parameter names in the order they appear in the original function
-    param_names = list(signature.parameters.keys())
-
-    # Create a mapping of positional arguments to parameter names
-    args_to_kwargs = {}
-    if args:
-        for index, arg in enumerate(args):
-            if index < len(param_names):
-                param_name = param_names[index]
-                args_to_kwargs[param_name] = arg
-
-    return args_to_kwargs
+    return dict(zip(_positional_param_names(original_function), args))

--- a/tests/test_litellm/caching/test_caching_handler.py
+++ b/tests/test_litellm/caching/test_caching_handler.py
@@ -622,3 +622,40 @@ def test_request_kwargs_does_not_retain_logging_obj():
     assert "litellm_logging_obj" not in handler.request_kwargs
     assert handler.request_kwargs["messages"] == kwargs["messages"]
     assert handler.request_kwargs["model"] == "gpt-4o"
+
+
+def test_convert_args_to_kwargs_maps_positional_args_on_decorated_functions():
+    """
+    convert_args_to_kwargs must resolve positional arguments against the
+    signature litellm's public entry points actually expose, not against the
+    `client` decorator's `(*args, **kwargs)` wrapper.
+
+    litellm.completion is decorated, so wrapper.__code__.co_argcount is 0 and
+    reading __code__ directly yields no parameter names at all. Those names are
+    what turns a positional call into cache-key material, so losing them makes
+    distinct requests collide on one key instead of raising.
+    """
+    import litellm
+    from litellm.caching.caching_handler import convert_args_to_kwargs
+
+    messages = [{"role": "user", "content": "hello"}]
+
+    mapped = convert_args_to_kwargs(litellm.completion, ("gpt-4o", messages))
+
+    assert mapped["model"] == "gpt-4o"
+    assert mapped["messages"] == messages
+
+    assert convert_args_to_kwargs(litellm.completion, ()) == {}
+    assert convert_args_to_kwargs(litellm.completion, None) == {}
+
+
+def test_convert_args_to_kwargs_truncates_extra_positional_args():
+    """More positional args than parameters must not raise or invent names."""
+    from litellm.caching.caching_handler import convert_args_to_kwargs
+
+    def sample(model, messages, temperature=None):
+        return None
+
+    mapped = convert_args_to_kwargs(sample, ("gpt-4o", [], 0.5, "extra", "extra2"))
+
+    assert mapped == {"model": "gpt-4o", "messages": [], "temperature": 0.5}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Every sync completion does cache bookkeeping even when caching is off
- `convert_args_to_kwargs` calls `inspect.signature` on every single call

How it solves it:

- Return from `sync_set_cache` before building `new_kwargs`
- Memoize the parameter-name lookup, keeping `inspect.signature` semantics

## Relevant issues

None filed; this came out of profiling the request path

## Linear ticket

## Changes

`LLMCachingHandler.sync_set_cache` builds `new_kwargs`, which is a `kwargs.copy()` plus a `convert_args_to_kwargs` call, and only then checks `if litellm.cache is None: return`. The other three call sites in this file test `litellm.cache` first, and `_sync_get_cache` carries the comment "Check if caching should be performed BEFORE doing expensive kwargs copy". This one site has the order reversed, so a deployment with caching disabled, which is the default, pays the full cost on every completion and then throws the result away

`convert_args_to_kwargs` calls `inspect.signature(original_function)` and uses only `parameters.keys()`. A given function's signature does not change between calls, so it can be computed once per function and reused. The rewrite also returns early when `args` is empty, which the old version could not do because it computed the signature before testing `args`

## Measurements

Python 3.13, one pinned core, `mock_response` so no network or provider call sits inside the timed region. CPU time via `time.process_time`, reported per `litellm.completion()` call

`convert_args_to_kwargs` costs 45.0 us per call. It costs the same 45.0 us whether `args` is empty or not, because the signature is computed before the `if args` test, so a call with no positional args burns 45.0 us to return `{}`

With caching disabled, removing the wasted work from `sync_set_cache` takes a completion from 0.8834 ms to 0.8046 ms. That is 0.0787 ms per call, or 8.91%. The two arms did not overlap across two separate measurement blocks: unpatched ranged 0.865 to 0.960, patched 0.799 to 0.819

On a mixed workload, half the calls with caching disabled and half with an in-memory cache enabled, both changes together move per-call CPU cost from 0.93027 ms to 0.82402 ms, a reduction of 11.4%. Run-to-run spread of that measurement is 0.65%, so the effect is about 18 times the noise

What this is and is not: these are CPU-time figures for the Python request path, not an end-to-end proxy latency claim. Under real provider latency this is a fixed per-request CPU saving, so it shows up as throughput headroom per worker rather than as latency any single user would notice. I am not claiming a wall-clock proxy improvement

## A note on the earlier attempt

PR #14343 proposed the same signature optimization and was closed by the stale bot in December after seven months without review. It targeted `main` rather than `litellm_internal_staging`

I would not recommend reviving it as written. It replaced `inspect.signature(fn)` with `fn.__code__.co_varnames[:co_argcount]`. litellm's public entry points are wrapped by the `client` decorator, whose wrapper is `def wrapper(*args, **kwargs)`, so `co_argcount` is 0 and that expression returns an empty tuple. `inspect.signature` follows `__wrapped__` and returns the real 43-parameter signature; reading `__code__` does not. Verified on current staging:

```
litellm.completion   has __wrapped__: True, co_name: wrapper, co_argcount: 0
co_varnames[:co_argcount]  -> ()
inspect.signature          -> ('model', 'messages', 'timeout', 'temperature', ...) 43 params
```

So `convert_args_to_kwargs(litellm.completion, ("gpt-4o", messages))` would return `{}` rather than `{"model": ..., "messages": ...}`. Positionally-passed `model` and `messages` would drop out of the cache key, and distinct requests would then collide on one key. It fails quietly rather than raising. This PR keeps `inspect.signature` and memoizes its result, which preserves the `__wrapped__` handling

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This changes CPU cost on the Python request path with no user-visible behaviour change, so a curl against a live proxy would show identical output before and after. The honest proof here is a reproduction anyone can run, plus a regression test that fails on the bug

Reproduction, run at commit `23de7a1` before and after:

```bash
python - <<'EOF'
import time, litellm
litellm.suppress_debug_info = True
msgs = [{"role": "user", "content": "hi"}]
def call():
    return litellm.completion(model="gpt-4o", messages=msgs,
                              temperature=0.3, max_tokens=32,
                              mock_response="ok")
for _ in range(200): call()
t0 = time.process_time()
for _ in range(2000): call()
print("ms/call:", (time.process_time() - t0) / 2000 * 1000)
EOF
```

```
before (23de7a1)          ms/call: 0.8834
after  (this branch)      ms/call: 0.8046
```

The two added tests pin the property PR #14343 broke. Applying that PR's `__code__.co_varnames` approach to this branch makes `test_convert_args_to_kwargs_maps_positional_args_on_decorated_functions` fail, and the fix makes it pass:

```
$ pytest tests/test_litellm/caching/test_caching_handler.py \
         tests/test_litellm/caching/test_llm_caching_handler.py -q
24 passed, 9 warnings in 0.70s

# same tests, with PR #14343's approach substituted in:
FAILED tests/test_litellm/caching/test_caching_handler.py::test_convert_args_to_kwargs_maps_positional_args_on_decorated_functions
1 failed, 1 passed
```

If you would rather see this measured through a live proxy against a real provider, tell me which config you want and I will run it and post the output

## Type

Infrastructure
