### PR TITLE
fix(proxy): apply key/team router_settings.model_group_alias

### DIFF
--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -43,6 +43,7 @@ from litellm.litellm_core_utils.llm_response_utils.get_headers import (
 )
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.proxy._types import ProxyException, UserAPIKeyAuth
+from litellm.proxy.auth.auth_checks import can_key_call_resolved_model
 from litellm.proxy.auth.auth_utils import check_response_size_is_safe
 from litellm.proxy.common_utils.callback_utils import (
     get_logging_caching_headers,
@@ -53,6 +54,7 @@ from litellm.proxy.route_llm_request import route_request
 from litellm.proxy.utils import ProxyLogging, _check_and_merge_model_level_guardrails
 from litellm.router import Router
 from litellm.router_utils.add_retry_fallback_headers import get_hidden_params_dict
+from litellm.router_utils.common_utils import resolve_model_group_alias
 from litellm.types.guardrails import GuardrailEventHooks
 from litellm.types.router import RouterRateLimitError
 from litellm.types.utils import ServerToolUse
@@ -382,6 +384,39 @@ async def _authorize_response_file_search_vector_stores(
             vector_store_id=vector_store_id,
             user_api_key_dict=user_api_key_dict,
         )
+
+
+async def _resolve_per_request_model_group_alias(
+    requested_model: object,
+    router_settings: Mapping[str, object],
+    user_api_key_dict: UserAPIKeyAuth,
+    llm_router: Router,
+) -> str | None:
+    """
+    Resolve ``router_settings.model_group_alias`` coming from a key or team.
+
+    The Router only ever resolves aliases from its own instance attribute, which
+    holds the global config map and is shared across requests, so a per-request
+    map has to be applied here instead of being forwarded to the Router.
+
+    Model access was authorized against the requested group, so the target is
+    authorized in its own right before the rewrite; a key that may not call the
+    target gets the usual 403 rather than being quietly served it.
+
+    Returns the target model group, or None when no alias applies.
+    """
+    if not isinstance(requested_model, str):
+        return None
+    target = resolve_model_group_alias(router_settings.get("model_group_alias"), requested_model)
+    if target is None or target == requested_model:
+        return None
+    await can_key_call_resolved_model(
+        model=target,
+        llm_model_list=llm_router.model_list,
+        valid_token=user_api_key_dict,
+        llm_router=llm_router,
+    )
+    return target
 
 
 async def _parse_event_data_for_error(event_line: str | bytes) -> int | None:
@@ -1285,6 +1320,35 @@ class ProxyBaseLLMRequestProcessing:
         ):
             self.data["model"] = user_api_key_dict.aliases[self.data["model"]]
 
+        # Apply hierarchical router_settings (Key > Team)
+        # Global router_settings are already on the Router object itself.
+        # This sits with the other alias rewrites, and ahead of the guardrail
+        # merge and the pre-call hooks, so everything that keys off the model
+        # group -- model-level guardrails, per-model budgets and rate limits,
+        # the logging object -- sees the group that will actually serve.
+        if llm_router is not None and proxy_config is not None:
+            from litellm.proxy.proxy_server import prisma_client
+
+            router_settings = await proxy_config._get_hierarchical_router_settings(
+                user_api_key_dict=user_api_key_dict,
+                prisma_client=prisma_client,
+                proxy_logging_obj=proxy_logging_obj,
+            )
+
+            # If router_settings found (from key or team), apply them
+            # Pass settings as per-request overrides instead of creating a new Router
+            # This avoids expensive Router instantiation on each request
+            if router_settings is not None:
+                self.data["router_settings_override"] = router_settings
+                alias_target = await _resolve_per_request_model_group_alias(
+                    requested_model=self.data.get("model"),
+                    router_settings=router_settings,
+                    user_api_key_dict=user_api_key_dict,
+                    llm_router=llm_router,
+                )
+                if alias_target is not None:
+                    self.data["model"] = alias_target
+
         self.data["litellm_call_id"] = request.headers.get("x-litellm-call-id", str(uuid.uuid4()))
         DDSpanTagger.tag_call_id(self.data.get("litellm_call_id"))
         DDSpanTagger.tag_request(
@@ -1338,23 +1402,6 @@ class ProxyBaseLLMRequestProcessing:
             data=self.data,
             call_type=route_type,  # type: ignore
         )
