### PR TITLE
fix(router): honor request-level num_retries over a deployment's litellm_params value

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -2948,20 +2948,14 @@ class Router:
     ) -> None:
         """
         Adds/updates to kwargs:
-        - num_retries
         - litellm_trace_id
         - metadata
+
+        num_retries is deliberately left as the caller passed it, with no default filled in.
+        async_function_with_retries resolves the router/global default itself, and it can only
+        honour the precedence request > deployment litellm_params > litellm_settings while an
+        absent num_retries still means "the caller did not ask for one".
         """
-        # Normalise an explicit num_retries=None to the router default here (dict.get()
-        # only falls back when the key is absent, not when its value is None), then to 0
-        # if the router default is itself None - mirroring the guard in
-        # async_function_with_retries, which remains the safety net for paths that bypass
-        # this setter.
-        _req_num_retries = kwargs.get("num_retries")
-        if _req_num_retries is not None:
-            kwargs["num_retries"] = _req_num_retries
-        else:
-            kwargs["num_retries"] = self.num_retries if self.num_retries is not None else 0
         kwargs.setdefault("litellm_trace_id", str(uuid.uuid4()))
         model_group_alias: Optional[str] = None
         if self._get_model_from_alias(model=model):
@@ -3684,7 +3678,6 @@ class Router:
             kwargs["model"] = model
             kwargs["prompt"] = prompt
             kwargs["original_function"] = self._image_generation
-            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
             kwargs.setdefault("metadata", {}).update({"model_group": model})
             response = self.function_with_fallbacks(**kwargs)
 
@@ -3739,7 +3732,6 @@ class Router:
             kwargs["model"] = model
             kwargs["prompt"] = prompt
             kwargs["original_function"] = self._aimage_generation
-            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
             response = await self.async_function_with_fallbacks(**kwargs)
 
@@ -4244,7 +4236,6 @@ class Router:
             kwargs["model"] = model
             kwargs["adapter_id"] = adapter_id
             kwargs["original_function"] = self._aadapter_completion
-            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
             kwargs.setdefault("metadata", {}).update({"model_group": model})
             response = await self.async_function_with_fallbacks(**kwargs)
 
@@ -4865,7 +4856,6 @@ class Router:
         try:
             kwargs["model"] = model
             kwargs["original_function"] = self._acreate_file
-            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
             self._update_kwargs_before_fallbacks(model=model, kwargs=kwargs)
             response = await self.async_function_with_fallbacks(**kwargs)
 
@@ -5126,7 +5116,6 @@ class Router:
         try:
             kwargs["model"] = model
             kwargs["original_function"] = self._acreate_batch
