### PR TITLE
fix(mcp): report per-request auth headers in MCP debug auth resolution

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_debug.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_debug.py
@@ -156,13 +156,22 @@ class MCPDebug:
 
         Returns one of: ``per-request-header``, ``m2m-client-credentials``,
         ``static-token``, ``oauth2-passthrough``, or ``no-auth``.
+
+        Per-server header matching goes through ``lookup_mcp_server_auth_in_headers``
+        so this reports what egress actually resolves; a raw dict lookup would miss
+        the case-insensitive and header-sanitized alias forms that egress matches.
         """
+        from litellm.proxy._experimental.mcp_server.utils import (
+            lookup_mcp_server_auth_in_headers,
+        )
         from litellm.types.mcp import MCPAuth
 
         has_server_specific = bool(
             mcp_server_auth_headers
-            and (
-                mcp_server_auth_headers.get(server.alias or "") or mcp_server_auth_headers.get(server.server_name or "")
+            and lookup_mcp_server_auth_in_headers(
+                mcp_server_auth_headers,
+                alias=server.alias,
+                server_name=server.server_name,
             )
         )
         if has_server_specific or mcp_auth_header:
@@ -285,20 +294,49 @@ class MCPDebug:
         from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
             global_mcp_server_manager,
         )
+        from litellm.proxy._experimental.mcp_server.utils import (
+            lookup_mcp_server_auth_in_headers,
+        )
 
-        server_url: Optional[str] = None
-        server_auth_type: Optional[str] = None
-        auth_resolution = "no-auth"
-
-        for server_name in mcp_servers or []:
-            server = global_mcp_server_manager.get_mcp_server_by_name(server_name, client_ip=client_ip)
-            if server:
-                server_url = server.url
-                server_auth_type = server.auth_type
-                auth_resolution = MCPDebug.resolve_auth_resolution(
-                    server, mcp_auth_header, mcp_server_auth_headers, oauth2_headers
+        named_servers = (
+            tuple(
+                server
+                for server in (
+                    global_mcp_server_manager.get_mcp_server_by_name(name, client_ip=client_ip) for name in mcp_servers
                 )
-                break
+                if server is not None
+            )
+            if mcp_servers
+            else ()
+        )
+        candidate_servers = named_servers or (
+            tuple(
+                server
+                for server in global_mcp_server_manager.get_filtered_registry(client_ip=client_ip).values()
+                if lookup_mcp_server_auth_in_headers(
+                    mcp_server_auth_headers,
+                    alias=server.alias,
+                    server_name=server.server_name,
+                )
+            )
+            if mcp_server_auth_headers
+            else ()
+        )
+        resolutions = tuple(
+            (
+                server,
+                MCPDebug.resolve_auth_resolution(server, mcp_auth_header, mcp_server_auth_headers, oauth2_headers),
+            )
+            for server in candidate_servers
+        )
+        reported = next(
+            ((server, resolution) for server, resolution in resolutions if resolution != "no-auth"),
+            resolutions[0] if resolutions else None,
+        )
+
+        server_url = reported[0].url if reported else None
+        server_auth_type = reported[0].auth_type if reported else None
+        auth_resolution = reported[1] if reported else "no-auth"
 
         scope_headers = MCPRequestHandler._safe_get_headers_from_scope(scope)
         litellm_key = MCPRequestHandler.get_litellm_api_key_from_headers(scope_headers)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_debug.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_debug.py
@@ -5,10 +5,14 @@ Tests for MCPDebug — MCP OAuth2 debug response headers.
 import asyncio
 from unittest.mock import MagicMock
 
+import pytest
+
 from litellm.proxy._experimental.mcp_server.mcp_debug import (
     MCP_DEBUG_REQUEST_HEADER,
     MCPDebug,
 )
+from litellm.types.mcp import MCPAuth, MCPTransport
+from litellm.types.mcp_server.mcp_server_manager import MCPServer
 
 
 class TestIsDebugEnabled:
@@ -235,6 +239,154 @@ class TestResolveAuthResolution:
             oauth2_headers=None,
         )
         assert result == "no-auth"
+
+    def test_server_specific_header_matches_lowercased_alias(self):
+        """Header names arrive lowercased, so an alias with uppercase letters must
+        still match; egress resolves it, so debug must report it the same way."""
+        server = self._make_server(alias="MyServer", server_name="MyServer")
+        result = MCPDebug.resolve_auth_resolution(
+            server,
+            mcp_auth_header=None,
+            mcp_server_auth_headers={"myserver": {"Authorization": "Bearer xxx"}},
+            oauth2_headers=None,
+        )
+        assert result == "per-request-header"
+
+    def test_server_specific_header_matches_sanitized_alias(self):
+        """Aliases are sanitized to [a-z0-9_] for the x-mcp-{alias}-* header form."""
+        server = self._make_server(alias="My Server", server_name="My Server")
+        result = MCPDebug.resolve_auth_resolution(
+            server,
+            mcp_auth_header=None,
+            mcp_server_auth_headers={"my_server": {"Authorization": "Bearer xxx"}},
+            oauth2_headers=None,
+        )
+        assert result == "per-request-header"
+
+    def test_server_specific_header_for_a_different_server_is_not_claimed(self):
+        server = self._make_server(alias="alpha", server_name="alpha")
+        result = MCPDebug.resolve_auth_resolution(
+            server,
+            mcp_auth_header=None,
+            mcp_server_auth_headers={"beta": {"Authorization": "Bearer xxx"}},
+            oauth2_headers=None,
+        )
+        assert result == "no-auth"
+
+
+@pytest.fixture
+def registry():
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        global_mcp_server_manager,
+    )
+
+    saved = dict(global_mcp_server_manager.registry)
+    global_mcp_server_manager.registry.clear()
+    yield global_mcp_server_manager.registry
+    global_mcp_server_manager.registry.clear()
+    global_mcp_server_manager.registry.update(saved)
+
+
+def _server(server_id, name, url):
+    return MCPServer(
+        server_id=server_id,
+        name=name,
+        server_name=name,
+        alias=name,
+        url=url,
+        transport=MCPTransport.http,
+        auth_type=MCPAuth.none,
+    )
+
+
+_DEBUG_SCOPE = {"type": "http", "headers": [(b"x-litellm-mcp-debug", b"true")]}
+_DEBUG_RAW_HEADERS = {MCP_DEBUG_REQUEST_HEADER: "true"}
+
+
+class TestMaybeBuildDebugHeaders:
+    """The aggregate /mcp endpoint carries no server name in the path or the
+    x-mcp-servers header, so debug reporting must fall back to the servers the
+    caller addressed with x-mcp-{alias}-* headers."""
+
+    def test_aggregate_endpoint_reports_per_request_header(self, registry):
+        registry["s1"] = _server("s1", "myserver", "https://upstream.example.com/mcp")
+
+        headers = MCPDebug.maybe_build_debug_headers(
+            raw_headers=_DEBUG_RAW_HEADERS,
+            scope=_DEBUG_SCOPE,
+            mcp_servers=None,
+            mcp_auth_header=None,
+            mcp_server_auth_headers={"myserver": {"Authorization": "Bearer upstream-tok"}},
+            oauth2_headers=None,
+            client_ip=None,
+        )
+
+        assert headers["x-mcp-debug-auth-resolution"] == "per-request-header"
+        assert headers["x-mcp-debug-outbound-url"] == "https://upstream.example.com/mcp"
+
+    def test_aggregate_endpoint_without_per_server_headers_reports_no_auth(self, registry):
+        registry["s1"] = _server("s1", "myserver", "https://upstream.example.com/mcp")
+
+        headers = MCPDebug.maybe_build_debug_headers(
+            raw_headers=_DEBUG_RAW_HEADERS,
+            scope=_DEBUG_SCOPE,
+            mcp_servers=None,
+            mcp_auth_header=None,
+            mcp_server_auth_headers=None,
+            oauth2_headers=None,
+            client_ip=None,
+        )
+
+        assert headers["x-mcp-debug-auth-resolution"] == "no-auth"
+        assert headers["x-mcp-debug-outbound-url"] == "(unknown)"
+
+    def test_aggregate_endpoint_reports_the_server_the_header_addresses(self, registry):
+        registry["s1"] = _server("s1", "alpha", "https://alpha.example.com/mcp")
+        registry["s2"] = _server("s2", "beta", "https://beta.example.com/mcp")
+
+        headers = MCPDebug.maybe_build_debug_headers(
+            raw_headers=_DEBUG_RAW_HEADERS,
+            scope=_DEBUG_SCOPE,
+            mcp_servers=None,
+            mcp_auth_header=None,
+            mcp_server_auth_headers={"beta": {"Authorization": "Bearer beta-tok"}},
+            oauth2_headers=None,
+            client_ip=None,
+        )
+
+        assert headers["x-mcp-debug-auth-resolution"] == "per-request-header"
+        assert headers["x-mcp-debug-outbound-url"] == "https://beta.example.com/mcp"
+
+    def test_named_server_still_reported(self, registry):
+        registry["s1"] = _server("s1", "myserver", "https://upstream.example.com/mcp")
+
+        headers = MCPDebug.maybe_build_debug_headers(
+            raw_headers=_DEBUG_RAW_HEADERS,
+            scope=_DEBUG_SCOPE,
+            mcp_servers=["myserver"],
+            mcp_auth_header=None,
+            mcp_server_auth_headers={"myserver": {"Authorization": "Bearer upstream-tok"}},
+            oauth2_headers=None,
+            client_ip=None,
+        )
+
+        assert headers["x-mcp-debug-auth-resolution"] == "per-request-header"
+        assert headers["x-mcp-debug-outbound-url"] == "https://upstream.example.com/mcp"
+
+    def test_debug_disabled_returns_nothing(self, registry):
+        registry["s1"] = _server("s1", "myserver", "https://upstream.example.com/mcp")
+
+        headers = MCPDebug.maybe_build_debug_headers(
+            raw_headers={"host": "localhost"},
+            scope=_DEBUG_SCOPE,
+            mcp_servers=None,
+            mcp_auth_header=None,
+            mcp_server_auth_headers={"myserver": {"Authorization": "Bearer upstream-tok"}},
+            oauth2_headers=None,
+            client_ip=None,
+        )
+
+        assert headers == {}
 
 
 class TestWrapSendWithDebugHeaders:


### PR DESCRIPTION
## TLDR

Problem this solves:

- `x-mcp-debug-auth-resolution` says `no-auth` on the aggregate `/mcp` endpoint
- It also misses aliases differing in case or sanitization
- Operators conclude their per-request header was dropped when it was forwarded

How it solves it:

- Fall back to the servers the caller addressed with `x-mcp-{alias}-*` headers
- Match aliases with `lookup_mcp_server_auth_in_headers`, the helper egress already uses

## Relevant issues

Fixes #35403

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A local MCP server on `127.0.0.1:9099` records the headers it receives, registered with no static credential so the request relies entirely on the per-request client header:

```yaml
mcp_servers:
  myserver:
    url: "http://127.0.0.1:9099/mcp"
    transport: "http"
```

### BEFORE (commit 23de7a15d9)

```
$ curl -sS -D - -o /dev/null -X POST http://localhost:4000/mcp/ \
    -H "x-litellm-api-key: Bearer sk-1234" \
    -H "x-mcp-myserver-authorization: Bearer upstream-secret-token-abc123" \
    -H "x-litellm-mcp-debug: true" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | grep -i x-mcp-debug

x-mcp-debug-inbound-auth: x-litellm-api-key=Bearer****1234
x-mcp-debug-oauth2-token: (none)
x-mcp-debug-auth-resolution: no-auth
x-mcp-debug-outbound-url: (unknown)
x-mcp-debug-server-auth-type: (none)
```

The upstream server nevertheless received the token, so the report was wrong rather than the forwarding:

```
$ curl -sS http://localhost:9099/_dump
[{"path":"/mcp","jsonrpc_method":"initialize","authorization":null},
 {"path":"/mcp","jsonrpc_method":"initialize","authorization":"Bearer upstream-secret-token-abc123"},
 {"path":"/mcp","jsonrpc_method":"notifications/initialized","authorization":"Bearer upstream-secret-token-abc123"},
 {"path":"/mcp","jsonrpc_method":"tools/list","authorization":"Bearer upstream-secret-token-abc123"}]
```

### AFTER (commit 043410f53d)

```
$ curl -sS -D - -o /dev/null -X POST http://localhost:4000/mcp/ \
    -H "x-litellm-api-key: Bearer sk-1234" \
    -H "x-mcp-myserver-authorization: Bearer upstream-secret-token-abc123" \
    -H "x-litellm-mcp-debug: true" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | grep -i x-mcp-debug

x-mcp-debug-inbound-auth: x-litellm-api-key=Bearer****1234
x-mcp-debug-oauth2-token: (none)
x-mcp-debug-auth-resolution: per-request-header
x-mcp-debug-outbound-url: http://127.0.0.1:9099/mcp
x-mcp-debug-server-auth-type: (none)
```

The upstream dump is byte-identical across both runs, confirming outbound auth did not change.

The case-sensitivity half reproduces the same way with the server registered as `MyServer` and the header still sent as `x-mcp-myserver-authorization`, against `POST /mcp/MyServer`: `no-auth` before, `per-request-header` after, with the token forwarded in both.

## Type

🐛 Bug Fix

## Changes

`MCPDebug.maybe_build_debug_headers` only resolved servers named in the path or in `x-mcp-servers`. A request to the aggregate `/mcp` endpoint names neither, so the candidate list came out empty and the reported resolution kept its `no-auth` initial value, with `(unknown)` for the outbound URL. It now falls back to the servers the caller addressed through their own `x-mcp-{alias}-*` headers; it deliberately does not fall back to the whole registry, so the debug headers never describe a server the caller did not name

`MCPDebug.resolve_auth_resolution` matched the alias with a plain `dict.get`, while egress resolves it through `lookup_mcp_server_auth_in_headers`, which is case-insensitive and also accepts the sanitized `[a-z0-9_]` alias form. Since header names arrive lowercased, any server whose alias carries an uppercase letter or a space reported `no-auth` while its token was in fact being forwarded. Both paths now share the one helper

Outbound auth behavior is unchanged; this only corrects what is reported

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
