### PR TITLE
fix(responses): merge text and tool calls into one choice

### DIFF
--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -497,35 +497,42 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                 reasoning_content = " ".join(s["text"] for s in pending_reasoning_item["summary"] if s.get("text"))
 
             elif isinstance(item, ResponseOutputMessage):
+                response_text = ""
+                annotations: list[ChatCompletionAnnotation] | None = None
                 for content in item.content:
-                    response_text = getattr(content, "text", "")
-                    # Extract annotations from content if present
+                    response_text += getattr(content, "text", "")
                     raw_annotations = getattr(content, "annotations", None)
-                    annotations = LiteLLMResponsesTransformationHandler._convert_annotations_to_chat_format(
+                    content_annotations = LiteLLMResponsesTransformationHandler._convert_annotations_to_chat_format(
                         raw_annotations
                     )
-                    msg = Message(
-                        role=item.role,
-                        content=response_text if response_text else "",
-                        reasoning_content=reasoning_content,
-                        annotations=annotations,
-                        reasoning_items=cast(
-                            list[ChatCompletionReasoningItem] | None,
-                            ([pending_reasoning_item] if pending_reasoning_item is not None else None),
-                        ),
-                    )
+                    if content_annotations:
+                        if annotations is None:
+                            annotations = content_annotations
+                        else:
+                            annotations.extend(content_annotations)
 
-                    choices.append(
-                        Choices(
-                            message=msg,
-                            finish_reason="stop",
-                            index=index,
-                        )
-                    )
+                msg = Message(
+                    role=item.role,
+                    content=response_text,
+                    reasoning_content=reasoning_content,
+                    annotations=annotations,
+                    reasoning_items=cast(
+                        list[ChatCompletionReasoningItem] | None,
+                        ([pending_reasoning_item] if pending_reasoning_item is not None else None),
+                    ),
+                )
 
-                    reasoning_content = None  # flush
-                    pending_reasoning_item = None  # flush
-                    index += 1
+                choices.append(
+                    Choices(
+                        message=msg,
+                        finish_reason="stop",
+                        index=index,
+                    )
+                )
+
+                reasoning_content = None  # flush
+                pending_reasoning_item = None  # flush
+                index += 1
 
             elif isinstance(item, ResponseFunctionToolCall):
                 from litellm.responses.litellm_completion_transformation.transformation import (

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -4,7 +4,7 @@ Handler for transforming /chat/completions api requests to litellm.responses req
 
 import json
 import os
-from collections.abc import AsyncIterator, Callable, Iterable, Iterator
+from collections.abc import AsyncIterator, Callable, Iterable, Iterator, Mapping
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -130,6 +130,37 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                 return {"type": "function", "name": fn_name}
         return tool_choice
 
+    @staticmethod
+    def _handle_raw_dict_message_item(item: Mapping[str, Any], index: int) -> tuple[Any | None, int]:
+        """Convert a raw Responses message item into one chat choice."""
+        from litellm.types.utils import Choices, Message
+
+        response_text = ""
+        annotations: tuple[ChatCompletionAnnotation, ...] = ()
+        has_output_text = False
+        for content_item in item.get("content", []):
+            if not isinstance(content_item, dict) or content_item.get("type") != "output_text":
+                continue
+
+            has_output_text = True
+            response_text += content_item.get("text", "")
+            content_annotations = LiteLLMResponsesTransformationHandler._convert_annotations_to_chat_format(
+                content_item.get("annotations", None)
+            )
+            if content_annotations:
+                annotations += tuple(content_annotations)
+
+        if not has_output_text:
+            return None, index
+
+        msg = Message(
+            role=item.get("role", "assistant"),
+            content=response_text,
+            annotations=annotations or None,
+        )
+        choice = Choices(message=msg, finish_reason="stop", index=index)
+        return choice, index + 1
+
     def _handle_raw_dict_response_item(self, item: dict[str, Any], index: int) -> tuple[Any | None, int]:
         """
         Handle raw dict response items from Responses API (e.g., GPT-5 Codex format).
@@ -151,23 +182,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
         # Handle message items with output_text content
         if item_type == "message":
-            content_list = item.get("content", [])
-            for content_item in content_list:
-                if isinstance(content_item, dict):
-                    content_type = content_item.get("type")
-                    if content_type == "output_text":
-                        response_text = content_item.get("text", "")
-                        # Extract annotations from content if present
-                        annotations = LiteLLMResponsesTransformationHandler._convert_annotations_to_chat_format(
-                            content_item.get("annotations", None)
-                        )
-                        msg = Message(
-                            role=item.get("role", "assistant"),
-                            content=response_text if response_text else "",
-                            annotations=annotations,
-                        )
-                        choice = Choices(message=msg, finish_reason="stop", index=index)
-                        return choice, index + 1
+            return self._handle_raw_dict_message_item(item=item, index=index)
 
         # Handle function_call items (e.g., from GPT-5 Codex format)
         if item_type == "function_call":
@@ -202,6 +217,30 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
         # Unknown or unsupported type
         return None, index
+
+    @staticmethod
+    def _collect_raw_dict_choice(
+        choice: Any,
+        choices: list[Any],  # mutable-ok: shared output-choice accumulator
+        accumulated_tool_calls: list[dict[str, Any]],  # mutable-ok: shared tool-call accumulator
+        index: int,
+        next_index: int,
+    ) -> tuple[int, int]:
+        """Collect a raw tool choice, or retain a raw message choice."""
+        if choice is None:
+            return index, 0
+
+        raw_tool_calls = choice.message.tool_calls
+        if not raw_tool_calls:
+            choices.append(choice)
+            return next_index, 0
+
+        for tool_call in raw_tool_calls:
+            if isinstance(tool_call, dict):
+                accumulated_tool_calls.append(tool_call)
+            else:
+                accumulated_tool_calls.append(tool_call.model_dump(exclude_none=True))
+        return index, len(raw_tool_calls)
 
     def convert_chat_completion_messages_to_responses_api(
         self, messages: list["AllMessageValues"]
@@ -498,7 +537,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
             elif isinstance(item, ResponseOutputMessage):
                 response_text = ""
-                annotations: list[ChatCompletionAnnotation] | None = None
+                annotations: tuple[ChatCompletionAnnotation, ...] = ()
                 for content in item.content:
                     response_text += getattr(content, "text", "")
                     raw_annotations = getattr(content, "annotations", None)
@@ -506,16 +545,13 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                         raw_annotations
                     )
                     if content_annotations:
-                        if annotations is None:
-                            annotations = content_annotations
-                        else:
-                            annotations.extend(content_annotations)
+                        annotations += tuple(content_annotations)
 
                 msg = Message(
                     role=item.role,
                     content=response_text,
                     reasoning_content=reasoning_content,
-                    annotations=annotations,
+                    annotations=annotations or None,
                     reasoning_items=cast(
                         list[ChatCompletionReasoningItem] | None,
                         ([pending_reasoning_item] if pending_reasoning_item is not None else None),
@@ -564,9 +600,15 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
             elif isinstance(item, dict) and handle_raw_dict_callback is not None:
                 # Handle raw dict responses (e.g., from GPT-5 Codex)
-                choice, index = handle_raw_dict_callback(item=item, index=index)
-                if choice is not None:
-                    choices.append(choice)
+                choice, next_index = handle_raw_dict_callback(item=item, index=index)
+                index, raw_tool_call_count = LiteLLMResponsesTransformationHandler._collect_raw_dict_choice(
+                    choice=choice,
+                    choices=choices,
+                    accumulated_tool_calls=accumulated_tool_calls,
+                    index=index,
+                    next_index=next_index,
+                )
+                tool_call_index += raw_tool_call_count
             else:
                 pass  # don't fail request if item in list is not supported
 

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -565,6 +565,14 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
         # If we accumulated tool calls, create a single choice with all of them
         if accumulated_tool_calls:
+            if len(choices) == 1 and choices[0].message.tool_calls is None:
+                text_choice = choices[0]
+                text_choice.message = Message(
+                    **text_choice.message.model_dump(exclude_none=True),
+                    tool_calls=accumulated_tool_calls,
+                )
+                text_choice.finish_reason = "tool_calls"
+                return choices
             msg = Message(
                 content=None,
                 tool_calls=accumulated_tool_calls,

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1501,7 +1501,7 @@ def test_multiple_tool_calls_in_single_choice():
     print("✓ Multiple tool calls are correctly grouped in a single choice")
 
 
-def test_message_and_tool_call_are_merged_into_single_choice():
+def test_message_content_and_tool_call_are_merged_into_single_choice():
     from openai.types.responses import (
         ResponseFunctionToolCall,
         ResponseOutputMessage,
@@ -1514,7 +1514,13 @@ def test_message_and_tool_call_are_merged_into_single_choice():
         content=[
             ResponseOutputText(
                 annotations=[],
-                text="Let me check that.",
+                text="Let me check that. ",
+                type="output_text",
+                logprobs=[],
+            ),
+            ResponseOutputText(
+                annotations=[],
+                text="I am still checking.",
                 type="output_text",
                 logprobs=[],
             )
@@ -1540,7 +1546,7 @@ def test_message_and_tool_call_are_merged_into_single_choice():
     choice = choices[0]
     assert choice.index == 0
     assert choice.finish_reason == "tool_calls"
-    assert choice.message.content == "Let me check that."
+    assert choice.message.content == "Let me check that. I am still checking."
     assert choice.message.tool_calls is not None
     assert len(choice.message.tool_calls) == 1
     assert choice.message.tool_calls[0].id == "call_paris"

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1553,6 +1553,53 @@ def test_message_content_and_tool_call_are_merged_into_single_choice():
     assert choice.message.tool_calls[0].function.name == "get_weather"
 
 
+def test_raw_dict_message_and_tool_call_are_merged_into_single_choice():
+    handler = LiteLLMResponsesTransformationHandler()
+    output_items = [
+        {
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "Let me check that. ",
+                    "annotations": [],
+                },
+                {
+                    "type": "output_text",
+                    "text": "I am still checking.",
+                    "annotations": [],
+                },
+            ],
+        },
+        {
+            "id": "fc_1",
+            "type": "function_call",
+            "status": "completed",
+            "arguments": '{"location": "Paris"}',
+            "call_id": "call_paris",
+            "name": "get_weather",
+        },
+    ]
+
+    choices = handler._convert_response_output_to_choices(
+        output_items=output_items,
+        handle_raw_dict_callback=handler._handle_raw_dict_response_item,
+    )
+
+    assert len(choices) == 1
+    choice = choices[0]
+    assert choice.index == 0
+    assert choice.finish_reason == "tool_calls"
+    assert choice.message.content == "Let me check that. I am still checking."
+    assert choice.message.tool_calls is not None
+    assert len(choice.message.tool_calls) == 1
+    assert choice.message.tool_calls[0].id == "call_paris"
+    assert choice.message.tool_calls[0].function.name == "get_weather"
+
+
 def test_map_reasoning_effort_adds_summary_detailed():
     """
     Test that _map_reasoning_effort behavior with reasoning_auto_summary flag.

--- a/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
+++ b/tests/test_litellm/completion_extras/litellm_responses_transformation/test_completion_extras_litellm_responses_transformation_transformation.py
@@ -1501,6 +1501,52 @@ def test_multiple_tool_calls_in_single_choice():
     print("✓ Multiple tool calls are correctly grouped in a single choice")
 
 
+def test_message_and_tool_call_are_merged_into_single_choice():
+    from openai.types.responses import (
+        ResponseFunctionToolCall,
+        ResponseOutputMessage,
+        ResponseOutputText,
+    )
+
+    handler = LiteLLMResponsesTransformationHandler()
+    output_message = ResponseOutputMessage(
+        id="msg_1",
+        content=[
+            ResponseOutputText(
+                annotations=[],
+                text="Let me check that.",
+                type="output_text",
+                logprobs=[],
+            )
+        ],
+        role="assistant",
+        status="completed",
+        type="message",
+    )
+    tool_call = ResponseFunctionToolCall(
+        id="fc_1",
+        type="function_call",
+        status="completed",
+        arguments='{"location": "Paris"}',
+        call_id="call_paris",
+        name="get_weather",
+    )
+
+    choices = handler._convert_response_output_to_choices(
+        output_items=[output_message, tool_call]
+    )
+
+    assert len(choices) == 1
+    choice = choices[0]
+    assert choice.index == 0
+    assert choice.finish_reason == "tool_calls"
+    assert choice.message.content == "Let me check that."
+    assert choice.message.tool_calls is not None
+    assert len(choice.message.tool_calls) == 1
+    assert choice.message.tool_calls[0].id == "call_paris"
+    assert choice.message.tool_calls[0].function.name == "get_weather"
+
+
 def test_map_reasoning_effort_adds_summary_detailed():
     """
     Test that _map_reasoning_effort behavior with reasoning_auto_summary flag.


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mixed Responses output splits text and tool calls
- Chat clients inspect only `choices[0]`

How it solves it:

- Merge both into one chat choice for typed and raw-dict/Codex output
- Cover mixed multi-content output with regression test

## Relevant issues

Related to #16215

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Live calls used the same model, messages, function schema, and required tool choice against an OpenAI-compatible Responses endpoint

Before at `23de7a15d9d40006ee596e617475ba101d60c5e9`

```json
{"choice_count": 2, "choices": [{"index": 0, "finish_reason": "stop", "content": "I’ll check the current weather in Paris.", "tool_call_count": 0, "tool_name": null, "tool_call_type": null}, {"index": 1, "finish_reason": "tool_calls", "content": null, "tool_call_count": 1, "tool_name": "get_weather", "tool_call_type": "ChatCompletionMessageToolCall"}]}
```

After at `d05f802a468d6d521f2d152cbb3f7af019f3686a`

```json
{"choice_count": 1, "choices": [{"index": 0, "finish_reason": "tool_calls", "content": "I’ll check the current weather in Paris.", "tool_call_count": 1, "tool_name": "get_weather", "tool_call_type": "ChatCompletionMessageToolCall"}]}
```

## Type

Bug Fix

## Changes

- Aggregate multiple output text blocks from one Responses message
- Merge the resulting message with accumulated tool calls
- Rebuild the message through LiteLLM validation to preserve tool call typing
- Add regression coverage for multiple content blocks followed by a function call
- Pass all 50 tests in the mapped transformation test module
- Pass `make pre-commit`, including lint, format, import, and type gates
- Full `make test-unit` stopped during collection on duplicate `test_models` module names before running tests

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