-            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
             metadata_variable_name = _get_router_metadata_variable_name(function_name="_acreate_batch")
             self._update_kwargs_before_fallbacks(
                 model=model,
@@ -5342,7 +5331,6 @@ class Router:
         try:
             kwargs["model"] = model
             kwargs["original_function"] = self._acancel_batch
-            kwargs["num_retries"] = kwargs.get("num_retries", self.num_retries)
             metadata_variable_name = _get_router_metadata_variable_name(function_name="_acancel_batch")
             self._update_kwargs_before_fallbacks(
                 model=model,
@@ -6503,7 +6491,8 @@ class Router:
         # Support per-request model_group_retry_policy override (from key/team settings)
         model_group_retry_policy = kwargs.pop("model_group_retry_policy", self.model_group_retry_policy)
         model_group: Optional[str] = kwargs.get("model")
-        num_retries = kwargs.pop("num_retries", None)
+        request_num_retries: Optional[int] = kwargs.pop("num_retries", None)
+        num_retries = request_num_retries
         if num_retries is None:
             # Fall back to the router setting (then 0) so the comparisons below never
             # hit `None > int`, which would mask the real upstream error with a TypeError.
@@ -6533,7 +6522,11 @@ class Router:
             original_exception = e
             deployment_num_retries = getattr(e, "num_retries", None)
 
-            if deployment_num_retries is not None and isinstance(deployment_num_retries, int):
+            if (
+                request_num_retries is None
+                and deployment_num_retries is not None
+                and isinstance(deployment_num_retries, int)
+            ):
                 num_retries = deployment_num_retries
             """
             Retry Logic

--- a/tests/test_litellm/test_router_per_deployment_num_retries.py
+++ b/tests/test_litellm/test_router_per_deployment_num_retries.py
@@ -139,9 +139,12 @@ class TestPerDeploymentNumRetries:
         router._update_kwargs_before_fallbacks(model="test-model", kwargs=kwargs)
         assert kwargs["num_retries"] == 10  # Request-level takes precedence
 
-    def test_global_num_retries_used_when_no_deployment_setting(self):
+    def test_update_kwargs_does_not_fill_in_a_num_retries_default(self):
         """
-        Test that global num_retries is used when deployment has no num_retries.
+        A request that carries no num_retries must stay that way through
+        _update_kwargs_before_fallbacks. Filling in the router default here is what made a
+        request indistinguishable from "no request value", which let a deployment's
+        litellm_params.num_retries outrank the header/body value.
         """
         router = Router(
             model_list=[
@@ -150,16 +153,15 @@ class TestPerDeploymentNumRetries:
                     "litellm_params": {
                         "model": "openai/gpt-4",
                         "api_key": "test-key",
-                        # No num_retries set
                     },
                 },
             ],
             num_retries=7,  # Global setting
         )
 
-        kwargs = {}
+        kwargs: dict = {}
         router._update_kwargs_before_fallbacks(model="test-model", kwargs=kwargs)
-        assert kwargs["num_retries"] == 7  # Uses global
+        assert kwargs.get("num_retries") is None
 
     def test_set_deployment_num_retries_with_string_value(self):
         """
@@ -226,33 +228,22 @@ class TestNumRetriesNoneGuard:
             num_retries=num_retries,
         )
 
-    def test_update_kwargs_normalises_explicit_none_to_router_default(self):
+    def test_update_kwargs_preserves_an_explicit_zero(self):
         """
-        _update_kwargs_before_fallbacks must normalise an explicit num_retries=None to
-        the router default (not leave it as None), while preserving an explicit 0.
+        An explicit num_retries=0 must survive _update_kwargs_before_fallbacks (retries stay
+        disabled), and an explicit None must not be turned into a value that reads as a
+        request-level setting. Resolving None to the router default is
+        async_function_with_retries' job, which the behavioural tests below pin.
         """
         router = self._mock_router(num_retries=4)
 
-        # explicit None -> router default
-        kwargs = {"num_retries": None}
-        router._update_kwargs_before_fallbacks(model="mock-model", kwargs=kwargs)
-        assert kwargs["num_retries"] == 4
-
-        # explicit 0 is preserved (retries stay disabled)
-        kwargs = {"num_retries": 0}
+        kwargs: dict = {"num_retries": 0}
         router._update_kwargs_before_fallbacks(model="mock-model", kwargs=kwargs)
         assert kwargs["num_retries"] == 0
 
-        # absent -> router default (unchanged behaviour)
-        kwargs = {}
-        router._update_kwargs_before_fallbacks(model="mock-model", kwargs=kwargs)
-        assert kwargs["num_retries"] == 4
-
-        # explicit None with router default also None -> 0 (mirrors the downstream guard)
-        router.num_retries = None  # simulate update_settings(num_retries=None) (#28126)
         kwargs = {"num_retries": None}
         router._update_kwargs_before_fallbacks(model="mock-model", kwargs=kwargs)
-        assert kwargs["num_retries"] == 0
+        assert kwargs.get("num_retries") is None
 
     @pytest.mark.asyncio
     async def test_acompletion_num_retries_none_does_not_raise_typeerror(self):
@@ -575,3 +566,183 @@ class TestRequestNumRetriesBeatsGlobal:
                     model="mock", messages=[{"role": "user", "content": "hi"}]
                 )
         assert counter.attempts == 3
