### PR TITLE
test(e2e): derive the throughput SLO per replica and surface locust's error breakdown

### DIFF
--- a/tests/e2e/e2e_config.py
+++ b/tests/e2e/e2e_config.py
@@ -80,14 +80,22 @@ EXPECT_RUST = os.environ.get("E2E_EXPECT_RUST", "").strip().lower() in ("1", "tr
 # Deliberately modest concurrency. The suite shares its proxy with every other
 # suite in the run, and 750 users at spawn rate 50 saturated the request path hard
 # enough to distort latency-sensitive neighbours (and to spend real provider money
-# fast). The SLO is scaled with the user count to keep the same per-user throughput
-# expectation (~0.47 RPS/user), so this still catches a request-path regression
-# rather than becoming a formality. Raise all four via env for a real load run.
+# fast).
 LOAD_USERS = int(os.environ.get("E2E_LOAD_USERS", "200"))
 LOAD_SPAWN_RATE = float(os.environ.get("E2E_LOAD_SPAWN_RATE", "20"))
 LOAD_DURATION_SECONDS = float(os.environ.get("E2E_LOAD_DURATION_SECONDS", "60"))
-LOAD_MIN_RPS = float(os.environ.get("E2E_LOAD_MIN_RPS", "90"))
 LOAD_MAX_FAILURE_RATIO = float(os.environ.get("E2E_LOAD_MAX_FAILURE_RATIO", "0.01"))
+
+# The throughput floor is derived per replica instead of being an absolute fleet
+# number, so the verdict does not depend on how many replicas happen to be warm.
+# One closed-loop user only ever occupies one replica at a time, so a short serial
+# pass measures a single replica's request path: its throughput is 1/latency, and
+# the concurrent phase then has to reach at least that much no matter how large
+# the fleet is. An absolute floor instead asserted replicas x per-replica rate,
+# which reactive autoscaling decides rather than the request path.
+LOAD_BASELINE_SECONDS = float(os.environ.get("E2E_LOAD_BASELINE_SECONDS", "15"))
+LOAD_MAX_SERIAL_LATENCY_SECONDS = float(os.environ.get("E2E_LOAD_MAX_SERIAL_LATENCY_SECONDS", "0.5"))
+LOAD_MIN_CONCURRENCY_EFFICIENCY = float(os.environ.get("E2E_LOAD_MIN_CONCURRENCY_EFFICIENCY", "0.8"))
 
 WEEKLY_ANOMALY_OPT_IN_ENV = "E2E_WEEKLY_ANOMALY"
 ANOMALY_SESSIONS = int(os.environ.get("E2E_ANOMALY_SESSIONS", "6"))

--- a/tests/e2e/load/locust_load.py
+++ b/tests/e2e/load/locust_load.py
@@ -1,24 +1,38 @@
 from __future__ import annotations
 
+import csv
 import os
 import subprocess
 import sys
+import tempfile
 from dataclasses import dataclass
+from itertools import accumulate
 from pathlib import Path
 
 from pydantic import BaseModel, TypeAdapter
 
 _LOCUSTFILE = Path(__file__).with_name("locustfile.py")
+_CSV_PREFIX = "locust"
+_GENERATOR_SATURATION_MARKER = "CPU usage above"
+_MAX_REPORTED_ERRORS = 5
 
 
-class _LocustStatEntry(BaseModel):
+class LocustStatEntry(BaseModel):
     num_requests: int
     num_failures: int
     start_time: float
     last_request_timestamp: float
+    response_times: dict[int, int]
 
 
-_STATS_ADAPTER: TypeAdapter[list[_LocustStatEntry]] = TypeAdapter(list[_LocustStatEntry])
+_STATS_ADAPTER: TypeAdapter[list[LocustStatEntry]] = TypeAdapter(list[LocustStatEntry])
+
+
+@dataclass(frozen=True, slots=True)
+class LoadError:
+    name: str
+    error: str
+    occurrences: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,20 +40,93 @@ class LoadResult:
     requests: int
     failures: int
     requests_per_second: float
+    median_response_seconds: float
+    errors: tuple[LoadError, ...]
+    generator_warnings: tuple[str, ...]
 
     @property
     def failure_ratio(self) -> float:
         return self.failures / self.requests if self.requests else 1.0
 
+    def diagnosis(self) -> str:
+        """What the failed requests actually got, so a red run reads without log archaeology."""
+        ranked = sorted(self.errors, key=lambda error: error.occurrences, reverse=True)
+        lines = [f"{error.occurrences}x {error.name}: {error.error}" for error in ranked[:_MAX_REPORTED_ERRORS]]
+        remainder = len(ranked) - len(lines)
+        if remainder > 0:
+            lines.append(f"and {remainder} more distinct errors")
+        if not lines:
+            lines.append("locust recorded no error breakdown")
+        return "; ".join((*lines, *self.generator_warnings))
 
-def _aggregate(entries: list[_LocustStatEntry]) -> LoadResult:
+
+def median_seconds(entries: list[LocustStatEntry]) -> float:
+    samples = sorted(
+        (milliseconds, count) for entry in entries for milliseconds, count in entry.response_times.items()
+    )
+    total = sum(count for _, count in samples)
+    if total == 0:
+        return 0.0
+    running = accumulate(count for _, count in samples)
+    return next(
+        milliseconds for (milliseconds, _), seen in zip(samples, running) if seen >= total / 2
+    ) / 1000.0
+
+
+def aggregate_stats(
+    entries: list[LocustStatEntry],
+    errors: tuple[LoadError, ...],
+    generator_warnings: tuple[str, ...],
+) -> LoadResult:
     requests = sum(entry.num_requests for entry in entries)
     failures = sum(entry.num_failures for entry in entries)
     if not entries or requests == 0:
-        return LoadResult(requests=requests, failures=failures, requests_per_second=0.0)
+        return LoadResult(
+            requests=requests,
+            failures=failures,
+            requests_per_second=0.0,
+            median_response_seconds=0.0,
+            errors=errors,
+            generator_warnings=generator_warnings,
+        )
     elapsed = max(entry.last_request_timestamp for entry in entries) - min(entry.start_time for entry in entries)
-    rps = requests / elapsed if elapsed > 0 else 0.0
-    return LoadResult(requests=requests, failures=failures, requests_per_second=rps)
+    return LoadResult(
+        requests=requests,
+        failures=failures,
+        requests_per_second=requests / elapsed if elapsed > 0 else 0.0,
+        median_response_seconds=median_seconds(entries),
+        errors=errors,
+        generator_warnings=generator_warnings,
+    )
+
+
+def read_errors(failures_csv: Path) -> tuple[LoadError, ...]:
+    """Locust's per-error breakdown, which its --json summary omits entirely.
+
+    Written on a one-second tick, so the final second of a run may be missing. That is fine
+    for a diagnostic: the counts that decide the assertions come from the JSON summary.
+    A run with no failures writes no rows, and locust omits the file altogether.
+    """
+    if not failures_csv.exists():
+        return ()
+    with failures_csv.open(newline="") as handle:
+        return tuple(
+            LoadError(name=row["Name"], error=row["Error"], occurrences=int(row["Occurrences"]))
+            for row in csv.DictReader(handle)
+        )
+
+
+def read_generator_warnings(stderr: str) -> tuple[str, ...]:
+    """Locust reports its own CPU saturation on stderr; a saturated generator caps the measured rate.
+
+    Kept from the marker onward so the per-line timestamp does not defeat the de-duplication.
+    """
+    saturated = (
+        line[line.index(_GENERATOR_SATURATION_MARKER) :].strip()
+        for line in stderr.splitlines()
+        if _GENERATOR_SATURATION_MARKER in line
+    )
+    return tuple(dict.fromkeys(saturated))
 
 
 def run_chat_load(
@@ -51,43 +138,51 @@ def run_chat_load(
     spawn_rate: float,
     duration_seconds: float,
 ) -> LoadResult:
-    completed = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "locust",
-            "--headless",
-            "--json",
-            "--locustfile",
-            str(_LOCUSTFILE),
-            "--host",
-            base_url,
-            "--users",
-            str(users),
-            "--spawn-rate",
-            str(spawn_rate),
-            "--run-time",
-            f"{int(duration_seconds)}s",
-            "--exit-code-on-error",
-            "0",
-        ],
-        env={**os.environ, "LOAD_API_KEY": api_key, "LOAD_MODEL": model},
-        capture_output=True,
-        text=True,
-        timeout=duration_seconds + 120,
-        check=False,
-    )
-    if completed.returncode != 0:
-        raise RuntimeError(
-            f"locust exited {completed.returncode} before it could report throughput "
-            f"(a startup failure, not request failures, which are folded into the JSON summary via "
-            f"--exit-code-on-error 0):\n{completed.stderr}"
+    with tempfile.TemporaryDirectory(prefix="e2e-load-") as report_dir:
+        csv_prefix = Path(report_dir) / _CSV_PREFIX
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "locust",
+                "--headless",
+                "--json",
+                "--csv",
+                str(csv_prefix),
+                "--locustfile",
+                str(_LOCUSTFILE),
+                "--host",
+                base_url,
+                "--users",
+                str(users),
+                "--spawn-rate",
+                str(spawn_rate),
+                "--run-time",
+                f"{int(duration_seconds)}s",
+                "--exit-code-on-error",
+                "0",
+            ],
+            env={**os.environ, "LOAD_API_KEY": api_key, "LOAD_MODEL": model},
+            capture_output=True,
+            text=True,
+            timeout=duration_seconds + 120,
+            check=False,
         )
