### PR TITLE
build(makefile): swap npm ci for npm install so bootstrap no-ops on unchanged ui deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,14 @@ install-dev:
 bootstrap:
 	$(UV) sync --inexact --frozen --extra proxy --group proxy-dev --group e2e-dev
 	$(UV_RUN) python scripts/prisma_generate_if_needed.py
-	cd ui/litellm-dashboard && npm ci --no-audit --no-fund
+	@cd ui/litellm-dashboard && \
+	dep_hash=$$(git hash-object package.json package-lock.json); \
+	stamp=node_modules/.bootstrap-stamp; \
+	if [ "$$(cat "$$stamp" 2>/dev/null)" = "$$dep_hash" ]; then \
+		echo "bootstrap: ui deps up to date, skipping npm ci"; \
+	else \
+		npm ci --no-audit --no-fund && echo "$$dep_hash" > "$$stamp"; \
+	fi
 	@main_root=$$(git worktree list --porcelain | head -1 | sed 's/^worktree //'); \
 	if [ "$$main_root" != "$$(git rev-parse --show-toplevel)" ] && [ -f "$$main_root/.env" ] && [ ! -f .env ]; then \
 		cp "$$main_root/.env" .env && echo "bootstrap: copied .env from $$main_root"; \

--- a/Makefile
+++ b/Makefile
@@ -75,14 +75,7 @@ install-dev:
 bootstrap:
 	$(UV) sync --inexact --frozen --extra proxy --group proxy-dev --group e2e-dev
 	$(UV_RUN) python scripts/prisma_generate_if_needed.py
-	@cd ui/litellm-dashboard && \
-	dep_hash=$$(git hash-object package.json package-lock.json); \
-	stamp=node_modules/.bootstrap-stamp; \
-	if [ "$$(cat "$$stamp" 2>/dev/null)" = "$$dep_hash" ]; then \
-		echo "bootstrap: ui deps up to date, skipping npm ci"; \
-	else \
-		npm ci --no-audit --no-fund && echo "$$dep_hash" > "$$stamp"; \
-	fi
+	cd ui/litellm-dashboard && npm install --no-audit --no-fund
 	@main_root=$$(git worktree list --porcelain | head -1 | sed 's/^worktree //'); \
 	if [ "$$main_root" != "$$(git rev-parse --show-toplevel)" ] && [ -f "$$main_root/.env" ] && [ ! -f .env ]; then \
 		cp "$$main_root/.env" .env && echo "bootstrap: copied .env from $$main_root"; \


### PR DESCRIPTION
## TLDR

Problem this solves:

- `make bootstrap` reruns `npm ci` every time, wasting ~16s per run
- `npm ci` wipes and reinstalls node_modules even when nothing changed

How it solves it:

- swap `npm ci` for `npm install`, which no-ops when node_modules matches the lockfile

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before, at base b1fd20f4cd (its Makefile run from the same checkout): two consecutive bootstraps both reinstall all 835 packages even though nothing changed

```
$ for i in 1 2; do echo "--- base run $i ---"; time make -f base_Makefile bootstrap 2>&1 | grep -E "added .* packages|bootstrap: done"; done
--- base run 1 ---
added 835 packages in 16s
bootstrap: done
make -f base_Makefile bootstrap 2>&1  9.01s user 26.13s system 209% cpu 16.772 total
--- base run 2 ---
added 835 packages in 15s
bootstrap: done
make -f base_Makefile bootstrap 2>&1  9.42s user 26.76s system 230% cpu 15.701 total
```

After, at 25b89a6740: a cold run (node_modules deleted first) installs everything, the warm rerun no-ops in under a second, and the lockfile is untouched either way

```
$ rm -rf ui/litellm-dashboard/node_modules
$ time make bootstrap 2>&1 | grep -E "added .* packages|up to date in|bootstrap: done"
added 835 packages in 10s
bootstrap: done
make bootstrap 2>&1  8.42s user 16.20s system 242% cpu 10.147 total
$ time make bootstrap 2>&1 | grep -E "added .* packages|up to date in|bootstrap: done"
up to date in 482ms
bootstrap: done
make bootstrap 2>&1  0.69s user 0.21s system 120% cpu 0.739 total
$ git diff --stat ui/litellm-dashboard/package.json ui/litellm-dashboard/package-lock.json && echo "lockfile untouched"
lockfile untouched
```

## Type

🚄 Infrastructure

## Changes

The `npm ci` step in `make bootstrap` becomes `npm install`. When node_modules already matches package.json and package-lock.json, npm compares against node_modules/.package-lock.json and no-ops in well under a second instead of wiping and reinstalling everything; when they differ it installs exactly the locked versions. The one behavioral difference from `npm ci` is that an out-of-sync package.json and lockfile pair (hand-edited package.json without reinstalling, or a bad merge) gets the lockfile rewritten instead of erroring, which `git status` makes visible immediately