+
+
+class TestRequestNumRetriesBeatsDeployment:
+    """
+    Documented precedence for num_retries on the proxy:
+
+        x-litellm-num-retries header > request body > model_list litellm_params > litellm_settings
+
+    The header and the body both arrive at the router as the num_retries kwarg (the proxy
+    overwrites the body value with the header one), so "request level" covers both.
+
+    The regression: a failing deployment stamps its own litellm_params.num_retries onto the
+    raised exception, and async_function_with_retries adopted that value unconditionally, so a
+    deployment setting outranked the header and the body instead of sitting below them.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _restore_litellm_globals(self):
+        prev_num_retries = litellm.num_retries
+        prev_callbacks = litellm.callbacks
+        yield
+        litellm.num_retries = prev_num_retries
+        litellm.callbacks = prev_callbacks
+
+    @staticmethod
+    def _router(*, global_num_retries, deployment_num_retries):
+        litellm_params = {
+            "model": "openai/mock",
+            "api_key": "sk-fake",
+            "mock_response": "litellm.InternalServerError",
+        }
+        if deployment_num_retries is not None:
+            litellm_params["num_retries"] = deployment_num_retries
+        return Router(
+            model_list=[{"model_name": "mock", "litellm_params": litellm_params}],
+            num_retries=global_num_retries,
+        )
+
+    async def _count_attempts(
+        self,
+        *,
+        global_num_retries,
+        deployment_num_retries,
+        request_num_retries,
+        mock_testing_rate_limit_error=False,
+    ):
+        counter = _AttemptCounter()
+        litellm.callbacks = [counter]
+        litellm.num_retries = global_num_retries
+        router = self._router(
+            global_num_retries=global_num_retries,
+            deployment_num_retries=deployment_num_retries,
+        )
+        kwargs = {"model": "mock", "messages": [{"role": "user", "content": "hi"}]}
+        if request_num_retries is not None:
+            kwargs["num_retries"] = request_num_retries
+        if mock_testing_rate_limit_error:
+            kwargs["mock_testing_rate_limit_error"] = True
+        with patch("asyncio.sleep", return_value=None):
+            with pytest.raises((litellm.InternalServerError, litellm.RateLimitError)):
+                await router.acompletion(**kwargs)
+        return counter.attempts
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("request_num_retries, expected_attempts", [(3, 4), (0, 1)])
+    async def test_request_num_retries_overrides_deployment(
+        self, request_num_retries, expected_attempts
+    ):
+        """
+        global=1, deployment=2, request=3 -> 4 attempts, and request=0 -> a single attempt.
+        Before the fix the deployment value won, so both cases sent 3 attempts.
+        """
+        attempts = await self._count_attempts(
+            global_num_retries=1,
+            deployment_num_retries=2,
+            request_num_retries=request_num_retries,
+        )
+        assert attempts == expected_attempts
+
+    @pytest.mark.asyncio
+    async def test_deployment_num_retries_still_beats_global_when_request_omits_it(self):
+        """
+        The deployment value keeps its place directly above litellm_settings: global=1 and
+        deployment=2 with no request value -> 1 initial attempt + 2 retries.
+        """
+        attempts = await self._count_attempts(
+            global_num_retries=1, deployment_num_retries=2, request_num_retries=None
+        )
+        assert attempts == 3
+
+    @pytest.mark.asyncio
+    async def test_global_num_retries_applies_when_neither_request_nor_deployment_sets_it(self):
+        """Bottom of the chain is unchanged: global=3, nothing else set -> 4 attempts."""
+        attempts = await self._count_attempts(
+            global_num_retries=3, deployment_num_retries=None, request_num_retries=None
+        )
+        assert attempts == 4
+
+    @pytest.mark.asyncio
+    async def test_request_num_retries_overrides_deployment_on_the_rate_limit_mock_path(self):
+        """
+        mock_testing_rate_limit_error raises before the first upstream call and carries the
+        deployment's num_retries on the mock exception - a second place the deployment value is
+        injected. The request value must still win: request=3 leaves 3 real attempts, where the
+        deployment value would leave 2.
+        """
+        attempts = await self._count_attempts(
+            global_num_retries=1,
+            deployment_num_retries=2,
+            request_num_retries=3,
+            mock_testing_rate_limit_error=True,
+        )
+        assert attempts == 3
+
+
+class TestDeploymentNumRetriesOnNonCompletionEntryPoints:
+    """
+    aimage_generation and its siblings (adapter completion, file create, batch create, batch cancel)
+    run through the same retry loop as acompletion, so a deployment's litellm_params.num_retries must
+    apply there too whenever the request carries none.
+
+    These entry points used to pre-fill num_retries with the router default before handing kwargs to
+    the retry loop. That default is indistinguishable from a caller-supplied value, so it would
+    permanently suppress the deployment setting once the loop started ranking request above
+    deployment.
+
+    The provider SDK adds a fixed number of its own attempts per router attempt on this path, so the
+    factor is calibrated from a single-router-attempt run rather than hard coded.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _isolate(self):
+        prev = litellm.num_retries
+        litellm.num_retries = None
+        litellm.in_memory_llm_clients_cache.flush_cache()
+        yield
+        litellm.num_retries = prev
+        litellm.aclient_session = None
+        litellm.in_memory_llm_clients_cache.flush_cache()
+
+    async def _upstream_count(self, label, deployment_num_retries=None, **call_kwargs):
+        counter = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            counter["n"] += 1
+            return httpx.Response(500, headers={"retry-after": "0"}, json={"error": {"message": "boom"}})
+
+        litellm.aclient_session = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        litellm.in_memory_llm_clients_cache.flush_cache()
+        litellm_params = {
+            "model": "openai/dall-e-3",
+            "api_key": "sk-fake",
+            "api_base": f"https://imgretry-{label}.local/v1",
+        }
+        if deployment_num_retries is not None:
+            litellm_params["num_retries"] = deployment_num_retries
+        router = Router(
+            model_list=[{"model_name": "img", "litellm_params": litellm_params}],
+            num_retries=0,
+        )
+        with patch("asyncio.sleep", return_value=None):
+            with pytest.raises(litellm.InternalServerError):
+                await router.aimage_generation(model="img", prompt="a cat", **call_kwargs)
+        return counter["n"]
+
+    @pytest.mark.asyncio
+    async def test_deployment_num_retries_applies_to_image_generation(self):
+        """
+        Router default 0, deployment 2, no request value -> 3 router attempts. Asserted against a
+        calibrated single-attempt run so the provider SDK's own attempt count does not matter.
+        """
+        one_attempt = await self._upstream_count("calibrate")
+        assert one_attempt > 0
+        assert await self._upstream_count("dep2", deployment_num_retries=2) == 3 * one_attempt
+
+    @pytest.mark.asyncio
+    async def test_request_num_retries_still_wins_on_image_generation(self):
+        """A request value outranks the deployment here too: deployment 4, request 1 -> 2 attempts."""
+        one_attempt = await self._upstream_count("calibrate2")
+        assert await self._upstream_count("req1", deployment_num_retries=4, num_retries=1) == 2 * one_attempt


