### PR TITLE
fix(proxy): apply user_url_allowed_hosts from litellm_settings in DB config sync

### DIFF
--- a/litellm/litellm_core_utils/url_utils.py
+++ b/litellm/litellm_core_utils/url_utils.py
@@ -293,7 +293,7 @@ def validate_url(url: str) -> Tuple[str, str]:
                 raise SSRFError(
                     f"URL targets a blocked address ({resolved_ip}). "
                     "If this is a legitimate internal service, add the host "
-                    "to `user_url_allowed_hosts` in general_settings."
+                    "to `user_url_allowed_hosts` in litellm_settings."
                 )
 
     # For HTTPS with SSL verification enabled, TLS certificate validation

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3651,7 +3651,7 @@ def _normalize_user_url_validation(value: object) -> Optional[bool]:
     return bool(value)
 
 
-def _apply_ssrf_general_settings(settings: Mapping[str, object]) -> None:
+def _apply_ssrf_settings(settings: Mapping[str, object]) -> None:
     if "user_url_allowed_hosts" in settings:
         litellm.user_url_allowed_hosts = cast(list[str], settings["user_url_allowed_hosts"])
 
@@ -4923,7 +4923,7 @@ class ProxyConfig:
                 ]
 
             ### SSRF URL VALIDATION SETTINGS ###
-            _apply_ssrf_general_settings(general_settings)
+            _apply_ssrf_settings(general_settings)
 
             ## check if user has set a premium feature in general_settings
             if general_settings.get("enforced_params") is not None and premium_user is not True:
@@ -5978,7 +5978,12 @@ class ProxyConfig:
         ):
             if key in _general_settings:
                 general_settings[key] = _general_settings[key]
