### PR TITLE
test(proxy): separate the member_add permission gate from the provisioning gate

### DIFF
--- a/tests/proxy_behavior/management/conftest.py
+++ b/tests/proxy_behavior/management/conftest.py
@@ -194,6 +194,33 @@ async def create_scratch_team(
     return team_id
 
 
+async def create_scratch_user(
+    prisma,
+    scratch_prefix: str,
+    *,
+    suffix: str,
+    user_email: Optional[str] = None,
+) -> str:
+    """Raw-seed a scratch-tagged user row with no key; returns its user_id.
+
+    The passive counterpart to create_scratch_actor: a user that requests are
+    made *about* rather than *by*, so it needs no verification token. The
+    user_id matches Scratch.tag(suffix), so the teardown reclaims it.
+
+    A member named by user_id must already exist for a non-proxy-admin caller
+    — `_validate_member_user_id_provisioning` 403s a user_id with no user row
+    — so an authz matrix targeting a member has to seed one, or every
+    non-proxy-admin row 403s on provisioning and the permission gate under
+    test goes unexercised.
+    """
+    user_id = f"{scratch_prefix}-{suffix}"
+    data: Dict[str, Any] = {"user_id": user_id, "user_role": "internal_user"}
+    if user_email is not None:
+        data["user_email"] = user_email
+    await prisma.db.litellm_usertable.create(data=data)
+    return user_id
+
+
 async def create_scratch_org(
     prisma,
     scratch_prefix: str,
@@ -331,8 +358,16 @@ async def scratch(prisma):
         await prisma.db.litellm_teamtable.delete_many(
             where={"team_id": {"startswith": handle.prefix}}
         )
+        # Inviting a member by user_email allocates the user_id server-side
+        # (a uuid), so a scratch-prefixed email is the only handle on that
+        # row — sweep both, matching the token sweep above.
         await prisma.db.litellm_usertable.delete_many(
-            where={"user_id": {"startswith": handle.prefix}}
+            where={
+                "OR": [
+                    {"user_id": {"startswith": handle.prefix}},
+                    {"user_email": {"startswith": handle.prefix}},
+                ]
+            }
         )
         # F1+F3 seed scratch orgs via create_scratch_org; the world seeder is
         # the only other writer of LiteLLM_OrganizationTable and uses the

--- a/tests/proxy_behavior/management/test_team_member_add.py
+++ b/tests/proxy_behavior/management/test_team_member_add.py
@@ -2,7 +2,7 @@ import litellm
 import pytest
 
 from .actors import Actor
-from .conftest import create_scratch_team
+from .conftest import create_scratch_team, create_scratch_user
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
 
@@ -12,6 +12,12 @@ pytestmark = pytest.mark.asyncio(loop_scope="session")
 # or an org admin of the team's org may add members; everyone else is 403.
 # Unlike /team/update there is no route gate in front, so the team-admin
 # branch is reachable (TEAM_ADMIN, an internal_user, is allowed on its team).
+#
+# The member being added is seeded as a real user row so this matrix reads the
+# permission gate alone. Naming a user_id with no user row would 403 every
+# non-proxy-admin on the downstream provisioning gate instead, which would
+# leave the matrix green even with _validate_team_member_add_permissions
+# deleted. That gate gets its own matrix below.
 _MATRIX = [
     ("alpha/proxy_admin", Actor.PROXY_ADMIN, "alpha", 200),
     ("alpha/org_admin", Actor.ORG_ADMIN, "alpha", 200),
@@ -68,7 +74,9 @@ async def test_team_member_add_authz_matrix(
 ):
     await _seed_target(prisma, world, shape, scratch.prefix)
     caller = world.keys[actor]
-    new_member_id = scratch.tag("newmember")
+    new_member_id = await create_scratch_user(
+        prisma, scratch.prefix, suffix="newmember"
+    )
 
     resp = await proxy_client.post(
         "/team/member_add",
@@ -90,6 +98,110 @@ async def test_team_member_add_authz_matrix(
         assert new_member_id in _member_ids(row)
     else:
         assert new_member_id not in _member_ids(row), "denied but member added"
+
+
+# Naming a user_id with no user row creates that user as a side effect, so
+# _validate_member_user_id_provisioning restricts it to PROXY_ADMIN — creating
+# users outright is proxy-admin-only, and member_add must not be a way around
+# that. Every actor here clears the permission gate on the alpha team (all
+# three are 200 in the matrix above), so the only thing separating them is the
+# provisioning gate.
+_UNPROVISIONED = [
+    ("proxy_admin", Actor.PROXY_ADMIN, 200),
+    ("team_admin", Actor.TEAM_ADMIN, 403),
+    ("org_admin", Actor.ORG_ADMIN, 403),
+]
+
+
+@pytest.mark.parametrize(
+    "actor,expected_status",
+    [(a, s) for (_id, a, s) in _UNPROVISIONED],
+    ids=[s[0] for s in _UNPROVISIONED],
+)
+async def test_team_member_add_unprovisioned_user_id_is_proxy_admin_only(
+    actor: Actor,
+    expected_status: int,
+    proxy_client,
+    prisma,
+    scratch,
+    world,
+):
+    await _seed_target(prisma, world, "alpha", scratch.prefix)
+    caller = world.keys[actor]
+    # Deliberately NOT seeded — create_scratch_user is what the matrix above
+    # calls, and its absence here is the whole scenario.
+    unprovisioned_id = scratch.tag("unprovisioned")
+    assert (
+        await prisma.db.litellm_usertable.find_unique(
+            where={"user_id": unprovisioned_id}
+        )
+        is None
+    ), "setup: user must not exist yet"
+
+    resp = await proxy_client.post(
+        "/team/member_add",
+        headers={"Authorization": f"Bearer {caller.cleartext}"},
+        json={
+            "team_id": scratch.prefix,
+            "member": {"user_id": unprovisioned_id, "role": "user"},
+        },
+    )
+    assert (
+        resp.status_code == expected_status
+    ), f"{actor.value}: {resp.status_code} {resp.text}"
+
+    row = await prisma.db.litellm_teamtable.find_unique(
+        where={"team_id": scratch.prefix}
+    )
+    assert row is not None
+    created = await prisma.db.litellm_usertable.find_unique(
+        where={"user_id": unprovisioned_id}
+    )
+    if expected_status == 200:
+        assert unprovisioned_id in _member_ids(row)
+        assert created is not None, "proxy admin add did not provision the user"
+    else:
+        assert unprovisioned_id not in _member_ids(row), "denied but member added"
+        # The point of the gate: a denied caller must not leave a user row behind.
+        assert created is None, "denied but user row was created"
+
+
+async def test_team_member_add_email_invite_open_to_team_admin(
+    proxy_client,
+    prisma,
+    scratch,
+    world,
+):
+    """The escape hatch the provisioning 403 names must actually work.
+
+    That message tells a non-proxy-admin to add the member by user_email
+    instead. Inviting an unknown email allocates the user_id server-side, so
+    it stays open to team admins; if it ever closed, the 403 would be sending
+    callers down a dead end.
+    """
+    await _seed_target(prisma, world, "alpha", scratch.prefix)
+    caller = world.keys[Actor.TEAM_ADMIN]
+    email = f"{scratch.prefix}-invitee@example.com"
+
+    resp = await proxy_client.post(
+        "/team/member_add",
+        headers={"Authorization": f"Bearer {caller.cleartext}"},
+        json={
+            "team_id": scratch.prefix,
+            "member": {"user_email": email, "role": "user"},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    invited = await prisma.db.litellm_usertable.find_first(
+        where={"user_email": email}
+    )
+    assert invited is not None, "invite did not create the user"
+    row = await prisma.db.litellm_teamtable.find_unique(
+        where={"team_id": scratch.prefix}
+    )
+    assert row is not None
+    assert invited.user_id in _member_ids(row)
 
 
 # Available-team self-join: a non-admin caller may add ITSELF to a team listed

--- a/tests/proxy_behavior/management/test_team_member_info_validation.py
+++ b/tests/proxy_behavior/management/test_team_member_info_validation.py
@@ -11,31 +11,12 @@ shape: a payload that silently lands the membership against the WRONG
 user_id is invisible from response-body alone).
 """
 
-from typing import Any, Dict, Optional
-
 import pytest
 
 from .actors import Actor
-from .conftest import create_scratch_team
+from .conftest import create_scratch_team, create_scratch_user
 
 pytestmark = pytest.mark.asyncio(loop_scope="session")
-
-
-async def _seed_scratch_user(
-    prisma,
-    scratch_prefix: str,
-    *,
-    suffix: str,
-    user_email: Optional[str] = None,
-) -> str:
-    """Raw-seed a scratch-prefixed user row; returns user_id. Scratch teardown
-    reclaims by user_id prefix."""
-    user_id = f"{scratch_prefix}-{suffix}"
-    data: Dict[str, Any] = {"user_id": user_id, "user_role": "internal_user"}
-    if user_email is not None:
-        data["user_email"] = user_email
-    await prisma.db.litellm_usertable.create(data=data)
-    return user_id
 
 
 # ---------------------------------------------------------------------------
@@ -68,10 +49,10 @@ async def test_member_add_email_id_mismatch_rejected(
     proxy_client, prisma, scratch, world
 ):
     email = f"{scratch.prefix}-mismatch@example.com"
-    real_user_id = await _seed_scratch_user(
+    real_user_id = await create_scratch_user(
         prisma, scratch.prefix, suffix="real", user_email=email
     )
-    other_user_id = await _seed_scratch_user(prisma, scratch.prefix, suffix="other")
+    other_user_id = await create_scratch_user(prisma, scratch.prefix, suffix="other")
     assert real_user_id != other_user_id  # sanity
     team_id = await create_scratch_team(prisma, team_id=scratch.tag("team"))
     seeder = world.keys[Actor.PROXY_ADMIN].cleartext
@@ -102,7 +83,7 @@ async def test_member_add_email_only_resolves_user_id(
     proxy_client, prisma, scratch, world
 ):
     email = f"{scratch.prefix}-resolve@example.com"
-    user_id = await _seed_scratch_user(
+    user_id = await create_scratch_user(
         prisma, scratch.prefix, suffix="lookup", user_email=email
     )
     team_id = await create_scratch_team(prisma, team_id=scratch.tag("team"))
@@ -171,8 +152,8 @@ async def test_member_add_duplicate_email_rejected(
     proxy_client, prisma, scratch, world
 ):
     email = f"{scratch.prefix}-dup@example.com"
-    await _seed_scratch_user(prisma, scratch.prefix, suffix="dup1", user_email=email)
-    await _seed_scratch_user(prisma, scratch.prefix, suffix="dup2", user_email=email)
+    await create_scratch_user(prisma, scratch.prefix, suffix="dup1", user_email=email)
+    await create_scratch_user(prisma, scratch.prefix, suffix="dup2", user_email=email)
     team_id = await create_scratch_team(prisma, team_id=scratch.tag("team"))
     seeder = world.keys[Actor.PROXY_ADMIN].cleartext
     resp = await proxy_client.post(


### PR DESCRIPTION
## TLDR

Problem this solves:

- member_add authz matrix broke on the new provisioning rule
- Relaxing its expectations would have made all 18 rows vacuous
- The new rule had no HTTP-boundary coverage, only helper-level

How it solves it:

- Seed the member as a real user so the matrix reads the permission gate
- Add a matrix for the provisioning gate, plus its email escape hatch
- Share the user seeder the member-info pins kept private

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at `ff4a50c768` against a local proxy on port 4001, no mocks. Setup is a team admin (an `internal_user` holding the `admin` role on their own team) plus the team itself:

```bash
curl -sS -X POST $P/user/new -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"user_id": "memberadd-1785620648-teamadmin", "user_role": "internal_user"}'
curl -sS -X POST $P/key/generate -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"user_id": "memberadd-1785620648-teamadmin"}'
curl -sS -X POST $P/team/new -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"team_alias": "memberadd-1785620648-team", "members_with_roles": [{"user_id": "memberadd-1785620648-teamadmin", "role": "admin"}]}'
```

**A. The team admin cannot conjure a user_id that has no user row, and nothing is created behind the refusal.** This is the leg the tests had no boundary coverage for.

```bash
curl -sS -w '\nHTTP %{http_code}\n' -X POST $P/team/member_add \
  -H "Authorization: Bearer $TA_KEY" -H 'Content-Type: application/json' \
  -d '{"team_id": "ed7d2558-3999-475f-92cd-ff671537efec", "member": {"user_id": "memberadd-1785620648-ghost", "role": "user"}}'
```

```
{"detail":{"error":"Only proxy admins can add a user_id that does not exist yet: memberadd-1785620648-ghost. Add the member by user_email to invite a new user, or ask a proxy admin to create the user first."}}
HTTP 403
```

```bash
curl -sS -w '\nHTTP %{http_code}\n' -X GET "$P/user/info?user_id=memberadd-1785620648-ghost" \
  -H "Authorization: Bearer sk-1234"
```

```
{"error":{"message":"User memberadd-1785620648-ghost not found","type":"internal_server_error","param":"None","code":"404"}}
HTTP 404
```

**B. The escape hatch that refusal names actually works for the same caller.** Inviting by `user_email` allocates the user_id server-side, so a team admin keeps it:

```bash
curl -sS -w '\nHTTP %{http_code}\n' -X POST $P/team/member_add \
  -H "Authorization: Bearer $TA_KEY" -H 'Content-Type: application/json' \
  -d '{"team_id": "ed7d2558-3999-475f-92cd-ff671537efec", "member": {"user_email": "memberadd-1785620648-invitee@example.com", "role": "user"}}'
```

```
{
  "team_id": "ed7d2558-3999-475f-92cd-ff671537efec",
  "members_with_roles": [
    {"user_id": "memberadd-1785620648-teamadmin", "user_email": null, "role": "admin"},
    {"user_id": "default_user_id", "user_email": null, "role": "admin"},
    {"user_id": "525c08f9-19e7-422d-9fde-648ee65f23d3", "user_email": "memberadd-1785620648-invitee@example.com", "role": "user"}
  ],
  "updated_users": [
    {"user_id": "525c08f9-19e7-422d-9fde-648ee65f23d3", "user_email": "memberadd-1785620648-invitee@example.com"}
  ]
}
HTTP 200
```

**C. A proxy admin adding that same unprovisioned user_id is still allowed, and does provision the row.** The gate is a role split, not a blanket block:

```bash
curl -sS -o /dev/null -w 'HTTP %{http_code}\n' -X POST $P/team/member_add \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"team_id": "ed7d2558-3999-475f-92cd-ff671537efec", "member": {"user_id": "memberadd-1785620648-ghost", "role": "user"}}'
curl -sS -X GET "$P/user/info?user_id=memberadd-1785620648-ghost" -H "Authorization: Bearer sk-1234"
```

```
HTTP 200
{"user_id": "memberadd-1785620648-ghost", "teams": ["ed7d2558-3999-475f-92cd-ff671537efec"]}
```

**D. The team admin can still add a member that already exists.** This is the behavior the matrix rows in question were written to pin, and the reason relaxing them to 403 would have been wrong:

```bash
curl -sS -X POST $P/user/new -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"user_id": "memberadd-1785620648-existing", "user_role": "internal_user"}'
curl -sS -w '\nHTTP %{http_code}\n' -X POST $P/team/member_add \
  -H "Authorization: Bearer $TA_KEY" -H 'Content-Type: application/json' \
  -d '{"team_id": "ed7d2558-3999-475f-92cd-ff671537efec", "member": {"user_id": "memberadd-1785620648-existing", "role": "user"}}'
```

```
{"members_with_roles": ["memberadd-1785620648-teamadmin", "default_user_id", "525c08f9-19e7-422d-9fde-648ee65f23d3", "memberadd-1785620648-ghost", "memberadd-1785620648-existing"]}
HTTP 200
```

## Type

✅ Test

## Changes

Adding a team member by a `user_id` with no user row is now proxy-admin-only. The `/team/member_add` authz matrix targeted a never-seeded `user_id`, so it started refusing every non-proxy-admin caller and three rows went red. That matrix exists to pin `_validate_team_member_add_permissions`, which the provisioning rule did not touch, so the member is now seeded as a real user row and the matrix goes back to its original expectations.

Relaxing those three rows to 403 instead would have been the wrong repair. Every non-proxy-admin row in the matrix would then be explainable by the provisioning gate alone; I built that variant and ran it against a tree with `_validate_team_member_add_permissions` deleted outright, and all 18 rows stayed green. With the member seeded, the same deletion fails 13 of them.

The provisioning rule itself was pinned only by unit tests calling the helper directly, so nothing proved it was wired into the route. It gets its own matrix, over three actors who all clear the permission check on the same team, so the provisioning gate is the only variable between them; the denial legs also assert no user row is left behind, which is the actual claim. One more test covers the `user_email` invite the 403 message points callers at, so closing that path for non-proxy-admins cannot pass silently.

The user seeder that `test_team_member_info_validation.py` kept private moves to `conftest.py` alongside the other `create_scratch_*` seeders. The scratch teardown now also reclaims users by scratch-prefixed email, since an invite allocates the user_id server-side and the id-prefix sweep cannot see it.

Verified by mutation rather than by the suite passing. Deleting the provisioning gate fails the two new denial rows; deleting the permission gate fails 13 matrix rows; widening the provisioning gate to also reject email-only members fails the escape-hatch test. `tests/proxy_behavior` is 733 passed, up from 729.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