### PR DESCRIPTION
## TLDR

Problem this solves:

- `model_list` `num_retries` outranked the header and the body
- Documented precedence was inverted for any deployment that sets it
- `x-litellm-num-retries: 0` could not disable retries

How it solves it:

- Adopt the deployment value only when the request carried none
- Stop pre-filling the router default, which erased that distinction
- Precedence is now header > body > model_list > litellm_settings

## Relevant issues

Docs companion, which writes the precedence down and explains the `max_retries` answer: BerriAI/litellm-docs#734. It carries no CI dependency on this PR and can merge in either order

## Linear ticket

Resolves LIT-4772

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The observable is the number of requests one proxy call sends upstream, which no real provider emits deterministically, so the deployment points at a tiny counting upstream that 500s every `POST /v1/chat/completions` and serves its tally on `GET /count`. One proxy call, then read the tally; `1 + effective num_retries` is what the customer counts as "number of queries"

Both runs use the same config, the same proxy launcher and the same driver script, on the same machine. Before was captured at `1e7b39d15c` (the base branch tip this PR was cut from, i.e. `litellm/router.py` in its pre-fix state) and after at `f95038231f`, which the current head `eaad030fe6` carries forward with an identical tree (`git diff f95038231f eaad030fe6` is empty; only the commit message changed)

