### PR TITLE
fix(componentized): honor USE_DDTRACE in the gateway and backend deployments

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -63,6 +63,8 @@ RUN mkdir -p /home/nonroot && \
     HOME=/home/nonroot prisma generate --schema=./schema.prisma && \
     chown -R nonroot:nonroot /home/nonroot/.cache
 
+RUN sed -i 's/\r$//' docker/component_entrypoint.sh && chmod +x docker/component_entrypoint.sh
+
 # ---------- Runtime ----------
 FROM $LITELLM_RUNTIME_IMAGE AS runtime
 
@@ -93,5 +95,5 @@ USER nonroot
 
 EXPOSE 4001/tcp
 
-ENTRYPOINT ["uvicorn", "backend.main:app"]
+ENTRYPOINT ["/app/docker/component_entrypoint.sh", "uvicorn", "backend.main:app"]
 CMD ["--host", "0.0.0.0", "--port", "4001"]

--- a/docker/component_entrypoint.sh
+++ b/docker/component_entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ "$USE_DDTRACE" = "true" ]; then
+    export DD_TRACE_OPENAI_ENABLED="False"
+    exec ddtrace-run "$@"
+fi
+
+exec "$@"

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -65,6 +65,8 @@ RUN mkdir -p /home/nonroot && \
     HOME=/home/nonroot prisma generate --schema=./schema.prisma && \
     chown -R nonroot:nonroot /home/nonroot/.cache
 
+RUN sed -i 's/\r$//' docker/component_entrypoint.sh && chmod +x docker/component_entrypoint.sh
+
 # ---------- Runtime ----------
 FROM $LITELLM_RUNTIME_IMAGE AS runtime
 
@@ -95,5 +97,5 @@ USER nonroot
 
 EXPOSE 4000/tcp
 
-ENTRYPOINT ["sh", "-c", "exec uvicorn gateway.main:app --workers \"${NUM_WORKERS:-1}\" \"$@\"", "--"]
+ENTRYPOINT ["sh", "-c", "exec /app/docker/component_entrypoint.sh uvicorn gateway.main:app --workers \"${NUM_WORKERS:-1}\" \"$@\"", "--"]
 CMD ["--host", "0.0.0.0", "--port", "4000"]

--- a/terraform/litellm/aws/ecs.tf
+++ b/terraform/litellm/aws/ecs.tf
@@ -186,21 +186,23 @@ locals {
   gateway_uvicorn_args = "--host 0.0.0.0 --port 4000 --workers ${var.gateway_num_workers}"
   backend_uvicorn_args = "--host 0.0.0.0 --port 4001"
 
+  gateway_launch_cmd = "if [ \"$USE_DDTRACE\" = \"true\" ]; then export DD_TRACE_OPENAI_ENABLED=\"False\"; exec ddtrace-run uvicorn gateway.main:app ${local.gateway_uvicorn_args}; else exec uvicorn gateway.main:app ${local.gateway_uvicorn_args}; fi"
+  backend_launch_cmd = "if [ \"$USE_DDTRACE\" = \"true\" ]; then export DD_TRACE_OPENAI_ENABLED=\"False\"; exec ddtrace-run uvicorn backend.main:app ${local.backend_uvicorn_args}; else exec uvicorn backend.main:app ${local.backend_uvicorn_args}; fi"
+
   gateway_proxy_overrides = local.proxy_config_enabled ? {
     entryPoint = ["sh", "-c"]
     command = [
-      "${local.proxy_config_fetch_cmd} && exec uvicorn gateway.main:app ${local.gateway_uvicorn_args}"
+      "${local.proxy_config_fetch_cmd} && ${local.gateway_launch_cmd}"
     ]
     } : {
-    # Mirror the image's ENTRYPOINT so we can append --workers via command.
-    entryPoint = ["uvicorn", "gateway.main:app"]
-    command    = split(" ", local.gateway_uvicorn_args)
+    entryPoint = ["sh", "-c"]
+    command    = [local.gateway_launch_cmd]
   }
 
   backend_proxy_overrides = local.proxy_config_enabled ? {
     entryPoint = ["sh", "-c"]
     command = [
-      "${local.proxy_config_fetch_cmd} && exec uvicorn backend.main:app ${local.backend_uvicorn_args}"
+      "${local.proxy_config_fetch_cmd} && ${local.backend_launch_cmd}"
     ]
   } : {}
 }

--- a/terraform/litellm/gcp/cloudrun.tf
+++ b/terraform/litellm/gcp/cloudrun.tf
@@ -135,16 +135,22 @@ locals {
     "export DATABASE_URL_READ_REPLICA=\"postgresql://$${DATABASE_USER}:$${DATABASE_PASSWORD}@$${DATABASE_HOST_READ_REPLICA}:$${DATABASE_PORT_READ_REPLICA}/$${DATABASE_NAME}\"",
   ]
 
