### PR TITLE
fix(bedrock): cache AssumeRole credentials per attributed identity

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -357,6 +357,15 @@ NON_LLM_CONNECTION_TIMEOUT = int(
 MAX_EXCEPTION_MESSAGE_LENGTH = int(os.getenv("MAX_EXCEPTION_MESSAGE_LENGTH", 2000))
 MAX_STRING_LENGTH_PROMPT_IN_DB = int(os.getenv("MAX_STRING_LENGTH_PROMPT_IN_DB", 2048))
 BEDROCK_MAX_POLICY_SIZE = int(os.getenv("BEDROCK_MAX_POLICY_SIZE", 75))
+# One entry per distinct AWS credential-argument set. Per-user cost attribution passes the attributed
+# identity as aws_session_name, so this bounds how many attributed identities keep a cached STS session.
+BEDROCK_IAM_CACHE_MAX_ENTRIES = 1000
+# Single-flight lock stripes over that cache. Only keys landing on the same stripe wait for each
+# other, so a burst of distinct identities still resolves its credentials in parallel.
+BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES = 64
+# Retire a cached STS credential this many seconds before AWS expires it, so a request that reads it
+# still has a usable credential for the whole call.
+STS_CREDENTIAL_EXPIRY_SAFETY_MARGIN_SECONDS = 60
 BEDROCK_MIN_THINKING_BUDGET_TOKENS = int(os.getenv("BEDROCK_MIN_THINKING_BUDGET_TOKENS", 1024))
 # Anthropic's Messages API rejects thinking.budget_tokens < 1024.
 ANTHROPIC_MIN_THINKING_BUDGET_TOKENS = 1024

--- a/litellm/llms/bedrock/base_aws_llm.py
+++ b/litellm/llms/bedrock/base_aws_llm.py
@@ -5,6 +5,7 @@ import os
 import re
 import urllib.parse
 from datetime import datetime
+from threading import Lock
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -24,10 +25,14 @@ from pydantic import BaseModel, ValidationError
 
 from litellm._logging import verbose_logger
 from litellm.caching.caching import DualCache
+from litellm.caching.in_memory_cache import InMemoryCache
 from litellm.constants import (
     BEDROCK_EMBEDDING_PROVIDERS_LITERAL,
+    BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES,
+    BEDROCK_IAM_CACHE_MAX_ENTRIES,
     BEDROCK_INVOKE_PROVIDERS_LITERAL,
     BEDROCK_MAX_POLICY_SIZE,
+    STS_CREDENTIAL_EXPIRY_SAFETY_MARGIN_SECONDS,
 )
 from litellm.litellm_core_utils.dd_tracing import tracer
 from litellm.secret_managers.main import get_secret, get_secret_str
@@ -75,14 +80,28 @@ class AwsAuthError(Exception):
 
 class BaseAWSLLM:
     # Process-wide IAM credential cache (shared across instances — Bedrock passthrough is per-request).
-    # Storage is in-process memory only: default ``DualCache()`` has no Redis backend unless attached
-    # elsewhere. Entry TTL: static access-key + secret + region use ``_get_default_ttl_for_boto3_credentials``
-    # (~59 minutes); ambient env (``_auth_with_env_vars`` returns ``ttl=None``) uses ``InMemoryCache``'s
-    # ``default_ttl`` (600 seconds / 10 minutes); web identity STS credentials use
-    # ``_get_default_ttl_for_boto3_credentials`` (~59 minutes), keyed on all aws_* credential args
-    # plus ssl_verify. AssumeRole, profiles, and explicit session-token tuples are not cached — see
-    # ``get_credentials`` and ``_get_or_set_cached_credentials``.
-    _shared_iam_cache: ClassVar[DualCache] = DualCache()
+    # Storage is in-process memory only: no Redis backend unless attached elsewhere. Entry TTL: static
+    # access-key + secret + region use ``_get_default_ttl_for_boto3_credentials`` (~59 minutes); ambient
+    # env (``_auth_with_env_vars`` returns ``ttl=None``) uses ``InMemoryCache``'s ``default_ttl``
+    # (600 seconds / 10 minutes); web identity STS credentials use
+    # ``_get_default_ttl_for_boto3_credentials`` (~59 minutes); AssumeRole STS credentials expire with
+    # the STS session itself (Expiration minus a safety margin). All are keyed on all aws_* credential
+    # args plus ssl_verify, so ``aws_session_name`` scopes an entry to one attributed identity. Profiles
+    # and explicit session-token tuples are not cached — see ``get_credentials`` and
+    # ``_get_or_set_cached_credentials``. The bound is larger than ``InMemoryCache``'s default because
+    # per-user cost attribution puts one entry per attributed identity in this cache.
+    _shared_iam_cache: ClassVar[DualCache] = DualCache(
+        in_memory_cache=InMemoryCache(max_size_in_memory=BEDROCK_IAM_CACHE_MAX_ENTRIES)
+    )
+
+    # Striped single-flight locks over ``_shared_iam_cache``. Concurrent misses on one credential
+    # key would otherwise each issue their own STS call, which is the same thundering herd the cache
+    # exists to prevent, just moved to the miss window. Striping keeps distinct identities from
+    # serialising behind each other without a per-key registry that grows with the identity count.
+    # A cache hit holds its stripe only for the lookup itself.
+    _credential_fetch_locks: ClassVar[tuple[Lock, ...]] = tuple(
+        Lock() for _ in range(BEDROCK_IAM_CACHE_FETCH_LOCK_STRIPES)
+    )
 
     def __init__(self) -> None:
         self.iam_cache = BaseAWSLLM._shared_iam_cache
@@ -140,19 +159,21 @@ class BaseAWSLLM:
 
         Used for static access-key credentials, ambient credentials from
         ``_auth_with_env_vars`` (including when skipping AssumeRole because the runtime identity
-        already matches ``aws_role_name``), and web identity STS credentials (plain
-        non-refreshable ``Credentials`` cached ~59 min, inside the 3600s STS session).
+        already matches ``aws_role_name``), web identity STS credentials (plain
+        non-refreshable ``Credentials`` cached ~59 min, inside the 3600s STS session), and AssumeRole
+        STS credentials (cached for the lifetime of the STS session minus a safety margin).
 
