### PR TITLE
fix(batches): map Responses API usage fields when reconciling batch cost

### DIFF
--- a/litellm/batches/batch_utils.py
+++ b/litellm/batches/batch_utils.py
@@ -432,6 +432,10 @@ def _get_batch_job_usage_from_response_body(response_body: dict, custom_llm_prov
             reasoning_content=None,
         )
     _usage_dict = response_body.get("usage", None) or {}
+    if "input_tokens" in _usage_dict or "output_tokens" in _usage_dict:
+        from litellm.responses.utils import ResponseAPILoggingUtils
+
+        return ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage(_usage_dict)
     usage: Usage = Usage(**_usage_dict)
     return usage
 

--- a/tests/test_litellm/batches/test_batch_utils.py
+++ b/tests/test_litellm/batches/test_batch_utils.py
@@ -124,6 +124,28 @@ def test_get_usage_from_response_body_missing_is_zero():
     )
 
 
+def test_get_usage_from_response_body_responses_api_input_output_tokens():
+    usage = bu._get_batch_job_usage_from_response_body(
+        {"usage": {"input_tokens": 33, "output_tokens": 57, "total_tokens": 90}}
+    )
+    assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (
+        33,
+        57,
+        90,
+    )
+
+
+def test_get_usage_from_response_body_responses_api_without_total_tokens():
+    usage = bu._get_batch_job_usage_from_response_body(
+        {"usage": {"input_tokens": 12, "output_tokens": 8}}
+    )
+    assert (usage.prompt_tokens, usage.completion_tokens, usage.total_tokens) == (
+        12,
+        8,
+        20,
+    )
+
+
 # =========================================================================== #
 # _get_file_content_as_dictionary  (JSONL parsing)
 # =========================================================================== #


### PR DESCRIPTION
## TLDR

Problem this solves:

- Batches submitted with `endpoint="/v1/responses"` reconcile to zero prompt tokens, zero completion tokens and $0.00 spend, with no error and no warning, so their spend never reaches `LiteLLM_SpendLogs` with a real value and per-key and per-team `max_budget` is not enforced for those workloads

How it solves it:

- Routes Responses-shaped usage through the existing `ResponseAPILoggingUtils._transform_response_api_usage_to_chat_usage` helper instead of constructing `Usage` directly from a dict whose keys do not match

## Relevant issues

Fixes #35363

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

CI is green at 74 passing checks, including `db-and-spend` and `endpoints-and-responses`. Greptile returned 5/5. Locally `make pre-commit` passes (ruff, basedpyright, type discipline gates, circular imports, budget ceilings) and `tests/test_litellm/batches` plus `tests/test_litellm/responses` pass at 543 tests

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`_get_batch_job_usage_from_response_body` built `Usage(**usage_dict)` straight from the response body. Chat Completions usage carries `prompt_tokens` and `completion_tokens`; Responses usage carries `input_tokens` and `output_tokens`, so neither field matched and both fell back to their defaults. Every Responses batch line therefore aggregated to zero, and because nothing in that path raises, the shortfall stays invisible until someone queries spend logs and filters on `spend > 0`

The two regression tests fail on current `main` with `(0, 0, 0)` against an expected `(33, 57, 90)`, which is the same 33 input / 57 output line reported in #35363, and pass after the change. The second test covers a provider that omits `total_tokens`, where the helper derives it from the input and output counts

I have not attached a live proxy batch run because a real batch has up to a 24 hour completion window. The change is a pure usage mapping with no I/O, so the regression tests exercise it directly. Happy to add a live run before merge if you would rather see one

## Type

Bug Fix

## Changes

`litellm/batches/batch_utils.py` detects the Responses usage shape by the presence of `input_tokens` or `output_tokens` and delegates to the existing shared helper, rather than adding another per-surface parser. Anthropic and Bedrock return earlier in the same function, so those paths are untouched

`tests/test_litellm/batches/test_batch_utils.py` adds two regression tests next to the existing coverage for that function

## QA runbook

Submit a batch with `endpoint="/v1/responses"`, wait for it to reach `completed`, then read the `aretrieve_batch` row in `LiteLLM_SpendLogs`. Before this change the row carries zero prompt tokens, zero completion tokens and zero spend even though the batch output file reports real usage; after it carries the usage from the output file and the batch counts against `max_budget`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
