### PR TITLE
fix(vertex_ai): use last-write-wins for multi-breakpoint cache_contro…

### DIFF
--- a/litellm/llms/vertex_ai/context_caching/transformation.py
+++ b/litellm/llms/vertex_ai/context_caching/transformation.py
@@ -120,6 +120,14 @@ def separate_cached_messages(
     """
     Returns separated cached and non-cached messages.
 
+    Anthropic allows multiple, non-contiguous cache_control breakpoints
+    (e.g. one on the system prompt, another added later as the conversation
+    grows). Gemini only supports a single contiguous prefix cache, so the
+    cache boundary must extend through the LAST marked message rather than
+    stopping at the first gap -- caching up to the last tag implicitly
+    covers the earlier tags too, since they share the same prefix.
+    See GitHub issue #17201.
+
     Args:
         messages: List of messages to be separated.
 
@@ -137,12 +145,11 @@ def separate_cached_messages(
         if is_cached_message(message=message):
             filtered_messages.append((idx, message))
 
-    # Validate only one block of continuous cached messages
-    last_continuous_block_idx = get_first_continuous_block_idx(filtered_messages)
-    # Separate messages based on the block of cached messages
-    if filtered_messages and last_continuous_block_idx is not None:
+    if filtered_messages:
         first_cached_idx = filtered_messages[0][0]
-        last_cached_idx = filtered_messages[last_continuous_block_idx][0]
+        # Last-write-wins: extend the boundary through the last marked
+        # message, not just the first contiguous run.
+        last_cached_idx = filtered_messages[-1][0]
 
         cached_messages = messages[first_cached_idx : last_cached_idx + 1]
         non_cached_messages = messages[:first_cached_idx] + messages[last_cached_idx + 1 :]

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -1947,9 +1947,18 @@ def test_gemini_cache_control_non_contiguous_breakpoints_last_wins():
 
     cached, non_cached = separate_cached_messages(messages)
 
-    # The last-marked message must be part of the cached prefix, since
-    # Gemini's cache boundary should extend to the last cache_control tag.
-    assert messages[3] in cached, (
-        "Second cache_control breakpoint was dropped -- only the first "
-        "contiguous block was cached, reproducing issue #17201"
+    # Assert the exact partition, not just membership -- this protects
+    # against implementations that duplicate, reorder, or over-cache
+    # messages while still happening to include messages[3] somewhere.
+    # The boundary should span from the first breakpoint (system, idx 0)
+    # through the last one (idx 3), so all four messages are cached and
+    # none are left over.
+    assert cached == messages, (
+        "Expected the full first-to-last breakpoint range to be cached, "
+        "reproducing issue #17201 if this fails. "
+        f"Got cached={cached!r}"
+    )
+    assert non_cached == [], (
+        f"Expected no non-cached messages once the boundary spans the "
+        f"full breakpoint range. Got non_cached={non_cached!r}"
     )

--- a/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
+++ b/tests/test_litellm/integrations/test_anthropic_cache_control_hook.py
@@ -1909,3 +1909,47 @@ class TestAnthropicPromptCachingEnvVars:
         """An unparseable TTL must fall back to Anthropic's 5m default, never reach the provider verbatim."""
         _, ttl = self._import_litellm_with_env({"LITELLM_ANTHROPIC_PROMPT_CACHING_TTL": value})
         assert ttl is None
+
+
+def test_gemini_cache_control_non_contiguous_breakpoints_last_wins():
+    """
+    Anthropic allows multiple, non-contiguous cache_control breakpoints
+    (e.g. system prompt + a later turn re-marked as conversation grows).
+    Gemini only supports a single contiguous prefix cache, so LiteLLM must
+    resolve multiple breakpoints to one boundary at the LAST marked message
+    -- caching up to the last tag implicitly covers earlier tags too.
+
+    Regression test for GitHub issue #17201: LiteLLM currently uses a
+    "first-found" strategy (get_first_continuous_block_idx stops at the
+    first gap), which silently drops any breakpoint after the first
+    contiguous block. This causes the Gemini cache to stay "stuck" at the
+    system-prompt level for clients like Claude Code that re-mark later
+    turns as the conversation grows.
+    """
+    from litellm.llms.vertex_ai.context_caching.transformation import (
+        separate_cached_messages,
+    )
+
+    messages: List[AllMessageValues] = [
+        {
+            "role": "system",
+            "content": "You are a helpful assistant.",
+            "cache_control": {"type": "ephemeral"},
+        },
+        {"role": "user", "content": "First question."},
+        {"role": "assistant", "content": "First answer."},
+        {
+            "role": "user",
+            "content": "Second question, now marked for caching too.",
+            "cache_control": {"type": "ephemeral"},
+        },
+    ]
+
+    cached, non_cached = separate_cached_messages(messages)
+
+    # The last-marked message must be part of the cached prefix, since
+    # Gemini's cache boundary should extend to the last cache_control tag.
+    assert messages[3] in cached, (
+        "Second cache_control breakpoint was dropped -- only the first "
+        "contiguous block was cached, reproducing issue #17201"
+    )


### PR DESCRIPTION
Anthropic allows multiple, non-contiguous cache_control breakpoints, but Gemini only supports a single contiguous prefix cache. separate_cached_messages() previously used get_first_continuous_block_idx(), which stops at the first gap and silently drops any later breakpoint. This left the Gemini cache stuck at the system-prompt level for clients like Claude Code that re-mark later turns as the conversation grows.

Extend the cache boundary through the last marked message instead, since caching through the last breakpoint implicitly covers the earlier ones (same prefix chain).

Fixes #17201

## TLDR

- Fix Gemini cache boundary to extend through the last cache_control breakpoint, not the first
- Anthropic allows multiple breakpoints; Gemini supports only one contiguous prefix cache
- Previous logic silently dropped any breakpoint after the first contiguous block

Problem this solves:
- Gemini cache stayed stuck at system-prompt level for multi-turn clients like Claude Code
- Growing conversation history was never cached despite being explicitly marked

How it solves it:
- separate_cached_messages() now uses the last cache-marked index as the boundary, not the first contiguous block
- Verified get_first_continuous_block_idx has no other callers, so this is a safe, isolated change

## Relevant issues

Fixes #17201

## Linear ticket

## Pre-Submission checklist