+  gateway_uvicorn_args = "--host 0.0.0.0 --port 4000 --workers ${var.gateway_num_workers}"
+  backend_uvicorn_args = "--host 0.0.0.0 --port 4001"
+
+  gateway_launch_cmd = "if [ \"$USE_DDTRACE\" = \"true\" ]; then export DD_TRACE_OPENAI_ENABLED=\"False\"; exec ddtrace-run uvicorn gateway.main:app ${local.gateway_uvicorn_args}; else exec uvicorn gateway.main:app ${local.gateway_uvicorn_args}; fi"
+  backend_launch_cmd = "if [ \"$USE_DDTRACE\" = \"true\" ]; then export DD_TRACE_OPENAI_ENABLED=\"False\"; exec ddtrace-run uvicorn backend.main:app ${local.backend_uvicorn_args}; else exec uvicorn backend.main:app ${local.backend_uvicorn_args}; fi"
+
   gateway_args = join(" && ", concat(
     local.redis_ca_fragment,
     local.database_url_fragment,
-    ["exec uvicorn gateway.main:app --host 0.0.0.0 --port 4000 --workers ${var.gateway_num_workers}"],
+    [local.gateway_launch_cmd],
   ))
 
   backend_args = join(" && ", concat(
     local.redis_ca_fragment,
     local.database_url_fragment,
-    ["exec uvicorn backend.main:app --host 0.0.0.0 --port 4001"],
+    [local.backend_launch_cmd],
   ))
 
   # Env shipped to the migrations Job. The migrations image runs run.py

