### PR TITLE
fix(deps): move pydantic-settings into the base dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,6 +281,32 @@ jobs:
             uv build --wheel --out-dir dist
             uv run --no-sync python tests/windows_tests/check_windows_wheel_install.py
 
+  base_sdk_install:
+    docker:
+      - image: cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c
+        auth:
+          username: ${DOCKERHUB_USERNAME}
+          password: ${DOCKERHUB_PASSWORD}
+    working_directory: ~/project
+    steps:
+      - checkout
+      - setup_google_dns
+      - install_uv
+      - run:
+          name: Build the wheel
+          environment:
+            UV_HTTP_TIMEOUT: "300"
+          command: |
+            uv build --wheel --out-dir dist
+      - run:
+          name: Install the wheel with no extras and smoke-check it
+          environment:
+            UV_HTTP_TIMEOUT: "300"
+          command: |
+            uv venv /tmp/base-sdk --python 3.12
+            VIRTUAL_ENV=/tmp/base-sdk uv pip install dist/*.whl
+            /tmp/base-sdk/bin/python tests/base_sdk_tests/check_base_sdk_install.py
+
   local_testing_part1:
     docker:
       - &python312_image
@@ -3031,6 +3057,8 @@ workflows:
               only:
                 - main
                 - /litellm_.*/
+      - base_sdk_install:
+          filters: *main_branches
       - local_testing_part1:
           filters: *main_branches
       - local_testing_part2:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "jinja2>=3.1.6,<4.0",
     "aiohttp>=3.14.2,<4.0",
     "pydantic>=2.10.0,<3.0.0",
+    "pydantic-settings>=2.14.1,<3.0",
     "jsonschema>=4.0.0,<5.0",
 ]
 
@@ -70,7 +71,6 @@ proxy = [
     "polars>=1.38.1,<2.0",
     "soundfile>=0.12.1,<1.0",
     "pyroscope-io>=0.8.16,<1.0; sys_platform != 'win32'",
-    "pydantic-settings>=2.14.1,<3.0",
     "expression>=5.6.0,<6.0",
 ]
 # Thin client install for the `lite` CLI on developer laptops. The CLI's heavy

