### PR TITLE
fix(mcp): configurable session owner fingerprint and cap for shared keys

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -121,6 +121,23 @@ MCP_TOOL_LISTING_TIMEOUT = float(os.getenv("LITELLM_MCP_TOOL_LISTING_TIMEOUT", "
 MCP_METADATA_TIMEOUT = float(os.getenv("LITELLM_MCP_METADATA_TIMEOUT", "10.0"))
 MCP_HEALTH_CHECK_TIMEOUT = float(os.getenv("LITELLM_MCP_HEALTH_CHECK_TIMEOUT", "10.0"))
 
+# Cap concurrent stateful MCP sessions per caller fingerprint. Shared API keys
+# collapse many users into one bucket unless session ownership is customized
+# via MCP_SESSION_OWNER_HEADER / MCP_SESSION_OWNER_PREFER_IP (see #35383).
+MCP_MAX_STATEFUL_SESSIONS_PER_OWNER = int(os.getenv("LITELLM_MCP_MAX_STATEFUL_SESSIONS_PER_OWNER", "100"))
+# When present on a request, this header is hashed and preferred over the API
+# key for session-owner fingerprinting — so IDE / plugin users behind a shared
+# service-account key get independent session caps. Empty string disables.
+MCP_SESSION_OWNER_HEADER = os.getenv("LITELLM_MCP_SESSION_OWNER_HEADER", "x-litellm-mcp-session-owner")
+# When true, bucket sessions by client IP before the API key so callers that
+# share a service-account key but arrive from different IPs get separate caps.
+MCP_SESSION_OWNER_PREFER_IP = os.getenv("LITELLM_MCP_SESSION_OWNER_PREFER_IP", "false").lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
+
 # Allowlist of commands permitted for MCP stdio transport.
 # Prevents arbitrary command execution via /mcp-rest/test/* endpoints or server creation.
 # Note: allowlisted runtimes can still execute code via args (e.g. python -c "...").

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -121,16 +121,44 @@ MCP_TOOL_LISTING_TIMEOUT = float(os.getenv("LITELLM_MCP_TOOL_LISTING_TIMEOUT", "
 MCP_METADATA_TIMEOUT = float(os.getenv("LITELLM_MCP_METADATA_TIMEOUT", "10.0"))
 MCP_HEALTH_CHECK_TIMEOUT = float(os.getenv("LITELLM_MCP_HEALTH_CHECK_TIMEOUT", "10.0"))
 
+
+def _positive_int_env(name: str, default: int) -> int:
+    """Parse a positive int env var; invalid or non-positive values use ``default``."""
+    raw = os.getenv(name)
+    if raw is None or str(raw).strip() == "":
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
 # Cap concurrent stateful MCP sessions per caller fingerprint. Shared API keys
 # collapse many users into one bucket unless session ownership is customized
 # via MCP_SESSION_OWNER_HEADER / MCP_SESSION_OWNER_PREFER_IP (see #35383).
-MCP_MAX_STATEFUL_SESSIONS_PER_OWNER = int(os.getenv("LITELLM_MCP_MAX_STATEFUL_SESSIONS_PER_OWNER", "100"))
-# When present on a request, this header is hashed and preferred over the API
-# key for session-owner fingerprinting — so IDE / plugin users behind a shared
-# service-account key get independent session caps. Empty string disables.
+# Non-positive / invalid values fall back to 100 so every initialize is not 429'd.
+MCP_MAX_STATEFUL_SESSIONS_PER_OWNER = _positive_int_env("LITELLM_MCP_MAX_STATEFUL_SESSIONS_PER_OWNER", 100)
+# Hard ceiling across all sub-buckets of one authenticated identity. Stops a
+# client from rotating x-litellm-mcp-session-owner (or client IPs) to bypass
+# the per-owner cap under a single valid API key. Never tighter than the
+# per-owner cap.
+_MCP_AUTH_IDENTITY_CEILING_DEFAULT = max(1000, MCP_MAX_STATEFUL_SESSIONS_PER_OWNER * 10)
+MCP_MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY = max(
+    _positive_int_env(
+        "LITELLM_MCP_MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY",
+        _MCP_AUTH_IDENTITY_CEILING_DEFAULT,
+    ),
+    MCP_MAX_STATEFUL_SESSIONS_PER_OWNER,
+)
+# When present on a request, this header is combined with the authenticated
+# identity (not a replacement) so IDE / plugin users behind a shared
+# service-account key get independent session caps without enabling
+# cross-key session hijacking. Empty string disables.
 MCP_SESSION_OWNER_HEADER = os.getenv("LITELLM_MCP_SESSION_OWNER_HEADER", "x-litellm-mcp-session-owner")
-# When true, bucket sessions by client IP before the API key so callers that
-# share a service-account key but arrive from different IPs get separate caps.
+# When true, combine client IP with the authenticated identity (not a
+# replacement) so callers that share a key but arrive from distinct IPs
+# get separate per-owner caps.
 MCP_SESSION_OWNER_PREFER_IP = os.getenv("LITELLM_MCP_SESSION_OWNER_PREFER_IP", "false").lower() in (
     "1",
     "true",

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -134,6 +134,22 @@ def _positive_int_env(name: str, default: int) -> int:
     return value if value > 0 else default
 
 
+def _env_str(name: str, default: str) -> str:
+    """Read a string env var; missing values use ``default``."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return str(raw)
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    """Parse a boolean env var (1/true/yes/on); missing values use ``default``."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return str(raw).lower() in ("1", "true", "yes", "on")
+
+
 # Cap concurrent stateful MCP sessions per caller fingerprint. Shared API keys
 # collapse many users into one bucket unless session ownership is customized
 # via MCP_SESSION_OWNER_HEADER / MCP_SESSION_OWNER_PREFER_IP (see #35383).
@@ -155,16 +171,11 @@ MCP_MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY = max(
 # identity (not a replacement) so IDE / plugin users behind a shared
 # service-account key get independent session caps without enabling
 # cross-key session hijacking. Empty string disables.
-MCP_SESSION_OWNER_HEADER = os.getenv("LITELLM_MCP_SESSION_OWNER_HEADER", "x-litellm-mcp-session-owner")
+MCP_SESSION_OWNER_HEADER = _env_str("LITELLM_MCP_SESSION_OWNER_HEADER", "x-litellm-mcp-session-owner")
 # When true, combine client IP with the authenticated identity (not a
 # replacement) so callers that share a key but arrive from distinct IPs
 # get separate per-owner caps.
-MCP_SESSION_OWNER_PREFER_IP = os.getenv("LITELLM_MCP_SESSION_OWNER_PREFER_IP", "false").lower() in (
-    "1",
-    "true",
-    "yes",
-    "on",
-)
+MCP_SESSION_OWNER_PREFER_IP = _env_bool("LITELLM_MCP_SESSION_OWNER_PREFER_IP", False)
 
 # Allowlist of commands permitted for MCP stdio transport.
 # Prevents arbitrary command execution via /mcp-rest/test/* endpoints or server creation.

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -29,7 +29,12 @@ from starlette.responses import JSONResponse
 from starlette.types import Message, Receive, Scope, Send
 
 from litellm._logging import verbose_logger
-from litellm.constants import MAXIMUM_TRACEBACK_LINES_TO_LOG
+from litellm.constants import (
+    MAXIMUM_TRACEBACK_LINES_TO_LOG,
+    MCP_MAX_STATEFUL_SESSIONS_PER_OWNER,
+    MCP_SESSION_OWNER_HEADER,
+    MCP_SESSION_OWNER_PREFER_IP,
+)
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.llms.custom_httpx.http_handler import (
     get_async_httpx_client,
@@ -98,8 +103,8 @@ _STATEFUL_SESSION_IDLE_TIMEOUT_SECONDS = 30 * 60
 # without a cap an authenticated client could spam `initialize` and exhaust
 # memory. The caller's own oldest idle sessions are evicted to make room; if
 # the cap is still hit (every session in flight), the new `initialize` is
-# rejected with 429.
-_MAX_STATEFUL_SESSIONS_PER_OWNER = 100
+# rejected with 429. Override via LITELLM_MCP_MAX_STATEFUL_SESSIONS_PER_OWNER.
+_MAX_STATEFUL_SESSIONS_PER_OWNER = MCP_MAX_STATEFUL_SESSIONS_PER_OWNER
 # Maximum bytes to peek when sniffing the JSON-RPC method on a POST.
 # An `initialize` envelope is a few hundred bytes; capping the peek
 # prevents an authenticated client from forcing the proxy to buffer an
@@ -3431,6 +3436,7 @@ if MCP_AVAILABLE:
         user_api_key_auth: UserAPIKeyAuth | None,
         oauth2_headers: dict[str, str] | None = None,
         client_ip: str | None = None,
+        request_headers: dict[str, str] | None = None,
     ) -> str:
         """
         Stable, non-reversible identifier for the caller used to bind an
@@ -3441,6 +3447,17 @@ if MCP_AVAILABLE:
         the caller's identity is the upstream OAuth bearer; hash it so two
         OAuth callers with different tokens don't both fingerprint to
         ``anonymous`` and end up sharing a session.
+
+        Shared API keys collapse every caller into one owner bucket by default.
+        Deployments that distribute one service-account key to many IDE /
+        plugin users can opt out of that collapse in two ways:
+
+        1. Send ``LITELLM_MCP_SESSION_OWNER_HEADER`` (default
+           ``x-litellm-mcp-session-owner``) with a per-user value — that header
+           is preferred over the API key when present.
+        2. Set ``LITELLM_MCP_SESSION_OWNER_PREFER_IP=true`` so the client IP is
+           preferred over the API key (useful when callers share a key but
+           arrive from distinct IPs).
 
         When no caller-identifying credentials are available at all
         (e.g. proxy running without master key, or an unauthenticated
@@ -3464,6 +3481,21 @@ if MCP_AVAILABLE:
             if isinstance(value, str):
                 return value.encode("utf-8")
             return None
+
+        # Prefer an explicit per-caller owner header over a shared API key so
+        # IDE / plugin users behind one service-account key get independent
+        # session caps (#35383).
+        if MCP_SESSION_OWNER_HEADER and request_headers:
+            normalized = {str(k).lower(): v for k, v in request_headers.items() if isinstance(k, str)}
+            owner_hdr = normalized.get(MCP_SESSION_OWNER_HEADER.lower())
+            owner_bytes = _bytes_for_hash(owner_hdr)
+            if owner_bytes:
+                return f"hdr:{hashlib.sha256(owner_bytes).hexdigest()}"
+
+        # Prefer client IP over API key when configured for shared-key
+        # deployments that still have distinct source IPs.
+        if MCP_SESSION_OWNER_PREFER_IP and client_ip and isinstance(client_ip, str):
+            return f"ip:{hashlib.sha256(client_ip.encode('utf-8')).hexdigest()}"
 
         if user_api_key_auth is not None:
             key_material = _bytes_for_hash(getattr(user_api_key_auth, "api_key", None))
@@ -4198,7 +4230,7 @@ if MCP_AVAILABLE:
             # response sees a pristine ``receive`` channel.
             if session_id:
                 expected_owner = _stateful_session_owners.get(session_id)
-                request_owner = _owner_fingerprint_for(user_api_key_auth, oauth2_headers, _client_ip)
+                request_owner = _owner_fingerprint_for(user_api_key_auth, oauth2_headers, _client_ip, raw_headers)
                 if expected_owner is not None and expected_owner != request_owner:
                     verbose_logger.warning(
                         "Rejecting MCP request: session '%s' owner mismatch.",
@@ -4242,7 +4274,7 @@ if MCP_AVAILABLE:
             # session. Cap how many a single caller can hold so an authenticated
             # client cannot spam `initialize` and exhaust memory.
             if is_initialize and not session_id:
-                request_owner = _owner_fingerprint_for(user_api_key_auth, oauth2_headers, _client_ip)
+                request_owner = _owner_fingerprint_for(user_api_key_auth, oauth2_headers, _client_ip, raw_headers)
                 if not await _enforce_stateful_session_cap_for_owner(request_owner):
                     verbose_logger.warning(
                         "Rejecting MCP initialize: caller already holds the maximum number of active stateful sessions."
@@ -4361,7 +4393,7 @@ if MCP_AVAILABLE:
                     local_send = _wrap_send_with_stateful_session_auth_context(
                         local_send,
                         auth_user,
-                        _owner_fingerprint_for(user_api_key_auth, oauth2_headers, _client_ip),
+                        _owner_fingerprint_for(user_api_key_auth, oauth2_headers, _client_ip, raw_headers),
                         _track_initialized_stateful_session,
                     )
 

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -557,7 +557,9 @@ if MCP_AVAILABLE:
     # Maps session_id -> authenticated-identity fingerprint (API key / user /
     # OAuth bearer only). Used for the hard ceiling that stops header/IP
     # rotation from creating unbounded sessions under one credential.
-    _stateful_session_auth_identities: dict[str, str] = {}
+    _stateful_session_auth_identities: dict[
+        str, str
+    ] = {}  # mutable-ok: session registry mutated on initialize/terminate
     # Per-session lock that serializes ``handle_request`` for the same
     # mcp-session-id. The stored ``MCPAuthenticatedUser`` is mutated in place
     # by ``_update_auth_context`` each request; without this lock, two
@@ -681,14 +683,16 @@ if MCP_AVAILABLE:
             # owner fingerprint (header/IP/anonymous).
             return True
 
-        server_instances = getattr(session_manager_stateful, "_server_instances", {})
+        server_instances = getattr(session_manager_stateful, "_server_instances", None)
+        if server_instances is None:
+            server_instances = types.MappingProxyType({})
 
-        def _identity_live_session_ids() -> list[str]:
-            return [
+        def _identity_live_session_ids() -> tuple[str, ...]:
+            return tuple(
                 session_id
                 for session_id, identity in _stateful_session_auth_identities.items()
                 if identity == auth_identity and session_id in server_instances
-            ]
+            )
 
         owned = _identity_live_session_ids()
         if len(owned) < _MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY:
@@ -3497,7 +3501,7 @@ if MCP_AVAILABLE:
 
     def _auth_identity_material(
         user_api_key_auth: UserAPIKeyAuth | None,
-        oauth2_headers: dict[str, str] | None = None,
+        oauth2_headers: Mapping[str, str] | None = None,
     ) -> tuple[str, bytes] | None:
         """
         Return ``(kind, material)`` for the authenticated caller, or ``None``
@@ -3522,7 +3526,7 @@ if MCP_AVAILABLE:
 
     def _auth_identity_fingerprint_for(
         user_api_key_auth: UserAPIKeyAuth | None,
-        oauth2_headers: dict[str, str] | None = None,
+        oauth2_headers: Mapping[str, str] | None = None,
     ) -> str:
         """
         Authenticated-identity fingerprint used for the hard session ceiling.
@@ -3538,9 +3542,9 @@ if MCP_AVAILABLE:
 
     def _owner_fingerprint_for(
         user_api_key_auth: UserAPIKeyAuth | None,
-        oauth2_headers: dict[str, str] | None = None,
+        oauth2_headers: Mapping[str, str] | None = None,
         client_ip: str | None = None,
-        request_headers: dict[str, str] | None = None,
+        request_headers: Mapping[str, str] | None = None,
     ) -> str:
         """
         Stable, non-reversible identifier for the caller used to bind an
@@ -3584,8 +3588,13 @@ if MCP_AVAILABLE:
 
         owner_hdr_bytes: bytes | None = None
         if MCP_SESSION_OWNER_HEADER and request_headers:
-            normalized = {str(k).lower(): v for k, v in request_headers.items() if isinstance(k, str)}
-            owner_hdr_bytes = _bytes_for_owner_hash(normalized.get(MCP_SESSION_OWNER_HEADER.lower()))
+            target = MCP_SESSION_OWNER_HEADER.lower()
+            owner_hdr_value: str | None = None
+            for key, value in request_headers.items():
+                if isinstance(key, str) and key.lower() == target and isinstance(value, str):
+                    owner_hdr_value = value
+                    break
+            owner_hdr_bytes = _bytes_for_owner_hash(owner_hdr_value)
 
         # Bind optional sub-identity to authenticated material so shared-key
         # users get independent buckets without enabling cross-key hijacking.
@@ -4372,31 +4381,23 @@ if MCP_AVAILABLE:
             if is_initialize and not session_id:
                 request_owner = _owner_fingerprint_for(user_api_key_auth, oauth2_headers, _client_ip, raw_headers)
                 auth_identity = _auth_identity_fingerprint_for(user_api_key_auth, oauth2_headers)
-                if not await _enforce_stateful_session_cap_for_owner(request_owner):
-                    verbose_logger.warning(
-                        "Rejecting MCP initialize: caller already holds the maximum number of active stateful sessions."
-                    )
+
+                async def _reject_too_many_sessions(details: str) -> None:
+                    verbose_logger.warning("Rejecting MCP initialize: %s", details)
                     too_many_response = JSONResponse(
                         status_code=429,
-                        content={
+                        content={  # mutable-ok: JSONResponse requires a JSON object payload
                             "error": "Too Many Requests",
-                            "details": "Too many active MCP sessions for this caller.",
+                            "details": details,
                         },
                     )
                     await too_many_response(scope, receive, send)
+
+                if not await _enforce_stateful_session_cap_for_owner(request_owner):
+                    await _reject_too_many_sessions("Too many active MCP sessions for this caller.")
                     return
                 if not await _enforce_stateful_session_cap_for_auth_identity(auth_identity):
-                    verbose_logger.warning(
-                        "Rejecting MCP initialize: authenticated identity already holds the maximum number of active stateful sessions."
-                    )
-                    too_many_response = JSONResponse(
-                        status_code=429,
-                        content={
-                            "error": "Too Many Requests",
-                            "details": "Too many active MCP sessions for this authenticated identity.",
-                        },
-                    )
-                    await too_many_response(scope, receive, send)
+                    await _reject_too_many_sessions("Too many active MCP sessions for this authenticated identity.")
                     return
 
             # Replay body messages if we consumed them for peeking

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -3598,6 +3598,9 @@ if MCP_AVAILABLE:
 
         # Bind optional sub-identity to authenticated material so shared-key
         # users get independent buckets without enabling cross-key hijacking.
+        # Intentionally ignore the owner header when there is no authenticated
+        # identity: otherwise an unauthenticated client can rotate the header
+        # on every initialize and bypass both session caps (#35383 / Veria).
         if identity is not None and owner_hdr_bytes is not None:
             kind, material = identity
             digest = hashlib.sha256(material + b"\0" + owner_hdr_bytes).hexdigest()
@@ -3612,10 +3615,8 @@ if MCP_AVAILABLE:
             kind, material = identity
             return f"{kind}:{hashlib.sha256(material).hexdigest()}"
 
-        # No authenticated identity: optional header still distinguishes
-        # anonymous callers, then IP, then the anonymous sentinel.
-        if owner_hdr_bytes is not None:
-            return f"hdr:{hashlib.sha256(owner_hdr_bytes).hexdigest()}"
+        # No authenticated identity: fall back to client IP, then anonymous.
+        # Do not honor a client-supplied owner header here.
         if client_ip and isinstance(client_ip, str):
             return f"ip:{hashlib.sha256(client_ip.encode('utf-8')).hexdigest()}"
         return "anonymous"

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -31,6 +31,7 @@ from starlette.types import Message, Receive, Scope, Send
 from litellm._logging import verbose_logger
 from litellm.constants import (
     MAXIMUM_TRACEBACK_LINES_TO_LOG,
+    MCP_MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY,
     MCP_MAX_STATEFUL_SESSIONS_PER_OWNER,
     MCP_SESSION_OWNER_HEADER,
     MCP_SESSION_OWNER_PREFER_IP,
@@ -105,6 +106,10 @@ _STATEFUL_SESSION_IDLE_TIMEOUT_SECONDS = 30 * 60
 # the cap is still hit (every session in flight), the new `initialize` is
 # rejected with 429. Override via LITELLM_MCP_MAX_STATEFUL_SESSIONS_PER_OWNER.
 _MAX_STATEFUL_SESSIONS_PER_OWNER = MCP_MAX_STATEFUL_SESSIONS_PER_OWNER
+# Hard ceiling across all owner sub-buckets of one authenticated identity
+# (shared API key / user / OAuth bearer). Prevents rotating session-owner
+# headers or client IPs from bypassing the per-owner cap.
+_MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY = MCP_MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY
 # Maximum bytes to peek when sniffing the JSON-RPC method on a POST.
 # An `initialize` envelope is a few hundred bytes; capping the peek
 # prevents an authenticated client from forcing the proxy to buffer an
@@ -549,6 +554,10 @@ if MCP_AVAILABLE:
     # Without this, a leaked mcp-session-id could be driven (or terminated)
     # by any other authenticated proxy user.
     _stateful_session_owners: dict[str, str] = {}
+    # Maps session_id -> authenticated-identity fingerprint (API key / user /
+    # OAuth bearer only). Used for the hard ceiling that stops header/IP
+    # rotation from creating unbounded sessions under one credential.
+    _stateful_session_auth_identities: dict[str, str] = {}
     # Per-session lock that serializes ``handle_request`` for the same
     # mcp-session-id. The stored ``MCPAuthenticatedUser`` is mutated in place
     # by ``_update_auth_context`` each request; without this lock, two
@@ -562,6 +571,7 @@ if MCP_AVAILABLE:
         _stateful_session_auth_contexts.pop(session_id, None)
         _stateful_session_auth_context_last_seen.pop(session_id, None)
         _stateful_session_owners.pop(session_id, None)
+        _stateful_session_auth_identities.pop(session_id, None)
         _stateful_session_locks.pop(session_id, None)
         _stateful_session_active_request_counts.pop(session_id, None)
 
@@ -655,6 +665,49 @@ if MCP_AVAILABLE:
             _remove_stateful_session_tracking(session_id)
 
         return len(_owned_live_session_ids()) < _MAX_STATEFUL_SESSIONS_PER_OWNER
+
+    async def _enforce_stateful_session_cap_for_auth_identity(auth_identity: str) -> bool:
+        """
+        Hard ceiling across every owner sub-bucket of one authenticated
+        identity (API key / user / OAuth bearer).
+
+        Complements ``_enforce_stateful_session_cap_for_owner``: a client that
+        rotates ``x-litellm-mcp-session-owner`` (or client IP) under one valid
+        credential cannot open unbounded stateful sessions.
+        """
+        if not auth_identity or auth_identity == "anonymous":
+            # Unauthenticated callers have no shared credential to abuse via
+            # header rotation; the per-owner cap still applies to their
+            # owner fingerprint (header/IP/anonymous).
+            return True
+
+        server_instances = getattr(session_manager_stateful, "_server_instances", {})
+
+        def _identity_live_session_ids() -> list[str]:
+            return [
+                session_id
+                for session_id, identity in _stateful_session_auth_identities.items()
+                if identity == auth_identity and session_id in server_instances
+            ]
+
+        owned = _identity_live_session_ids()
+        if len(owned) < _MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY:
+            return True
+
+        for session_id in sorted(
+            owned,
+            key=lambda sid: _stateful_session_auth_context_last_seen.get(sid, 0.0),
+        ):
+            if len(_identity_live_session_ids()) < _MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY:
+                break
+            if _stateful_session_active_request_counts.get(session_id, 0) > 0:
+                continue
+            transport = server_instances.pop(session_id, None)
+            if transport is not None:
+                await transport.terminate()
+            _remove_stateful_session_tracking(session_id)
+
+        return len(_identity_live_session_ids()) < _MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY
 
     async def _cleanup_expired_stateful_session_auth_contexts() -> None:
         while True:
@@ -3432,6 +3485,57 @@ if MCP_AVAILABLE:
                 return header_value.decode() if isinstance(header_value, bytes) else str(header_value)
         return None
 
+    def _bytes_for_owner_hash(value: Any) -> bytes | None:
+        """Only hash str/bytes secrets; skip mocks and other unexpected types."""
+        if value is None:
+            return None
+        if isinstance(value, (bytes, bytearray)):
+            return bytes(value)
+        if isinstance(value, str):
+            return value.encode("utf-8")
+        return None
+
+    def _auth_identity_material(
+        user_api_key_auth: UserAPIKeyAuth | None,
+        oauth2_headers: dict[str, str] | None = None,
+    ) -> tuple[str, bytes] | None:
+        """
+        Return ``(kind, material)`` for the authenticated caller, or ``None``
+        when no authenticated identity is available.
+
+        Kind is one of ``key``, ``user``, or ``oauth``. Material is the raw
+        secret bytes used for hashing — never logged or stored in cleartext.
+        """
+        if user_api_key_auth is not None:
+            key_material = _bytes_for_owner_hash(getattr(user_api_key_auth, "api_key", None))
+            if key_material:
+                return ("key", key_material)
+            uid_material = _bytes_for_owner_hash(getattr(user_api_key_auth, "user_id", None))
+            if uid_material:
+                return ("user", uid_material)
+        if oauth2_headers:
+            authz = oauth2_headers.get("Authorization") or oauth2_headers.get("authorization")
+            authz_bytes = _bytes_for_owner_hash(authz)
+            if authz_bytes:
+                return ("oauth", authz_bytes)
+        return None
+
+    def _auth_identity_fingerprint_for(
+        user_api_key_auth: UserAPIKeyAuth | None,
+        oauth2_headers: dict[str, str] | None = None,
+    ) -> str:
+        """
+        Authenticated-identity fingerprint used for the hard session ceiling.
+
+        Intentionally ignores session-owner headers and client IP so rotating
+        those values cannot open a new unlimited bucket under one credential.
+        """
+        identity = _auth_identity_material(user_api_key_auth, oauth2_headers)
+        if identity is None:
+            return "anonymous"
+        kind, material = identity
+        return f"{kind}:{hashlib.sha256(material).hexdigest()}"
+
     def _owner_fingerprint_for(
         user_api_key_auth: UserAPIKeyAuth | None,
         oauth2_headers: dict[str, str] | None = None,
@@ -3450,14 +3554,19 @@ if MCP_AVAILABLE:
 
         Shared API keys collapse every caller into one owner bucket by default.
         Deployments that distribute one service-account key to many IDE /
-        plugin users can opt out of that collapse in two ways:
+        plugin users can subdivide that bucket in two ways — both **combine**
+        the sub-identity with the authenticated credential (they never replace
+        it), so a different API key cannot satisfy another caller's owner
+        check by replaying the same header/IP:
 
         1. Send ``LITELLM_MCP_SESSION_OWNER_HEADER`` (default
-           ``x-litellm-mcp-session-owner``) with a per-user value — that header
-           is preferred over the API key when present.
-        2. Set ``LITELLM_MCP_SESSION_OWNER_PREFER_IP=true`` so the client IP is
-           preferred over the API key (useful when callers share a key but
-           arrive from distinct IPs).
+           ``x-litellm-mcp-session-owner``) with a per-user value.
+        2. Set ``LITELLM_MCP_SESSION_OWNER_PREFER_IP=true`` to combine client
+           IP with the authenticated identity.
+
+        A separate per-auth-identity ceiling
+        (``LITELLM_MCP_MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY``) still bounds
+        total sessions under one credential when headers/IPs are rotated.
 
         When no caller-identifying credentials are available at all
         (e.g. proxy running without master key, or an unauthenticated
@@ -3471,46 +3580,33 @@ if MCP_AVAILABLE:
         unauthenticated caller who learns the session id — owner-binding
         is best-effort in that mode.
         """
+        identity = _auth_identity_material(user_api_key_auth, oauth2_headers)
 
-        def _bytes_for_hash(value: Any) -> bytes | None:
-            """Only hash str/bytes secrets; skip mocks and other unexpected types."""
-            if value is None:
-                return None
-            if isinstance(value, (bytes, bytearray)):
-                return bytes(value)
-            if isinstance(value, str):
-                return value.encode("utf-8")
-            return None
-
-        # Prefer an explicit per-caller owner header over a shared API key so
-        # IDE / plugin users behind one service-account key get independent
-        # session caps (#35383).
+        owner_hdr_bytes: bytes | None = None
         if MCP_SESSION_OWNER_HEADER and request_headers:
             normalized = {str(k).lower(): v for k, v in request_headers.items() if isinstance(k, str)}
-            owner_hdr = normalized.get(MCP_SESSION_OWNER_HEADER.lower())
-            owner_bytes = _bytes_for_hash(owner_hdr)
-            if owner_bytes:
-                return f"hdr:{hashlib.sha256(owner_bytes).hexdigest()}"
+            owner_hdr_bytes = _bytes_for_owner_hash(normalized.get(MCP_SESSION_OWNER_HEADER.lower()))
 
-        # Prefer client IP over API key when configured for shared-key
-        # deployments that still have distinct source IPs.
-        if MCP_SESSION_OWNER_PREFER_IP and client_ip and isinstance(client_ip, str):
-            return f"ip:{hashlib.sha256(client_ip.encode('utf-8')).hexdigest()}"
+        # Bind optional sub-identity to authenticated material so shared-key
+        # users get independent buckets without enabling cross-key hijacking.
+        if identity is not None and owner_hdr_bytes is not None:
+            kind, material = identity
+            digest = hashlib.sha256(material + b"\0" + owner_hdr_bytes).hexdigest()
+            return f"{kind}+hdr:{digest}"
 
-        if user_api_key_auth is not None:
-            key_material = _bytes_for_hash(getattr(user_api_key_auth, "api_key", None))
-            if key_material:
-                api_key_hash = hashlib.sha256(key_material).hexdigest()
-                return f"key:{api_key_hash}"
-            uid_material = _bytes_for_hash(getattr(user_api_key_auth, "user_id", None))
-            if uid_material:
-                user_id_hash = hashlib.sha256(uid_material).hexdigest()
-                return f"user:{user_id_hash}"
-        if oauth2_headers:
-            authz = oauth2_headers.get("Authorization") or oauth2_headers.get("authorization")
-            authz_bytes = _bytes_for_hash(authz)
-            if authz_bytes:
-                return f"oauth:{hashlib.sha256(authz_bytes).hexdigest()}"
+        if identity is not None and MCP_SESSION_OWNER_PREFER_IP and client_ip and isinstance(client_ip, str):
+            kind, material = identity
+            digest = hashlib.sha256(material + b"\0" + client_ip.encode("utf-8")).hexdigest()
+            return f"{kind}+ip:{digest}"
+
+        if identity is not None:
+            kind, material = identity
+            return f"{kind}:{hashlib.sha256(material).hexdigest()}"
+
+        # No authenticated identity: optional header still distinguishes
+        # anonymous callers, then IP, then the anonymous sentinel.
+        if owner_hdr_bytes is not None:
+            return f"hdr:{hashlib.sha256(owner_hdr_bytes).hexdigest()}"
         if client_ip and isinstance(client_ip, str):
             return f"ip:{hashlib.sha256(client_ip.encode('utf-8')).hexdigest()}"
         return "anonymous"
@@ -4275,6 +4371,7 @@ if MCP_AVAILABLE:
             # client cannot spam `initialize` and exhaust memory.
             if is_initialize and not session_id:
                 request_owner = _owner_fingerprint_for(user_api_key_auth, oauth2_headers, _client_ip, raw_headers)
+                auth_identity = _auth_identity_fingerprint_for(user_api_key_auth, oauth2_headers)
                 if not await _enforce_stateful_session_cap_for_owner(request_owner):
                     verbose_logger.warning(
                         "Rejecting MCP initialize: caller already holds the maximum number of active stateful sessions."
@@ -4284,6 +4381,19 @@ if MCP_AVAILABLE:
                         content={
                             "error": "Too Many Requests",
                             "details": "Too many active MCP sessions for this caller.",
+                        },
+                    )
+                    await too_many_response(scope, receive, send)
+                    return
+                if not await _enforce_stateful_session_cap_for_auth_identity(auth_identity):
+                    verbose_logger.warning(
+                        "Rejecting MCP initialize: authenticated identity already holds the maximum number of active stateful sessions."
+                    )
+                    too_many_response = JSONResponse(
+                        status_code=429,
+                        content={
+                            "error": "Too Many Requests",
+                            "details": "Too many active MCP sessions for this authenticated identity.",
                         },
                     )
                     await too_many_response(scope, receive, send)
@@ -4395,6 +4505,7 @@ if MCP_AVAILABLE:
                         auth_user,
                         _owner_fingerprint_for(user_api_key_auth, oauth2_headers, _client_ip, raw_headers),
                         _track_initialized_stateful_session,
+                        _auth_identity_fingerprint_for(user_api_key_auth, oauth2_headers),
                     )
 
                 async with _gateway_initialize_instructions_request_scope(
@@ -4704,6 +4815,7 @@ if MCP_AVAILABLE:
         auth_user: MCPAuthenticatedUser,
         owner_fingerprint: str,
         on_session_registered: Callable[[str], None] | None = None,
+        auth_identity_fingerprint: str | None = None,
     ) -> Send:
         async def wrapped_send(message: Message) -> None:
             if message.get("type") == "http.response.start":
@@ -4717,6 +4829,8 @@ if MCP_AVAILABLE:
                         _stateful_session_auth_contexts[session_id] = auth_user
                         _stateful_session_auth_context_last_seen[session_id] = time.monotonic()
                         _stateful_session_owners[session_id] = owner_fingerprint
+                        if auth_identity_fingerprint is not None:
+                            _stateful_session_auth_identities[session_id] = auth_identity_fingerprint
                         break
             await send(message)
 

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_session_owner.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_session_owner.py
@@ -2,15 +2,16 @@
 
 import pytest
 
+from litellm.constants import _positive_int_env
 from litellm.proxy._types import UserAPIKeyAuth
 
 
 @pytest.mark.asyncio
-async def test_owner_fingerprint_prefers_session_owner_header_over_shared_api_key():
+async def test_owner_fingerprint_binds_session_owner_header_to_api_key():
     """
     Shared service-account keys collapse every caller into one owner bucket.
-    An explicit session-owner header must take priority so IDE / plugin users
-    behind the same key get independent session caps (#35383).
+    An explicit session-owner header must subdivide that bucket while remaining
+    bound to the API key so a different key cannot hijack the session (#35383).
     """
     try:
         from litellm.proxy._experimental.mcp_server.server import (
@@ -20,6 +21,7 @@ async def test_owner_fingerprint_prefers_session_owner_header_over_shared_api_ke
         pytest.skip("MCP server not available")
 
     shared_auth = UserAPIKeyAuth(api_key="shared-service-account-key")
+    other_auth = UserAPIKeyAuth(api_key="different-service-account-key")
     fp_user_a = _owner_fingerprint_for(
         shared_auth,
         request_headers={"x-litellm-mcp-session-owner": "ide-user-a"},
@@ -32,22 +34,28 @@ async def test_owner_fingerprint_prefers_session_owner_header_over_shared_api_ke
         shared_auth,
         request_headers={"x-litellm-mcp-session-owner": "ide-user-a"},
     )
+    fp_other_key_same_header = _owner_fingerprint_for(
+        other_auth,
+        request_headers={"x-litellm-mcp-session-owner": "ide-user-a"},
+    )
     fp_key_only = _owner_fingerprint_for(shared_auth)
 
     assert fp_user_a != fp_user_b
     assert fp_user_a == fp_user_a_again
-    assert fp_user_a.startswith("hdr:")
+    assert fp_user_a.startswith("key+hdr:")
     assert fp_key_only.startswith("key:")
     assert fp_user_a != fp_key_only
+    # Different API keys with the same owner header must not collide.
+    assert fp_user_a != fp_other_key_same_header
     assert "ide-user-a" not in fp_user_a
     assert "shared-service-account-key" not in fp_user_a
 
 
 @pytest.mark.asyncio
-async def test_owner_fingerprint_prefer_ip_over_shared_api_key(monkeypatch):
+async def test_owner_fingerprint_binds_prefer_ip_to_api_key(monkeypatch):
     """
-    When LITELLM_MCP_SESSION_OWNER_PREFER_IP is enabled, client IP must win
-    over a shared API key so distinct source IPs get separate session caps.
+    When LITELLM_MCP_SESSION_OWNER_PREFER_IP is enabled, client IP subdivides
+    the authenticated key bucket — it must not replace the key identity.
     """
     try:
         from litellm.proxy._experimental.mcp_server import server as mcp_server
@@ -60,29 +68,123 @@ async def test_owner_fingerprint_prefer_ip_over_shared_api_key(monkeypatch):
     monkeypatch.setattr(mcp_server, "MCP_SESSION_OWNER_PREFER_IP", True)
 
     shared_auth = UserAPIKeyAuth(api_key="shared-service-account-key")
+    other_auth = UserAPIKeyAuth(api_key="different-service-account-key")
     fp_ip_a = _owner_fingerprint_for(shared_auth, client_ip="10.0.0.1")
     fp_ip_b = _owner_fingerprint_for(shared_auth, client_ip="10.0.0.2")
+    fp_other_key_same_ip = _owner_fingerprint_for(other_auth, client_ip="10.0.0.1")
     fp_key_only = _owner_fingerprint_for(shared_auth)
 
     assert fp_ip_a != fp_ip_b
-    assert fp_ip_a.startswith("ip:")
+    assert fp_ip_a.startswith("key+ip:")
     assert fp_key_only.startswith("key:")
     assert fp_ip_a != fp_key_only
+    assert fp_ip_a != fp_other_key_same_ip
     assert "10.0.0.1" not in fp_ip_a
 
 
 @pytest.mark.asyncio
-async def test_max_stateful_sessions_per_owner_reads_from_env_constant():
-    """Session cap must come from LITELLM_MCP_MAX_STATEFUL_SESSIONS_PER_OWNER."""
+async def test_auth_identity_fingerprint_ignores_owner_header_and_ip():
+    """Hard-ceiling identity must stay stable when headers/IPs rotate."""
     try:
-        from litellm.constants import MCP_MAX_STATEFUL_SESSIONS_PER_OWNER
+        from litellm.proxy._experimental.mcp_server.server import (
+            _auth_identity_fingerprint_for,
+            _owner_fingerprint_for,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    auth = UserAPIKeyAuth(api_key="shared-service-account-key")
+    auth_fp = _auth_identity_fingerprint_for(auth)
+    auth_fp_with_header = _auth_identity_fingerprint_for(auth)
+    owner_fp = _owner_fingerprint_for(
+        auth,
+        request_headers={"x-litellm-mcp-session-owner": "rotating-1"},
+    )
+
+    assert auth_fp == auth_fp_with_header
+    assert auth_fp.startswith("key:")
+    assert owner_fp.startswith("key+hdr:")
+    assert auth_fp != owner_fp
+
+
+@pytest.mark.asyncio
+async def test_max_stateful_sessions_caps_are_positive():
+    """Session caps must come from env helpers and stay strictly positive."""
+    try:
+        from litellm.constants import (
+            MCP_MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY,
+            MCP_MAX_STATEFUL_SESSIONS_PER_OWNER,
+        )
         from litellm.proxy._experimental.mcp_server import server as mcp_server
     except ImportError:
         pytest.skip("MCP server not available")
 
     assert mcp_server._MAX_STATEFUL_SESSIONS_PER_OWNER == MCP_MAX_STATEFUL_SESSIONS_PER_OWNER
-    assert isinstance(mcp_server._MAX_STATEFUL_SESSIONS_PER_OWNER, int)
-    assert mcp_server._MAX_STATEFUL_SESSIONS_PER_OWNER > 0
+    assert mcp_server._MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY == MCP_MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY
+    assert MCP_MAX_STATEFUL_SESSIONS_PER_OWNER > 0
+    assert MCP_MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY >= MCP_MAX_STATEFUL_SESSIONS_PER_OWNER
+
+
+def test_positive_int_env_rejects_non_positive_and_invalid(monkeypatch):
+    """Invalid / non-positive env values must fall back to the default."""
+    monkeypatch.setenv("LITELLM_TEST_POSITIVE_INT", "0")
+    assert _positive_int_env("LITELLM_TEST_POSITIVE_INT", 100) == 100
+    monkeypatch.setenv("LITELLM_TEST_POSITIVE_INT", "-5")
+    assert _positive_int_env("LITELLM_TEST_POSITIVE_INT", 100) == 100
+    monkeypatch.setenv("LITELLM_TEST_POSITIVE_INT", "not-an-int")
+    assert _positive_int_env("LITELLM_TEST_POSITIVE_INT", 100) == 100
+    monkeypatch.setenv("LITELLM_TEST_POSITIVE_INT", "42")
+    assert _positive_int_env("LITELLM_TEST_POSITIVE_INT", 100) == 42
+    monkeypatch.delenv("LITELLM_TEST_POSITIVE_INT", raising=False)
+    assert _positive_int_env("LITELLM_TEST_POSITIVE_INT", 100) == 100
+
+
+@pytest.mark.asyncio
+async def test_enforce_auth_identity_ceiling_evicts_across_owner_sub_buckets():
+    """
+    Rotating session-owner headers under one API key must still hit the
+    per-auth-identity hard ceiling (Veria / Greptile concern).
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    try:
+        from litellm.proxy._experimental.mcp_server import server as mcp_server
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    auth_identity = "key:shared-auth"
+    owners = {
+        "s0": "key+hdr:owner-0",
+        "s1": "key+hdr:owner-1",
+        "s2": "key+hdr:owner-2",
+    }
+    identities = {sid: auth_identity for sid in owners}
+    last_seen = {"s0": 1.0, "s1": 2.0, "s2": 3.0}
+    mock_transport = MagicMock()
+    mock_transport.terminate = AsyncMock()
+    server_instances = {sid: mock_transport for sid in owners}
+
+    with (
+        patch.object(mcp_server, "_MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY", 2),
+        patch.dict(mcp_server._stateful_session_owners, owners, clear=True),
+        patch.dict(mcp_server._stateful_session_auth_identities, identities, clear=True),
+        patch.dict(mcp_server._stateful_session_auth_context_last_seen, last_seen, clear=True),
+        patch.dict(mcp_server._stateful_session_active_request_counts, {}, clear=True),
+        patch.object(
+            mcp_server.session_manager_stateful,
+            "_server_instances",
+            server_instances,
+        ),
+    ):
+        allowed = await mcp_server._enforce_stateful_session_cap_for_auth_identity(auth_identity)
+        assert allowed is True
+        # Evicts oldest idle sessions until there is room for one new initialize
+        # (ceiling 2 → leave 1 live session).
+        assert "s0" not in mcp_server._stateful_session_auth_identities
+        assert "s1" not in mcp_server._stateful_session_auth_identities
+        assert "s2" in mcp_server._stateful_session_auth_identities
+        assert len(mcp_server._stateful_session_auth_identities) == 1
+        mock_transport.terminate.assert_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_session_owner.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_session_owner.py
@@ -108,6 +108,38 @@ async def test_auth_identity_fingerprint_ignores_owner_header_and_ip():
 
 
 @pytest.mark.asyncio
+async def test_owner_fingerprint_ignores_header_when_unauthenticated():
+    """
+    Unauthenticated callers must not open a new owner bucket by rotating
+    x-litellm-mcp-session-owner — that would bypass both session caps.
+    Fall back to IP (or anonymous) instead.
+    """
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _owner_fingerprint_for,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    anon = UserAPIKeyAuth()
+    fp_hdr_a = _owner_fingerprint_for(
+        anon,
+        client_ip="10.0.0.1",
+        request_headers={"x-litellm-mcp-session-owner": "rotating-a"},
+    )
+    fp_hdr_b = _owner_fingerprint_for(
+        anon,
+        client_ip="10.0.0.1",
+        request_headers={"x-litellm-mcp-session-owner": "rotating-b"},
+    )
+    fp_ip_only = _owner_fingerprint_for(anon, client_ip="10.0.0.1")
+
+    assert fp_hdr_a == fp_hdr_b == fp_ip_only
+    assert fp_ip_only.startswith("ip:")
+    assert not fp_ip_only.startswith("hdr:")
+
+
+@pytest.mark.asyncio
 async def test_max_stateful_sessions_caps_are_positive():
     """Session caps must come from env helpers and stay strictly positive."""
     try:

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_session_owner.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_session_owner.py
@@ -1,0 +1,103 @@
+"""Regression tests for MCP stateful-session owner fingerprinting (#35383)."""
+
+import pytest
+
+from litellm.proxy._types import UserAPIKeyAuth
+
+
+@pytest.mark.asyncio
+async def test_owner_fingerprint_prefers_session_owner_header_over_shared_api_key():
+    """
+    Shared service-account keys collapse every caller into one owner bucket.
+    An explicit session-owner header must take priority so IDE / plugin users
+    behind the same key get independent session caps (#35383).
+    """
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _owner_fingerprint_for,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    shared_auth = UserAPIKeyAuth(api_key="shared-service-account-key")
+    fp_user_a = _owner_fingerprint_for(
+        shared_auth,
+        request_headers={"x-litellm-mcp-session-owner": "ide-user-a"},
+    )
+    fp_user_b = _owner_fingerprint_for(
+        shared_auth,
+        request_headers={"X-LiteLLM-MCP-Session-Owner": "ide-user-b"},
+    )
+    fp_user_a_again = _owner_fingerprint_for(
+        shared_auth,
+        request_headers={"x-litellm-mcp-session-owner": "ide-user-a"},
+    )
+    fp_key_only = _owner_fingerprint_for(shared_auth)
+
+    assert fp_user_a != fp_user_b
+    assert fp_user_a == fp_user_a_again
+    assert fp_user_a.startswith("hdr:")
+    assert fp_key_only.startswith("key:")
+    assert fp_user_a != fp_key_only
+    assert "ide-user-a" not in fp_user_a
+    assert "shared-service-account-key" not in fp_user_a
+
+
+@pytest.mark.asyncio
+async def test_owner_fingerprint_prefer_ip_over_shared_api_key(monkeypatch):
+    """
+    When LITELLM_MCP_SESSION_OWNER_PREFER_IP is enabled, client IP must win
+    over a shared API key so distinct source IPs get separate session caps.
+    """
+    try:
+        from litellm.proxy._experimental.mcp_server import server as mcp_server
+        from litellm.proxy._experimental.mcp_server.server import (
+            _owner_fingerprint_for,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    monkeypatch.setattr(mcp_server, "MCP_SESSION_OWNER_PREFER_IP", True)
+
+    shared_auth = UserAPIKeyAuth(api_key="shared-service-account-key")
+    fp_ip_a = _owner_fingerprint_for(shared_auth, client_ip="10.0.0.1")
+    fp_ip_b = _owner_fingerprint_for(shared_auth, client_ip="10.0.0.2")
+    fp_key_only = _owner_fingerprint_for(shared_auth)
+
+    assert fp_ip_a != fp_ip_b
+    assert fp_ip_a.startswith("ip:")
+    assert fp_key_only.startswith("key:")
+    assert fp_ip_a != fp_key_only
+    assert "10.0.0.1" not in fp_ip_a
+
+
+@pytest.mark.asyncio
+async def test_max_stateful_sessions_per_owner_reads_from_env_constant():
+    """Session cap must come from LITELLM_MCP_MAX_STATEFUL_SESSIONS_PER_OWNER."""
+    try:
+        from litellm.constants import MCP_MAX_STATEFUL_SESSIONS_PER_OWNER
+        from litellm.proxy._experimental.mcp_server import server as mcp_server
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    assert mcp_server._MAX_STATEFUL_SESSIONS_PER_OWNER == MCP_MAX_STATEFUL_SESSIONS_PER_OWNER
+    assert isinstance(mcp_server._MAX_STATEFUL_SESSIONS_PER_OWNER, int)
+    assert mcp_server._MAX_STATEFUL_SESSIONS_PER_OWNER > 0
+
+
+@pytest.mark.asyncio
+async def test_owner_fingerprint_default_still_uses_api_key_when_no_overrides():
+    """Default behavior must remain key-based when header/prefer-ip are unused."""
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _owner_fingerprint_for,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    auth = UserAPIKeyAuth(api_key="custom-master-key")
+    fp = _owner_fingerprint_for(auth, client_ip="10.0.0.1")
+
+    assert fp.startswith("key:")
+    assert "custom-master-key" not in fp
+    assert "10.0.0.1" not in fp


### PR DESCRIPTION
## TLDR

Problem this solves:

- Shared API keys collapse all MCP callers into one 100-session bucket
- Cap was hardcoded, so teams could not raise or tune it per deployment

How it solves it:

- `LITELLM_MCP_MAX_STATEFUL_SESSIONS_PER_OWNER` makes the per-owner cap configurable
- Optional `x-litellm-mcp-session-owner` (or client IP) is **bound to** the authenticated identity (`key+hdr` / `key+ip`), not a replacement — shared-key users get independent buckets without cross-key hijacking
- `LITELLM_MCP_MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY` hard-caps total sessions under one credential so rotating the owner header cannot bypass the per-owner limit
- Unauthenticated callers ignore the owner header and fall back to IP / `anonymous` (same as pre-fix keyless behavior)

## Relevant issues

Fixes #35383

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Unit regression coverage for the session-owner fingerprint paths (no live LLM calls required — this is proxy MCP session accounting):

```text
uv run pytest tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_session_owner.py -v
# 8 passed
```

## Type

🐛 Bug Fix

## Changes

- Read per-owner / per-auth-identity caps from env (`LITELLM_MCP_MAX_STATEFUL_SESSIONS_PER_OWNER`, `LITELLM_MCP_MAX_STATEFUL_SESSIONS_PER_AUTH_IDENTITY`); clamp non-positive values
- Fingerprint authenticated callers as `key+hdr:…` / `key+ip:…` when the owner header or prefer-IP is set; default remains `key:…`
- Ignore client-supplied owner header when unauthenticated; fall back to IP / `anonymous`
- Enforce both per-owner and per-auth-identity session ceilings on initialize
- Add mocked unit tests in `tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_session_owner.py`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR