### PR TITLE
fix(mcp): invalidate toolset tool-permission cache on server allowed tools edit

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -2602,6 +2602,24 @@ class MCPServerManager:
             )
             return list(dict.fromkeys(allow_all_server_ids + submitted_server_ids))
 
+    @staticmethod
+    def _toolset_perms_cache_key(toolset_id: str) -> str:
+        return f"toolset_perms:{toolset_id}"
+
+    @staticmethod
+    def _tools_by_server(
+        toolset: Any,
+    ) -> dict[str, list[str]]:  # mutable-ok: matches the toolset_perms cache contract
+        tool_permissions: dict[str, list[str]] = {}  # mutable-ok: same cache contract
+        for tool in toolset.tools:
+            allowed_names = tool_permissions.setdefault(
+                tool["server_id"],
+                [],  # mutable-ok: same cache contract
+            )
+            if tool["tool_name"] not in allowed_names:
+                allowed_names.append(tool["tool_name"])
+        return tool_permissions
+
     async def resolve_toolset_tool_permissions(
         self,
         toolset_ids: list[str],
@@ -2610,9 +2628,12 @@ class MCPServerManager:
         Resolve a list of toolset IDs into a mcp_tool_permissions dict.
 
         Returns: {server_id: [tool_name, ...]} — the union of all tools across
-        the given toolsets.  Results are cached via ``user_api_key_cache`` (a
-        Redis-backed ``DualCache`` in production) so that cache entries are
-        shared across workers and cold-cache DB hits are minimised.
+        the given toolsets.  Each toolset's own resolution is cached under its
+        own key (``toolset_perms:{toolset_id}``) in ``user_api_key_cache`` (a
+        Redis-backed ``DualCache`` in production), so a single toolset can be
+        invalidated precisely — in both the in-memory layer and Redis — via
+        ``invalidate_toolset_cache(toolset_id)`` without evicting every other
+        toolset's cache entry.
 
         A row names a tool on the server identified by ``server_id``, so the
         stored name is the tool's own name and is used as written.  It is never
@@ -2627,41 +2648,84 @@ class MCPServerManager:
         if not toolset_ids or prisma_client is None:
             return {}
 
-        cache_key = "toolset_perms:" + ",".join(sorted(toolset_ids))
-        cached = await user_api_key_cache.async_get_cache(key=cache_key)
-        if cached is not None:
-            return cached
+        per_toolset: dict[str, dict[str, list[str]]] = {}  # mutable-ok: per-toolset result accumulator
+        uncached_ids: list[str] = []  # mutable-ok: cache-miss accumulator
+        for toolset_id in toolset_ids:
+            cached = await user_api_key_cache.async_get_cache(key=self._toolset_perms_cache_key(toolset_id))
+            if cached is not None:
+                per_toolset[toolset_id] = cached
+            else:
+                uncached_ids.append(toolset_id)
 
+        if uncached_ids:
+            try:
+                toolsets = await list_mcp_toolsets(prisma_client, toolset_ids=uncached_ids)
+                ttl = get_management_object_ttl(user_api_key_cache)
+                for toolset in toolsets:
+                    toolset_perms = self._tools_by_server(toolset)
+                    await user_api_key_cache.async_set_cache(
+                        key=self._toolset_perms_cache_key(toolset.toolset_id),
+                        value=toolset_perms,
+                        ttl=ttl,
+                    )
+                    per_toolset[toolset.toolset_id] = toolset_perms
+            except Exception as e:  # noqa: BLE001 - best-effort resolution; a DB blip must not break tool listing/calls
+                verbose_logger.warning(f"Failed to resolve toolset permissions: {e!s}")
+
+        merged: dict[str, list[str]] = {}  # mutable-ok: union-across-toolsets accumulator
+        for toolset_perms in per_toolset.values():
+            for server_id, tool_names in toolset_perms.items():
+                existing = merged.setdefault(server_id, [])  # mutable-ok: same accumulator
+                for tool_name in tool_names:
+                    if tool_name not in existing:
+                        existing.append(tool_name)
+        return merged
+
+    async def invalidate_toolset_cache_for_server(self, server_id: str) -> None:
+        """Invalidate the cached tool permissions of every toolset that references
+        ``server_id``, precisely and across workers (memory + Redis).
+
+        Call this after an MCP server edit that changes tool availability
+        (``allowed_tools``) for that server, so a toolset built on top of it
+        re-resolves permissions instead of serving a stale cached set.
+        """
+        from litellm.proxy._experimental.mcp_server.toolset_db import list_mcp_toolsets
+        from litellm.proxy.proxy_server import prisma_client
+
+        if prisma_client is None:
+            return
         try:
-            toolsets = await list_mcp_toolsets(prisma_client, toolset_ids=toolset_ids)
-            tool_permissions: dict[str, list[str]] = {}
-            for toolset in toolsets:
-                for tool in toolset.tools:
-                    allowed_names = tool_permissions.setdefault(tool["server_id"], [])
-                    if tool["tool_name"] not in allowed_names:
-                        allowed_names.append(tool["tool_name"])
-            await user_api_key_cache.async_set_cache(
-                key=cache_key,
-                value=tool_permissions,
-                ttl=get_management_object_ttl(user_api_key_cache),
-            )
-            return tool_permissions
-        except Exception as e:
-            verbose_logger.warning(f"Failed to resolve toolset permissions: {e!s}")
-            return {}
+            all_toolsets = await list_mcp_toolsets(prisma_client)
+        except Exception as e:  # noqa: BLE001 - best-effort invalidation; a DB blip must not fail the server edit
+            verbose_logger.warning(f"invalidate_toolset_cache_for_server: failed to list toolsets: {e}")
+            return
+        affected_ids = (
+            toolset.toolset_id
+            for toolset in all_toolsets
+            if any(tool["server_id"] == server_id for tool in toolset.tools)
+        )
+        for toolset_id in affected_ids:
+            await self.invalidate_toolset_cache(toolset_id)
 
-    def invalidate_toolset_cache(self, toolset_id: str | None = None) -> None:
+    async def invalidate_toolset_cache(self, toolset_id: str | None = None) -> None:
         """Evict cached toolset permission entries.
 
-        Called after create/update/delete of a toolset so stale data is not served.
-        The in-memory layer of ``user_api_key_cache`` is cleared immediately;
-        Redis entries expire naturally after the configured TTL.
-        Pass toolset_id to evict only entries containing that ID, or None to clear all.
+        Called after create/update/delete of a toolset, or (via
+        ``invalidate_toolset_cache_for_server``) after an MCP server edit that
+        changes tool availability for toolsets referencing it.
+
+        Pass toolset_id to evict exactly that toolset's ``toolset_perms``
+        entry from both the in-memory layer and Redis (correct across
+        workers). Pass None to clear every in-memory ``toolset_``-prefixed
+        entry on this worker only — Redis keys can't be enumerated by
+        pattern, so a full cross-worker clear isn't attempted; callers that
+        know the affected toolset_id should prefer that precise path.
         """
-        # Clear the in-memory layer of the shared DualCache for affected keys.
-        # We can't enumerate Redis keys by pattern, so Redis entries expire via TTL.
         try:
             from litellm.proxy.proxy_server import user_api_key_cache
+
+            if toolset_id is not None:
+                await user_api_key_cache.async_delete_cache(key=self._toolset_perms_cache_key(toolset_id))
 
             in_mem: InMemoryCache | None = getattr(user_api_key_cache, "in_memory_cache", None)
             if in_mem is None:
@@ -2670,19 +2734,16 @@ class MCPServerManager:
             if toolset_id is None:
                 keys_to_remove = [k for k in cache_dict if k.startswith("toolset_")]
             else:
-                # Evict permission-cache entries that reference this toolset ID.
                 # Also evict ALL name-cache entries (toolset_name:*): we can't map
                 # toolset_id → toolset_name without a DB call, and the name may have
                 # changed in an update anyway.
-                keys_to_remove = [
-                    k
-                    for k in cache_dict
-                    if (k.startswith("toolset_perms:") and toolset_id in k) or k.startswith("toolset_name:")
+                keys_to_remove = [  # mutable-ok: transient, discarded below
+                    k for k in cache_dict if k.startswith("toolset_name:")
                 ]
             for k in keys_to_remove:
                 cache_dict.pop(k, None)
-        except Exception as e:
-            verbose_logger.warning(f"invalidate_toolset_cache: failed to evict in-memory entries: {e}")
+        except Exception as e:  # noqa: BLE001 - best-effort cache eviction must not fail the caller's primary action
+            verbose_logger.warning(f"invalidate_toolset_cache: failed to evict cache entries: {e}")
 
     async def get_toolset_by_name_cached(
         self,

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -2481,6 +2481,14 @@ if MCP_AVAILABLE:
         # Ensure registry is up to date by reloading from database
         await global_mcp_server_manager.reload_servers_from_database()
 
+        # allowed_tools changed: any toolset referencing this server has a cached
+        # resolve_toolset_tool_permissions() result (see mcp_server_manager.py) keyed
+        # only by toolset_id, so it is never invalidated by a server-level edit. Clear
+        # it here so a re-enabled tool is immediately callable through a toolset again,
+        # instead of only after the cache's TTL expires.
+        if "allowed_tools" in payload_fields_set:
+            global_mcp_server_manager.invalidate_toolset_cache()
+
         # If a field that determines which upstream OAuth token gets minted changed (url/audience, OAuth
         # mode/grant, authorization-server endpoints, or the OAuth client + scopes), every stored per-user
         # token was minted for the old configuration and is stale. Purge them (DB + cache) so the next

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -2483,11 +2483,12 @@ if MCP_AVAILABLE:
 
         # allowed_tools changed: any toolset referencing this server has a cached
         # resolve_toolset_tool_permissions() result (see mcp_server_manager.py) keyed
-        # only by toolset_id, so it is never invalidated by a server-level edit. Clear
-        # it here so a re-enabled tool is immediately callable through a toolset again,
-        # instead of only after the cache's TTL expires.
+        # by toolset_id, so it is never invalidated by a server-level edit. Evict it
+        # (in-memory and Redis, so every worker sees the change) so a re-enabled tool
+        # is immediately callable through a toolset again, instead of only after the
+        # cache's TTL expires.
         if "allowed_tools" in payload_fields_set:
-            global_mcp_server_manager.invalidate_toolset_cache()
+            await global_mcp_server_manager.invalidate_toolset_cache_for_server(payload.server_id)
 
         # If a field that determines which upstream OAuth token gets minted changed (url/audience, OAuth
         # mode/grant, authorization-server endpoints, or the OAuth client + scopes), every stored per-user
@@ -2749,7 +2750,7 @@ if MCP_AVAILABLE:
             global_mcp_server_manager,
         )
 
-        global_mcp_server_manager.invalidate_toolset_cache()
+        await global_mcp_server_manager.invalidate_toolset_cache()
         return result
 
     @router.get(
@@ -2848,7 +2849,7 @@ if MCP_AVAILABLE:
             global_mcp_server_manager,
         )
 
-        global_mcp_server_manager.invalidate_toolset_cache(getattr(payload, "toolset_id", None))
+        await global_mcp_server_manager.invalidate_toolset_cache(getattr(payload, "toolset_id", None))
         return result
 
     @router.delete(
@@ -2878,5 +2879,5 @@ if MCP_AVAILABLE:
             global_mcp_server_manager,
         )
 
-        global_mcp_server_manager.invalidate_toolset_cache(toolset_id)
+        await global_mcp_server_manager.invalidate_toolset_cache(toolset_id)
         return Response(status_code=status.HTTP_202_ACCEPTED)

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -8909,6 +8909,7 @@ async def test_resolve_toolset_tool_permissions_single_db_fetch_across_checks():
 
     manager = MCPServerManager()
     toolset = MagicMock()
+    toolset.toolset_id = "ts-1"
     toolset.tools = [{"server_id": "server-a", "tool_name": "lookup_status"}]
     list_toolsets_mock = AsyncMock(return_value=[toolset])
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_manager.py
@@ -8929,6 +8929,150 @@ async def test_resolve_toolset_tool_permissions_single_db_fetch_across_checks():
     list_toolsets_mock.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_resolve_toolset_tool_permissions_survives_db_error():
+    """A DB error resolving one batch of toolset_ids must not raise or lose
+    whatever was already resolved from cache; the caller (tool listing/calls)
+    must keep working with partial data rather than 500."""
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+
+    manager = MCPServerManager()
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.toolset_db.list_mcp_toolsets",
+            AsyncMock(side_effect=RuntimeError("db unavailable")),
+        ),
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", DualCache()),
+    ):
+        result = await manager.resolve_toolset_tool_permissions(toolset_ids=["ts-1"])
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_invalidate_toolset_cache_deletes_specific_toolset_precisely():
+    """Regression: invalidating a specific toolset_id must delete its own
+    toolset_perms entry from both the in-memory layer and Redis, without
+    touching a different toolset's still-cached entry. Before the fix, only
+    the in-memory layer was ever cleared, leaving Redis (and every other
+    worker) serving the stale permission set until its TTL expired."""
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+
+    manager = MCPServerManager()
+    cache = DualCache(redis_cache=MagicMock(async_delete_cache=AsyncMock()))
+    await cache.in_memory_cache.async_set_cache(key="toolset_perms:ts-1", value={"server-a": ["tool1"]})
+    await cache.in_memory_cache.async_set_cache(key="toolset_perms:ts-2", value={"server-b": ["tool2"]})
+    await cache.in_memory_cache.async_set_cache(key="toolset_name:some-name", value={"toolset_id": "ts-1"})
+
+    with patch("litellm.proxy.proxy_server.user_api_key_cache", cache):
+        await manager.invalidate_toolset_cache("ts-1")
+
+    cache.redis_cache.async_delete_cache.assert_awaited_once_with("toolset_perms:ts-1")
+    assert "toolset_perms:ts-1" not in cache.in_memory_cache.cache_dict
+    assert "toolset_perms:ts-2" in cache.in_memory_cache.cache_dict, (
+        "invalidating one toolset must not evict a different toolset's cached entry"
+    )
+    assert "toolset_name:some-name" not in cache.in_memory_cache.cache_dict
+
+
+@pytest.mark.asyncio
+async def test_invalidate_toolset_cache_clear_all_evicts_every_toolset_entry():
+    """Passing toolset_id=None (used only by toolset creation, which can't have
+    a stale entry for its own brand-new id) clears every in-memory toolset_*
+    entry as a blunt fallback; Redis keys expire via TTL since they can't be
+    enumerated by pattern."""
+    from litellm.caching.caching import DualCache
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+
+    manager = MCPServerManager()
+    cache = DualCache(redis_cache=MagicMock(async_delete_cache=AsyncMock()))
+    await cache.in_memory_cache.async_set_cache(key="toolset_perms:ts-1", value={"server-a": ["tool1"]})
+    await cache.in_memory_cache.async_set_cache(key="toolset_name:some-name", value={"toolset_id": "ts-1"})
+    await cache.in_memory_cache.async_set_cache(key="unrelated_key", value="keep-me")
+
+    with patch("litellm.proxy.proxy_server.user_api_key_cache", cache):
+        await manager.invalidate_toolset_cache(None)
+
+    cache.redis_cache.async_delete_cache.assert_not_awaited()
+    assert "toolset_perms:ts-1" not in cache.in_memory_cache.cache_dict
+    assert "toolset_name:some-name" not in cache.in_memory_cache.cache_dict
+    assert "unrelated_key" in cache.in_memory_cache.cache_dict
+
+
+@pytest.mark.asyncio
+async def test_invalidate_toolset_cache_for_server_invalidates_only_referencing_toolsets():
+    """Regression: an MCP server allowed_tools edit must invalidate exactly the
+    toolsets that reference that server, not every toolset in the DB."""
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+
+    manager = MCPServerManager()
+    referencing = MagicMock(toolset_id="ts-1", tools=[{"server_id": "server-a", "tool_name": "tool1"}])
+    unrelated = MagicMock(toolset_id="ts-2", tools=[{"server_id": "server-b", "tool_name": "tool2"}])
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.toolset_db.list_mcp_toolsets",
+            AsyncMock(return_value=[referencing, unrelated]),
+        ),
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch.object(manager, "invalidate_toolset_cache", AsyncMock()) as mock_invalidate,
+    ):
+        await manager.invalidate_toolset_cache_for_server("server-a")
+
+    mock_invalidate.assert_awaited_once_with("ts-1")
+
+
+@pytest.mark.asyncio
+async def test_invalidate_toolset_cache_for_server_noop_without_prisma_client():
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+
+    manager = MCPServerManager()
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", None),
+        patch.object(manager, "invalidate_toolset_cache", AsyncMock()) as mock_invalidate,
+    ):
+        await manager.invalidate_toolset_cache_for_server("server-a")
+
+    mock_invalidate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_invalidate_toolset_cache_for_server_survives_db_error():
+    """A DB error listing toolsets must not raise out of the caller (the MCP
+    server edit endpoint), whose primary job -- updating the server -- has
+    already succeeded by the time this runs."""
+    from litellm.proxy._experimental.mcp_server.mcp_server_manager import (
+        MCPServerManager,
+    )
+
+    manager = MCPServerManager()
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.toolset_db.list_mcp_toolsets",
+            AsyncMock(side_effect=RuntimeError("db unavailable")),
+        ),
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch.object(manager, "invalidate_toolset_cache", AsyncMock()) as mock_invalidate,
+    ):
+        await manager.invalidate_toolset_cache_for_server("server-a")
+
+    mock_invalidate.assert_not_awaited()
+
+
 class TestMaterializeAuthHeaders:
     """_materialize_auth_headers drives one step of a resolved httpx.Auth's own flow to turn it
     into a header dict for the OpenAPI egress arm, which sends plain headers and cannot carry an

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_toolset_scope.py
@@ -358,7 +358,7 @@ class TestToolsetPrefixResolution:
             global_mcp_server_manager,
         )
 
-        toolset = SimpleNamespace(tools=[{"server_id": server_id, "tool_name": stored}])
+        toolset = SimpleNamespace(toolset_id="ts-1", tools=[{"server_id": server_id, "tool_name": stored}])
         cache = MagicMock(
             async_get_cache=AsyncMock(return_value=None),
             async_set_cache=AsyncMock(),

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -6012,7 +6012,7 @@ def test_stamp_oauth2_flow_ignores_non_oauth2():
     assert payload.oauth2_flow is None
 
 
-async def _run_edit(old_record, updated_record, purge_mock=None):
+async def _run_edit(old_record, updated_record, purge_mock=None, allowed_tools=None):
     from litellm.proxy.management_endpoints.mcp_management_endpoints import edit_mcp_server
 
     server_id = updated_record.server_id
@@ -6044,10 +6044,14 @@ async def _run_edit(old_record, updated_record, purge_mock=None):
     ):
         mock_manager.update_server = AsyncMock()
         mock_manager.reload_servers_from_database = AsyncMock()
-        payload = UpdateMCPServerRequest(server_id=server_id, alias=updated_record.alias, url=updated_record.url)
+        mock_manager.invalidate_toolset_cache = MagicMock()
+        payload_kwargs = {"server_id": server_id, "alias": updated_record.alias, "url": updated_record.url}
+        if allowed_tools is not None:
+            payload_kwargs["allowed_tools"] = allowed_tools
+        payload = UpdateMCPServerRequest(**payload_kwargs)
         user_auth = UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN)
         result = await edit_mcp_server(payload=payload, user_api_key_dict=user_auth)
-        return result, mock_purge
+        return result, mock_purge, mock_manager
 
 
 @pytest.mark.asyncio
@@ -6056,7 +6060,7 @@ async def test_edit_mcp_server_purges_user_tokens_on_mint_relevant_change():
     old = generate_mock_mcp_server_db_record(server_id=server_id, url="https://old.example.com/mcp")
     updated = generate_mock_mcp_server_db_record(server_id=server_id, url="https://new.example.com/mcp")
 
-    result, mock_purge = await _run_edit(old, updated)
+    result, mock_purge, _ = await _run_edit(old, updated)
 
     assert result.server_id == server_id
     mock_purge.assert_awaited_once()
@@ -6069,10 +6073,44 @@ async def test_edit_mcp_server_skips_purge_when_identity_unchanged():
     old = generate_mock_mcp_server_db_record(server_id=server_id, alias="Before")
     updated = generate_mock_mcp_server_db_record(server_id=server_id, alias="After")
 
-    result, mock_purge = await _run_edit(old, updated)
+    result, mock_purge, _ = await _run_edit(old, updated)
 
     assert result.server_id == server_id
     mock_purge.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_edit_mcp_server_invalidates_toolset_cache_when_allowed_tools_changes():
+    """
+    Regression test: a toolset that resolves this server's tools via
+    resolve_toolset_tool_permissions() caches the result in user_api_key_cache,
+    keyed only by toolset_id. Re-enabling a tool on the server (allowed_tools
+    change) must invalidate that cache so the toolset immediately reflects the
+    change, instead of serving a stale permission set (403 on the re-enabled
+    tool) until the cache's TTL expires.
+    """
+    server_id = str(uuid.uuid4())
+    old = generate_mock_mcp_server_db_record(server_id=server_id, alias="Same")
+    updated = generate_mock_mcp_server_db_record(server_id=server_id, alias="Same")
+
+    result, _, mock_manager = await _run_edit(old, updated, allowed_tools=["add", "add1", "add2"])
+
+    assert result.server_id == server_id
+    mock_manager.invalidate_toolset_cache.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_edit_mcp_server_skips_toolset_cache_invalidation_when_allowed_tools_unchanged():
+    """An edit that never touches allowed_tools has no reason to evict the toolset
+    permission cache; skip it to avoid unnecessary cache churn on unrelated edits."""
+    server_id = str(uuid.uuid4())
+    old = generate_mock_mcp_server_db_record(server_id=server_id, alias="Before")
+    updated = generate_mock_mcp_server_db_record(server_id=server_id, alias="After")
+
+    result, _, mock_manager = await _run_edit(old, updated)
+
+    assert result.server_id == server_id
+    mock_manager.invalidate_toolset_cache.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -6083,7 +6121,7 @@ async def test_edit_mcp_server_purge_failure_does_not_fail_the_edit():
     old = generate_mock_mcp_server_db_record(server_id=server_id, url="https://old.example.com/mcp")
     updated = generate_mock_mcp_server_db_record(server_id=server_id, url="https://new.example.com/mcp")
 
-    result, mock_purge = await _run_edit(old, updated, purge_mock=AsyncMock(side_effect=RuntimeError("db down")))
+    result, mock_purge, _ = await _run_edit(old, updated, purge_mock=AsyncMock(side_effect=RuntimeError("db down")))
 
     assert result.server_id == server_id
     mock_purge.assert_awaited_once()
@@ -6096,7 +6134,7 @@ async def test_edit_mcp_server_snapshot_failure_skips_purge_but_edit_succeeds():
     server_id = str(uuid.uuid4())
     updated = generate_mock_mcp_server_db_record(server_id=server_id, url="https://new.example.com/mcp")
 
-    result, mock_purge = await _run_edit(RuntimeError("db read failed"), updated)
+    result, mock_purge, _ = await _run_edit(RuntimeError("db read failed"), updated)
 
     assert result.server_id == server_id
     mock_purge.assert_not_awaited()

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -6044,7 +6044,7 @@ async def _run_edit(old_record, updated_record, purge_mock=None, allowed_tools=N
     ):
         mock_manager.update_server = AsyncMock()
         mock_manager.reload_servers_from_database = AsyncMock()
-        mock_manager.invalidate_toolset_cache = MagicMock()
+        mock_manager.invalidate_toolset_cache_for_server = AsyncMock()
         payload_kwargs = {"server_id": server_id, "alias": updated_record.alias, "url": updated_record.url}
         if allowed_tools is not None:
             payload_kwargs["allowed_tools"] = allowed_tools
@@ -6084,10 +6084,10 @@ async def test_edit_mcp_server_invalidates_toolset_cache_when_allowed_tools_chan
     """
     Regression test: a toolset that resolves this server's tools via
     resolve_toolset_tool_permissions() caches the result in user_api_key_cache,
