### PR TITLE
fix(docker): bake prisma offline in the componentized migrations image

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -9,6 +9,8 @@ on:
       - "litellm_**"
     paths:
       - docker/Dockerfile.non_root
+      - migrations/Dockerfile
+      - migrations/run.py
       - tests/proxy_migration_tests/test_offline_image_migration.py
       - uv.lock
       - ui/litellm-dashboard/package-lock.json
@@ -83,3 +85,34 @@ jobs:
             --only-fixed \
             --fail-on high \
             --output table
+
+  migrations-image:
+    name: migrations-image
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+
+      - name: Build migrations image
+        run: docker build -f migrations/Dockerfile -t litellm-migrations-scan:${{ github.sha }} .
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify offline migration as a non-root uid
+        env:
+          LITELLM_IMAGE: litellm-migrations-scan:${{ github.sha }}
+          LITELLM_MIGRATION_INTERPRETER: python3
+          LITELLM_MIGRATION_SCRIPT: /app/run.py
+        run: |
+          python -m pip install "pytest==9.0.3"
+          python -m pytest tests/proxy_migration_tests/test_offline_image_migration.py -v

--- a/migrations/Dockerfile
+++ b/migrations/Dockerfile
@@ -77,9 +77,9 @@ COPY migrations/run.py /app/run.py
 # client at runtime — the migration job invokes `prisma migrate deploy`
 # via subprocess — but having it cached is harmless and the alternative
 # (`prisma py fetch`) doesn't reliably trigger engine downloads.
-RUN mkdir -p /home/nonroot && \
-    HOME=/home/nonroot prisma generate --schema=./schema.prisma && \
-    chown -R nonroot:nonroot /home/nonroot/.cache
+RUN HOME=/opt/prisma XDG_CACHE_HOME=/opt/prisma/.cache PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \
+    npm_config_cache=/root/.npm \
+    prisma generate --schema=./schema.prisma
 
 # ---------- Runtime ----------
 FROM $LITELLM_RUNTIME_IMAGE AS runtime
@@ -87,7 +87,7 @@ FROM $LITELLM_RUNTIME_IMAGE AS runtime
 USER root
 
 RUN for i in 1 2 3; do \
-      apk add --no-cache bash openssl tzdata python3 libsndfile libatomic && break; \
+      apk add --no-cache bash openssl tzdata python3 nodejs libsndfile libatomic && break; \
       [ $i = 3 ] && { echo "apk add failed after 3 retries" >&2; exit 1; }; \
       sleep 5; \
     done
@@ -100,10 +100,18 @@ ENV HOME=/home/nonroot \
     PATH="/app/.venv/bin:${PATH}" \
     PYTHONPATH="/app" \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \
+    PRISMA_CLI_PATH=/opt/prisma/binaries/node_modules/.bin/prisma \
+    PRISMA_CLI_QUERY_ENGINE_TYPE=binary \
+    PRISMA_OFFLINE_MODE=true
 
 COPY --from=builder --chown=nonroot:nonroot /app /app
-COPY --from=builder --chown=nonroot:nonroot /home/nonroot/.cache /home/nonroot/.cache
+COPY --from=builder /opt/prisma /opt/prisma
+
+RUN chmod -R a+rX /opt/prisma && \
+    test -x /opt/prisma/binaries/node_modules/.bin/prisma && \
+    test -f /opt/prisma/binaries/node_modules/prisma/build/index.js
 
 USER nonroot
 

--- a/tests/proxy_migration_tests/test_offline_image_migration.py
+++ b/tests/proxy_migration_tests/test_offline_image_migration.py
@@ -26,6 +26,11 @@ POSTGRES_IMAGE = os.getenv("LITELLM_TEST_POSTGRES_IMAGE", "postgres:16-alpine")
 MIN_TABLES = int(os.getenv("LITELLM_TEST_MIN_TABLES", "20"))
 NON_ROOT_UID = "12345:0"  # arbitrary uid in GID 0, as OpenShift restricted-v2 assigns
 