-        AssumeRole, profiles, and explicit session-token tuples are not
-        cached here — shared ``Credentials`` / refresh state must not span logical sessions.
+        Profiles and explicit session-token tuples are not cached here — shared ``Credentials`` /
+        refresh state must not span logical sessions.
         """
         cache_key = self.get_cache_key(credential_args)
-        _cached = self.iam_cache.get_cache(cache_key)
-        if _cached:
-            return _cached
-        credentials, ttl = credential_fetcher()
-        self.iam_cache.set_cache(cache_key, credentials, ttl=ttl)
-        return credentials
+        with self._credential_fetch_locks[hash(cache_key) % len(self._credential_fetch_locks)]:
+            _cached = self.iam_cache.get_cache(cache_key)
+            if _cached:
+                return _cached
+            credentials, ttl = credential_fetcher()
+            self.iam_cache.set_cache(cache_key, credentials, ttl=ttl)
+            return credentials
 
     @staticmethod
     def _is_auth_with_web_identity_token(
@@ -269,8 +290,8 @@ class BaseAWSLLM:
         #   Credentials - boto3.Credentials
         #   cache ttl - Optional[int]. If None, the credentials are not cached. Some auth flows have no expiry time.
         #
-        # iam_cache: static keys, ambient env (including skip-AssumeRole path), and web identity.
-        # Do not cache AssumeRole / profile / explicit session-token paths here.
+        # iam_cache: static keys, ambient env (including skip-AssumeRole path), web identity, and
+        # AssumeRole. Do not cache profile / explicit session-token paths here.
         #########################################################
         if self._is_auth_with_web_identity_token(
             aws_web_identity_token,
@@ -290,30 +311,20 @@ class BaseAWSLLM:
                 ),
             )
         elif self._is_auth_with_aws_role(aws_role_name):
-            # Same role (IRSA/ECS/EC2): ambient creds via _get_or_set_cached_credentials like the
-            # default env branch; never pre-read cache (must run _is_already_running_as_role first).
-            if self._is_already_running_as_role(cast(str, aws_role_name), ssl_verify=ssl_verify):
-                verbose_logger.debug(
-                    "Already running as target role %s, using ambient credentials",
-                    aws_role_name,
-                )
-                return self._get_or_set_cached_credentials(args, self._auth_with_env_vars)
-            verbose_logger.debug("Using role assumption: calling _auth_with_aws_role")
-            # If aws_session_name is not provided, generate a default one
-            if aws_session_name is None:
-                aws_session_name = f"litellm-session-{int(datetime.now().timestamp())}"
-            credentials, _assume_ttl = self._auth_with_aws_role(
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-                aws_session_token=aws_session_token,
-                aws_role_name=cast(str, aws_role_name),
-                aws_session_name=aws_session_name,
-                aws_region_name=aws_region_name,
-                aws_sts_endpoint=aws_sts_endpoint,
-                aws_external_id=aws_external_id,
-                ssl_verify=ssl_verify,
+            return self._get_or_set_cached_credentials(
+                args,
+                lambda: self._resolve_role_credentials(
+                    aws_access_key_id=aws_access_key_id,
+                    aws_secret_access_key=aws_secret_access_key,
+                    aws_session_token=aws_session_token,
+                    aws_role_name=cast(str, aws_role_name),
+                    aws_session_name=aws_session_name,
+                    aws_region_name=aws_region_name,
+                    aws_sts_endpoint=aws_sts_endpoint,
+                    aws_external_id=aws_external_id,
+                    ssl_verify=ssl_verify,
+                ),
             )
-            return credentials
 
         elif self._is_auth_with_aws_profile(aws_profile_name):
             credentials, _cache_ttl = self._auth_with_aws_profile(cast(str, aws_profile_name))
@@ -1046,7 +1057,11 @@ class BaseAWSLLM:
         return sts_client.assume_role(**assume_role_params)
 
     def _extract_credentials_and_ttl(self, sts_response: dict) -> Tuple[Credentials, Optional[int]]:
-        """Extract credentials and TTL from STS response."""
+        """Extract credentials and TTL from STS response.
+
+        The TTL carries the same safety margin as the non-IRSA assume path, so a cached entry is
+        never handed out close enough to expiry to die mid-request.
+        """
         from botocore.credentials import Credentials
 
         sts_credentials = sts_response["Credentials"]
@@ -1057,9 +1072,51 @@ class BaseAWSLLM:
         )
 
         expiration_time = sts_credentials["Expiration"]
-        ttl = int((expiration_time - datetime.now(expiration_time.tzinfo)).total_seconds())
+        ttl = int(
+            (expiration_time - datetime.now(expiration_time.tzinfo)).total_seconds()
+            - STS_CREDENTIAL_EXPIRY_SAFETY_MARGIN_SECONDS
+        )
 
         return credentials, ttl
+
+    def _resolve_role_credentials(
+        self,
+        aws_access_key_id: str | None,
+        aws_secret_access_key: str | None,
+        aws_session_token: str | None,
+        aws_role_name: str,
+        aws_session_name: str | None,
+        aws_region_name: str | None,
+        aws_sts_endpoint: str | None,
+        aws_external_id: str | None,
+        ssl_verify: bool | str | None,
+    ) -> tuple[Credentials, int | None]:
+        """
+        Resolve credentials for a target role, either from the ambient identity or via sts:AssumeRole.
+
+        Both the ``sts:GetCallerIdentity`` probe and the assume itself run here, so a cache hit on the
+        caller's key skips both. ``aws_session_name`` defaults inside this fetcher rather than in
+        ``get_credentials`` so the cache key stays stable when the caller does not supply one.
+        """
+        if self._is_already_running_as_role(aws_role_name, ssl_verify=ssl_verify):
+            verbose_logger.debug(
+                "Already running as target role %s, using ambient credentials",
+                aws_role_name,
+            )
+            return self._auth_with_env_vars()
+
+        verbose_logger.debug("Using role assumption: calling _auth_with_aws_role")
+        return self._auth_with_aws_role(
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token,
+            aws_role_name=aws_role_name,
+            aws_session_name=aws_session_name or f"litellm-session-{int(datetime.now().timestamp())}",
+            aws_region_name=aws_region_name,
+            aws_sts_endpoint=aws_sts_endpoint,
+            aws_external_id=aws_external_id,
+            ssl_verify=ssl_verify,
+        )
 
     @tracer.wrap()
     def _auth_with_aws_role(
@@ -1192,7 +1249,7 @@ class BaseAWSLLM:
         sts_expiry = sts_credentials["Expiration"]
         # Convert to timezone-aware datetime for comparison
         current_time = datetime.now(sts_expiry.tzinfo)
-        sts_ttl = (sts_expiry - current_time).total_seconds() - 60
+        sts_ttl = (sts_expiry - current_time).total_seconds() - STS_CREDENTIAL_EXPIRY_SAFETY_MARGIN_SECONDS
         return credentials, sts_ttl
 
     @tracer.wrap()

--- a/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
+++ b/tests/test_litellm/llms/bedrock/test_base_aws_llm.py
@@ -1,6 +1,8 @@
 import json
 import os
 import sys
+import threading
+import time
 
 import pytest
 from fastapi.testclient import TestClient
@@ -933,7 +935,7 @@ def test_role_assumption_without_session_name():
         call_args = mock_sts_client.assume_role.call_args
         assert call_args[1]["RoleSessionName"] == "my-custom-session"
 
-    # Test case 3: AssumeRole is not stored in iam_cache; identical calls each invoke STS.
+    # Test case 3: identical AssumeRole args reuse the cached STS session instead of re-assuming.
     BaseAWSLLM._shared_iam_cache.flush_cache()
     mock_sts_client.reset_mock()
     with patch("boto3.client", return_value=mock_sts_client):
@@ -945,49 +947,218 @@ def test_role_assumption_without_session_name():
             aws_role_name="arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole"
         )
 
-        assert mock_sts_client.assume_role.call_count == 2
+        assert mock_sts_client.assume_role.call_count == 1
         assert credentials1.access_key == credentials2.access_key
 
 
-def test_assume_role_path_does_not_use_process_iam_cache():
-    """AssumeRole credentials are not cached; each get_credentials repeats STS AssumeRole."""
-    base_aws_llm = BaseAWSLLM()
-
+def _assume_role_sts_mock(access_key: str = "assumed-access-key") -> MagicMock:
+    """STS client mock whose caller identity is a different role, forcing the AssumeRole path."""
     mock_sts_client = MagicMock()
-    mock_expiry = MagicMock()
-    mock_expiry.tzinfo = timezone.utc
-    time_diff = MagicMock()
-    time_diff.total_seconds.return_value = 3600
-    mock_expiry.__sub__ = MagicMock(return_value=time_diff)
-
     mock_sts_client.assume_role.return_value = {
         "Credentials": {
-            "AccessKeyId": "assumed-access-key",
+            "AccessKeyId": access_key,
             "SecretAccessKey": "assumed-secret-key",
             "SessionToken": "assumed-session-token",
-            "Expiration": mock_expiry,
+            "Expiration": datetime.now(timezone.utc) + timedelta(hours=1),
         }
     }
     mock_sts_client.get_caller_identity.return_value = {
         "Arn": "arn:aws:sts::111111111111:assumed-role/SomeOtherRole/session-name",
     }
+    return mock_sts_client
 
-    role_arn = "arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole"
-    env_without_irsa = {
+
+def _env_without_irsa() -> dict:
+    return {
         k: v
         for k, v in os.environ.items()
         if k not in ("AWS_ROLE_ARN", "AWS_WEB_IDENTITY_TOKEN_FILE")
     }
 
-    with patch.dict(os.environ, env_without_irsa, clear=True):
+
+def test_assume_role_path_uses_process_iam_cache():
+    """Repeat calls with identical AssumeRole args make no further STS calls of either kind."""
+    base_aws_llm = BaseAWSLLM()
+    mock_sts_client = _assume_role_sts_mock()
+    role_arn = "arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole"
+
+    with patch.dict(os.environ, _env_without_irsa(), clear=True):
         with patch("boto3.client", return_value=mock_sts_client):
-            base_aws_llm.get_credentials(aws_role_name=role_arn)
+            first = base_aws_llm.get_credentials(
+                aws_role_name=role_arn, aws_session_name="attributed-user-1"
+            )
             mock_sts_client.get_caller_identity.reset_mock()
 
-            base_aws_llm.get_credentials(aws_role_name=role_arn)
+            second = base_aws_llm.get_credentials(
+                aws_role_name=role_arn, aws_session_name="attributed-user-1"
+            )
 
-            mock_sts_client.get_caller_identity.assert_called()
-            assert mock_sts_client.assume_role.call_count == 2
+            mock_sts_client.get_caller_identity.assert_not_called()
+            assert mock_sts_client.assume_role.call_count == 1
+            assert first.access_key == second.access_key
+            assert first.token == second.token
+
+
+def test_assume_role_cache_is_scoped_per_session_name():
+    """Each attributed identity gets its own STS session; no user is served another user's creds."""
+    base_aws_llm = BaseAWSLLM()
+    mock_sts_client = _assume_role_sts_mock()
+    mock_sts_client.assume_role.side_effect = [
+        {
+            "Credentials": {
+                "AccessKeyId": f"assumed-access-key-{session_name}",
+                "SecretAccessKey": "assumed-secret-key",
+                "SessionToken": f"assumed-session-token-{session_name}",
+                "Expiration": datetime.now(timezone.utc) + timedelta(hours=1),
+            }
+        }
+        for session_name in ("attributed-user-1", "attributed-user-2")
+    ]
+    role_arn = "arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole"
+
+    with patch.dict(os.environ, _env_without_irsa(), clear=True):
+        with patch("boto3.client", return_value=mock_sts_client):
+            user_1 = base_aws_llm.get_credentials(
+                aws_role_name=role_arn, aws_session_name="attributed-user-1"
+            )
+            user_2 = base_aws_llm.get_credentials(
+                aws_role_name=role_arn, aws_session_name="attributed-user-2"
+            )
+            user_1_again = base_aws_llm.get_credentials(
+                aws_role_name=role_arn, aws_session_name="attributed-user-1"
+            )
+
+    assert mock_sts_client.assume_role.call_count == 2
+    session_names = [
+        call.kwargs["RoleSessionName"] for call in mock_sts_client.assume_role.call_args_list
+    ]
+    assert session_names == ["attributed-user-1", "attributed-user-2"]
+
+    assert user_1.access_key == "assumed-access-key-attributed-user-1"
+    assert user_2.access_key == "assumed-access-key-attributed-user-2"
+    assert user_1_again.access_key == user_1.access_key
+
+
+def test_assume_role_cache_entry_expires_with_the_sts_session():
+    """The cache entry is written with the STS lifetime, not an indefinite or default TTL."""
+    base_aws_llm = BaseAWSLLM()
+    mock_sts_client = _assume_role_sts_mock()
+    role_arn = "arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole"
+
+    with patch.dict(os.environ, _env_without_irsa(), clear=True):
+        with patch("boto3.client", return_value=mock_sts_client):
+            base_aws_llm.get_credentials(
+                aws_role_name=role_arn, aws_session_name="attributed-user-1"
+            )
+
+    in_memory_cache = BaseAWSLLM._shared_iam_cache.in_memory_cache
+    assert len(in_memory_cache.ttl_dict) == 1
+    remaining_ttl = list(in_memory_cache.ttl_dict.values())[0] - time.time()
+    # 1h STS session minus the 60s safety margin, minus test execution time
+    assert 3400 < remaining_ttl <= 3540
+
+
+def test_assume_role_credentials_expired_in_cache_trigger_a_fresh_sts_call():
+    """Once the STS session lapses the next call re-assumes rather than serving dead credentials."""
+    base_aws_llm = BaseAWSLLM()
+    mock_sts_client = _assume_role_sts_mock()
+    role_arn = "arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole"
+
+    with patch.dict(os.environ, _env_without_irsa(), clear=True):
+        with patch("boto3.client", return_value=mock_sts_client):
+            base_aws_llm.get_credentials(
+                aws_role_name=role_arn, aws_session_name="attributed-user-1"
+            )
+
+            in_memory_cache = BaseAWSLLM._shared_iam_cache.in_memory_cache
+            expired_key = list(in_memory_cache.ttl_dict.keys())[0]
+            in_memory_cache.ttl_dict[expired_key] = time.time() - 1
+
+            base_aws_llm.get_credentials(
+                aws_role_name=role_arn, aws_session_name="attributed-user-1"
+            )
+
+    assert mock_sts_client.assume_role.call_count == 2
+
+
+def test_concurrent_cold_cache_calls_for_one_identity_make_a_single_sts_call():
+    """Concurrent misses on one identity single-flight instead of each issuing its own AssumeRole."""
+    base_aws_llm = BaseAWSLLM()
+    role_arn = "arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole"
+
+    calling_threads = set()
+    threads_lock = threading.Lock()
+
+    def slow_assume_role(**kwargs):
+        with threads_lock:
+            calling_threads.add(threading.get_ident())
+        # Hold the fetch open so every other worker is inside get_credentials while this one runs;
+        # without that overlap the test would pass against unsynchronised code.
+        time.sleep(0.2)
+        return {
+            "Credentials": {
+                "AccessKeyId": "assumed-access-key",
+                "SecretAccessKey": "assumed-secret-key",
+                "SessionToken": "assumed-session-token",
+                "Expiration": datetime.now(timezone.utc) + timedelta(hours=1),
+            }
+        }
+
+    mock_sts_client = _assume_role_sts_mock()
+    mock_sts_client.assume_role.side_effect = slow_assume_role
+
+    barrier = threading.Barrier(8)
+    resolved = []
+
+    def resolve():
+        barrier.wait()
+        resolved.append(
+            base_aws_llm.get_credentials(aws_role_name=role_arn, aws_session_name="attribution-1")
+        )
+
+    with patch.dict(os.environ, _env_without_irsa(), clear=True):
+        with patch("boto3.client", return_value=mock_sts_client):
+            workers = [threading.Thread(target=resolve) for _ in range(8)]
+            for worker in workers:
+                worker.start()
+            for worker in workers:
+                worker.join(timeout=30)
+
+    # The harness has to have produced real concurrency, or the assertion below proves nothing
+    assert len(resolved) == 8
+    assert len({id(credentials) for credentials in resolved}) == 1
+
+    assert mock_sts_client.assume_role.call_count == 1
+    assert len(calling_threads) == 1
+
+
+def test_ambient_identity_matching_target_role_is_cached_without_repeating_the_probe():
+    """The skip-AssumeRole branch caches too, so GetCallerIdentity stops running per request."""
+    base_aws_llm = BaseAWSLLM()
+    role_arn = "arn:aws:iam::2222222222222:role/LitellmEvalBedrockRole"
+
+    mock_sts_client = MagicMock()
+    mock_sts_client.get_caller_identity.return_value = {
+        "Arn": "arn:aws:sts::2222222222222:assumed-role/LitellmEvalBedrockRole/session-name",
+    }
+
+    mock_ambient_credentials = MagicMock()
+    mock_ambient_credentials.access_key = "ambient-access-key"
+
+    with patch.dict(os.environ, _env_without_irsa(), clear=True):
+        with patch("boto3.client", return_value=mock_sts_client):
+            with patch.object(
+                base_aws_llm,
+                "_auth_with_env_vars",
+                return_value=(mock_ambient_credentials, None),
+            ) as mock_env_auth:
+                first = base_aws_llm.get_credentials(aws_role_name=role_arn)
+                second = base_aws_llm.get_credentials(aws_role_name=role_arn)
+
+    assert mock_sts_client.get_caller_identity.call_count == 1
+    assert mock_sts_client.assume_role.call_count == 0
+    mock_env_auth.assert_called_once()
+    assert first.access_key == second.access_key == "ambient-access-key"
 
 
 def test_cache_keys_are_different_for_different_roles():