--- a/tests/base_sdk_tests/check_base_sdk_install.py
+++ b/tests/base_sdk_tests/check_base_sdk_install.py
@@ -1,0 +1,123 @@
+"""Smoke-check that a base ``pip install litellm`` (no extras) is importable and usable.
+
+Run against a virtualenv that has the built wheel installed with no extras, using
+that venv's own interpreter and nothing else. Deliberately stdlib-only: pytest would
+pull ``packaging``, ``pluggy`` and ``iniconfig`` into the environment and could mask
+the very class of undeclared-dependency bug this guards against.
+"""
+
+import importlib.util
+import sys
+import traceback
+from collections.abc import Callable
+
+EXTRAS_ONLY_MODULES = ("fastapi", "boto3", "uvicorn")
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def check_environment_is_base_only() -> str:
+    present = tuple(name for name in EXTRAS_ONLY_MODULES if importlib.util.find_spec(name) is not None)
+    _require(
+        not present,
+        f"{', '.join(present)} installed, so this environment is not base-only and the run proves nothing",
+    )
+    return f"no extras-only packages present ({', '.join(EXTRAS_ONLY_MODULES)})"
+
+
+def check_import() -> str:
+    from importlib.metadata import version
+
+    import litellm
+
+    _require(bool(litellm.__file__), "litellm has no __file__")
+    return f"imported litellm {version('litellm')}"
+
+
+def check_completion() -> str:
+    import litellm
+
+    response = litellm.completion(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "ping"}],
+        mock_response="pong",
+    )
+    content = response.choices[0].message.content
+    _require(content == "pong", f"mock completion returned {content!r}")
+    return "mock completion round-trips"
+
+
+def check_embedding() -> str:
+    import litellm
+
+    response = litellm.embedding(
+        model="text-embedding-3-small",
+        input=["ping"],
+        mock_response=[[0.1, 0.2]],
+    )
+    _require(len(response.data) == 1, f"mock embedding returned {len(response.data)} rows")
+    return "mock embedding round-trips"
+
+
+def check_bundled_model_metadata() -> str:
+    import litellm
+
+    max_input_tokens = litellm.get_model_info("gpt-4o")["max_input_tokens"]
+    _require(
+        isinstance(max_input_tokens, int) and max_input_tokens > 0,
+        f"get_model_info returned max_input_tokens={max_input_tokens!r}",
+    )
+    prompt_cost, completion_cost = litellm.cost_per_token(model="gpt-4o", prompt_tokens=1000, completion_tokens=1000)
+    _require(
+        prompt_cost > 0 and completion_cost > 0,
+        f"cost_per_token returned ({prompt_cost}, {completion_cost})",
+    )
+    return f"bundled pricing metadata readable (gpt-4o max_input_tokens={max_input_tokens})"
+
+
+def check_token_counter() -> str:
+    import litellm
+
+    count = litellm.token_counter(model="gpt-4o", text="hello world")
+    _require(count > 0, f"token_counter returned {count!r}")
+    return f"token_counter returned {count}"
+
+
+CHECKS: tuple[tuple[str, Callable[[], str]], ...] = (
+    ("environment is base-only", check_environment_is_base_only),
+    ("import litellm", check_import),
+    ("chat completion", check_completion),
+    ("embedding", check_embedding),
+    ("bundled model metadata", check_bundled_model_metadata),
+    ("token counter", check_token_counter),
+)
+
+
+def _run(check: Callable[[], str]) -> tuple[bool, str]:
+    try:
+        return True, check()
+    except Exception:
+        return False, traceback.format_exc()
+
+
+def main() -> int:
+    print(f"base SDK smoke check on {sys.executable}")
+    for label, check in CHECKS:
+        passed, detail = _run(check)
+        if not passed:
+            print(f"FAIL  {label}:\n{detail}")
+            print(f"A base `pip install litellm` is broken at: {label}")
+            print("Something needed at import or call time is missing from [project].dependencies")
+            print("in pyproject.toml. Declaring it only in an extra is what causes this.")
+            return 1
+        print(f"PASS  {label}: {detail}")
+
+    print(f"\nall {len(CHECKS)} checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-29T19:04:35.546526Z"
+exclude-newer = "2026-07-29T22:09:54.255381Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4128,6 +4128,7 @@ dependencies = [
     { name = "jsonschema" },
     { name = "openai" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "tiktoken" },
     { name = "tokenizers" },
@@ -4183,7 +4184,6 @@ proxy = [
     { name = "mcp" },
     { name = "orjson" },
     { name = "polars" },
-    { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "pynacl" },
     { name = "pyroscope-io", marker = "sys_platform != 'win32'" },
@@ -4385,7 +4385,7 @@ requires-dist = [
     { name = "prisma", marker = "extra == 'extra-proxy'", specifier = ">=0.11.0,<1.0" },
     { name = "prometheus-client", marker = "extra == 'proxy-runtime'", specifier = ">=0.20.0,<1.0" },
     { name = "pydantic", specifier = ">=2.10.0,<3.0.0" },
-    { name = "pydantic-settings", marker = "extra == 'proxy'", specifier = ">=2.14.1,<3.0" },
+    { name = "pydantic-settings", specifier = ">=2.14.1,<3.0" },
     { name = "pyjwt", marker = "extra == 'proxy'", specifier = ">=2.13.0,<3.0" },
     { name = "pynacl", marker = "extra == 'proxy'", specifier = ">=1.6.2,<2.0" },
     { name = "pypdf", marker = "extra == 'proxy-runtime'", specifier = ">=6.12.0,<7.0" },


### PR DESCRIPTION
## TLDR

Problem this solves:

- `pip install litellm` then `import litellm` fails
- `pydantic-settings` is declared only in the `proxy` extra
- The base import path needs it, so every non-proxy install breaks
- Only the Windows job installs without extras, so this was caught by luck

How it solves it:

- Move `pydantic-settings` into `[project].dependencies`
- Add a CI job that installs the built wheel with no extras
- Smoke-check import, completion, embedding, pricing data, token counter

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs build a wheel from the repo, install it into a clean venv with no extras, and make the same real Anthropic call. No mocks; the call costs real money

### Before, at `b1fd20f4cd`

```bash
uv build --wheel --out-dir beforedist
uv venv proof_before --python 3.13
VIRTUAL_ENV=proof_before uv pip install beforedist/*.whl
proof_before/bin/python -c "
import litellm
r = litellm.completion(model='claude-opus-5', messages=[{'role':'user','content':'Reply with exactly: base install works'}], max_tokens=20)
print('content:', r.choices[0].message.content)
"
```

```
  File ".../site-packages/litellm/integrations/otel/model/config.py", line 8, in <module>
    from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
ModuleNotFoundError: No module named 'pydantic_settings'
```

### After, at `7447f9babc`

Same three commands against a wheel built at the fix commit:

```
content: base install works
model: claude-opus-5
usage: 17 in / 5 out
cost USD: 0.00021
```

### The same break in a published artifact

The last two dev releases on PyPI carry it, so this is reproducible without building anything:

```bash
pip install litellm==1.96.0.dev2 && python -c "import litellm"
```

```
  File ".../litellm/integrations/opentelemetry.py", line 30, in <module>
    from litellm.integrations.otel.model.semconv import Metric
  File ".../litellm/integrations/otel/__init__.py", line 16, in <module>
    from litellm.integrations.otel.model.config import (
  File ".../litellm/integrations/otel/model/config.py", line 8, in <module>
    from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
ModuleNotFoundError: No module named 'pydantic_settings'
```

Current PyPI stable is 1.94.1 and imports fine, and the Docker images install `--extra proxy`, so neither is affected

### The new CI job, run end to end in the pinned CI image

Red against `b1fd20f4cd`, which is the tail of the log a reviewer would actually read:

```
    from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
ModuleNotFoundError: No module named 'pydantic_settings'

A base `pip install litellm` is broken at: import litellm
Something needed at import or call time is missing from [project].dependencies
in pyproject.toml. Declaring it only in an extra is what causes this.
### exit: 1
```

Green against `7447f9babc`:

```
PASS  environment is base-only: no extras-only packages present (fastapi, boto3, uvicorn)
PASS  import litellm: imported litellm 1.96.0
PASS  chat completion: mock completion round-trips
PASS  embedding: mock embedding round-trips
PASS  bundled model metadata: bundled pricing metadata readable (gpt-4o max_input_tokens=128000)
PASS  token counter: token_counter returned 2

all 6 checks passed
### exit: 0
```

## Type

🐛 Bug Fix

✅ Test

## Changes

`import litellm` reaches `litellm/integrations/otel/model/config.py` through `litellm_core_utils/litellm_logging.py`, which imports `integrations/agentops`, which imports `integrations/opentelemetry`, which imports a submodule of the `otel` package and therefore runs its `__init__`. Every link is unconditional and at module level, so `pydantic-settings` is required to import the SDK at all. It was declared only in the `proxy` extra, which left the base install and every other extra unimportable on all platforms

`tests/base_sdk_tests/check_base_sdk_install.py` is the guard. The CI job builds the wheel, installs it into a fresh venv with no extras, and runs the script with that venv's interpreter. It is stdlib-only on purpose: installing pytest into that venv would add `packaging`, `pluggy` and `iniconfig` and could mask the class of undeclared dependency it exists to catch. Its first check asserts `fastapi`, `boto3` and `uvicorn` are absent, so a job misconfiguration that installed extras fails loudly instead of passing as a no-op. It stops at the first failure because cascading import errors bury the real cause at the bottom of a CI log

`get_model_info` is in the check for packaging rather than logic; it only passes when the bundled pricing JSON actually shipped inside the wheel

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