+MIGRATION_INTERPRETER = os.getenv("LITELLM_MIGRATION_INTERPRETER", "python")
+MIGRATION_SCRIPT = os.getenv(
+    "LITELLM_MIGRATION_SCRIPT", "litellm/proxy/prisma_migration.py"
+)
+
 pytestmark = [
     pytest.mark.skipif(IMAGE is None, reason="requires a built image (set LITELLM_IMAGE)"),
     pytest.mark.skipif(shutil.which("docker") is None, reason="requires the docker CLI"),
@@ -108,8 +113,8 @@ def test_migration_offline_as_non_root_uid(offline_postgres):
         "-e", f"DATABASE_URL=postgresql://postgres:pw@{pg}:5432/litellm",
         "-e", "LITELLM_MASTER_KEY=sk-offline-migration-test",
         "-e", "DISABLE_SCHEMA_UPDATE=false",
-        "-w", "/app", "--entrypoint", "python",
-        IMAGE, "litellm/proxy/prisma_migration.py",
+        "-w", "/app", "--entrypoint", MIGRATION_INTERPRETER,
+        IMAGE, MIGRATION_SCRIPT,
         check=False,
     )
     tables = _table_count(pg)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Componentized migrations image downloads Node at startup
- `prisma migrate deploy` hangs in egress-restricted clusters
- Prisma bake sits behind a uid-specific `$HOME` path
- Root/non_root/database images were fixed; this one was missed

How it solves it:

- Bake prisma CLI and engines at `/opt/prisma`, world-readable
- Install `nodejs` in the migrations runtime stage
- Pin `PRISMA_CLI_PATH` / `PRISMA_OFFLINE_MODE` so no download is attempted
- Cover the image in the existing offline-migration CI check

## Relevant issues

Same failure class as #33167 and #24554, which were fixed for the root, `Dockerfile.database` and `Dockerfile.non_root` images. The componentized `migrations/Dockerfile` was never brought in line; this does that

## Linear ticket

Resolves LIT-4727

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The end-user surface here is the container, so the proof is the image itself running the way an air-gapped cluster runs it: a `--internal` docker network (no egress at all) with a reachable Postgres on it. Before captured at base `0a42f28850`, after at `d33e75853a`, then re-run at `355aaf50c1` after a comment-only amend

**Before, base image, no egress, arbitrary non-root uid**

```
$ docker build -f migrations/Dockerfile -t litfix-4727/migrations:base .
$ docker network create --internal litfix-4727-airgap
$ docker run -d --name litfix-4727-pg3 --network litfix-4727-airgap \
    -e POSTGRES_PASSWORD=litellm -e POSTGRES_USER=litellm -e POSTGRES_DB=litellm postgres:16
$ docker run --rm --network litfix-4727-airgap --user 12345:0 \
    -e DATABASE_URL="postgresql://litellm:litellm@litfix-4727-pg3:5432/litellm" \
    litfix-4727/migrations:base
...
subprocess.CalledProcessError: Command '['prisma', 'migrate', 'deploy']' returned non-zero exit status 1.
exit=1

$ docker exec litfix-4727-pg3 psql -U litellm -d litellm -tAc \
    "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"
0
```

Run as the image's own default uid, the same base image shows the download attempt directly:

```
  File "/app/.venv/lib/python3.13/site-packages/prisma/cli/_node.py", line 161, in resolve
    return NodeBinaryStrategy.from_nodeenv(target)
  File "/app/.venv/lib/python3.13/site-packages/prisma/cli/_node.py", line 174, in from_nodeenv
    subprocess.run(
urllib.error.URLError: <urlopen error [Errno -3] Temporary failure in name resolution>
nodeenv installation failed; You may want to try installing `nodejs-bin` as it is more reliable.
subprocess.CalledProcessError: Command '['/app/.venv/bin/python', '-m', 'nodeenv', '/home/nonroot/.cache/prisma-python/nodeenv']' returned non-zero exit status 1.
```

**After, same network, same flags**

```
$ docker build -f migrations/Dockerfile -t litfix-4727/migrations:fixed .
$ docker run --rm --network litfix-4727-airgap --user 12345:0 \
    -e DATABASE_URL="postgresql://litellm:litellm@litfix-4727-pg2:5432/litellm" \
    litfix-4727/migrations:fixed
...
All migrations have been successfully applied.
2026-08-01 19:42:49,244 - litellm_proxy_extras - INFO - Migration job completed successfully.
exit=0

$ docker exec litfix-4727-pg2 psql -U litellm -d litellm -tAc \
    "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"
69
```