@@ -1961,7 +2132,10 @@ def test_auth_with_aws_role_irsa_environment():
                 assert creds.access_key == "irsa-access-key"
                 assert creds.secret_key == "irsa-secret-key"
                 assert creds.token == "irsa-session-token"
-                assert ttl > 0  # TTL should be positive
+                # 1h STS session minus the safety margin, so a cached entry retires before AWS
+                # expires the credential
+                assert ttl is not None
+                assert 3400 < ttl <= 3540
     finally:
         # Clean up the temporary file
         os.unlink(token_file)
@@ -2336,20 +2510,19 @@ def test_get_credentials_ecs_same_role_skips_assume_role():
                     aws_region_name="us-east-1",
                 )
 
-                # Each get_credentials must check identity first; second call still checks before
-                # taking the iam_cache hit (no pre-peek that bypasses _is_already_running_as_role).
-                assert mock_already_running.call_count == 2
-                # Cached env resolution: second call hits iam_cache, not _auth_with_env_vars again.
+                # The identity probe and the env resolution are both behind the iam_cache, so the
+                # second call repeats neither.
+                mock_already_running.assert_called_once()
                 mock_env_auth.assert_called_once()
                 mock_role_auth.assert_not_called()
                 assert credentials.access_key == "ecs-access-key"
 
 
