### PR TITLE
fix(team-callbacks): report API-registered callbacks from GET /team/{team_id}/callback

### DIFF
--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -28,6 +28,7 @@ from litellm.proxy._types import (
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.common_utils.callback_utils import (
+    _CALLBACK_VAR_ENCRYPTED_PREFIX,
     decrypt_callback_vars,
     encrypt_callback_vars,
     is_sensitive_callback_key,
@@ -81,6 +82,11 @@ def _mask_sensitive_callback_vars(callbacks: TeamCallbackMetadata) -> None:
     what makes a read of this endpoint useful, so only the sensitive keys are
     replaced, using the same marker as the audit-log redaction above.
 
+    A value that still carries the encrypted prefix here failed to decrypt, so
+    it is masked too. Handing back a ciphertext blob under a key that is not
+    classified as sensitive would give the caller something it cannot use and
+    cannot tell apart from a real value.
+
     Masking in place rather than rebuilding the mapping keeps this under the
     LIT002 mutable-collection-construction budget. It is safe because the only
     caller passes an object it just built from a decrypted deep copy of the
@@ -89,7 +95,8 @@ def _mask_sensitive_callback_vars(callbacks: TeamCallbackMetadata) -> None:
     if not callbacks.callback_vars:
         return
     for key in tuple(callbacks.callback_vars):
-        if is_sensitive_callback_key(key):
+        value = callbacks.callback_vars[key]
+        if is_sensitive_callback_key(key) or str(value).startswith(_CALLBACK_VAR_ENCRYPTED_PREFIX):
             callbacks.callback_vars[key] = _CALLBACK_VARS_REDACTED
 
 

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -118,11 +118,6 @@ def _resolve_team_callbacks(team_metadata: object) -> TeamCallbackMetadata:
     logging_entries = decrypted.get("logging")
 
     if logging_entries is not None:
-        # Same predicate the request path uses, so an empty logging slot reports
-        # no callbacks instead of falling through to the deprecated shape that a
-        # request would already be ignoring. A non-list value is a row that fails
-        # at request time; reporting nothing beats reporting a config that never
-        # fires.
         resolved = TeamCallbackMetadata()
         for entry in logging_entries if isinstance(logging_entries, list) else ():
             if not isinstance(entry, dict):

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -27,7 +27,15 @@ from litellm.proxy._types import (
     UserAPIKeyAuth,
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
-from litellm.proxy.common_utils.callback_utils import encrypt_callback_vars
+from litellm.proxy.common_utils.callback_utils import (
+    decrypt_callback_vars,
+    encrypt_callback_vars,
+    is_sensitive_callback_key,
+)
+from litellm.proxy.litellm_pre_call_utils import (
+    _get_validated_callback_metadata,
+    convert_key_logging_metadata_to_callback,
+)
 from litellm.proxy.management_endpoints.team_endpoints import _verify_team_access
 from litellm.proxy.management_helpers.utils import management_endpoint_wrapper
 from litellm.repositories.team_repository import TeamRepository
@@ -62,6 +70,75 @@ def _redact_callback_secrets(metadata: Any) -> Any:
     if isinstance(callback_settings, dict) and isinstance(callback_settings.get("callback_vars"), dict):
         callback_settings["callback_vars"] = {k: _CALLBACK_VARS_REDACTED for k in callback_settings["callback_vars"]}
     return redacted
+
+
+def _mask_sensitive_callback_vars(callbacks: TeamCallbackMetadata) -> None:
+    """Mask credential-bearing callback vars in place, keeping the rest readable.
+
+    ``callback_vars`` mixes credentials (``langsmith_api_key``,
+    ``langfuse_secret_key``, ``gcs_path_service_account``) with plain
+    configuration (project names, bucket names, hosts). The configuration is
+    what makes a read of this endpoint useful, so only the sensitive keys are
+    replaced, using the same marker as the audit-log redaction above.
+
+    Masking in place rather than rebuilding the mapping keeps this under the
+    LIT002 mutable-collection-construction budget. It is safe because the only
+    caller passes an object it just built from a decrypted deep copy of the
+    row, so nothing here is reachable from the team's stored metadata.
+    """
+    if not callbacks.callback_vars:
+        return
+    for key in tuple(callbacks.callback_vars):
+        if is_sensitive_callback_key(key):
+            callbacks.callback_vars[key] = _CALLBACK_VARS_REDACTED
+
+
+def _resolve_team_callbacks(team_metadata: object) -> TeamCallbackMetadata:
+    """Report the callbacks that are actually in effect for a team.
+
+    A team's callback config can live in either of two metadata slots.
+    ``metadata["logging"]`` holds the ``AddTeamCallback`` entries written by
+    ``POST /team/{team_id}/callback`` and by the Admin UI, while
+    ``metadata["callback_settings"]`` holds the older ``TeamCallbackMetadata``
+    shape. Request-time resolution in ``_get_dynamic_logging_metadata`` treats
+    the two as mutually exclusive: a populated ``logging`` slot wins outright
+    and ``callback_settings`` is consulted only as the deprecated fallback.
+    This reader applies the same precedence so it reports what a request would
+    really do. Merging the two instead would report a ``callback_settings``
+    entry as active for a team whose requests never fire it.
+
+    Credential ``callback_vars`` are stored encrypted, so they are decrypted
+    before being masked by key; a value encrypted under a key that is no longer
+    classified as sensitive would otherwise come back as raw ciphertext.
+    """
+    if not isinstance(team_metadata, dict):
+        return TeamCallbackMetadata()
+
+    decrypted = decrypt_callback_vars(team_metadata)
+    logging_entries = decrypted.get("logging")
+
+    if logging_entries is not None:
+        # Same predicate the request path uses, so an empty logging slot reports
+        # no callbacks instead of falling through to the deprecated shape that a
+        # request would already be ignoring. A non-list value is a row that fails
+        # at request time; reporting nothing beats reporting a config that never
+        # fires.
+        resolved = TeamCallbackMetadata()
+        for entry in logging_entries if isinstance(logging_entries, list) else ():
+            if not isinstance(entry, dict):
+                continue
+            callback = _get_validated_callback_metadata(item=entry, source="team-level read")
+            if callback is None:
+                continue
+            resolved = convert_key_logging_metadata_to_callback(data=callback, team_callback_settings_obj=resolved)
+    else:
+        callback_settings = decrypted.get("callback_settings")
+        resolved = (
+            TeamCallbackMetadata(**callback_settings) if isinstance(callback_settings, dict) else TeamCallbackMetadata()
+        )
+
+    _mask_sensitive_callback_vars(resolved)
+    return resolved
 
 
 def _log_audit_task_exception(task: "asyncio.Task[None]") -> None:
@@ -410,6 +487,12 @@ async def get_team_callbacks(
 
     This will return the callback settings for the team with id dbe2f686-a686-4896-864a-4c3924458709
 
+    Covers callbacks registered through POST /team/{team_id}/callback and the Admin UI as well as
+    teams still on the deprecated callback_settings shape, resolved from the team's stored metadata
+    with the same precedence used at request time. A key-level logging config overrides the team's
+    at request time and is not reflected here. Credential-bearing callback_vars are returned masked
+    as `***REDACTED***`
+
     Returns {
             "status": "success",
             "data": {
@@ -442,12 +525,7 @@ async def get_team_callbacks(
             user_api_key_dict=user_api_key_dict,
         )
 
-        # Retrieve team callback settings from metadata
-        team_metadata = _existing_team.metadata
-        team_callback_settings = team_metadata.get("callback_settings", {})
-
-        # Convert to TeamCallbackMetadata object for consistent structure
-        team_callback_settings_obj = TeamCallbackMetadata(**team_callback_settings)
+        team_callback_settings_obj = _resolve_team_callbacks(_existing_team.metadata)
 
         return {
             "status": "success",

--- a/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
@@ -459,3 +459,220 @@ async def test_add_team_callbacks_writes_encrypted_callback_vars(monkeypatch):
     recovered = decrypt_callback_vars(written)["logging"][0]["callback_vars"]
     assert recovered["langfuse_secret_key"] == "sk-lf-real-secret"
     assert recovered["langfuse_public_key"] == "pk-lf-real-public"
+
+
+@pytest.mark.asyncio
+async def test_get_team_callbacks_returns_callbacks_registered_via_post(monkeypatch):
+    """POST then GET must round-trip.
+
+    add_team_callbacks writes metadata["logging"]; a GET that reads only
+    metadata["callback_settings"] reports an empty list for every team
+    configured through the API. The row handed to the GET here is the exact
+    payload the POST wrote, so the two code paths cannot drift apart again.
+    """
+    monkeypatch.setenv("LITELLM_SALT_KEY", "test-salt-32-bytes-aaaaaaaaaaaaaa")
+    row = _team_row(team_id="team-1", metadata={})
+    mock_prisma = _patch_prisma(row)
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        await add_team_callbacks(
+            data=AddTeamCallback(
+                callback_name="langsmith",
+                callback_type="success",
+                callback_vars={
+                    "langsmith_api_key": "lsv2-real-secret",
+                    "langsmith_project": "tenant-project",
+                },
+            ),
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+        # Feed the GET exactly what the POST persisted.
+        row.metadata = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
+        row.model_dump.return_value["metadata"] = row.metadata
+
+        response = await get_team_callbacks(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+        )
+
+    assert response["data"]["success_callbacks"] == ["langsmith"]
+    assert response["data"]["failure_callbacks"] == []
+    # Non-secret vars come back usable, the credential is masked, and the
+    # ciphertext that is stored on the row never reaches the response.
+    assert response["data"]["callback_vars"]["langsmith_project"] == "tenant-project"
+    assert response["data"]["callback_vars"]["langsmith_api_key"] == "***REDACTED***"
+    assert "lsv2-real-secret" not in json.dumps(response)
+    assert "litellm_enc::" not in json.dumps(response)
+
+
+@pytest.mark.asyncio
+async def test_get_team_callbacks_prefers_logging_over_deprecated_callback_settings():
+    """A team carrying both shapes must report only the one that actually fires.
+
+    Request-time resolution in _get_dynamic_logging_metadata stops at the
+    first populated slot: metadata["logging"] wins and callback_settings is
+    never consulted. Reporting the union here would tell an operator that
+    gcs_bucket is active on a team whose requests never send to it.
+    """
+    metadata = {
+        "callback_settings": {
+            "success_callback": ["gcs_bucket"],
+            "failure_callback": [],
+            "callback_vars": {"gcs_bucket_name": "legacy-bucket"},
+        },
+        "logging": [
+            {
+                "callback_name": "langsmith",
+                "callback_type": "success_and_failure",
+                "callback_vars": {"langsmith_project": "tenant-project"},
+            },
+            {"callback_name": "missing-required-fields"},
+        ],
+    }
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=metadata))
+
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+        response = await get_team_callbacks(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+        )
+
+    assert response["data"]["success_callbacks"] == ["langsmith"]
+    assert response["data"]["failure_callbacks"] == ["langsmith"]
+    # The deprecated slot contributes nothing, and the malformed logging entry
+    # is skipped rather than failing the whole read.
+    assert response["data"]["callback_vars"] == {"langsmith_project": "tenant-project"}
+
+
+@pytest.mark.asyncio
+async def test_get_team_callbacks_reports_nothing_when_logging_slot_is_empty():
+    """An empty logging slot must not fall through to callback_settings.
+
+    Request-time resolution stops at the first non-None slot, so a team whose
+    logging list is empty fires no callbacks at all even when the deprecated
+    shape is still populated next to it. Reporting gcs_bucket here would tell
+    an operator a destination is live when nothing is being sent to it.
+    """
+    metadata = {
+        "logging": [],
+        "callback_settings": {
+            "success_callback": ["gcs_bucket"],
+            "failure_callback": [],
+            "callback_vars": {"gcs_bucket_name": "legacy-bucket"},
+        },
+    }
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=metadata))
+
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+        response = await get_team_callbacks(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+        )
+
+    assert response["data"]["success_callbacks"] == []
+    assert response["data"]["failure_callbacks"] == []
+    assert response["data"]["callback_vars"] == {}
+
+
+@pytest.mark.asyncio
+async def test_get_team_callbacks_decrypts_vars_stored_under_non_sensitive_keys(monkeypatch):
+    """Stored ciphertext must be decrypted, not handed back raw.
+
+    Which keys count as sensitive is a moving classification, so a value can be
+    encrypted at rest under a key that later stops being masked on read. Without
+    the decrypt step that value comes back as an unusable litellm_enc:: blob.
+    """
+    from litellm.proxy.common_utils.callback_utils import _CALLBACK_VAR_ENCRYPTED_PREFIX, is_sensitive_callback_key
+    from litellm.proxy.common_utils.encrypt_decrypt_utils import encrypt_value_helper
+
+    monkeypatch.setenv("LITELLM_SALT_KEY", "test-salt-32-bytes-aaaaaaaaaaaaaa")
+    assert not is_sensitive_callback_key("langsmith_project"), "test needs a key that is not masked on read"
+
+    metadata = {
+        "logging": [
+            {
+                "callback_name": "langsmith",
+                "callback_type": "success",
+                "callback_vars": {
+                    "langsmith_project": _CALLBACK_VAR_ENCRYPTED_PREFIX + encrypt_value_helper("tenant-project"),
+                },
+            }
+        ]
+    }
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=metadata))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        response = await get_team_callbacks(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+        )
+
+    assert response["data"]["callback_vars"]["langsmith_project"] == "tenant-project"
+
+
+@pytest.mark.asyncio
+async def test_get_team_callbacks_falls_back_to_deprecated_callback_settings():
+    """Teams that never used the API keep working: with no logging slot, the
+    deprecated callback_settings shape is still reported, exactly as the
+    request-time fallback would use it."""
+    metadata = {
+        "callback_settings": {
+            "success_callback": ["gcs_bucket"],
+            "failure_callback": ["langfuse"],
+            "callback_vars": {
+                "gcs_bucket_name": "legacy-bucket",
+                "langfuse_secret_key": "sk-lf-legacy-plaintext",
+            },
+        }
+    }
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=metadata))
+
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+        response = await get_team_callbacks(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+        )
+
+    assert response["data"]["success_callbacks"] == ["gcs_bucket"]
+    assert response["data"]["failure_callbacks"] == ["langfuse"]
+    assert response["data"]["callback_vars"]["gcs_bucket_name"] == "legacy-bucket"
+    # Legacy rows predate encryption at rest, so this endpoint is where the
+    # plaintext secret would otherwise escape.
+    assert response["data"]["callback_vars"]["langfuse_secret_key"] == "***REDACTED***"
+    assert "sk-lf-legacy-plaintext" not in json.dumps(response)
+
+
+@pytest.mark.asyncio
+async def test_get_team_callbacks_reports_empty_for_team_without_callbacks():
+    """A team with no callback config still returns the documented empty shape."""
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata={}))
+
+    with patch("litellm.proxy.proxy_server.prisma_client", mock_prisma):
+        response = await get_team_callbacks(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+        )
+
+    assert response["data"] == {
+        "team_id": "team-1",
+        "success_callbacks": [],
+        "failure_callbacks": [],
+        "callback_vars": {},
+    }

