### PR TITLE
fix(ui): land general login on the keys dashboard, send MCP consent to /ui/connect

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/gateway_dcr_flow.py
+++ b/litellm/proxy/_experimental/mcp_server/gateway_dcr_flow.py
@@ -369,7 +369,7 @@ def aggregate_authorize(
         exp=int(now.timestamp()) + CONNECT_FLOW_TTL_SECONDS,
     )
     connect_url = _append_query_params(
-        f"{base_url}/ui/chat/integrations",
+        f"{base_url}/ui/connect",
         {"connect_flow": handle, "connect_client": _origin_only(redirect_uri)},
     )
     response = RedirectResponse(connect_url, status_code=303)

--- a/tests/e2e/ui/tests/internal-user/internalUserNoTeam.spec.ts
+++ b/tests/e2e/ui/tests/internal-user/internalUserNoTeam.spec.ts
@@ -17,9 +17,8 @@ test.describe("Internal User with no team memberships", () => {
     await page.getByPlaceholder("Enter your username").fill("noteam@test.local");
     await page.getByPlaceholder("Enter your password").fill("test");
     await page.getByRole("button", { name: "Login", exact: true }).click();
-    // A non-admin with no keys lands on /ui/connect, so the keys dashboard has
-    // to be asked for explicitly once that redirect settles.
-    await page.waitForURL(/\/ui\/connect/, { timeout: 30_000 });
+    await expect(page.getByRole("complementary").getByText("Virtual Keys")).toBeVisible({ timeout: 30_000 });
+    expect(new URL(page.url()).pathname).not.toMatch(/\/connect$/);
     await navigateToPage(page, Page.ApiKeys);
     // Scope to the sidebar; the top-bar breadcrumb also shows "Virtual Keys".
     await expect(page.getByRole("complementary").getByText("Virtual Keys")).toBeVisible({ timeout: 15_000 });

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_gateway_dcr_flow.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_gateway_dcr_flow.py
@@ -212,7 +212,7 @@ async def test_authorize_with_session_hands_browser_to_connect_page_with_flow_co
     response = _authorize(client_id, session_user_id="u1")
     assert response.status_code == 303
     location = urlparse(response.headers["location"])
-    assert location.path == "/ui/chat/integrations"
+    assert location.path == "/ui/connect"
     params = parse_qs(location.query)
     handle = params["connect_flow"][0]
     assert params["connect_client"] == ["https://claude.ai"]

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/keys/useKeys.ts
@@ -101,14 +101,13 @@ export const useKeys = (
   page: number,
   pageSize: number,
   options: KeyListCallOptions = {},
-  enabled: boolean = true,
 ): UseQueryResult<KeysResponse> => {
   const { accessToken } = useAuthorized();
 
   return useQuery<KeysResponse>({
     queryKey: keyKeys.list({ page, limit: pageSize, ...options }),
     queryFn: async () => await keyListCall(accessToken!, page, pageSize, options),
-    enabled: Boolean(accessToken) && enabled,
+    enabled: Boolean(accessToken),
     staleTime: 30000, // 30 seconds
     placeholderData: keepPreviousData,
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import CreateKeyPage from "./page";
 
@@ -11,16 +11,15 @@ const { mockReplace, mockUseKeys, mockMigratedHref, state } = vi.hoisted(() => {
     login: "success" as string | null,
     userRole: "Internal User",
     keys: [] as KeyRow[],
-    keysLoading: false,
     returnUrl: null as string | null,
   };
   return {
     state,
     mockReplace: vi.fn(),
     mockMigratedHref: vi.fn((segment: string) => `/mocked-ui/${segment}`),
-    mockUseKeys: vi.fn((_page: number, _size: number, _opts: unknown, _enabled: boolean) => ({
-      data: state.keysLoading ? undefined : { keys: state.keys, total_count: state.keys.length },
-      isLoading: state.keysLoading,
+    mockUseKeys: vi.fn(() => ({
+      data: { keys: state.keys, total_count: state.keys.length },
+      isLoading: false,
     })),
   };
 });
@@ -55,73 +54,60 @@ vi.mock("@/utils/returnUrlUtils", () => ({
   storeReturnUrl: () => undefined,
 }));
 
-describe("dashboard landing keyless redirect", () => {
+const realLocation = window.location;
+const mockLocationReplace = vi.fn();
+
+describe("dashboard landing", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        origin: "http://localhost:3000",
+        href: "http://localhost:3000/ui/?login=success",
+        replace: mockLocationReplace,
+      },
+    });
+  });
+
   afterEach(() => {
+    Object.defineProperty(window, "location", { configurable: true, value: realLocation });
     state.login = "success";
     state.userRole = "Internal User";
     state.keys = [];
-    state.keysLoading = false;
     state.returnUrl = null;
     mockReplace.mockClear();
     mockUseKeys.mockClear();
     mockMigratedHref.mockClear();
+    mockLocationReplace.mockClear();
   });
 
-  it.each(["Internal User", "Internal Viewer"])("sends a keyless %s to the connect page after login", (role) => {
-    state.userRole = role;
-    render(<CreateKeyPage />);
-    expect(mockReplace).toHaveBeenCalledWith("/mocked-ui/connect");
-    expect(screen.queryByTestId("api-keys-dashboard")).not.toBeInTheDocument();
-  });
+  it.each(["Internal User", "Internal Viewer", "Admin", "Admin Viewer", "Org Admin", ""])(
+    "lands a keyless %s on the keys dashboard, never on the MCP connect page",
+    (role) => {
+      state.userRole = role;
+      render(<CreateKeyPage />);
+      expect(screen.getByTestId("api-keys-dashboard")).toBeInTheDocument();
+      expect(screen.queryByTestId("loading-screen")).not.toBeInTheDocument();
+      expect(mockReplace).not.toHaveBeenCalled();
+      expect(mockMigratedHref).not.toHaveBeenCalledWith("connect");
+    },
+  );
 
-  it.each(["Admin", "Admin Viewer", "Org Admin"])("leaves a keyless %s on the dashboard", (role) => {
-    state.userRole = role;
-    render(<CreateKeyPage />);
-    expect(mockReplace).not.toHaveBeenCalled();
-    expect(screen.getByTestId("api-keys-dashboard")).toBeInTheDocument();
-  });
-
-  it("leaves a user who already has a key on the dashboard", () => {
+  it("lands a user who already owns a key on the keys dashboard", () => {
     state.keys = [{ token: "sk-abc" }];
     render(<CreateKeyPage />);
-    expect(mockReplace).not.toHaveBeenCalled();
     expect(screen.getByTestId("api-keys-dashboard")).toBeInTheDocument();
-  });
-
-  it("does not redirect outside the post-login landing, and skips the key lookup entirely", () => {
-    state.login = null;
-    render(<CreateKeyPage />);
-    expect(mockReplace).not.toHaveBeenCalled();
-    expect(screen.getByTestId("api-keys-dashboard")).toBeInTheDocument();
-    expect(mockUseKeys.mock.calls[0][3]).toBe(false);
-  });
-
-  it("holds the loading screen on the landing until the role hydrates, instead of flashing the dashboard", () => {
-    state.userRole = "";
-    render(<CreateKeyPage />);
-    expect(screen.getByTestId("loading-screen")).toBeInTheDocument();
-    expect(screen.queryByTestId("api-keys-dashboard")).not.toBeInTheDocument();
     expect(mockReplace).not.toHaveBeenCalled();
   });
 
-  it("does not hold the dashboard for an unhydrated role outside the post-login landing", () => {
-    state.login = null;
-    state.userRole = "";
+  it("never looks a user's keys up to decide where the landing goes", () => {
     render(<CreateKeyPage />);
-    expect(screen.getByTestId("api-keys-dashboard")).toBeInTheDocument();
+    expect(mockUseKeys).not.toHaveBeenCalled();
   });
 
-  it("holds the loading screen while the key lookup is in flight", () => {
-    state.keysLoading = true;
-    render(<CreateKeyPage />);
-    expect(screen.getByTestId("loading-screen")).toBeInTheDocument();
-    expect(screen.queryByTestId("api-keys-dashboard")).not.toBeInTheDocument();
-    expect(mockReplace).not.toHaveBeenCalled();
-  });
-
-  it("yields to an explicit return URL instead of the connect redirect", () => {
+  it("still sends the user to an explicit stored return URL", () => {
     state.returnUrl = "/ui/models-and-endpoints";
     render(<CreateKeyPage />);
-    expect(mockReplace).not.toHaveBeenCalledWith("/mocked-ui/connect");
+    expect(mockLocationReplace).toHaveBeenCalledWith("http://localhost:3000/ui/models-and-endpoints");
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/page.tsx
@@ -3,8 +3,6 @@
 import ApiKeysDashboard from "@/app/(dashboard)/api-keys/ApiKeysDashboard";
 import LoadingScreen from "@/components/common_components/LoadingScreen";
 import { proxyBaseUrl } from "@/components/networking";
-import { useKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
-import { internalUserRoles } from "@/utils/roles";
 import { useAuth } from "@/contexts/AuthContext";
 import {
   buildLoginUrlWithReturn,
@@ -19,7 +17,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useRef } from "react";
 
 function CreateKeyPageContent() {
-  const { authLoading, token, userRole, userID } = useAuth();
+  const { authLoading, token } = useAuth();
 
   const router = useRouter();
   const searchParams = useSearchParams()!;
@@ -28,7 +26,6 @@ function CreateKeyPageContent() {
 
   // Track if we've already attempted a return URL redirect to prevent race conditions
   const hasAttemptedReturnRedirectRef = useRef(false);
-  const didReturnRedirectRef = useRef(false);
 
   const redirectToLogin = authLoading === false && token === null;
 
@@ -78,7 +75,6 @@ function CreateKeyPageContent() {
       // Only redirect if the return URL is different from the current URL
       // This prevents infinite redirect loops
       if (normalizedReturnUrl !== normalizedCurrentUrl) {
-        didReturnRedirectRef.current = true;
         window.location.replace(safeUrl.href);
       }
     }
@@ -87,26 +83,10 @@ function CreateKeyPageContent() {
   useEffect(() => {
     if (!token) {
       hasAttemptedReturnRedirectRef.current = false;
-      didReturnRedirectRef.current = false;
     }
   }, [token]);
 
-  const isPostLoginLanding = searchParams.get("login") === "success";
-  const isSignedIn = !authLoading && Boolean(token);
-  const isAwaitingRole = isPostLoginLanding && isSignedIn && userRole === "";
-  const shouldCheckForKeys = isPostLoginLanding && isSignedIn && internalUserRoles.includes(userRole);
-  const { data: keysData, isLoading: keysLoading } = useKeys(1, 1, { userID }, shouldCheckForKeys);
-  const isKeylessLanding = shouldCheckForKeys && !keysLoading && keysData?.keys?.length === 0;
-  const isResolvingKeylessLanding = (shouldCheckForKeys && keysLoading) || isKeylessLanding;
-  const isResolvingLanding = isAwaitingRole || isResolvingKeylessLanding;
-
-  useEffect(() => {
-    if (isKeylessLanding && !didReturnRedirectRef.current) {
-      router.replace(migratedHref("connect"));
-    }
-  }, [isKeylessLanding, router]);
-
-  const isRedirecting = redirectToLogin || isLegacyRedirect || isResolvingLanding;
+  const isRedirecting = redirectToLogin || isLegacyRedirect;
 
   if (authLoading || isRedirecting) {
     return <LoadingScreen />;

--- a/ui/litellm-dashboard/src/app/connect/page.test.tsx
+++ b/ui/litellm-dashboard/src/app/connect/page.test.tsx
@@ -6,33 +6,53 @@ interface PanelProps {
   accessToken: string;
   selectedServers: string[];
   onChange: (servers: string[]) => void;
+  connectMode?: boolean;
 }
 
-const { mockReplace, mockPanel, state } = vi.hoisted(() => {
+interface BannerProps {
+  flowHandle: string;
+  clientOrigin: string | null;
+}
+
+const { mockReplace, mockPanel, mockBanner, state } = vi.hoisted(() => {
   const state = {
     oauthReturn: null as string | null,
+    connectFlow: null as string | null,
+    connectClient: null as string | null,
   };
   return {
     state,
     mockReplace: vi.fn(),
     mockPanel: vi.fn((_props: PanelProps) => <div data-testid="mcp-apps-panel" />),
+    mockBanner: vi.fn((_props: BannerProps) => <div data-testid="connect-flow-banner" />),
   };
 });
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: mockReplace }),
-  useSearchParams: () => ({ get: (key: string) => (key === "mcpOauthReturn" ? state.oauthReturn : null) }),
+  useSearchParams: () => ({
+    get: (key: string) => {
+      if (key === "mcpOauthReturn") return state.oauthReturn;
+      if (key === "connect_flow") return state.connectFlow;
+      if (key === "connect_client") return state.connectClient;
+      return null;
+    },
+  }),
 }));
 vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
   default: () => ({ accessToken: "token-123" }),
 }));
 vi.mock("@/components/chat/MCPAppsPanel", () => ({ default: mockPanel }));
+vi.mock("@/components/chat/ConnectFlowBanner", () => ({ default: mockBanner }));
 
 describe("ConnectPage", () => {
   afterEach(() => {
     state.oauthReturn = null;
+    state.connectFlow = null;
+    state.connectClient = null;
     mockReplace.mockClear();
     mockPanel.mockClear();
+    mockBanner.mockClear();
   });
 
   it("renders the MCP connect panel with the user's access token", () => {
@@ -51,5 +71,32 @@ describe("ConnectPage", () => {
   it("does not rewrite the URL when there is no OAuth return param", () => {
     render(<ConnectPage />);
     expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("mounts the gateway connect banner and puts the panel in connect mode for a DCR flow", () => {
+    state.connectFlow = "flow-handle-123";
+    state.connectClient = "https://claude.ai";
+    render(<ConnectPage />);
+    expect(screen.getByTestId("connect-flow-banner")).toBeInTheDocument();
+    expect(mockBanner.mock.calls[0][0]).toMatchObject({
+      flowHandle: "flow-handle-123",
+      clientOrigin: "https://claude.ai",
+    });
+    expect(mockPanel.mock.calls[0][0].connectMode).toBe(true);
+  });
+
+  it("shows no connect banner and leaves connect mode off for a plain visit", () => {
+    render(<ConnectPage />);
+    expect(screen.queryByTestId("connect-flow-banner")).not.toBeInTheDocument();
+    expect(mockBanner).not.toHaveBeenCalled();
+    expect(mockPanel.mock.calls[0][0].connectMode).toBe(false);
+  });
+
+  it("keeps the connect flow handle in the URL while stripping the OAuth return param", () => {
+    state.oauthReturn = "apps";
+    state.connectFlow = "flow-handle-123";
+    window.history.replaceState({}, "", "/connect?connect_flow=flow-handle-123&mcpOauthReturn=apps");
+    render(<ConnectPage />);
+    expect(mockReplace).toHaveBeenCalledWith("/connect?connect_flow=flow-handle-123");
   });
 });

--- a/ui/litellm-dashboard/src/app/connect/page.tsx
+++ b/ui/litellm-dashboard/src/app/connect/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import MCPAppsPanel from "@/components/chat/MCPAppsPanel";
+import ConnectFlowBanner from "@/components/chat/ConnectFlowBanner";
 
 function ConnectPageContent() {
   const { accessToken } = useAuthorized();
@@ -11,6 +12,8 @@ function ConnectPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const oauthReturn = searchParams.get("mcpOauthReturn");
+  const connectFlow = searchParams.get("connect_flow");
+  const connectClient = searchParams.get("connect_client");
 
   useEffect(() => {
     if (oauthReturn) {
@@ -22,7 +25,13 @@ function ConnectPageContent() {
 
   return (
     <div className="mx-auto w-full max-w-5xl px-8 py-8">
-      <MCPAppsPanel accessToken={accessToken ?? ""} selectedServers={selectedServers} onChange={setSelectedServers} />
+      {connectFlow && <ConnectFlowBanner flowHandle={connectFlow} clientOrigin={connectClient} />}
+      <MCPAppsPanel
+        accessToken={accessToken ?? ""}
+        selectedServers={selectedServers}
+        onChange={setSelectedServers}
+        connectMode={!!connectFlow}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Signing in to the Admin UI as a non-admin with no virtual keys dumped you on `/ui/connect`, a page that renders nothing but the MCP servers grid with per-server OAuth buttons. General gateway login has nothing to do with MCP
- The MCP flow that genuinely belongs on that page reached it only through the chat shell. The gateway DCR consent redirect pointed at `/ui/chat/integrations`, which hard-blocks when `enable_chat_ui` is off, and off is the default, so on those deployments the consent step dead-ends

How it solves it:

- The post-login landing renders the keys dashboard for every role, so login routing no longer depends on role or key count
- The gateway DCR consent redirect now points at `/ui/connect`, which reads `connect_flow` / `connect_client`, mounts the consent banner and puts the apps panel in connect mode

## Relevant issues

- General login (form or SSO) redirected keyless internal users onto the MCP OAuth surface; the landing now always renders Virtual Keys
- The gateway DCR consent flow reached its page only when `enable_chat_ui` was on; on deployments left at the default of false the handle is dropped and the flow dead-ends. It now lands on the ungated `/ui/connect`, and deployments that already have chat on see a routing change only
- `/ui/connect` had exactly one caller, the login redirect being removed here, so this swaps its only entry point for the correct one

## Linear ticket

Resolves LIT-5104
Resolves LIT-4911

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Rig: proxy on `:4581` against a throwaway Postgres, a local OIDC provider on `:8999` serving two personas, `enable_chat_ui` left at its default of false. The SSO user provisions as `internal_user` with zero keys, which is the exact condition that used to trigger the redirect.

```
$ curl -s http://localhost:4581/.well-known/litellm-ui-config
{"server_root_path":"","proxy_base_url":"http://localhost:4581","auto_redirect_to_sso":false,
 "admin_ui_disabled":false,"sso_configured":true,"hide_default_credentials_hint":false,
 "is_control_plane":false,"workers":[]}

$ curl -s http://localhost:4581/get/ui_settings | jq '.values.enable_chat_ui'
false

$ curl -s -H 'Authorization: Bearer sk-1234' "http://localhost:4581/user/info?user_id=keyless.user"
  user_id: keyless.user | role: internal_user
  keys owned: 0
```

Backend, gateway DCR authorize. Same registered client, same PKCE shape, only the branch differs.

```
# before
$ curl -s -o /dev/null -D - -b jar "http://localhost:4581/authorize?client_id=$CID&redirect_uri=...&response_type=code&code_challenge=$C&code_challenge_method=S256&state=probe123"
HTTP/1.1 303 See Other
location: http://127.0.0.1:4581/ui/chat/integrations?connect_flow=Ge5ir1lhBTPO-p1_MSKzYv_W0GaMbsLR&connect_client=http%3A%2F%2F127.0.0.1%3A8765

# after
HTTP/1.1 303 See Other
location: http://127.0.0.1:4581/ui/connect?connect_flow=g0VgBe2u5odmDUDAcPJCn75k2LHwoXmX&connect_client=http%3A%2F%2F127.0.0.1%3A8765
set-cookie: mcp_connect_flow_g0VgBe2u...; HttpOnly; Max-Age=600; Path=/; SameSite=lax
```

Browser, same signed-in keyless user and the same URL, only the served bundle differs.

| | `/ui/?login=success` renders |
|---|---|
| before | redirected to `/ui/connect/`, heading "MCP Servers", no sidebar |
| after | Virtual Keys, "No keys found", sidebar present |

Full gateway DCR walk in a browser from a cold session, `enable_chat_ui` false throughout, driven end to end rather than inspected:

1. `POST /register` mints a DCR client
2. `GET /authorize` with S256 PKCE and no session cookie 303s to `/sso/key/generate?return_to=/authorize...`
3. sign in at the local IdP as the keyless internal user
4. the callback returns to `/authorize`, which 303s to `/ui/connect/?connect_flow=...&connect_client=...` and sets the sealed `mcp_connect_flow_<handle>` cookie, `HttpOnly`, `Path=/`, `Max-Age=600`
5. the page mounts the consent banner reading "Connect your MCP servers to http://127.0.0.1:8765", the "Finish connecting" button and the remote/SSH delivery checkbox. The panel is provably in connect mode: the subtitle reads "Click a server to see its tools and connect" and the empty state reads "No MCP servers are available to this connection yet", both differing from a plain visit to the same route
6. clicking "Finish connecting" 303s to `http://127.0.0.1:8765/callback?code=llm_gcode_...&state=coldwalk`, with `state` echoed intact
7. exchanging that code at `/token` with the PKCE verifier returns `token_type: Bearer`, `expires_in: 3600`, `access_token: llm_session_...`
8. replaying the same code returns `400 {"error":"invalid_grant","error_description":"the authorization code was already used"}`, so single-use enforcement survives the page move

Step 2 is the leg worth calling out: `/ui/connect`'s layout gates on `isAuthorized` where the chat layout never did, so the cold path was the one place the stricter gate could have bounced a mid-flow user to login. It does not; the session cookie set by the SSO callback is readable by the time the page mounts.

Screenshots to follow.

## Type

🐛 Bug Fix

## Changes

- `(dashboard)/page.tsx`: drop the keyless landing redirect, the `useKeys` lookup that fed it, and the role-hydration hold that existed to stop it flashing the dashboard for a frame
- `useKeys.ts`: drop the `enabled` parameter; the deleted call site was its only non-default caller
- `gateway_dcr_flow.py`: point the connect redirect at `/ui/connect`
- `connect/page.tsx`: read `connect_flow` / `connect_client`, mount `ConnectFlowBanner`, pass `connectMode`
- Tests: `page.test.tsx` now pins that role and key count do not affect the landing and that no key lookup happens at all; `connect/page.test.tsx` covers connect mode and the flow handle surviving the OAuth-return cleanup; the e2e spec asserts the keyless landing keeps its sidebar

Production code is a net 12 lines smaller. `/ui/chat/integrations` keeps its connect-mode handling for one release so flows sealed in a 600s cookie before the deploy still finish; retiring it is follow-up work.

### Things a reviewer will ask about

Why the two halves belong in one PR: `(dashboard)/page.tsx` held the only reference to `/ui/connect` in the dashboard. Removing it alone orphans the route, and repointing the consent flow alone leaves general login on the MCP page. Together they swap that route's single entry point.

Why removing `isAwaitingRole` is safe: it existed only so the keyless decision would not read a not-yet-hydrated role and flash the dashboard. `ApiKeysDashboard` sources its role from `useAuthorized()`, a synchronous cookie decode, not from the `useAuth()` value that lags, so nothing else depended on that hold.

Why the two halves cannot interact: `_sso_return_to_redirect` sends a same-origin relative `return_to`, which is what the DCR `/authorize` round-trip uses, straight back to `/authorize` without appending `login=success`, so the DCR flow never touches the dashboard landing.

## QA runbook

1. Bring up a proxy with SSO configured and leave `enable_chat_ui` at its default
2. Sign in through the Admin UI as a non-admin with no virtual keys, by form or by SSO. Expect the Virtual Keys page with the sidebar, not the MCP servers grid
3. Sign in as a proxy admin. Expect the same Virtual Keys page, unchanged from before
4. Register a DCR client against `/register`, then open `/authorize` with PKCE while signed in. Expect `/ui/connect` carrying `connect_flow` and `connect_client`, the consent banner at the top, and a working "Finish connecting" that returns to the client's redirect URI
5. Repeat step 4 with `enable_chat_ui` on. Expect the same result
6. Visit `/ui/connect` directly with no `connect_flow`. Expect the apps grid with no consent banner

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