<details>
<summary>config.yaml, counting upstream, and the driver (click to expand)</summary>

```yaml
model_list:
  - model_name: retry-test
    litellm_params:
      model: openai/gpt-fake
      api_base: http://127.0.0.1:8772/v1
      api_key: sk-fake
      num_retries: 2

  - model_name: retry-test-nomodel
    litellm_params:
      model: openai/gpt-fake
      api_base: http://127.0.0.1:8772/v1
      api_key: sk-fake

litellm_settings:
  num_retries: 1

router_settings:
  disable_cooldowns: true

general_settings:
  master_key: sk-1234
```

```python
# mock_upstream.py - counts every upstream chat completion and always fails it
import json
from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer

count = 0


class Handler(BaseHTTPRequestHandler):
    def _send(self, code, payload):
        body = json.dumps(payload).encode()
        self.send_response(code)
        self.send_header("content-type", "application/json")
        self.send_header("content-length", str(len(body)))
        self.send_header("retry-after", "0")
        self.end_headers()
        self.wfile.write(body)

    def do_POST(self):
        global count
        if self.path.endswith("/reset"):
            count = 0
            self._send(200, {"count": count})
            return
        self.rfile.read(int(self.headers.get("content-length", 0) or 0))
        count += 1
        self._send(500, {"error": {"message": "upstream boom", "type": "server_error"}})

    def do_GET(self):
        self._send(200, {"count": count})

    def log_message(self, *args):
        pass


ThreadingHTTPServer(("127.0.0.1", 8772), Handler).serve_forever()
```

```bash
python mock_upstream.py &
litellm --config config.yaml --port 4772 &

run() {  # run <model> <header num_retries> <body num_retries>
  curl -s -X POST http://127.0.0.1:8772/reset >/dev/null
  hdr=(); [ "$2" != "-" ] && hdr=(-H "x-litellm-num-retries: $2")
  body="{\"model\":\"$1\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]"
  [ "$3" != "-" ] && body="$body,\"num_retries\":$3"
  body="$body}"
  curl -s -o /dev/null http://127.0.0.1:4772/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    "${hdr[@]}" -d "$body"
  n=$(curl -s http://127.0.0.1:8772/count | python3 -c 'import sys,json;print(json.load(sys.stdin)["count"])')
  printf '| %-18s | %-6s | %-4s | %s |\n' "$1" "$2" "$3" "$n"
}

run retry-test-nomodel -  -
run retry-test-nomodel 3  -
run retry-test-nomodel -  5
run retry-test         -  -
run retry-test         3  -
run retry-test         -  5
run retry-test         3  5
run retry-test         0  -
```

</details>

### Before, at `1e7b39d15c`

```
| model              | header | body | upstream requests |
| ------------------ | ------ | ---- | ----------------- |
| retry-test-nomodel | -      | -    | 2 |
| retry-test-nomodel | 3      | -    | 4 |
| retry-test-nomodel | -      | 5    | 6 |
| retry-test         | -      | -    | 3 |
| retry-test         | 3      | -    | 3 |
| retry-test         | -      | 5    | 3 |
| retry-test         | 3      | 5    | 3 |
| retry-test         | 0      | -    | 3 |
```

