### PR TITLE
feat(ui): show auto-router savings on the cost-optimization dashboard

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
@@ -29,12 +29,14 @@ vi.mock("@/components/shared/charts", () => ({
     colors,
     showLegend,
     maxBarSize,
+    stack,
   }: {
     data: unknown;
     categories: string[];
     colors?: readonly string[];
     showLegend?: boolean;
     maxBarSize?: number;
+    stack?: boolean;
   }) => (
     <div
       data-testid="bar-chart"
@@ -42,6 +44,7 @@ vi.mock("@/components/shared/charts", () => ({
       data-colors={(colors ?? []).join(",")}
       data-show-legend={String(showLegend ?? true)}
       data-max-bar-size={maxBarSize === undefined ? "" : String(maxBarSize)}
+      data-stack={String(stack ?? false)}
       data-series={JSON.stringify(data)}
     />
   ),
@@ -216,8 +219,8 @@ describe("UsageTab", () => {
 
     const slices = JSON.parse(getByTestId("donut-chart").getAttribute("data-slices") ?? "[]");
     expect(slices).toEqual([
-      { driver: "Compression", usd: expect.closeTo(0.14, 5) },
-      { driver: "Prompt caching", usd: expect.closeTo(0.016, 5) },
+      { driver: "Compression", color: "emerald", usd: expect.closeTo(0.14, 5) },
+      { driver: "Prompt caching", color: "blue", usd: expect.closeTo(0.016, 5) },
     ]);
   });
 
@@ -225,7 +228,110 @@ describe("UsageTab", () => {
     const { getByTestId } = renderWith([day("2026-07-12", { compression_savings_spend: 0.04 })]);
 
     const slices = JSON.parse(getByTestId("donut-chart").getAttribute("data-slices") ?? "[]");
-    expect(slices).toEqual([{ driver: "Compression", usd: expect.closeTo(0.04, 5) }]);
+    expect(slices).toEqual([{ driver: "Compression", color: "emerald", usd: expect.closeTo(0.04, 5) }]);
+  });
+
+  it("does not stack the per-day drivers, because one of them can be negative", async () => {
+    // Stacking sums the series into one bar. Auto-router savings go negative when a
+    // model switch pays for a cold cache, and that segment would be drawn below the
+    // axis while the rest of the bar still read as the day's total.
+    const { getByRole, getByTestId } = renderWith([
+      day("2026-07-12", {
+        compression_savings_spend: 0.1,
+        prompt_caching_savings_spend: 0.02,
+        autorouter_savings_spend: -0.05,
+      }),
+    ]);
+
+    await userEvent.click(getByRole("tab", { name: "Per day" }));
+    const bars = getByTestId("bar-chart");
+    expect(bars.getAttribute("data-stack")).toBe("false");
+    expect(readSeries(bars)[0]).toMatchObject({ "Auto-router": -0.05 });
+  });
+
+  it("lays the savings header out with the card's own slots so nothing shifts between tabs", async () => {
+    // The subtitle differs in length between the tabs ("Running total saved" vs "Saved
+    // per day"). Hand-rolled rows made it compete with the legend and the toggle for
+    // width, so the header grew a line on one tab and the chart moved with it. CardHeader
+    // sizes the action column to its content and gives the rest to the title column.
+    const { getByRole, getByTestId, container } = renderWith(twoDays());
+
+    const header = () => {
+      const legend = getByTestId("chart-legend");
+      const action = legend.closest('[data-slot="card-action"]') as HTMLElement;
+      const cardHeader = action.parentElement as HTMLElement;
+      const description = cardHeader.querySelector('[data-slot="card-description"]') as HTMLElement;
+      return { action, cardHeader, description };
+    };
+
+    const before = header();
+    expect(before.action).toBeTruthy();
+    expect(before.description).toBeTruthy();
+    // the toggle rides in the same action slot as the legend, so neither moves alone
+    expect(before.action.contains(getByRole("tablist"))).toBe(true);
+    // the subtitle lives outside that slot, so its length cannot reposition the controls
+    expect(before.action.contains(before.description)).toBe(false);
+    expect(before.description.textContent).toContain("Running total saved");
+
+    await userEvent.click(getByRole("tab", { name: "Per day" }));
+
+    const after = header();
+    expect(after.action).toBe(before.action);
+    expect(after.cardHeader).toBe(before.cardHeader);
+    expect(after.action.contains(after.description)).toBe(false);
+    expect(after.description.textContent).toContain("Saved per day");
+    expect(container.textContent).toContain("Savings");
+  });
+
+  it("subtracts a losing auto-router route from the total and keeps it out of the donut", () => {
+    // Switching models leaves the new one with a cold cache, so a route can cost more
+    // than the baseline would have. A negative slice is meaningless in a donut, but the
+    // total has to keep the loss or the page can only ever report good news.
+    const { getByText, getByTestId } = renderWith([
+      day("2026-07-12", {
+        compression_savings_spend: 0.1,
+        prompt_caching_savings_spend: 0.02,
+        autorouter_savings_spend: -0.05,
+      }),
+    ]);
+
+    expect(getByText("$0.0700")).toBeInTheDocument();
+    expect(getByText("-$0.0500")).toBeInTheDocument();
+
+    const slices = JSON.parse(getByTestId("donut-chart").getAttribute("data-slices") ?? "[]");
+    expect(slices.map((d: { driver: string }) => d.driver)).toEqual(["Compression", "Prompt caching"]);
+    expect(getByTestId("donut-chart").getAttribute("data-label")).toBe("$0.1200");
+  });
+
+  it("carries auto-router savings into the summary card, donut slice, and cumulative series", () => {
+    const { getByText, getByTestId } = renderWith([
+      day("2026-07-12", {
+        compression_savings_spend: 0.04,
+        prompt_caching_savings_spend: 0.006,
+        autorouter_savings_spend: 0.02,
+      }),
+      day("2026-07-13", {
+        compression_savings_spend: 0.1,
+        prompt_caching_savings_spend: 0.01,
+        autorouter_savings_spend: 0.05,
+      }),
+    ]);
+
+    // Total saved now sums three drivers, and the auto-router card carries its own total.
+    expect(getByText("$0.2260")).toBeInTheDocument();
+    expect(getByText("$0.0700")).toBeInTheDocument();
+
+    // The driver donut gains a third slice priced from the range totals.
+    const slices = JSON.parse(getByTestId("donut-chart").getAttribute("data-slices") ?? "[]");
+    expect(slices).toEqual([
+      { driver: "Compression", color: "emerald", usd: expect.closeTo(0.14, 5) },
+      { driver: "Prompt caching", color: "blue", usd: expect.closeTo(0.016, 5) },
+      { driver: "Auto-router", color: "amber", usd: expect.closeTo(0.07, 5) },
+    ]);
+
+    // And the cumulative line accumulates the auto-router series alongside the others.
+    const series = readSeries(getByTestId("area-chart"));
+    expect(series[2]["Auto-router"]).toBeCloseTo(0.07, 5);
   });
 
   it("renders spend-by-tool bars from the tool spend endpoint", async () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.tsx
@@ -5,7 +5,7 @@ import { Info } from "lucide-react";
 
 import { AreaChart, BarChart, CustomLegend, DonutChart, SEQUENTIAL_COLOR_RAMP } from "@/components/shared/charts";
 import AdvancedDatePicker from "@/components/shared/advanced_date_picker";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardAction, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { getToolSpend, ToolSpendResponse } from "@/components/networking";
@@ -16,6 +16,8 @@ import {
   formatRangeLabel,
   localIsoDay,
   MAX_POINTS_WITH_DOTS,
+  SAVINGS_COLORS,
+  SAVINGS_DRIVERS,
   SAVINGS_SERIES,
   SavingsAccumulation,
   SavingsPoint,
@@ -38,8 +40,6 @@ const EMPTY_TOOL_SPEND: ToolSpendResponse = {
   end_date: null,
 };
 
-const SAVINGS_COLORS = ["emerald", "blue"] as const;
-
 const shortDate = (iso: string): string =>
   new Date(`${iso}T00:00:00`).toLocaleDateString("en-US", { month: "short", day: "numeric" });
 
@@ -47,6 +47,7 @@ const isoDay = (d: Date): string => d.toISOString().slice(0, 10);
 
 const compressionOf = (m: SpendMetrics): number => m.compression_savings_spend ?? 0;
 const cachingOf = (m: SpendMetrics): number => m.prompt_caching_savings_spend ?? 0;
+const autorouterOf = (m: SpendMetrics): number => m.autorouter_savings_spend ?? 0;
 const savedTokensOf = (m: SpendMetrics): number => m.compression_saved_tokens ?? 0;
 
 const SummaryCard = ({ label, value, hint, info }: { label: string; value: string; hint?: string; info?: string }) => (
@@ -105,8 +106,9 @@ const UsageTab: React.FC<UsageTabProps> = ({ accessToken, activity }) => {
 
   const compressionTotal = useMemo(() => results.reduce((sum, d) => sum + compressionOf(d.metrics), 0), [results]);
   const cachingTotal = useMemo(() => results.reduce((sum, d) => sum + cachingOf(d.metrics), 0), [results]);
+  const autorouterTotal = useMemo(() => results.reduce((sum, d) => sum + autorouterOf(d.metrics), 0), [results]);
   const savedTokensTotal = useMemo(() => results.reduce((sum, d) => sum + savedTokensOf(d.metrics), 0), [results]);
-  const totalSaved = compressionTotal + cachingTotal;
+  const totalSaved = compressionTotal + cachingTotal + autorouterTotal;
 
   const [accumulation, setAccumulation] = useState<SavingsAccumulation>("cumulative");
 
@@ -122,6 +124,7 @@ const UsageTab: React.FC<UsageTabProps> = ({ accessToken, activity }) => {
           date: shortDate(d.date),
           Compression: compressionOf(d.metrics),
           "Prompt caching": cachingOf(d.metrics),
+          "Auto-router": autorouterOf(d.metrics),
         })),
     [results],
   );
@@ -143,14 +146,19 @@ const UsageTab: React.FC<UsageTabProps> = ({ accessToken, activity }) => {
     .filter(Boolean)
     .join(" \u00b7 ");
 
+  // A driver can come out negative (auto-router pays a cold-cache write on every
+  // model switch), and a negative slice has no meaning in a donut, so only drivers
+  // that actually saved are plotted; the range total keeps the signed truth.
   const byDriver = useMemo(
     () =>
-      [
-        { driver: "Compression", usd: compressionTotal },
-        { driver: "Prompt caching", usd: cachingTotal },
-      ].filter((d) => d.usd > 0),
-    [compressionTotal, cachingTotal],
+      SAVINGS_DRIVERS.map(({ name, color }) => ({
+        driver: name,
+        color,
+        usd: { Compression: compressionTotal, "Prompt caching": cachingTotal, "Auto-router": autorouterTotal }[name],
+      })).filter((d) => d.usd > 0),
+    [compressionTotal, cachingTotal, autorouterTotal],
   );
+  const plottedDriverTotal = useMemo(() => byDriver.reduce((sum, d) => sum + d.usd, 0), [byDriver]);
 
   const topTools = useMemo(() => topToolsBySpend(toolSpend?.by_tool ?? []), [toolSpend]);
   const topToolNames = useMemo(() => topTools.map((t) => t.tool_name), [topTools]);
@@ -174,11 +182,11 @@ const UsageTab: React.FC<UsageTabProps> = ({ accessToken, activity }) => {
         <AdvancedDatePicker value={dateValue} onValueChange={onDateChange} />
       </div>
 
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
         <SummaryCard
           label="Total saved"
           value={usd(totalSaved)}
-          hint={loading || isFetchingMore ? "Loading..." : "Compression + prompt caching"}
+          hint={loading || isFetchingMore ? "Loading..." : "Compression + prompt caching + auto-router"}
         />
         <SummaryCard
           label="Compression savings"
@@ -192,26 +200,32 @@ const UsageTab: React.FC<UsageTabProps> = ({ accessToken, activity }) => {
           hint="Cache read discount"
           info="Tokens the provider served from cache, priced at the discount between the input and cache-read rates."
         />
+        <SummaryCard
+          label="Auto-router savings"
+          value={usd(autorouterTotal)}
+          hint="vs. the priciest model it could pick"
+          info="What this traffic would have cost had every request gone to the most expensive model the auto-router can route to, minus what it actually cost. Switching leaves the new model with a cold cache, so it pays to write the prompt again while the baseline is priced as already warm; a route that thrashes the cache can total below zero, and a genuine first turn, where neither side had anything cached, is undercounted."
+        />
       </div>
 
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         <Card className="lg:col-span-2">
+          {/* CardHeader's own slots rather than hand-rolled rows: the action column is
+              sized to its content and the title column takes the rest, so the subtitle
+              never competes with the controls for width and neither moves when it grows.
+              The controls wrap within their column instead of pushing past the card */}
           <CardHeader>
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div>
-                <CardTitle>Savings</CardTitle>
-                <p className="text-sm text-muted-foreground">{savingsSubtitle}</p>
-              </div>
-              <div className="flex items-center gap-4">
-                <CustomLegend categories={SAVINGS_SERIES} colors={SAVINGS_COLORS} />
-                <Tabs value={accumulation} onValueChange={(value) => setAccumulation(value as SavingsAccumulation)}>
-                  <TabsList>
-                    <TabsTrigger value="cumulative">Cumulative</TabsTrigger>
-                    <TabsTrigger value="per-interval">{intervalLabel}</TabsTrigger>
-                  </TabsList>
-                </Tabs>
-              </div>
-            </div>
+            <CardTitle>Savings</CardTitle>
+            <CardDescription>{savingsSubtitle}</CardDescription>
+            <CardAction className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2">
+              <CustomLegend categories={SAVINGS_SERIES} colors={SAVINGS_COLORS} />
+              <Tabs value={accumulation} onValueChange={(value) => setAccumulation(value as SavingsAccumulation)}>
+                <TabsList>
+                  <TabsTrigger value="cumulative">Cumulative</TabsTrigger>
+                  <TabsTrigger value="per-interval">{intervalLabel}</TabsTrigger>
+                </TabsList>
+              </Tabs>
+            </CardAction>
           </CardHeader>
           <CardContent>
             {accumulation === "cumulative" ? (
@@ -225,12 +239,14 @@ const UsageTab: React.FC<UsageTabProps> = ({ accessToken, activity }) => {
                 showDots={overTime.length <= MAX_POINTS_WITH_DOTS}
               />
             ) : (
+              // Not stacked: a driver can be negative once a model switch is charged
+              // for its cold cache, and stacking would draw that segment below the axis
+              // while the remaining bar still read as the day's total
               <BarChart
                 data={overTime}
                 index="date"
                 categories={SAVINGS_SERIES}
                 colors={SAVINGS_COLORS}
-                stack
                 valueFormatter={usd}
                 showLegend={false}
               />
@@ -247,10 +263,10 @@ const UsageTab: React.FC<UsageTabProps> = ({ accessToken, activity }) => {
               data={byDriver}
               index="driver"
               category="usd"
-              colors={["emerald", "blue"]}
+              colors={byDriver.map((d) => d.color)}
               valueFormatter={usd}
               showLabel
-              label={usd(totalSaved)}
+              label={usd(plottedDriverTotal)}
             />
           </CardContent>
         </Card>

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/costOptimizationUtils.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/costOptimizationUtils.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from "vitest";
 import type { DailyData, SpendMetrics } from "@/components/UsagePage/types";
 import type { ToolSpendDailyEntry, ToolSpendEntry } from "@/components/networking";
 import {
+  SAVINGS_COLORS,
+  SAVINGS_DRIVERS,
+  SAVINGS_SERIES,
   buildDailyToolSeries,
   computeCacheLeakage,
   formatRangeLabel,
@@ -10,6 +13,7 @@ import {
   localIsoDay,
   toCumulative,
   topToolsBySpend,
+  usd,
   withStartAnchor,
 } from "./costOptimizationUtils";
 
@@ -239,22 +243,25 @@ describe("localIsoDay", () => {
 });
 
 describe("toCumulative", () => {
-  const point = (date: string, compression: number, caching: number) => ({
+  const point = (date: string, compression: number, caching: number, autorouter: number = 0) => ({
     date,
     Compression: compression,
     "Prompt caching": caching,
+    "Auto-router": autorouter,
   });
 
   it("turns each reading into everything saved up to that point", () => {
     const running = toCumulative([point("Jul 1", 1, 10), point("Jul 2", 2, 20), point("Jul 3", 3, 30)]);
     expect(running.map((p) => p.Compression)).toEqual([1, 3, 6]);
     expect(running.map((p) => p["Prompt caching"])).toEqual([10, 30, 60]);
+    expect(running.map((p) => p["Auto-router"])).toEqual([0, 0, 0]);
   });
 
   it("accumulates each driver on its own, so one flat series cannot lift the other", () => {
     const running = toCumulative([point("Jul 1", 0, 5), point("Jul 2", 0, 5)]);
     expect(running.map((p) => p.Compression)).toEqual([0, 0]);
     expect(running.map((p) => p["Prompt caching"])).toEqual([5, 10]);
+    expect(running.map((p) => p["Auto-router"])).toEqual([0, 0]);
   });
 
   it("never falls, even across a quiet interval", () => {
@@ -267,13 +274,19 @@ describe("toCumulative", () => {
     expect(running.map((p) => p.date)).toEqual(["9am", "10am"]);
     expect(toCumulative([])).toEqual([]);
   });
+
+  it("accumulates auto-router savings like other drivers", () => {
+    const running = toCumulative([point("Jul 1", 1, 1, 5), point("Jul 2", 1, 1, 10)]);
+    expect(running.map((p) => p["Auto-router"])).toEqual([5, 15]);
+  });
 });
 
 describe("withStartAnchor", () => {
-  const point = (date: string, compression: number, caching: number) => ({
+  const point = (date: string, compression: number, caching: number, autorouter: number = 0) => ({
     date,
     Compression: compression,
     "Prompt caching": caching,
+    "Auto-router": autorouter,
   });
 
   it("lifts a single-day cumulative off a floating dot by prepending a $0 origin", () => {
@@ -285,6 +298,7 @@ describe("withStartAnchor", () => {
     const anchored = withStartAnchor([point("Jul 16", 5, 1), point("Jul 17", 9, 4)], "Jul 16");
     expect(anchored.map((p) => p.Compression)).toEqual([0, 5, 9]);
     expect(anchored.map((p) => p["Prompt caching"])).toEqual([0, 1, 4]);
+    expect(anchored.map((p) => p["Auto-router"])).toEqual([0, 0, 0]);
   });
 
   it("leaves an empty series alone so the chart's own no-data state can show", () => {
@@ -304,5 +318,46 @@ describe("formatRangeLabel", () => {
   it("is empty until both ends are picked", () => {
     expect(formatRangeLabel(undefined, new Date(2026, 6, 23))).toBe("");
     expect(formatRangeLabel(new Date(2026, 6, 23), undefined)).toBe("");
+  });
+});
+
+describe("usd", () => {
+  it("keeps four decimals for sub-dollar amounts so small savings stay visible", () => {
+    expect(usd(0.05)).toBe("$0.0500");
+    expect(usd(1.5)).toBe("$1.50");
+    expect(usd(0)).toBe("$0.00");
+  });
+
+  it("signs a loss ahead of the symbol and keeps its precision", () => {
+    // A driver can be negative once a model switch is charged for its cold cache.
+    // Sizing decimals off the raw value would render this as "$-0.00".
+    expect(usd(-0.05)).toBe("-$0.0500");
+    expect(usd(-0.0004)).toBe("-$0.0004");
+    expect(usd(-12.4)).toBe("-$12.40");
+  });
+});
+
+describe("savings driver colours", () => {
+  it("keeps a driver's colour when a driver above it is filtered out", () => {
+    // Charts colour by position in the data they are given, and the donut is given
+    // only drivers that saved something. Compression is zero on any deployment not
+    // running the compression guardrail, so the survivors must not slide onto the
+    // colours of the drivers dropped above them.
+    const totals = { Compression: 0, "Prompt caching": 4, "Auto-router": 7 } as const;
+    const plotted = SAVINGS_DRIVERS.map(({ name, color }) => ({ name, color, usd: totals[name] })).filter(
+      (d) => d.usd > 0,
+    );
+
+    expect(plotted.map((d) => [d.name, d.color])).toEqual([
+      ["Prompt caching", "blue"],
+      ["Auto-router", "amber"],
+    ]);
+  });
+
+  it("agrees with the legend, which is built from the unfiltered list", () => {
+    const legend = new Map(SAVINGS_SERIES.map((name, i) => [SAVINGS_COLORS[i], name]));
+    for (const { name, color } of SAVINGS_DRIVERS) {
+      expect(legend.get(color)).toBe(name);
+    }
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/costOptimizationUtils.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/costOptimizationUtils.ts
@@ -3,8 +3,11 @@ import { ToolSpendDailyEntry, ToolSpendEntry } from "@/components/networking";
 import { formatNumberWithCommas } from "@/utils/dataUtils";
 
 export const usd = (value: number): string => {
-  const decimals = value > 0 && value < 1 ? 4 : 2;
-  return `$${formatNumberWithCommas(value, decimals)}`;
+  // Sized and signed off the magnitude: a driver can come out negative, and a small
+  // loss rendered at two decimals would read as "$-0.00"
+  const magnitude = Math.abs(value);
+  const decimals = magnitude > 0 && magnitude < 1 ? 4 : 2;
+  return `${value < 0 ? "-" : ""}$${formatNumberWithCommas(magnitude, decimals)}`;
 };
 
 export const pct = (ratio: number): string => `${formatNumberWithCommas(ratio * 100, 1)}%`;
@@ -161,9 +164,27 @@ export type SavingsPoint = {
   date: string;
   Compression: number;
   "Prompt caching": number;
+  "Auto-router": number;
 };
 
-export const SAVINGS_SERIES = ["Compression", "Prompt caching"] as const;
+/**
+ * The savings drivers, each owning its own colour.
+ *
+ * One list rather than a names list beside a colours list, because the donut is
+ * given only the drivers that saved anything and charts assign colours by position
+ * in the data they receive. Two lists that line up by index therefore stop lining
+ * up the moment a driver is filtered out: the survivors slide down and inherit the
+ * colours of the drivers above them, while the legend still reports the original
+ * mapping. Colour travels with the driver so filtering cannot separate them.
+ */
+export const SAVINGS_DRIVERS = [
+  { name: "Compression", color: "emerald" },
+  { name: "Prompt caching", color: "blue" },
+  { name: "Auto-router", color: "amber" },
+] as const;
+
+export const SAVINGS_SERIES = SAVINGS_DRIVERS.map((d) => d.name);
+export const SAVINGS_COLORS = SAVINGS_DRIVERS.map((d) => d.color);
 
 /**
  * Running total of each series across the selected window. The total restarts
@@ -179,6 +200,7 @@ export const toCumulative = (points: readonly SavingsPoint[]): SavingsPoint[] =>
         date: point.date,
         Compression: (previous?.Compression ?? 0) + point.Compression,
         "Prompt caching": (previous?.["Prompt caching"] ?? 0) + point["Prompt caching"],
+        "Auto-router": (previous?.["Auto-router"] ?? 0) + point["Auto-router"],
       },
     ];
   }, []);
@@ -193,7 +215,7 @@ export const toCumulative = (points: readonly SavingsPoint[]): SavingsPoint[] =>
 export const withStartAnchor = (cumulative: readonly SavingsPoint[], startLabel: string): SavingsPoint[] =>
   cumulative.length === 0
     ? [...cumulative]
-    : [{ date: startLabel, Compression: 0, "Prompt caching": 0 }, ...cumulative];
+    : [{ date: startLabel, Compression: 0, "Prompt caching": 0, "Auto-router": 0 }, ...cumulative];
 
 /** "Jul 16 – Jul 23", collapsing to a single date when the range is one day. */
 export const formatRangeLabel = (from: Date | undefined, to: Date | undefined): string => {

--- a/ui/litellm-dashboard/src/components/UsagePage/types.ts
+++ b/ui/litellm-dashboard/src/components/UsagePage/types.ts
@@ -11,6 +11,7 @@ export interface SpendMetrics {
   compression_saved_tokens?: number;
   compression_savings_spend?: number;
   prompt_caching_savings_spend?: number;
+  autorouter_savings_spend?: number;
 }
 
 export type DailyData = {


### PR DESCRIPTION
## TLDR

Problem this solves:

- The cost-optimization page shows two savings drivers, not the auto-router
- A routing loss has nowhere to appear, so the page can only flatter

How it solves it:

- Adds an auto-router card, donut segment and series to the savings graph
- Keeps the sign on the card and the range total; the donut plots gains only
- States the cold-cache caveat in the card's popover

## Relevant issues

- Frontend half of the auto-router savings driver; stacked on #35521, which adds the backend field this reads
- Renders `autorouter_savings_spend` from `/user/daily/activity`, the same rollup response the other two drivers already use
- Do not merge before #35521, or the card reads $0.00

## Linear ticket

Resolves LIT-5046

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix
<img width="1439" height="1073" alt="image" src="https://github.com/user-attachments/assets/4b0fa852-c53b-40df-9c9f-dce528715e0f" />


Owed, and needs the backend PR deployed alongside. Steps for a reviewer running both branches:

1. Start the proxy against a real Postgres with a complexity router configured, and the dashboard dev server with `npm run dev` in `ui/litellm-dashboard`
2. Send auto-routed traffic that lands on more than one tier, including at least one multi-turn conversation
3. Open `http://localhost:4000/ui/?page=cost-optimization`
4. Expect four summary cards with "Auto-router savings" among them, three donut segments, and three series in the savings graph on both the Cumulative and Per-day tabs
5. Click the info icon on the auto-router card and expect the popover to mention the cold-cache write and that the total can be negative

## Type

🆕 New Feature

## Changes

The auto-router joins compression and prompt caching as a third driver on the cost-optimization page: a summary card, a donut segment, and a series in the savings graph across the cumulative and per-day views.

The value is signed. Switching models leaves the new one with a cold cache, so a request pays a cache-creation charge that staying on one model would not have incurred; when that charge outweighs the cheaper rates the route lost money, and an operator needs the page to say so. The donut plots only drivers that saved, since a negative slice has no meaning, while the card and the range total keep the sign. `usd()` sizes and signs off the magnitude, so a small loss renders as -$0.01 rather than the "$-0.00" the previous formatting produced.

The card's popover carries the caveat rather than leaving it to the PR description. It states the counterfactual, that switching pays to re-warm the cache, and that a first turn the router could not identify is charged that write and therefore under-reported, so nobody reads a small or negative total as a bug.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only presentation and formatting of an existing rollup field; behavior is covered by unit tests and has no auth or data-mutation impact.
> 
> **Overview**
> Adds **auto-router** as a third savings driver on the cost-optimization **Usage** tab, wired to optional `autorouter_savings_spend` on daily activity metrics.
> 
> The summary row becomes four cards; **Total saved** and the cumulative/per-day charts include an **Auto-router** series. The driver donut only plots drivers with **positive** savings (with per-driver colors via `SAVINGS_DRIVERS`), while cards and the signed range total still reflect **losses**. **`usd()`** now formats negatives as `-$…` with magnitude-based decimals.
> 
> **Per-day** savings bars are **unstacked** so negative auto-router days don’t misread as totals. The savings card header uses **`CardDescription` / `CardAction`** so the legend and tab toggle don’t shift when the subtitle changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 957e0f87af553a3d109b23028e95360af3676ce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->