### PR TITLE
test(proxy): assert _delete_deployment's still-desired id set instead of a delete count

### DIFF
--- a/tests/local_testing/test_config.py
+++ b/tests/local_testing/test_config.py
@@ -88,10 +88,11 @@ async def test_delete_deployment():
     )
 
     db_models = [db_model]
-    deleted_deployments = await pc._delete_deployment(db_models=db_models)
+    still_desired = await pc._delete_deployment(db_models=db_models)
 
-    assert deleted_deployments == 1
+    assert still_desired == frozenset({deployment.model_info.id})
     assert len(llm_router.model_list) == 1
+    assert llm_router.get_model_ids() == [deployment.model_info.id]
 
     """
     Scenario 2 - if model id != model_info["id"]
@@ -115,10 +116,11 @@ async def test_delete_deployment():
     )
 
     db_models = [db_model]
-    deleted_deployments = await pc._delete_deployment(db_models=db_models)
+    still_desired = await pc._delete_deployment(db_models=db_models)
 
-    assert deleted_deployments == 1
+    assert still_desired == frozenset({deployment.model_info.id})
     assert len(llm_router.model_list) == 1
+    assert llm_router.get_model_ids() == [deployment.model_info.id]
 
 
 @pytest.mark.asyncio
@@ -239,10 +241,16 @@ async def test_db_error_new_model_check():
         new=AsyncMock(return_value={"model_list": config_model_list}),
     ):
         db_models = []
-        deleted_deployments = await pc._delete_deployment(db_models=db_models)
-    assert deleted_deployments == 0
+        still_desired = await pc._delete_deployment(db_models=db_models)
+    assert still_desired == frozenset(
+        {deployment.model_info.id, deployment_2.model_info.id}
+    )
 
     assert init_len_list == len(llm_router.model_list)
+    assert set(llm_router.get_model_ids()) == {
+        deployment.model_info.id,
+        deployment_2.model_info.id,
+    }
 
 
 litellm_params = LiteLLM_Params(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Two tests in `tests/local_testing/test_config.py` fail on staging
- They compare a frozenset against an int
- `_delete_deployment` stopped returning a delete count in #35400
- That directory is ungated in CI, so nothing caught it

How it solves it:

- Assert the still-desired id set the helper now returns
- Pin the router's surviving ids, not just their count
- No product code changes; the eviction behavior was never broken

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR touches no product code, so there is no runtime surface to exercise against a live proxy; a curl against `/model/new` or `/model/delete` would behave identically before and after. Calling that out rather than staging a proxy run that proves nothing. The evidence that matters here is that the repaired assertions are red on broken code and green on correct code, which is shown below.

Before, at `b1fd20f4cd` (staging head, no changes applied):

```
$ pytest tests/local_testing/test_config.py::test_delete_deployment tests/local_testing/test_config.py::test_db_error_new_model_check -p no:randomly -q

E       AssertionError: assert frozenset({'1849e068-d759-4573-bd88-96981ee701d1', '2f38bc61-29b1-4784-80b6-a7a1c3d595bb'}) == 0
tests/local_testing/test_config.py:243: AssertionError

E       AssertionError: assert frozenset({'83cda9f0-d35b-4fce-9f41-064665eaaaa7'}) == 1
tests/local_testing/test_config.py:93: AssertionError
```

After, at `67dd8924ee`:

```
$ pytest tests/local_testing/test_config.py -q
11 passed, 8 warnings in 3.92s
```

The repaired assertions were then checked against two mutations of `_delete_deployment`, with the source restored and re-verified clean against HEAD afterward. Disabling the eviction loop (`if model_id not in combined_id_list` to `if False`) fails `test_delete_deployment` on both the surviving-count and surviving-id assertions:

```
E       AssertionError: assert 2 == 1
FAILED tests/local_testing/test_config.py::test_delete_deployment
1 failed, 1 passed
```

Returning the wrong set (`frozenset()` in place of `frozenset(combined_id_list)`) fails both:

```
FAILED tests/local_testing/test_config.py::test_db_error_new_model_check
FAILED tests/local_testing/test_config.py::test_delete_deployment
2 failed
```

`test_db_error_new_model_check` surviving the first mutation is correct rather than a gap: it asserts that nothing is evicted, so disabling eviction cannot change its outcome.

## Type

✅ Test

## Changes

#35400 changed `_delete_deployment` from returning a count of evictions to returning the frozenset of ids the db and config still want, so a model write that judges its own reload can tell a deliberate eviction from a deployment that went missing. The commit noted the count had no callers in the proxy, which held for the proxy but not for these two tests, which were left comparing the new frozenset against `0` and `1`

Only the assertions move. The eviction loop issues exactly the same `llm_router.delete_deployment(id=...)` calls it did before, and both tests' behavioral checks on `llm_router.model_list` pass untouched, so this is stale test code rather than a regression

Alongside repairing the comparison, each test now pins the ids the router is left holding. The old `len(llm_router.model_list) == 1` check cannot distinguish evicting the right deployment from evicting the wrong one, and the mutation run above is what demonstrates the difference

Worth flagging separately since it is what let this rot: `tests/local_testing/` is referenced only by `.circleci/config.yml`, no GitHub Actions workflow touches it, and #35400 ran 81 checks with zero CircleCI among them, so the directory is not gating PRs today

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