-    keyed only by toolset_id. Re-enabling a tool on the server (allowed_tools
-    change) must invalidate that cache so the toolset immediately reflects the
-    change, instead of serving a stale permission set (403 on the re-enabled
-    tool) until the cache's TTL expires.
+    keyed by toolset_id. Re-enabling a tool on the server (allowed_tools
+    change) must invalidate every toolset's cached entry for this server so
+    the toolset immediately reflects the change, instead of serving a stale
+    permission set (403 on the re-enabled tool) until the cache's TTL expires.
     """
     server_id = str(uuid.uuid4())
     old = generate_mock_mcp_server_db_record(server_id=server_id, alias="Same")
@@ -6096,7 +6096,7 @@ async def test_edit_mcp_server_invalidates_toolset_cache_when_allowed_tools_chan
     result, _, mock_manager = await _run_edit(old, updated, allowed_tools=["add", "add1", "add2"])
 
     assert result.server_id == server_id
-    mock_manager.invalidate_toolset_cache.assert_called_once_with()
+    mock_manager.invalidate_toolset_cache_for_server.assert_called_once_with(server_id)
 
 
 @pytest.mark.asyncio
@@ -6110,7 +6110,7 @@ async def test_edit_mcp_server_skips_toolset_cache_invalidation_when_allowed_too
     result, _, mock_manager = await _run_edit(old, updated)
 
     assert result.server_id == server_id
-    mock_manager.invalidate_toolset_cache.assert_not_called()
+    mock_manager.invalidate_toolset_cache_for_server.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_mcp_management_endpoints.py
@@ -6114,6 +6114,94 @@ async def test_edit_mcp_server_skips_toolset_cache_invalidation_when_allowed_too
 
 
 @pytest.mark.asyncio
+async def test_add_mcp_toolset_invalidates_cache():
+    """Creating a toolset must invalidate the toolset cache (defensively — a
+    brand-new toolset_id can't itself have a stale entry, but the call must
+    still succeed rather than raise now that invalidate_toolset_cache is async)."""
+    from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+        add_mcp_toolset,
+    )
+    from litellm.types.mcp_server.mcp_toolset import MCPToolset, NewMCPToolsetRequest
+
+    created = MCPToolset(toolset_id="ts-new", toolset_name="my-toolset", tools=[])
+    payload = NewMCPToolsetRequest(toolset_name="my-toolset", tools=[])
+    user_auth = UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN)
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.create_mcp_toolset",
+            AsyncMock(return_value=created),
+        ),
+        patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_manager,
+    ):
+        mock_manager.invalidate_toolset_cache = AsyncMock()
+        result = await add_mcp_toolset(payload=payload, user_api_key_dict=user_auth)
+
+    assert result.toolset_id == "ts-new"
+    mock_manager.invalidate_toolset_cache.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_edit_mcp_toolset_invalidates_cache_for_toolset_id():
+    """Updating a toolset must invalidate precisely that toolset's cache entry."""
+    from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+        edit_mcp_toolset,
+    )
+    from litellm.types.mcp_server.mcp_toolset import MCPToolset, UpdateMCPToolsetRequest
+
+    updated = MCPToolset(toolset_id="ts-1", toolset_name="renamed", tools=[])
+    payload = UpdateMCPToolsetRequest(toolset_id="ts-1", toolset_name="renamed")
+    user_auth = UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN)
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.update_mcp_toolset",
+            AsyncMock(return_value=updated),
+        ),
+        patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_manager,
+    ):
+        mock_manager.invalidate_toolset_cache = AsyncMock()
+        result = await edit_mcp_toolset(payload=payload, user_api_key_dict=user_auth)
+
+    assert result.toolset_id == "ts-1"
+    mock_manager.invalidate_toolset_cache.assert_awaited_once_with("ts-1")
+
+
+@pytest.mark.asyncio
+async def test_remove_mcp_toolset_invalidates_cache_for_toolset_id():
+    """Deleting a toolset must invalidate precisely that toolset's cache entry."""
+    from litellm.proxy.management_endpoints.mcp_management_endpoints import (
+        remove_mcp_toolset,
+    )
+
+    user_auth = UserAPIKeyAuth(user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN)
+
+    with (
+        patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.get_prisma_client_or_throw",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "litellm.proxy.management_endpoints.mcp_management_endpoints.delete_mcp_toolset",
+            AsyncMock(return_value={"toolset_id": "ts-1"}),
+        ),
+        patch("litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager") as mock_manager,
+    ):
+        mock_manager.invalidate_toolset_cache = AsyncMock()
+        await remove_mcp_toolset(toolset_id="ts-1", user_api_key_dict=user_auth)
+
+    mock_manager.invalidate_toolset_cache.assert_awaited_once_with("ts-1")
+
+
+@pytest.mark.asyncio
 async def test_edit_mcp_server_purge_failure_does_not_fail_the_edit():
     """The purge is best-effort: a purge exception after a successful update must be swallowed and
     logged, never turned into an error response for an edit whose primary job already succeeded."""