-def test_get_credentials_role_second_call_not_same_role_uses_assume_not_env_cache():
+def test_get_credentials_role_reevaluates_identity_once_the_cached_entry_lapses():
     """
     First request: already target role -> env path fills iam_cache.
-    Second request (e.g. identity changed): not same role -> AssumeRole path; must not reuse
-    cached env resolution from the first call.
+    Once that entry expires and the identity no longer matches, the next request must take the
+    AssumeRole path rather than serving the cached env resolution.
     """
     base_aws_llm = BaseAWSLLM()
 
@@ -2384,6 +2557,11 @@ def test_get_credentials_role_second_call_not_same_role_uses_assume_not_env_cach
                     aws_role_name=role_arn,
                     aws_region_name="us-east-1",
                 )
+
+                in_memory_cache = BaseAWSLLM._shared_iam_cache.in_memory_cache
+                lapsed_key = list(in_memory_cache.ttl_dict.keys())[0]
+                in_memory_cache.ttl_dict[lapsed_key] = time.time() - 1
+
                 second = base_aws_llm.get_credentials(
                     aws_role_name=role_arn,
                     aws_region_name="us-east-1",


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock AssumeRole bypassed the IAM cache entirely
- Every model request issued a fresh sts:AssumeRole
- On ECS/EC2 an uncached sts:GetCallerIdentity ran first too
- Per-user cost attribution therefore cost 1-2 STS calls per request

How it solves it:

- Route the whole role branch through the existing IAM cache
- Use the STS TTL `_auth_with_aws_role` already computed and threw away
- Key includes `aws_session_name`, so one session per attributed identity
- Raise the IAM cache bound, since attribution makes it high cardinality

## Relevant issues

## Linear ticket

Resolves LIT-5053

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Full disclosure on the rig: this machine has no AWS credentials, so I could not spend real money against real Bedrock. Everything except the two AWS endpoints is real; a live proxy, real boto3 clients, real SigV4 signing, real HTTP over the wire. `aws_sts_endpoint` and `aws_bedrock_runtime_endpoint` point at a local server I control that logs every `sts:AssumeRole` with its `RoleSessionName`, which is what makes the STS call volume countable from outside the gateway. The reproduction commands below work unchanged against real AWS if you drop those two endpoint overrides

Config used for both runs, with a per-request `aws_session_name` carrying the attributed identity, which is how per-user Bedrock cost attribution reaches the provider:

```yaml
model_list:
  - model_name: bedrock-attributed
    litellm_params:
      model: bedrock/converse/anthropic.claude-sonnet-4-5-20250929-v1:0
      aws_region_name: us-east-1
      aws_role_name: arn:aws:iam::123456789012:role/BedrockAttributionRole
      aws_sts_endpoint: http://127.0.0.1:15053
      aws_bedrock_runtime_endpoint: http://127.0.0.1:15054
general_settings:
  master_key: sk-lit5053
```

Both runs send the same 25 chat completions spread over 4 attributed identities:

```bash
for i in 1 2 3 4 5; do for u in alice bob carol dave; do
  curl -s -X POST http://127.0.0.1:14053/v1/chat/completions \
    -H "Authorization: Bearer sk-lit5053" -H "Content-Type: application/json" \
    -d "{\"model\":\"bedrock-attributed\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"aws_session_name\":\"attribution-$u\"}" \
    -o /dev/null -w "%{http_code} "
done; done
curl -s http://127.0.0.1:15053/__assume_role_count
```

### Before, at b5cfc2ca00 (litellm_internal_staging, fix absent)

```
$ grep -c "_resolve_role_credentials" litellm/llms/bedrock/base_aws_llm.py
0

200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200
TOTAL sts:AssumeRole for 25 chat requests = 25
   attribution-alice: 8
   attribution-bob: 7
   attribution-carol: 5
   attribution-dave: 5
```

One `sts:AssumeRole` per model request, exactly as reported

### After, at 78509ffc16 (this branch)

```
200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200 200
TOTAL sts:AssumeRole for 25 chat requests = 4
   attribution-alice: 1
   attribution-bob: 1
   attribution-carol: 1
   attribution-dave: 1
```

25 requests, 4 STS calls, one per attributed identity. Each identity holds its own STS session for the life of that session, and a new identity still gets its own assume rather than inheriting anyone else's credentials

### Concurrent misses, at 13610adf96

Greptile's first pass flagged that concurrent misses on one key would still each issue their own STS call. That reproduced on the same rig, so it is fixed rather than argued. 10 simultaneous requests for one identity against a cold cache, before single-flight went in:

```
200 200 200 200 200 200 200 200 200 200
sts:AssumeRole for 10 concurrent cold-cache requests = 10
   attribution-stampede: 10
```

The same burst plus 40 more across 4 fresh identities, all fired simultaneously, with single-flight in place:

```
TOTAL sts:AssumeRole for 50 concurrent requests = 5
   attribution-eve: 1
   attribution-frank: 1
   attribution-grace: 1
   attribution-heidi: 1
   attribution-stampede: 1
```

## Type

🐛 Bug Fix

## Changes

`BaseAWSLLM.get_credentials` routed only three flows through `_get_or_set_cached_credentials`: web identity, static access key plus secret, and ambient env. The explicit AssumeRole branch called `_auth_with_aws_role` and returned its result directly, dropping the STS TTL into an unused `_assume_ttl` local, so credential resolution re-issued `sts:AssumeRole` on every request. On anything that is not IRSA, `_is_already_running_as_role` also ran first with its own uncached `sts:GetCallerIdentity`, making it two STS round trips per request on ECS and EC2

The whole role branch now goes through the cache. `_resolve_role_credentials` holds what used to be inline: the identity probe, the session-name default, and the assume itself, and returns the `(credentials, ttl)` pair the cache already understands. A hit skips both STS calls

The cache key is the same `aws_*` argument snapshot the other flows use. It is taken before the session-name default is filled in, which is why that default moved into the fetcher: generating `litellm-session-{timestamp}` above the snapshot would give every request a unique key and the cache would never hit. Because the snapshot includes `aws_session_name`, per-identity scoping is structural rather than something callers have to opt into, and one attributed identity can never be served another's credentials

Two smaller pieces follow from that. The IAM cache now carries an explicit 1000 entry bound instead of `InMemoryCache`'s default 200, because attribution turns this cache from one entry per model config into one entry per attributed identity, and thrashing at 200 users would quietly degrade back to per-request STS. And `_extract_credentials_and_ttl`, used by the IRSA assume paths, now applies the same 60 second safety margin the non-IRSA path always had, so no cached entry is handed out close enough to expiry to die mid-request

One deliberate behavior change worth calling out: the `sts:GetCallerIdentity` identity probe used to run on every request, so a runtime identity that stopped matching `aws_role_name` was noticed immediately. It is now re-evaluated when the cache entry lapses instead, which is 10 minutes on the ambient branch and the STS session lifetime on the assume branch. Keeping the probe per-request would have left the ECS and EC2 deployments at one STS call per request, which is most of the reported problem. `test_get_credentials_role_reevaluates_identity_once_the_cached_entry_lapses` pins the weaker guarantee that remains

Credential fetches also single-flight now. `_get_or_set_cached_credentials` holds a striped lock across the read and the fetch, so concurrent callers for one identity produce one STS call instead of one each. Striping rather than a per-key lock registry keeps distinct identities from serialising behind each other without a structure that grows with the identity count; a cache hit holds its stripe only for the dictionary lookup. This covers the web identity and static-key flows too, which had the same gap

Profile and explicit session-token flows are still uncached, unchanged

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Mutation results on the new and updated tests, all against the real suite:

| mutation | tests that fail |
| --- | --- |
| revert `base_aws_llm.py` to staging | 8 |
| drop `aws_session_name` from the cache key | 2, including the cross-identity one |
| discard the STS TTL on the cache write | 1 |
| hoist the identity probe back outside the cache | 4 |
| remove the safety margin, assume path | 1 |
| remove the safety margin, IRSA path | 1 |
| remove the single-flight lock | 1 |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Bedrock/AWS credential caching and STS call patterns on a hot path; wrong cache keys or TTLs could serve stale or cross-identity credentials, though tests target per-session scoping and expiry.
> 
> **Overview**
> **Bedrock IAM credential resolution** no longer re-issues `sts:AssumeRole` (and often `sts:GetCallerIdentity`) on every request when `aws_role_name` is used. The full role branch—including identity probe, session-name defaulting, and assume—runs inside `_get_or_set_cached_credentials` via `_resolve_role_credentials`, with cache keys that include `aws_session_name` so each attributed identity keeps its own STS session.
> 
> The process-wide IAM cache is **raised to 1000 entries** and guarded by **64 striped locks** so concurrent cache misses for the same identity single-flight instead of stampeding STS. AssumeRole and IRSA TTLs now use a shared **60s expiry safety margin** (`STS_CREDENTIAL_EXPIRY_SAFETY_MARGIN_SECONDS`).
> 
> **Behavior change:** `GetCallerIdentity` for “already on target role” is re-run when the cache entry expires (ambient ~10m, assume ~session lifetime), not on every request. Profile and explicit session-token auth remain uncached.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13610adf96684939a09d594f15061c8eb2a3e1c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->