--- a/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
@@ -626,6 +626,48 @@ async def test_get_team_callbacks_decrypts_vars_stored_under_non_sensitive_keys(
 
 
 @pytest.mark.asyncio
+async def test_get_team_callbacks_masks_values_that_fail_to_decrypt(monkeypatch):
+    """A value that cannot be decrypted must never leave as ciphertext.
+
+    After a salt-key rotation an existing value no longer decrypts, and the
+    shared helper passes it through untouched. Under a key that is not
+    classified as sensitive it would otherwise reach the caller as an opaque
+    blob that is indistinguishable from a real value.
+    """
+    from litellm.proxy.common_utils.callback_utils import _CALLBACK_VAR_ENCRYPTED_PREFIX
+    from litellm.proxy.common_utils.encrypt_decrypt_utils import encrypt_value_helper
+
+    monkeypatch.setenv("LITELLM_SALT_KEY", "test-salt-32-bytes-aaaaaaaaaaaaaa")
+    stale = _CALLBACK_VAR_ENCRYPTED_PREFIX + encrypt_value_helper("tenant-project")
+    monkeypatch.setenv("LITELLM_SALT_KEY", "test-salt-32-bytes-bbbbbbbbbbbbbb")
+
+    metadata = {
+        "logging": [
+            {
+                "callback_name": "langsmith",
+                "callback_type": "success",
+                "callback_vars": {"langsmith_project": stale},
+            }
+        ]
+    }
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=metadata))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        response = await get_team_callbacks(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+        )
+
+    assert response["data"]["success_callbacks"] == ["langsmith"]
+    assert response["data"]["callback_vars"]["langsmith_project"] == "***REDACTED***"
+    assert _CALLBACK_VAR_ENCRYPTED_PREFIX not in json.dumps(response)
+
+
+@pytest.mark.asyncio
 async def test_get_team_callbacks_falls_back_to_deprecated_callback_settings():
     """Teams that never used the API keep working: with no logging slot, the
     deprecated callback_settings shape is still reported, exactly as the

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -14019,6 +14019,12 @@ export interface paths {
          *
          *     This will return the callback settings for the team with id dbe2f686-a686-4896-864a-4c3924458709
          *
+         *     Covers callbacks registered through POST /team/{team_id}/callback and the Admin UI as well as
+         *     teams still on the deprecated callback_settings shape, resolved from the team's stored metadata
+         *     with the same precedence used at request time. A key-level logging config overrides the team's
+         *     at request time and is not reflected here. Credential-bearing callback_vars are returned masked
+         *     as `***REDACTED***`
+         *
          *     Returns {
          *             "status": "success",
          *             "data": {


### PR DESCRIPTION
## TLDR

Problem this solves:

- `GET /team/{team_id}/callback` always returned an empty list
- Callbacks registered via the API or Admin UI were invisible to the API
- Programmatic callback management had no data to work with

How it solves it:

- Read the metadata slot the POST actually writes
- Apply the same precedence request-time resolution uses
- Mask credential values instead of returning ciphertext

## Relevant issues

## Linear ticket

Resolves LIT-5093

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Root cause

`POST /team/{team_id}/callback` writes its entries to `metadata["logging"]`, while `GET /team/{team_id}/callback` read `metadata["callback_settings"]`. Those are two different slots in the team row, so the GET reported nothing for any team configured through the API or the dashboard.

The divergence came from `c620d76fe4` (2025-09-17), which migrated the writer in `add_team_callbacks` to the newer `logging` key and left the reader on the old one. The Admin UI kept working because it reads `metadata.logging` from `/team/info` rather than calling this endpoint.

## Approach

`_resolve_team_callbacks` mirrors the precedence that `_get_dynamic_logging_metadata` applies at request time: a `logging` slot that is present wins outright, and `callback_settings` is consulted only as the deprecated fallback. The two are resolved as mutually exclusive rather than merged, because merging would report a `callback_settings` destination as active for a team whose requests never send to it. An empty `logging` list therefore reports no callbacks, which is what such a team's requests actually do.

`callback_vars` are decrypted for the response and credential keys are masked with the marker the audit-log redaction in this file already uses. The masking predicate is `is_sensitive_callback_key`, the same predicate that decides what gets encrypted on write, so read masking and write encryption cannot disagree. Non-secret configuration such as project names, bucket names, and hosts stays readable, which is what makes the response useful.

## Behavior changes

- `callback_vars` credential values now come back as `***REDACTED***`. Previously they were returned as stored: ciphertext for rows written after callback encryption landed, and plaintext for rows predating it. No first-party consumer reads secrets back from this endpoint; the repo, `ui/litellm-dashboard`, `litellm/proxy/client/`, the e2e suites, and the docs were swept and only a POST-side helper exists.
- A team row whose `metadata` is not a JSON object previously produced a 500 from an `AttributeError` and now returns the documented empty shape.
- A callback var that cannot be decrypted is masked rather than returned. The shared decrypt helper passes such a value through untouched, which happens to existing rows after a salt-key rotation, and under a key that is not classified as sensitive it would otherwise reach the caller as opaque ciphertext indistinguishable from a real value.
- Entries under `logging` that fail `AddTeamCallback` validation are skipped rather than failing the read, matching how request-time resolution treats them. Such entries do not fire callbacks either, so the response stays consistent with behavior.

## Known limitation, tracked separately

The masked value is a marker, not an absence, and the write paths have no rule for it. A caller that reads this endpoint and posts the payload back, for example a script that clones one team's logging config onto another, stores the literal `***REDACTED***` as the credential. It is encrypted at rest like any real secret, so the row looks normal and that team's logging silently stops working. Reproduced on a live proxy: the source team keeps `lsv2-REAL-WORKING-KEY` while the destination team ends up holding `***REDACTED***`.

This is not a regression for any consumer that exists. Nothing in the repo reads this endpoint; the sweep covered `ui/litellm-dashboard/src`, `litellm/proxy/client/`, the e2e suites, cookbooks and load tests, and the only caller anywhere is a POST-only e2e helper that reads `status` with `extra="ignore"`. The same clone flow did work before this PR, but only for pre-encryption rows and only because the endpoint handed back the credential in the clear, which is the exposure this PR closes; for teams configured through the API or the Admin UI the endpoint returned nothing at all, so there was no working flow to preserve.

Tracked as LIT-5110 rather than fixed here, since the likely fix is to stop returning the credential keys at all rather than to add marker-restore logic to four separate write paths.

## Scope

Limited to the GET. Two adjacent problems in the same area were found while reproducing this one and are tracked separately rather than bundled here:

- LIT-5101: `POST /team/{team_id}/disable_logging` clears only `callback_settings`, so it is a no-op for teams configured through the API. Confirmed on the live rig: the endpoint returns success while the callback keeps delivering.
- LIT-5102: `/team/info`, `/team/list`, `/v2/team/list`, and `/key/info` return team callback `callback_vars` unmasked, on a wider access gate than this endpoint.

## Screenshots / Proof of Fix

Live proxy with real Postgres and a real Bedrock model (`us.anthropic.claude-haiku-4-5-20251001-v1:0`). No mocks.

Before, at base `b1fd20f4cd`. Register a callback, then read it back:

```
$ curl -sS -X POST "$P/team/$TEAM/callback" -H "$K" -H "$J" \
  -d '{"callback_name":"langsmith","callback_type":"success","callback_vars":{"langsmith_api_key":"lsv2-secret-abc","langsmith_project":"lit5093-proj"}}'
HTTP 200   {"status":"success", ...}

$ curl -sS -X GET "$P/team/$TEAM/callback" -H "$K"
{"status":"success","data":{"team_id":"96278faf-892e-4eb2-a307-243ff007b797","success_callbacks":[],"failure_callbacks":[],"callback_vars":{}}}
HTTP 200
```

The data was written correctly the whole time; `/team/info` on the same row shows where it went:

```
{
  "logging": [
    {
      "callback_name": "langsmith",
      "callback_type": "success",
      "callback_vars": {
        "langsmith_api_key": "litellm_enc::-8GKg2WuRqi13MVFtFarpxi7XCnvBJaVpwQF1xW4_KpvmnxA1b-qUcN5qHt2eYW_3ZXcuF60iA==",
        "langsmith_project": "lit5093-proj"
      }
    }
  ]
}
```

After, at `f02f4c1813`, same team row written by the unfixed build, same curl, no re-registration:

```
$ curl -sS -X GET "$P/team/$TEAM/callback" -H "$K"
{
    "status": "success",
    "data": {
        "team_id": "96278faf-892e-4eb2-a307-243ff007b797",
        "success_callbacks": ["langsmith"],
        "failure_callbacks": ["langfuse"],
        "callback_vars": {
            "langsmith_api_key": "***REDACTED***",
            "langsmith_project": "lit5093-proj",
            "langfuse_public_key": "***REDACTED***",
            "langfuse_secret_key": "***REDACTED***"
        }
    }
}
```

Edge cases on the same live rig:

```
legacy callback_settings only   success=['gcs_bucket'] failure=['langfuse'] vars={'gcs_bucket_name': 'legacy-bucket', 'langfuse_secret_key': '***REDACTED***'}
both shapes present             success=['langsmith']  failure=['langsmith'] vars={'langsmith_project': 'tenant-proj'}
empty logging slot              success=[]             failure=[]            vars={}
malformed entry skipped         success=['langsmith']  failure=[]            vars={'langsmith_project': 'ok-proj'}
no callbacks configured         success=[]             failure=[]            vars={}
non-admin caller                HTTP 401, access guard intact
```

The response is only correct if it agrees with what a request would really do, so every team row on the rig was resolved through both this endpoint's resolver and the real `_get_dynamic_logging_metadata`:

```
lit5093-both             runtime=(['langsmith'], ['langsmith'])   GET=(['langsmith'], ['langsmith'])   -> MATCH
lit5093-empty            runtime=([], [])                        GET=([], [])                         -> MATCH
lit5093-emptylogging     runtime=([], [])                        GET=([], [])                         -> MATCH
lit5093-legacy           runtime=(['gcs_bucket'], ['langfuse'])  GET=(['gcs_bucket'], ['langfuse'])   -> MATCH
lit5093-legacy2          runtime=(['gcs_bucket'], ['langfuse'])  GET=(['gcs_bucket'], ['langfuse'])   -> MATCH
lit5093-malformed        runtime=(['langsmith'], [])             GET=(['langsmith'], [])              -> MATCH
lit5093-repro            runtime=(['langsmith'], ['langfuse'])   GET=(['langsmith'], ['langfuse'])    -> MATCH
lit5093-runtime          runtime=(['langsmith'], [])             GET=(['langsmith'], [])              -> MATCH

mismatches: 0
```

Mutation matrix over the six new tests, each mutation applied to the fixed source and asserted to be a real edit before the suite ran:

```
pre-fix reader (callback_settings only)   killed, 5 tests
decryption removed                        killed, 1 test
masking removed                           killed, 2 tests
union instead of precedence               killed, 1 test
invalid-entry skip removed                killed, 1 test
```

### End-to-end evidence

Captured after the fix, on the live rig, with the step order deliberately inverted from the verify run: a fresh team, read before any write, and the failure callback registered before the success one.

```
step 1  GET before any callback        {"success_callbacks":[],"failure_callbacks":[],"callback_vars":{}}   HTTP 200
step 2  POST langfuse / failure                                                                            HTTP 200
step 3  GET   success=[]  failure=['langfuse']  vars={langfuse_host: https://cloud.langfuse.com,
                                                     langfuse_public_key: ***REDACTED***,
                                                     langfuse_secret_key: ***REDACTED***}
step 4  POST langsmith / success_and_failure                                                               HTTP 200
step 5  GET   success=['langsmith']  failure=['langfuse', 'langsmith']
              vars={langfuse_host: https://cloud.langfuse.com, langfuse_public_key: ***REDACTED***,
                    langfuse_secret_key: ***REDACTED***, langsmith_api_key: ***REDACTED***,
                    langsmith_project: e2e-proj}
```

A `success_and_failure` registration lands in both lists, the non-secret `langfuse_host` stays readable, and every credential is masked.

The response is only worth anything if it names the callbacks that really run, so the last check ties the report to an actual delivery. A team was given a langsmith callback pointed at a local HTTP collector, then a real Bedrock request was sent on a key scoped to that team:

```
what the endpoint REPORTS:
   success_callbacks = ['langsmith']
   langsmith_project = correlate-proj
   langsmith_api_key = ***REDACTED***

real Bedrock call on a key scoped to that team:
   model: bedrock-claude
   content: verified
   usage: 17 tokens

what ACTUALLY fired: collector deliveries 2 -> 3 (delta 1)
   {"path": "/api/v1/runs/batch", "bytes": 11764}
```

The ticket noted the callback was visible in the Admin UI while the API returned nothing. Both now agree; the dashboard for the team above shows the same two integrations the API reports, Langfuse as Failure Only and LangSmith as Success and Failure:

![Team logging settings in the Admin UI](https://raw.githubusercontent.com/yucheng-berri/pr-assets/assets-pr35512/ui-logging-settings.png)

No UI code is touched by this PR; the screenshot is there to show the dashboard and the API agree after the fix.

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/management_endpoints/team_callback_endpoints.py` gains `_resolve_team_callbacks` and `_mask_sensitive_callback_vars`, and `get_team_callbacks` reads through the resolver. Six regression tests are added to the mapped test file, including a POST-then-GET round trip that feeds the GET exactly the payload the POST persisted so the two paths cannot drift apart again. `schema.d.ts` carries the regenerated docstring delta. A second commit masks callback vars that fail to decrypt, raised by Greptile against the first commit and covered by its own regression test.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