-    try:
-        entries = _STATS_ADAPTER.validate_json(completed.stdout)
-    except ValueError as exc:
-        raise RuntimeError(
-            f"locust exited 0 but did not print a parseable --json throughput summary on stdout; "
-            f"got stdout={completed.stdout!r}, stderr={completed.stderr!r}"
-        ) from exc
-    return _aggregate(entries)
+        if completed.returncode != 0:
+            raise RuntimeError(
+                f"locust exited {completed.returncode} before it could report throughput "
+                f"(a startup failure, not request failures, which are folded into the JSON summary via "
+                f"--exit-code-on-error 0):\n{completed.stderr}"
+            )
+        try:
+            entries = _STATS_ADAPTER.validate_json(completed.stdout)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"locust exited 0 but did not print a parseable --json throughput summary on stdout; "
+                f"got stdout={completed.stdout!r}, stderr={completed.stderr!r}"
+            ) from exc
+        return aggregate_stats(
+            entries,
+            read_errors(csv_prefix.with_name(f"{_CSV_PREFIX}_failures.csv")),
+            read_generator_warnings(completed.stderr),
+        )

--- a/tests/e2e/load/test_chat_completions_throughput_e2e.py
+++ b/tests/e2e/load/test_chat_completions_throughput_e2e.py
@@ -1,9 +1,11 @@
 import pytest
 
 from e2e_config import (
+    LOAD_BASELINE_SECONDS,
     LOAD_DURATION_SECONDS,
     LOAD_MAX_FAILURE_RATIO,
-    LOAD_MIN_RPS,
+    LOAD_MAX_SERIAL_LATENCY_SECONDS,
+    LOAD_MIN_CONCURRENCY_EFFICIENCY,
     LOAD_SPAWN_RATE,
     LOAD_USERS,
     PROXY_BASE_URL,
@@ -16,19 +18,37 @@ pytestmark = [pytest.mark.e2e, pytest.mark.load]
 
 
 class TestChatCompletionsThroughput:
-    @pytest.mark.skip(
-        reason=(
-            "LIT-5054: the SLO measures how many gateway replicas happen to be warm, not the "
-            "request path. Clearing the floor needs roughly 5-7 replicas at ~10-14 RPS each, "
-            "stage idles at one, and reactive HPA scale-up lands minutes into a ~3 minute "
-            "test. It has failed both assertions on consecutive days: 93.3% errors at an "
-            "inflated 264 RPS (closed-loop RPS rises when requests fail fast, and those "
-            "requests never reached a pod), then 16.7 RPS with zero failures. Unskip once the "
-            "assertion is independent of fleet size."
-        )
-    )
     @pytest.mark.covers("reliability.perf.throughput.under_slo")
     def test_sustains_throughput_slo_under_load(self, client: LoadClient, load_key: str) -> None:
+        baseline = run_chat_load(
+            base_url=PROXY_BASE_URL,
+            api_key=load_key,
+            model=LOAD_MODEL,
+            users=1,
+            spawn_rate=1,
+            duration_seconds=LOAD_BASELINE_SECONDS,
+        )
+
+        assert baseline.requests > 0 and baseline.requests_per_second > 0, (
+            f"no requests completed against {PROXY_BASE_URL} in the {LOAD_BASELINE_SECONDS}s serial "
+            f"baseline; the load generator never drove traffic (proxy unreachable or model unservable). "
+            f"{baseline.diagnosis()}"
+        )
+        assert baseline.failure_ratio <= LOAD_MAX_FAILURE_RATIO, (
+            f"{baseline.failures}/{baseline.requests} requests failed in the serial baseline "
+            f"({baseline.failure_ratio:.1%} > {LOAD_MAX_FAILURE_RATIO:.1%} allowed), so it calibrates "
+            f"nothing: a request that fails in milliseconds reads as a fast one, passing the latency "
+            f"budget and inflating the floor it derives. {baseline.diagnosis()}"
+        )
+        assert baseline.median_response_seconds <= LOAD_MAX_SERIAL_LATENCY_SECONDS, (
+            f"one user with no competing load saw a median of {baseline.median_response_seconds * 1000:.0f}ms "
+            f"per request, over the {LOAD_MAX_SERIAL_LATENCY_SECONDS * 1000:.0f}ms budget; the request path "
+            f"itself is slow, before any concurrency. {baseline.diagnosis()}"
+        )
+
+        replica_rps = baseline.requests_per_second
+        min_rps = replica_rps * LOAD_MIN_CONCURRENCY_EFFICIENCY
+
         result = run_chat_load(
             base_url=PROXY_BASE_URL,
             api_key=load_key,
@@ -40,14 +60,20 @@ class TestChatCompletionsThroughput:
 
         assert result.requests > 0, (
             f"no requests completed against {PROXY_BASE_URL} in {LOAD_DURATION_SECONDS}s; "
-            f"the load generator never drove traffic (proxy unreachable or model unservable)"
+            f"the load generator never drove traffic (proxy unreachable or model unservable). "
+            f"{result.diagnosis()}"
         )
         assert result.failure_ratio <= LOAD_MAX_FAILURE_RATIO, (
             f"{result.failures}/{result.requests} requests failed "
             f"({result.failure_ratio:.1%} > {LOAD_MAX_FAILURE_RATIO:.1%} allowed); "
-            f"throughput of {result.requests_per_second:.1f} RPS is not a clean read under this error rate"
+            f"throughput of {result.requests_per_second:.1f} RPS is not a clean read under this error rate, "
+            f"since closed-loop throughput rises when requests fail fast. {result.diagnosis()}"
         )
-        assert result.requests_per_second >= LOAD_MIN_RPS, (
+        assert result.requests_per_second >= min_rps, (
             f"sustained {result.requests_per_second:.1f} RPS over {LOAD_DURATION_SECONDS}s with "
-            f"{LOAD_USERS} users, below the {LOAD_MIN_RPS} RPS SLO; the proxy request path regressed under load"
+            f"{LOAD_USERS} users, below the {min_rps:.1f} RPS floor that one replica set on its own "
+            f"({replica_rps:.1f} RPS serial at a {baseline.median_response_seconds * 1000:.0f}ms median, "
+            f"x {LOAD_MIN_CONCURRENCY_EFFICIENCY:.0%}); concurrency made the request path slower per "
+            f"request than a single user did, so the fleet is serialising rather than merely saturated. "
+            f"{result.diagnosis()}"
         )

--- a/tests/e2e/load/test_locust_load.py
+++ b/tests/e2e/load/test_locust_load.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from locust_load import (
+    LoadError,
+    LoadResult,
+    LocustStatEntry,
+    aggregate_stats,
+    median_seconds,
+    read_errors,
+    read_generator_warnings,
+)
+
+_FAILURES_HEADER = "Method,Name,Error,Occurrences,First Seen,Last Seen\n"
+
+
+def _entry(
+    *,
+    num_requests: int,
+    num_failures: int = 0,
+    start_time: float = 1000.0,
+    last_request_timestamp: float = 1010.0,
+    response_times: dict[int, int] | None = None,
+) -> LocustStatEntry:
+    return LocustStatEntry(
+        num_requests=num_requests,
+        num_failures=num_failures,
+        start_time=start_time,
+        last_request_timestamp=last_request_timestamp,
+        response_times=response_times if response_times is not None else {50: num_requests},
+    )
+
+
+def _result(
+    *,
+    errors: tuple[LoadError, ...] = (),
+    generator_warnings: tuple[str, ...] = (),
+) -> LoadResult:
+    return LoadResult(
+        requests=10,
+        failures=10,
+        requests_per_second=1.0,
+        median_response_seconds=0.05,
+        errors=errors,
+        generator_warnings=generator_warnings,
+    )
+
+
+class TestSerialLatency:
+    def test_median_is_the_middle_sample_not_the_mean_a_slow_tail_would_drag(self) -> None:
+        # Nine fast requests and one very slow one: the mean is 1.99s, the median is 20ms.
+        entry = _entry(num_requests=10, response_times={20: 9, 20000: 1})
+
+        assert median_seconds([entry]) == 0.02
+
+    def test_median_merges_the_histograms_of_every_stats_entry(self) -> None:
+        # Per entry the median would be 10ms and 90ms; merged, the middle of the five samples is 90ms.
+        entries = [
+            _entry(num_requests=2, response_times={10: 2}),
+            _entry(num_requests=3, response_times={90: 3}),
+        ]
+
+        assert median_seconds(entries) == 0.09
+
+    def test_an_even_split_takes_the_lower_middle_sample_as_locust_itself_does(self) -> None:
+        entry = _entry(num_requests=4, response_times={10: 2, 90: 2})
+
+        assert median_seconds([entry]) == 0.01
+
+    def test_no_samples_reports_zero_rather_than_dividing_by_an_empty_histogram(self) -> None:
+        assert median_seconds([]) == 0.0
+
+
+class TestAggregate:
+    def test_throughput_spans_the_whole_window_and_latency_comes_from_the_histogram(self) -> None:
+        entry = _entry(
+            num_requests=180,
+            start_time=1000.0,
+            last_request_timestamp=1060.0,
+            response_times={57: 180},
+        )
+
+        result = aggregate_stats([entry], (), ())
+
+        assert result.requests_per_second == 3.0
+        assert result.median_response_seconds == 0.057
+        assert result.failure_ratio == 0.0
+
+    def test_throughput_spans_from_the_earliest_start_when_locust_reports_several_entries(self) -> None:
+        entries = [
+            _entry(num_requests=60, start_time=1000.0, last_request_timestamp=1030.0),
+            _entry(num_requests=60, start_time=1020.0, last_request_timestamp=1060.0),
+        ]
+
+        result = aggregate_stats(entries, (), ())
+
+        assert result.requests_per_second == 2.0
+
+    def test_a_run_that_drove_no_traffic_reports_a_total_failure_ratio(self) -> None:
+        result = aggregate_stats([], (), ())
+
+        assert result.requests == 0
+        assert result.requests_per_second == 0.0
+        assert result.failure_ratio == 1.0
+
+
+class TestErrorBreakdown:
+    def test_locust_failure_rows_become_the_error_breakdown(self, tmp_path: Path) -> None:
+        failures_csv = tmp_path / "locust_failures.csv"
+        failures_csv.write_text(
+            _FAILURES_HEADER
+            + 'POST,/chat/completions,"LocustBadStatusCode(code=401)",381,2026-07-30 12:42:01,2026-07-30 12:45:00\n'
+        )
+
+        assert read_errors(failures_csv) == (
+            LoadError(name="/chat/completions", error="LocustBadStatusCode(code=401)", occurrences=381),
+        )
+
+    def test_a_run_with_no_failures_writes_no_csv_and_reports_no_errors(self, tmp_path: Path) -> None:
+        assert read_errors(tmp_path / "locust_failures.csv") == ()
+
+    def test_diagnosis_leads_with_the_most_common_error(self) -> None:
+        result = _result(
+            errors=(
+                LoadError(name="/chat/completions", error="ConnectionRefused", occurrences=12),
+                LoadError(name="/chat/completions", error="LocustBadStatusCode(code=503)", occurrences=43675),
+            )
+        )
+
+        assert result.diagnosis().startswith("43675x /chat/completions: LocustBadStatusCode(code=503)")
+
+    def test_diagnosis_caps_the_list_and_says_how_many_it_left_out(self) -> None:
+        result = _result(
+            errors=tuple(
+                LoadError(name="/chat/completions", error=f"error-{index}", occurrences=index)
+                for index in range(1, 9)
+            )
+        )
+
+        assert result.diagnosis().count("x /chat/completions") == 5
+        assert "and 3 more distinct errors" in result.diagnosis()
+
+    def test_diagnosis_says_so_when_locust_recorded_nothing(self) -> None:
+        assert _result().diagnosis() == "locust recorded no error breakdown"
+
+
+class TestGeneratorSaturation:
+    def test_repeated_cpu_warnings_collapse_to_one_and_reach_the_diagnosis(self) -> None:
+        stderr = (
+            "[2026-07-31 12:47:01] WARNING/locust.runners: CPU usage above 90%!\n"
+            "[2026-07-31 12:47:02] INFO/locust.main: Run time limit reached\n"
+            "[2026-07-31 12:47:03] WARNING/locust.runners: CPU usage above 90%!\n"
+        )
+
+        warnings = read_generator_warnings(stderr)
+
+        assert len(warnings) == 1
+        assert "CPU usage above 90%!" in warnings[0]
+        assert "CPU usage above 90%!" in _result(generator_warnings=warnings).diagnosis()
+
+    def test_ordinary_locust_chatter_is_not_reported_as_a_warning(self) -> None:
+        assert read_generator_warnings("[2026-07-31] INFO/locust.main: Shutting down (exit code 0)\n") == ()


### PR DESCRIPTION
## TLDR

Problem this solves:

- The throughput floor asserted fleet capacity, not the request path
- It failed on how many gateway replicas HPA had warmed
- A red run said nothing about what the failed requests got

How it solves it:

- Measure one replica first, then require the fleet to match it
- Add a serial latency budget as the request-path assertion
- Read locust's error breakdown and generator warnings back

## Relevant issues

## Linear ticket

Resolves LIT-5054

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Everything below runs against the real stage gateway (`litellm` namespace), from a pod inside the same cluster the daily e2e job runs in, so the network path and the ALB hop are the ones the failing runs took. The load model is a `mock_response` deployment, so no provider is called and no money is spent; that is deliberate, since the assertion is about the proxy request path rather than about an upstream.

### The environment the SLO was actually measuring

```
$ kubectl -n litellm get deploy litellm-gateway -o json | ...
replicas: 1
resources: {"limits":{"cpu":"2","memory":"4Gi"},"requests":{"cpu":"1","memory":"4Gi"}}
env: NUM_WORKERS=1

$ kubectl -n litellm get hpa litellm-gateway
NAME              REFERENCE                    TARGETS                          MINPODS  MAXPODS  REPLICAS
litellm-gateway   Deployment/litellm-gateway   cpu: 6%/60%, memory: 29%/80%     1        10       1

$ kubectl -n litellm get job litellm-e2e-... -o json | ...
E2E_LOAD_USERS = 100      E2E_LOAD_SPAWN_RATE = 25
E2E_LOAD_MIN_RPS = 50     E2E_LOAD_DURATION_SECONDS = 180
```

One warm replica, a floor of 50 RPS, and a three minute window for reactive scale-up to a target of 60% CPU.

### Where 16.7 RPS and "6 seconds per request" come from

Fifty serial requests through the ALB to the gateway, one at a time, twenty five reusing the locust payload and twenty five with a unique prompt so the response cache cannot flatter the result:

```
$ kubectl -n litellm exec lit5054-probe -- sh -c '
    for i in $(seq 1 25); do
      curl -s -o /dev/null -w "%{time_total} %{http_code}\n" -X POST "$PROXY/chat/completions" \
        -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
        -d "{\"model\":\"load-mock\",\"messages\":[{\"role\":\"user\",\"content\":\"load test ping\"}],\"temperature\":0,\"max_tokens\":16}"
    done'
0.090547 200
0.055660 200
0.053988 200
0.056949 200
...
0.089890 200      <- identical payload, median 57ms

0.092396 200
0.089418 200
0.095235 200
...
0.056928 200      <- unique payload, same shape
```

A single-worker replica serves this in about 57ms, so its ceiling is `1 / 0.057 = 17.5` RPS. A hundred closed-loop users against 17 RPS of capacity queue at `100 / 16.7 = 6.0s` each, which is Little's law and not a slow request. Predicted and observed capacity agree, so nothing in the request path is hiding behind the capacity noise.

The same identity on a local single-worker proxy with the same mock model, sweeping the user count over 30s runs:

```
users=  1 req= 10499 fail=0 rps= 351.3 mean_ms=  2.8
users= 10 req= 12242 fail=0 rps= 410.2 mean_ms= 24.3
users= 25 req= 11551 fail=0 rps= 387.0 mean_ms= 64.5
users= 50 req= 11358 fail=0 rps= 381.0 mean_ms=128.7
users=100 req= 11999 fail=0 rps= 402.3 mean_ms=235.4
users=200 req= 10632 fail=0 rps= 356.3 mean_ms=492.1
```

Throughput is flat and latency is `users / throughput` in every row. Throughput is a property of the replica; the reported RPS is a property of how many replicas answered.

### Before, at 0e9a624a97 (the commit before the test was skipped)

The pre-skip test, run in-cluster against stage:

```
$ kubectl -n litellm exec lit5054-runner -- sh -c 'cd /app/e2e && date -u && \
    /app/.venv/bin/python -m pytest load/test_chat_completions_throughput_e2e.py -q -p no:randomly --tb=short'
Sat Aug  1 20:05:20 UTC 2026
F                                                                        [100%]
=================================== FAILURES ===================================
____ TestChatCompletionsThroughput.test_sustains_throughput_slo_under_load _____
E   AssertionError: 22365/25712 requests failed (87.0% > 1.0% allowed); throughput of 144.2 RPS
    is not a clean read under this error rate
E   assert 0.8698273179838207 <= 0.01
1 failed in 181.94s (0:03:01)
Sat Aug  1 20:08:25 UTC 2026
```

That is the ticket's first failure mode reproduced on demand: a large fraction of requests failing, an inflated closed-loop RPS, and no statement anywhere about what the failures actually were.

### After, at a3bfdc6c57

Same pod, same 100 users, same 180s window, twenty seconds later:

```
$ kubectl -n litellm exec lit5054-runner -- sh -c 'cd /app/e2e && date -u && \
    /app/.venv/bin/python -m pytest load/test_chat_completions_throughput_e2e.py -q -p no:randomly --tb=short'
Sat Aug  1 20:08:46 UTC 2026
.                                                                        [100%]
1 passed in 197.27s (0:03:17)
Sat Aug  1 20:12:06 UTC 2026
```

That run had a warm fleet under it, because the run before it had already driven HPA up. Repeating it from a settled single replica, which is the state stage idles in and the state the old floor could never clear, at the amended head `a3bfdc6c57`:

```
$ kubectl -n litellm get deploy litellm-gateway -o jsonpath='{.spec.replicas}'
1
$ kubectl -n litellm exec lit5054-runner -- sh -c 'cd /app/e2e && date -u && \
    /app/.venv/bin/python -m pytest load/test_chat_completions_throughput_e2e.py -q -p no:randomly --tb=short'
Sat Aug  1 20:46:34 UTC 2026
.                                                                        [100%]
1 passed in 197.10s (0:03:17)
Sat Aug  1 20:49:53 UTC 2026
```

Applying the new formulation to the ticket's own recorded failures is the clearest statement of what changed. The three runs that failed with essentially no errors measured 46.1, 16.5, and 23.0 RPS against an absolute 50 RPS floor. One replica serves this model at 13.7 to 17.5 RPS measured two ways, so the floor those runs would face now is 11 to 14 RPS and all three clear it, while a request path that genuinely doubled in cost would show up in the serial median long before the fleet number moved.

### The observability the runner used to throw away

The same rig against a cold replica, printing what the phases measure rather than only whether they passed:

```
[20:22:52Z] serial baseline: 1 user, 15s
  one replica: 13.7 RPS, median 62ms, 0/199 failed
  derived floor: 11.0 RPS
[20:23:08Z] load: 100 users, 180s
  fleet: 81.2 RPS, median 3ms, 9337/14572 failed (64.1%)
  diagnosis: 9335x /chat/completions: LocustBadStatusCode(code=503); 2x /chat/completions: LocustBadStatusCode(code=502)
  old absolute floor 50 RPS -> PASS
  new per-replica floor 11.0 RPS -> PASS
```

Two things to read off that. The failures are 503s from the load balancer rather than anything the proxy returned, which is the ticket's "the failures never reached a proxy" identified by name in the assertion message instead of by log archaeology across pods. And both RPS floors pass, at 81.2 RPS, while 64% of requests are failing: closed-loop throughput rises when requests fail in milliseconds, which is the same artifact the ticket saw at 264 RPS and the reason the failure ratio is asserted first.

That run happened moments after the fleet scaled from eight replicas down to one, so it overlapped load-balancer target churn, and a later run from a settled single replica did not reproduce it. I am not claiming a cause for the 503 storm here; the point is that the next occurrence names itself.

One thing the runs did surface consistently is that the gateway's probes cannot be met under load. `helm/litellm/values.yaml` sets no `timeoutSeconds` on them, so Kubernetes applies its one second default, and a single-worker event loop queueing at seconds cannot answer inside it:

```
$ kubectl -n litellm get events --sort-by=.lastTimestamp | grep -i "probe failed"
Warning  Unhealthy  pod/litellm-gateway-...  Readiness probe failed: Get ".../health/readiness":
  context deadline exceeded (Client.Timeout exceeded while awaiting headers)
Warning  Unhealthy  pod/litellm-gateway-...  Liveness probe failed: Get ".../health/liveliness":
  context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

A working pod failing its own probes during a burst is worth fixing on its own, and it is addressed in a companion chart PR rather than here.

### The error breakdown, and why the baseline now has to be clean

Greptile caught that the serial baseline had no failure check of its own, which is real: a request that fails in milliseconds reads as a fast one. Driving the baseline with an invalid key shows what that would have done, at `a3bfdc6c57`:

```
$ python /tmp/baseline_guard.py sk-bogus-not-a-key
baseline: 95.0 RPS, median 10ms, 1398/1398 failed (100.0%)
  diagnosis: 1329x /chat/completions: LocustBadStatusCode(code=401)
  latency budget 500ms -> PASS
  it would derive a floor of 76.0 RPS
  new baseline failure-ratio guard -> FAIL
```

Without the guard a completely failing baseline passes the latency budget on a 10ms median and hands the load phase a 76 RPS floor built from nothing. With it the test stops at the baseline and names the 401. The old runner, given the same traffic, would have said `1398/1398 requests failed (100.0% > 1.0% allowed)` and nothing else.

Driving the same load against the same proxy with a key that is not valid, so every request fails, shows what the old runner threw away:

```
$ python -c 'from locust_load import run_chat_load; r = run_chat_load(..., api_key="sk-bogus-not-a-key", ...); ...'
requests 455 failures 455 ratio 100.0%
errors (LoadError(name='/chat/completions', error='LocustBadStatusCode(code=401)', occurrences=381),)
DIAGNOSIS: 381x /chat/completions: LocustBadStatusCode(code=401)
```

The old runner would have reported `455/455 requests failed (100.0% > 1.0% allowed)` and stopped there.

### Harness tests and gates, at a3bfdc6c57

```
$ python -m pytest load/test_locust_load.py load/test_session_anomaly.py -q -p no:randomly
......................                                                   [100%]
22 passed in 0.03s

$ uv run --no-sync basedpyright tests/e2e
0 errors, 0 warnings, 0 notes

$ python -m coverage_registry.collector --strict
Headline coverage: 286/436  (65.6%)
23 cell(s) are claimed only by skipped tests, so they count as uncovered
  (reliability.perf.throughput.under_slo is no longer among them)
```

Mutation check on the new harness tests: nine mutations of `locust_load.py`, nine killed, and the restored file verified byte-identical against the pre-mutation copy.

```
m1_mean_not_median  -> 3 failed, 11 passed      m6_elapsed_wrong   -> 1 failed, 13 passed
m2_strict_gt        -> 1 failed, 13 passed      m7_errors_dropped  -> 1 failed, 13 passed
m3_raw_line         -> 1 failed, 13 passed      m8_ratio_zero      -> 1 failed, 13 passed
m4_sort_ascending   -> 1 failed, 13 passed      m9_no_dedupe       -> 1 failed, 13 passed
m5_cap_ten          -> 1 failed, 13 passed      RESTORED           -> 14 passed
```

### One follow-up for the deployment repo

`E2E_LOAD_MIN_RPS` on the e2e job becomes inert with this change and can be dropped from that manifest; nothing reads it after the floor stops being absolute. It does no harm if it stays.

## Type

✅ Test

## Changes

`LOAD_MIN_RPS` was an absolute number the whole fleet had to clear, so the test asserted `replicas x per-replica rate`. One warm gateway pod serves the load model at roughly 17 RPS, so a 50 RPS floor needed three warm replicas and a 90 RPS floor needed five to seven; stage idles at one and reactive HPA scale-up lands minutes into a three minute test. The verdict came from autoscaler timing rather than from anything in the request path.

The test now measures a single replica before it measures the fleet. A closed-loop user only ever occupies one replica at a time, so a short serial pass gives that replica's own throughput and its median per-request latency, both independent of how large the fleet is. Two assertions come out of it. The serial median has to stay inside a latency budget, which is the request-path assertion the absolute floor used to imply; and the concurrent phase has to sustain at least the serial rate, which catches a path that serialises under concurrency instead of merely saturating. Both hold at one replica and at seven, so scale-up timing no longer decides the outcome.

While the failure ratio assertion is unchanged, the runner kept only locust's `--json` stats summary and discarded everything else, so the run where 93% of requests failed reported nothing about what they got and recovering it took log archaeology across gateway pods. The runner now also passes `--csv`, reads locust's failure breakdown back, and keeps locust's own generator-saturation warnings from stderr, both folded into every assertion message. A saturated load generator caps the measured rate, so a run that reports it is a run you can throw out rather than one you chase.

`tests/e2e/load/test_locust_load.py` is new and covers the runner's parsing and aggregation without a proxy, in the same shape as the existing `test_session_anomaly.py` harness tests. It pins the median against a slow tail that would drag a mean, the throughput window across several locust stats entries, the empty-run case, the failure-CSV parsing, the ranking and cap in the diagnosis, and the de-duplication of repeated CPU warnings.

Also worth recording for anyone reading the ticket: the "sustained 16.7 RPS with zero errors" runs were queueing, not slow requests. The load model is a `mock_response` deployment with no upstream at all, one replica serves it in about 57ms, and 100 closed-loop users against `1/0.057` RPS of capacity sit at 6s each by Little's law. Predicted capacity and observed capacity agree, so there is no request-path regression hiding behind the capacity noise.

## QA runbook

- tests/e2e/load/test_chat_completions_throughput_e2e.py::TestChatCompletionsThroughput::test_sustains_throughput_slo_under_load - the gateway serves a mock completion inside a latency budget, and concurrency does not make it slower per request than a single user does
  - [ ] Bring up a proxy with a `load-mock` deployment (`model: openai/load-mock`, `mock_response: "This is a mock response for the throughput load test."`), which the suite's `ensure_load_model` fixture registers through `/model/new` when it is absent
  - [ ] Generate a key scoped to it: `curl -X POST $PROXY/key/generate -H "Authorization: Bearer $LITELLM_MASTER_KEY" -d '{"models":["load-mock"],"user_id":"e2e-load"}'`
  - [ ] Drive one closed-loop user for 15s and read the median per-request time: expect it inside `E2E_LOAD_MAX_SERIAL_LATENCY_SECONDS` (0.5s), and note the RPS it reached
  - [ ] Drive `E2E_LOAD_USERS` users for `E2E_LOAD_DURATION_SECONDS` against the same key and expect at most 1% failures and at least 80% of the single-user rate
  - [ ] Point the same run at a fleet with more warm replicas and expect it to pass unchanged, with a higher measured rate against the same floor
  - [ ] Repeat the single-user pass with a bogus key: expect it to stop at the baseline naming the status code (`LocustBadStatusCode(code=401)`) rather than passing the latency budget on a 10ms median and deriving a floor from failed traffic
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
