### PR TITLE
feat(proxy): bound DB statement and lock time via general_settings

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -3,6 +3,7 @@ import importlib
 import json
 import os
 import random
+import re
 import subprocess
 import sys
 import urllib.parse as urlparse
@@ -12,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Optional, Union
 import click
 import httpx
 from dotenv import load_dotenv
+from pydantic import BaseModel, ConfigDict
 
 import litellm
 from litellm.constants import DEFAULT_NUM_WORKERS_LITELLM_PROXY
@@ -89,6 +91,72 @@ def _build_db_connection_url_params(
     if extra_params:
         params.update(extra_params)
     return params
+
+
+class DatabaseTimeoutSettings(BaseModel):
+    """The `general_settings` keys that bound how long a statement may hold locks.
+
+    Validated at the boundary so a mistyped value fails at startup with a clear
+    pydantic error instead of a TypeError deep inside URL assembly.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    database_statement_timeout: float | None = None
+    database_lock_timeout: float | None = None
+
+
+def _pg_options_with_timeouts(
+    existing_options: str,
+    statement_timeout: float | None,
+    lock_timeout: float | None,
+) -> str:
+    """Return the Postgres ``options`` value carrying the configured timeouts.
+
+    Prisma has no URL parameter for `statement_timeout` / `lock_timeout`; they are
+    server settings delivered through the standard libpq ``options`` parameter as
+    ``-c <name>=<value>``. Values arrive in seconds (matching the sibling
+    ``database_*_timeout`` settings) and are emitted as integer milliseconds,
+    which is the unit Postgres assumes for a unit-less value.
+
+    Both settings are bounds on how long a single statement may hold its locks.
+    Without them a batch that outlives the Prisma client's HTTP read timeout keeps
+    running server side, holding row locks for as long as the database takes,
+    while the client has already given up; every later flush queues behind it.
+    The query engine's own transaction timeout cannot end that wait, because it
+    cannot interrupt a statement that is already executing.
+
+    Any ``options`` the operator already pinned on the URL is preserved, and a
+    setting they pinned there wins over the configured one. Postgres applies the
+    last occurrence of a setting, so a pinned one is honoured by not appending
+    ours at all; it is matched in every spelling the backend accepts
+    (``-c name=``, ``-cname=``, ``--name=``). The result is applied to
+    ``DATABASE_URL`` only, never ``DIRECT_URL``: that one serves migrations,
+    which legitimately run long and must not be cancelled mid-way.
+    """
+    configured = tuple(
+        f"-c {name}={int(seconds * 1000)}"
+        for name, seconds in (
+            ("statement_timeout", statement_timeout),
+            ("lock_timeout", lock_timeout),
+        )
+        if seconds is not None and not re.search(rf"(?:-c\s*|--){re.escape(name)}=", existing_options)
+    )
+    return " ".join(part for part in (existing_options, *configured) if part)
+
+
+def _url_query_value(url: str | None, key: str) -> str:
+    """Return a single query-param value already present on ``url``, else ""."""
+    if not isinstance(url, str) or url == "":
+        return ""
+    return next(iter(urlparse.parse_qs(urlparse.urlparse(url).query).get(key) or ()), "")
+
+
+def _with_query_value(url: str, key: str, value: str) -> str:
+    """Return ``url`` with a single query param replaced by ``value``."""
+    parsed = urlparse.urlparse(url)
+    pairs = tuple((k, v) for k, v in urlparse.parse_qsl(parsed.query) if k != key) + ((key, value),)
+    return urlparse.urlunparse(parsed._replace(query=urlparse.urlencode(pairs)))
 
 
 def append_query_params(url: Optional[str], params: dict) -> str:
@@ -1007,6 +1075,8 @@ def run_server(
         db_socket_timeout: Optional[Union[int, float]] = None
         db_disable_prepared_statements: bool = False
         db_extra_connection_params: Optional[dict] = None
+        db_statement_timeout: float | None = None
+        db_lock_timeout: float | None = None
         general_settings = {}
         ### GET DB TOKEN FOR IAM AUTH ###
 
@@ -1117,6 +1187,9 @@ def run_server(
             else:
                 db_disable_prepared_statements = bool(_disable_prepared_statements)
             db_extra_connection_params = general_settings.get("database_extra_connection_params")
+            db_timeouts = DatabaseTimeoutSettings.model_validate(general_settings)
+            db_statement_timeout = db_timeouts.database_statement_timeout
+            db_lock_timeout = db_timeouts.database_lock_timeout
             if database_url and database_url.startswith("os.environ/"):
                 original_dir = os.getcwd()
                 # set the working directory to where this script is
@@ -1176,8 +1249,19 @@ def run_server(
                 )
                 if os.getenv("DATABASE_URL", None) is not None:
                     database_url = get_secret("DATABASE_URL", default_value=None)
+                    resolved_url: str | None = str(database_url) if database_url else None
+                    pg_options: str = _pg_options_with_timeouts(
+                        _url_query_value(resolved_url, "options"),
+                        db_statement_timeout,
+                        db_lock_timeout,
+                    )
+                    writer_url = (
+                        _with_query_value(resolved_url, "options", pg_options)
+                        if resolved_url and pg_options
+                        else resolved_url
+                    )
                     modified_url = append_query_params(
-                        str(database_url) if database_url else None,
+                        writer_url,
                         connection_url_params,
                     )
                     os.environ["DATABASE_URL"] = modified_url

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -15,6 +15,7 @@ sys.path.insert(
 
 import builtins
 import types
+import urllib.parse as urlparse
 
 import uvicorn
 
@@ -2072,3 +2073,207 @@ class TestWorkerStartupHooks:
 
         assert _dummy_hook_called is True, "First hook was not called"
         assert _dummy_async_hook_called is True, "Second hook was not called"
+
+
+@pytest.mark.xdist_group("proxy_cli")
+class TestPostgresStatementTimeoutOptions:
+    """A batch that outlives the Prisma client's HTTP read timeout keeps running
+    server side and holds its row locks until the database finishes it. Postgres
+    `statement_timeout` / `lock_timeout` are the only bound that ends that wait,
+    so they must survive the trip from general_settings into the connection URL.
+    """
+
+    @pytest.mark.parametrize(
+        "existing, statement_timeout, lock_timeout, expected",
+        [
+            ("", 60, 15, "-c statement_timeout=60000 -c lock_timeout=15000"),
+            ("", 60, None, "-c statement_timeout=60000"),
+            ("", None, 15, "-c lock_timeout=15000"),
+            ("", None, None, ""),
+            ("", 0.25, None, "-c statement_timeout=250"),
+            (
+                "-c search_path=app",
+                60,
+                15,
+                "-c search_path=app -c statement_timeout=60000 -c lock_timeout=15000",
+            ),
+            (
+                "-c statement_timeout=5000",
+                60,
+                15,
+                "-c statement_timeout=5000 -c lock_timeout=15000",
+            ),
+            (
+                "-cstatement_timeout=5000",
+                60,
+                15,
+                "-cstatement_timeout=5000 -c lock_timeout=15000",
+            ),
+            (
+                "--statement_timeout=5000",
+                60,
+                15,
+                "--statement_timeout=5000 -c lock_timeout=15000",
+            ),
+            (
+                "-c  statement_timeout=5000",
+                60,
+                15,
+                "-c  statement_timeout=5000 -c lock_timeout=15000",
+            ),
+        ],
+        ids=[
+            "both",
+            "statement_only",
+            "lock_only",
+            "neither",
+            "fractional_seconds",
+            "preserves_unrelated_option",
+            "pinned_spaced_wins",
+            "pinned_compact_wins",
+            "pinned_double_dash_wins",
+            "pinned_extra_spaces_wins",
+        ],
+    )
+    def test_pg_options_with_timeouts(self, existing, statement_timeout, lock_timeout, expected):
+        from litellm.proxy.proxy_cli import _pg_options_with_timeouts
+
+        assert _pg_options_with_timeouts(existing, statement_timeout, lock_timeout) == expected
+
+    def test_timeouts_reach_the_database_url_from_general_settings(self, tmp_path):
+        """The whole point of the setting: it has to land on DATABASE_URL."""
+        import yaml
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.dump(
+                {
+                    "model_list": [],
+                    "general_settings": {
+                        "database_statement_timeout": 60,
+                        "database_lock_timeout": 15,
+                    },
+                }
+            )
+        )
+
+        modified_url = self._run_server_and_capture_database_url(str(config_path))
+
+        options = urlparse.parse_qs(urlparse.urlparse(modified_url).query)["options"][0]
+        assert "-c statement_timeout=60000" in options
+        assert "-c lock_timeout=15000" in options
+
+    def test_no_options_param_when_unset(self, tmp_path):
+        """Unset must mean today's behavior, not an empty options string."""
+        import yaml
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(yaml.dump({"model_list": [], "general_settings": {}}))
+
+        modified_url = self._run_server_and_capture_database_url(str(config_path))
+
+        assert "options" not in urlparse.parse_qs(urlparse.urlparse(modified_url).query)
+
+    def test_direct_url_is_never_bounded(self, tmp_path):
+        """DIRECT_URL serves migrations, which must not be cancelled mid-way."""
+        import yaml
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.dump({"model_list": [], "general_settings": {"database_statement_timeout": 60}})
+        )
+
+        captured = self._run_server_and_capture_urls(
+            str(config_path), direct_url="postgresql://t:t@localhost:5432/t"
+        )
+
+        assert "options" in urlparse.parse_qs(urlparse.urlparse(captured["DATABASE_URL"]).query)
+        assert "options" not in urlparse.parse_qs(urlparse.urlparse(captured["DIRECT_URL"]).query)
+
+    def test_non_numeric_timeout_fails_fast(self, tmp_path):
+        """A mistyped value must fail at startup, not deep inside URL assembly."""
+        import yaml
+        from pydantic import ValidationError
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.dump({"model_list": [], "general_settings": {"database_statement_timeout": "sixty"}})
+        )
+
+        with pytest.raises(ValidationError):
+            self._run_server_and_capture_database_url(str(config_path))
+
+    def test_operator_pinned_url_options_are_preserved(self, tmp_path):
+        """An operator's own `options` on DATABASE_URL must not be clobbered."""
+        import yaml
+
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.dump(
+                {
+                    "model_list": [],
+                    "general_settings": {"database_statement_timeout": 60},
+                }
+            )
+        )
+
+        modified_url = self._run_server_and_capture_database_url(
+            str(config_path),
+            database_url="postgresql://t:t@localhost:5432/t?options=-c%20search_path%3Dapp",
+        )
+
+        options = urlparse.parse_qs(urlparse.urlparse(modified_url).query)["options"][0]
+        assert "-c search_path=app" in options
+        assert "-c statement_timeout=60000" in options
+
+    @classmethod
+    def _run_server_and_capture_database_url(
+        cls,
+        config_path: str,
+        database_url: str = "postgresql://t:t@localhost:5432/t",
+    ) -> str:
+        return cls._run_server_and_capture_urls(config_path, database_url=database_url)["DATABASE_URL"]
+
+    @staticmethod
+    def _run_server_and_capture_urls(
+        config_path: str,
+        database_url: str = "postgresql://t:t@localhost:5432/t",
+        direct_url: str | None = None,
+    ) -> dict:
+        from litellm.proxy.proxy_cli import run_server
+
+        import yaml
+
+        loaded_config = yaml.safe_load(Path(config_path).read_text())
+        mock_proxy_config = MagicMock()
+        mock_proxy_config.return_value.get_config = AsyncMock(return_value=loaded_config)
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=mock_proxy_config,
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+        clean_env = {k: v for k, v in os.environ.items() if k not in ("DATABASE_URL", "DIRECT_URL")}
+        clean_env["DATABASE_URL"] = database_url
+        if direct_url is not None:
+            clean_env["DIRECT_URL"] = direct_url
+
+        with (
+            patch.dict(os.environ, clean_env, clear=True),
+            patch.dict(
+                "sys.modules",
+                {
+                    "proxy_server": mock_proxy_module,
+                    "litellm.proxy.proxy_server": mock_proxy_module,
+                },
+            ),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)),
+            patch("atexit.register"),
+            patch("litellm.proxy.db.prisma_client.should_update_prisma_schema", return_value=False),
+            patch("litellm.proxy.db.check_migration.check_prisma_schema_diff"),
+        ):
+            run_server.main(
+                ["--config", config_path, "--local", "--skip_server_startup"],
+                standalone_mode=False,
+            )
+            return {k: os.environ[k] for k in ("DATABASE_URL", "DIRECT_URL") if k in os.environ}


