### PR TITLE
ci(circleci): install a pinned Rust toolchain on the Linux jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,6 +323,7 @@ jobs:
       - checkout
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Build the wheel
           environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,36 @@ commands:
             rm -f /tmp/uv-install.sh
             echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$BASH_ENV"
             export PATH="$HOME/.local/bin:$PATH"
+  install_rust:
+    description: "Install pinned rustup (1.28.2) and Rust toolchain (1.97.1) with checksum verification. Adds ~/.cargo/bin to PATH. Run this before any `uv sync` or `uv build` of the workspace: the root package builds litellm-rust through maturin, and on an image without cargo maturin fetches an unpinned rustup and a floating toolchain by itself."
+    steps:
+      - run:
+          name: Install Rust (rustup 1.28.2, toolchain 1.97.1)
+          command: |
+            case "$(uname -m)" in
+              x86_64)
+                RUSTUP_TRIPLE=x86_64-unknown-linux-gnu
+                RUSTUP_SHA256=20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c
+                ;;
+              aarch64)
+                RUSTUP_TRIPLE=aarch64-unknown-linux-gnu
+                RUSTUP_SHA256=e3853c5a252fca15252d07cb23a1bdd9377a8c6f3efa01531109281ae47f841c
+                ;;
+              *)
+                echo "install_rust: unsupported architecture $(uname -m)" >&2
+                exit 1
+                ;;
+            esac
+            curl -sSLf -o /tmp/rustup-init \
+              "https://static.rust-lang.org/rustup/archive/1.28.2/${RUSTUP_TRIPLE}/rustup-init"
+            echo "${RUSTUP_SHA256}  /tmp/rustup-init" | sha256sum -c -
+            chmod +x /tmp/rustup-init
+            /tmp/rustup-init -y --no-modify-path --profile minimal --default-toolchain 1.97.1
+            rm -f /tmp/rustup-init
+            echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"
+            export PATH="$HOME/.cargo/bin:$PATH"
+            rustc --version
+            cargo --version
   start_postgres:
     description: "Start a postgres-db container on port 5432 and wait until it accepts connections."
     parameters:
@@ -178,6 +208,7 @@ commands:
       - checkout
       - setup_google_dns
       - install_uv
+      - install_rust
       - restore_cache:
           keys:
             - v1-uv-cache-{{ checksum "uv.lock" }}
@@ -298,6 +329,7 @@ jobs:
           keys:
             - v1-uv-cache-{{ checksum "uv.lock" }}
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -371,6 +403,7 @@ jobs:
           keys:
             - v1-uv-cache-{{ checksum "uv.lock" }}
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -445,6 +478,7 @@ jobs:
           keys:
             - v1-uv-cache-{{ checksum "uv.lock" }}
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -496,6 +530,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -562,6 +597,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -602,6 +638,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -643,6 +680,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -676,6 +714,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - restore_cache:
           keys:
             - v1-uv-cache-{{ checksum "uv.lock" }}
@@ -726,6 +765,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - restore_cache:
           keys:
             - v1-uv-cache-{{ checksum "uv.lock" }}
@@ -777,6 +817,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -810,6 +851,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - restore_cache:
           keys:
             - v1-uv-cache-{{ checksum "uv.lock" }}
@@ -856,6 +898,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -902,6 +945,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -944,6 +988,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -990,6 +1035,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1037,6 +1083,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - restore_cache:
           keys:
             - v1-uv-cache-{{ checksum "uv.lock" }}