**After, default uid, read-only root filesystem**

This is the constraint the report came in under, so it gets its own run

```
$ docker run --rm --network litfix-4727-airgap --read-only \
    -e DATABASE_URL="postgresql://litellm:litellm@litfix-4727-pg4:5432/litellm" \
    litfix-4727/migrations:fixed
...
All migrations have been successfully applied.
2026-08-01 19:44:50,040 - litellm_proxy_extras - INFO - Migration job completed successfully.
exit=0
69
```

**The regression test discriminates**

`tests/proxy_migration_tests/test_offline_image_migration.py` already encodes this contract for the single image; the change makes the migration invocation configurable so the same suite covers this image, and a new `migrations-image` job in `image-scan.yml` runs it

```
$ export LITELLM_MIGRATION_INTERPRETER=python3 LITELLM_MIGRATION_SCRIPT=/app/run.py

$ LITELLM_IMAGE=litfix-4727/migrations:fixed pytest tests/proxy_migration_tests/test_offline_image_migration.py -q
..                                                                       [100%]
2 passed in 12.00s

$ LITELLM_IMAGE=litfix-4727/migrations:base pytest tests/proxy_migration_tests/test_offline_image_migration.py -q
E   PermissionError: [Errno 13] Permission denied: '/home/nonroot/.cache/prisma-python/binaries/5.4.2/ac9d7041ed77bcc8a8dbd2ab6616b39013829574'
E   assert 1 == 0
FAILED tests/proxy_migration_tests/test_offline_image_migration.py::test_migration_offline_as_non_root_uid
1 failed, 1 passed in 10.14s
```

Re-run after the comment-only amend, rebuilding the image from `355aaf50c1`, to confirm the discriminator survived it

```
### FIXED @ 355aaf50c1 (expect PASS)
2 passed in 6.33s
### BASE @ 0a42f28850 (expect FAIL)
FAILED tests/proxy_migration_tests/test_offline_image_migration.py::test_migration_offline_as_non_root_uid
1 failed, 1 passed in 10.20s
```

## Type

🐛 Bug Fix

## Changes

`migrations/Dockerfile` now bakes the prisma CLI and engines under `/opt/prisma` with `a+rX` modes instead of anchoring them in `$HOME`, installs `nodejs` in the runtime stage, and pins `PRISMA_BINARY_CACHE_DIR`, `PRISMA_CLI_PATH`, `PRISMA_CLI_QUERY_ENGINE_TYPE` and `PRISMA_OFFLINE_MODE`. Those last two env vars are what `litellm_proxy_extras.utils._get_prisma_command` and `_get_prisma_env` read to run the cached CLI directly rather than falling through the python wrapper, which is the path that reaches for nodeenv. The build now asserts the two baked artifacts exist, so a future edit that breaks the bake fails the build instead of the cluster

There are two distinct symptoms behind one root cause. Without node in the runtime stage prisma-client-py resolves its node target through nodeenv and downloads a runtime; with the bake behind `/home/nonroot`, an arbitrary uid cannot read it. Moving to `/opt/prisma` plus a runtime node closes both, which is exactly what the root, non_root and database images already do

Worth calling out why this survived the earlier round of fixes: `grep -rn 'migrations/Dockerfile\|gateway/Dockerfile\|backend/Dockerfile' .github/ ci_cd/ Makefile .circleci/config.yml` came back empty on the base branch, so no job in this repo built any componentized image and nothing would have caught it. The `migrations-image` job here is the first

No grype step was added for this image. Its runtime apk set is a subset of `Dockerfile.non_root`, which the existing scan job covers, and `nodejs` was already in that image's runtime layer, so this introduces no unscanned package surface

Scope note: the gateway and backend images also lack node in their runtime stage, but neither runs a prisma schema update. That path lives in `proxy_cli.py`, which the componentized entrypoints bypass by importing the ASGI app directly, so they are unaffected

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