-
-        # Apply hierarchical router_settings (Key > Team)
-        # Global router_settings are already on the Router object itself.
-        if llm_router is not None and proxy_config is not None:
-            from litellm.proxy.proxy_server import prisma_client
-
-            router_settings = await proxy_config._get_hierarchical_router_settings(
-                user_api_key_dict=user_api_key_dict,
-                prisma_client=prisma_client,
-                proxy_logging_obj=proxy_logging_obj,
-            )
-
-            # If router_settings found (from key or team), apply them
-            # Pass settings as per-request overrides instead of creating a new Router
-            # This avoids expensive Router instantiation on each request
-            if router_settings is not None:
-                self.data["router_settings_override"] = router_settings
 
         if "messages" in self.data and self.data["messages"]:
             logging_obj.update_messages(self.data["messages"])

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -115,6 +115,7 @@ from litellm.router_utils.common_utils import (
     _is_proxy_admin_request,
     filter_team_based_models,
     filter_web_search_deployments,
+    resolve_model_group_alias,
 )
 from litellm.router_utils.cooldown_cache import CooldownCache
 from litellm.router_utils.cooldown_handlers import (
@@ -10331,16 +10332,7 @@ class Router:
         - str, the litellm model name
         - None, if model is not in model group alias
         """
-        if model not in self.model_group_alias:
-            return None
-
-        _item = self.model_group_alias[model]
-        if isinstance(_item, str):
-            model = _item
-        else:
-            model = _item["model"]
-
-        return model
+        return resolve_model_group_alias(self.model_group_alias, model)
 
     def _get_deployment_by_litellm_model(self, model: str) -> list:
         """

--- a/litellm/router_utils/common_utils.py
+++ b/litellm/router_utils/common_utils.py
@@ -22,6 +22,27 @@ def _is_proxy_admin_request(request_kwargs: Mapping[str, object] | None) -> bool
     return getattr(user_api_key_auth, "user_role", None) == "proxy_admin"
 
 
+def resolve_model_group_alias(model_group_alias: object, model: str) -> str | None:
+    """
+    Resolve ``model`` through a ``model_group_alias`` map.
+
+    Handles both supported entry shapes, the plain string form
+    ``{"alias": "target"}`` and the item form
+    ``{"alias": {"model": "target", "hidden": true}}``, and tolerates malformed
+    entries: the map can come from a key or team row rather than from validated
+    config, so a bad value must not raise mid-request.
+
+    Returns the target model group, or None when the map does not rewrite ``model``.
+    """
+    if not isinstance(model_group_alias, Mapping):
+        return None
+    entry = model_group_alias.get(model)
+    target = entry.get("model") if isinstance(entry, Mapping) else entry
+    if not isinstance(target, str) or not target:
+        return None
+    return target
+
+
 def get_litellm_params_sensitive_credential_hash(litellm_params: dict) -> str:
     """
     Hash of the credential params, used for mapping the file id to the right model

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -2016,6 +2016,48 @@ async def test_ProxyConfig__get_hierarchical_router_settings_missing_returns_non
     assert out is None
 
 
+@pytest.mark.asyncio
+async def test_ProxyConfig__get_hierarchical_router_settings_falls_back_to_team(monkeypatch):
+    """A key with no router_settings inherits the team's, so a team-level
+    model_group_alias reaches the request path at all."""
+    pc = ProxyConfig()
+    fake_key = SimpleNamespace(router_settings=None, team_id="team-1")
+    team_settings = {"model_group_alias": {"group-a": "group-b"}}
+    monkeypatch.setattr(
+        "litellm.proxy.proxy_server.get_team_object",
+        AsyncMock(return_value=SimpleNamespace(router_settings=team_settings)),
+    )
+
+    out = await pc._get_hierarchical_router_settings(
+        user_api_key_dict=fake_key,
+        prisma_client=None,
+        proxy_logging_obj=None,
+    )
+
+    assert out == team_settings
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__get_hierarchical_router_settings_key_shadows_team_entirely(monkeypatch):
+    """Resolution returns whichever object it finds first, it does not merge
+    per field, so a key that sets any router setting hides every team setting
+    including an alias the key itself never set."""
+    pc = ProxyConfig()
+    fake_key = SimpleNamespace(router_settings={"num_retries": 3}, team_id="team-1")
+    team_lookup = AsyncMock(return_value=SimpleNamespace(router_settings={"model_group_alias": {"group-a": "group-b"}}))
+    monkeypatch.setattr("litellm.proxy.proxy_server.get_team_object", team_lookup)
+
+    out = await pc._get_hierarchical_router_settings(
+        user_api_key_dict=fake_key,
+        prisma_client=None,
+        proxy_logging_obj=None,
+    )
+
+    assert out == {"num_retries": 3}
+    assert "model_group_alias" not in out
+    team_lookup.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # ProxyConfig._add_router_settings_from_db_config
 # ---------------------------------------------------------------------------

--- a/tests/test_litellm/proxy/test_common_request_processing.py
+++ b/tests/test_litellm/proxy/test_common_request_processing.py
@@ -1,6 +1,7 @@
 import asyncio
 import copy
 import datetime
+from types import SimpleNamespace
 from typing import AsyncGenerator, Callable, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -28,11 +29,14 @@ from litellm.proxy.common_request_processing import (
     _is_azure_model_router_request,
     _override_openai_response_model,
     _parse_event_data_for_error,
+    _resolve_per_request_model_group_alias,
     _should_return_raw_model_name,
     _UpstreamClosingStreamingResponse,
     create_response,
 )
 from litellm.proxy.dd_span_tagger import DDSpanTagger
+from litellm.proxy._types import ProxyException
+from litellm.proxy._types import UserAPIKeyAuth as ProxyUserAPIKeyAuth
 from litellm.proxy.utils import ProxyLogging
 
 
@@ -5354,3 +5358,228 @@ class TestModelDeploymentsSupportStreamOptions:
 
     def test_non_string_model_is_not_injected(self):
         assert self._support(None, None) is False
+
+
+class TestPerRequestModelGroupAlias:
+    """``router_settings.model_group_alias`` on a key or team has to be resolved
+    by the proxy: the Router resolves aliases from its own shared instance
+    attribute, which only ever holds the global config map."""
+
+    @staticmethod
+    def _router() -> litellm.Router:
+        return litellm.Router(
+            model_list=[
+                {
+                    "model_name": "group-a",
+                    "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-fake"},
+                },
+                {
+                    "model_name": "group-b",
+                    "litellm_params": {"model": "openai/gpt-4o-mini", "api_key": "sk-fake"},
+                },
+            ]
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "alias_map, expected",
+        [
+            ({"group-a": "group-b"}, "group-b"),
+            ({"group-a": {"model": "group-b", "hidden": True}}, "group-b"),
+            ({"group-b": "group-a"}, None),
+            ({"group-a": "group-a"}, None),
+            ({"group-a": {"hidden": True}}, None),
+            ({}, None),
+            (None, None),
+        ],
+    )
+    async def test_resolves_alias_for_the_requested_model_group(self, alias_map, expected):
+        resolved = await _resolve_per_request_model_group_alias(
+            requested_model="group-a",
+            router_settings={"model_group_alias": alias_map},
+            user_api_key_dict=ProxyUserAPIKeyAuth(api_key="hash", models=[]),
+            llm_router=self._router(),
+        )
+
+        assert resolved == expected
+
+    @pytest.mark.asyncio
+    async def test_alias_target_outside_the_key_allowlist_is_rejected(self):
+        """Access was authorized against the requested group, so a rewrite that
+        the key could not have requested directly must not be served."""
+        with pytest.raises(ProxyException) as exc_info:
+            await _resolve_per_request_model_group_alias(
+                requested_model="group-a",
+                router_settings={"model_group_alias": {"group-a": "group-b"}},
+                user_api_key_dict=ProxyUserAPIKeyAuth(api_key="hash", models=["group-a"]),
+                llm_router=self._router(),
+            )
+
+        assert exc_info.value.code == "403"
+        assert "group-b" in exc_info.value.message
+
+    @pytest.mark.asyncio
+    async def test_alias_target_inside_the_key_allowlist_resolves(self):
+        resolved = await _resolve_per_request_model_group_alias(
+            requested_model="group-a",
+            router_settings={"model_group_alias": {"group-a": "group-b"}},
+            user_api_key_dict=ProxyUserAPIKeyAuth(api_key="hash", models=["group-a", "group-b"]),
+            llm_router=self._router(),
+        )
+
+        assert resolved == "group-b"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("requested_model", [None, ["group-a", "group-b"]])
+    async def test_non_string_requested_model_is_left_alone(self, requested_model):
+        """The routed model is not always a string (a batch request carries a
+        list), and an unhashable one must not blow up the alias lookup."""
+        resolved = await _resolve_per_request_model_group_alias(
+            requested_model=requested_model,
+            router_settings={"model_group_alias": {"group-a": "group-b"}},
+            user_api_key_dict=ProxyUserAPIKeyAuth(api_key="hash", models=[]),
+            llm_router=self._router(),
+        )
+
+        assert resolved is None
+
+    @pytest.mark.asyncio
+    async def test_pre_call_logic_rewrites_the_requested_model(self, monkeypatch):
+        """End to end through the request path: a key carrying the alias must
+        leave pre-call processing pointing at the alias target, not at the
+        group the caller asked for."""
+        processing_obj = ProxyBaseLLMRequestProcessing(data={"model": "group-a"})
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {}
+
+        async def mock_add_litellm_data_to_request(*args, **kwargs):
+            return kwargs.get("data", {})
+
+        async def passthrough_pre_call_hook(user_api_key_dict, data, call_type):
+            return copy.deepcopy(data)
+
+        mock_proxy_logging_obj = MagicMock(spec=ProxyLogging)
+        mock_proxy_logging_obj.pre_call_hook = AsyncMock(side_effect=passthrough_pre_call_hook)
+        monkeypatch.setattr(
+            litellm.proxy.common_request_processing,
+            "add_litellm_data_to_request",
+            mock_add_litellm_data_to_request,
+        )
+        monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MagicMock())
+
+        mock_proxy_config = MagicMock(spec=ProxyConfig)
+        mock_proxy_config._get_hierarchical_router_settings = AsyncMock(
+            return_value={"model_group_alias": {"group-a": "group-b"}}
+        )
+
+        returned_data, _ = await processing_obj.common_processing_pre_call_logic(
+            request=mock_request,
+            general_settings={},
+            user_api_key_dict=ProxyUserAPIKeyAuth(api_key="hash", models=[]),
+            proxy_logging_obj=mock_proxy_logging_obj,
+            proxy_config=mock_proxy_config,
+            route_type="acompletion",
+            llm_router=self._router(),
+        )
+
+        assert returned_data["model"] == "group-b"
+        assert returned_data["router_settings_override"] == {"model_group_alias": {"group-a": "group-b"}}
+        # The rewrite has to land before the pre-call hooks: they are where
+        # per-model budgets and rate limits are enforced, so resolving later
+        # applies the requested group's limits to a call the target serves.
+        assert mock_proxy_logging_obj.pre_call_hook.call_args.kwargs["data"]["model"] == "group-b"
+
+    @pytest.mark.asyncio
+    async def test_team_level_alias_rewrites_the_requested_model(self, monkeypatch):
+        """The team path is separate resolution, not a variant of the key path:
+        settings are looked up on the team only when the key carries none. Runs
+        the real hierarchical lookup rather than mocking it, so this covers the
+        team half of the fix end to end."""
+        from litellm.proxy.proxy_server import ProxyConfig as RealProxyConfig
+
+        processing_obj = ProxyBaseLLMRequestProcessing(data={"model": "group-a"})
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {}
+
+        async def mock_add_litellm_data_to_request(*args, **kwargs):
+            return kwargs.get("data", {})
+
+        async def passthrough_pre_call_hook(user_api_key_dict, data, call_type):
+            return copy.deepcopy(data)
+
+        mock_proxy_logging_obj = MagicMock(spec=ProxyLogging)
+        mock_proxy_logging_obj.pre_call_hook = AsyncMock(side_effect=passthrough_pre_call_hook)
+        monkeypatch.setattr(
+            litellm.proxy.common_request_processing,
+            "add_litellm_data_to_request",
+            mock_add_litellm_data_to_request,
+        )
+        monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MagicMock())
+        monkeypatch.setattr(
+            "litellm.proxy.proxy_server.get_team_object",
+            AsyncMock(return_value=SimpleNamespace(router_settings={"model_group_alias": {"group-a": "group-b"}})),
+        )
+
+        returned_data, _ = await processing_obj.common_processing_pre_call_logic(
+            request=mock_request,
+            general_settings={},
+            user_api_key_dict=ProxyUserAPIKeyAuth(api_key="hash", models=[], team_id="team-1"),
+            proxy_logging_obj=mock_proxy_logging_obj,
+            proxy_config=RealProxyConfig(),
+            route_type="acompletion",
+            llm_router=self._router(),
+        )
+
+        assert returned_data["model"] == "group-b"
+
+    @pytest.mark.asyncio
+    async def test_model_level_guardrails_resolve_against_the_alias_target(self, monkeypatch):
+        """Model-level guardrails are merged by model group name, so the merge
+        must see the target rather than the group the caller named."""
+        processing_obj = ProxyBaseLLMRequestProcessing(data={"model": "group-a"})
+        mock_request = MagicMock(spec=Request)
+        mock_request.headers = {}
+
+        async def mock_add_litellm_data_to_request(*args, **kwargs):
+            return kwargs.get("data", {})
+
+        async def passthrough_pre_call_hook(user_api_key_dict, data, call_type):
+            return copy.deepcopy(data)
+
+        mock_proxy_logging_obj = MagicMock(spec=ProxyLogging)
+        mock_proxy_logging_obj.pre_call_hook = AsyncMock(side_effect=passthrough_pre_call_hook)
+        monkeypatch.setattr(
+            litellm.proxy.common_request_processing,
+            "add_litellm_data_to_request",
+            mock_add_litellm_data_to_request,
+        )
+        monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", MagicMock())
+
+        merged_for: list = []
+
+        def recording_merge(data, llm_router, trust_client_model_info=True):
+            merged_for.append(data.get("model"))
+            return data
+
+        monkeypatch.setattr(
+            litellm.proxy.common_request_processing,
+            "_check_and_merge_model_level_guardrails",
+            recording_merge,
+        )
+
+        mock_proxy_config = MagicMock(spec=ProxyConfig)
+        mock_proxy_config._get_hierarchical_router_settings = AsyncMock(
+            return_value={"model_group_alias": {"group-a": "group-b"}}
+        )
+
+        await processing_obj.common_processing_pre_call_logic(
+            request=mock_request,
+            general_settings={},
+            user_api_key_dict=ProxyUserAPIKeyAuth(api_key="hash", models=[]),
+            proxy_logging_obj=mock_proxy_logging_obj,
+            proxy_config=mock_proxy_config,
+            route_type="acompletion",
+            llm_router=self._router(),
+        )
+
+        assert merged_for == ["group-b"]

--- a/tests/test_litellm/proxy/test_model_level_guardrails.py
+++ b/tests/test_litellm/proxy/test_model_level_guardrails.py
@@ -598,10 +598,15 @@ async def test_pre_call_merges_model_level_guardrails_before_pre_call_hook():
         }
     )
 
-    captured_pre_call_data: dict = {}
+    captured_pre_call_guardrails: list = []
 
     async def fake_pre_call_hook(*, user_api_key_dict, data, call_type):
-        captured_pre_call_data.update(data)
+        # Snapshot the list rather than the dict: metadata is shared by
+        # reference, so a merge that happens after this point would otherwise
+        # show up here retroactively and the assertion would pass either way.
+        captured_pre_call_guardrails.extend(
+            (data.get("metadata") or {}).get("guardrails") or data.get("guardrails") or []
+        )
         return data
 
     proxy_logging = MagicMock()
@@ -616,13 +621,9 @@ async def test_pre_call_merges_model_level_guardrails_before_pre_call_hook():
     proxy_config = MagicMock()
     proxy_config._get_hierarchical_router_settings = AsyncMock(return_value=None)
 
-    # Stop the function before any post-pre_call_hook logic so we can keep
-    # the test focused. Raising _StopAfterPreCall in the next await fires
-    # right after the guardrail merge + pre_call_hook complete.
-    class _StopAfterPreCall(Exception):
-        pass
-
-    proxy_config._get_hierarchical_router_settings.side_effect = _StopAfterPreCall()
+    # Assert on what pre_call_hook was handed rather than short-circuiting the
+    # function part way through: a sentinel keyed to one particular later call
+    # silently stops testing the ordering as soon as that call moves.
 
     with (
         patch(
@@ -640,30 +641,24 @@ async def test_pre_call_merges_model_level_guardrails_before_pre_call_hook():
     ):
         from litellm.proxy._types import UserAPIKeyAuth
 
-        try:
-            await processing.common_processing_pre_call_logic(
-                request=MagicMock(headers={}, url=MagicMock(path="/v1/chat/completions")),
-                general_settings={},
-                user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
-                proxy_logging_obj=proxy_logging,
-                proxy_config=proxy_config,
-                route_type="acompletion",
-                version=None,
-                user_model=None,
-                user_temperature=None,
-                user_request_timeout=None,
-                user_max_tokens=None,
-                user_api_base=None,
-                model=None,
-                llm_router=mock_router,
-            )
-        except _StopAfterPreCall:
-            pass
+        await processing.common_processing_pre_call_logic(
+            request=MagicMock(headers={}, url=MagicMock(path="/v1/chat/completions")),
+            general_settings={},
+            user_api_key_dict=UserAPIKeyAuth(api_key="test-key"),
+            proxy_logging_obj=proxy_logging,
+            proxy_config=proxy_config,
+            route_type="acompletion",
+            version=None,
+            user_model=None,
+            user_temperature=None,
+            user_request_timeout=None,
+            user_max_tokens=None,
+            user_api_base=None,
+            model=None,
+            llm_router=mock_router,
+        )
 
     # The pre_call_hook must have received data with the model-level
     # guardrail already merged in. Before the fix, this assertion fails
     # because pre_call_hook saw the original data without merge.
-    merged = (captured_pre_call_data.get("metadata") or {}).get("guardrails") or (
-        captured_pre_call_data.get("guardrails") or []
-    )
-    assert "my-pre-call-guardrail" in merged
+    assert "my-pre-call-guardrail" in captured_pre_call_guardrails

--- a/tests/test_litellm/router_utils/test_router_utils_common_utils.py
+++ b/tests/test_litellm/router_utils/test_router_utils_common_utils.py
@@ -10,6 +10,7 @@ from litellm.router_utils.common_utils import (
     add_model_file_id_mappings,
     filter_team_based_models,
     filter_web_search_deployments,
+    resolve_model_group_alias,
 )
 
 
@@ -516,3 +517,44 @@ class TestAddModelFileIdMappings:
     def test_should_return_empty_mapping_when_given_empty_list(self):
         result = add_model_file_id_mappings([], [])
         assert result == {}
+
+
+class TestResolveModelGroupAlias:
+    """``model_group_alias`` maps reach this helper from validated config and
+    from key/team rows, so both entry shapes must resolve and malformed entries
+    must not raise mid-request."""
+
+    @pytest.mark.parametrize(
+        "alias_map, expected",
+        [
+            ({"group-a": "group-b"}, "group-b"),
+            ({"group-a": {"model": "group-b", "hidden": True}}, "group-b"),
+            ({"group-a": {"model": "group-b"}}, "group-b"),
+            ({"other": "group-b"}, None),
+            ({}, None),
+            (None, None),
+            ("not-a-map", None),
+            ({"group-a": {"hidden": True}}, None),
+            ({"group-a": {"model": 5}}, None),
+            ({"group-a": 5}, None),
+            ({"group-a": None}, None),
+            ({"group-a": ""}, None),
+        ],
+    )
+    def test_resolves_both_entry_shapes_and_tolerates_malformed_entries(self, alias_map, expected):
+        assert resolve_model_group_alias(alias_map, "group-a") == expected
+
+    def test_router_alias_resolution_uses_the_shared_helper(self):
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "group-b",
+                    "litellm_params": {"model": "openai/gpt-4o", "api_key": "sk-fake"},
+                }
+            ],
+            model_group_alias={"group-a": "group-b", "group-item": {"model": "group-b", "hidden": True}},
+        )
+
+        assert router._get_model_from_alias("group-a") == "group-b"
+        assert router._get_model_from_alias("group-item") == "group-b"
+        assert router._get_model_from_alias("group-b") is None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Key and team `router_settings.model_group_alias` is accepted, persisted and echoed back by `/key/info`, but never applied at request time, so the request runs on the group the caller asked for
- The failure is silent: 200 on write, 200 on the call, no warning; `fallbacks` in the same `router_settings` object does work, so the two paths disagree

How it solves it:

- Resolve the alias in the proxy, where the hierarchical key/team settings are already unpacked, and rewrite the requested model group before dispatch
- Authorize the alias target in its own right first, since model access was checked against the group the caller named
- Share one alias resolver between the Router and the proxy so both entry shapes and malformed map entries behave the same way

## Relevant issues

## Linear ticket

Resolves LIT-4879

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on a namespaced port, Postgres-backed, `store_model_in_db: false`, real OpenAI calls. Config carries two model groups plus a global alias and a deliberately broken group as controls:

```yaml
model_list:
  - model_name: group-a
    litellm_params: {model: openai/gpt-5.5, api_key: os.environ/OPENAI_API_KEY}
  - model_name: group-b
    litellm_params: {model: openai/gpt-5.4-mini, api_key: os.environ/OPENAI_API_KEY}
  - model_name: group-broken
    litellm_params: {model: openai/gpt-5.5, api_key: sk-invalid-key-for-fallback-control}
router_settings:
  model_group_alias:
    group-c: group-b
general_settings:
  store_model_in_db: false
```

Keys and the team, created once and reused across both runs so the only variable is the code:

```bash
curl -s $P/key/generate -H "$A" -H "$C" -d '{"key_alias":"k-alias","router_settings":{"model_group_alias":{"group-a":"group-b"}}}'
curl -s $P/team/new     -H "$A" -H "$C" -d '{"team_alias":"alias-team","router_settings":{"model_group_alias":{"group-a":"group-b"}}}'
curl -s $P/key/generate -H "$A" -H "$C" -d '{"key_alias":"k-fallbacks","router_settings":{"fallbacks":[{"group-broken":["group-b"]}]}}'
curl -s $P/key/generate -H "$A" -H "$C" -d '{"key_alias":"k-restricted","models":["group-a"],"router_settings":{"model_group_alias":{"group-a":"group-b"}}}'
curl -s $P/key/generate -H "$A" -H "$C" -d '{"key_alias":"k-both","models":["group-a","group-b"],"router_settings":{"model_group_alias":{"group-a":"group-b"}}}'
curl -s $P/key/generate -H "$A" -H "$C" -d '{"key_alias":"k-item","router_settings":{"model_group_alias":{"group-a":{"model":"group-b","hidden":true}}}}'
curl -s $P/key/generate -H "$A" -H "$C" -d '{"key_alias":"k-malformed","router_settings":{"model_group_alias":{"group-a":{"nope":1}}}}'
```

The write path was never the problem:

```bash
$ curl -s "$P/key/info?key=$K_KEY_ALIAS" -H "$A" | python3 -c 'import sys,json;print(json.load(sys.stdin)["info"]["router_settings"])'
{'model_group_alias': {'group-a': 'group-b'}}
```

Each probe below is one real `/v1/chat/completions` call, printing the status line and the two model headers:

```bash
ask () {
  curl -si $P/v1/chat/completions -H "Authorization: Bearer $1" -H "$C" \
    -d "{\"model\":\"$2\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":16$3}" \
    | grep -iE "^HTTP/|^x-litellm-model-name|^x-litellm-model-group"
}
```

Before, on `litellm_internal_staging`. The alias is dropped on both the key and the team path, while every control behaves:

```
1. key-level alias  group-a -> group-b
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.5
x-litellm-model-group: group-a

2. team-level alias group-a -> group-b
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.5
x-litellm-model-group: group-a

3. control: global config alias group-c -> group-b
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.4-mini
x-litellm-model-group: group-c

4. control: key-level fallbacks on the same router_settings path
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.4-mini
x-litellm-model-group: group-b

5. control: master key, no key-level router_settings
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.5
x-litellm-model-group: group-a

6. alias target outside the key's models allowlist
{"id":"chatcmpl-...","model":"group-a",...}  HTTP 200

7. same shape, alias target also granted
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.5
x-litellm-model-group: group-a

8. alias in the {model, hidden} item form
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.5
x-litellm-model-group: group-a

9. malformed alias entry is ignored, request still served
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.5
x-litellm-model-group: group-a

10. key-level alias, streaming
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.5
x-litellm-model-group: group-a
```

After, on the branch, same keys, same probes:

```
1. key-level alias  group-a -> group-b
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.4-mini
x-litellm-model-group: group-b

2. team-level alias group-a -> group-b
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.4-mini
x-litellm-model-group: group-b

3. control: global config alias group-c -> group-b
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.4-mini
x-litellm-model-group: group-c

4. control: key-level fallbacks on the same router_settings path
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.4-mini
x-litellm-model-group: group-b

5. control: master key, no key-level router_settings
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.5
x-litellm-model-group: group-a

6. alias target outside the key's models allowlist
{"error":{"message":"key not allowed to access model. This key can only access models=['group-a']. Tried to access group-b","type":"key_model_access_denied","param":"model","code":"403"}}  HTTP 403

7. same shape, alias target also granted
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.4-mini
x-litellm-model-group: group-b

8. alias in the {model, hidden} item form
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.4-mini
x-litellm-model-group: group-b

9. malformed alias entry is ignored, request still served
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.5
x-litellm-model-group: group-a

10. key-level alias, streaming
HTTP/1.1 200 OK
x-litellm-model-name: openai/gpt-5.4-mini
x-litellm-model-group: group-b
```

Probes 1, 2, 8 and 10 flip; 3, 4, 5 and 9 are unchanged. Probe 6 goes from silently serving the un-aliased group to a 403 on the target, which is the intended new behavior: the alias is honored now, and honoring it needs access to the group it points at.

The rewrite lands with the other alias rewrites, ahead of the pre-call hooks, so per-model limits are enforced against the group that serves the request. Key carrying the alias plus `model_rpm_limit: {"group-b": 1}`, three requests naming `group-a`:

```bash
$ K=$(curl -s $P/key/generate -H "$A" -H "$C" \
    -d '{"key_alias":"k-rpm-on-target","router_settings":{"model_group_alias":{"group-a":"group-b"}},"model_rpm_limit":{"group-b":1}}' \
    | python3 -c 'import sys,json;print(json.load(sys.stdin)["key"])')
$ for i in 1 2 3; do curl -s -o /dev/null -w "req$i HTTP %{http_code}\n" $P/v1/chat/completions \
    -H "Authorization: Bearer $K" -H "$C" -d '{"model":"group-a","messages":[{"role":"user","content":"hi"}],"max_tokens":8}'; done
req1 HTTP 200
req2 HTTP 429
req3 HTTP 429
```

Resolving the alias after the pre-call hooks instead leaves that limit unenforced, which is why the rewrite sits where it does. Same key, same three requests, with the resolution moved back below `pre_call_hook`:

```
req1 HTTP 200
req2 HTTP 200
req3 HTTP 200
```

Model-level guardrails resolve against the target too. `group-b`'s deployment carries `guardrails: ["block-word"]`, which blocks any message containing `TRIPWIRE`; `group-a` carries none:

```bash
$ curl -s $P/v1/chat/completions -H "Authorization: Bearer $K_KEY_ALIAS" -H "$C" \
    -d '{"model":"group-a","messages":[{"role":"user","content":"TRIPWIRE"}],"max_tokens":8}'
{"error":{"message":"blocked by group-b model-level guardrail","code":"400",
 "provider_specific_fields":{"guardrail_name":"block-word","guardrail_mode":"pre_call"}}}

$ curl -s -o /dev/null -w '%{http_code}\n' $P/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "$C" \
    -d '{"model":"group-a","messages":[{"role":"user","content":"TRIPWIRE"}],"max_tokens":8}'
200
```

The late placement still blocks this one, but at a later stage and without the `guardrail_name` / `guardrail_mode` attribution, so guardrails are not the argument for the placement; the rate limit above is.

Spend logs for the after run, so the rewrite lands on the group that actually served the request:

```bash
$ psql -tAc "select model, coalesce(model_group,'(rejected)'), metadata->>'user_api_key_alias' from \"LiteLLM_SpendLogs\" order by \"startTime\" desc limit 10;"
openai/gpt-5.4-mini|group-b|k-alias        # 10, streaming
openai/gpt-5.5|group-a|k-malformed         # 9
openai/gpt-5.4-mini|group-b|k-item         # 8
openai/gpt-5.4-mini|group-b|k-both         # 7
group-a|(rejected)|k-restricted            # 6
openai/gpt-5.5|group-a|                    # 5, master key
openai/gpt-5.4-mini|group-b|k-fallbacks    # 4
openai/gpt-5.4-mini|group-c|k-alias        # 3, global alias
openai/gpt-5.4-mini|group-b|k-team-v4      # 2
openai/gpt-5.4-mini|group-b|k-alias        # 1
```

## Type

🐛 Bug Fix

## Changes

Key and team `router_settings` reach the request as `data["router_settings_override"]`, and `route_request` forwards only the settings the Router accepts as per-request kwargs (`fallbacks`, `num_retries`, `timeout`, ...). `model_group_alias` is not one of them, which is why `fallbacks` on the same key worked and the alias did not. Adding the name to that list would not have helped either: alias resolution reads `Router.model_group_alias`, an instance attribute that holds the global config map and is shared across every request, so there is nowhere for a per-request map to go.

So the alias is resolved in the proxy, in `common_processing_pre_call_logic`, alongside the existing `litellm.model_alias_map` and key-`aliases` rewrites and ahead of the pre-call hooks:

```python
if router_settings is not None:
    self.data["router_settings_override"] = router_settings
    alias_target = await _resolve_per_request_model_group_alias(
        requested_model=self.data.get("model"),
        router_settings=router_settings,
        user_api_key_dict=user_api_key_dict,
        llm_router=llm_router,
    )
    if alias_target is not None:
        self.data["model"] = alias_target
```

Model access was authorized against the group the caller named, so the rewrite goes through `can_key_call_resolved_model` on the target first. That is deliberately stricter than the global alias path, where access to the alias name alone is enough: the global map is admin-controlled config, while a key's `router_settings` is set on the key itself, so a rewrite it authorizes cannot be allowed to reach a group the key was not granted. A key whose alias points somewhere it may not call gets the usual 403 instead of quietly being served the target.

`Router._get_model_from_alias` and the proxy now share one `resolve_model_group_alias` helper in `litellm/router_utils/common_utils.py`. It handles the plain string form `{"a": "b"}` and the item form `{"a": {"model": "b", "hidden": true}}`, and returns None for a malformed entry rather than raising, which matters because this map can arrive from a key or team row rather than from validated config. The Router previously indexed `entry["model"]` directly, so a bad entry there would have raised mid-request.

`tests/test_litellm/proxy/test_model_level_guardrails.py` changes because moving the block broke its scaffolding, not its subject. That test pinned "guardrails are merged before pre_call_hook" by making `_get_hierarchical_router_settings` raise, using it as a stop-sentinel to freeze execution just past the assertion point; once that call moved above the merge, the sentinel fired too early. Simply deleting the sentinel made the test pass under both branches, because it captured `data["metadata"]` by reference and a merge happening later showed up retroactively. It now snapshots the guardrail list at pre-call time, so it fails if the merge moves below `pre_call_hook`, which the original could not have caught either.

One deliberate difference from the global alias path: because the group is rewritten before routing, spend logs and `x-litellm-model-group` report the target (`group-b`), whereas a global alias reports the alias name (`group-c`). Spend then lands on the group that actually served the request, which is what the report asked for

## QA runbook

1. Start a proxy with a `DATABASE_URL` and the config above
2. `POST /key/generate` with `{"router_settings": {"model_group_alias": {"group-a": "group-b"}}}`, then `POST /v1/chat/completions` with `{"model": "group-a"}` and read `x-litellm-model-name`; it must be the `group-b` deployment
3. Repeat with the same alias on a team's `router_settings` and a key in that team
4. Add `"models": ["group-a"]` to the key and repeat; the call must 403 naming `group-b`, and must 200 once `group-b` is added to `models`
5. Confirm a key with no `router_settings`, a global `model_group_alias`, and a key carrying only `fallbacks` are all unaffected

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