@@ -1077,6 +1124,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1122,6 +1170,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1166,6 +1215,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1198,6 +1248,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1241,6 +1292,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1285,6 +1337,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1329,6 +1382,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1360,6 +1414,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1406,6 +1461,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1451,6 +1507,7 @@ jobs:
           keys:
             - v1-uv-cache-{{ checksum "uv.lock" }}
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1501,6 +1558,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1525,6 +1583,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1551,6 +1610,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1652,6 +1712,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1747,6 +1808,7 @@ jobs:
           at: ~/project
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1835,6 +1897,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -1918,6 +1981,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -2050,6 +2114,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -2136,6 +2201,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -2232,6 +2298,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -2307,6 +2374,7 @@ jobs:
       - setup_google_dns
       # Remove Docker CLI installation since it's already available in machine executor
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -2388,6 +2456,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -2527,6 +2596,7 @@ jobs:
       - skip_if_unrelated_changes
       - setup_google_dns
       - install_uv
+      - install_rust
       - run:
           name: Install Dependencies
           command: |
@@ -2717,6 +2787,7 @@ jobs:
           category: client
       - setup_google_dns
       - install_uv
+      - install_rust
       - restore_cache:
           keys:
             - v1-uv-cache-{{ checksum "uv.lock" }}
@@ -2859,6 +2930,7 @@ jobs:
           category: client
       - setup_google_dns
       - install_uv
+      - install_rust
       - restore_cache:
           keys:
             - v1-uv-cache-{{ checksum "uv.lock" }}