--- a/tests/test_litellm/test_component_entrypoint.py
+++ b/tests/test_litellm/test_component_entrypoint.py
@@ -1,0 +1,323 @@
+"""Unit tests for `docker/component_entrypoint.sh` and its wiring into the
+componentized `gateway` / `backend` images and Terraform deployments."""
+
+import json
+import os
+import re
+import stat
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COMPONENT_ENTRYPOINT = REPO_ROOT / "docker" / "component_entrypoint.sh"
+PROD_ENTRYPOINT = REPO_ROOT / "docker" / "prod_entrypoint.sh"
+GATEWAY_DOCKERFILE = REPO_ROOT / "gateway" / "Dockerfile"
+BACKEND_DOCKERFILE = REPO_ROOT / "backend" / "Dockerfile"
+TERRAFORM_ECS = REPO_ROOT / "terraform" / "litellm" / "aws" / "ecs.tf"
+TERRAFORM_CLOUDRUN = REPO_ROOT / "terraform" / "litellm" / "gcp" / "cloudrun.tf"
+
+IMAGE_ENTRYPOINT_PATH = "/app/docker/component_entrypoint.sh"
+
+PYTHONPATH_SENTINEL = "/lit-entrypoint-sentinel:/app"
+
+_STUB_TEMPLATE = """#!/bin/sh
+{{
+  echo "exec={name}"
+  echo "args=$*"
+  echo "DD_TRACE_OPENAI_ENABLED=${{DD_TRACE_OPENAI_ENABLED-<unset>}}"
+  echo "PYTHONPATH=${{PYTHONPATH-<unset>}}"
+}} >> "$RECORD"
+"""
+
+_ENTRYPOINT_RE = re.compile(r"^ENTRYPOINT\s+(\[.*\])\s*$", re.MULTILINE)
+_CMD_RE = re.compile(r"^CMD\s+(\[.*\])\s*$", re.MULTILINE)
+_APP_TARGET_RE = re.compile(r"(?:gateway|backend)\.main:app")
+_TF_STRING_LOCAL_RE = re.compile(r'^\s*(\w+)\s*=\s*"((?:[^"\\]|\\.)*)"\s*$', re.MULTILINE)
+_TF_INTERPOLATION_RE = re.compile(r"\$\{(local|var)\.(\w+)\}")
+
+TERRAFORM_LAUNCH_SITES = {TERRAFORM_ECS: 2, TERRAFORM_CLOUDRUN: 2}
+TERRAFORM_VAR_STUBS = {"gateway_num_workers": "2"}
+_MAX_INTERPOLATION_PASSES = 5
+
+
+def _write_stubs(bin_dir: Path, names: tuple[str, ...]) -> None:
+    for name in names:
+        stub = bin_dir / name
+        stub.write_text(_STUB_TEMPLATE.format(name=name))
+        stub.chmod(0o755)
+
+
+def _run_entrypoint(
+    script: Path,
+    argv: tuple[str, ...],
+    use_ddtrace: Optional[str],
+    tmp_path: Path,
+) -> tuple[str, ...]:
+    """Run `script` with stubbed executables on PATH and return the recorded lines."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    _write_stubs(bin_dir, ("ddtrace-run", "uvicorn", "litellm"))
+    record = tmp_path / "record.txt"
+
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "RECORD": str(record),
+        "PYTHONPATH": PYTHONPATH_SENTINEL,
+    }
+    env.pop("USE_DDTRACE", None)
+    env.pop("DD_TRACE_OPENAI_ENABLED", None)
+    if use_ddtrace is not None:
+        env["USE_DDTRACE"] = use_ddtrace
+
+    result = subprocess.run(
+        ["sh", str(script), *argv],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
+    return tuple(record.read_text().splitlines()) if record.exists() else ()
+
+
+def _run_shell_command(command: str, bin_dir: Path, record: Path, use_ddtrace: Optional[str]) -> tuple[str, ...]:
+    """Run a resolved Terraform launch command through `sh -c` and return the recorded lines."""
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "RECORD": str(record),
+        "PYTHONPATH": PYTHONPATH_SENTINEL,
+    }
+    env.pop("USE_DDTRACE", None)
+    env.pop("DD_TRACE_OPENAI_ENABLED", None)
+    if use_ddtrace is not None:
+        env["USE_DDTRACE"] = use_ddtrace
+
+    result = subprocess.run(["sh", "-c", command], env=env, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, f"stdout={result.stdout} stderr={result.stderr}"
+    return tuple(record.read_text().splitlines()) if record.exists() else ()
+
+
+def _resolve_tf_local(terraform_file: Path, name: str) -> str:
+    """Read a string local out of a .tf file and expand its `local.` / `var.` interpolations."""
+    values = {
+        m.group(1): m.group(2).replace('\\"', '"') for m in _TF_STRING_LOCAL_RE.finditer(terraform_file.read_text())
+    }
+
+    assert name in values, f"{terraform_file} defines no {name} local"
+    resolved = values[name]
+    for _ in range(_MAX_INTERPOLATION_PASSES):
+        if "${" not in resolved:
+            return resolved
+        resolved = _TF_INTERPOLATION_RE.sub(
+            lambda m: values[m.group(2)] if m.group(1) == "local" else TERRAFORM_VAR_STUBS[m.group(2)],
+            resolved,
+        )
+    raise AssertionError(f"{terraform_file}:{name} still has unresolved interpolations: {resolved}")
+
+
+def _entrypoint_argv(dockerfile: Path) -> tuple[str, ...]:
+    matches = _ENTRYPOINT_RE.findall(dockerfile.read_text())
+    assert matches, f"no exec-form ENTRYPOINT found in {dockerfile}"
+    parsed = json.loads(matches[-1])
+    return tuple(str(part) for part in parsed)
+
+
+def _cmd_argv(dockerfile: Path) -> tuple[str, ...]:
+    matches = _CMD_RE.findall(dockerfile.read_text())
+    assert matches, f"no exec-form CMD found in {dockerfile}"
+    return tuple(str(part) for part in json.loads(matches[-1]))
+
+
+def test_ddtrace_enabled_wraps_the_command_and_disables_the_openai_integration(
+    tmp_path: Path,
+) -> None:
+    """`USE_DDTRACE=true` must prefix the command with `ddtrace-run`, turn the openai
+    integration off, and leave PYTHONPATH alone.
+
+    `ddtrace-run` installs its instrumentation by PREPENDING a bootstrap directory to
+    PYTHONPATH, and the images set PYTHONPATH=/app so the app package is importable. A
+    wrapper that assigned PYTHONPATH instead of inheriting it would either drop the
+    bootstrap (silently disabling tracing) or drop /app (breaking the import), so the
+    recorded value is asserted verbatim.
+
+    PYTHONPATH_SENTINEL deliberately differs from the images' own /app: with /app as the
+    fixture value, a wrapper that overwrote PYTHONPATH with /app would still satisfy this
+    assertion and the check would prove nothing.
+
+    The openai integration is disabled because under `ddtrace-run` the bootstrap patches
+    it before any litellm code runs, so litellm's in-process `patch_all(..., openai=False)`
+    can no longer suppress it; leaving it on double-reports every LLM call.
+    """
+    recorded = _run_entrypoint(
+        COMPONENT_ENTRYPOINT,
+        ("uvicorn", "gateway.main:app", "--workers", "2", "--port", "4000"),
+        use_ddtrace="true",
+        tmp_path=tmp_path,
+    )
+
+    assert recorded == (
+        "exec=ddtrace-run",
+        "args=uvicorn gateway.main:app --workers 2 --port 4000",
+        "DD_TRACE_OPENAI_ENABLED=False",
+        f"PYTHONPATH={PYTHONPATH_SENTINEL}",
+    )
+
+
+def test_ddtrace_disabled_execs_the_command_directly(tmp_path: Path) -> None:
+    recorded = _run_entrypoint(
+        COMPONENT_ENTRYPOINT,
+        ("uvicorn", "backend.main:app", "--port", "4001"),
+        use_ddtrace=None,
+        tmp_path=tmp_path,
+    )
+
+    assert recorded == (
+        "exec=uvicorn",
+        "args=backend.main:app --port 4001",
+        "DD_TRACE_OPENAI_ENABLED=<unset>",
+        f"PYTHONPATH={PYTHONPATH_SENTINEL}",
+    )
+
+
+@pytest.mark.parametrize("use_ddtrace", [None, "", "false", "True", "TRUE", "1", "yes"])
+def test_gating_matches_the_monolithic_entrypoint(use_ddtrace: Optional[str], tmp_path: Path) -> None:
+    """The componentized images must honor `USE_DDTRACE` exactly as the monolith does."""
+    component = _run_entrypoint(
+        COMPONENT_ENTRYPOINT,
+        ("uvicorn", "gateway.main:app"),
+        use_ddtrace=use_ddtrace,
+        tmp_path=tmp_path / "component",
+    )
+    monolith = _run_entrypoint(
+        PROD_ENTRYPOINT,
+        ("--port", "4000"),
+        use_ddtrace=use_ddtrace,
+        tmp_path=tmp_path / "monolith",
+    )
+
+    assert component[0].startswith("exec=") and monolith[0].startswith("exec=")
+    assert (component[0] == "exec=ddtrace-run") == (monolith[0] == "exec=ddtrace-run")
+
+
+def test_entrypoint_script_is_executable() -> None:
+    mode = COMPONENT_ENTRYPOINT.stat().st_mode
+    assert mode & stat.S_IXUSR, "entrypoint must be committed executable to run as the image ENTRYPOINT"
+    assert mode & stat.S_IXOTH, "entrypoint must be executable by the unprivileged `nonroot` user"
+
+
+def test_entrypoint_script_has_no_carriage_returns() -> None:
+    assert b"\r" not in COMPONENT_ENTRYPOINT.read_bytes()
+
+
+@pytest.mark.parametrize(
+    "dockerfile, app_target",
+    [
+        (GATEWAY_DOCKERFILE, "gateway.main:app"),
+        (BACKEND_DOCKERFILE, "backend.main:app"),
+    ],
+)
+def test_component_images_launch_uvicorn_through_the_entrypoint(dockerfile: Path, app_target: str) -> None:
+    entrypoint = " ".join(_entrypoint_argv(dockerfile))
+
+    assert IMAGE_ENTRYPOINT_PATH in entrypoint, f"{dockerfile} bypasses the ddtrace-aware entrypoint"
+    assert app_target in entrypoint
+    assert entrypoint.index(IMAGE_ENTRYPOINT_PATH) < entrypoint.index("uvicorn"), (
+        f"{dockerfile} must invoke uvicorn through the entrypoint, not the other way around"
+    )
+
+
+@pytest.mark.parametrize("dockerfile", [GATEWAY_DOCKERFILE, BACKEND_DOCKERFILE])
+def test_component_images_make_the_entrypoint_executable(dockerfile: Path) -> None:
+    body = dockerfile.read_text()
+    assert "chmod +x docker/component_entrypoint.sh" in body
+
+
+@pytest.mark.parametrize("terraform_file", TERRAFORM_LAUNCH_SITES, ids=lambda p: p.parent.name)
+@pytest.mark.parametrize("component", ["gateway", "backend"])
+@pytest.mark.parametrize("use_ddtrace", [None, "true", "false", "True"])
+def test_terraform_launch_command_matches_the_script_contract(
+    terraform_file: Path, component: str, use_ddtrace: Optional[str], tmp_path: Path
+) -> None:
+    """The Terraform command and `docker/component_entrypoint.sh` must decide identically.
+
+    The decision deliberately lives in two places. The script is what the image ENTRYPOINT runs;
+    the Terraform strings are what runs when a deployment overrides that ENTRYPOINT, and they
+    cannot call the script because the caller supplies the image tag and it may predate the file.
+    Both modules default to a tag that does. So instead of asserting a shared path, this runs both
+    implementations under the same environment and asserts they agree on which binary is exec'd
+    and on whether the openai integration is disabled.
+    """
+    app_target = f"{component}.main:app"
+    command = _resolve_tf_local(terraform_file, f"{component}_launch_cmd")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True)
+    _write_stubs(bin_dir, ("ddtrace-run", "uvicorn"))
+    from_terraform = _run_shell_command(command, bin_dir, tmp_path / "terraform.txt", use_ddtrace)
+
+    from_script = _run_entrypoint(
+        COMPONENT_ENTRYPOINT,
+        ("uvicorn", app_target),
+        use_ddtrace=use_ddtrace,
+        tmp_path=tmp_path / "script",
+    )
+
+    assert from_terraform[0] == from_script[0], (
+        f"{terraform_file} disagrees with the script on USE_DDTRACE={use_ddtrace}"
+    )
+    assert from_terraform[2] == from_script[2], f"{terraform_file} disagrees with the script on the openai integration"
+    assert app_target in from_terraform[1]
+
+    if use_ddtrace == "true":
+        assert from_terraform[0] == "exec=ddtrace-run"
+        assert from_terraform[2] == "DD_TRACE_OPENAI_ENABLED=False"
+    else:
+        assert from_terraform[0] == "exec=uvicorn"
+        assert from_terraform[2] == "DD_TRACE_OPENAI_ENABLED=<unset>"
+
+
+@pytest.mark.parametrize("terraform_file", TERRAFORM_LAUNCH_SITES, ids=lambda p: p.parent.name)
+def test_terraform_routes_every_launch_site_through_a_traced_command(terraform_file: Path) -> None:
+    """Every place Terraform names a component ASGI target has to honor `USE_DDTRACE`.
+
+    The count is pinned as well: a launch site that is deleted or renamed would otherwise drop
+    out of the scan and let this pass while covering less than it claims.
+    """
+    launch_sites = tuple(line for line in terraform_file.read_text().splitlines() if _APP_TARGET_RE.search(line))
+
+    assert len(launch_sites) == TERRAFORM_LAUNCH_SITES[terraform_file], (
+        f"{terraform_file} launch-site count changed; re-check each one honors USE_DDTRACE"
+    )
+    for line in launch_sites:
+        assert "ddtrace-run" in line, f"{terraform_file} launches uvicorn without honoring USE_DDTRACE: {line.strip()}"
+
+    body = terraform_file.read_text()
+    for component in ("gateway", "backend"):
+        assert f"local.{component}_launch_cmd" in body, (
+            f"{terraform_file} defines a {component} launch command but never uses it"
+        )
+
+
+@pytest.mark.parametrize("terraform_file", TERRAFORM_LAUNCH_SITES, ids=lambda p: p.parent.name)
+def test_terraform_does_not_depend_on_the_entrypoint_script(terraform_file: Path) -> None:
+    """Terraform must not reference a file the caller-supplied image may not contain.
+
+    Both modules default to an image tag published before the script existed, so exec'ing that
+    path would fail at container start rather than degrade to an untraced process.
+    """
+    assert IMAGE_ENTRYPOINT_PATH not in terraform_file.read_text(), (
+        f"{terraform_file} depends on a script that images predating it do not ship"
+    )
+
+
+def test_gateway_keeps_its_worker_count_and_backend_keeps_a_single_process() -> None:
+    gateway = " ".join(_entrypoint_argv(GATEWAY_DOCKERFILE)) + " " + " ".join(_cmd_argv(GATEWAY_DOCKERFILE))
+    backend = " ".join(_entrypoint_argv(BACKEND_DOCKERFILE)) + " " + " ".join(_cmd_argv(BACKEND_DOCKERFILE))
+
+    assert "--workers" in gateway and "NUM_WORKERS" in gateway
+    assert "--workers" not in backend and "NUM_WORKERS" not in backend


### PR DESCRIPTION
## TLDR

Problem this solves:

- Componentized deployments never run `ddtrace-run`
- Datadog APM gets no HTTP request spans from them
- Terraform overrides bypass the image entrypoint too

How it solves it:

- Shared entrypoint wraps uvicorn when `USE_DDTRACE=true`
- Terraform inlines the same check, so old images trace too
- Exports `DD_TRACE_OPENAI_ENABLED=False` like the monolith

## Relevant issues

Fixes #34251

## Linear ticket

Resolves LIT-4727

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The end-user surface here is the container, so the proof runs the real images against a trace agent. The agent is a small HTTP server standing in for the Datadog agent; it msgpack-decodes the v0.5 payloads and prints the span names in each one, which is what makes the difference legible. No mocks inside the image; the gateway boots its real lifespan and serves real traffic

The headline is the span names. Before, the agent receives orphaned `fastapi.serialize_response` children and a `fastapi.request` count of 0. After, that count is 6, one per served request. That is what a Datadog user actually sees: today the split deployment produces traces with no root span, so APM has no route, method, status or end-to-end latency to show

Before is commit `0a42f288` and after is commit `203844df`

```bash
# confirm the "before" tree really lacks the wiring
$ git grep -c ddtrace 0a42f288 -- gateway/Dockerfile backend/Dockerfile
(no output; zero matches)

$ docker build -f gateway/Dockerfile -t lit4727-ddt-gateway:base .    # at 0a42f288
$ python fake_dd_agent.py 18126 > agent.log &
$ docker run -d --name lit4727-ddt-gw-base -p 14727:4000 \
    --add-host host.docker.internal:host-gateway \
    -e USE_DDTRACE=true -e DD_TRACE_AGENT_URL=http://host.docker.internal:18126 \
    -e NUM_WORKERS=2 -e CONFIG_FILE_PATH=/app/config.yaml -e LITELLM_MASTER_KEY=sk-... \
    -v $PWD/config.yaml:/app/config.yaml:ro lit4727-ddt-gateway:base
$ for i in 1 2 3 4 5; do curl -s -o /dev/null -w "%{http_code} " http://127.0.0.1:14727/health/liveliness; done
200 200 200 200 200

$ grep /traces agent.log
POST /v0.5/traces bytes=751 spans=['fastapi.serialize_response', 'fastapi.serialize_response', 'fastapi.serialize_response', 'fastapi.serialize_response', 'fastapi.serialize_response']
$ grep -c fastapi.request agent.log
0
```

Child spans arrive, no root request span ever does. A trace with no root span carries no route, method, status or end-to-end latency, so the split deployment shows nothing usable in APM

Same commands against the fixed image:

```bash
$ docker build -f gateway/Dockerfile -t lit4727-ddt-gateway:fixed .   # at 203844df
$ docker run -d --name lit4727-ddt-gw-fixed -p 14727:4000 ...same flags... lit4727-ddt-gateway:fixed
$ for i in 1 2 3 4 5; do curl -s -o /dev/null -w "%{http_code} " http://127.0.0.1:14727/health/liveliness; done
200 200 200 200 200

$ grep /traces agent.log
POST /v0.5/traces bytes=688  spans=['http.request']
POST /v0.5/traces bytes=688  spans=['http.request']
POST /v0.5/traces bytes=1973 spans=['fastapi.request', 'fastapi.serialize_response', 'fastapi.request', 'fastapi.serialize_response', 'fastapi.request', 'fastapi.serialize_response', 'fastapi.request', 'fastapi.serialize_response', 'fastapi.request', 'fastapi.serialize_response', 'fastapi.request', 'fastapi.serialize_response']
$ grep -o fastapi.request agent.log | wc -l
6
```

Six root spans for six served requests, counting the readiness probe

`ddtrace-run` reaches every uvicorn worker, read straight out of the running container rather than inferred from the payload batching:

```bash
$ docker exec lit4727-ddt-gw-fixed sh -c 'for p in /proc/[0-9]*; do ... done'
pid=1  uvicorn gateway.main:app --workers 2 --host 0.0.0.0 --port 4000
    PYTHONPATH=/app/.venv/lib/python3.13/site-packages/ddtrace/bootstrap:/app
    DD_TRACE_OPENAI_ENABLED=False
pid=17 python -B -c from multiprocessing.spawn import spawn_main; ... --multiprocessing-fork
    PYTHONPATH=/app/.venv/lib/python3.13/site-packages/ddtrace/bootstrap:/app
    DD_TRACE_OPENAI_ENABLED=False
pid=18 python -B -c from multiprocessing.spawn import spawn_main; ... --multiprocessing-fork
    PYTHONPATH=/app/.venv/lib/python3.13/site-packages/ddtrace/bootstrap:/app
    DD_TRACE_OPENAI_ENABLED=False
```

The bootstrap directory is prepended to the image's own `PYTHONPATH=/app` rather than replacing it, and it survives uvicorn's spawn into both workers. This is the same arrangement the monolith already ships, where `ddtrace-run litellm` fronts a multi-worker uvicorn

The backend image, which has no worker knob:

```bash
$ for i in 1 2 3 4 5; do curl -s -o /dev/null -w "%{http_code} " http://127.0.0.1:14729/health/liveliness; done
200 200 200 200 200
$ grep /traces agent.log
POST /v0.5/traces bytes=675  spans=['http.request']
POST /v0.5/traces bytes=1960 spans=['fastapi.request', 'fastapi.serialize_response', ...x6]
```

With `USE_DDTRACE` unset the fixed image is unchanged from today; the wrapper execs uvicorn with the same argv and touches no environment:

```bash
$ docker run -d --name lit4727-ddt-gw-noddt -p 14728:4000 ...no USE_DDTRACE... lit4727-ddt-gateway:fixed
$ for i in 1 2 3 4 5; do curl -s -o /dev/null -w "%{http_code} " http://127.0.0.1:14728/health/liveliness; done
200 200 200 200 200
$ docker exec lit4727-ddt-gw-noddt sh -c '...'
cmd=/app/.venv/bin/python /app/.venv/bin/uvicorn gateway.main:app --workers 2 --host 0.0.0.0 --port 4000
PYTHONPATH=/app
$ grep -c /traces agent.log
0
```

The Terraform change was checked against real images rather than only in the unit tests, using the command string resolved straight out of `cloudrun.tf`. The image under test is `ghcr.io/berriai/litellm-gateway:v1.86.0-dev`, which is what both modules default to and which predates this PR, so it does not contain `docker/component_entrypoint.sh` at all:

```bash
$ CMD='if [ "$USE_DDTRACE" = "true" ]; then export DD_TRACE_OPENAI_ENABLED="False"; exec ddtrace-run uvicorn gateway.main:app --host 0.0.0.0 --port 4000 --workers 2; else exec uvicorn gateway.main:app --host 0.0.0.0 --port 4000 --workers 2; fi'

$ docker run --rm --entrypoint sh ghcr.io/berriai/litellm-gateway:v1.86.0-dev -c 'ls /app/docker/component_entrypoint.sh; command -v ddtrace-run'
ls: /app/docker/component_entrypoint.sh: No such file or directory
/app/.venv/bin/ddtrace-run

$ docker run -d --name pub -p 14734:4000 -e USE_DDTRACE=true ... \
    --entrypoint sh ghcr.io/berriai/litellm-gateway:v1.86.0-dev -c "$CMD"
$ for i in 1 2 3 4 5; do curl -s -o /dev/null -w "%{http_code} " http://127.0.0.1:14734/health/liveliness; done
200 200 200 200 200

$ docker exec pub sh -c 'tr "\0" "\n" < /proc/1/environ | grep -E "^(PYTHONPATH|DD_TRACE_OPENAI_ENABLED)="'
DD_TRACE_OPENAI_ENABLED=False
PYTHONPATH=/app/.venv/lib/python3.13/site-packages/ddtrace/bootstrap:/app

$ grep -o fastapi.request agent.log | wc -l
6
```

That is the point of inlining. An image published long before this PR, with no entrypoint script anywhere in it, starts emitting root request spans the moment the module is applied. Had Terraform called the script instead, this same deployment would either have failed to start or, with an existence check in front of it, come up silently untraced

## Type

🐛 Bug Fix

## Changes

`USE_DDTRACE` was not being wholly ignored in the componentized images, which is worth stating precisely because it explains why the symptom looks partial rather than absent. `gateway/main.py` and `backend/main.py` wrap proxy_server's lifespan, so `ProxyStartupEvent._init_dd_tracer` still runs `ddtrace.patch_all(logging=True, openai=False)`, and `litellm/litellm_core_utils/dd_tracing.py` still binds the real tracer at import time, so litellm's own manual spans emit normally

What never gets installed is ddtrace's ASGI `TraceMiddleware`. The fastapi integration works by wrapping `FastAPI.build_middleware_stack`, and starlette builds that stack lazily on the first `__call__`, which is the lifespan scope. By the time `patch_all` runs inside the lifespan body the stack already exists, and adding middleware after startup raises. The monolith does not hit this because `ddtrace-run` installs its `sitecustomize` bootstrap at interpreter start, before `import fastapi`. The same timing argument covers the httpx, redis and aiohttp references litellm binds at module import

The componentized images bypassed `docker/prod_entrypoint.sh` entirely and exec'd uvicorn directly, so nothing ever wrapped the interpreter. Both now route through a new `docker/component_entrypoint.sh` that prefixes the command with `ddtrace-run` when the flag is on and execs it untouched otherwise. It takes the whole command rather than an app target on purpose: the gateway honors `NUM_WORKERS` and the backend deliberately does not, so leaving argv construction in each Dockerfile keeps that asymmetry intact instead of quietly granting the backend workers it never had

The `DD_TRACE_OPENAI_ENABLED=False` export carries over from `docker/prod_entrypoint.sh`, and it matters more under `ddtrace-run` than it looks. The bootstrap patches the openai integration before any litellm code runs, so the in-process `patch_all(..., openai=False)` cannot suppress it afterwards. Without the export every LLM call gets instrumented twice, once by ddtrace and once by litellm's own Datadog and LLM Observability loggers, and ddtrace additionally captures prompt and completion payloads that litellm's redaction settings are supposed to govern

The wrapping stays behind the `USE_DDTRACE` branch rather than becoming unconditional, since `ddtrace-run` always starts the tracer and a writer thread that tries to reach an agent whether or not one exists

Fixing the images alone would have left this half done, because this repo's own Terraform modules override the image entrypoint and would have kept exec'ing uvicorn directly. Those overrides are already shell strings that spell out the uvicorn invocation, so they now spell out the tracing decision too:

```sh
if [ "$USE_DDTRACE" = "true" ]; then export DD_TRACE_OPENAI_ENABLED="False"; exec ddtrace-run uvicorn gateway.main:app <args>; else exec uvicorn gateway.main:app <args>; fi
```

Inlining rather than calling the script is deliberate. Both modules take a caller-supplied image tag and both default to `v1.86.0-dev`, published long before this PR creates `docker/component_entrypoint.sh`. Terraform therefore cannot reference that file: exec'ing a path the image does not contain fails at container start, and testing for it first would only downgrade those deployments to silently untraced, which is the exact failure this change exists to remove. `ddtrace-run` on the other hand is already present in every componentized image ever published, because `ddtrace` ships in the `proxy-runtime` extra that both Dockerfiles have always installed. Writing the two-line decision inline means old images start tracing as soon as the module is applied, new images do the same, and nothing has to be released in a particular order

On ECS the gateway and backend prepend an S3 config fetch to that command when `proxy_config` is set; the gateway's other branch previously overrode `entryPoint` as an exec-form array, which cannot express a conditional, so it now uses the same `sh -c` shape as its sibling with the uvicorn args folded into the string. On Cloud Run both services join the command onto their existing startup fragments. The ECS backend has one branch that overrides nothing and inherits the image `ENTRYPOINT`, so it needed no change and got none. One comment went away with the branch it described, since it explained appending `--workers` through `command`, which that branch no longer does

The decision now lives in two places, `docker/component_entrypoint.sh` for image-default startup and the Terraform strings for override startup, and that duplication is the price of not depending on a file the caller's image may lack. The tests pin the two to the same contract rather than trusting them to stay in step

Tests live in `tests/test_litellm/test_component_entrypoint.py` and run in the misc unit shard. They drive the script with stub `ddtrace-run` and `uvicorn` executables on `PATH` and assert which one got exec'd, that the openai integration was disabled on that branch only, and that `PYTHONPATH` passes through untouched so `ddtrace-run` still has something to prepend to. A parametrized case pins the componentized gating to `docker/prod_entrypoint.sh` across `unset`, empty, `false`, `True`, `TRUE`, `1` and `yes`, so the two entrypoints cannot drift apart. The rest assert the wiring itself: both images invoke uvicorn through the entrypoint, both make it executable, the gateway keeps `NUM_WORKERS` and the backend stays single-process

The Terraform side gets the same treatment, and it is the only guard those files have, since no CI job lints or validates `terraform/litellm/`. Rather than matching strings, the tests resolve each launch command out of the `.tf` file, expand its interpolations, and run it against the same stub binaries under `USE_DDTRACE` unset, `true`, `false` and `True`, asserting it reaches the same verdict as `docker/component_entrypoint.sh` run under that same value: the same binary exec'd, and the openai integration disabled on the traced branch only. That is what keeps the two copies of the decision honest. Alongside it, every line naming a component ASGI target must honor the knob, the launch-site count is pinned so a deleted site cannot quietly shrink the scan, and the modules are asserted to contain no reference to the entrypoint script path at all

Reverting the Dockerfile wiring while leaving the script in place, which is exactly the shipped bug, fails four of these tests; removing only the `DD_TRACE_OPENAI_ENABLED` export fails one; overwriting `PYTHONPATH` in the wrapper fails one. Collapsing either module's conditional to a bare uvicorn exec fails three tests in that module, dropping only its `DD_TRACE_OPENAI_ENABLED` export fails two, and bypassing any one of the five individual launch sites fails that module's wiring assertion

The `PYTHONPATH` check is worth a note, because its first version was worthless and mutation testing is what exposed that. It originally used `/app` as the fixture value, the same thing the images themselves set. Mutating the wrapper to `export PYTHONPATH="/app"`, which is precisely the bug the assertion exists to catch, left all tests green: the assertion was satisfied by the defect. The sentinel is now a value the wrapper could not plausibly invent, and the identical mutation fails

One thing this PR does not touch: `docker/build_from_pip/Dockerfile.build_from_pip` pins ddtrace yet has a bare `ENTRYPOINT ["litellm"]`, so it carries the same defect. Keeping the scope to the two componentized images

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
