### PR TITLE
fix(fireworks_ai): add kimi-k3 pricing so tool_choice is not rejected locally

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -16726,6 +16726,21 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "fireworks_ai/accounts/fireworks/models/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://docs.fireworks.ai/serverless/pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "fireworks_ai/accounts/fireworks/models/llama-v3p1-405b-instruct": {
         "input_cost_per_token": 3e-06,
         "litellm_provider": "fireworks_ai",
@@ -17129,6 +17144,21 @@
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "fireworks_ai/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://docs.fireworks.ai/serverless/pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": true
     },

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -16726,6 +16726,21 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
+    "fireworks_ai/accounts/fireworks/models/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://docs.fireworks.ai/serverless/pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "fireworks_ai/accounts/fireworks/models/llama-v3p1-405b-instruct": {
         "input_cost_per_token": 3e-06,
         "litellm_provider": "fireworks_ai",
@@ -17129,6 +17144,21 @@
         "supports_function_calling": true,
         "supports_reasoning": true,
         "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "fireworks_ai/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "fireworks_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://docs.fireworks.ai/serverless/pricing",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": true
     },

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -1282,3 +1282,29 @@ def test_streaming_surfaces_fireworks_response_fields():
     assert surfaced["fireworks_raw_outputs"] == [raw_output]
     assert surfaced["fireworks_perf_metrics"] == {"prompt-tokens": 5}
     assert surfaced["fireworks_prompt_token_ids"] == [1, 2, 3]
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["accounts/fireworks/models/kimi-k3", "kimi-k3"],
+)
+def test_fireworks_kimi_k3_supports_tool_choice(monkeypatch, model):
+    """
+    Kimi K3 on Fireworks had no entry in the model cost map, so
+    supports_tool_choice() came back False and FireworksAIConfig dropped
+    tool_choice from its supported params. Callers passing tool_choice got a
+    local UnsupportedParamsError before the request ever left LiteLLM, even
+    though Fireworks itself accepts it.
+    """
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
+
+    model_info = litellm.model_cost.get(f"fireworks_ai/{model}")
+    assert model_info is not None, f"Missing model pricing entry: fireworks_ai/{model}"
+    assert model_info["supports_tool_choice"] is True
+    assert model_info["input_cost_per_token"] == 3e-06
+    assert model_info["output_cost_per_token"] == 1.5e-05
+    assert model_info["cache_read_input_token_cost"] == 3e-07
+    assert model_info["max_input_tokens"] == 1048576
+
+    assert "tool_choice" in FireworksAIConfig().get_supported_openai_params(model=model)


### PR DESCRIPTION
## Relevant issues

Fixes #35382

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Kimi K3 on Fireworks had no entry in the model cost map, so `supports_tool_choice()` returned False and `FireworksAIConfig.get_supported_openai_params` left `tool_choice` out of the supported list. Callers got a local `UnsupportedParamsError` before the request ever left LiteLLM, even though Fireworks accepts the parameter and returns tool calls, which the reporter confirmed by forcing it through with `allowed_openai_params`.

Proxy config used for both runs, pointed at an unreachable base so the outgoing request body is what gets inspected rather than a completion:

```yaml
model_list:
  - model_name: kimi-k3
    litellm_params:
      model: fireworks_ai/accounts/fireworks/models/kimi-k3
      api_key: dummy-fireworks-key
      api_base: http://127.0.0.1:9/inference/v1
```

Both runs use `LITELLM_LOCAL_MODEL_COST_MAP=True` so the proxy reads this repo's map rather than the published one.

```bash
curl -s -X POST http://127.0.0.1:4000/v1/chat/completions \
  -H 'Authorization: Bearer sk-proof-1234' -H 'Content-Type: application/json' \
  -d '{"model":"kimi-k3","messages":[{"role":"user","content":"weather in SF?"}],
       "tools":[{"type":"function","function":{"name":"get_weather","description":"Get weather",
         "parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}}],
       "tool_choice":"auto"}'
```

Before, on base `7c56317edf`, the call is rejected locally and never reaches Fireworks:

```
litellm.UnsupportedParamsError: fireworks_ai does not support parameters: ['tool_choice'],
for model=accounts/fireworks/models/kimi-k3.
```

After, with this PR, validation passes and `tool_choice` is forwarded. The request now gets as far as the network, and the only error is the deliberately unreachable base:

```
POST Request Sent from LiteLLM:
-d '{'model': 'accounts/fireworks/models/kimi-k3', 'messages': [...],
     'tools': [{'type': 'function', 'function': {'name': 'get_weather', ...}}],
     'tool_choice': 'auto'}'
```

```
litellm.InternalServerError: Fireworks_aiException - Cannot connect to host 127.0.0.1:9
```

As a control, the same request without `tool_choice` already reached the network on the base commit, which places the failure squarely in the capability gate rather than anywhere downstream.

## Type

🐛 Bug Fix

## Changes

Adds `fireworks_ai/accounts/fireworks/models/kimi-k3` and the short `fireworks_ai/kimi-k3` alias to `model_prices_and_context_window.json` and its backup mirror, following the existing Kimi entries which carry both key forms. Pricing is $3.00 per million input, $0.30 per million cached input and $15.00 per million output, taken from the Fireworks serverless pricing page; the 1M context window, function calling and image input come from the model page. Those input and output figures also match Moonshot's own published K3 pricing. `supports_tool_choice` is set to true, which is what actually unblocks the reported error.

A parametrized regression test covers both key forms, asserting the pricing fields and that `tool_choice` appears in the supported params; it fails on the base commit for both.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

---

Disclosure: I'm fairly new to this codebase and used Claude Code to trace the capability gate and run the before and after proxy captures. I checked the pricing against the Fireworks pages myself and confirmed the repro before and after; happy to correct anything that looks off.