The four `retry-test` rows that carry a header or a body value all send 3 requests, which is the deployment's `num_retries: 2` plus the initial attempt. The header and the body are ignored, including `x-litellm-num-retries: 0`, which should have disabled retries entirely. The `retry-test-nomodel` rows show the precedence is already correct as soon as no deployment value exists

### After, at `eaad030fe6`

```
| model              | header | body | upstream requests |
| ------------------ | ------ | ---- | ----------------- |
| retry-test-nomodel | -      | -    | 2 |
| retry-test-nomodel | 3      | -    | 4 |
| retry-test-nomodel | -      | 5    | 6 |
| retry-test         | -      | -    | 3 |
| retry-test         | 3      | -    | 4 |
| retry-test         | -      | 5    | 6 |
| retry-test         | 3      | 5    | 4 |
| retry-test         | 0      | -    | 1 |
```

Every row now matches `header > body > model_list > litellm_settings`. The rows that were already correct are unchanged, so the deployment value keeps its place directly above `litellm_settings` when the request says nothing (`retry-test` with no header and no body still sends 3), and `x-litellm-num-retries: 0` now disables retries

### One row verbatim, both sides

Same command, same rig, the only difference being which commit the proxy is running. `retry-test` carries `num_retries: 2`, and the request asks for 3 via the header

Before, at `1e7b39d15c`

```
$ curl -s -X POST http://127.0.0.1:8772/reset
{"count": 0}
$ curl -s http://127.0.0.1:4772/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -H 'x-litellm-num-retries: 3' \
    -d '{"model":"retry-test","messages":[{"role":"user","content":"hi"}]}'
{"error":{"message":"litellm.InternalServerError: InternalServerError: OpenAIException - upstream boom. Received Model Group=retry-test\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"500"}}
$ curl -s http://127.0.0.1:8772/count
{"count": 3}
```

After, at `eaad030fe6`

```
$ curl -s -X POST http://127.0.0.1:8772/reset
{"count": 0}
$ curl -s http://127.0.0.1:4772/v1/chat/completions \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -H 'x-litellm-num-retries: 3' \
    -d '{"model":"retry-test","messages":[{"role":"user","content":"hi"}]}'
{"error":{"message":"litellm.InternalServerError: InternalServerError: OpenAIException - upstream boom. Received Model Group=retry-test\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"500"}}
$ curl -s http://127.0.0.1:8772/count
{"count": 4}
```

3 upstream requests is the deployment's `num_retries: 2` plus the initial attempt, with the header discarded. 4 is the header's 3 plus the initial attempt

### The other entry points keep their deployment retries

Dropping the pre-fill from `_update_kwargs_before_fallbacks` alone would have left the six entry points that repeat it ranking their own default above the deployment, silently disabling a `model_list` `num_retries` on image generation, adapter completion, and the file and batch routes. Measured through `router.aimage_generation` against a counting upstream, deployment `num_retries: 4` with the router default at `0`, counting every upstream request (the provider SDK contributes its own attempts per router attempt on this route, hence the multiples of 3)

| tree | upstream requests |
| -- | -- |
| base `1e7b39d15c` | 15 |
| helper fix only, the six pre-fills left in place | 3 |
| this PR at `eaad030fe6` | 15 |

15 is 5 router attempts, so the deployment's 4 retries are honoured before and after. The middle row is the regression this PR does not ship, and a test pins it: restoring the `aimage_generation` pre-fill alone fails `test_deployment_num_retries_applies_to_image_generation`

### On the second question in the report, request body `max_retries`