### PR DESCRIPTION
## Problem this solves:

MCP Toolsets aggregate a curated subset of tools from one or more MCP servers behind a single scoped endpoint (/toolset/{name}/mcp). Per-toolset tool permissions are resolved from the database and cached in user_api_key_cache so repeated toolset calls don't hit Postgres every time. That cache is keyed only by toolset_id and is explicitly invalidated on toolset create/update/delete, but nothing invalidated it when the underlying MCP server's allowed_tools changed. So toggling a tool off then back on for a server (Admin UI: MCP Servers, select which tools users can call) updated the server correctly, but any toolset built on top of it kept serving the stale cached permission set until the cache's TTL expired, causing calls through the toolset to 403 on a tool that had just been re-enabled and that worked fine when called directly through /mcp.

## How it solves it:

edit_mcp_server (PUT /v1/mcp/server) now calls global_mcp_server_manager.invalidate_toolset_cache() whenever allowed_tools is among the fields changed in the request, right after the existing registry reload. This clears the cached toolset_perms:* entries so the next call through any toolset referencing that server re-resolves permissions from the database instead of serving the stale set. The invalidation is gated on allowed_tools actually being in the request's field set, so edits that don't touch tool visibility (renaming a server, changing its URL, etc.) don't pay for an unnecessary cache clear.

## Relevant issues

Fixes #35342

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), include proof for every single one of them, not just one
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