-        _apply_ssrf_general_settings(_general_settings)
+        _apply_ssrf_settings(_general_settings)
+
+    def _update_litellm_settings_ssrf(self, db_litellm_settings: Optional[Json]):
+        if not isinstance(db_litellm_settings, Mapping):
+            return
+        _apply_ssrf_settings(db_litellm_settings)
 
     def _update_config_fields(
         self,
@@ -6187,6 +6192,13 @@ class ProxyConfig:
 
                 # update llm router
                 await self._update_llm_router(new_models=new_models, proxy_logging_obj=proxy_logging_obj)
+
+            db_litellm_settings = await get_config_param(prisma_client, "litellm_settings")
+
+            if db_litellm_settings is not None:
+                self._update_litellm_settings_ssrf(
+                    db_litellm_settings=db_litellm_settings.param_value,
+                )
 
             db_general_settings = await get_config_param(prisma_client, "general_settings")
 
@@ -14894,7 +14906,7 @@ async def update_config_general_settings(
 
     if data.field_name == "plugins":
         register_plugins_from_config(general_settings)
-    _apply_ssrf_general_settings(general_settings)
+    _apply_ssrf_settings(general_settings)
 
     return response
 

--- a/tests/test_litellm/litellm_core_utils/test_url_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_url_utils.py
@@ -130,6 +130,11 @@ class TestValidateUrl:
         with pytest.raises(SSRFError):
             validate_url("http://192.168.1.1/")
 
+    def test_blocked_address_error_names_documented_config_location(self):
+        """The docs place user_url_allowed_hosts under litellm_settings; the hint must match."""
+        with pytest.raises(SSRFError, match="`user_url_allowed_hosts` in litellm_settings"):
+            validate_url("http://10.0.1.5:8080/v1/completions")
+
     def test_blocks_file_scheme(self):
         with pytest.raises(SSRFError):
             validate_url("file:///etc/passwd")

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -6713,6 +6713,68 @@ async def test_update_general_settings_store_model_in_db_false():
         assert ps.general_settings["store_model_in_db"] is False
 
 
+def test_update_litellm_settings_ssrf_applies_documented_location():
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+
+    with patch.object(litellm, "user_url_allowed_hosts", []):
+        proxy_config._update_litellm_settings_ssrf(
+            db_litellm_settings={"user_url_allowed_hosts": ["files.example.com"]}
+        )
+
+        assert litellm.user_url_allowed_hosts == ["files.example.com"]
+
+
+@pytest.mark.asyncio
+async def test_update_general_settings_wins_over_litellm_settings_for_ssrf_keys():
+    """general_settings wins on conflict, matching the YAML load order in load_config."""
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+
+    with (
+        patch.object(litellm, "user_url_allowed_hosts", []),
+        patch("litellm.proxy.proxy_server.general_settings", {}),
+    ):
+        proxy_config._update_litellm_settings_ssrf(
+            db_litellm_settings={"user_url_allowed_hosts": ["litellm-settings.example.com"]}
+        )
+        await proxy_config._update_general_settings(
+            db_general_settings={"user_url_allowed_hosts": ["general-settings.example.com"]}
+        )
+
+        assert litellm.user_url_allowed_hosts == ["general-settings.example.com"]
+
+
+@pytest.mark.asyncio
+async def test_add_deployment_applies_db_litellm_settings_ssrf():
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+
+    db_row = MagicMock()
+    db_row.param_name = "litellm_settings"
+    db_row.param_value = {"user_url_allowed_hosts": ["files.example.com"]}
+
+    async def fake_get_config_param(prisma_client, param_name):
+        return db_row if param_name == "litellm_settings" else None
+
+    with (
+        patch.object(litellm, "user_url_allowed_hosts", []),
+        patch("litellm.proxy.proxy_server.prefetch_config_params", new=AsyncMock()),
+        patch(
+            "litellm.proxy.proxy_server.get_config_param",
+            side_effect=fake_get_config_param,
+        ),
+        patch.object(proxy_config, "_should_load_db_object", return_value=False),
+        patch.object(proxy_config, "_init_non_llm_objects_in_db", new=AsyncMock()),
+    ):
+        await proxy_config.add_deployment(prisma_client=MagicMock(), proxy_logging_obj=MagicMock())
+
+        assert litellm.user_url_allowed_hosts == ["files.example.com"]
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "db_value,expected",

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -6726,6 +6726,17 @@ def test_update_litellm_settings_ssrf_applies_documented_location():
         assert litellm.user_url_allowed_hosts == ["files.example.com"]
 
 
+def test_update_litellm_settings_ssrf_ignores_non_mapping():
+    from litellm.proxy.proxy_server import ProxyConfig
+
+    proxy_config = ProxyConfig()
+
+    with patch.object(litellm, "user_url_allowed_hosts", ["keep.example.com"]):
+        proxy_config._update_litellm_settings_ssrf(db_litellm_settings=None)
+
+        assert litellm.user_url_allowed_hosts == ["keep.example.com"]
+
+
 @pytest.mark.asyncio
 async def test_update_general_settings_wins_over_litellm_settings_for_ssrf_keys():
     """general_settings wins on conflict, matching the YAML load order in load_config."""


### PR DESCRIPTION

## TLDR

Problem this solves:

- The docs say `user_url_allowed_hosts` goes under `litellm_settings`
- DB backed deployments only read it from `general_settings`
- The SSRF error message also says `general_settings` which actually contradicts the docs

How it solves it:

- Now we have the DB config sync applying the SSRF keys from `litellm_settings` too
- `general_settings` still wins on conflict which matches the YAML load order
- The error message now names `litellm_settings` instead


## Relevant issues

Fixes #35177

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

So I used a live proxy on localhost:4000 backed by postgres with `store_model_in_db: true` without mocks alongside a local agent card server on 127.0.0.1:9999 which was used for the original issue reporters blocked range host since loopback is in the same SSRF blocklist 

Below is the bug on the base commit 3c2264cf. I stored the allowlist in the DB under `litellm_settings` and waited for the config sync poll and noted discovery of that host is still blocked. Here you can see the error even says to put the settings in `general_settings`

```
$ docker exec litellm-vet-pg psql -U litellm -d litellm -c \
    "INSERT INTO \"LiteLLM_Config\" (param_name, param_value) VALUES ('litellm_settings', '{\"user_url_allowed_hosts\": [\"127.0.0.1:9999\"]}') ON CONFLICT (param_name) DO UPDATE SET param_value = EXCLUDED.param_value;"
INSERT 0 1

$ curl -s -X POST "http://localhost:4000/v1/a2a/discover" \
    -H "Authorization: Bearer sk-vet-1234" -H "Content-Type: application/json" \
    -d '{"url": "http://127.0.0.1:9999"}'
{
    "detail": "Could not fetch agent card from http://127.0.0.1:9999 (mode=well_known_fallback). Last error: http://127.0.0.1:9999/agent.json: URL targets a blocked address (127.0.0.1). If this is a legitimate internal service, add the host to `user_url_allowed_hosts` in general_settings."
}
```

Now below with the fix in place on commit 05014d01 and no allowlist configured we see the block still fires and the message now names the documented location

```
$ curl -s -X POST "http://localhost:4000/v1/a2a/discover" \
    -H "Authorization: Bearer sk-vet-1234" -H "Content-Type: application/json" \
    -d '{"url": "http://127.0.0.1:9999"}'
{
    "detail": "Could not fetch agent card from http://127.0.0.1:9999 (mode=well_known_fallback). Last error: http://127.0.0.1:9999/agent.json: URL targets a blocked address (127.0.0.1). If this is a legitimate internal service, add the host to `user_url_allowed_hosts` in litellm_settings."
}
```

Lastly below on the same commit 05014d01 with the same DB row as the run before, once one 30s sync poll completes the same curl now succeeds and returns the agent card

```
$ curl -s -X POST "http://localhost:4000/v1/a2a/discover" \
    -H "Authorization: Bearer sk-vet-1234" -H "Content-Type: application/json" \
    -d '{"url": "http://127.0.0.1:9999"}'
{
    "url": "http://127.0.0.1:9999",
    "agent_card": {
        "name": "vet-agent",
        "description": "local card for litellm 35177 verification",
        "url": "http://127.0.0.1:9999",
        "version": "1.0.0",
        "capabilities": {},
        "skills": []
    }
}
```

I also checked the normal yaml path and it already works fine on both this branch and v1.93.0 so the only things this PR changes are the DB sync path and the error message 

## Type

🐛 Bug Fix

## Changes

- In `litellm/proxy/proxy_server.py` I added `_update_litellm_settings_ssrf` to `ProxyConfig` and called it from `add_deployment` just before `_update_general_settings` so `general_settings` still wins if both sections set the same key. Also renamed `_apply_ssrf_general_settings` to `_apply_ssrf_settings` since it now handles both config sections
- In `litellm/litellm_core_utils/url_utils.py` I changed the SSRF block message so it now says `litellm_settings`
- Added three tests to `tests/test_litellm/proxy/test_proxy_server.py` covering the new method, the general-settings-wins precedence, and the full `add_deployment` wiring with mocked DB reads and all three tests fail without the fix
- Added a regression test to `tests/test_litellm/litellm_core_utils/test_url_utils.py` pinning the error message to the documented config location


### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR