### PR TITLE
chore(proxy): remove duplicate Sequence import in team endpoints

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -22,7 +22,6 @@ from typing import (
     Mapping,
     Optional,
     Protocol,
-    Sequence,
     Tuple,
     TypeVar,
     Union,


### PR DESCRIPTION
## TLDR

Problem this solves:

- `team_endpoints.py` trips ruff F811 on staging
- `Sequence` is imported from both `collections.abc` and `typing`
- the `typing` copy shadows the one every annotation reads

How it solves it:

- drop `Sequence` from the `typing` import block
- keep `from collections.abc import Sequence`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

No test is added here on purpose. `F811` is enforced repo-wide by `make lint`, so reintroducing the duplicate import turns CI red on its own; a unit test asserting the shape of an import block would assert nothing the linter does not already catch

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This change removes a shadowed import name; it has no request path and no runtime behavior to exercise, so the proof is the linter that currently fails

Before, at `1e7b39d15c` (current `litellm_internal_staging` head):

```bash
git show 1e7b39d15c:litellm/proxy/management_endpoints/team_endpoints.py | uv run ruff check --stdin-filename litellm/proxy/management_endpoints/team_endpoints.py -
```

```
F811 Redefinition of unused `Sequence` from line 16
  --> litellm/proxy/management_endpoints/team_endpoints.py:25:5
   |
23 |     Optional,
24 |     Protocol,
25 |     Sequence,
   |     ^^^^^^^^ `Sequence` redefined here
26 |     Tuple,
27 |     TypeVar,
   |
  ::: litellm/proxy/management_endpoints/team_endpoints.py:16:29
   |
14 | import math
15 | import traceback
16 | from collections.abc import Sequence
   |                             -------- previous definition of `Sequence` here
17 | from datetime import datetime, timezone
18 | from typing import (
   |
help: Remove definition: `Sequence`

Found 1 error.
```

After, at `c541fb2b7a` (this PR):

```bash
uv run ruff check litellm/proxy/management_endpoints/team_endpoints.py
```

```
All checks passed!
```

Full `make pre-commit` on the branch also passes: ruff, the strict / type-discipline / basedpyright budget gates, the circular-import check, format, and the dashboard API type sync

## Type

🐛 Bug Fix

## Changes

`from collections.abc import Sequence` landed in `e8e2e07ef6` (#35435) while `Sequence` was already in the file's `typing` import block, and the two only met when that PR merged into staging, so the duplicate reached staging without either side seeing it. All 11 uses in the file are subscripted generics (`Sequence[Member]` and friends), which behave identically under both spellings, so keeping the `collections.abc` one and deleting the `typing` one is a no-op at runtime

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
