### PR TITLE
fix(caching): forward metadata to valkey semantic cache sync embedding calls

### DIFF
--- a/litellm/caching/valkey_semantic_cache.py
+++ b/litellm/caching/valkey_semantic_cache.py
@@ -240,7 +240,7 @@ class ValkeySemanticCache(RedisSemanticCache):
                 print_verbose("No prompt provided for semantic caching")
                 return
 
-            embedding = self._get_embedding(prompt)
+            embedding = self._get_embedding(prompt, metadata=kwargs.get("metadata"))
             self._ensure_index_sync(len(embedding))
 
             doc_key = self._doc_key(key)
@@ -259,7 +259,7 @@ class ValkeySemanticCache(RedisSemanticCache):
                 kwargs.setdefault("metadata", {})["semantic-similarity"] = 0.0
                 return None
 
-            embedding = self._get_embedding(prompt)
+            embedding = self._get_embedding(prompt, metadata=kwargs.get("metadata"))
             self._ensure_index_sync(len(embedding))
 
             search_result = self.sync_client.ft(self.index_name).search(

--- a/tests/test_litellm/caching/test_valkey_semantic_cache.py
+++ b/tests/test_litellm/caching/test_valkey_semantic_cache.py
@@ -265,6 +265,56 @@ def test_get_cache_query_filters_by_scope_tag():
     assert "KNN 1 @embedding" in query.query_string()
 
 
+def test_set_cache_passes_only_metadata_to_get_embedding():
+    sync_client = MagicMock()
+    cache = _make_cache(sync_client=sync_client)
+    captured: dict[str, object] = {}
+
+    def spy_embedding(prompt: str, metadata: dict | None = None) -> list[float]:
+        captured["prompt"] = prompt
+        captured["metadata"] = metadata
+        return [0.1, 0.2, 0.3]
+
+    cache._get_embedding = spy_embedding
+
+    cache.set_cache(
+        key="cache-key",
+        value={"content": "Paris"},
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        metadata={"user_api_key": "sk-test"},
+        cache_key="abc123",
+        custom_llm_provider="openai",
+    )
+
+    assert captured["metadata"] == {"user_api_key": "sk-test"}
+    sync_client.hset.assert_called_once()
+
+
+def test_get_cache_passes_only_metadata_to_get_embedding():
+    sync_client = MagicMock()
+    sync_client.ft.return_value.search.return_value = _search_result(0.05)
+    cache = _make_cache(sync_client=sync_client)
+    captured: dict[str, object] = {}
+
+    def spy_embedding(prompt: str, metadata: dict | None = None) -> list[float]:
+        captured["prompt"] = prompt
+        captured["metadata"] = dict(metadata) if metadata is not None else None
+        return [0.1, 0.2, 0.3]
+
+    cache._get_embedding = spy_embedding
+
+    result = cache.get_cache(
+        key="cache-key",
+        messages=[{"role": "user", "content": "What is the capital of France?"}],
+        metadata={"user_api_key": "sk-test"},
+        cache_key="abc123",
+        custom_llm_provider="openai",
+    )
+
+    assert result == {"content": "Paris"}
+    assert captured["metadata"] == {"user_api_key": "sk-test"}
+
+
 def _async_ft(search_distance):
     search_obj = SimpleNamespace(
         search=AsyncMock(return_value=_search_result(search_distance)),


### PR DESCRIPTION
Problem this solves:

- Valkey semantic cache sync path drops request metadata
- Router-served embeddings lose per-deployment auth context
- Errors are swallowed, so it degrades to a silent cache bypass
- #32295 fixed the async twins but missed the two sync callers

How it solves it:

- Forward `metadata=kwargs.get("metadata")` in sync `set_cache`/`get_cache`
- Brings Valkey in line with the redis and qdrant backends
- Adds two sync regression tests mirroring the existing async pair

## Relevant issues

Follow-up to #32295, which fixed `_get_async_embedding` at lines 282/301 but left the
two sync `_get_embedding` callers at lines 243/262 untouched.

## Type

🐛 Bug Fix

## Changes

`ValkeySemanticCache.set_cache` and `get_cache` called `self._get_embedding(prompt)`
with no `metadata`. The inherited `RedisSemanticCache._get_embedding` feeds that
argument to `build_router_embedding_metadata()` before `router.embedding(...)`, and its
own docstring says it does so "mirroring `_get_async_embedding`".

Across the three semantic-cache backends there are six sync embedding call sites.
Valkey's two were the only ones dropping metadata:

| backend | sync call sites | forwards metadata |
|---|---|---|
| `qdrant_semantic_cache.py` | 246, 285 | yes |
| `redis_semantic_cache.py` | 393, 430 | yes |
| `valkey_semantic_cache.py` | 243, 262 | **no** |

Impact: on a sync `completion()` against `cache_type: valkey-semantic` with a
Router-served embedding deployment, the embedding call loses `user_api_key`,
`user_api_key_team_id`, Bedrock `aws_role_name`, etc. Per-deployment auth can then fail,
and since `set_cache`/`get_cache` swallow exceptions the failure surfaces only as a
permanently cold cache. The async path was already correct, so this is sync-only.

Scope is limited to the two argument lists plus tests.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

A production e2e needs ElastiCache for Valkey 8.2+ running valkey-search, which I don't
have access to. Instead, below is a **fully unmocked** reproduction exercising the real
code path: a real `litellm.Router`, a real `ValkeySemanticCache`, real proxy globals, and
a real litellm `CustomLogger` observing what the Router actually received. Nothing is
patched or stubbed. Embeddings are served by a local HTTP server implementing the OpenAI
embeddings API, so the run costs $0. Happy to attach the script if useful.

```
litellm valkey semantic cache -- sync embedding metadata
base: origin/litellm_internal_staging @ 23de7a15d

Unmocked reproduction. Real litellm.Router, real ValkeySemanticCache, real proxy
globals, real litellm CustomLogger observing what the Router actually received.
Nothing patched or stubbed. Embeddings served by a local HTTP server implementing
the OpenAI embeddings API, so the run costs $0.

######## BEFORE (unfixed source) ########
====================================================================
  metadata the Router actually received, per embedding call
====================================================================

  call #1  (sync set_cache)
    semantic-cache-embedding : True
    user_api_key             : None
    user_api_key_team_id     : None
    user_api_key_alias       : None
    ==> METADATA DROPPED

  call #2  (sync get_cache)
    semantic-cache-embedding : True
    user_api_key             : None
    user_api_key_team_id     : None
    user_api_key_alias       : None
    ==> METADATA DROPPED

====================================================================

######## AFTER (fix applied) ########
====================================================================
  metadata the Router actually received, per embedding call
====================================================================

  call #1  (sync set_cache)
    semantic-cache-embedding : True
    user_api_key             : sk-proof-1234
    user_api_key_team_id     : team-abc
    user_api_key_alias       : nikhil-key
    ==> CARRIES request metadata

  call #2  (sync get_cache)
    semantic-cache-embedding : True
    user_api_key             : sk-proof-1234
    user_api_key_team_id     : team-abc
    user_api_key_alias       : nikhil-key
    ==> CARRIES request metadata

====================================================================
```

Unit tests (`tests/test_litellm/caching`, base 23de7a15d):

- unfixed source + the two new tests: `2 failed` — `assert None == {'user_api_key': 'sk-test'}`
- with the fix: `263 passed` (261 pre-existing + 2 new)

### Final Attestation

- [x] The tests check the right things, including the edge cases