### PR DESCRIPTION
## TLDR

Problem this solves:

- A slow spend batch holds DB row locks with no bound
- Client times out at 30s; the server keeps the locks
- Later flush cycles queue behind, exhausting DB sessions
- No way to cap statement or lock time from config

How it solves it:

- New opt-in `database_statement_timeout` / `database_lock_timeout`
- Emitted as libpq `options=-c ...` on `DATABASE_URL`
- Unset keeps today's behavior; never applied to `DIRECT_URL`

## Relevant issues

Related reports: #34232, #33872, #30281

Docs companion: BerriAI/litellm-docs#736 (merge that one first; it documents the two new `general_settings` keys)

## Linear ticket

Resolves LIT-4718

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs are a real proxy against a real Postgres 16, driven by a real paid OpenAI call through `/v1/chat/completions`, with the daily-spend flush doing the writing. To make a flush outlive prisma-client-py's 30s HTTP read timeout on demand, the target table carries a trigger that sleeps; the upsert fires it twice (`BEFORE INSERT` then `BEFORE UPDATE` via `ON CONFLICT`), so the statement runs about 90s

```bash
docker exec -i litfix-4718-pg psql -U litellm -d litellm <<'SQL'
CREATE OR REPLACE FUNCTION slow_daily_spend() RETURNS trigger AS $$
BEGIN PERFORM pg_sleep(45); RETURN NEW; END;
$$ LANGUAGE plpgsql;
CREATE TRIGGER slow_daily_spend_trg BEFORE INSERT OR UPDATE ON "LiteLLM_DailyUserSpend"
  FOR EACH ROW EXECUTE FUNCTION slow_daily_spend();
SQL

curl -s http://127.0.0.1:4718/v1/chat/completions -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.6","messages":[{"role":"user","content":"Say OK"}],"max_completion_tokens":16}'
```