--- a/tests/test_litellm/test_circleci_rust_toolchain.py
+++ b/tests/test_litellm/test_circleci_rust_toolchain.py
@@ -1,0 +1,148 @@
+"""Static guardrails for how CircleCI provisions Rust.
+
+The root package builds `litellm-rust` through maturin, so any job that runs
+`uv sync` or `uv build` compiles the bridge. The `cimg/python` images ship no
+Rust toolchain, and when cargo is missing maturin's `puccinialin` helper
+quietly provisions one itself: it fetches `rustup-init` from the unversioned
+`https://static.rust-lang.org/rustup/dist/<triple>/` path with no checksum and
+installs a floating `stable` toolchain. uv suppresses build-backend output on a
+successful sync, so that happens with nothing in the job log to show for it,
+and the compiler a job builds with changes whenever upstream publishes.
+
+Two invariants are pinned here:
+
+  1. No step list (job or reusable command) reaches a `uv sync` / `uv build`
+     without a Rust toolchain already provisioned ahead of it. That is the
+     `install_rust` command on Linux and an inline pinned rustup install in the
+     Windows job, so the check accepts either. A new job that syncs without one
+     falls back to the unpinned path, which is exactly the regression a static
+     check catches at PR time and a green CI run does not.
+  2. `install_rust` itself pins what it downloads: an explicit rustup version in
+     the URL, a verified SHA-256, and an exact toolchain version rather than a
+     channel name.
+
+The Windows job predates `install_rust` and provisions its toolchain inline, so
+invariant 2 is scoped to `install_rust`; invariant 1 covers both.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG = REPO_ROOT / ".circleci" / "config.yml"
+
+BUILDS_WORKSPACE = re.compile(r"\buv\s+(?:sync|build)\b")
+RUSTUP_ARCHIVE_URL = re.compile(r"https://static\.rust-lang\.org/rustup/archive/\d+\.\d+\.\d+/")
+EXACT_TOOLCHAIN = re.compile(r"--default-toolchain\s+\"?\d+\.\d+\.\d+\"?")
+
+
+def _config() -> dict[str, object]:
+    return yaml.safe_load(CONFIG.read_text())
+
+
+def _step_text(step: object) -> str:
+    """Flatten one step into the shell text it runs, or '' for a command reference."""
+    if isinstance(step, dict):
+        run = step.get("run")
+        if isinstance(run, str):
+            return run
+        if isinstance(run, dict):
+            command = run.get("command")
+            return command if isinstance(command, str) else ""
+    return ""
+
+
+def _without_comments(text: str) -> str:
+    return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
+
+
+def _provisions_rust(step: object) -> bool:
+    if step == "install_rust":
+        return True
+    text = _step_text(step)
+    return "rustup-init" in text and ("sha256sum" in text or "SHA256" in text)
+
+
+def _step_lists() -> dict[str, list[object]]:
+    config = _config()
+    lists: dict[str, list[object]] = {}
+    for kind in ("jobs", "commands"):
+        section = config.get(kind)
+        if not isinstance(section, dict):
+            continue
+        for name, body in section.items():
+            steps = body.get("steps") if isinstance(body, dict) else None
+            if isinstance(steps, list):
+                lists[f"{kind[:-1]} {name}"] = steps
+    return lists
+
+
+def _first_unprovisioned_build(steps: list[object]) -> str | None:
+    """Return the shell text of the first workspace build reached without Rust, if any."""
+    rust_ready = False
+    for step in steps:
+        if _provisions_rust(step):
+            rust_ready = True
+        text = _step_text(step)
+        if BUILDS_WORKSPACE.search(_without_comments(text)) and not rust_ready:
+            return text
+    return None
+
+
+def test_step_lists_exist() -> None:
+    lists = _step_lists()
+    assert "command install_rust" in lists
+    building = {
+        name
+        for name, steps in lists.items()
+        if any(BUILDS_WORKSPACE.search(_without_comments(_step_text(s))) for s in steps)
+    }
+    assert len(building) > 10, f"expected many workspace-building step lists, found {sorted(building)}"
+
+
+def test_no_workspace_build_without_a_provisioned_rust_toolchain() -> None:
+    offenders = {
+        name: build for name, steps in _step_lists().items() if (build := _first_unprovisioned_build(steps)) is not None
+    }
+    assert not offenders, (
+        "these CircleCI step lists run `uv sync`/`uv build` with no Rust toolchain provisioned first, "
+        "so maturin will download an unpinned rustup and a floating toolchain instead: "
+        f"{ {name: build.strip().splitlines()[0] for name, build in offenders.items()} }"
+    )
+
+
+@pytest.fixture(name="install_rust_command")
+def _install_rust_command() -> str:
+    steps = _step_lists()["command install_rust"]
+    return "\n".join(_step_text(step) for step in steps)
+
+
+def test_install_rust_pins_the_rustup_version_in_the_url(install_rust_command: str) -> None:
+    assert RUSTUP_ARCHIVE_URL.search(install_rust_command), (
+        "install_rust must download rustup-init from a version-pinned /rustup/archive/<x.y.z>/ URL; "
+        "the /rustup/dist/ path always serves whatever rustup is current"
+    )
+    assert "/rustup/dist/" not in install_rust_command
+
+
+def test_install_rust_verifies_the_installer_checksum(install_rust_command: str) -> None:
+    assert "sha256sum -c" in install_rust_command
+    assert re.search(r"RUSTUP_SHA256=[0-9a-f]{64}\b", install_rust_command), (
+        "install_rust must compare the downloaded installer against a hardcoded SHA-256 "
+        "taken from rust-lang's published .sha256 sidecar"
+    )
+    checksum_index = install_rust_command.index("sha256sum -c")
+    execute_index = install_rust_command.index("/tmp/rustup-init -y")
+    assert checksum_index < execute_index, "the checksum must be verified before the installer is executed"
+
+
+def test_install_rust_pins_an_exact_toolchain_version(install_rust_command: str) -> None:
+    assert EXACT_TOOLCHAIN.search(install_rust_command), (
+        "install_rust must pin an exact toolchain version (e.g. 1.97.1); a channel name like "
+        "stable/beta/nightly makes the compiler drift with whatever upstream published that day"
+    )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Linux CI images have no Rust; maturin installs one itself
- That rustup download is unversioned and unverified
- The toolchain floats, so the compiler drifts daily
- uv hides it, so no job log shows it happening

How it solves it:

- New `install_rust` command, pinned rustup 1.28.2
- SHA-256 checked against rust-lang's published sidecar
- Pins toolchain 1.97.1 and puts cargo on PATH
- Wired into the 43 step lists that build the workspace

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Everything below runs in the same `cimg/python:3.12` image the Linux jobs use, pinned to the digest in `.circleci/config.yml`. Both runs execute the `install_uv` and `install_rust` bodies extracted straight out of the checked-out `config.yml`, so the proof exercises the committed steps rather than a retyped copy. Run 1 is at `11ad3ff939` (the commit before this PR), run 2 at `ed087c7aab`. Local runs are arm64; CircleCI is x86_64, and `install_rust` selects the triple and checksum from `uname -m`

1. Confirm the image genuinely has no Rust

```bash
docker run --rm cimg/python:3.12@sha256:9c796c23c84e84a66a964acb508d39dc5433c81a47e07efd56dccbbc2427e07c bash -lc 'command -v cargo rustc rustup || echo "no rust toolchain in the image"; find / -name cargo -maxdepth 6 2>/dev/null | wc -l'
```

```
no rust toolchain in the image
0
```

2. Before (`11ad3ff939`): `install_uv`, then a sync and a build

```
=== step: install_uv ===
  uvx
everything's installed!
=== step: uv sync --frozen --no-default-groups ===
      Built litellm @ file:///home/circleci/project
Installed 55 packages in 3.84s
=== step: uv build --wheel (same maturin path, prints backend output) ===
Installation directory: /home/circleci/.cache/puccinialin
Rust not found, installing into a temporary directory
Successfully built /tmp/dist/litellm-1.96.0-cp312-cp312-linux_aarch64.whl
=== which cargo built the bridge ===
cargo NOT on PATH
/home/circleci/.cache/puccinialin
^ maturin downloaded its own rustup
  toolchain maturin picked: stable-aarch64-unknown-linux-gnu
```

Note that the `uv sync` line, which is what the Linux jobs actually run, prints a clean `Built litellm` and nothing else; uv swallows the backend's output when the build succeeds. The bridge was still compiled by a toolchain maturin fetched on its own. `uv build` surfaces the same backend output, which is why it is included

3. Before (`11ad3ff939`): where that toolchain came from, with the puccinialin cache cleared so the download is not skipped

```bash
docker exec proof-before bash -lc 'rm -rf ~/.cache/puccinialin; uv build --wheel --out-dir /tmp/dist3 2>&1 | tr "\r" "\n" | grep -E "Downloading rustup-init from|Rust not found|latest update on|default toolchain set to"'
```

```
Downloading rustup-init from https://static.rust-lang.org/rustup/dist/aarch64-unknown-linux-gnu/rustup-init
Rust not found, installing into a temporary directory
info: latest update on 2026-07-16 for version 1.97.1 (8bab26f4f 2026-07-14)
info: default toolchain set to stable-aarch64-unknown-linux-gnu
```

`/rustup/dist/` carries no version, nothing verifies the 19.5 MB installer, and the toolchain is whatever `stable` resolved to that day

4. After (`ed087c7aab`): same image, same commands, with `install_rust` in front

```
=== step: install_uv ===
  uvx
everything's installed!
=== step: install_rust ===
/tmp/rustup-init: OK
rustc 1.97.1 (8bab26f4f 2026-07-14)
cargo 1.97.1 (c980f4866 2026-06-30)
=== step: uv sync --frozen --no-default-groups ===
      Built litellm @ file:///home/circleci/project
Installed 55 packages in 4.78s
=== step: uv build --wheel (same maturin path, prints backend output) ===
Successfully built /tmp/dist/litellm-1.96.0-cp312-cp312-linux_aarch64.whl
=== which cargo built the bridge ===
/home/circleci/.cargo/bin/cargo
~/.cache/puccinialin ABSENT
```

`/tmp/rustup-init: OK` is the checksum passing, the puccinialin lines are gone, the cache directory is never created, and both the sync and the wheel build succeed against the pinned 1.97.1

5. The checksum is a real gate, not decoration. Flipping the expected hash to zeroes aborts the step before the installer is ever executed

```bash
sed 's/RUSTUP_SHA256=e3853c.../RUSTUP_SHA256=0000.../' install_rust.sh > tampered.sh && docker exec proof bash -lc 'bash -eo pipefail /tmp/tampered.sh; echo "EXIT=$?"; ls -d ~/.cargo 2>&1'
```

```
sha256sum: WARNING: 1 computed checksum did NOT match
/tmp/rustup-init: FAILED
EXIT=1
ls: cannot access '/home/circleci/.cargo': No such file or directory
```

6. The guardrail test, and the mutations it kills

```bash
python -m pytest tests/test_litellm/test_circleci_rust_toolchain.py -q
```

```
.....                                                                    [100%]
5 passed in 0.46s
```

Each mutation below was applied to `.circleci/config.yml` on its own and the file restored afterwards

```
M0 baseline (must be green):        5 passed
M1 one job loses install_rust:      1 failed, 4 passed
M2 toolchain -> floating stable:    1 failed, 4 passed
M3 URL -> unversioned /dist/:       1 failed, 4 passed
M4 checksum check deleted:          1 failed, 4 passed
M5 checksum moved after execute:    1 failed, 4 passed
M6 new job syncs w/o install_rust:  1 failed, 4 passed
```

M6 is the one that matters for maintenance, and it stopped being hypothetical: `base_sdk_install` landed on staging while this branch was open, building a wheel behind `install_uv` alone, and the guardrail failed on the merge result and named it. The failure below is the synthetic M6; the real one read the same way with `base_sdk_install` in place of the placeholder

```
AssertionError: these CircleCI step lists run `uv sync`/`uv build` with no Rust toolchain
provisioned first, so maturin will download an unpinned rustup and a floating toolchain
instead: {'job brand_new_job_placeholder': 'uv sync --frozen --all-groups --all-extras --python 3.12'}
```

## Type

🚄 Infrastructure

## Changes

The root package builds `litellm-rust` through maturin, so every job that runs `uv sync` or `uv build` compiles the bridge. The `cimg/python` images ship no Rust toolchain, and when cargo is missing maturin's `puccinialin` helper provisions one for itself from the unversioned `/rustup/dist/` path with no checksum, then installs a floating `stable` toolchain. The Windows job already did this properly with a pinned, hash-verified rustup 1.28.2; the Linux jobs had no equivalent, so they picked up whatever the current rustup and current stable happened to be on the day the job ran

`install_rust` closes that. It resolves the triple and expected SHA-256 from `uname -m`, downloads rustup 1.28.2 from the version-pinned `/rustup/archive/1.28.2/` path, verifies it against the hash published in rust-lang's `.sha256` sidecar for that exact artifact, installs toolchain 1.97.1 with the minimal profile, and exports `~/.cargo/bin` through `BASH_ENV` so later steps see cargo. Toolchain components are verified by rustup itself against the signed channel manifest

It is wired in after `install_uv` in the 43 jobs and reusable commands that build the workspace. `upload-coverage` is the one caller left alone; it only runs `uv tool run coverage` and never builds anything. It sits after `skip_if_unrelated_changes`, so a path-filtered job that halts never pays for it

Net download cost is unchanged, since puccinialin was already pulling a rustup plus a toolchain in each of these jobs. The difference is that both are now pinned, verified, and visible in the job log

Two things left deliberately out of scope, worth a follow-up:

The Windows job still passes `--default-toolchain stable`, so its rustup is pinned but its compiler is not. Pinning it to 1.97.1 would make both platforms build with the same toolchain, but it touches a job this PR otherwise does not

`install_uv` downloads the uv installer over a verified checksum, and the installer then reports `no checksums to verify` for the uv binary it fetches. That is a gap in a different tool's install path and belongs in its own change

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

