### PR TITLE
fix(exception_mapping): map Gemini 429 quota errors before the 403 substring branch

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -1120,6 +1120,26 @@ def _map_vertex_exception(
             llm_provider=custom_llm_provider,
             litellm_debug_info=extra_information,
         )
+    elif (
+        "429 Quota exceeded" in error_str
+        or "Quota exceeded for" in error_str
+        or "Resource exhausted" in error_str
+        or "IndexError: list index out of range" in error_str
+        or "429 Unable to submit request because the service is temporarily out of capacity." in error_str
+    ):
+        raise RateLimitError(
+            message=f"litellm.RateLimitError: {custom_llm_provider}Exception - {error_str}",
+            model=model,
+            llm_provider=custom_llm_provider,
+            litellm_debug_info=extra_information,
+            response=httpx.Response(
+                status_code=429,
+                request=httpx.Request(
+                    method="POST",
+                    url=" https://cloud.google.com/vertex-ai/",
+                ),
+            ),
+        )
     elif "403" in error_str:
         raise BadRequestError(
             message=f"{custom_llm_provider.capitalize()}Exception BadRequestError - {error_str}",
@@ -1145,26 +1165,6 @@ def _map_vertex_exception(
             litellm_debug_info=extra_information,
             response=httpx.Response(
                 status_code=400,
-                request=httpx.Request(
-                    method="POST",
-                    url=" https://cloud.google.com/vertex-ai/",
-                ),
-            ),
-        )
-    elif (
-        "429 Quota exceeded" in error_str
-        or "Quota exceeded for" in error_str
-        or "Resource exhausted" in error_str
-        or "IndexError: list index out of range" in error_str
-        or "429 Unable to submit request because the service is temporarily out of capacity." in error_str
-    ):
-        raise RateLimitError(
-            message=f"litellm.RateLimitError: {custom_llm_provider}Exception - {error_str}",
-            model=model,
-            llm_provider=custom_llm_provider,
-            litellm_debug_info=extra_information,
-            response=httpx.Response(
-                status_code=429,
                 request=httpx.Request(
                     method="POST",
                     url=" https://cloud.google.com/vertex-ai/",

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -373,6 +373,55 @@ def test_vertex_ai_rate_limit_error_mapping(error_message, should_raise_rate_lim
             )
 
 
+# Regression tests for https://github.com/BerriAI/litellm/issues/34954
+# A Gemini/Vertex 429 whose RESOURCE_EXHAUSTED body carries a sub-second retry
+# hint such as "Please retry in 18.403470473s." must still map to RateLimitError.
+# The digits "403" in that delay used to hit an unanchored `"403" in error_str`
+# branch that was evaluated before the quota branch, yielding BadRequestError(403)
+# and disabling Router retries for a transient rate limit.
+def _gemini_quota_body(retry_delay: str) -> str:
+    return (
+        '{"error": {"code": 429, "message": "You exceeded your current quota. '
+        "Quota exceeded for metric: generativelanguage.googleapis.com/generate_content_free_tier_requests, "
+        "limit: 15. Please retry in " + retry_delay + '.", "status": "RESOURCE_EXHAUSTED"}}'
+    )
+
+
+@pytest.mark.parametrize(
+    "retry_delay",
+    [
+        "18.403470473s",  # digits contain "403" - the bug case
+        "18.9s",  # control: no "403" digits, already mapped correctly
+    ],
+)
+def test_gemini_429_quota_maps_to_rate_limit_regardless_of_retry_delay(retry_delay):
+    original_exception = Exception(_gemini_quota_body(retry_delay))
+
+    with pytest.raises(litellm.RateLimitError) as excinfo:
+        exception_type(
+            model="gemini/gemini-2.5-flash",
+            original_exception=original_exception,
+            custom_llm_provider="vertex_ai",
+        )
+    assert excinfo.value.status_code == 429
+
+
+def test_vertex_genuine_403_still_maps_to_bad_request():
+    body = (
+        '{"error": {"code": 403, "message": "Permission denied on resource project foo.", '
+        '"status": "PERMISSION_DENIED"}}'
+    )
+    original_exception = Exception(body)
+
+    with pytest.raises(litellm.BadRequestError) as excinfo:
+        exception_type(
+            model="gemini/gemini-2.5-flash",
+            original_exception=original_exception,
+            custom_llm_provider="vertex_ai",
+        )
+    assert excinfo.value.status_code == 403
+
+
 class TestGetBodyErrorCode:
     """Unit tests for _get_body_error_code helper."""
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- A Gemini/Vertex HTTP 429 whose quota body carries a sub-second retry hint like `Please retry in 18.403470473s.` maps to `BadRequestError(status_code=403)` instead of `RateLimitError`, because the digits `403` in the retry delay match an unanchored `"403" in error_str` branch that runs before the 429/quota branch
- Since `litellm._should_retry(403)` is `False`, the Router's retry/fallback machinery declines to retry, so a transient rate limit becomes a hard 4xx failure. The outcome is nondeterministic; it depends only on the random decimals Google puts in the retry delay

How it solves it:

- In `_map_vertex_exception`, move the quota/429 branch (`"Quota exceeded for"`, `"Resource exhausted"`, etc.) above the `elif "403" in error_str` branch, so a 429 body is classified as `RateLimitError` regardless of which digits appear in the retry delay
- Genuine 403 bodies still fall through to the 403 branch, so their mapping is unchanged

## Relevant issues

Resolves #34954

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

The issue includes a reproduction that uses only the public `litellm.completion` API with an `httpx.MockTransport`, so no API key, network, or real quota exhaustion is needed. The only difference between the two runs is the retry-delay float in the 429 body

Before this change

```
retry delay 18.403470473s -> BadRequestError  status_code=403  litellm._should_retry=False
retry delay          18.9s -> RateLimitError   status_code=429  litellm._should_retry=True
```

After this change both map to `RateLimitError(status_code=429)` with `litellm._should_retry=True`, so the Router retries the transient rate limit

## Type

🐛 Bug Fix

## Changes

The reorder is the whole fix; the correct branch already existed and already matched the quota body (`Quota exceeded for metric:` is a literal hit for the existing `"Quota exceeded for"` clause), it just sat below the `"403"` substring branch. Regression coverage in `tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py` asserts that a 429 quota body whose retry delay contains `403` maps to `RateLimitError(429)`, that a control body without those digits keeps mapping correctly, and that a real 403 permission-denied body still maps to `BadRequestError(403)`. The 403 case fails before this change and passes after

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
