### PR TITLE
fix(team-callbacks): actually stop logging when disable_logging is called

### DIFF
--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -37,7 +37,10 @@ from litellm.proxy.litellm_pre_call_utils import (
     _get_validated_callback_metadata,
     convert_key_logging_metadata_to_callback,
 )
-from litellm.proxy.management_endpoints.team_endpoints import _verify_team_access
+from litellm.proxy.management_endpoints.team_endpoints import (
+    _refresh_cached_team,
+    _verify_team_access,
+)
 from litellm.proxy.management_helpers.utils import management_endpoint_wrapper
 from litellm.repositories.team_repository import TeamRepository
 
@@ -262,7 +265,11 @@ async def add_team_callbacks(
     """
     try:
         from litellm.proxy._types import CommonProxyErrors
-        from litellm.proxy.proxy_server import prisma_client
+        from litellm.proxy.proxy_server import (
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
 
         if prisma_client is None:
             raise HTTPException(
@@ -316,6 +323,17 @@ async def add_team_callbacks(
         new_team_row = await TeamRepository(prisma_client).table.update(
             where={"team_id": team_id},
             data={"metadata": team_metadata_json},  # type: ignore
+            # `object_permission` is included so `_refresh_cached_team` doesn't
+            # write a cached team with the relation nulled out — see
+            # team_model_add for the full rationale.
+            include={"object_permission": True},  # mutable-ok: prisma include takes a dict literal
+        )
+
+        # Without this a newly registered callback stays dormant for existing keys.
+        await _refresh_cached_team(
+            team_row=new_team_row,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
         )
 
         await _emit_team_callback_audit_log(
@@ -363,6 +381,9 @@ async def disable_team_logging(
     """
     Disable all logging callbacks for a team
 
+    Callbacks registered through POST /team/{team_id}/callback and the Admin UI are cleared, so
+    re-enabling logging means registering them again with their callback_vars
+
     Parameters:
     - team_id (str, required): The unique identifier for the team
 
@@ -375,7 +396,11 @@ async def disable_team_logging(
 
     """
     try:
-        from litellm.proxy.proxy_server import prisma_client
+        from litellm.proxy.proxy_server import (
+            prisma_client,
+            proxy_logging_obj,
+            user_api_key_cache,
+        )
 
         if prisma_client is None:
             raise HTTPException(status_code=500, detail={"error": "No db connected"})
@@ -408,6 +433,9 @@ async def disable_team_logging(
 
         # Update metadata
         team_metadata["callback_settings"] = team_callback_settings_obj.model_dump()
+        # _get_dynamic_logging_metadata stops at metadata["logging"], where the API
+        # and Admin UI register callbacks, without ever reading callback_settings.
+        team_metadata["logging"] = []  # mutable-ok: the disabled state is persisted as an empty JSON array
         team_metadata = encrypt_callback_vars(team_metadata)
         team_metadata_json = json.dumps(team_metadata)
 
@@ -415,6 +443,10 @@ async def disable_team_logging(
         updated_team = await TeamRepository(prisma_client).table.update(
             where={"team_id": team_id},
             data={"metadata": team_metadata_json},  # type: ignore
+            # `object_permission` is included so `_refresh_cached_team` doesn't
+            # write a cached team with the relation nulled out — see
+            # team_model_add for the full rationale.
+            include={"object_permission": True},  # mutable-ok: prisma include takes a dict literal
         )
 
         if updated_team is None:
@@ -422,6 +454,14 @@ async def disable_team_logging(
                 status_code=404,
                 detail={"error": f"Team id = {team_id} does not exist. Error updating team logging"},
             )
+
+        # Request-time callback resolution reads the cached team, so without this
+        # the DB says logging is off while live keys keep sending until it expires.
+        await _refresh_cached_team(
+            team_row=updated_team,
+            user_api_key_cache=user_api_key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+        )
 
         # Disabling a team's logging callbacks is itself a logging-control
         # action — emit an audit-log row so the action remains traceable

--- a/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_callback_endpoints.py
@@ -66,6 +66,23 @@ def _admin_auth() -> UserAPIKeyAuth:
     )
 
 
+@pytest.fixture(autouse=True)
+def stub_team_cache_refresh():
+    """Keep the cached-team refresh out of the way of the mocked prisma rows.
+
+    The endpoints under test now refresh the auth cache after their DB write.
+    That helper validates a real Prisma row into LiteLLM_TeamTableCachedObj,
+    which the MagicMock rows these tests use cannot satisfy. The refresh being
+    called at all is asserted explicitly in
+    test_disable_team_logging_refreshes_cached_team.
+    """
+    with patch(
+        "litellm.proxy.management_endpoints.team_callback_endpoints._refresh_cached_team",
+        new_callable=AsyncMock,
+    ) as refresh:
+        yield refresh
+
+
 @pytest.fixture
 def unauthorized_caller():
     return UserAPIKeyAuth(
@@ -238,6 +255,9 @@ async def test_disable_team_logging_emits_audit_log_when_enabled(monkeypatch):
     assert before["metadata"]["callback_settings"]["success_callback"] == ["langfuse"]
     assert after["metadata"]["callback_settings"]["success_callback"] == []
     assert after["metadata"]["callback_settings"]["failure_callback"] == []
+    # The audit row has to show the slot the callbacks actually live in, so a
+    # disable of a logging-configured team does not record an empty diff.
+    assert after["metadata"]["logging"] == []
 
 
 @pytest.mark.asyncio
@@ -718,3 +738,207 @@ async def test_get_team_callbacks_reports_empty_for_team_without_callbacks():
         "failure_callbacks": [],
         "callback_vars": {},
     }
+
+
+@pytest.mark.asyncio
+async def test_disable_team_logging_stops_callbacks_registered_via_api():
+    """Disabling logging must stop the callbacks that are actually running.
+
+    Callbacks registered through the API or the Admin UI live in
+    metadata["logging"], and request-time resolution stops at that slot without
+    reading callback_settings. Clearing only callback_settings therefore reports
+    success while the team keeps sending to its logging destination. This drives
+    the endpoint and then asks the real request-time resolver what the written
+    row would do.
+    """
+    from litellm.proxy.litellm_pre_call_utils import _get_dynamic_logging_metadata
+
+    metadata = {
+        "logging": [
+            {
+                "callback_name": "langsmith",
+                "callback_type": "success",
+                "callback_vars": {"langsmith_project": "tenant-project"},
+            }
+        ]
+    }
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=metadata))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        response = await disable_team_logging(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+    assert response["status"] == "success"
+    written = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
+    assert written["logging"] == []
+
+    resolved = _get_dynamic_logging_metadata(
+        UserAPIKeyAuth(api_key="hashed", team_id="team-1", team_metadata=written),
+        proxy_config=MagicMock(**{"load_team_config.return_value": {}}),
+    )
+    assert not (resolved.success_callback if resolved else None)
+    assert not (resolved.failure_callback if resolved else None)
+
+
+@pytest.mark.asyncio
+async def test_disable_team_logging_refreshes_cached_team(stub_team_cache_refresh):
+    """The DB write alone does not stop delivery.
+
+    Auth serves a cached team object and request-time callback resolution reads
+    the metadata off it, so without this refresh a key that is already in flight
+    keeps sending to the destination until the cache entry expires.
+    """
+    metadata = {
+        "logging": [
+            {
+                "callback_name": "langsmith",
+                "callback_type": "success",
+                "callback_vars": {"langsmith_project": "tenant-project"},
+            }
+        ]
+    }
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=metadata))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        await disable_team_logging(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+    stub_team_cache_refresh.assert_awaited_once()
+    refreshed = stub_team_cache_refresh.await_args.kwargs["team_row"]
+    assert refreshed is mock_prisma.db.litellm_teamtable.update.return_value
+    # The row fed to the cache has to carry object_permission, or the refresh
+    # publishes a team whose tool allowlists look empty, which reads as
+    # unrestricted on the search-tool and MCP-tool checks.
+    update_kwargs = mock_prisma.db.litellm_teamtable.update.await_args.kwargs
+    assert update_kwargs["include"]["object_permission"] is True
+
+
+@pytest.mark.asyncio
+async def test_add_team_callbacks_refreshes_cached_team(stub_team_cache_refresh):
+    """Registering a callback must take effect for keys that are already live."""
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata={"logging": []}))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        await add_team_callbacks(
+            data=AddTeamCallback(
+                callback_name="langsmith",
+                callback_type="success",
+                callback_vars={"langsmith_project": "tenant-project"},
+            ),
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+    stub_team_cache_refresh.assert_awaited_once()
+    refreshed = stub_team_cache_refresh.await_args.kwargs["team_row"]
+    assert refreshed is mock_prisma.db.litellm_teamtable.update.return_value
+    update_kwargs = mock_prisma.db.litellm_teamtable.update.await_args.kwargs
+    assert update_kwargs["include"]["object_permission"] is True
+
+
+@pytest.mark.asyncio
+async def test_disable_team_logging_clears_both_metadata_shapes():
+    """A team carrying both shapes ends up with neither active."""
+    from litellm.proxy.litellm_pre_call_utils import _get_dynamic_logging_metadata
+
+    metadata = {
+        "logging": [
+            {
+                "callback_name": "langsmith",
+                "callback_type": "success_and_failure",
+                "callback_vars": {"langsmith_project": "tenant-project"},
+            }
+        ],
+        "callback_settings": {
+            "success_callback": ["gcs_bucket"],
+            "failure_callback": ["langfuse"],
+            "callback_vars": {"gcs_bucket_name": "legacy-bucket"},
+        },
+    }
+    mock_prisma = _patch_prisma(_team_row(team_id="team-1", metadata=metadata))
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        await disable_team_logging(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+    written = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
+    assert written["logging"] == []
+    assert written["callback_settings"]["success_callback"] == []
+    assert written["callback_settings"]["failure_callback"] == []
+
+    resolved = _get_dynamic_logging_metadata(
+        UserAPIKeyAuth(api_key="hashed", team_id="team-1", team_metadata=written),
+        proxy_config=MagicMock(**{"load_team_config.return_value": {}}),
+    )
+    assert not (resolved.success_callback if resolved else None)
+    assert not (resolved.failure_callback if resolved else None)
+
+
+@pytest.mark.asyncio
+async def test_disable_team_logging_leaves_team_re_enablable():
+    """The emptied slot must still accept a fresh registration afterwards."""
+    metadata = {
+        "logging": [
+            {
+                "callback_name": "langsmith",
+                "callback_type": "success",
+                "callback_vars": {"langsmith_project": "tenant-project"},
+            }
+        ]
+    }
+    row = _team_row(team_id="team-1", metadata=metadata)
+    mock_prisma = _patch_prisma(row)
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client", mock_prisma),
+        patch("litellm.proxy.proxy_server.master_key", None),
+    ):
+        await disable_team_logging(
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+        row.metadata = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
+        row.model_dump.return_value["metadata"] = row.metadata
+
+        await add_team_callbacks(
+            data=AddTeamCallback(
+                callback_name="langfuse",
+                callback_type="success",
+                callback_vars={"langfuse_public_key": "pk-lf-new"},
+            ),
+            http_request=MagicMock(spec=Request),
+            team_id="team-1",
+            user_api_key_dict=_admin_auth(),
+            litellm_changed_by=None,
+        )
+
+    written = json.loads(mock_prisma.db.litellm_teamtable.update.await_args.kwargs["data"]["metadata"])
+    assert [entry["callback_name"] for entry in written["logging"]] == ["langfuse"]

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -14092,6 +14092,9 @@ export interface paths {
          * Disable Team Logging
          * @description Disable all logging callbacks for a team
          *
+         *     Callbacks registered through POST /team/{team_id}/callback and the Admin UI are cleared, so
+         *     re-enabling logging means registering them again with their callback_vars
+         *
          *     Parameters:
          *     - team_id (str, required): The unique identifier for the team
          *


### PR DESCRIPTION
## TLDR

Problem this solves:

- disable_logging reported success while the team kept logging
- Data kept flowing to the third-party destination after disable
- A registered callback also stayed dormant for live keys

How it solves it:

- Clear the metadata slot the callbacks actually live in
- Refresh the cached team so it applies immediately

## Relevant issues

## Linear ticket

Resolves LIT-5101

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Root cause

`disable_team_logging` cleared only `metadata["callback_settings"]`. Callbacks registered through `POST /team/{team_id}/callback` and the Admin UI are written to `metadata["logging"]`, and request-time resolution in `_get_dynamic_logging_metadata` is an elif chain where a `logging` slot that is present wins outright and `callback_settings` is never read. So for every team configured through the API or the dashboard, the endpoint cleared a slot nothing was reading and returned success.

Same origin as LIT-5093: `c620d76fe4` (2025-09-17) migrated the writer in `add_team_callbacks` to the new key and left the readers behind.

## Approach

Empty `metadata["logging"]` alongside the existing `callback_settings` reset. Writing an empty list rather than deleting the key is deliberate: an empty list is still "present and not None", so it keeps winning the elif chain and nothing falls back to the deprecated shape. Verified that an empty dynamic list does not suppress globally configured callbacks, since `get_combined_callback_list` returns the global list for both `None` and `[]`.

The DB write alone turned out not to be enough. Auth serves a cached team object and callback resolution reads the metadata off it, so with a warm cache the callback kept firing after a successful disable and only stopped once the entry expired. `_refresh_cached_team` is now called after the write, which is what its docstring already required of every endpoint that mutates the team table. The same call is added to `add_team_callbacks`, which had the symmetric problem of a newly registered callback staying dormant for keys that were already live.

Both updates pass `include={"object_permission": True}`, matching every other `_refresh_cached_team` caller. Without it the refresh publishes a cached team whose `object_permission` relation is nulled out, which reads as an empty search-tool and MCP-tool allowlist, and an empty allowlist means unrestricted.

## Behavior changes

- Disabling logging now clears registered callbacks outright, credentials included, so re-enabling means registering them again. The `callback_settings` path was non-destructive by comparison. The endpoint docstring now says so.
- After a disable, a team's `callback_vars` are no longer unpacked into the request, so globally configured callbacks stop being steered by that team's credentials and use the proxy default instead. This only affects teams that have been explicitly disabled.
- `add_team_callbacks` and `disable_team_logging` now write to the team cache. Both already held the team-management access guard, so no new caller reaches them.

## Screenshots / Proof of Fix

Live proxy, real Postgres, real Bedrock (`us.anthropic.claude-haiku-4-5-20251001-v1:0`). The langsmith callback points at a local HTTP collector so delivery is observable as a count. No mocks.

Before, at base `b1fd20f4cd`:

```
register callback on the team                      HTTP 200
chat completion on a team-scoped key               HTTP 200
   collector deliveries 0 -> 1

POST /team/{team_id}/disable_logging               HTTP 200
   {"status":"success","message":"Logging disabled for team ..."}

stored metadata after the disable:
   "logging": [ { "callback_name": "langsmith", ... } ]      <- untouched
   "callback_settings": { "success_callback": [], ... }      <- cleared

chat completion after the disable                  HTTP 200
   collector deliveries 1 -> 2                               <- still logging
```

After, at `f161cd162e`, with the cache warmed by a delivering request first so the disable has to invalidate it:

```
chat completion (warms the cached team)            HTTP 200
   collector deliveries 6 -> 7

POST /team/{team_id}/disable_logging               HTTP 200
chat completion immediately after                  HTTP 200
   collector deliveries 7 -> 7                               <- stopped on the very next request

stored metadata after the disable:
   "logging": []
   "callback_settings": {"callbacks": [], "callback_vars": {}, "failure_callback": [], "success_callback": []}
```

The DB write on its own was not sufficient, which is what motivated the cache refresh. With the write applied but no refresh, delivery continued and only stopped once the entry expired:

```
disable applied, DB shows "logging": []
   probe at +45s   deliveries 4 -> 4
   probe at +100s  deliveries 4 -> 4
   probe at +155s  deliveries 4 -> 4
immediately after the disable, before the refresh existed:  deliveries 3 -> 4
```

The symmetric registration path, on the same rig:

```
chat completion with no callback registered (warms the cache)   HTTP 200
   collector baseline 5
register the callback                                           HTTP 200
chat completion immediately after                               HTTP 200
   collector deliveries 5 -> 6                                  <- effective at once
```

Mutation matrix, each mutation asserted to be a real edit before the suite ran:

```
remove team_metadata["logging"] = []          killed, 4 tests
remove both _refresh_cached_team calls        killed, 2 tests
remove both object_permission includes        killed, 2 tests
```

## Type

🐛 Bug Fix

## Changes

`disable_team_logging` empties `metadata["logging"]` and refreshes the cached team; `add_team_callbacks` gains the same refresh. Both DB updates now include the `object_permission` relation. Nine regression tests are added to the mapped test file, three of which resolve the written metadata through the real `_get_dynamic_logging_metadata` so the assertion is about what a request would actually do rather than about the shape of a dict.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/berriai/litellm/pull/35520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes team observability and cached auth team objects used at request time; behavior is intentional but affects live keys and tool permission reads if includes were wrong.
> 
> **Overview**
> **`disable_team_logging`** now clears **`metadata["logging"]`** (where API/Admin UI callbacks are stored), not only the legacy **`callback_settings`** slot that request-time resolution ignores when **`logging`** is present. Disable is destructive: credentials are removed and must be re-registered; the endpoint docstring reflects that.
> 
> Both **`add_team_callbacks`** and **`disable_team_logging`** call **`_refresh_cached_team`** after the DB update so in-flight API keys see callback changes immediately instead of waiting for cache expiry. Team updates use **`include={"object_permission": True}`** so the refreshed cache does not drop permission relations.
> 
> Tests add an autouse stub for cache refresh, assert audit logs record **`logging: []`**, and cover resolver behavior, cache refresh, dual metadata shapes, and re-enable after disable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f161cd162e2f4ed0ccecbd2ecdeb08a68d3e9ad4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->