### PR TITLE
fix(langfuse): handle missing dynamic callback params

### DIFF
--- a/litellm/integrations/langfuse/langfuse_handler.py
+++ b/litellm/integrations/langfuse/langfuse_handler.py
@@ -21,7 +21,7 @@ else:
 class LangFuseHandler:
     @staticmethod
     def get_langfuse_logger_for_request(
-        standard_callback_dynamic_params: StandardCallbackDynamicParams,
+        standard_callback_dynamic_params: StandardCallbackDynamicParams | None,
         in_memory_dynamic_logger_cache: DynamicLoggingCache,
         globalLangfuseLogger: Optional[LangFuseLogger] = None,
     ) -> LangFuseLogger:
@@ -139,7 +139,7 @@ class LangFuseHandler:
 
     @staticmethod
     def _dynamic_langfuse_credentials_are_passed(
-        standard_callback_dynamic_params: StandardCallbackDynamicParams,
+        standard_callback_dynamic_params: StandardCallbackDynamicParams | None,
     ) -> bool:
         """
         This function is used to check if the dynamic langfuse credentials are passed in standard_callback_dynamic_params
@@ -147,6 +147,9 @@ class LangFuseHandler:
         Returns:
             bool: True if the dynamic langfuse credentials are passed, False otherwise
         """
+
+        if standard_callback_dynamic_params is None:
+            return False
 
         if (
             standard_callback_dynamic_params.get("langfuse_host") is not None

--- a/tests/test_litellm/test_langfuse_handler.py
+++ b/tests/test_litellm/test_langfuse_handler.py
@@ -1,0 +1,26 @@
+from unittest.mock import MagicMock
+
+from litellm.integrations.langfuse.langfuse_handler import LangFuseHandler
+
+
+def test_missing_dynamic_params_returns_global_logger() -> None:
+    global_logger = MagicMock()
+    dynamic_logger_cache = MagicMock()
+
+    logger = LangFuseHandler.get_langfuse_logger_for_request(
+        standard_callback_dynamic_params=None,
+        in_memory_dynamic_logger_cache=dynamic_logger_cache,
+        globalLangfuseLogger=global_logger,
+    )
+
+    assert logger is global_logger
+    dynamic_logger_cache.get_cache.assert_not_called()
+
+
+def test_missing_dynamic_params_are_not_dynamic_credentials() -> None:
+    assert (
+        LangFuseHandler._dynamic_langfuse_credentials_are_passed(
+            standard_callback_dynamic_params=None
+        )
+        is False
+    )


### PR DESCRIPTION
## Summary
- treat an absent `standard_callback_dynamic_params` value as no dynamic Langfuse credentials
- preserve the configured global Langfuse logger instead of dereferencing `None`
- add focused regression coverage for the helper and logger selection paths

## Root cause
`get_langfuse_logger_for_request()` forwards `kwargs.get("standard_callback_dynamic_params")`. That value can be `None`, but `_dynamic_langfuse_credentials_are_passed()` unconditionally called `.get()` on it, raising `AttributeError: 'NoneType' object has no attribute 'get'` from the asynchronous success callback.

## Validation
- `.venv/bin/python -m pytest -q tests/test_litellm/test_langfuse_handler.py` -> `2 passed`
- `uv run --no-sync python scripts/ruff_strict_gate.py --base 23de7a15d9d40006ee596e617475ba101d60c5e9` -> strict budget OK
- `git diff --check`

No deployment is included in this PR. The change can be rolled back by reverting commit `ca1329b572e6ffd4860e3ae7ce93af357e027919`.