then poll what the database is actually holding

```bash
docker exec litfix-4718-pg psql -U litellm -d litellm -t -A -F'|' -c "
  SELECT pid, state, round(extract(epoch from (now()-xact_start)))||'s', left(query,42)
  FROM pg_stat_activity WHERE datname='litellm' AND xact_start IS NOT NULL;"
docker exec litfix-4718-pg psql -U litellm -d litellm -t -A -c "
  SELECT count(*) FROM pg_locks l JOIN pg_class c ON l.relation=c.oid
  WHERE c.relname='LiteLLM_DailyUserSpend';"
```

### Before, at `97ec0470bf` (no timeouts configured, which is also the default after this PR)

The client gave up at 30s; the transaction kept its lock for 90s

```
t=10s  table_locks=1  | 3327|active|3s |INSERT INTO "public"."LiteLLM_DailyUserSpe
t=31s  table_locks=1  | 3327|active|24s|INSERT INTO "public"."LiteLLM_DailyUserSpe
t=57s  table_locks=1  | 3327|active|50s|INSERT INTO "public"."LiteLLM_DailyUserSpe
t=94s  table_locks=1  | 3327|active|87s|INSERT INTO "public"."LiteLLM_DailyUserSpe
t=99s  table_locks=0  | -none-
```

### After, at `ec24b64126`, with the new settings

