### PR TITLE
fix(http): retain async client cleanup tasks

### DIFF
--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -13,6 +13,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Set,
     Tuple,
     Union,
 )
@@ -133,6 +134,18 @@ _DEFAULT_TIMEOUT = httpx.Timeout(
     timeout=COMPLETION_HTTP_FALLBACK_SECONDS,
     connect=HTTP_HANDLER_CONNECT_TIMEOUT_SECONDS,
 )
+
+_async_client_cleanup_tasks: Set[asyncio.Task] = set()
+
+
+def _discard_async_client_cleanup_task(task: asyncio.Task) -> None:
+    _async_client_cleanup_tasks.discard(task)
+    if task.cancelled():
+        return
+    try:
+        task.exception()
+    except Exception:
+        pass
 
 
 def _prepare_request_data_and_content(
@@ -830,7 +843,9 @@ class AsyncHTTPHandler:
 
     def __del__(self) -> None:
         try:
-            asyncio.get_running_loop().create_task(self.close())
+            task = asyncio.get_running_loop().create_task(self.close())
+            _async_client_cleanup_tasks.add(task)
+            task.add_done_callback(_discard_async_client_cleanup_task)
         except Exception:
             pass
 

--- a/tests/test_litellm/llms/custom_httpx/test_async_http_client_cleanup.py
+++ b/tests/test_litellm/llms/custom_httpx/test_async_http_client_cleanup.py
@@ -1,0 +1,38 @@
+import asyncio
+
+
+def test_async_http_handler_retains_destructor_cleanup_task():
+    from litellm.llms.custom_httpx.http_handler import (
+        AsyncHTTPHandler,
+        _async_client_cleanup_tasks,
+    )
+
+    async def exercise_cleanup():
+        _async_client_cleanup_tasks.clear()
+        release_close = asyncio.Event()
+        close_finished = asyncio.Event()
+
+        async def delayed_close():
+            await release_close.wait()
+            close_finished.set()
+
+        handler = object.__new__(AsyncHTTPHandler)
+        handler.close = delayed_close
+
+        handler.__del__()
+
+        assert len(_async_client_cleanup_tasks) == 1
+        cleanup_task = next(iter(_async_client_cleanup_tasks))
+
+        await asyncio.sleep(0)
+        assert cleanup_task in _async_client_cleanup_tasks
+        assert not close_finished.is_set()
+
+        release_close.set()
+        await cleanup_task
+        await asyncio.sleep(0)
+
+        assert close_finished.is_set()
+        assert not _async_client_cleanup_tasks
+
+    asyncio.run(exercise_cleanup())


### PR DESCRIPTION
## Summary

- keep a strong reference to `AsyncHTTPHandler` destructor cleanup tasks until they finish
- retrieve task exceptions in the done callback so failed cleanup does not become an unobserved task exception
- add a regression test that holds `close()` open and proves the task remains retained until completion

## Incident evidence

A production LiteLLM 1.84.x runtime emitted bursts of `Unclosed client session` warnings while background model health checks continued. The installed `AsyncHTTPHandler.__del__()` schedules `self.close()` with `create_task()` but does not retain the task. Python's event loop only keeps weak references to tasks, so a pending destructor cleanup task can be garbage-collected before `close()` completes.

The installed weak-reference branch matches the observed failure mode. The exact warning allocation stack was not present in the runtime logs, so this PR does not claim that every warning in the incident was conclusively allocated by this handler.

Operational tracking: https://github.com/HYOSUNG-ITX-AI-Business-Department/hyosung-llm-gateway-ops/issues/119

## Test plan

- `uv run --no-sync pytest -q tests/test_litellm/llms/custom_httpx/test_async_http_client_cleanup.py` (`1 passed`)
- `uv run --no-sync black --check litellm/llms/custom_httpx/http_handler.py tests/test_litellm/llms/custom_httpx/test_async_http_client_cleanup.py`
- `uv run --no-sync ruff check tests/test_litellm/llms/custom_httpx/test_async_http_client_cleanup.py`

Running Ruff on the full existing handler still reports its pre-existing wildcard-import `F403/F405` findings; none are introduced by this diff.

## Deployment and rollback

No deployment was performed. After merge, rollout should be node-by-node with health and warning verification. Rollback is a revert of commit `978a3fbf108218487ed660d5be74b2758204430b` or restoration of the prior image digest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous HTTP client cleanup to prevent lingering background tasks and unobserved errors.
  * Ensured cleanup tasks are tracked until completion and then removed automatically.

* **Tests**
  * Added regression coverage verifying delayed client cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->