`num_retries` and `max_retries` are different knobs: `num_retries` is the router's own retry loop, `max_retries` is the provider SDK's internal retry count. For a routed call the router is the sole retry owner, so the provider client is pinned to `max_retries: 0`; that is deliberate, and it is what stops a deployment `num_retries: N` from being applied twice and turning one call into `(1 + N) ** 2` upstream requests. A request body `max_retries` therefore has no effect through the proxy, which this PR does not change. Same rig, after the fix, at `eaad030fe6`

```
| model              | request                | upstream requests |
| ------------------ | ---------------------- | ----------------- |
| retry-test-nomodel | body max_retries=5     | 2 |
| retry-test         | body max_retries=5     | 3 |
```

Both counts are exactly what the same request sends without `max_retries`, so the value is inert rather than partially applied

## Type

🐛 Bug Fix

## Changes

`Router._update_kwargs_before_fallbacks` used to fill `kwargs["num_retries"]` in with `self.num_retries` whenever the caller omitted it. That collapsed "the request asked for N retries" and "nobody asked, use the global" into one indistinguishable value, so by the time `async_function_with_retries` ran it had no way to rank a request value against a deployment one. It now leaves `num_retries` exactly as the caller passed it; `async_function_with_retries` already resolves the router default (and remains the safety net for an explicit `num_retries=None`, so the `None > int` TypeError guard is untouched)

Six entry points repeated the same pre-fill a line above their own call to that helper: `image_generation`, `aimage_generation`, `aadapter_completion`, `acreate_file`, `acreate_batch`, `acancel_batch`. All six reach `async_function_with_retries`, so leaving them would have made the request value never `None` there and permanently suppressed a deployment `num_retries` on those routes, which is a regression rather than the fix. They are dropped too. The one remaining pre-fill, in the sync `text_completion`, stays deliberately: that path resolves a deployment and calls `litellm.text_completion` directly without entering the retry loop, so no request-versus-deployment ranking happens there and there is nothing for this fix to correct. Removing the line would only change which value is forwarded into `litellm.text_completion`, which is a behaviour change this bug does not call for. Two pre-existing quirks of that path, neither introduced nor addressed here: the final spread puts `**kwargs` after `**data`, so the router default already shadows the deployment's own `litellm_params.num_retries` there, and because the same function sets `metadata.model_group`, the router-call check in `litellm/main.py` forces `max_retries = 0` on the chat funnel anyway

`async_function_with_retries` keeps the request-level value it popped and adopts the deployment's exception-stamped `num_retries` only when the request carried none. Nothing else about the deployment path changes: it still beats `litellm_settings`, still accepts a string value from an env var, and still applies on the `mock_testing_rate_limit_error` path

Tests extend the mapped file. Three new behavioural tests drive `router.acompletion` through the real retry loop and count attempts via a callback: request beats deployment (and request `0` disables retries), deployment still beats global when the request is silent, and the request value also wins on the rate-limit mock path, which is the second place a deployment value is stamped onto an exception. All three fail on the unfixed tree and pass with the fix. Two existing tests asserted the old kwargs-filling contract directly and were rewritten against the new one; the invariants they protected (`num_retries=None` must not raise, an explicit `0` must survive) stay covered by the behavioural tests in the same class

Two more cover the non-completion entry points through `aimage_generation`, counting real upstream requests: a deployment `num_retries` still applies there when the request is silent, and a request value still wins. The provider SDK contributes a fixed number of its own attempts per router attempt on that route, so those two calibrate that factor from a single-attempt run rather than hard coding it. Restoring the pre-fill on `aimage_generation` alone fails the first of them, which is the regression the six deletions close

One knock-on worth calling out: a key/team `router_settings_override.num_retries` is merged into the request data by `route_llm_request.py` only when the request itself did not set one, so it reaches the router as the same `num_retries` kwarg and now also outranks a deployment value. That reads as the intent of a per-key/team override, which is described there as overriding the global router settings for that request, and it lands in the same slot a body value would. Distinguishing it from a real request value would need a second kwarg, which is not something this fix needs; flagging it so the ranking is a deliberate call rather than a surprise

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