```yaml
general_settings:
  database_statement_timeout: 20
  database_lock_timeout: 15
```

The lock is released at the configured bound, and the writer gets a real error instead of a silent stall

```
t=5s   table_locks=1  | 3824|active|0s |INSERT INTO "public"."LiteLLM_DailyUserSpe
t=21s  table_locks=1  | 3824|active|16s|INSERT INTO "public"."LiteLLM_DailyUserSpe
t=26s  table_locks=0  | -none-
```

```
code: "57014", message: "canceling statement due to statement timeout"
```

### Why this is not fixed by wrapping the batch in a bounded transaction

The obvious fix is to run the batch inside `db.tx(timeout=timedelta(seconds=60))`, matching the six sibling spend writers in `db_spend_update_writer.py`. I built that first and measured it against the same rig; it changes nothing, because the query engine's transaction timeout cannot interrupt a statement that is already executing. Postgres `log_statement='all'` on that run

```
2026-08-01 19:41:56.966 UTC [2779] LOG:  BEGIN
2026-08-01 19:41:56.968 UTC [2779] LOG:  execute s18: INSERT INTO "public"."LiteLLM_DailyUserSpend" ...
2026-08-01 19:43:26.981 UTC [2779] LOG:  ROLLBACK
```

90.0s of held locks with a 60s transaction timeout in force. The rollback lands only once the statement finishes, so the bound has to come from Postgres

## Type

🆕 New Feature

## Changes

`litellm/proxy/proxy_cli.py` reads `database_statement_timeout` and `database_lock_timeout` from `general_settings`, validated through a small pydantic model so a mistyped value fails at startup rather than deep inside URL assembly. Values are seconds, matching the sibling `database_connect_timeout` / `database_socket_timeout` settings, and are emitted as integer milliseconds because that is the unit Postgres assumes for a unit-less value

Prisma has no URL parameter for either setting, so they travel as the standard libpq `options` parameter (`-c statement_timeout=60000`). An `options` value the operator already pinned on `DATABASE_URL` is preserved, and a setting pinned there wins over the configured one. Postgres applies the last occurrence of a setting, so honouring a pinned value means not appending ours at all, and the pinned value is matched in every spelling the backend accepts (`-c name=`, `-cname=`, `--name=`), all four of which were confirmed live; `database_extra_connection_params` still wins over both, matching its documented contract. The result is applied to `DATABASE_URL` only and never to `DIRECT_URL`, which Prisma uses for migrations that legitimately run long and must not be cancelled part way

Recommended starting values for a busy deployment are `database_statement_timeout: 60` and `database_lock_timeout: 15`. The lock timeout wants to be well under the statement timeout so a request blocked behind someone else's lock fails fast instead of consuming the whole statement budget

Regression coverage in `tests/test_litellm/proxy/test_proxy_cli.py::TestPostgresStatementTimeoutOptions` covers the seconds-to-milliseconds conversion, both settings independently, an operator-pinned `search_path` surviving, an operator-pinned `statement_timeout` winning in all four accepted spellings, the settings reaching `DATABASE_URL` through a real `run_server` invocation, `DIRECT_URL` staying unbounded, no `options` parameter at all when unset, and a non-numeric value failing fast. Seven mutants of the production code were each killed by at least one of them

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
