### PR TITLE
refactor(lint): drop redundant !s f-string conversion flags and fix displaced import-group comments

### DIFF
--- a/litellm/_lazy_imports.py
+++ b/litellm/_lazy_imports.py
@@ -23,6 +23,7 @@ from typing import Any, cast
 # Import all the data structures that define what can be lazy-loaded
 # These are just lists of names and maps of where to find them
 from ._lazy_imports_registry import (
+    # Import maps
     _BEDROCK_TYPES_IMPORT_MAP,
     _CACHING_IMPORT_MAP,
     _COST_CALCULATOR_IMPORT_MAP,
@@ -33,12 +34,11 @@ from ._lazy_imports_registry import (
     _TOKEN_COUNTER_IMPORT_MAP,
     _TYPES_IMPORT_MAP,
     _TYPES_UTILS_IMPORT_MAP,
-    # Import maps
     _UTILS_IMPORT_MAP,
     _UTILS_MODULE_IMPORT_MAP,
+    # Name tuples
     BEDROCK_TYPES_NAMES,
     CACHING_NAMES,
-    # Name tuples
     COST_CALCULATOR_NAMES,
     DOTPROMPT_NAMES,
     HTTP_HANDLER_NAMES,

--- a/litellm/batch_completion/main.py
+++ b/litellm/batch_completion/main.py
@@ -249,7 +249,7 @@ def batch_completion_models_all_responses(*args, **kwargs):
                 if result is not None:
                     responses.append(result)
             except Exception as e:
-                print_verbose(f"batch_completion_models_all_responses: model request failed: {e!s}")
+                print_verbose(f"batch_completion_models_all_responses: model request failed: {e}")
                 continue
 
     return responses

--- a/litellm/batches/main.py
+++ b/litellm/batches/main.py
@@ -182,7 +182,7 @@ def create_batch(
                 )
         except Exception as e:
             verbose_logger.exception(
-                f"litellm.batches.main.py::create_batch() - Error inferring custom_llm_provider - {e!s}"
+                f"litellm.batches.main.py::create_batch() - Error inferring custom_llm_provider - {e}"
             )
 
         _is_async = kwargs.pop("acreate_batch", False) is True
@@ -890,7 +890,7 @@ def cancel_batch(
                 )
         except Exception as e:
             verbose_logger.exception(
-                f"litellm.batches.main.py::cancel_batch() - Error inferring custom_llm_provider - {e!s}"
+                f"litellm.batches.main.py::cancel_batch() - Error inferring custom_llm_provider - {e}"
             )
         optional_params = GenericLiteLLMParams(**kwargs)
         litellm_params = get_litellm_params(

--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -353,13 +353,13 @@ class Cache:
             if param in combined_kwargs:
                 param_value: str | None = self._get_param_value(param, kwargs)
                 if param_value is not None:
-                    cache_key += f"{param!s}: {param_value!s}"
+                    cache_key += f"{param}: {param_value}"
             elif param not in litellm_param_kwargs:  # check if user passed in optional param - e.g. top_k
                 if litellm.enable_caching_on_provider_specific_optional_params is True:  # feature flagged for now
                     if kwargs[param] is None:
                         continue  # ignore None params
                     param_value = kwargs[param]
-                    cache_key += f"{param!s}: {param_value!s}"
+                    cache_key += f"{param}: {param_value}"
 
         if is_semantic_cache:
             cache_key += self._get_semantic_cache_tenant_scope(kwargs)
@@ -676,7 +676,7 @@ class Cache:
             cache_key, cached_data, kwargs = self._add_cache_logic(result=result, **kwargs)
             self.cache.set_cache(cache_key, cached_data, **kwargs)
         except Exception as e:
-            verbose_logger.exception(f"LiteLLM Cache: Excepton add_cache: {e!s}")
+            verbose_logger.exception(f"LiteLLM Cache: Excepton add_cache: {e}")
 
     async def async_add_cache(self, result, dynamic_cache_object: BaseCache | None = None, **kwargs):
         """
@@ -695,7 +695,7 @@ class Cache:
                 else:
                     await self.cache.async_set_cache(cache_key, cached_data, **kwargs)
         except Exception as e:
-            verbose_logger.exception(f"LiteLLM Cache: Excepton add_cache: {e!s}")
+            verbose_logger.exception(f"LiteLLM Cache: Excepton add_cache: {e}")
 
     def _convert_to_cached_embedding(
         self,
@@ -874,7 +874,7 @@ class Cache:
             else:
                 await self.cache.async_set_cache_pipeline(cache_list=cache_list, **kwargs)
         except Exception as e:
-            verbose_logger.exception(f"LiteLLM Cache: Excepton add_cache: {e!s}")
+            verbose_logger.exception(f"LiteLLM Cache: Excepton add_cache: {e}")
 
     def should_use_cache(self, **kwargs):
         """

--- a/litellm/caching/dual_cache.py
+++ b/litellm/caching/dual_cache.py
@@ -147,7 +147,7 @@ class DualCache(BaseCache):
 
             return result
         except Exception as e:
-            verbose_logger.error(f"LiteLLM Cache: Excepton async add_cache: {e!s}")
+            verbose_logger.error(f"LiteLLM Cache: Excepton async add_cache: {e}")
             raise e
 
     def get_cache(
@@ -347,7 +347,7 @@ class DualCache(BaseCache):
             if self.redis_cache is not None and local_only is False:
                 await self.redis_cache.async_set_cache(key, value, **kwargs)
         except Exception as e:
-            verbose_logger.exception(f"LiteLLM Cache: Excepton async add_cache: {e!s}")
+            verbose_logger.exception(f"LiteLLM Cache: Excepton async add_cache: {e}")
 
     # async_batch_set_cache
     async def async_set_cache_pipeline(self, cache_list: list, local_only: bool = False, **kwargs):
@@ -366,7 +366,7 @@ class DualCache(BaseCache):
                     cache_list=cache_list, ttl=kwargs.pop("ttl", None), **kwargs
                 )
         except Exception as e:
-            verbose_logger.exception(f"LiteLLM Cache: Excepton async add_cache: {e!s}")
+            verbose_logger.exception(f"LiteLLM Cache: Excepton async add_cache: {e}")
 
     async def async_increment_cache(
         self,

--- a/litellm/caching/qdrant_semantic_cache.py
+++ b/litellm/caching/qdrant_semantic_cache.py
@@ -178,7 +178,7 @@ class QdrantSemanticCache(BaseCache):
             if response.status_code not in (200, 201):
                 print_verbose(f"Qdrant semantic-cache could not create cache-key payload index: {response.text}")
         except Exception as exc:
-            print_verbose(f"Qdrant semantic-cache could not create cache-key payload index: {exc!s}")
+            print_verbose(f"Qdrant semantic-cache could not create cache-key payload index: {exc}")
 
     def _payload_matches_cache_key(self, payload: dict, key: str) -> bool:
         # Pre-isolation points stored only prompt + response with no cache-key

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -346,7 +346,7 @@ class RedisCache(BaseCache):
                 verbose_logger.debug("Ignoring async redis ping. No running event loop.")
             else:
                 verbose_logger.error(
-                    f"Error connecting to Async Redis client - {e!s}",
+                    f"Error connecting to Async Redis client - {e}",
                     extra={"error": str(e)},
                 )
                 self._handle_async_ping_error(e)
@@ -483,7 +483,7 @@ class RedisCache(BaseCache):
             )
         except Exception as e:
             # NON blocking - notify users Redis is throwing an exception
-            print_verbose(f"litellm.caching.caching: set() - Got exception from REDIS : {e!s}")
+            print_verbose(f"litellm.caching.caching: set() - Got exception from REDIS : {e}")
 
     def increment_cache(self, key, value: int, ttl: float | None = None, **kwargs) -> int:
         _redis_client = self.redis_client
@@ -1139,7 +1139,7 @@ class RedisCache(BaseCache):
 
             return decoded_results
         except Exception as e:
-            verbose_logger.error(f"Error occurred in batch get cache - {e!s}")
+            verbose_logger.error(f"Error occurred in batch get cache - {e}")
             return key_value_dict
 
     @_redis_circuit_breaker_guard
@@ -1185,7 +1185,7 @@ class RedisCache(BaseCache):
                     event_metadata={"key": key},
                 )
             )
-            print_verbose(f"litellm.caching.caching: async get() - Got exception from REDIS: {e!s}")
+            print_verbose(f"litellm.caching.caching: async get() - Got exception from REDIS: {e}")
             _record_swallowed_redis_failure(self._circuit_breaker, e)
 
     @_redis_circuit_breaker_guard
@@ -1257,7 +1257,7 @@ class RedisCache(BaseCache):
                     parent_otel_span=parent_otel_span,
                 )
             )
-            verbose_logger.error(f"Error occurred in async batch get cache - {e!s}")
+            verbose_logger.error(f"Error occurred in async batch get cache - {e}")
             _record_swallowed_redis_failure(self._circuit_breaker, e)
             return key_value_dict
 
@@ -1292,7 +1292,7 @@ class RedisCache(BaseCache):
                 error=e,
                 call_type=f"sync_ping <- {_get_call_stack_info()}",
             )
-            verbose_logger.error(f"LiteLLM Redis Cache PING: - Got exception from REDIS : {e!s}")
+            verbose_logger.error(f"LiteLLM Redis Cache PING: - Got exception from REDIS : {e}")
             raise e
 
     async def ping(self) -> bool:
@@ -1326,7 +1326,7 @@ class RedisCache(BaseCache):
                     call_type=f"async_ping <- {_get_call_stack_info()}",
                 )
             )
-            verbose_logger.error(f"LiteLLM Redis Cache PING: - Got exception from REDIS : {e!s}")
+            verbose_logger.error(f"LiteLLM Redis Cache PING: - Got exception from REDIS : {e}")
             raise e
 
     @_redis_circuit_breaker_guard
@@ -1388,10 +1388,10 @@ class RedisCache(BaseCache):
             else:
                 return {"status": "failed", "message": "Redis ping returned False"}
         except Exception as e:
-            verbose_logger.error(f"Redis connection test failed: {e!s}")
+            verbose_logger.error(f"Redis connection test failed: {e}")
             return {
                 "status": "failed",
-                "message": f"Redis connection failed: {e!s}",
+                "message": f"Redis connection failed: {e}",
                 "error": str(e),
             }
 
@@ -1565,7 +1565,7 @@ class RedisCache(BaseCache):
                     call_type=f"async_rpush <- {_get_call_stack_info()}",
                 )
             )
-            verbose_logger.error(f"LiteLLM Redis Cache RPUSH: - Got exception from REDIS : {e!s}")
+            verbose_logger.error(f"LiteLLM Redis Cache RPUSH: - Got exception from REDIS : {e}")
             raise e
 
     async def _pipeline_rpush_helper(
@@ -1711,7 +1711,7 @@ class RedisCache(BaseCache):
                     call_type=f"async_lpop <- {_get_call_stack_info()}",
                 )
             )
-            verbose_logger.error(f"LiteLLM Redis Cache LPOP: - Got exception from REDIS : {e!s}")
+            verbose_logger.error(f"LiteLLM Redis Cache LPOP: - Got exception from REDIS : {e}")
             raise e
 
     async def _pipeline_lpop_helper(

--- a/litellm/caching/redis_cluster_cache.py
+++ b/litellm/caching/redis_cluster_cache.py
@@ -100,9 +100,9 @@ class RedisClusterCache(RedisCache):
         except Exception as e:
             from litellm._logging import verbose_logger
 
-            verbose_logger.error(f"Redis Cluster connection test failed: {e!s}")
+            verbose_logger.error(f"Redis Cluster connection test failed: {e}")
             return {
                 "status": "failed",
-                "message": f"Redis Cluster connection failed: {e!s}",
+                "message": f"Redis Cluster connection failed: {e}",
                 "error": str(e),
             }

--- a/litellm/caching/redis_semantic_cache.py
+++ b/litellm/caching/redis_semantic_cache.py
@@ -364,7 +364,7 @@ class RedisSemanticCache(BaseCache):
             try:
                 cached_response = ast.literal_eval(cached_response)
             except (ValueError, SyntaxError) as e:
-                print_verbose(f"Error parsing cached response: {e!s}")
+                print_verbose(f"Error parsing cached response: {e}")
                 return None
 
         return cached_response
@@ -403,7 +403,7 @@ class RedisSemanticCache(BaseCache):
                 store_kwargs["ttl"] = int(ttl)
             self.llmcache.store(prompt, value_str, **store_kwargs)
         except Exception as e:
-            print_verbose(f"Error setting {value_str or value} in the Redis semantic cache: {e!s}")
+            print_verbose(f"Error setting {value_str or value} in the Redis semantic cache: {e}")
 
     def get_cache(self, key: str, **kwargs) -> Any:
         """
@@ -468,7 +468,7 @@ class RedisSemanticCache(BaseCache):
 
             return self._get_cache_logic(cached_response=cached_response)
         except Exception as e:
-            print_verbose(f"Error retrieving from Redis semantic cache: {e!s}")
+            print_verbose(f"Error retrieving from Redis semantic cache: {e}")
             kwargs.setdefault("metadata", {})["semantic-similarity"] = 0.0
 
     async def _get_async_embedding(self, prompt: str, metadata: dict[str, Any] | None = None) -> list[float]:
@@ -505,8 +505,8 @@ class RedisSemanticCache(BaseCache):
                 )
             return embedding_response["data"][0]["embedding"]
         except Exception as e:
-            print_verbose(f"Error generating async embedding: {e!s}")
-            raise ValueError(f"Failed to generate embedding: {e!s}") from e
+            print_verbose(f"Error generating async embedding: {e}")
+            raise ValueError(f"Failed to generate embedding: {e}") from e
 
     async def async_set_cache(self, key: str, value: Any, **kwargs) -> None:
         """
@@ -546,7 +546,7 @@ class RedisSemanticCache(BaseCache):
                 **store_kwargs,
             )
         except Exception as e:
-            print_verbose(f"Error in async_set_cache: {e!s}")
+            print_verbose(f"Error in async_set_cache: {e}")
 
     async def async_get_cache(self, key: str, **kwargs) -> Any:
         """
@@ -612,7 +612,7 @@ class RedisSemanticCache(BaseCache):
 
             return self._get_cache_logic(cached_response=cached_response)
         except Exception as e:
-            print_verbose(f"Error in async_get_cache: {e!s}")
+            print_verbose(f"Error in async_get_cache: {e}")
             kwargs.setdefault("metadata", {})["semantic-similarity"] = 0.0
 
     async def _index_info(self) -> dict[str, Any]:
@@ -639,4 +639,4 @@ class RedisSemanticCache(BaseCache):
                 tasks.append(self.async_set_cache(val[0], val[1], **kwargs))
             await asyncio.gather(*tasks)
         except Exception as e:
-            print_verbose(f"Error in async_set_cache_pipeline: {e!s}")
+            print_verbose(f"Error in async_set_cache_pipeline: {e}")

--- a/litellm/caching/valkey_semantic_cache.py
+++ b/litellm/caching/valkey_semantic_cache.py
@@ -249,7 +249,7 @@ class ValkeySemanticCache(RedisSemanticCache):
             if ttl is not None:
                 self.sync_client.expire(doc_key, ttl)
         except Exception as e:
-            print_verbose(f"Error in Valkey semantic-cache set_cache: {e!s}")
+            print_verbose(f"Error in Valkey semantic-cache set_cache: {e}")
 
     def get_cache(self, key: str, **kwargs: Any) -> Any:
         print_verbose(f"Valkey semantic-cache get_cache, kwargs: {kwargs}")
@@ -268,7 +268,7 @@ class ValkeySemanticCache(RedisSemanticCache):
             )
             return self._resolve_hit(self._first_hit(search_result), key, **kwargs)
         except Exception as e:
-            print_verbose(f"Error in Valkey semantic-cache get_cache: {e!s}")
+            print_verbose(f"Error in Valkey semantic-cache get_cache: {e}")
             kwargs.setdefault("metadata", {})["semantic-similarity"] = 0.0
 
     async def async_set_cache(self, key: str, value: Any, **kwargs: Any) -> None:
@@ -288,7 +288,7 @@ class ValkeySemanticCache(RedisSemanticCache):
             if ttl is not None:
                 await self.async_client.expire(doc_key, ttl)
         except Exception as e:
-            print_verbose(f"Error in async Valkey semantic-cache set_cache: {e!s}")
+            print_verbose(f"Error in async Valkey semantic-cache set_cache: {e}")
 
     async def async_get_cache(self, key: str, **kwargs: Any) -> Any:
         print_verbose(f"Async Valkey semantic-cache get_cache, kwargs: {kwargs}")
@@ -307,14 +307,14 @@ class ValkeySemanticCache(RedisSemanticCache):
             )
             return self._resolve_hit(self._first_hit(search_result), key, **kwargs)
         except Exception as e:
-            print_verbose(f"Error in async Valkey semantic-cache get_cache: {e!s}")
+            print_verbose(f"Error in async Valkey semantic-cache get_cache: {e}")
             kwargs.setdefault("metadata", {})["semantic-similarity"] = 0.0
 
     async def async_set_cache_pipeline(self, cache_list: list[tuple[str, Any]], **kwargs: Any) -> None:
         try:
             await asyncio.gather(*[self.async_set_cache(key, value, **kwargs) for key, value in cache_list])
         except Exception as e:
-            print_verbose(f"Error in Valkey semantic-cache async_set_cache_pipeline: {e!s}")
+            print_verbose(f"Error in Valkey semantic-cache async_set_cache_pipeline: {e}")
 
     async def _index_info(self) -> dict:
         return await self.async_client.ft(self.index_name).info()

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -715,7 +715,7 @@ def _get_provider_for_cost_calc(
         _, custom_llm_provider, _, _ = litellm.get_llm_provider(model=model)
     except Exception as e:
         verbose_logger.debug(
-            f"litellm.cost_calculator.py::_get_provider_for_cost_calc() - Error inferring custom_llm_provider - {e!s}"
+            f"litellm.cost_calculator.py::_get_provider_for_cost_calc() - Error inferring custom_llm_provider - {e}"
         )
         return None
 
@@ -1092,7 +1092,7 @@ def _store_cost_breakdown_in_logging_obj(
         )
 
     except Exception as breakdown_error:
-        verbose_logger.debug(f"Error storing cost breakdown: {breakdown_error!s}")
+        verbose_logger.debug(f"Error storing cost breakdown: {breakdown_error}")
         # Don't fail the main cost calculation if breakdown storage fails
 
 
@@ -1315,7 +1315,7 @@ def completion_cost(
                         )  # strip the llm provider from the model name -> for image gen cost calculation
                     except Exception as e:
                         verbose_logger.debug(
-                            f"litellm.cost_calculator.py::completion_cost() - Error inferring custom_llm_provider - {e!s}"
+                            f"litellm.cost_calculator.py::completion_cost() - Error inferring custom_llm_provider - {e}"
                         )
                 if CostCalculatorUtils._call_type_has_image_response(call_type) and isinstance(
                     completion_response, ImageResponse
@@ -1662,7 +1662,7 @@ def completion_cost(
                 return _final_cost
             except Exception as e:
                 verbose_logger.debug(
-                    f"litellm.cost_calculator.py::completion_cost() - Error calculating cost for model={model} - {e!s}"
+                    f"litellm.cost_calculator.py::completion_cost() - Error calculating cost for model={model} - {e}"
                 )
                 if idx == len(potential_model_names) - 1:
                     raise e

--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -1140,7 +1140,7 @@ class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
         if self.max_retries:
             _message += f", LiteLLM Max Retries: {self.max_retries}"
         if self.original_exception:
-            _message += f" Original exception: {type(self.original_exception).__name__}: {self.original_exception!s}"
+            _message += f" Original exception: {type(self.original_exception).__name__}: {self.original_exception}"
         return _message
 
     def __repr__(self):

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -515,7 +515,7 @@ class MCPClient:
             _log(
                 f"MCP client list_tools failed - "
                 f"Error Type: {error_type}, "
-                f"Error: {e!s}, "
+                f"Error: {e}, "
                 f"Server: {self.server_url or 'stdio'}, "
                 f"Transport: {self.transport_type}"
             )
@@ -536,7 +536,7 @@ class MCPClient:
     def error_tool_result(exc: Exception) -> MCPCallToolResult:
         """The error result ``call_tool`` returns when it swallows a failure (no re-execution)."""
         return MCPCallToolResult(
-            content=[TextContent(type="text", text=f"{type(exc).__name__}: {exc!s}")],
+            content=[TextContent(type="text", text=f"{type(exc).__name__}: {exc}")],
             isError=True,
         )
 
@@ -601,7 +601,7 @@ class MCPClient:
             _log(
                 f"MCP client call_tool failed - "
                 f"Error Type: {error_type}, "
-                f"Error: {e!s}, "
+                f"Error: {e}, "
                 f"Tool: {call_tool_request_params.name}, "
                 f"Server: {self.server_url or 'stdio'}, "
                 f"Transport: {self.transport_type}"
@@ -640,7 +640,7 @@ class MCPClient:
             verbose_logger.error(
                 f"MCP client list_prompts failed - "
                 f"Error Type: {error_type}, "
-                f"Error: {e!s}, "
+                f"Error: {e}, "
                 f"Server: {self.server_url or 'stdio'}, "
                 f"Transport: {self.transport_type}"
             )
@@ -681,7 +681,7 @@ class MCPClient:
             verbose_logger.error(
                 f"MCP client get_prompt failed - "
                 f"Error Type: {error_type}, "
-                f"Error: {e!s}, "
+                f"Error: {e}, "
                 f"Prompt: {get_prompt_request_params.name}, "
                 f"Server: {self.server_url or 'stdio'}, "
                 f"Transport: {self.transport_type}"
@@ -717,7 +717,7 @@ class MCPClient:
             verbose_logger.error(
                 f"MCP client list_resources failed - "
                 f"Error Type: {error_type}, "
-                f"Error: {e!s}, "
+                f"Error: {e}, "
                 f"Server: {self.server_url or 'stdio'}, "
                 f"Transport: {self.transport_type}"
             )
@@ -753,7 +753,7 @@ class MCPClient:
             verbose_logger.error(
                 f"MCP client list_resource_templates failed - "
                 f"Error Type: {error_type}, "
-                f"Error: {e!s}, "
+                f"Error: {e}, "
                 f"Server: {self.server_url or 'stdio'}, "
                 f"Transport: {self.transport_type}"
             )
@@ -791,7 +791,7 @@ class MCPClient:
             verbose_logger.error(
                 f"MCP client read_resource failed - "
                 f"Error Type: {error_type}, "
-                f"Error: {e!s}, "
+                f"Error: {e}, "
                 f"Url: {url}, "
                 f"Server: {self.server_url or 'stdio'}, "
                 f"Transport: {self.transport_type}"

--- a/litellm/google_genai/adapters/handler.py
+++ b/litellm/google_genai/adapters/handler.py
@@ -98,7 +98,7 @@ class GenerateContentToCompletionHandler:
                 return generate_content_response
 
         except Exception as e:
-            raise ValueError(f"Error calling litellm.acompletion for generate_content: {e!s}")
+            raise ValueError(f"Error calling litellm.acompletion for generate_content: {e}")
 
     @staticmethod
     def generate_content_handler(
@@ -159,4 +159,4 @@ class GenerateContentToCompletionHandler:
                 return generate_content_response
 
         except Exception as e:
-            raise ValueError(f"Error calling litellm.completion for generate_content: {e!s}")
+            raise ValueError(f"Error calling litellm.completion for generate_content: {e}")

--- a/litellm/integrations/SlackAlerting/batching_handler.py
+++ b/litellm/integrations/SlackAlerting/batching_handler.py
@@ -70,6 +70,6 @@ async def send_to_webhook(slackAlertingInstance: SlackAlertingType, item, count)
         if response.status_code != 200:
             verbose_proxy_logger.debug(f"Error sending slack alert to url={item['url']}. Error={response.text}")
     except Exception as e:
-        verbose_proxy_logger.debug(f"Error sending slack alert: {e!s}")
+        verbose_proxy_logger.debug(f"Error sending slack alert: {e}")
     finally:
         _print_alerting_payload_warning(payload, slackAlertingInstance=slackAlertingInstance)

--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -1467,7 +1467,7 @@ Model Info:
             try:
                 await self._flush_digest_buckets()
             except Exception as e:
-                verbose_proxy_logger.debug(f"Error flushing digest buckets: {e!s}")
+                verbose_proxy_logger.debug(f"Error flushing digest buckets: {e}")
             await self.flush_queue()
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
@@ -1502,7 +1502,7 @@ Model Info:
                 )
         except Exception as e:
             verbose_proxy_logger.error(
-                f"[Non-Blocking Error] Slack Alerting: Got error in logging LLM deployment latency: {e!s}"
+                f"[Non-Blocking Error] Slack Alerting: Got error in logging LLM deployment latency: {e}"
             )
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
@@ -1522,7 +1522,7 @@ Model Info:
                         )
                     )
                 except Exception as e:
-                    verbose_logger.debug(f"Exception raises -{e!s}")
+                    verbose_logger.debug(f"Exception raises -{e}")
 
             if isinstance(kwargs.get("exception", ""), APIError):
                 if "outage_alerts" in self.alert_types:

--- a/litellm/integrations/arize/arize.py
+++ b/litellm/integrations/arize/arize.py
@@ -169,7 +169,7 @@ class ArizeLogger(OpenTelemetry):
         except Exception as e:
             return {
                 "status": "unhealthy",
-                "error_message": f"Arize health check failed: {e!s}",
+                "error_message": f"Arize health check failed: {e}",
             }
 
     def construct_dynamic_otel_headers(

--- a/litellm/integrations/azure_sentinel/azure_sentinel.py
+++ b/litellm/integrations/azure_sentinel/azure_sentinel.py
@@ -203,7 +203,7 @@ class AzureSentinelLogger(CustomBatchLogger):
                 await self.async_send_batch()
 
         except Exception as e:
-            verbose_logger.exception(f"Azure Sentinel Layer Error - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"Azure Sentinel Layer Error - {e}\n{traceback.format_exc()}")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         """
@@ -233,7 +233,7 @@ class AzureSentinelLogger(CustomBatchLogger):
                 await self.async_send_batch()
 
         except Exception as e:
-            verbose_logger.exception(f"Azure Sentinel Layer Error - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"Azure Sentinel Layer Error - {e}\n{traceback.format_exc()}")
 
     async def async_log_audit_log_event(self, audit_log: StandardAuditLogPayload) -> None:
         """
@@ -256,7 +256,7 @@ class AzureSentinelLogger(CustomBatchLogger):
                 await self.async_send_audit_batch()
 
         except Exception as e:
-            verbose_logger.exception(f"Azure Sentinel Audit Log Layer Error - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"Azure Sentinel Audit Log Layer Error - {e}\n{traceback.format_exc()}")
 
     async def async_send_batch(self):
         """
@@ -323,7 +323,7 @@ class AzureSentinelLogger(CustomBatchLogger):
             )
 
         except Exception as e:
-            verbose_logger.exception(f"Azure Sentinel Error sending batch API - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"Azure Sentinel Error sending batch API - {e}\n{traceback.format_exc()}")
         finally:
             log_queue.clear()
 

--- a/litellm/integrations/azure_storage/azure_storage.py
+++ b/litellm/integrations/azure_storage/azure_storage.py
@@ -53,9 +53,7 @@ class AzureBlobStorageLogger(CustomBatchLogger):
             self.log_queue: list[StandardLoggingPayload] = []
             super().__init__(**kwargs, flush_lock=self.flush_lock)
         except Exception as e:
-            verbose_logger.exception(
-                f"AzureBlobStorageLogger: Got exception on init AzureBlobStorageLogger client {e!s}"
-            )
+            verbose_logger.exception(f"AzureBlobStorageLogger: Got exception on init AzureBlobStorageLogger client {e}")
             raise e
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
@@ -79,7 +77,7 @@ class AzureBlobStorageLogger(CustomBatchLogger):
             self.log_queue.append(standard_logging_payload)
 
         except Exception as e:
-            verbose_logger.exception(f"AzureBlobStorageLogger Layer Error - {e!s}")
+            verbose_logger.exception(f"AzureBlobStorageLogger Layer Error - {e}")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         """
@@ -101,7 +99,7 @@ class AzureBlobStorageLogger(CustomBatchLogger):
 
             self.log_queue.append(standard_logging_payload)
         except Exception as e:
-            verbose_logger.exception(f"AzureBlobStorageLogger Layer Error - {e!s}")
+            verbose_logger.exception(f"AzureBlobStorageLogger Layer Error - {e}")
 
     async def async_send_batch(self):
         """
@@ -124,7 +122,7 @@ class AzureBlobStorageLogger(CustomBatchLogger):
                 await self.async_upload_payload_to_azure_blob_storage(payload=payload)
 
         except Exception as e:
-            verbose_logger.exception(f"AzureBlobStorageLogger Error sending batch API - {e!s}")
+            verbose_logger.exception(f"AzureBlobStorageLogger Error sending batch API - {e}")
 
     async def async_upload_payload_to_azure_blob_storage(self, payload: StandardLoggingPayload):
         """
@@ -153,7 +151,7 @@ class AzureBlobStorageLogger(CustomBatchLogger):
                 verbose_logger.debug(f"Successfully uploaded log to Azure Blob Storage: {filename}")
 
         except Exception as e:
-            verbose_logger.exception(f"Error uploading to Azure Blob Storage: {e!s}")
+            verbose_logger.exception(f"Error uploading to Azure Blob Storage: {e}")
             raise e
 
     async def _create_file(self, client: AsyncHTTPHandler, base_url: str):
@@ -169,7 +167,7 @@ class AzureBlobStorageLogger(CustomBatchLogger):
             response.raise_for_status()
             verbose_logger.debug("Successfully created file resource")
         except Exception as e:
-            verbose_logger.exception(f"Error creating file resource: {e!s}")
+            verbose_logger.exception(f"Error creating file resource: {e}")
             raise
 
     async def _append_data(self, client: AsyncHTTPHandler, base_url: str, json_payload: str):
@@ -189,7 +187,7 @@ class AzureBlobStorageLogger(CustomBatchLogger):
             response.raise_for_status()
             verbose_logger.debug("Successfully appended data")
         except Exception as e:
-            verbose_logger.exception(f"Error appending data: {e!s}")
+            verbose_logger.exception(f"Error appending data: {e}")
             raise
 
     async def _flush_data(self, client: AsyncHTTPHandler, base_url: str, position: int):
@@ -205,7 +203,7 @@ class AzureBlobStorageLogger(CustomBatchLogger):
             response.raise_for_status()
             verbose_logger.debug("Successfully flushed data")
         except Exception as e:
-            verbose_logger.exception(f"Error flushing data: {e!s}")
+            verbose_logger.exception(f"Error flushing data: {e}")
             raise
 
     ####### Helper methods to managing Authentication to Azure Storage #######
@@ -345,4 +343,4 @@ class AzureBlobStorageLogger(CustomBatchLogger):
             verbose_logger.debug(f"Successfully uploaded and wrote to {today}/{file_name}")
 
         except Exception as e:
-            verbose_logger.exception(f"Error occurred: {e!s}")
+            verbose_logger.exception(f"Error occurred: {e}")

--- a/litellm/integrations/cloudzero/cloudzero.py
+++ b/litellm/integrations/cloudzero/cloudzero.py
@@ -153,7 +153,7 @@ class CloudZeroLogger(CustomLogger):
             verbose_logger.debug(f"CloudZero Logger: Successfully exported {len(cbf_data)} records to CloudZero")
 
         except Exception as e:
-            verbose_logger.error(f"CloudZero Logger: Error exporting usage data: {e!s}")
+            verbose_logger.error(f"CloudZero Logger: Error exporting usage data: {e}")
             raise
 
     async def dry_run_export_usage_data(self, limit: int | None = 10000):
@@ -244,8 +244,8 @@ class CloudZeroLogger(CustomLogger):
             }
 
         except Exception as e:
-            verbose_logger.error(f"CloudZero Logger: Error in dry run export: {e!s}")
-            verbose_logger.error(f"CloudZero Dry Run Error: {e!s}")
+            verbose_logger.error(f"CloudZero Logger: Error in dry run export: {e}")
+            verbose_logger.error(f"CloudZero Dry Run Error: {e}")
             raise
 
     def _display_cbf_data_on_screen(self, cbf_data):

--- a/litellm/integrations/cloudzero/database.py
+++ b/litellm/integrations/cloudzero/database.py
@@ -98,4 +98,4 @@ class LiteLLMDatabase:
             # This prevents schema mismatch errors when data types vary across rows
             return pl.DataFrame(db_response, infer_schema_length=None)
         except Exception as e:
-            raise Exception(f"Error retrieving usage data: {e!s}")
+            raise Exception(f"Error retrieving usage data: {e}")

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -927,7 +927,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
         except Exception as e:
             from litellm._logging import verbose_logger
 
-            verbose_logger.debug(f"Error in handle_callback_failure for {callback_name}: {e!s}")
+            verbose_logger.debug(f"Error in handle_callback_failure for {callback_name}: {e}")
 
     async def _strip_base64_from_messages(
         self,

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -171,7 +171,7 @@ class DataDogLogger(
                 batch_size=_resolve_dd_batch_size(),
             )
         except Exception as e:
-            verbose_logger.exception(f"Datadog: Got exception on init Datadog client {e!s}")
+            verbose_logger.exception(f"Datadog: Got exception on init Datadog client {e}")
             raise e
 
     def _get_datadog_params(self) -> dict:
@@ -257,7 +257,7 @@ class DataDogLogger(
             await self._log_async_event(kwargs, response_obj, start_time, end_time)
 
         except Exception as e:
-            verbose_logger.exception(f"Datadog Layer Error - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"Datadog Layer Error - {e}\n{traceback.format_exc()}")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
@@ -265,7 +265,7 @@ class DataDogLogger(
             await self._log_async_event(kwargs, response_obj, start_time, end_time)
 
         except Exception as e:
-            verbose_logger.exception(f"Datadog Layer Error - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"Datadog Layer Error - {e}\n{traceback.format_exc()}")
 
     async def async_post_call_failure_hook(
         self,
@@ -340,7 +340,7 @@ class DataDogLogger(
             if len(self.log_queue) >= self.batch_size:
                 await self.flush_queue()
         except Exception as e:
-            verbose_logger.exception(f"Datadog: async_post_call_failure_hook - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"Datadog: async_post_call_failure_hook - {e}\n{traceback.format_exc()}")
         return None
 
     async def async_send_batch(self):
@@ -380,7 +380,7 @@ class DataDogLogger(
 
         except Exception as e:
             self.log_queue = batch_to_send + self.log_queue
-            verbose_logger.exception(f"Datadog Error sending batch API - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"Datadog Error sending batch API - {e}\n{traceback.format_exc()}")
 
     async def _send_with_413_split(self, batch: list) -> list:
         """
@@ -411,7 +411,7 @@ class DataDogLogger(
                 if isinstance(e, MaskedHTTPStatusError) and e.status_code == 413:
                     response = e.response
                 else:
-                    verbose_logger.exception(f"Datadog Error sending batch API - {e!s}")
+                    verbose_logger.exception(f"Datadog Error sending batch API - {e}")
                     return self._undelivered(chunk, pending)
 
             if response.status_code == 413:
@@ -515,7 +515,7 @@ class DataDogLogger(
             )
 
         except Exception as e:
-            verbose_logger.exception(f"Datadog Layer Error - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"Datadog Layer Error - {e}\n{traceback.format_exc()}")
 
     async def _log_async_event(self, kwargs, response_obj, start_time, end_time):
         dd_payload = self.create_datadog_logging_payload(

--- a/litellm/integrations/datadog/datadog_cost_management.py
+++ b/litellm/integrations/datadog/datadog_cost_management.py
@@ -84,7 +84,7 @@ class DatadogCostManagementLogger(CustomBatchLogger):
                     await self.async_send_batch()
 
         except Exception as e:
-            verbose_logger.exception(f"Datadog Cost Management: Error in async_log_success_event: {e!s}")
+            verbose_logger.exception(f"Datadog Cost Management: Error in async_log_success_event: {e}")
 
     async def async_send_batch(self):
         if not self.log_queue:
@@ -104,7 +104,7 @@ class DatadogCostManagementLogger(CustomBatchLogger):
             await self._upload_to_datadog(aggregated_entries)
         except Exception as e:
             self.log_queue = batch_to_send + self.log_queue
-            verbose_logger.exception(f"Datadog Cost Management: Error in async_send_batch: {e!s}")
+            verbose_logger.exception(f"Datadog Cost Management: Error in async_send_batch: {e}")
 
     def _aggregate_costs(self, logs: list[StandardLoggingPayload]) -> list[DatadogFOCUSCostEntry]:
         """

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -89,7 +89,7 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             kwargs.update(dict_datadog_llm_obs_params)
             CustomBatchLogger.__init__(self, **kwargs, flush_lock=self.flush_lock)
         except Exception as e:
-            verbose_logger.exception(f"DataDogLLMObs: Error initializing - {e!s}")
+            verbose_logger.exception(f"DataDogLLMObs: Error initializing - {e}")
             raise e
 
     def _configure_dd_agent(self, dd_agent_host: str):
@@ -145,7 +145,7 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             if len(self.log_queue) >= self.batch_size:
                 await self.async_send_batch()
         except Exception as e:
-            verbose_logger.exception(f"DataDogLLMObs: Error logging success event - {e!s}")
+            verbose_logger.exception(f"DataDogLLMObs: Error logging success event - {e}")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
@@ -157,7 +157,7 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             if len(self.log_queue) >= self.batch_size:
                 await self.async_send_batch()
         except Exception as e:
-            verbose_logger.exception(f"DataDogLLMObs: Error logging failure event - {e!s}")
+            verbose_logger.exception(f"DataDogLLMObs: Error logging failure event - {e}")
 
     async def async_send_batch(self):
         try:
@@ -214,7 +214,7 @@ class DataDogLLMObsLogger(CustomBatchLogger):
         except httpx.HTTPStatusError as e:
             verbose_logger.exception(f"DataDogLLMObs: Error sending batch - {e.response.text}")
         except Exception as e:
-            verbose_logger.exception(f"DataDogLLMObs: Error sending batch - {e!s}")
+            verbose_logger.exception(f"DataDogLLMObs: Error sending batch - {e}")
 
     def create_llm_obs_payload(self, kwargs: dict, start_time: datetime, end_time: datetime) -> LLMObsPayload:
         standard_logging_payload: StandardLoggingPayload | None = kwargs.get("standard_logging_object")
@@ -707,7 +707,7 @@ class DataDogLLMObsLogger(CustomBatchLogger):
 
                             kv_pairs[f"tool_calls.{idx}.function.arguments"] = json.dumps(function_arguments)
             except (KeyError, TypeError, ValueError) as e:
-                verbose_logger.debug(f"DataDogLLMObs: Error processing tool call {idx}: {e!s}")
+                verbose_logger.debug(f"DataDogLLMObs: Error processing tool call {idx}: {e}")
                 continue
 
         return kv_pairs
@@ -747,6 +747,6 @@ class DataDogLLMObsLogger(CustomBatchLogger):
                                     tool_call_metadata[f"output_{key}"] = value
 
         except Exception as e:
-            verbose_logger.debug(f"DataDogLLMObs: Error extracting tool call metadata: {e!s}")
+            verbose_logger.debug(f"DataDogLLMObs: Error extracting tool call metadata: {e}")
 
         return tool_call_metadata

--- a/litellm/integrations/datadog/datadog_metrics.py
+++ b/litellm/integrations/datadog/datadog_metrics.py
@@ -180,7 +180,7 @@ class DatadogMetricsLogger(CustomBatchLogger):
                 await self.flush_queue()
 
         except Exception as e:
-            verbose_logger.exception(f"Datadog Metrics: Error in async_log_success_event: {e!s}")
+            verbose_logger.exception(f"Datadog Metrics: Error in async_log_success_event: {e}")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
@@ -202,7 +202,7 @@ class DatadogMetricsLogger(CustomBatchLogger):
                 await self.flush_queue()
 
         except Exception as e:
-            verbose_logger.exception(f"Datadog Metrics: Error in async_log_failure_event: {e!s}")
+            verbose_logger.exception(f"Datadog Metrics: Error in async_log_failure_event: {e}")
 
     async def async_send_batch(self):
         if not self.log_queue:
@@ -214,7 +214,7 @@ class DatadogMetricsLogger(CustomBatchLogger):
         try:
             await self._upload_to_datadog(payload_data)
         except Exception as e:
-            verbose_logger.exception(f"Datadog Metrics: Error in async_send_batch: {e!s}")
+            verbose_logger.exception(f"Datadog Metrics: Error in async_send_batch: {e}")
             raise
 
     async def _upload_to_datadog(self, payload: DatadogMetricsPayload):

--- a/litellm/integrations/dynamodb.py
+++ b/litellm/integrations/dynamodb.py
@@ -70,7 +70,7 @@ class DyanmoDBLogger:
             # Assuming log_data is a dictionary with log information
             response = table.put_item(Item=payload)
 
-            print_verbose(f"Response from DynamoDB:{response!s}")
+            print_verbose(f"Response from DynamoDB:{response}")
 
             print_verbose(f"DynamoDB Layer Logging - final response object: {response_obj}")
             return response

--- a/litellm/integrations/galileo.py
+++ b/litellm/integrations/galileo.py
@@ -128,7 +128,7 @@ class GalileoObserve(CustomLogger):
         except Exception as e:
             return IntegrationHealthCheckStatus(
                 status="unhealthy",
-                error_message=f"Galileo health check failed: {e!s}",
+                error_message=f"Galileo health check failed: {e}",
             )
 
     async def async_set_galileo_headers(self) -> None:

--- a/litellm/integrations/gcs_bucket/gcs_bucket.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket.py
@@ -76,7 +76,7 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
             await self.log_queue.put(GCSLogQueueItem(payload=logging_payload, kwargs=kwargs, response_obj=response_obj))
 
         except Exception as e:
-            verbose_logger.exception(f"GCS Bucket logging error: {e!s}")
+            verbose_logger.exception(f"GCS Bucket logging error: {e}")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
@@ -95,7 +95,7 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
             await self.log_queue.put(GCSLogQueueItem(payload=logging_payload, kwargs=kwargs, response_obj=response_obj))
 
         except Exception as e:
-            verbose_logger.exception(f"GCS Bucket logging error: {e!s}")
+            verbose_logger.exception(f"GCS Bucket logging error: {e}")
 
     def _drain_queue_batch(self) -> list[GCSLogQueueItem]:
         """
@@ -218,7 +218,7 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
         except Exception as e:
             success_count = 0
             error_count = len(items)
-            verbose_logger.exception(f"GCS Bucket error logging batch payload to GCS bucket: {e!s}")
+            verbose_logger.exception(f"GCS Bucket error logging batch payload to GCS bucket: {e}")
             return (success_count, error_count)
 
     async def _send_individual_logs(self, items: list[GCSLogQueueItem]) -> None:
@@ -255,7 +255,7 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
                 logging_payload=item["payload"],
             )
         except Exception as e:
-            verbose_logger.exception(f"GCS Bucket error logging individual payload to GCS bucket: {e!s}")
+            verbose_logger.exception(f"GCS Bucket error logging individual payload to GCS bucket: {e}")
 
     async def async_send_batch(self):
         """
@@ -336,7 +336,7 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
                     loaded_response = json.loads(response)
                     return loaded_response
             except Exception as e:
-                verbose_logger.debug(f"Failed to fetch payload for date {date_str}: {e!s}")
+                verbose_logger.debug(f"Failed to fetch payload for date {date_str}: {e}")
                 continue
 
         return None

--- a/litellm/integrations/gcs_pubsub/pub_sub.py
+++ b/litellm/integrations/gcs_pubsub/pub_sub.py
@@ -132,7 +132,7 @@ class GcsPubSubLogger(CustomBatchLogger):
                 await self.async_send_batch()
 
         except Exception as e:
-            verbose_logger.exception(f"PubSub Layer Error - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"PubSub Layer Error - {e}\n{traceback.format_exc()}")
 
     async def async_send_batch(self):
         """
@@ -148,7 +148,7 @@ class GcsPubSubLogger(CustomBatchLogger):
                 await self.publish_message(message)
 
         except Exception as e:
-            verbose_logger.exception(f"PubSub Error sending batch - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"PubSub Error sending batch - {e}\n{traceback.format_exc()}")
         finally:
             self.log_queue.clear()
 

--- a/litellm/integrations/generic_api/generic_api_callback.py
+++ b/litellm/integrations/generic_api/generic_api_callback.py
@@ -42,7 +42,7 @@ def load_compatible_callbacks() -> dict:
         with open(json_path, "r") as f:
             return json.load(f)
     except Exception as e:
-        verbose_logger.warning(f"Error loading generic_api_compatible_callbacks.json: {e!s}")
+        verbose_logger.warning(f"Error loading generic_api_compatible_callbacks.json: {e}")
         return {}
 
 
@@ -214,7 +214,7 @@ class GenericAPILogger(CustomBatchLogger):
                         key, value = item.split("=", 1)
                         headers_dict[key.strip()] = value.strip()
             except Exception as e:
-                verbose_logger.warning(f"Error parsing headers from environment variables: {e!s}")
+                verbose_logger.warning(f"Error parsing headers from environment variables: {e}")
 
         # 2. Update with litellm generic headers if available
         if litellm.generic_logger_headers:
@@ -308,7 +308,7 @@ class GenericAPILogger(CustomBatchLogger):
                 await self.async_send_batch()
 
         except Exception as e:
-            verbose_logger.exception(f"Generic API Logger Error - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"Generic API Logger Error - {e}\n{traceback.format_exc()}")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         """
@@ -339,7 +339,7 @@ class GenericAPILogger(CustomBatchLogger):
                 await self.async_send_batch()
 
         except Exception as e:
-            verbose_logger.exception(f"Generic API Logger Error - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"Generic API Logger Error - {e}\n{traceback.format_exc()}")
 
     async def async_send_batch(self):
         """
@@ -395,7 +395,7 @@ class GenericAPILogger(CustomBatchLogger):
                 )
 
         except Exception as e:
-            verbose_logger.exception(f"Generic API Logger Error sending batch - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"Generic API Logger Error sending batch - {e}\n{traceback.format_exc()}")
         finally:
             self.log_queue.clear()
 

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -330,7 +330,7 @@ class LangFuseLogger:
 
             return {"trace_id": trace_id, "generation_id": generation_id}
         except Exception as e:
-            verbose_logger.exception(f"Langfuse Layer Error(): Exception occured - {e!s}")
+            verbose_logger.exception(f"Langfuse Layer Error(): Exception occured - {e}")
             return {"trace_id": None, "generation_id": None}
 
     def _get_langfuse_input_output_content(

--- a/litellm/integrations/langfuse/langfuse_prompt_management.py
+++ b/litellm/integrations/langfuse/langfuse_prompt_management.py
@@ -317,7 +317,7 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
         except Exception as e:
             from litellm._logging import verbose_logger
 
-            verbose_logger.exception(f"Langfuse Layer Error - Exception occurred while logging success event: {e!s}")
+            verbose_logger.exception(f"Langfuse Layer Error - Exception occurred while logging success event: {e}")
             self.handle_callback_failure(callback_name="langfuse")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
@@ -347,5 +347,5 @@ class LangfusePromptManagement(LangFuseLogger, PromptManagementBase, CustomLogge
         except Exception as e:
             from litellm._logging import verbose_logger
 
-            verbose_logger.exception(f"Langfuse Layer Error - Exception occurred while logging failure event: {e!s}")
+            verbose_logger.exception(f"Langfuse Layer Error - Exception occurred while logging failure event: {e}")
             self.handle_callback_failure(callback_name="langfuse")

--- a/litellm/integrations/logfire_logger.py
+++ b/litellm/integrations/logfire_logger.py
@@ -35,7 +35,7 @@ class LogfireLogger:
             if logfire.DEFAULT_LOGFIRE_INSTANCE.config.send_to_logfire:
                 logfire.configure(token=os.getenv("LOGFIRE_TOKEN"))
         except Exception as e:
-            print_verbose(f"Got exception on init logfire client {e!s}")
+            print_verbose(f"Got exception on init logfire client {e}")
             raise e
 
     def _get_span_config(self, payload) -> SpanConfig:
@@ -159,4 +159,4 @@ class LogfireLogger:
 
             print_verbose(f"Logfire Layer Logging - final response object: {response_obj}")
         except Exception as e:
-            verbose_logger.debug(f"Logfire Layer Error - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.debug(f"Logfire Layer Error - {e}\n{traceback.format_exc()}")

--- a/litellm/integrations/opik/opik.py
+++ b/litellm/integrations/opik/opik.py
@@ -81,7 +81,7 @@ class OpikLogger(CustomBatchLogger):
             self.flush_lock: asyncio.Lock | None = asyncio.Lock()
         except Exception as e:
             verbose_logger.exception(
-                f"OpikLogger - Asynchronous processing not initialized as we are not running in an async context {e!s}"
+                f"OpikLogger - Asynchronous processing not initialized as we are not running in an async context {e}"
             )
             self.flush_lock = None
 
@@ -161,7 +161,7 @@ class OpikLogger(CustomBatchLogger):
                     verbose_logger.debug("OpikLogger - Flushing batch")
                     await self.flush_queue()
         except Exception as e:
-            verbose_logger.exception(f"OpikLogger failed to log success event - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"OpikLogger failed to log success event - {e}\n{traceback.format_exc()}")
 
     def _sync_send(self, url: str, headers: dict[str, str], batch: dict[str, Any]) -> None:
         try:
@@ -174,7 +174,7 @@ class OpikLogger(CustomBatchLogger):
             if response.status_code != 204:
                 raise Exception(f"Response from opik API status_code: {response.status_code}, text: {response.text}")
         except Exception as e:
-            verbose_logger.exception(f"OpikLogger failed to send batch - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"OpikLogger failed to send batch - {e}\n{traceback.format_exc()}")
 
     def log_success_event(
         self,
@@ -245,7 +245,7 @@ class OpikLogger(CustomBatchLogger):
                     batch={"spans": [span_payload.__dict__]},
                 )
         except Exception as e:
-            verbose_logger.exception(f"OpikLogger failed to log success event - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"OpikLogger failed to log success event - {e}\n{traceback.format_exc()}")
 
     async def _submit_batch(self, url: str, headers: dict[str, str], batch: dict[str, Any]) -> None:
         try:
@@ -261,7 +261,7 @@ class OpikLogger(CustomBatchLogger):
             else:
                 verbose_logger.info(f"OpikLogger - {len(self.log_queue)} Opik events submitted")
         except Exception as e:
-            verbose_logger.exception(f"OpikLogger failed to send batch - {e!s}")
+            verbose_logger.exception(f"OpikLogger failed to send batch - {e}")
 
     def _create_opik_headers(self) -> dict[str, str]:
         headers: dict[str, str] = {}

--- a/litellm/integrations/posthog.py
+++ b/litellm/integrations/posthog.py
@@ -72,7 +72,7 @@ class PostHogLogger(CustomBatchLogger):
             super().__init__(**kwargs, flush_lock=None, batch_size=POSTHOG_MAX_BATCH_SIZE)
 
         except Exception as e:
-            verbose_logger.exception(f"PostHog: Got exception on init PostHog client {e!s}")
+            verbose_logger.exception(f"PostHog: Got exception on init PostHog client {e}")
             raise e
 
     def log_success_event(self, kwargs, response_obj, start_time, end_time):
@@ -107,7 +107,7 @@ class PostHogLogger(CustomBatchLogger):
                 verbose_logger.debug("PostHog: Sync event successfully sent")
 
         except Exception as e:
-            verbose_logger.exception(f"PostHog Sync Layer Error - {e!s}")
+            verbose_logger.exception(f"PostHog Sync Layer Error - {e}")
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         try:
@@ -115,7 +115,7 @@ class PostHogLogger(CustomBatchLogger):
             self._ensure_async_setup()  # Lazy initialization
             await self._log_async_event(kwargs, response_obj, start_time, end_time)
         except Exception as e:
-            verbose_logger.exception(f"PostHog Layer Error - {e!s}")
+            verbose_logger.exception(f"PostHog Layer Error - {e}")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
@@ -123,7 +123,7 @@ class PostHogLogger(CustomBatchLogger):
             self._ensure_async_setup()  # Lazy initialization
             await self._log_async_event(kwargs, response_obj, start_time, end_time)
         except Exception as e:
-            verbose_logger.exception(f"PostHog Layer Error - {e!s}")
+            verbose_logger.exception(f"PostHog Layer Error - {e}")
 
     async def _log_async_event(self, kwargs, response_obj=None, start_time=0.0, end_time=0.0):
         # Note: response_obj, start_time, end_time not used - all data comes from kwargs
@@ -367,7 +367,7 @@ class PostHogLogger(CustomBatchLogger):
             else:
                 verbose_logger.debug(f"PostHog: Batch of {len(self.log_queue)} events successfully sent")
         except Exception as e:
-            verbose_logger.exception(f"PostHog Error sending batch API - {e!s}")
+            verbose_logger.exception(f"PostHog Error sending batch API - {e}")
 
     def _ensure_async_setup(self):
         if not self._async_initialized:
@@ -377,7 +377,7 @@ class PostHogLogger(CustomBatchLogger):
                 self._async_initialized = True
                 verbose_logger.debug("PostHog: Async components initialized")
             except Exception as e:
-                verbose_logger.error(f"PostHog: Failed to initialize async components: {e!s}")
+                verbose_logger.error(f"PostHog: Failed to initialize async components: {e}")
                 raise
 
     def _extract_metadata(self, kwargs: dict[str, Any]) -> dict[str, Any]:
@@ -445,4 +445,4 @@ class PostHogLogger(CustomBatchLogger):
             self.log_queue.clear()
 
         except Exception as e:
-            verbose_logger.error(f"PostHog: Error flushing events on exit: {e!s}")
+            verbose_logger.error(f"PostHog: Error flushing events on exit: {e}")

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -683,7 +683,7 @@ class PrometheusLogger(CustomLogger):
             )
 
         except Exception as e:
-            print_verbose(f"Got exception on init prometheus client {e!s}")
+            print_verbose(f"Got exception on init prometheus client {e}")
             raise e
 
     def _parse_prometheus_config(self) -> dict[str, list[str]]:
@@ -2132,7 +2132,7 @@ class PrometheusLogger(CustomLogger):
                 response_cost=0,
             )
         except Exception as e:
-            verbose_logger.exception(f"prometheus Layer Error(): Exception occured - {e!s}")
+            verbose_logger.exception(f"prometheus Layer Error(): Exception occured - {e}")
 
     def _extract_status_code(
         self,
@@ -2383,7 +2383,7 @@ class PrometheusLogger(CustomLogger):
             )
 
         except Exception as e:
-            verbose_logger.exception(f"prometheus Layer Error(): Exception occured - {e!s}")
+            verbose_logger.exception(f"prometheus Layer Error(): Exception occured - {e}")
 
     async def async_post_call_success_hook(self, data: dict, user_api_key_dict: UserAPIKeyAuth, response):
         """
@@ -2608,7 +2608,7 @@ class PrometheusLogger(CustomLogger):
             )
 
         except Exception as e:
-            verbose_logger.debug(f"Prometheus Error: set_llm_deployment_failure_metrics. Exception occured - {e!s}")
+            verbose_logger.debug(f"Prometheus Error: set_llm_deployment_failure_metrics. Exception occured - {e}")
 
     def _set_deployment_tpm_rpm_limit_metrics(
         self,
@@ -2722,9 +2722,7 @@ class PrometheusLogger(CustomLogger):
                 )
                 self.litellm_remaining_requests_metric.labels(**_labels).set(remaining_requests)
         except Exception as e:
-            verbose_logger.exception(
-                f"Prometheus Error: _async_set_router_remaining_metrics. Exception occured - {e!s}"
-            )
+            verbose_logger.exception(f"Prometheus Error: _async_set_router_remaining_metrics. Exception occured - {e}")
 
     def set_llm_deployment_success_metrics(
         self,
@@ -2867,7 +2865,7 @@ class PrometheusLogger(CustomLogger):
                 self.litellm_deployment_latency_per_output_token.labels(**_labels).observe(latency_per_token)
 
         except Exception as e:
-            verbose_logger.exception(f"Prometheus Error: set_llm_deployment_success_metrics. Exception occured - {e!s}")
+            verbose_logger.exception(f"Prometheus Error: set_llm_deployment_success_metrics. Exception occured - {e}")
             return
 
     def _record_guardrail_metrics(
@@ -2912,7 +2910,7 @@ class PrometheusLogger(CustomLogger):
                     hook_type=hook_type,
                 ).inc()
         except Exception as e:
-            verbose_logger.debug(f"Error recording guardrail metrics: {e!s}")
+            verbose_logger.debug(f"Error recording guardrail metrics: {e}")
 
     ########################################
     # Managed Batch Metric Recording Methods
@@ -3315,7 +3313,7 @@ class PrometheusLogger(CustomLogger):
                 await set_metrics_function(data)
 
         except Exception as e:
-            verbose_logger.exception(f"Error initializing {data_type} budget metrics: {e!s}")
+            verbose_logger.exception(f"Error initializing {data_type} budget metrics: {e}")
 
     async def _initialize_team_budget_metrics(self):
         """
@@ -3506,7 +3504,7 @@ class PrometheusLogger(CustomLogger):
             self.litellm_teams_count_metric.set(total_teams)
             verbose_logger.debug(f"Prometheus: set litellm_teams_count to {total_teams}")
         except Exception as e:
-            verbose_logger.exception(f"Error initializing user/team count metrics: {e!s}")
+            verbose_logger.exception(f"Error initializing user/team count metrics: {e}")
 
     async def _set_key_list_budget_metrics(self, keys: list[str | UserAPIKeyAuth]):
         """Helper function to set budget metrics for a list of keys"""
@@ -3597,7 +3595,7 @@ class PrometheusLogger(CustomLogger):
                 user_api_key_cache=user_api_key_cache,
             )
         except Exception as e:
-            verbose_logger.debug(f"[Non-Blocking] Prometheus: Error getting team info: {e!s}")
+            verbose_logger.debug(f"[Non-Blocking] Prometheus: Error getting team info: {e}")
             return team_object
 
         if team_info:
@@ -3695,7 +3693,7 @@ class PrometheusLogger(CustomLogger):
                 include_budget_table=True,
             )
         except Exception as e:
-            verbose_logger.debug(f"[Non-Blocking] Prometheus: Error getting org info: {e!s}")
+            verbose_logger.debug(f"[Non-Blocking] Prometheus: Error getting org info: {e}")
             return
 
         if org_info is None:
@@ -3852,7 +3850,7 @@ class PrometheusLogger(CustomLogger):
                 if key_object:
                     user_api_key_dict.budget_reset_at = key_object.budget_reset_at
         except Exception as e:
-            verbose_logger.debug(f"[Non-Blocking] Prometheus: Error getting key info: {e!s}")
+            verbose_logger.debug(f"[Non-Blocking] Prometheus: Error getting key info: {e}")
 
         return user_api_key_dict
 
@@ -3917,7 +3915,7 @@ class PrometheusLogger(CustomLogger):
                 check_db_only=False,
             )
         except Exception as e:
-            verbose_logger.debug(f"[Non-Blocking] Prometheus: Error getting user info: {e!s}")
+            verbose_logger.debug(f"[Non-Blocking] Prometheus: Error getting user info: {e}")
             return user_object
 
         if user_info:

--- a/litellm/integrations/prometheus_services.py
+++ b/litellm/integrations/prometheus_services.py
@@ -82,7 +82,7 @@ class PrometheusServicesLogger:
             self.mock_testing_failure_calls = 0
 
         except Exception as e:
-            print_verbose(f"Got exception on init prometheus client {e!s}")
+            print_verbose(f"Got exception on init prometheus client {e}")
             raise e
 
     def _get_service_metrics_initialize(self, service: ServiceTypes) -> list[ServiceMetrics]:

--- a/litellm/integrations/s3.py
+++ b/litellm/integrations/s3.py
@@ -78,7 +78,7 @@ class S3Logger:
                 **kwargs,
             )
         except Exception as e:
-            print_verbose(f"Got exception on init s3 client {e!s}")
+            print_verbose(f"Got exception on init s3 client {e}")
             raise e
 
     async def _async_log_event(self, kwargs, response_obj, start_time, end_time, print_verbose):
@@ -163,12 +163,12 @@ class S3Logger:
                 **sse_params,
             )
 
-            print_verbose(f"Response from s3:{response!s}")
+            print_verbose(f"Response from s3:{response}")
 
             print_verbose(f"s3 Layer Logging - final response object: {response_obj}")
             return response
         except Exception as e:
-            verbose_logger.exception(f"s3 Layer Error - {e!s}")
+            verbose_logger.exception(f"s3 Layer Error - {e}")
 
 
 def _validated_sse_value(name: str, value: str | None) -> str | None:

--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -125,7 +125,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             BaseAWSLLM.__init__(self)
 
         except Exception as e:
-            print_verbose(f"Got exception on init s3 client {e!s}")
+            print_verbose(f"Got exception on init s3 client {e}")
             raise e
 
     def _init_s3_params(
@@ -284,7 +284,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 self.batch_size,
             )
         except Exception as e:
-            verbose_logger.exception(f"s3 Layer Error - {e!s}")
+            verbose_logger.exception(f"s3 Layer Error - {e}")
             self.handle_callback_failure(callback_name="S3Logger")
 
     async def async_upload_data_to_s3(self, batch_logging_element: s3BatchLoggingElement):
@@ -383,7 +383,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 response.raise_for_status()
                 break
         except Exception as e:
-            verbose_logger.exception(f"Error uploading to s3: {e!s}")
+            verbose_logger.exception(f"Error uploading to s3: {e}")
             self.handle_callback_failure(callback_name="S3Logger")
 
     async def async_send_batch(self):
@@ -557,7 +557,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 response.raise_for_status()
                 break
         except Exception as e:
-            verbose_logger.exception(f"Error uploading to s3: {e!s}")
+            verbose_logger.exception(f"Error uploading to s3: {e}")
             self.handle_callback_failure(callback_name="S3Logger")
 
     async def _download_object_from_s3(self, s3_object_key: str) -> dict | None:
@@ -642,7 +642,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             return response.json()
 
         except Exception as e:
-            verbose_logger.exception(f"Error downloading from S3: {e!s}")
+            verbose_logger.exception(f"Error downloading from S3: {e}")
             return None
 
     async def get_proxy_server_request_from_cold_storage_with_object_key(
@@ -666,5 +666,5 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             downloaded_object = await self._download_object_from_s3(object_key)
             return downloaded_object
         except Exception as e:
-            verbose_logger.exception(f"Error retrieving object {object_key} from cold storage: {e!s}")
+            verbose_logger.exception(f"Error retrieving object {object_key} from cold storage: {e}")
             return None

--- a/litellm/integrations/sqs.py
+++ b/litellm/integrations/sqs.py
@@ -113,7 +113,7 @@ class SQSLogger(CustomBatchLogger, BaseAWSLLM):
             BaseAWSLLM.__init__(self)
 
         except Exception as e:
-            print_verbose(f"Got exception on init sqs client {e!s}")
+            print_verbose(f"Got exception on init sqs client {e}")
             raise e
 
     def _init_sqs_params(
@@ -215,7 +215,7 @@ class SQSLogger(CustomBatchLogger, BaseAWSLLM):
                 self.batch_size,
             )
         except Exception as e:
-            verbose_logger.exception(f"sqs Layer Error - {e!s}")
+            verbose_logger.exception(f"sqs Layer Error - {e}")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         try:
@@ -233,7 +233,7 @@ class SQSLogger(CustomBatchLogger, BaseAWSLLM):
             )
 
         except Exception as e:
-            verbose_logger.exception(f"Datadog Layer Error - {e!s}\n{traceback.format_exc()}")
+            verbose_logger.exception(f"Datadog Layer Error - {e}\n{traceback.format_exc()}")
 
     async def async_send_batch(self) -> None:
         verbose_logger.debug(f"sqs logger - sending batch of {len(self.log_queue)}")
@@ -305,7 +305,7 @@ class SQSLogger(CustomBatchLogger, BaseAWSLLM):
             )
             response.raise_for_status()
         except Exception as e:
-            verbose_logger.exception(f"Error sending to SQS: {e!s}")
+            verbose_logger.exception(f"Error sending to SQS: {e}")
 
     async def async_health_check(self) -> IntegrationHealthCheckStatus:
         """

--- a/litellm/integrations/vector_store_integrations/vector_store_pre_call_hook.py
+++ b/litellm/integrations/vector_store_integrations/vector_store_pre_call_hook.py
@@ -146,7 +146,7 @@ class VectorStorePreCallHook(CustomLogger):
             return model, modified_messages, non_default_params
 
         except Exception as e:
-            verbose_logger.exception(f"Error in VectorStorePreCallHook: {e!s}")
+            verbose_logger.exception(f"Error in VectorStorePreCallHook: {e}")
             # Return original parameters on error
             return model, messages, non_default_params
 
@@ -275,7 +275,7 @@ class VectorStorePreCallHook(CustomLogger):
             return response
 
         except Exception as e:
-            verbose_logger.exception(f"Error adding search results to response: {e!s}")
+            verbose_logger.exception(f"Error adding search results to response: {e}")
             # Don't fail the request if search results fail to be added
             return None
 
@@ -322,6 +322,6 @@ class VectorStorePreCallHook(CustomLogger):
             return response_chunk
 
         except Exception as e:
-            verbose_logger.exception(f"Error adding search results to streaming chunk: {e!s}")
+            verbose_logger.exception(f"Error adding search results to streaming chunk: {e}")
             # Don't fail the request if search results fail to be added
             return response_chunk

--- a/litellm/integrations/websearch_interception/handler.py
+++ b/litellm/integrations/websearch_interception/handler.py
@@ -224,7 +224,7 @@ class WebSearchInterceptionLogger(CustomLogger):
         content.append({"type": "text", "text": search_result_text})
 
         response: dict[str, object] = {
-            "id": f"msg_{uuid.uuid4()!s}",
+            "id": f"msg_{uuid.uuid4()}",
             "type": "message",
             "role": "assistant",
             "model": model,
@@ -1038,8 +1038,8 @@ class WebSearchInterceptionLogger(CustomLogger):
     @staticmethod
     def _extract_search_text(result: object) -> str:
         if isinstance(result, Exception):
-            verbose_logger.error(f"WebSearchInterception: Responses search failed with error: {result!s}")
-            return f"Search failed: {result!s}"
+            verbose_logger.error(f"WebSearchInterception: Responses search failed with error: {result}")
+            return f"Search failed: {result}"
         if isinstance(result, tuple) and len(result) == 2:
             text_value, _ = result
             return text_value if isinstance(text_value, str) else str(text_value)
@@ -1194,8 +1194,8 @@ class WebSearchInterceptionLogger(CustomLogger):
         structured_results: list[SearchResponse | None] = []
         for i, result in enumerate(search_results):
             if isinstance(result, Exception):
-                verbose_logger.error(f"WebSearchInterception: Search {i} failed with error: {result!s}")
-                final_search_results.append(f"Search failed: {result!s}")
+                verbose_logger.error(f"WebSearchInterception: Search {i} failed with error: {result}")
+                final_search_results.append(f"Search failed: {result}")
                 structured_results.append(None)
             elif isinstance(result, tuple) and len(result) == 2:
                 text_value, structured_value = result
@@ -1308,7 +1308,7 @@ class WebSearchInterceptionLogger(CustomLogger):
             )
             return search_result_text, result
         except Exception as e:
-            verbose_logger.error(f"WebSearchInterception: Search failed for '{query}': {e!s}")
+            verbose_logger.error(f"WebSearchInterception: Search failed for '{query}': {e}")
             raise
 
     async def _authorize_search_tool(
@@ -1486,8 +1486,8 @@ class WebSearchInterceptionLogger(CustomLogger):
         final_search_results: list[str] = []
         for i, result in enumerate(search_results):
             if isinstance(result, Exception):
-                verbose_logger.error(f"WebSearchInterception: Search {i} failed with error: {result!s}")
-                final_search_results.append(f"Search failed: {result!s}")
+                verbose_logger.error(f"WebSearchInterception: Search {i} failed with error: {result}")
+                final_search_results.append(f"Search failed: {result}")
             elif isinstance(result, tuple) and len(result) == 2:
                 text_value, _ = result
                 final_search_results.append(cast(str, text_value) if isinstance(text_value, str) else str(text_value))

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -679,7 +679,7 @@ def _map_replicate_exception(
             )
     raise APIError(
         status_code=500,
-        message=f"ReplicateException - {original_exception!s}",
+        message=f"ReplicateException - {original_exception}",
         llm_provider="replicate",
         model=model,
         request=httpx.Request(
@@ -2459,7 +2459,7 @@ def exception_type(  # type: ignore
         ):  # deal with edge-case invalid request error bug in openai-python sdk
             exception_mapping_worked = True
             raise BadRequestError(
-                message=f"{exception_provider} BadRequestError : This can happen due to missing AZURE_API_VERSION: {original_exception!s}",
+                message=f"{exception_provider} BadRequestError : This can happen due to missing AZURE_API_VERSION: {original_exception}",
                 model=model,
                 llm_provider=custom_llm_provider,
                 response=getattr(original_exception, "response", None),
@@ -2478,7 +2478,7 @@ def exception_type(  # type: ignore
                 )
             else:
                 raise APIConnectionError(
-                    message=f"{original_exception!s}\n{_redact_string(traceback.format_exc())}",
+                    message=f"{original_exception}\n{_redact_string(traceback.format_exc())}",
                     llm_provider=custom_llm_provider,
                     model=model,
                     request=httpx.Request(method="POST", url="https://api.openai.com/v1/"),  # stub the request

--- a/litellm/litellm_core_utils/fallback_utils.py
+++ b/litellm/litellm_core_utils/fallback_utils.py
@@ -70,7 +70,7 @@ async def async_completion_with_fallbacks(**kwargs):
                 )
 
         except Exception as e:
-            verbose_logger.exception(f"Fallback attempt failed for model {model}: {e!s}")
+            verbose_logger.exception(f"Fallback attempt failed for model {model}: {e}")
             most_recent_exception_str = str(e)
             continue
 

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -501,9 +501,9 @@ def get_llm_provider(
         if isinstance(e, litellm.exceptions.BadRequestError):
             raise e
         else:
-            error_str = f"GetLLMProvider Exception - {e!s}\n\noriginal model: {model}"
+            error_str = f"GetLLMProvider Exception - {e}\n\noriginal model: {model}"
             raise litellm.exceptions.BadRequestError(  # type: ignore
-                message=f"GetLLMProvider Exception - {e!s}\n\noriginal model: {model}",
+                message=f"GetLLMProvider Exception - {e}\n\noriginal model: {model}",
                 model=model,
                 response=None,
                 llm_provider="",

--- a/litellm/litellm_core_utils/get_model_cost_map.py
+++ b/litellm/litellm_core_utils/get_model_cost_map.py
@@ -292,7 +292,7 @@ def get_model_cost_map(url: str) -> dict:
             str(e),
         )
         _cost_map_source_info.source = "local"
-        _cost_map_source_info.fallback_reason = f"Remote fetch failed: {e!s}"
+        _cost_map_source_info.fallback_reason = f"Remote fetch failed: {e}"
         return _finalize_model_cost_map(GetModelCostMap.load_local_model_cost_map())
 
     # Validate using cached count (cheap int comparison, no file I/O)

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -199,7 +199,7 @@ try:
         EnterpriseStandardLoggingPayloadSetup
     )
 except Exception as e:
-    verbose_logger.debug(f"[Non-Blocking] Unable to import GenericAPILogger - LiteLLM Enterprise Feature - {e!s}")
+    verbose_logger.debug(f"[Non-Blocking] Unable to import GenericAPILogger - LiteLLM Enterprise Feature - {e}")
     GenericAPILogger = CustomLogger  # type: ignore
     ResendEmailLogger = CustomLogger  # type: ignore
     SendGridEmailLogger = CustomLogger  # type: ignore
@@ -968,7 +968,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         error=str(e),
                     )
                     _metadata["raw_request"] = f"Unable to Log \
-                        raw request: {e!s}"
+                        raw request: {e}"
             if getattr(self, "logger_fn", None) and callable(self.logger_fn):
                 try:
                     self.logger_fn(
@@ -976,7 +976,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     )  # Expectation: any logger function passed in by the user should accept a dict object
                 except Exception as e:
                     verbose_logger.exception(
-                        f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while logging {e!s}"
+                        f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while logging {e}"
                     )
 
             self.model_call_details["api_call_start_time"] = datetime.datetime.now()
@@ -1036,14 +1036,14 @@ class Logging(LiteLLMLoggingBaseClass):
                             callback_func=callback,
                         )
                 except Exception as e:
-                    verbose_logger.exception(f"litellm.Logging.pre_call(): Exception occured - {e!s}")
+                    verbose_logger.exception(f"litellm.Logging.pre_call(): Exception occured - {e}")
                     verbose_logger.debug(
                         f"LiteLLM.Logging: is sentry capture exception initialized {capture_exception}"
                     )
                     if capture_exception:  # log this error to sentry for debugging
                         capture_exception(e)
         except Exception as e:
-            verbose_logger.exception(f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while logging {e!s}")
+            verbose_logger.exception(f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while logging {e}")
             verbose_logger.error(f"LiteLLM.Logging: is sentry capture exception initialized {capture_exception}")
             if capture_exception:  # log this error to sentry for debugging
                 capture_exception(e)
@@ -1159,7 +1159,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     )  # Expectation: any logger function passed in by the user should accept a dict object
                 except Exception as e:
                     verbose_logger.exception(
-                        f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while logging {e!s}"
+                        f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while logging {e}"
                     )
             original_response = redact_message_input_output_from_logging(
                 model_call_details=(self.model_call_details if hasattr(self, "model_call_details") else {}),
@@ -1196,7 +1196,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         )
                 except Exception as e:
                     verbose_logger.exception(
-                        f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while post-call logging with integrations {e!s}"
+                        f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while post-call logging with integrations {e}"
                     )
                     verbose_logger.debug(
                         f"LiteLLM.Logging: is sentry capture exception initialized {capture_exception}"
@@ -1204,7 +1204,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     if capture_exception:  # log this error to sentry for debugging
                         capture_exception(e)
         except Exception as e:
-            verbose_logger.exception(f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while logging {e!s}")
+            verbose_logger.exception(f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while logging {e}")
 
     async def async_post_mcp_tool_call_hook(
         self,
@@ -1244,7 +1244,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     if response is not None:
                         response_obj = self._parse_post_mcp_call_hook_response(response=response)
             except Exception as e:
-                verbose_logger.exception(f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while logging {e!s}")
+                verbose_logger.exception(f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while logging {e}")
         return response_obj
 
     def _parse_post_mcp_call_hook_response(self, response: MCPPostCallResponseObject | None) -> Any:
@@ -1889,7 +1889,7 @@ class Logging(LiteLLMLoggingBaseClass):
 
             return start_time, end_time, result
         except Exception as e:
-            raise Exception(f"[Non-Blocking] LiteLLM.Success_Call Error: {e!s}")
+            raise Exception(f"[Non-Blocking] LiteLLM.Success_Call Error: {e}")
 
     def _is_recognized_call_type_for_logging(
         self,
@@ -2378,7 +2378,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         pass
         except Exception as e:
             verbose_logger.exception(
-                f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while success logging {e!s}",
+                f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while success logging {e}",
             )
 
     async def async_success_handler(self, result=None, start_time=None, end_time=None, cache_hit=None, **kwargs):
@@ -2694,7 +2694,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     break  # Only increment once
 
         except Exception as e:
-            verbose_logger.debug(f"Error in _handle_callback_failure: {e!s}")
+            verbose_logger.debug(f"Error in _handle_callback_failure: {e}")
 
     def _failure_handler_helper_fn(self, exception, traceback_exception, start_time=None, end_time=None):
         if start_time is None:
@@ -2931,14 +2931,14 @@ class Logging(LiteLLMLoggingBaseClass):
 
                 except Exception as e:
                     print_verbose(
-                        f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while failure logging with integrations {e!s}"
+                        f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while failure logging with integrations {e}"
                     )
                     print_verbose(f"LiteLLM.Logging: is sentry capture exception initialized {capture_exception}")
                     if capture_exception:  # log this error to sentry for debugging
                         capture_exception(e)
         except Exception as e:
             verbose_logger.exception(
-                f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while failure logging {e!s}"
+                f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while failure logging {e}"
             )
 
     async def async_failure_handler(self, exception, traceback_exception, start_time=None, end_time=None):
@@ -2995,7 +2995,7 @@ class Logging(LiteLLMLoggingBaseClass):
             except Exception as e:
                 verbose_logger.exception(
                     f"LiteLLM.LoggingError: [Non-Blocking] Exception occurred while failure \
-                        logging {e!s}\nCallback={callback}"
+                        logging {e}\nCallback={callback}"
                 )
                 # Track callback logging failures in Prometheus
                 self._handle_callback_failure(callback=callback)
@@ -5426,7 +5426,7 @@ def get_standard_logging_object_payload(
 
         return payload
     except Exception as e:
-        verbose_logger.exception(f"Error creating standard logging object - {e!s}")
+        verbose_logger.exception(f"Error creating standard logging object - {e}")
         return None
 
 

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -150,7 +150,7 @@ def _generic_cost_per_character(
         prompt_cost = prompt_characters * custom_prompt_cost
     except Exception as e:
         verbose_logger.exception(
-            f"litellm.litellm_core_utils.llm_cost_calc.utils.py::cost_per_character(): Exception occured - {e!s}\nDefaulting to None"
+            f"litellm.litellm_core_utils.llm_cost_calc.utils.py::cost_per_character(): Exception occured - {e}\nDefaulting to None"
         )
 
         prompt_cost = None
@@ -165,7 +165,7 @@ def _generic_cost_per_character(
         completion_cost = completion_characters * custom_completion_cost
     except Exception as e:
         verbose_logger.exception(
-            f"litellm.litellm_core_utils.llm_cost_calc.utils.py::cost_per_character(): Exception occured - {e!s}\nDefaulting to None"
+            f"litellm.litellm_core_utils.llm_cost_calc.utils.py::cost_per_character(): Exception occured - {e}\nDefaulting to None"
         )
 
         completion_cost = None

--- a/litellm/litellm_core_utils/llm_response_utils/get_api_base.py
+++ b/litellm/litellm_core_utils/llm_response_utils/get_api_base.py
@@ -53,7 +53,7 @@ def get_api_base(model: str, optional_params: dict | LiteLLM_Params) -> str | No
             api_key=_optional_params.api_key,
         )
     except Exception as e:
-        verbose_logger.debug(f"Error occurred in getting api base - {e!s}")
+        verbose_logger.debug(f"Error occurred in getting api base - {e}")
         custom_llm_provider = None
         dynamic_api_base = None
 

--- a/litellm/litellm_core_utils/logging_utils.py
+++ b/litellm/litellm_core_utils/logging_utils.py
@@ -178,7 +178,7 @@ def _get_parent_otel_span_from_logging_obj(
         return _get_parent_otel_span_from_kwargs(logging_obj.model_call_details)
 
     except Exception as e:
-        verbose_logger.exception(f"Error in _get_parent_otel_span_from_logging_obj: {e!s}")
+        verbose_logger.exception(f"Error in _get_parent_otel_span_from_logging_obj: {e}")
         return None
 
 
@@ -265,7 +265,7 @@ def _set_duration_in_model_call_details(
         else:
             verbose_logger.debug("`logging_obj` not found - unable to track `llm_api_duration_ms")
     except Exception as e:
-        verbose_logger.warning(f"Error setting `llm_api_duration_ms`: {e!s}")
+        verbose_logger.warning(f"Error setting `llm_api_duration_ms`: {e}")
 
 
 def track_llm_api_timing():
@@ -321,7 +321,7 @@ def track_llm_api_timing():
                         )
                     )
                 except Exception as e:
-                    verbose_logger.debug(f"Error in service logging: {e!s}")
+                    verbose_logger.debug(f"Error in service logging: {e}")
 
         @functools.wraps(func)
         def sync_wrapper(*args, **kwargs):
@@ -366,7 +366,7 @@ def track_llm_api_timing():
                         parent_otel_span=parent_otel_span,
                     )
                 except Exception as e:
-                    verbose_logger.debug(f"Error in service logging: {e!s}")
+                    verbose_logger.debug(f"Error in service logging: {e}")
 
         # Check if the function is async or sync
         if inspect.iscoroutinefunction(func):

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -1683,7 +1683,7 @@ def parse_tool_call_arguments(
         if context:
             error_parts.append(f"({context})")
 
-        error_message = " ".join(error_parts) + f". Error: {original_error!s}. Arguments: {arguments}"
+        error_message = " ".join(error_parts) + f". Error: {original_error}. Arguments: {arguments}"
 
         raise ValueError(error_message) from original_error
 

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -438,9 +438,7 @@ def _render_chat_template(env, chat_template: str, bos_token: str, eos_token: st
 
         return rendered_text
     except Exception as e:
-        raise Exception(
-            f"Error rendering template - {e!s}"
-        )  # don't use verbose_logger.exception, if exception is raised
+        raise Exception(f"Error rendering template - {e}")  # don't use verbose_logger.exception, if exception is raised
 
 
 async def _afetch_and_extract_template(
@@ -858,7 +856,7 @@ def convert_to_anthropic_image_obj(openai_image_url: str, format: str | None) ->
         raise
     except Exception as e:
         raise Exception(
-            f"""Image url not in expected format. Example Expected input - "image_url": "data:image/jpeg;base64,{{base64_image}}". Supported formats - ['image/jpeg', 'image/png', 'image/gif', 'image/webp']. Error: {e!s}"""
+            f"""Image url not in expected format. Example Expected input - "image_url": "data:image/jpeg;base64,{{base64_image}}". Supported formats - ['image/jpeg', 'image/png', 'image/gif', 'image/webp']. Error: {e}"""
         )
 
 
@@ -1361,7 +1359,7 @@ def convert_to_gemini_tool_call_invoke(
                 )
         return _parts_list
     except Exception as e:
-        raise Exception(f"Unable to convert openai tool calls={message} to gemini tool calls. Received error={e!s}")
+        raise Exception(f"Unable to convert openai tool calls={message} to gemini tool calls. Received error={e}")
 
 
 def convert_to_gemini_tool_call_result(
@@ -3713,7 +3711,7 @@ def _convert_to_bedrock_tool_call_invoke(
                         _parts_list.append(cache_point_block)
         return _parts_list
     except Exception as e:
-        raise Exception(f"Unable to convert openai tool calls={tool_calls} to bedrock tool calls. Received error={e!s}")
+        raise Exception(f"Unable to convert openai tool calls={tool_calls} to bedrock tool calls. Received error={e}")
 
 
 def _append_bedrock_tool_result_media_block(

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -618,7 +618,7 @@ class CustomStreamWrapper:
             else:
                 return ""
         except Exception as e:
-            verbose_logger.exception(f"litellm.CustomStreamWrapper.handle_baseten_chunk(): Exception occured - {e!s}")
+            verbose_logger.exception(f"litellm.CustomStreamWrapper.handle_baseten_chunk(): Exception occured - {e}")
             return ""
 
     def handle_triton_stream(self, chunk):
@@ -1179,7 +1179,7 @@ class CustomStreamWrapper:
                                 content=None,
                                 tool_calls=[
                                     {
-                                        "id": f"call_{uuid.uuid4()!s}",
+                                        "id": f"call_{uuid.uuid4()}",
                                         "function": {
                                             "arguments": args_str,
                                             "name": function_call.name,
@@ -1204,7 +1204,7 @@ class CustomStreamWrapper:
                         )
                 except Exception:
                     if chunk.candidates[0].finish_reason.name == "SAFETY":  # type: ignore
-                        raise Exception(f"The response was blocked by VertexAI. {chunk!s}")
+                        raise Exception(f"The response was blocked by VertexAI. {chunk}")
             else:
                 completion_obj["content"] = str(chunk)
         elif self.custom_llm_provider == "petals":
@@ -1430,7 +1430,7 @@ class CustomStreamWrapper:
                             model_response.choices[0].delta = Delta(**_json_delta)
                         except Exception as e:
                             verbose_logger.exception(
-                                f"litellm.CustomStreamWrapper.chunk_creator(): Exception occured - {e!s}"
+                                f"litellm.CustomStreamWrapper.chunk_creator(): Exception occured - {e}"
                             )
                             model_response.choices[0].delta = Delta()
                     elif self._has_any_special_delta_attributes(delta):
@@ -1538,7 +1538,7 @@ class CustomStreamWrapper:
         except Exception as e:
             from litellm._logging import verbose_logger
 
-            verbose_logger.exception(f"Error in post-call streaming deployment hook: {e!s}")
+            verbose_logger.exception(f"Error in post-call streaming deployment hook: {e}")
             return chunk
 
     def _add_mcp_list_tools_to_first_chunk(self, chunk: ModelResponseStream) -> ModelResponseStream:
@@ -1578,7 +1578,7 @@ class CustomStreamWrapper:
         except Exception as e:
             from litellm._logging import verbose_logger
 
-            verbose_logger.exception(f"Error adding MCP list tools to first chunk: {e!s}")
+            verbose_logger.exception(f"Error adding MCP list tools to first chunk: {e}")
 
         return chunk
 
@@ -1615,7 +1615,7 @@ class CustomStreamWrapper:
         except Exception as e:
             from litellm._logging import verbose_logger
 
-            verbose_logger.exception(f"Error adding MCP metadata to final chunk: {e!s}")
+            verbose_logger.exception(f"Error adding MCP metadata to final chunk: {e}")
 
         return chunk
 

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -104,7 +104,7 @@ def get_modified_max_tokens(
         return user_max_tokens
     except Exception as e:
         verbose_logger.debug(
-            f"litellm.litellm_core_utils.token_counter.py::get_modified_max_tokens() - Error while checking max token limit: {e!s}\nmodel={model}, base_model={base_model}"
+            f"litellm.litellm_core_utils.token_counter.py::get_modified_max_tokens() - Error while checking max token limit: {e}\nmodel={model}, base_model={base_model}"
         )
         return user_max_tokens
 

--- a/litellm/llms/a2a/chat/transformation.py
+++ b/litellm/llms/a2a/chat/transformation.py
@@ -279,7 +279,7 @@ class A2AConfig(BaseConfig):
         except Exception as e:
             raise A2AError(
                 status_code=raw_response.status_code,
-                message=f"Failed to parse A2A response: {e!s}",
+                message=f"Failed to parse A2A response: {e}",
                 headers=dict(raw_response.headers),
             )
 

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1875,7 +1875,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         except Exception as e:
             raise AnthropicError(
                 status_code=400,
-                message=f"{e!s}\nReceived Messages={messages}",
+                message=f"{e}\nReceived Messages={messages}",
             )  # don't use verbose_logger.exception, if exception is raised
 
         ## Auto-strip advisor blocks from history if advisor tool is absent.
@@ -2454,7 +2454,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         except Exception as e:
             response_headers = getattr(raw_response, "headers", None)
             raise AnthropicError(
-                message=f"Unable to get json response - {e!s}, Original Response: {raw_response.text}",
+                message=f"Unable to get json response - {e}, Original Response: {raw_response.text}",
                 status_code=raw_response.status_code,
                 headers=response_headers,
             )

--- a/litellm/llms/anthropic/count_tokens/handler.py
+++ b/litellm/llms/anthropic/count_tokens/handler.py
@@ -109,14 +109,14 @@ class AnthropicCountTokensHandler(AnthropicCountTokensConfig):
             raise
         except httpx.HTTPStatusError as e:
             # HTTP errors - preserve the actual status code
-            verbose_logger.error(f"HTTP error in CountTokens handler: {e!s}")
+            verbose_logger.error(f"HTTP error in CountTokens handler: {e}")
             raise AnthropicError(
                 status_code=e.response.status_code,
                 message=e.response.text,
             )
         except Exception as e:
-            verbose_logger.error(f"Error in CountTokens handler: {e!s}")
+            verbose_logger.error(f"Error in CountTokens handler: {e}")
             raise AnthropicError(
                 status_code=500,
-                message=f"CountTokens processing error: {e!s}",
+                message=f"CountTokens processing error: {e}",
             )

--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -684,7 +684,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             except json.JSONDecodeError as json_error:
                 raise AzureOpenAIError(
                     status_code=raw_response.status_code or 500,
-                    message=f"Failed to parse raw Azure embedding response: {json_error!s}",
+                    message=f"Failed to parse raw Azure embedding response: {json_error}",
                 ) from json_error
             if isinstance(response, str):
                 raise AzureOpenAIError(

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -333,7 +333,7 @@ def get_azure_ad_token(
             verbose_logger.debug("Azure AD Token Provider could not be used.")
         except Exception as e:
             verbose_logger.error(
-                f"Error calling Azure AD token provider: {e!s}. Follow docs - https://docs.litellm.ai/docs/providers/azure/#azure-ad-token-refresh---defaultazurecredential"
+                f"Error calling Azure AD token provider: {e}. Follow docs - https://docs.litellm.ai/docs/providers/azure/#azure-ad-token-refresh---defaultazurecredential"
             )
             raise e
 
@@ -359,8 +359,8 @@ def get_azure_ad_token(
             # Re-raise TypeError directly
             raise
         except Exception as e:
-            verbose_logger.error(f"Error calling Azure AD token provider: {e!s}")
-            raise RuntimeError(f"Failed to get Azure AD token: {e!s}") from e
+            verbose_logger.error(f"Error calling Azure AD token provider: {e}")
+            raise RuntimeError(f"Failed to get Azure AD token: {e}") from e
 
     return azure_ad_token
 
@@ -393,7 +393,7 @@ class BaseAzureLLM(BaseOpenAILLM):
             verbose_logger.debug("Successfully obtained Azure AD token provider using DefaultAzureCredential")
             return azure_ad_token_provider
         except Exception as e:
-            verbose_logger.debug(f"DefaultAzureCredential failed: {e!s}")
+            verbose_logger.debug(f"DefaultAzureCredential failed: {e}")
             return None
 
     def get_azure_openai_client(
@@ -580,7 +580,7 @@ class BaseAzureLLM(BaseOpenAILLM):
             # only show first 5 chars of api_key
             _api_key = _api_key[:8] + "*" * 15
         verbose_logger.debug(
-            f"Initializing Azure OpenAI Client for {model_name}, Api Base: {api_base!s}, Api Key:{_api_key}"
+            f"Initializing Azure OpenAI Client for {model_name}, Api Base: {api_base}, Api Key:{_api_key}"
         )
         azure_client_params = {
             "api_key": api_key,

--- a/litellm/llms/azure_ai/agents/handler.py
+++ b/litellm/llms/azure_ai/agents/handler.py
@@ -193,7 +193,7 @@ class AzureAIAgentsHandler:
                 ),
             )
         except Exception as e:
-            verbose_logger.warning(f"Failed to calculate token usage: {e!s}")
+            verbose_logger.warning(f"Failed to calculate token usage: {e}")
 
         return model_response
 

--- a/litellm/llms/azure_ai/anthropic/count_tokens/handler.py
+++ b/litellm/llms/azure_ai/anthropic/count_tokens/handler.py
@@ -114,14 +114,14 @@ class AzureAIAnthropicCountTokensHandler(AzureAIAnthropicCountTokensConfig):
             raise
         except httpx.HTTPStatusError as e:
             # HTTP errors - preserve the actual status code
-            verbose_logger.error(f"HTTP error in CountTokens handler: {e!s}")
+            verbose_logger.error(f"HTTP error in CountTokens handler: {e}")
             raise AnthropicError(
                 status_code=e.response.status_code,
                 message=e.response.text,
             )
         except Exception as e:
-            verbose_logger.error(f"Error in CountTokens handler: {e!s}")
+            verbose_logger.error(f"Error in CountTokens handler: {e}")
             raise AnthropicError(
                 status_code=500,
-                message=f"CountTokens processing error: {e!s}",
+                message=f"CountTokens processing error: {e}",
             )

--- a/litellm/llms/azure_ai/vector_stores/transformation.py
+++ b/litellm/llms/azure_ai/vector_stores/transformation.py
@@ -132,7 +132,7 @@ class AzureAIVectorStoreConfig(BaseVectorStoreConfig, BaseAzureLLM):
             )
             query_vector = embedding_response.data[0]["embedding"]
         except Exception as e:
-            raise Exception(f"Failed to generate embedding for query: {e!s}")
+            raise Exception(f"Failed to generate embedding for query: {e}")
 
         # Azure AI Search endpoint for search
         index_name = vector_store_id  # vector_store_id is the index name

--- a/litellm/llms/base_llm/files/azure_blob_storage_backend.py
+++ b/litellm/llms/base_llm/files/azure_blob_storage_backend.py
@@ -133,7 +133,7 @@ class AzureBlobStorageBackend(BaseFileStorageBackend, AzureBlobStorageLogger):
             return storage_url
 
         except Exception as e:
-            verbose_logger.exception(f"Error uploading file to Azure Blob Storage: {e!s}")
+            verbose_logger.exception(f"Error uploading file to Azure Blob Storage: {e}")
             raise
 
     async def _upload_file_with_account_key(self, file_content: bytes, full_path: str) -> str:
@@ -247,7 +247,7 @@ class AzureBlobStorageBackend(BaseFileStorageBackend, AzureBlobStorageLogger):
                 return await self._download_file_with_azure_ad(file_path)
 
         except Exception as e:
-            verbose_logger.exception(f"Error downloading file from Azure Blob Storage: {e!s}")
+            verbose_logger.exception(f"Error downloading file from Azure Blob Storage: {e}")
             raise
 
     async def _download_file_with_account_key(self, file_path: str) -> bytes:

--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -186,7 +186,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
             return session_id
 
         # Generate a session ID with 33+ characters
-        generated_id = f"litellm-session-{uuid.uuid4()!s}"
+        generated_id = f"litellm-session-{uuid.uuid4()}"
         verbose_logger.debug(f"Generated new session ID: {generated_id}")
         return generated_id
 
@@ -370,7 +370,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                 total_tokens=total_tokens,
             )
         except Exception as e:
-            verbose_logger.warning(f"Failed to calculate token usage: {e!s}")
+            verbose_logger.warning(f"Failed to calculate token usage: {e}")
             return None
 
     def _parse_json_response(self, response_json: dict) -> AgentCoreParsedResponse:
@@ -1023,9 +1023,9 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
             return model_response
 
         except Exception as e:
-            verbose_logger.error(f"Error processing Bedrock AgentCore response: {e!s}")
+            verbose_logger.error(f"Error processing Bedrock AgentCore response: {e}")
             raise BedrockError(
-                message=f"Error processing response: {e!s}",
+                message=f"Error processing response: {e}",
                 status_code=raw_response.status_code,
             )
 

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -2073,7 +2073,7 @@ class AmazonConverseConfig(BaseConfig):
             completion_response = ConverseResponseBlock(**response.json())  # type: ignore
         except Exception as e:
             raise BedrockError(
-                message=f"Error converting to valid response block={e!s}. File an issue if litellm error - https://github.com/BerriAI/litellm/issues",
+                message=f"Error converting to valid response block={e}. File an issue if litellm error - https://github.com/BerriAI/litellm/issues",
                 status_code=422,
             )
 

--- a/litellm/llms/bedrock/chat/invoke_agent/transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_agent/transformation.py
@@ -464,9 +464,9 @@ class AmazonInvokeAgentConfig(BaseConfig, BaseAWSLLM):
             )
 
         except Exception as e:
-            verbose_logger.error(f"Error processing Bedrock Invoke Agent response: {e!s}")
+            verbose_logger.error(f"Error processing Bedrock Invoke Agent response: {e}")
             raise BedrockError(
-                message=f"Error processing response: {e!s}",
+                message=f"Error processing response: {e}",
                 status_code=raw_response.status_code,
             )
 

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -590,7 +590,7 @@ class AWSEventStreamDecoder:
 
             return response
         except Exception as e:
-            raise Exception(f"Received streaming error - {e!s}")
+            raise Exception(f"Received streaming error - {e}")
 
     def _chunk_parser(self, chunk_data: dict) -> Union[GChunk, ModelResponseStream, dict]:
         text = ""

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_twelvelabs_pegasus_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_twelvelabs_pegasus_transformation.py
@@ -208,7 +208,7 @@ class AmazonTwelveLabsPegasusConfig(AmazonInvokeConfig, BaseConfig):
             completion_response = raw_response.json()
         except Exception as e:
             raise BedrockError(
-                message=f"Error parsing response: {raw_response.text}, error: {e!s}",
+                message=f"Error parsing response: {raw_response.text}, error: {e}",
                 status_code=raw_response.status_code,
             )
 
@@ -237,7 +237,7 @@ class AmazonTwelveLabsPegasusConfig(AmazonInvokeConfig, BaseConfig):
                 raise Exception("Unable to set message content")
         except Exception as e:
             raise BedrockError(
-                message=f"Error setting response content: {e!s}. Response: {completion_response}",
+                message=f"Error setting response content: {e}. Response: {completion_response}",
                 status_code=raw_response.status_code,
             )
 

--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -356,7 +356,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
                 outputText = completion_response.get("results")[0].get("outputText")
         except Exception as e:
             raise BedrockError(
-                message=f"Error processing={raw_response.text}, Received error={e!s}",
+                message=f"Error processing={raw_response.text}, Received error={e}",
                 status_code=422,
             )
 
@@ -379,7 +379,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
                 raise Exception()
         except Exception as e:
             raise BedrockError(
-                message=f"Error parsing received text={outputText}.\nError-{e!s}",
+                message=f"Error parsing received text={outputText}.\nError-{e}",
                 status_code=raw_response.status_code,
             )
 

--- a/litellm/llms/bedrock/count_tokens/handler.py
+++ b/litellm/llms/bedrock/count_tokens/handler.py
@@ -120,14 +120,14 @@ class BedrockCountTokensHandler(BedrockCountTokensConfig):
             raise
         except httpx.HTTPStatusError as e:
             # HTTP errors - preserve the actual status code
-            verbose_logger.error(f"HTTP error in CountTokens handler: {e!s}")
+            verbose_logger.error(f"HTTP error in CountTokens handler: {e}")
             raise BedrockError(
                 status_code=e.response.status_code,
                 message=e.response.text,
             )
         except Exception as e:
-            verbose_logger.error(f"Error in CountTokens handler: {e!s}")
+            verbose_logger.error(f"Error in CountTokens handler: {e}")
             raise BedrockError(
                 status_code=500,
-                message=f"CountTokens processing error: {e!s}",
+                message=f"CountTokens processing error: {e}",
             )

--- a/litellm/llms/bedrock/files/handler.py
+++ b/litellm/llms/bedrock/files/handler.py
@@ -130,7 +130,7 @@ class BedrockFilesHandler(BaseAWSLLM):
             response = s3_client.get_object(Bucket=bucket_name, Key=object_key)
             file_content = response["Body"].read()
         except Exception as e:
-            raise ValueError(f"Failed to download file from S3: {s3_uri}. Error: {e!s}")
+            raise ValueError(f"Failed to download file from S3: {s3_uri}. Error: {e}")
 
         # Create mock HTTP response
         mock_response = httpx.Response(

--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -652,7 +652,7 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
                 )
             except Exception as e:
                 verbose_logger.exception(
-                    f"litellm.llms.bedrock.files.transformation.py::_transform_openai_jsonl_content_to_bedrock_jsonl_content() - Error inferring custom_llm_provider - {e!s}"
+                    f"litellm.llms.bedrock.files.transformation.py::_transform_openai_jsonl_content_to_bedrock_jsonl_content() - Error inferring custom_llm_provider - {e}"
                 )
 
             # Determine provider from model name

--- a/litellm/llms/bedrock/realtime/handler.py
+++ b/litellm/llms/bedrock/realtime/handler.py
@@ -175,7 +175,7 @@ class BedrockRealtime(BaseAWSLLM):
         except Exception as e:
             verbose_proxy_logger.exception(f"Error in BedrockRealtime.async_realtime: {e}")
             try:
-                await websocket.close(code=1011, reason=_redact_string(f"Internal error: {e!s}"))
+                await websocket.close(code=1011, reason=_redact_string(f"Internal error: {e}"))
             except Exception:
                 pass
             raise

--- a/litellm/llms/black_forest_labs/image_edit/handler.py
+++ b/litellm/llms/black_forest_labs/image_edit/handler.py
@@ -159,7 +159,7 @@ class BlackForestLabsImageEdit:
         except Exception as e:
             raise BlackForestLabsError(
                 status_code=500,
-                message=f"Request failed: {e!s}",
+                message=f"Request failed: {e}",
             )
 
         # Poll for result
@@ -262,7 +262,7 @@ class BlackForestLabsImageEdit:
         except Exception as e:
             raise BlackForestLabsError(
                 status_code=500,
-                message=f"Request failed: {e!s}",
+                message=f"Request failed: {e}",
             )
 
         # Poll for result

--- a/litellm/llms/black_forest_labs/image_generation/handler.py
+++ b/litellm/llms/black_forest_labs/image_generation/handler.py
@@ -156,7 +156,7 @@ class BlackForestLabsImageGeneration:
         except Exception as e:
             raise BlackForestLabsError(
                 status_code=500,
-                message=f"Request failed: {e!s}",
+                message=f"Request failed: {e}",
             )
 
         # Poll for result
@@ -262,7 +262,7 @@ class BlackForestLabsImageGeneration:
         except Exception as e:
             raise BlackForestLabsError(
                 status_code=500,
-                message=f"Request failed: {e!s}",
+                message=f"Request failed: {e}",
             )
 
         # Poll for result

--- a/litellm/llms/clarifai/chat/transformation.py
+++ b/litellm/llms/clarifai/chat/transformation.py
@@ -106,7 +106,7 @@ class ClarifaiConfig(OpenAIGPTConfig):
         except Exception as e:
             raise OpenAIError(
                 status_code=raw_response.status_code,
-                message=f"Failed to parse Clarifai response: {e!s}",
+                message=f"Failed to parse Clarifai response: {e}",
                 headers=raw_response.headers,
             ) from e
 

--- a/litellm/llms/codestral/completion/handler.py
+++ b/litellm/llms/codestral/completion/handler.py
@@ -356,7 +356,7 @@ class CodestralTextCompletion:
             )
         except Exception as e:
             raise TextCompletionCodestralError(
-                status_code=500, message=f"{e!s}"
+                status_code=500, message=f"{e}"
             )  # don't use verbose_logger.exception, if exception is raised
         return self.process_text_completion_response(
             model=model,

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -5659,7 +5659,7 @@ class BaseLLMHTTPHandler:
                     fingerprint=fingerprint,
                 )
             except Exception as e:
-                verbose_logger.exception(f"LiteLLM.AgenticHookError: Exception in chat completion agentic hooks: {e!s}")
+                verbose_logger.exception(f"LiteLLM.AgenticHookError: Exception in chat completion agentic hooks: {e}")
 
         # Check if we need to convert response to fake stream for chat completions
         # This happens when:
@@ -5906,7 +5906,7 @@ class BaseLLMHTTPHandler:
         except Exception as e:
             verbose_logger.exception(f"Error connecting to backend: {e}")
             try:
-                await websocket.close(code=1011, reason=_redact_string(f"Internal server error: {e!s}"))
+                await websocket.close(code=1011, reason=_redact_string(f"Internal server error: {e}"))
             except RuntimeError as close_error:
                 if "already completed" in str(close_error) or "websocket.close" in str(close_error):
                     # The WebSocket is already closed or the response is completed, so we can ignore this error
@@ -6303,7 +6303,7 @@ class BaseLLMHTTPHandler:
         except Exception as e:
             verbose_logger.exception(f"Error in responses WS: {e}")
             try:
-                await websocket.close(code=1011, reason=_redact_string(f"Internal server error: {e!s}"))
+                await websocket.close(code=1011, reason=_redact_string(f"Internal server error: {e}"))
             except RuntimeError as close_error:
                 if "already completed" in str(close_error) or "websocket.close" in str(close_error):
                     pass

--- a/litellm/llms/dashscope/embed/transformation.py
+++ b/litellm/llms/dashscope/embed/transformation.py
@@ -130,7 +130,7 @@ class DashScopeEmbeddingConfig(BaseEmbeddingConfig):
         except Exception as e:
             raise DashScopeError(
                 status_code=raw_response.status_code,
-                message=f"Failed to parse DashScope response as JSON: {e!s}",
+                message=f"Failed to parse DashScope response as JSON: {e}",
             )
 
         logging_obj.post_call(

--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -630,7 +630,7 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
         except Exception as e:
             response_headers = getattr(raw_response, "headers", None)
             raise DatabricksException(
-                message=f"Unable to get json response - {e!s}, Original Response: {raw_response.text}",
+                message=f"Unable to get json response - {e}, Original Response: {raw_response.text}",
                 status_code=raw_response.status_code,
                 headers=response_headers,
             )

--- a/litellm/llms/databricks/common_utils.py
+++ b/litellm/llms/databricks/common_utils.py
@@ -245,7 +245,7 @@ class DatabricksBase:
         except requests.RequestException as e:
             raise DatabricksException(
                 status_code=500,
-                message=f"OAuth M2M token request failed: {e!s}",
+                message=f"OAuth M2M token request failed: {e}",
             )
 
         if response.status_code != 200:

--- a/litellm/llms/deepgram/audio_transcription/transformation.py
+++ b/litellm/llms/deepgram/audio_transcription/transformation.py
@@ -122,7 +122,7 @@ class DeepgramAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
             return response
 
         except Exception as e:
-            raise ValueError(f"Error transforming Deepgram response: {e!s}\nResponse: {raw_response.text}")
+            raise ValueError(f"Error transforming Deepgram response: {e}\nResponse: {raw_response.text}")
 
     def _reconstruct_diarized_transcript(self, words: list) -> str:
         """

--- a/litellm/llms/elevenlabs/audio_transcription/transformation.py
+++ b/litellm/llms/elevenlabs/audio_transcription/transformation.py
@@ -144,7 +144,7 @@ class ElevenLabsAudioTranscriptionConfig(BaseAudioTranscriptionConfig):
             return response
 
         except Exception as e:
-            raise ValueError(f"Error transforming ElevenLabs response: {e!s}\nResponse: {raw_response.text}")
+            raise ValueError(f"Error transforming ElevenLabs response: {e}\nResponse: {raw_response.text}")
 
     def get_complete_url(
         self,

--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -542,7 +542,7 @@ class FireworksAIConfig(FireworksAIMixin, OpenAIGPTConfig):
         except Exception as e:
             response_headers = getattr(raw_response, "headers", None)
             raise FireworksAIException(
-                message=f"Unable to get json response - {e!s}, Original Response: {raw_response.text}",
+                message=f"Unable to get json response - {e}, Original Response: {raw_response.text}",
                 status_code=raw_response.status_code,
                 headers=response_headers,
             )

--- a/litellm/llms/fireworks_ai/rerank/transformation.py
+++ b/litellm/llms/fireworks_ai/rerank/transformation.py
@@ -178,7 +178,7 @@ class FireworksAIRerankConfig(FireworksAIMixin, BaseRerankConfig):
             raw_response_json = raw_response.json()
         except Exception as e:
             raise self.get_error_class(
-                error_message=f"Failed to parse response: {e!s}",
+                error_message=f"Failed to parse response: {e}",
                 status_code=raw_response.status_code,
                 headers=raw_response.headers,
             )

--- a/litellm/llms/gdc/chat/transformation.py
+++ b/litellm/llms/gdc/chat/transformation.py
@@ -220,7 +220,7 @@ class GDCGeminiConfig(OpenAILikeChatConfig):
             AttributeError,
         ) as e:
             raise litellm.utils.AuthenticationError(
-                message=f"Failed to load service account credentials from api_key: {e!s}",
+                message=f"Failed to load service account credentials from api_key: {e}",
                 llm_provider="gdc",
                 model=model,
             ) from e

--- a/litellm/llms/gemini/count_tokens/handler.py
+++ b/litellm/llms/gemini/count_tokens/handler.py
@@ -155,8 +155,8 @@ class GoogleAIStudioTokenCounter:
                 status_code=e.response.status_code,
             ) from e
         except httpx.RequestError as e:
-            error_msg = f"Request to Google Gen AI Studio failed: {e!s}"
+            error_msg = f"Request to Google Gen AI Studio failed: {e}"
             raise litellm.APIConnectionError(message=error_msg, llm_provider="gemini", model=model) from e
         except Exception as e:
-            error_msg = f"Unexpected error during token counting: {e!s}"
+            error_msg = f"Unexpected error during token counting: {e}"
             raise Exception(error_msg) from e

--- a/litellm/llms/gemini/files/transformation.py
+++ b/litellm/llms/gemini/files/transformation.py
@@ -190,8 +190,8 @@ class GoogleAIStudioFilesHandler(GeminiModelInfo, BaseFilesConfig):
                 status_details=None,
             )
         except Exception as e:
-            verbose_logger.exception(f"Error parsing file upload response: {e!s}")
-            raise ValueError(f"Error parsing file upload response: {e!s}")
+            verbose_logger.exception(f"Error parsing file upload response: {e}")
+            raise ValueError(f"Error parsing file upload response: {e}")
 
     def transform_retrieve_file_request(
         self,
@@ -294,8 +294,8 @@ class GoogleAIStudioFilesHandler(GeminiModelInfo, BaseFilesConfig):
                 status_details=(str(response_json.get("error", "")) if gemini_state == "FAILED" else None),
             )
         except Exception as e:
-            verbose_logger.exception(f"Error parsing file retrieve response: {e!s}")
-            raise ValueError(f"Error parsing file retrieve response: {e!s}")
+            verbose_logger.exception(f"Error parsing file retrieve response: {e}")
+            raise ValueError(f"Error parsing file retrieve response: {e}")
 
     def transform_delete_file_request(
         self,
@@ -362,8 +362,8 @@ class GoogleAIStudioFilesHandler(GeminiModelInfo, BaseFilesConfig):
             else:
                 raise ValueError(f"Failed to delete file: {raw_response.text}")
         except Exception as e:
-            verbose_logger.exception(f"Error parsing file delete response: {e!s}")
-            raise ValueError(f"Error parsing file delete response: {e!s}")
+            verbose_logger.exception(f"Error parsing file delete response: {e}")
+            raise ValueError(f"Error parsing file delete response: {e}")
 
     def transform_list_files_request(
         self,

--- a/litellm/llms/gemini/vector_stores/transformation.py
+++ b/litellm/llms/gemini/vector_stores/transformation.py
@@ -256,7 +256,7 @@ class GeminiVectorStoreConfig(BaseVectorStoreConfig):
 
         except Exception as e:
             raise self.get_error_class(
-                error_message=f"Failed to parse Gemini response: {e!s}",
+                error_message=f"Failed to parse Gemini response: {e}",
                 status_code=response.status_code,
                 headers=response.headers,
             )
@@ -327,7 +327,7 @@ class GeminiVectorStoreConfig(BaseVectorStoreConfig):
 
         except Exception as e:
             raise self.get_error_class(
-                error_message=f"Failed to parse Gemini create response: {e!s}",
+                error_message=f"Failed to parse Gemini create response: {e}",
                 status_code=response.status_code,
                 headers=response.headers,
             )

--- a/litellm/llms/gigachat/authenticator.py
+++ b/litellm/llms/gigachat/authenticator.py
@@ -177,7 +177,7 @@ def _request_token_sync(
     except httpx.RequestError as e:
         raise GigaChatAuthError(
             status_code=500,
-            message=f"GigaChat authentication request failed: {e!s}",
+            message=f"GigaChat authentication request failed: {e}",
         )
 
 
@@ -212,7 +212,7 @@ async def _request_token_async(
     except httpx.RequestError as e:
         raise GigaChatAuthError(
             status_code=500,
-            message=f"GigaChat authentication request failed: {e!s}",
+            message=f"GigaChat authentication request failed: {e}",
         )
 
 

--- a/litellm/llms/github_copilot/authenticator.py
+++ b/litellm/llms/github_copilot/authenticator.py
@@ -68,7 +68,7 @@ class Authenticator:
                     verbose_logger.error("Error saving access token to file")
                 return access_token
             except (GetDeviceCodeError, GetAccessTokenError, RefreshAPIKeyError) as e:
-                verbose_logger.warning(f"Failed attempt {attempt + 1}: {e!s}")
+                verbose_logger.warning(f"Failed attempt {attempt + 1}: {e}")
                 continue
 
         raise GetAccessTokenError(
@@ -100,7 +100,7 @@ class Authenticator:
         except OSError:
             verbose_logger.warning("No API key file found or error opening file")
         except (json.JSONDecodeError, KeyError) as e:
-            verbose_logger.warning(f"Error reading API key from file: {e!s}")
+            verbose_logger.warning(f"Error reading API key from file: {e}")
         except APIKeyExpiredError:
             pass  # Already logged in the try block
 
@@ -117,14 +117,14 @@ class Authenticator:
                     status_code=401,
                 )
         except OSError as e:
-            verbose_logger.error(f"Error saving API key to file: {e!s}")
+            verbose_logger.error(f"Error saving API key to file: {e}")
             raise GetAPIKeyError(
-                message=f"Failed to save API key: {e!s}",
+                message=f"Failed to save API key: {e}",
                 status_code=500,
             )
         except RefreshAPIKeyError as e:
             raise GetAPIKeyError(
-                message=f"Failed to refresh API key: {e!s}",
+                message=f"Failed to refresh API key: {e}",
                 status_code=401,
             )
 
@@ -142,7 +142,7 @@ class Authenticator:
                 api_endpoint = endpoints.get("api")
                 return api_endpoint
         except (OSError, json.JSONDecodeError, KeyError) as e:
-            verbose_logger.warning(f"Error reading API endpoint from file: {e!s}")
+            verbose_logger.warning(f"Error reading API endpoint from file: {e}")
             return None
 
     def _refresh_api_key(self) -> dict[str, Any]:
@@ -173,9 +173,9 @@ class Authenticator:
                 else:
                     verbose_logger.warning(f"API key response missing token: {response_json}")
             except httpx.HTTPStatusError as e:
-                verbose_logger.error(f"HTTP error refreshing API key (attempt {attempt + 1}/{max_retries}): {e!s}")
+                verbose_logger.error(f"HTTP error refreshing API key (attempt {attempt + 1}/{max_retries}): {e}")
             except Exception as e:
-                verbose_logger.error(f"Unexpected error refreshing API key: {e!s}")
+                verbose_logger.error(f"Unexpected error refreshing API key: {e}")
 
         raise RefreshAPIKeyError(
             message="Failed to refresh API key after maximum retries",
@@ -245,21 +245,21 @@ class Authenticator:
 
             return resp_json
         except httpx.HTTPStatusError as e:
-            verbose_logger.error(f"HTTP error getting device code: {e!s}")
+            verbose_logger.error(f"HTTP error getting device code: {e}")
             raise GetDeviceCodeError(
-                message=f"Failed to get device code: {e!s}",
+                message=f"Failed to get device code: {e}",
                 status_code=400,
             )
         except json.JSONDecodeError as e:
-            verbose_logger.error(f"Error decoding JSON response: {e!s}")
+            verbose_logger.error(f"Error decoding JSON response: {e}")
             raise GetDeviceCodeError(
-                message=f"Failed to decode device code response: {e!s}",
+                message=f"Failed to decode device code response: {e}",
                 status_code=400,
             )
         except Exception as e:
-            verbose_logger.error(f"Unexpected error getting device code: {e!s}")
+            verbose_logger.error(f"Unexpected error getting device code: {e}")
             raise GetDeviceCodeError(
-                message=f"Failed to get device code: {e!s}",
+                message=f"Failed to get device code: {e}",
                 status_code=400,
             )
 
@@ -304,21 +304,21 @@ class Authenticator:
                 else:
                     verbose_logger.warning(f"Unexpected response: {resp_json}")
             except httpx.HTTPStatusError as e:
-                verbose_logger.error(f"HTTP error polling for access token: {e!s}")
+                verbose_logger.error(f"HTTP error polling for access token: {e}")
                 raise GetAccessTokenError(
-                    message=f"Failed to get access token: {e!s}",
+                    message=f"Failed to get access token: {e}",
                     status_code=400,
                 )
             except json.JSONDecodeError as e:
-                verbose_logger.error(f"Error decoding JSON response: {e!s}")
+                verbose_logger.error(f"Error decoding JSON response: {e}")
                 raise GetAccessTokenError(
-                    message=f"Failed to decode access token response: {e!s}",
+                    message=f"Failed to decode access token response: {e}",
                     status_code=400,
                 )
             except Exception as e:
-                verbose_logger.error(f"Unexpected error polling for access token: {e!s}")
+                verbose_logger.error(f"Unexpected error polling for access token: {e}")
                 raise GetAccessTokenError(
-                    message=f"Failed to get access token: {e!s}",
+                    message=f"Failed to get access token: {e}",
                     status_code=400,
                 )
 

--- a/litellm/llms/huggingface/common_utils.py
+++ b/litellm/llms/huggingface/common_utils.py
@@ -96,7 +96,7 @@ def _fetch_inference_provider_mapping(model: str) -> dict:
             status_code = 500
             headers = {}
         raise HuggingFaceError(
-            message=f"Failed to fetch provider mapping: {e!s}",
+            message=f"Failed to fetch provider mapping: {e}",
             status_code=status_code,
             headers=headers,
         )

--- a/litellm/llms/langgraph/chat/sse_iterator.py
+++ b/litellm/llms/langgraph/chat/sse_iterator.py
@@ -196,7 +196,7 @@ class LangGraphSSEStreamIterator:
         except httpx.StreamClosed:
             raise StopIteration
         except Exception as e:
-            verbose_logger.error(f"Error in LangGraph SSE stream: {e!s}")
+            verbose_logger.error(f"Error in LangGraph SSE stream: {e}")
             raise StopIteration
 
     async def __anext__(self) -> ModelResponseStream:
@@ -224,5 +224,5 @@ class LangGraphSSEStreamIterator:
         except httpx.StreamClosed:
             raise StopAsyncIteration
         except Exception as e:
-            verbose_logger.error(f"Error in LangGraph SSE stream: {e!s}")
+            verbose_logger.error(f"Error in LangGraph SSE stream: {e}")
             raise StopAsyncIteration

--- a/litellm/llms/langgraph/chat/transformation.py
+++ b/litellm/llms/langgraph/chat/transformation.py
@@ -451,14 +451,14 @@ class LangGraphConfig(BaseConfig):
                 )
                 setattr(model_response, "usage", usage)
             except Exception as e:
-                verbose_logger.warning(f"Failed to calculate token usage: {e!s}")
+                verbose_logger.warning(f"Failed to calculate token usage: {e}")
 
             return model_response
 
         except Exception as e:
-            verbose_logger.error(f"Error processing LangGraph response: {e!s}")
+            verbose_logger.error(f"Error processing LangGraph response: {e}")
             raise LangGraphError(
-                message=f"Error processing response: {e!s}",
+                message=f"Error processing response: {e}",
                 status_code=raw_response.status_code,
             )
 

--- a/litellm/llms/litellm_proxy/skills/code_execution.py
+++ b/litellm/llms/litellm_proxy/skills/code_execution.py
@@ -239,7 +239,7 @@ class CodeExecutionHandler:
                             tool_result += f"\n\nError:\n{exec_result['error']}"
 
                     except Exception as e:
-                        tool_result = f"Code execution failed: {e!s}"
+                        tool_result = f"Code execution failed: {e}"
                         execution_results.append(
                             {
                                 "iteration": iteration,

--- a/litellm/llms/manus/files/transformation.py
+++ b/litellm/llms/manus/files/transformation.py
@@ -279,8 +279,8 @@ class ManusFilesConfig(BaseFilesConfig):
                 status_details=response_json.get("status_details"),
             )
         except Exception as e:
-            verbose_logger.exception(f"Error parsing Manus file response: {e!s}")
-            raise ValueError(f"Error parsing Manus file response: {e!s}")
+            verbose_logger.exception(f"Error parsing Manus file response: {e}")
+            raise ValueError(f"Error parsing Manus file response: {e}")
 
     def transform_retrieve_file_request(
         self,

--- a/litellm/llms/milvus/vector_stores/transformation.py
+++ b/litellm/llms/milvus/vector_stores/transformation.py
@@ -158,7 +158,7 @@ class MilvusVectorStoreConfig(BaseVectorStoreConfig):
             )
             query_vector = embedding_response.data[0]["embedding"]
         except Exception as e:
-            raise Exception(f"Failed to generate embedding for query: {e!s}")
+            raise Exception(f"Failed to generate embedding for query: {e}")
 
         # Azure AI Search endpoint for search
         index_name = vector_store_id  # vector_store_id is the index name

--- a/litellm/llms/minimax/text_to_speech/transformation.py
+++ b/litellm/llms/minimax/text_to_speech/transformation.py
@@ -353,7 +353,7 @@ class MinimaxTextToSpeechConfig(BaseTextToSpeechConfig):
                 except Exception as e:
                     raise MinimaxException(
                         status_code=500,
-                        message=f"Failed to decode audio data: {e!s}",
+                        message=f"Failed to decode audio data: {e}",
                         headers=dict(raw_response.headers),
                     )
 
@@ -378,7 +378,7 @@ class MinimaxTextToSpeechConfig(BaseTextToSpeechConfig):
         except json.JSONDecodeError as e:
             raise MinimaxException(
                 status_code=500,
-                message=f"Failed to parse MiniMax response: {e!s}",
+                message=f"Failed to parse MiniMax response: {e}",
                 headers=dict(raw_response.headers),
             )
         except Exception as e:
@@ -386,7 +386,7 @@ class MinimaxTextToSpeechConfig(BaseTextToSpeechConfig):
                 raise
             raise MinimaxException(
                 status_code=500,
-                message=f"Error processing MiniMax response: {e!s}",
+                message=f"Error processing MiniMax response: {e}",
                 headers=dict(raw_response.headers),
             )
 

--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -330,7 +330,7 @@ class MistralConfig(OpenAIGPTConfig):
                         new_content = [{"type": "text", "text": reasoning_prompt + "\n\n"}] + existing_content
                     else:
                         # Fallback for any other type - convert to string
-                        new_content = f"{reasoning_prompt}\n\n{existing_content!s}"
+                        new_content = f"{reasoning_prompt}\n\n{existing_content}"
 
                     messages[i] = cast(AllMessageValues, {**msg, "content": new_content})
                     break

--- a/litellm/llms/oci/chat/cohere.py
+++ b/litellm/llms/oci/chat/cohere.py
@@ -201,7 +201,7 @@ def handle_cohere_response(
         cohere_response = CohereChatResult(**json_response)
     except (TypeError, ValidationError) as e:
         raise OCIError(
-            message=f"Response cannot be casted to CohereChatResult: {e!s}",
+            message=f"Response cannot be casted to CohereChatResult: {e}",
             status_code=raw_response.status_code,
         )
 
@@ -283,7 +283,7 @@ def handle_cohere_stream_chunk(
     except (TypeError, ValidationError) as e:
         raise OCIError(
             status_code=500,
-            message=f"Chunk cannot be parsed as CohereStreamChunk: {e!s}",
+            message=f"Chunk cannot be parsed as CohereStreamChunk: {e}",
         )
 
     if typed_chunk.index is None:

--- a/litellm/llms/oci/chat/generic.py
+++ b/litellm/llms/oci/chat/generic.py
@@ -309,7 +309,7 @@ def handle_generic_response(
         completion_response = OCICompletionResponse(**json_data)
     except (TypeError, ValidationError) as e:
         raise OCIError(
-            message=f"Response cannot be casted to OCICompletionResponse: {e!s}",
+            message=f"Response cannot be casted to OCICompletionResponse: {e}",
             status_code=raw_response.status_code,
         )
 
@@ -373,7 +373,7 @@ def handle_generic_stream_chunk(dict_chunk: dict) -> ModelResponseStream:
     except (TypeError, ValidationError) as e:
         raise OCIError(
             status_code=500,
-            message=f"Chunk cannot be parsed as OCIStreamChunk: {e!s}",
+            message=f"Chunk cannot be parsed as OCIStreamChunk: {e}",
         )
 
     if typed_chunk.index is None:

--- a/litellm/llms/oci/chat/transformation.py
+++ b/litellm/llms/oci/chat/transformation.py
@@ -741,7 +741,7 @@ class OCIStreamWrapper(CustomStreamWrapper):
         except json.JSONDecodeError as e:
             raise OCIError(
                 status_code=500,
-                message=f"Chunk cannot be parsed as JSON: {e!s}",
+                message=f"Chunk cannot be parsed as JSON: {e}",
             )
 
         if dict_chunk.get("apiFormat") == "COHERE":

--- a/litellm/llms/oci/common_utils.py
+++ b/litellm/llms/oci/common_utils.py
@@ -232,7 +232,7 @@ def sign_with_oci_signer(
         raise OCIError(
             status_code=500,
             message=(
-                f"Failed to sign request with provided oci_signer: {e!s}. "
+                f"Failed to sign request with provided oci_signer: {e}. "
                 "The signer must implement the OCI SDK Signer interface with a "
                 "do_request_sign(request, enforce_content_headers=True) method. "
                 "See: https://docs.oracle.com/en-us/iaas/tools/python/latest/api/signing.html"

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -369,7 +369,7 @@ class OllamaChatConfig(BaseConfig):
                 content=None,
                 tool_calls=[
                     {
-                        "id": f"call_{uuid.uuid4()!s}",
+                        "id": f"call_{uuid.uuid4()}",
                         "function": {
                             "name": function_call.get("name", litellm_params.get("function_name")),
                             "arguments": json.dumps(function_call.get("arguments", function_call)),

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -282,7 +282,7 @@ class OllamaConfig(BaseConfig):
                             content=None,
                             tool_calls=[
                                 {
-                                    "id": f"call_{uuid.uuid4()!s}",
+                                    "id": f"call_{uuid.uuid4()}",
                                     "function": {
                                         "name": function_call["name"],
                                         "arguments": json.dumps(function_call["arguments"]),

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -621,7 +621,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         except Exception as e:
             response_headers = getattr(raw_response, "headers", None)
             raise OpenAIError(
-                message=f"Unable to get json response - {e!s}, Original Response: {raw_response.text}",
+                message=f"Unable to get json response - {e}, Original Response: {raw_response.text}",
                 status_code=raw_response.status_code,
                 headers=response_headers,
             )

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -551,7 +551,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
 
             except Exception as e:
                 verbose_logger.exception(
-                    f"LiteLLM.AgenticHookError: Exception in agentic completion hooks for OpenAI: {e!s}"
+                    f"LiteLLM.AgenticHookError: Exception in agentic completion hooks for OpenAI: {e}"
                 )
 
         return None
@@ -774,7 +774,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                     # e.message
                 except Exception as e:
                     if print_verbose is not None:
-                        print_verbose(f"openai.py: Received openai error - {e!s}")
+                        print_verbose(f"openai.py: Received openai error - {e}")
                     if (
                         "Conversation roles must alternate user/assistant" in str(e)
                         or "user and assistant roles should be alternating" in str(e)
@@ -1089,7 +1089,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 if response is not None and hasattr(response, "text"):
                     raise OpenAIError(
                         status_code=status_code,
-                        message=f"{e!s}\n\nOriginal Response: {response.text}",  # type: ignore
+                        message=f"{e}\n\nOriginal Response: {response.text}",  # type: ignore
                         headers=error_headers,
                         body=exception_body,
                     )
@@ -1111,7 +1111,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                     else:
                         raise OpenAIError(
                             status_code=500,
-                            message=f"{e!s}",
+                            message=f"{e}",
                             headers=error_headers,
                             body=exception_body,
                         )

--- a/litellm/llms/openai/realtime/handler.py
+++ b/litellm/llms/openai/realtime/handler.py
@@ -178,7 +178,7 @@ class OpenAIRealtime(OpenAIChatCompletion):
             await websocket.close(code=e.status_code, reason=_redact_string(str(e)))
         except Exception as e:
             try:
-                await websocket.close(code=1011, reason=_redact_string(f"Internal server error: {e!s}"))
+                await websocket.close(code=1011, reason=_redact_string(f"Internal server error: {e}"))
             except RuntimeError as close_error:
                 if "already completed" in str(close_error) or "websocket.close" in str(close_error):
                     # The WebSocket is already closed or the response is completed, so we can ignore this error

--- a/litellm/llms/openai/responses/count_tokens/handler.py
+++ b/litellm/llms/openai/responses/count_tokens/handler.py
@@ -88,14 +88,14 @@ class OpenAICountTokensHandler(OpenAICountTokensConfig):
         except OpenAIError:
             raise
         except httpx.HTTPStatusError as e:
-            verbose_logger.error(f"HTTP error in CountTokens handler: {e!s}")
+            verbose_logger.error(f"HTTP error in CountTokens handler: {e}")
             raise OpenAIError(
                 status_code=e.response.status_code,
                 message=e.response.text,
             )
         except (httpx.RequestError, json.JSONDecodeError, ValueError) as e:
-            verbose_logger.error(f"Error in CountTokens handler: {e!s}")
+            verbose_logger.error(f"Error in CountTokens handler: {e}")
             raise OpenAIError(
                 status_code=500,
-                message=f"CountTokens processing error: {e!s}",
+                message=f"CountTokens processing error: {e}",
             )

--- a/litellm/llms/openrouter/image_edit/transformation.py
+++ b/litellm/llms/openrouter/image_edit/transformation.py
@@ -203,7 +203,7 @@ class OpenRouterImageEditConfig(BaseImageEditConfig):
             response_json = raw_response.json()
         except Exception as e:
             raise OpenRouterException(
-                message=f"Error parsing OpenRouter response: {e!s}",
+                message=f"Error parsing OpenRouter response: {e}",
                 status_code=raw_response.status_code,
                 headers=raw_response.headers,
             )
@@ -246,7 +246,7 @@ class OpenRouterImageEditConfig(BaseImageEditConfig):
 
         except Exception as e:
             raise OpenRouterException(
-                message=f"Error transforming OpenRouter image edit response: {e!s}",
+                message=f"Error transforming OpenRouter image edit response: {e}",
                 status_code=500,
                 headers={},
             )

--- a/litellm/llms/openrouter/image_generation/transformation.py
+++ b/litellm/llms/openrouter/image_generation/transformation.py
@@ -345,7 +345,7 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
             response_json = raw_response.json()
         except Exception as e:
             raise OpenRouterException(
-                message=f"Error parsing OpenRouter response: {e!s}",
+                message=f"Error parsing OpenRouter response: {e}",
                 status_code=raw_response.status_code,
                 headers=raw_response.headers,
             )
@@ -394,7 +394,7 @@ class OpenRouterImageGenerationConfig(BaseImageGenerationConfig):
 
         except Exception as e:
             raise OpenRouterException(
-                message=f"Error transforming OpenRouter image generation response: {e!s}",
+                message=f"Error transforming OpenRouter image generation response: {e}",
                 status_code=500,
                 headers={},
             )

--- a/litellm/llms/predibase/chat/handler.py
+++ b/litellm/llms/predibase/chat/handler.py
@@ -225,7 +225,7 @@ class PredibaseChatCompletion:
                 if isinstance(e, exception):
                     raise e
             raise PredibaseError(
-                status_code=500, message=f"{e!s}"
+                status_code=500, message=f"{e}"
             )  # don't use verbose_logger.exception, if exception is raised
         return predibase_config.transform_response(
             model=model,

--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -529,7 +529,7 @@ class SagemakerLLM(BaseAWSLLM):
                 )
                 raise e
         except Exception as e:
-            error_message = f"{e!s}"
+            error_message = f"{e}"
             if "Inference Component Name header is required" in error_message:
                 error_message += "\n pass in via `litellm.completion(..., model_id={InferenceComponentName})`"
             raise SagemakerError(status_code=500, message=error_message)

--- a/litellm/llms/sagemaker/embedding/transformation.py
+++ b/litellm/llms/sagemaker/embedding/transformation.py
@@ -97,7 +97,7 @@ class SagemakerEmbeddingConfig(BaseEmbeddingConfig):
             response_data = raw_response.json()
         except Exception as e:
             raise SagemakerError(
-                message=f"Failed to parse response: {e!s}",
+                message=f"Failed to parse response: {e}",
                 status_code=raw_response.status_code,
             )
 

--- a/litellm/llms/vertex_ai/agent_engine/transformation.py
+++ b/litellm/llms/vertex_ai/agent_engine/transformation.py
@@ -270,7 +270,7 @@ class VertexAgentEngineConfig(BaseConfig, VertexBase):
                 total_tokens=total_tokens,
             )
         except Exception as e:
-            verbose_logger.warning(f"Failed to calculate token usage: {e!s}")
+            verbose_logger.warning(f"Failed to calculate token usage: {e}")
             return None
 
     def transform_response(
@@ -335,9 +335,9 @@ class VertexAgentEngineConfig(BaseConfig, VertexBase):
             return model_response
 
         except Exception as e:
-            verbose_logger.error(f"Error processing Vertex Agent Engine response: {e!s}")
+            verbose_logger.error(f"Error processing Vertex Agent Engine response: {e}")
             raise VertexAgentEngineError(
-                message=f"Error processing response: {e!s}",
+                message=f"Error processing response: {e}",
                 status_code=raw_response.status_code,
             )
 

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -221,7 +221,7 @@ def get_supports_system_message(
             supports_system_message = True
     except Exception as e:
         verbose_logger.warning(
-            f"Unable to identify if system message supported. Defaulting to 'False'. Received error message - {e!s}\nAdd it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
+            f"Unable to identify if system message supported. Defaulting to 'False'. Received error message - {e}\nAdd it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json"
         )
         supports_system_message = False
 

--- a/litellm/llms/vertex_ai/cost_calculator.py
+++ b/litellm/llms/vertex_ai/cost_calculator.py
@@ -114,7 +114,7 @@ def cost_per_character(
                 prompt_cost = prompt_characters * model_info["input_cost_per_character"]
         except Exception as e:
             verbose_logger.debug(
-                f"litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occured - {e!s}\nDefaulting to None"
+                f"litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occured - {e}\nDefaulting to None"
             )
             prompt_cost, _ = cost_per_token(
                 model=model,
@@ -152,7 +152,7 @@ def cost_per_character(
                 completion_cost = completion_characters * model_info["output_cost_per_character"]
         except Exception as e:
             verbose_logger.debug(
-                f"litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occured - {e!s}\nDefaulting to None"
+                f"litellm.litellm_core_utils.llm_cost_calc.google.py::cost_per_character(): Exception occured - {e}\nDefaulting to None"
             )
             _, completion_cost = cost_per_token(
                 model=model,

--- a/litellm/llms/vertex_ai/files/transformation.py
+++ b/litellm/llms/vertex_ai/files/transformation.py
@@ -815,6 +815,6 @@ class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
                 "response": None,
                 "error": {
                     "code": "transformation_error",
-                    "message": f"Failed to transform response: {e!s}",
+                    "message": f"Failed to transform response: {e}",
                 },
             }

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -356,9 +356,7 @@ def _get_gcs_object_content_type(
             headers["Authorization"] = f"Bearer {access_token}"
         except Exception as e:
             raise litellm.BadRequestError(
-                message=(
-                    f"Unable to fetch GCS metadata with provided Vertex credentials/project. Original error: {e!s}"
-                ),
+                message=(f"Unable to fetch GCS metadata with provided Vertex credentials/project. Original error: {e}"),
                 model=None,
                 llm_provider="vertex_ai",
             )
@@ -844,7 +842,7 @@ def _gemini_convert_messages_with_history(
                                         f"{file_id or 'provided data'}, set this explicitly "
                                         f"using message[{msg_i}].content[{element_idx}].file.format "
                                         f"(or file.mime_type/content_type). "
-                                        f"Original error: {e!s}"
+                                        f"Original error: {e}"
                                     ),
                                     model=model,
                                     llm_provider="vertex_ai",

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -2405,7 +2405,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             completion_response = GenerateContentResponseBody(**raw_response.json())  # type: ignore
         except Exception as e:
             raise VertexAIError(
-                message=f"Error converting to valid response block={e!s}. File an issue if litellm error - https://github.com/BerriAI/litellm/issues",
+                message=f"Error converting to valid response block={e}. File an issue if litellm error - https://github.com/BerriAI/litellm/issues",
                 status_code=422,
                 headers=raw_response.headers,
             )
@@ -2512,7 +2512,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         except Exception as e:
             raise VertexAIError(
-                message=f"Error converting to valid response block={e!s}. File an issue if litellm error - https://github.com/BerriAI/litellm/issues",
+                message=f"Error converting to valid response block={e}. File an issue if litellm error - https://github.com/BerriAI/litellm/issues",
                 status_code=422,
                 headers=raw_response.headers,
             )

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/llama3/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/llama3/transformation.py
@@ -127,7 +127,7 @@ class VertexAILlama3Config(OpenAIGPTConfig):
         except Exception as e:
             response_headers = getattr(raw_response, "headers", None)
             raise VertexAIError(
-                message=f"Unable to get json response - {e!s}, Original Response: {raw_response.text}",
+                message=f"Unable to get json response - {e}, Original Response: {raw_response.text}",
                 status_code=raw_response.status_code,
                 headers=response_headers,
             )

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -783,7 +783,7 @@ class VertexBase:
         except Exception as retry_error:
             verbose_logger.error(
                 f"Reauthentication retry failed for project_id: {project_id}. "
-                f"Original error: {error!s}. Retry error: {retry_error!s}"
+                f"Original error: {error}. Retry error: {retry_error}"
             )
             # Re-raise the original error for better context
             raise error
@@ -837,7 +837,7 @@ class VertexBase:
         except Exception as retry_error:
             verbose_logger.error(
                 f"Async reauthentication retry failed for project_id: {project_id}. "
-                f"Original error: {error!s}. Retry error: {retry_error!s}"
+                f"Original error: {error}. Retry error: {retry_error}"
             )
             raise error
 
@@ -897,7 +897,7 @@ class VertexBase:
                 _credentials, credential_project_id = self.load_auth(credentials=credentials, project_id=project_id)
             except Exception as e:
                 verbose_logger.exception(
-                    f"Failed to load vertex credentials. Check to see if credentials containing partial/invalid information. Error: {e!s}"
+                    f"Failed to load vertex credentials. Check to see if credentials containing partial/invalid information. Error: {e}"
                 )
                 raise e
 

--- a/litellm/llms/volcengine/embedding/transformation.py
+++ b/litellm/llms/volcengine/embedding/transformation.py
@@ -162,7 +162,7 @@ class VolcEngineEmbeddingConfig(BaseEmbeddingConfig):
         try:
             response_json = raw_response.json()
         except Exception as e:
-            raise ValueError(f"Failed to parse Volcengine response as JSON: {e!s}")
+            raise ValueError(f"Failed to parse Volcengine response as JSON: {e}")
 
         # Volcengine response format matches OpenAI format closely
         # Just need to ensure all required fields are present

--- a/litellm/llms/watsonx/audio_transcription/transformation.py
+++ b/litellm/llms/watsonx/audio_transcription/transformation.py
@@ -170,7 +170,7 @@ class IBMWatsonXAudioTranscriptionConfig(IBMWatsonXMixin, OpenAIWhisperAudioTran
         try:
             raw_response_json = raw_response.json()
         except Exception as e:
-            raise ValueError(f"Error transforming response to json: {e!s}\nResponse: {raw_response.text}")
+            raise ValueError(f"Error transforming response to json: {e}\nResponse: {raw_response.text}")
 
         # Extract only valid fields for TranscriptionResponse.__init__()
         # TranscriptionResponse only accepts 'text' and 'usage' in __init__()

--- a/litellm/llms/watsonx/rerank/transformation.py
+++ b/litellm/llms/watsonx/rerank/transformation.py
@@ -164,7 +164,7 @@ class IBMWatsonXRerankConfig(IBMWatsonXMixin, BaseRerankConfig):
             raw_response_json = raw_response.json()
         except Exception as e:
             raise self.get_error_class(
-                error_message=f"Failed to parse response: {e!s}",
+                error_message=f"Failed to parse response: {e}",
                 status_code=raw_response.status_code,
                 headers=raw_response.headers,
             )

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -8303,7 +8303,7 @@ async def ahealth_check(
 
         if mode is None:
             return {
-                "error": f"error:{e!s}. Missing `mode`. Set the `mode` for the model - https://docs.litellm.ai/docs/proxy/health#embedding-models  \nstacktrace: {stack_trace}",
+                "error": f"error:{e}. Missing `mode`. Set the `mode` for the model - https://docs.litellm.ai/docs/proxy/health#embedding-models  \nstacktrace: {stack_trace}",
                 "exception": e,
             }
 
@@ -8669,7 +8669,7 @@ def stream_chunk_builder(
         processor.apply_provider_assembled_streaming_metadata(response, chunks, logging_obj)
         return response
     except Exception as e:
-        verbose_logger.exception(f"litellm.main.py::stream_chunk_builder() - Exception occurred - {e!s}")
+        verbose_logger.exception(f"litellm.main.py::stream_chunk_builder() - Exception occurred - {e}")
         raise litellm.APIError(
             status_code=500,
             message="Error building chunks for logging/streaming usage calculation",

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -1008,7 +1008,7 @@ class MCPRequestHandler:
                     limits[source.team_id] = applicable
             return limits or None
         except Exception as e:  # noqa: BLE001  # throttling metadata must never fail an allowed request
-            verbose_logger.warning(f"Failed to resolve per-team MCP rpm limits for admitted subject: {e!s}")
+            verbose_logger.warning(f"Failed to resolve per-team MCP rpm limits for admitted subject: {e}")
             return None
 
     @staticmethod
@@ -1514,9 +1514,9 @@ class MCPRequestHandler:
             if isinstance(e, UnloadableEntitlementError):
                 # A ceiling we KNOW exists and cannot read. Denying is the only answer that does not
                 # widen this caller past what an operator configured, for both caller shapes.
-                verbose_logger.warning(f"Denying MCP access, entitlement unreadable: {e!s}")
+                verbose_logger.warning(f"Denying MCP access, entitlement unreadable: {e}")
             else:
-                verbose_logger.warning(f"Failed to get allowed MCP servers: {e!s}")
+                verbose_logger.warning(f"Failed to get allowed MCP servers: {e}")
             return []
 
     @staticmethod
@@ -1649,7 +1649,7 @@ class MCPRequestHandler:
             # Fault isolation is per SOURCE: an unresolvable team contributes nothing (fail closed for
             # it alone, access only narrows) while every other source stands. Raising would collapse the
             # whole union to deny-all over one momentarily-unreadable row.
-            verbose_logger.warning(f"MCP admitted-subject source team {team_id!r} unresolvable, skipping: {e!s}")
+            verbose_logger.warning(f"MCP admitted-subject source team {team_id!r} unresolvable, skipping: {e}")
             return None
         if team_obj is None:
             return None
@@ -1682,10 +1682,10 @@ class MCPRequestHandler:
                 proxy_logging_obj=proxy_logging_obj,
             )
         except BudgetExceededError as e:
-            verbose_logger.info(f"MCP admitted-subject source team {team_id!r} over budget, not a grantor: {e!s}")
+            verbose_logger.info(f"MCP admitted-subject source team {team_id!r} over budget, not a grantor: {e}")
             return None
         except Exception as e:  # noqa: BLE001  # per-source isolation: a budget-check fault narrows, never raises
-            verbose_logger.warning(f"MCP budget check failed for source team {team_id!r}, skipping source: {e!s}")
+            verbose_logger.warning(f"MCP budget check failed for source team {team_id!r}, skipping source: {e}")
             return None
         return team_obj
 
@@ -1738,7 +1738,7 @@ class MCPRequestHandler:
             billed.org_id = source.org_id
             return billed
         except Exception as e:  # noqa: BLE001  # attribution must never fail an authorized call
-            verbose_logger.warning(f"MCP billing attribution failed for {tool_name!r}, billing the user: {e!s}")
+            verbose_logger.warning(f"MCP billing attribution failed for {tool_name!r}, billing the user: {e}")
             return auth
 
     @staticmethod
@@ -1946,9 +1946,9 @@ class MCPRequestHandler:
             # than the None (allow-all) key auth gets for an indeterminate fault.
             unreadable_entitlement = isinstance(e, UnloadableEntitlementError)
             if unreadable_entitlement:
-                verbose_logger.warning(f"Denying MCP tools, entitlement unreadable: {e!s}")
+                verbose_logger.warning(f"Denying MCP tools, entitlement unreadable: {e}")
             else:
-                verbose_logger.warning(f"Failed to get allowed tools for server: {e!s}")
+                verbose_logger.warning(f"Failed to get allowed tools for server: {e}")
             # Fail CLOSED for a keyless admitted subject: ANY error must deny the server's tools ([]),
             # not collapse to allow-all (None); key/JWT auth keeps its prior allow-all-on-error. Both
             # keyless_source AND the marker are needed: each source resolves through an UNMARKED auth, so
@@ -1999,7 +1999,7 @@ class MCPRequestHandler:
                     raise
                 verbose_logger.warning(
                     f"MCP org tool ceiling unresolvable for org_id={user_api_key_auth.org_id!r}; "
-                    f"skipping org intersect, key/team/agent restrictions stand: {e!s}"
+                    f"skipping org intersect, key/team/agent restrictions stand: {e}"
                 )
                 return allowed_tools
             org_tools = (
@@ -2102,7 +2102,7 @@ class MCPRequestHandler:
             # Permission entries may be server_ids OR names/aliases — expand to ids.
             return global_mcp_server_manager.expand_permission_list(raw_server_ids)
         except Exception as e:
-            verbose_logger.warning(f"Failed to get key access group MCP server grants: {e!s}")
+            verbose_logger.warning(f"Failed to get key access group MCP server grants: {e}")
             return []
 
     @staticmethod
@@ -2180,7 +2180,7 @@ class MCPRequestHandler:
             all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers + toolset_servers
             return list(set(all_servers))
         except Exception as e:
-            verbose_logger.warning(f"Failed to get allowed MCP servers for key: {e!s}")
+            verbose_logger.warning(f"Failed to get allowed MCP servers for key: {e}")
             return []
 
     @staticmethod
@@ -2238,7 +2238,7 @@ class MCPRequestHandler:
                 proxy_logging_obj=proxy_logging_obj,
             )
         except Exception as e:  # noqa: BLE001  # a team-resolution blip narrows access, never raises
-            verbose_logger.warning(f"Failed to resolve user teams for MCP grant: {e!s}")
+            verbose_logger.warning(f"Failed to resolve user teams for MCP grant: {e}")
             return []
         if user_object is None or not user_object.teams:
             return []
@@ -2323,7 +2323,7 @@ class MCPRequestHandler:
             servers = await MCPRequestHandler._team_granted_servers(team_obj, team_access_group_servers)
             return list(servers)
         except Exception as e:
-            verbose_logger.warning(f"Failed to get allowed MCP servers for team: {e!s}")
+            verbose_logger.warning(f"Failed to get allowed MCP servers for team: {e}")
             return []
 
     @staticmethod
@@ -2462,7 +2462,7 @@ class MCPRequestHandler:
             # A NAMED-but-unreadable ceiling is a stronger fact than "unresolved" and denies everywhere.
             if isinstance(e, UnloadableEntitlementError):
                 raise
-            verbose_logger.warning(f"Failed to get allowed MCP servers for org: {e!s}")
+            verbose_logger.warning(f"Failed to get allowed MCP servers for org: {e}")
             return None
 
     @staticmethod
@@ -2490,7 +2490,7 @@ class MCPRequestHandler:
                 route="/mcp",
             )
         except Exception as e:  # noqa: BLE001  # entitlement unknown, not known-absent: no ceiling, as before this level
-            verbose_logger.warning(f"Failed to resolve end_user for MCP permissions: {e!s}")
+            verbose_logger.warning(f"Failed to resolve end_user for MCP permissions: {e}")
             return None
 
         if end_user_obj is None:
@@ -2554,7 +2554,7 @@ class MCPRequestHandler:
             all_servers = direct_mcp_servers + access_group_servers + tool_perm_servers
             return list(set(all_servers))
         except Exception as e:
-            verbose_logger.warning(f"Failed to get allowed MCP servers for end_user: {e!s}")
+            verbose_logger.warning(f"Failed to get allowed MCP servers for end_user: {e}")
             return []
 
     @staticmethod
@@ -2637,7 +2637,7 @@ class MCPRequestHandler:
             )
             return object_permission_id
         except Exception as e:  # noqa: BLE001  # unknown whether entitled at all: no ceiling, as before
-            verbose_logger.warning(f"MCP user entitlement: link for {user_id!r} unresolved, no ceiling: {e!s}")
+            verbose_logger.warning(f"MCP user entitlement: link for {user_id!r} unresolved, no ceiling: {e}")
             return None
 
     @staticmethod
@@ -2669,7 +2669,7 @@ class MCPRequestHandler:
             )
             return list(set(direct_mcp_servers + access_group_servers + tool_perm_servers))
         except Exception as e:  # noqa: BLE001  # any resolution fault is an unresolved ceiling, never "no ceiling"
-            verbose_logger.warning(f"Failed to get allowed MCP servers for user: {e!s}")
+            verbose_logger.warning(f"Failed to get allowed MCP servers for user: {e}")
             return None
 
     @staticmethod
@@ -2739,7 +2739,7 @@ class MCPRequestHandler:
         try:
             object_permissions = await MCPRequestHandler._get_user_object_permission(user_api_key_auth)
         except Exception as e:  # noqa: BLE001  # an unresolved human entitlement must deny, not widen
-            verbose_logger.warning(f"MCP user tool ceiling unresolvable, denying tools on {server_id!r}: {e!s}")
+            verbose_logger.warning(f"MCP user tool ceiling unresolvable, denying tools on {server_id!r}: {e}")
             return []
 
         if object_permissions is None or not object_permissions.mcp_tool_permissions:
@@ -2785,7 +2785,7 @@ class MCPRequestHandler:
             )
             return object_permission_id
         except Exception as e:  # noqa: BLE001  # entitlement unknown, not known-absent: no ceiling, as before this level
-            verbose_logger.warning(f"Failed to resolve object_permission_id for agent {agent_id!r}: {e!s}")
+            verbose_logger.warning(f"Failed to resolve object_permission_id for agent {agent_id!r}: {e}")
             return None
 
     @staticmethod
@@ -2869,7 +2869,7 @@ class MCPRequestHandler:
             all_servers = expanded_direct_servers + access_group_servers
             return list(set(all_servers))
         except Exception as e:
-            verbose_logger.warning(f"Failed to get allowed MCP servers for agent: {e!s}")
+            verbose_logger.warning(f"Failed to get allowed MCP servers for agent: {e}")
             return []
 
     @staticmethod
@@ -2911,7 +2911,7 @@ class MCPRequestHandler:
             tools = global_mcp_server_manager.expand_tool_permissions(mcp_tool_permissions).get(server_id)
             return list(tools) if tools else None
         except Exception as e:
-            verbose_logger.warning(f"Failed to get agent tool permissions for server: {e!s}")
+            verbose_logger.warning(f"Failed to get agent tool permissions for server: {e}")
             return None
 
     @staticmethod
@@ -2969,7 +2969,7 @@ class MCPRequestHandler:
 
             return list(server_ids)
         except Exception as e:
-            verbose_logger.warning(f"Failed to get MCP servers from access groups: {e!s}")
+            verbose_logger.warning(f"Failed to get MCP servers from access groups: {e}")
             return []
 
     @staticmethod
@@ -3029,7 +3029,7 @@ class MCPRequestHandler:
 
             return key_object_permission.mcp_access_groups or []
         except Exception as e:
-            verbose_logger.warning(f"Failed to get MCP access groups for key: {e!s}")
+            verbose_logger.warning(f"Failed to get MCP access groups for key: {e}")
             return []
 
     @staticmethod
@@ -3077,7 +3077,7 @@ class MCPRequestHandler:
 
             return object_permissions.mcp_access_groups or []
         except Exception as e:
-            verbose_logger.warning(f"Failed to get MCP access groups for team: {e!s}")
+            verbose_logger.warning(f"Failed to get MCP access groups for team: {e}")
             return []
 
     @staticmethod

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -570,7 +570,7 @@ async def get_all_mcp_servers(
             decrypt_global_env_var_values(table.env_vars)
         return tables
     except Exception as e:
-        verbose_proxy_logger.debug(f"litellm.proxy._experimental.mcp_server.db.py::get_all_mcp_servers - {e!s}")
+        verbose_proxy_logger.debug(f"litellm.proxy._experimental.mcp_server.db.py::get_all_mcp_servers - {e}")
         return []
 
 

--- a/litellm/proxy/_experimental/mcp_server/elicitation_handler.py
+++ b/litellm/proxy/_experimental/mcp_server/elicitation_handler.py
@@ -79,7 +79,7 @@ async def handle_elicitation_request(
         verbose_logger.exception("MCP elicitation handler failed: %s", e)
         return ErrorData(
             code=-1,
-            message=f"Elicitation failed: {e!s}",
+            message=f"Elicitation failed: {e}",
         )
 
 

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -1951,7 +1951,7 @@ class MCPServerManager:
             verbose_logger.info(f"Successfully registered {registered_count} OpenAPI tools for server {server.name}")
 
         except Exception as e:
-            verbose_logger.error(f"Failed to register OpenAPI tools for server {server.name}: {e!s}")
+            verbose_logger.error(f"Failed to register OpenAPI tools for server {server.name}: {e}")
             raise e
 
     def _cleanup_server_tool_routing_artifacts(self, server: MCPServer) -> None:
@@ -2326,7 +2326,7 @@ class MCPServerManager:
                 verbose_logger.debug(f"Added MCP Server: {new_server.name}")
 
         except Exception as e:
-            verbose_logger.debug(f"Failed to add MCP server: {e!s}")
+            verbose_logger.debug(f"Failed to add MCP server: {e}")
             raise e
 
     async def update_server(self, mcp_server: LiteLLM_MCPServerTable):
@@ -2360,7 +2360,7 @@ class MCPServerManager:
                 verbose_logger.debug(f"Updated MCP Server: {new_server.name}")
 
         except Exception as e:
-            verbose_logger.debug(f"Failed to udpate MCP server: {e!s}")
+            verbose_logger.debug(f"Failed to udpate MCP server: {e}")
             raise e
 
     def get_all_mcp_server_ids(self) -> set[str]:
@@ -2386,7 +2386,7 @@ class MCPServerManager:
 
             await user_api_key_cache.async_delete_cache(key=self.get_byom_submitted_servers_cache_key(user_id))
         except Exception as e:  # noqa: BLE001
-            verbose_logger.warning(f"Failed to invalidate BYOM submitted MCP server cache: {e!s}")
+            verbose_logger.warning(f"Failed to invalidate BYOM submitted MCP server cache: {e}")
 
     async def _get_active_submitted_mcp_server_ids_for_user(
         self, user_api_key_auth: UserAPIKeyAuth | None
@@ -2401,7 +2401,7 @@ class MCPServerManager:
             )
             from litellm.proxy.proxy_server import prisma_client, user_api_key_cache
         except Exception as e:  # noqa: BLE001
-            verbose_logger.warning(f"Failed to load BYOM submitted MCP server cache dependencies: {e!s}")
+            verbose_logger.warning(f"Failed to load BYOM submitted MCP server cache dependencies: {e}")
             return []
 
         byom_cache_key = self.get_byom_submitted_servers_cache_key(submitter_user_id)
@@ -2411,7 +2411,7 @@ class MCPServerManager:
             if cached_submitted_server_ids is not None:
                 submitted_server_ids = cast(list[str], cached_submitted_server_ids)
         except Exception as e:  # noqa: BLE001
-            verbose_logger.warning(f"Failed to read BYOM submitted MCP server cache: {e!s}")
+            verbose_logger.warning(f"Failed to read BYOM submitted MCP server cache: {e}")
 
         if submitted_server_ids is None:
             if prisma_client is None:
@@ -2422,7 +2422,7 @@ class MCPServerManager:
                         prisma_client, submitter_user_id
                     )
                 except Exception as e:  # noqa: BLE001
-                    verbose_logger.warning(f"Failed to read BYOM submitted MCP servers from database: {e!s}")
+                    verbose_logger.warning(f"Failed to read BYOM submitted MCP servers from database: {e}")
                     submitted_server_ids = []
             try:
                 await user_api_key_cache.async_set_cache(
@@ -2431,7 +2431,7 @@ class MCPServerManager:
                     ttl=60,
                 )
             except Exception as e:  # noqa: BLE001
-                verbose_logger.warning(f"Failed to write BYOM submitted MCP server cache: {e!s}")
+                verbose_logger.warning(f"Failed to write BYOM submitted MCP server cache: {e}")
 
         return [server_id for server_id in submitted_server_ids if self.get_mcp_server_by_id(server_id) is not None]
 
@@ -2647,7 +2647,7 @@ class MCPServerManager:
             )
             return tool_permissions
         except Exception as e:
-            verbose_logger.warning(f"Failed to resolve toolset permissions: {e!s}")
+            verbose_logger.warning(f"Failed to resolve toolset permissions: {e}")
             return {}
 
     def invalidate_toolset_cache(self, toolset_id: str | None = None) -> None:
@@ -2764,7 +2764,7 @@ class MCPServerManager:
                 return []
             return await self._get_tools_from_server(server)
         except Exception as e:
-            verbose_logger.warning(f"Failed to get tools from server {server_id}: {e!s}")
+            verbose_logger.warning(f"Failed to get tools from server {server_id}: {e}")
             return []
 
     async def list_tools(
@@ -2822,7 +2822,7 @@ class MCPServerManager:
                 return tools
             except Exception as e:
                 verbose_logger.warning(
-                    f"Failed to list tools from server {server.name}: {e!s}. Continuing with other servers."
+                    f"Failed to list tools from server {server.name}: {e}. Continuing with other servers."
                 )
                 return []
 
@@ -3476,12 +3476,12 @@ class MCPServerManager:
                     www_authenticate=None if server.is_dcr_bridge else challenge_header,
                     server_name=server.name,
                 ) from e
-            verbose_logger.warning(f"Failed to get tools from server {server.name}: {e!s}")
+            verbose_logger.warning(f"Failed to get tools from server {server.name}: {e}")
             raise MCPServerListError(ServerListFault(tag="internal", status_code=e.status_code), server.name) from e
         except MCPServerListError:
             raise
         except Exception as e:
-            verbose_logger.warning(f"Failed to get tools from server {server.name}: {e!s}")
+            verbose_logger.warning(f"Failed to get tools from server {server.name}: {e}")
             raise_classified_list_failure(e, server.name, suppress_challenge=server.is_dcr_bridge)
 
     async def get_prompts_from_server(
@@ -3532,7 +3532,7 @@ class MCPServerManager:
             return prefixed_or_original_prompts
 
         except Exception as e:
-            verbose_logger.warning(f"Failed to get prompts from server {server.name}: {e!s}")
+            verbose_logger.warning(f"Failed to get prompts from server {server.name}: {e}")
             return []
 
     async def get_resources_from_server(
@@ -3574,7 +3574,7 @@ class MCPServerManager:
             return prefixed_resources
 
         except Exception as e:
-            verbose_logger.warning(f"Failed to get resources from server {server.name}: {e!s}")
+            verbose_logger.warning(f"Failed to get resources from server {server.name}: {e}")
             return []
 
     async def get_resource_templates_from_server(
@@ -3618,7 +3618,7 @@ class MCPServerManager:
             return prefixed_templates
 
         except Exception as e:
-            verbose_logger.warning(f"Failed to get resource templates from server {server.name}: {e!s}")
+            verbose_logger.warning(f"Failed to get resource templates from server {server.name}: {e}")
             return []
 
     async def read_resource_from_server(
@@ -4215,10 +4215,10 @@ class MCPServerManager:
             verbose_logger.warning(f"Task cancelled while listing tools from {server_name}")
             raise MCPServerListError(ServerListFault(tag="internal"), server_name) from e
         except ConnectionError as e:
-            verbose_logger.warning(f"Connection error while listing tools from {server_name}: {e!s}")
+            verbose_logger.warning(f"Connection error while listing tools from {server_name}: {e}")
             raise MCPServerListError(ServerListFault(tag="unreachable"), server_name) from e
         except Exception as e:
-            verbose_logger.warning(f"Error listing tools from {server_name}: {e!s}")
+            verbose_logger.warning(f"Error listing tools from {server_name}: {e}")
             raise_classified_list_failure(e, server_name)
 
     _SHORT_PREFIX_MAX_REHASH_ATTEMPTS = 1024
@@ -4533,7 +4533,7 @@ class MCPServerManager:
             return result
 
         except Exception as e:
-            error_msg = f"Error calling OpenAPI tool {tool_name}: {e!s}"
+            error_msg = f"Error calling OpenAPI tool {tool_name}: {e}"
             verbose_logger.error(error_msg)
             return CallToolResult(
                 content=[TextContent(type="text", text=error_msg)],
@@ -4639,7 +4639,7 @@ class MCPServerManager:
             HTTPException,
         ) as e:
             # Re-raise guardrail exceptions to properly fail the MCP call
-            verbose_logger.error(f"Guardrail blocked MCP tool call pre call: {e!s}")
+            verbose_logger.error(f"Guardrail blocked MCP tool call pre call: {e}")
             raise e
 
         return hook_result
@@ -4995,7 +4995,7 @@ class MCPServerManager:
             GuardrailRaisedException,
             HTTPException,
         ) as e:
-            verbose_logger.error(f"Guardrail blocked MCP tool call during result check: {e!s}")
+            verbose_logger.error(f"Guardrail blocked MCP tool call during result check: {e}")
             raise e
 
         # If proxy_logging_obj is None, the tool call result is at index 0
@@ -5194,7 +5194,7 @@ class MCPServerManager:
             GuardrailRaisedException,
             HTTPException,
         ) as e:
-            verbose_logger.error(f"Guardrail blocked MCP tool call during result check: {e!s}")
+            verbose_logger.error(f"Guardrail blocked MCP tool call during result check: {e}")
             raise e
 
     async def call_tool(
@@ -5345,7 +5345,7 @@ class MCPServerManager:
                 asyncio.create_task(self._initialize_tool_name_to_mcp_server_name_mapping())
         except RuntimeError as e:  # no running event loop
             verbose_logger.exception(
-                f"No running event loop - skipping tool name to MCP server name mapping initialization: {e!s}"
+                f"No running event loop - skipping tool name to MCP server name mapping initialization: {e}"
             )
 
     async def _initialize_tool_name_to_mcp_server_name_mapping(self):
@@ -5364,12 +5364,12 @@ class MCPServerManager:
                 # at startup we have none, so an upstream 401 is normal.
                 # Swallow it so we keep mapping the remaining servers.
                 verbose_logger.debug(
-                    f"Skipping tool name mapping for server {server.name} due to upstream auth error: {e!s}"
+                    f"Skipping tool name mapping for server {server.name} due to upstream auth error: {e}"
                 )
                 continue
             except Exception as e:
                 verbose_logger.warning(
-                    f"Failed to get tools from server {server.name} during tool name mapping initialization: {e!s}"
+                    f"Failed to get tools from server {server.name} during tool name mapping initialization: {e}"
                 )
                 continue
             for tool in tools:

--- a/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
+++ b/litellm/proxy/_experimental/mcp_server/rest_endpoints.py
@@ -654,7 +654,7 @@ if MCP_AVAILABLE:
             return {
                 "tools": [],
                 "error": "server_error",
-                "message": f"Failed to get tools from server {server.name}: {e!s}",
+                "message": f"Failed to get tools from server {server.name}: {e}",
             }
         return {
             "tools": list_tools_result,
@@ -866,7 +866,7 @@ if MCP_AVAILABLE:
                         errors.append(
                             f"{get_server_prefix(server)}: {classify_list_exception(e).tag}"
                             if isinstance(e, (MCPServerListError, MCPUpstreamAuthError))
-                            else f"{get_server_prefix(server)}: {e!s}"
+                            else f"{get_server_prefix(server)}: {e}"
                         )
                         continue
 
@@ -905,7 +905,7 @@ if MCP_AVAILABLE:
             return {
                 "tools": [],
                 "error": "unexpected_error",
-                "message": f"An unexpected error occurred: {e!s}",
+                "message": f"An unexpected error occurred: {e}",
             }
 
     @router.post("/tools/call", dependencies=[Depends(user_api_key_auth)])
@@ -1052,7 +1052,7 @@ if MCP_AVAILABLE:
                 },
             )
         except BlockedPiiEntityError as e:
-            verbose_logger.error(f"BlockedPiiEntityError in MCP tool call: {e!s}")
+            verbose_logger.error(f"BlockedPiiEntityError in MCP tool call: {e}")
             raise HTTPException(
                 status_code=400,
                 detail={
@@ -1063,7 +1063,7 @@ if MCP_AVAILABLE:
                 },
             )
         except GuardrailRaisedException as e:
-            verbose_logger.error(f"GuardrailRaisedException in MCP tool call: {e!s}")
+            verbose_logger.error(f"GuardrailRaisedException in MCP tool call: {e}")
             raise HTTPException(
                 status_code=400,
                 detail={
@@ -1082,15 +1082,15 @@ if MCP_AVAILABLE:
             # Locally generated denials (tool/server permission, IP filtering, BYOK) stay at error level
             # so restriction probing keeps full monitoring visibility; the relayed upstream 401 above is
             # the only status demoted to info.
-            verbose_logger.error(f"HTTPException in MCP tool call: {e!s}")
+            verbose_logger.error(f"HTTPException in MCP tool call: {e}")
             raise e
         except Exception as e:
-            verbose_logger.exception(f"Unexpected error in MCP tool call: {e!s}")
+            verbose_logger.exception(f"Unexpected error in MCP tool call: {e}")
             raise HTTPException(
                 status_code=500,
                 detail={
                     "error": "internal_server_error",
-                    "message": f"An unexpected error occurred: {e!s}",
+                    "message": f"An unexpected error occurred: {e}",
                 },
             )
 

--- a/litellm/proxy/_experimental/mcp_server/sampling_handler.py
+++ b/litellm/proxy/_experimental/mcp_server/sampling_handler.py
@@ -1292,5 +1292,5 @@ async def handle_sampling_create_message(
         verbose_logger.exception("MCP sampling handler failed: %s", e)
         return ErrorData(
             code=-1,
-            message=f"Sampling failed: {e!s}",
+            message=f"Sampling failed: {e}",
         )

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -805,7 +805,7 @@ if MCP_AVAILABLE:
             }
             return ListToolsResult.model_validate({"tools": listing.tools, "_meta": outcome_meta})
         except Exception as e:
-            verbose_logger.exception(f"Error in list_tools endpoint: {e!s}")
+            verbose_logger.exception(f"Error in list_tools endpoint: {e}")
             # Return empty list instead of failing completely
             # This prevents the HTTP stream from failing and allows the client to get a response
             return []
@@ -1080,26 +1080,26 @@ if MCP_AVAILABLE:
                     isError=True,
                 )
             except BlockedPiiEntityError as e:
-                verbose_logger.error(f"BlockedPiiEntityError in MCP tool call: {e!s}")
+                verbose_logger.error(f"BlockedPiiEntityError in MCP tool call: {e}")
                 return CallToolResult(
                     content=[
                         TextContent(
-                            text=f"Error: Blocked PII entity detected - {e!s}",
+                            text=f"Error: Blocked PII entity detected - {e}",
                             type="text",
                         )
                     ],
                     isError=True,
                 )
             except GuardrailRaisedException as e:
-                verbose_logger.error(f"GuardrailRaisedException in MCP tool call: {e!s}")
+                verbose_logger.error(f"GuardrailRaisedException in MCP tool call: {e}")
                 return CallToolResult(
-                    content=[TextContent(text=f"Error: Guardrail violation - {e!s}", type="text")],
+                    content=[TextContent(text=f"Error: Guardrail violation - {e}", type="text")],
                     isError=True,
                 )
             except HTTPException as e:
-                verbose_logger.error(f"HTTPException in MCP tool call: {e!s}")
+                verbose_logger.error(f"HTTPException in MCP tool call: {e}")
                 return CallToolResult(
-                    content=[TextContent(text=f"Error: {e.detail!s}", type="text")],
+                    content=[TextContent(text=f"Error: {e.detail}", type="text")],
                     isError=True,
                 )
             except MCPUpstreamAuthError as e:
@@ -1121,7 +1121,7 @@ if MCP_AVAILABLE:
             except Exception as e:
                 verbose_logger.exception(f"MCP mcp_server_tool_call - error: {e}")
                 return CallToolResult(
-                    content=[TextContent(text=f"Error: {e!s}", type="text")],
+                    content=[TextContent(text=f"Error: {e}", type="text")],
                     isError=True,
                 )
 
@@ -1173,7 +1173,7 @@ if MCP_AVAILABLE:
             verbose_logger.info(f"MCP list_prompts - Successfully returned {len(prompts)} prompts")
             return prompts
         except Exception as e:
-            verbose_logger.exception(f"Error in list_prompts endpoint: {e!s}")
+            verbose_logger.exception(f"Error in list_prompts endpoint: {e}")
             # Return empty list instead of failing completely
             # This prevents the HTTP stream from failing and allows the client to get a response
             return []
@@ -1265,7 +1265,7 @@ if MCP_AVAILABLE:
             verbose_logger.info(f"MCP list_resources - Successfully returned {len(resources)} resources")
             return resources
         except Exception as e:
-            verbose_logger.exception(f"Error in list_resources endpoint: {e!s}")
+            verbose_logger.exception(f"Error in list_resources endpoint: {e}")
             return []
         finally:
             if _session_reset_token is not None:
@@ -1310,7 +1310,7 @@ if MCP_AVAILABLE:
             )
             return resource_templates
         except Exception as e:
-            verbose_logger.exception(f"Error in list_resource_templates endpoint: {e!s}")
+            verbose_logger.exception(f"Error in list_resource_templates endpoint: {e}")
             return []
         finally:
             if _session_reset_token is not None:
@@ -2036,7 +2036,7 @@ if MCP_AVAILABLE:
                     verbose_logger.debug(f"MCP list_tools: omitting {server.name}; it needs upstream auth")
                     return [], classify_list_exception(e)
                 except Exception as e:
-                    verbose_logger.exception(f"Error getting tools from server {server.name}: {e!s}")
+                    verbose_logger.exception(f"Error getting tools from server {server.name}: {e}")
                     return [], classify_list_exception(e)
 
             # Fetch tools from all servers in parallel
@@ -2169,7 +2169,7 @@ if MCP_AVAILABLE:
 
                 verbose_logger.debug(f"Successfully fetched {len(prompts)} prompts from server {server.name}")
             except Exception as e:
-                verbose_logger.exception(f"Error getting prompts from server {server.name}: {e!s}")
+                verbose_logger.exception(f"Error getting prompts from server {server.name}: {e}")
                 # Continue with other servers instead of failing completely
 
         verbose_logger.info(f"Successfully fetched {len(all_prompts)} prompts total from all MCP servers")
@@ -2221,7 +2221,7 @@ if MCP_AVAILABLE:
 
                 verbose_logger.debug(f"Successfully fetched {len(resources)} resources from server {server.name}")
             except Exception as e:
-                verbose_logger.exception(f"Error getting resources from server {server.name}: {e!s}")
+                verbose_logger.exception(f"Error getting resources from server {server.name}: {e}")
 
         verbose_logger.info(f"Successfully fetched {len(all_resources)} resources total from all MCP servers")
 
@@ -2359,7 +2359,7 @@ if MCP_AVAILABLE:
             verbose_logger.debug(f"Successfully fetched {len(listing.tools)} tools from managed MCP servers")
             return listing
         except Exception as e:
-            verbose_logger.exception(f"Error getting tools from managed MCP servers: {e!s}")
+            verbose_logger.exception(f"Error getting tools from managed MCP servers: {e}")
             # Continue with an empty listing instead of failing completely
             return AggregateToolListing(tools=[], outcomes={})
 
@@ -2398,7 +2398,7 @@ if MCP_AVAILABLE:
             )
             verbose_logger.debug(f"Successfully fetched {len(managed_prompts)} prompts from managed MCP servers")
         except Exception as e:
-            verbose_logger.exception(f"Error getting tools from managed MCP servers: {e!s}")
+            verbose_logger.exception(f"Error getting tools from managed MCP servers: {e}")
             # Continue with empty managed tools list instead of failing completely
 
         return managed_prompts
@@ -2428,7 +2428,7 @@ if MCP_AVAILABLE:
             )
             verbose_logger.debug(f"Successfully fetched {len(managed_resources)} resources from managed MCP servers")
         except Exception as e:
-            verbose_logger.exception(f"Error getting resources from managed MCP servers: {e!s}")
+            verbose_logger.exception(f"Error getting resources from managed MCP servers: {e}")
 
         return managed_resources
 
@@ -3335,8 +3335,8 @@ if MCP_AVAILABLE:
                 result = tool.handler(**arguments)
             return [TextContent(text=str(result), type="text")]
         except Exception as e:
-            verbose_logger.exception(f"Error executing local tool {name}: {e!s}")
-            return [TextContent(text=f"Error: {e!s}", type="text")]
+            verbose_logger.exception(f"Error executing local tool {name}: {e}")
+            return [TextContent(text=f"Error: {e}", type="text")]
 
     def _get_mcp_servers_in_path(path: str) -> list[str] | None:
         """

--- a/litellm/proxy/_experimental/mcp_server/toolset_db.py
+++ b/litellm/proxy/_experimental/mcp_server/toolset_db.py
@@ -55,7 +55,7 @@ async def list_mcp_toolsets(
         rows = await MCPToolsetRepository(prisma_client).table.find_many(where=where)
         return [_toolset_from_row(r) for r in rows]
     except Exception as e:
-        verbose_proxy_logger.warning(f"litellm.proxy._experimental.mcp_server.toolset_db::list_mcp_toolsets - {e!s}")
+        verbose_proxy_logger.warning(f"litellm.proxy._experimental.mcp_server.toolset_db::list_mcp_toolsets - {e}")
         return []
 
 

--- a/litellm/proxy/a2a/discovery.py
+++ b/litellm/proxy/a2a/discovery.py
@@ -122,11 +122,11 @@ async def fetch_well_known_card(
             # dict so production (``user_url_validation=True``) doesn't 500.
             response = await async_safe_get(client, url, headers=headers or {})
         except SSRFError as exc:
-            last_error = f"{url}: {exc!s}"
+            last_error = f"{url}: {exc}"
             verbose_proxy_logger.debug("A2A discovery blocked by SSRF guard for %s: %s", url, exc)
             continue
         except Exception as exc:
-            last_error = f"{url}: {exc!s}"
+            last_error = f"{url}: {exc}"
             verbose_proxy_logger.debug("A2A discovery failed for %s: %s", url, exc)
             continue
 
@@ -138,7 +138,7 @@ async def fetch_well_known_card(
         try:
             card = response.json()
         except Exception as exc:
-            last_error = f"{url}: invalid JSON ({exc!s})"
+            last_error = f"{url}: invalid JSON ({exc})"
             continue
 
         if not isinstance(card, dict):

--- a/litellm/proxy/a2a/endpoints.py
+++ b/litellm/proxy/a2a/endpoints.py
@@ -104,7 +104,7 @@ async def discover_agent_card(
         raise HTTPException(status_code=400, detail=str(exc))
     except Exception as exc:
         verbose_proxy_logger.exception("Unexpected error during A2A discovery: %s", exc)
-        raise HTTPException(status_code=500, detail=f"Discovery failed: {exc!s}")
+        raise HTTPException(status_code=500, detail=f"Discovery failed: {exc}")
 
     return JSONResponse(
         content={"url": request.url, "agent_card": card},

--- a/litellm/proxy/agent_endpoints/a2a_endpoints.py
+++ b/litellm/proxy/agent_endpoints/a2a_endpoints.py
@@ -441,7 +441,7 @@ async def _handle_stream_message(
                                     "message": getattr(
                                         proxy_exc,
                                         "message",
-                                        f"Streaming error: {proxy_exc!s}",
+                                        f"Streaming error: {proxy_exc}",
                                     ),
                                 },
                             }
@@ -491,7 +491,7 @@ async def _handle_stream_message(
                         "id": request_id,
                         "error": {
                             "code": -32603,
-                            "message": f"Streaming error: {e!s}",
+                            "message": f"Streaming error: {e}",
                         },
                     }
                 )
@@ -974,4 +974,4 @@ async def invoke_agent_a2a(
             )
         except Exception:
             pass
-        return _jsonrpc_error(body.get("id"), -32603, f"Internal error: {e!s}", 500)
+        return _jsonrpc_error(body.get("id"), -32603, f"Internal error: {e}", 500)

--- a/litellm/proxy/agent_endpoints/agent_registry.py
+++ b/litellm/proxy/agent_endpoints/agent_registry.py
@@ -271,7 +271,7 @@ class AgentRegistry:
                     created_agent_dict["object_permission"] = created_agent.object_permission.dict()
             return AgentResponse(**created_agent_dict)  # type: ignore
         except Exception as e:
-            raise Exception(f"Error adding agent to DB: {e!s}")
+            raise Exception(f"Error adding agent to DB: {e}")
 
     async def delete_agent_from_db(self, agent_id: str, prisma_client: PrismaClient) -> Mapping[str, object]:
         """
@@ -281,7 +281,7 @@ class AgentRegistry:
             deleted_agent = await agents_table(prisma_client).delete(where={"agent_id": agent_id})
             return dict(deleted_agent)
         except Exception as e:
-            raise Exception(f"Error deleting agent from DB: {e!s}")
+            raise Exception(f"Error deleting agent from DB: {e}")
 
     async def patch_agent_in_db(
         self,
@@ -363,7 +363,7 @@ class AgentRegistry:
                     patched_agent_dict["object_permission"] = patched_agent.object_permission.dict()
             return AgentResponse(**patched_agent_dict)  # type: ignore
         except Exception as e:
-            raise Exception(f"Error patching agent in DB: {e!s}")
+            raise Exception(f"Error patching agent in DB: {e}")
 
     async def update_agent_in_db(
         self,
@@ -450,7 +450,7 @@ class AgentRegistry:
                     updated_agent_dict["object_permission"] = updated_agent.object_permission.dict()
             return AgentResponse(**updated_agent_dict)  # type: ignore
         except Exception as e:
-            raise Exception(f"Error updating agent in DB: {e!s}")
+            raise Exception(f"Error updating agent in DB: {e}")
 
     @staticmethod
     async def get_all_agents_from_db(
@@ -478,7 +478,7 @@ class AgentRegistry:
 
             return agents
         except Exception as e:
-            raise Exception(f"Error getting agents from DB: {e!s}")
+            raise Exception(f"Error getting agents from DB: {e}")
 
     def get_agent_by_id(
         self,
@@ -494,7 +494,7 @@ class AgentRegistry:
 
             return None
         except Exception as e:
-            raise Exception(f"Error getting agent from DB: {e!s}")
+            raise Exception(f"Error getting agent from DB: {e}")
 
     def get_agent_by_name(self, agent_name: str) -> AgentResponse | None:
         """
@@ -507,7 +507,7 @@ class AgentRegistry:
 
             return None
         except Exception as e:
-            raise Exception(f"Error getting agent from DB: {e!s}")
+            raise Exception(f"Error getting agent from DB: {e}")
 
 
 global_agent_registry = AgentRegistry()

--- a/litellm/proxy/agent_endpoints/auth/agent_permission_handler.py
+++ b/litellm/proxy/agent_endpoints/auth/agent_permission_handler.py
@@ -59,7 +59,7 @@ class AgentRequestHandler:
 
             return list(set(allowed_agents))
         except Exception as e:
-            verbose_logger.warning(f"Failed to get allowed agents: {e!s}")
+            verbose_logger.warning(f"Failed to get allowed agents: {e}")
             return []
 
     @staticmethod
@@ -179,7 +179,7 @@ class AgentRequestHandler:
 
             return list(set(all_agents))
         except Exception as e:
-            verbose_logger.warning(f"Failed to get allowed agents for key: {e!s}")
+            verbose_logger.warning(f"Failed to get allowed agents for key: {e}")
             return []
 
     @staticmethod
@@ -255,7 +255,7 @@ class AgentRequestHandler:
             # litellm-dashboard is the default UI team and will never have agents;
             # skip noisy warnings for it.
             if user_api_key_auth.team_id != UI_TEAM_ID:
-                verbose_logger.warning(f"Failed to get allowed agents for team: {e!s}")
+                verbose_logger.warning(f"Failed to get allowed agents for team: {e}")
             return []
 
     @staticmethod
@@ -310,7 +310,7 @@ class AgentRequestHandler:
 
             return list(agent_ids)
         except Exception as e:
-            verbose_logger.warning(f"Failed to get agents from access groups: {e!s}")
+            verbose_logger.warning(f"Failed to get agents from access groups: {e}")
             return []
 
     @staticmethod
@@ -369,7 +369,7 @@ class AgentRequestHandler:
 
             return key_object_permission.agent_access_groups or []
         except Exception as e:
-            verbose_logger.warning(f"Failed to get agent access groups for key: {e!s}")
+            verbose_logger.warning(f"Failed to get agent access groups for key: {e}")
             return []
 
     @staticmethod
@@ -412,5 +412,5 @@ class AgentRequestHandler:
 
             return object_permissions.agent_access_groups or []
         except Exception as e:
-            verbose_logger.warning(f"Failed to get agent access groups for team: {e!s}")
+            verbose_logger.warning(f"Failed to get agent access groups for team: {e}")
             return []

--- a/litellm/proxy/agent_endpoints/endpoints.py
+++ b/litellm/proxy/agent_endpoints/endpoints.py
@@ -316,8 +316,8 @@ async def get_agents(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.agent_endpoints.get_agents(): Exception occurred - {e!s}")
-        raise HTTPException(status_code=500, detail={"error": f"Internal server error: {e!s}"})
+        verbose_proxy_logger.exception(f"litellm.proxy.agent_endpoints.get_agents(): Exception occurred - {e}")
+        raise HTTPException(status_code=500, detail={"error": f"Internal server error: {e}"})
 
 
 #### CRUD ENDPOINTS FOR AGENTS ####

--- a/litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py
+++ b/litellm/proxy/anthropic_endpoints/claude_code_endpoints/claude_code_marketplace.py
@@ -121,7 +121,7 @@ async def get_marketplace():
         verbose_proxy_logger.exception(f"Error generating marketplace: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to generate marketplace: {e!s}"},
+            detail={"error": f"Failed to generate marketplace: {e}"},
         )
 
 
@@ -304,7 +304,7 @@ async def register_plugin(
         verbose_proxy_logger.exception(f"Error registering plugin: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Registration failed: {e!s}"},
+            detail={"error": f"Registration failed: {e}"},
         )
 
 

--- a/litellm/proxy/anthropic_endpoints/endpoints.py
+++ b/litellm/proxy/anthropic_endpoints/endpoints.py
@@ -142,7 +142,7 @@ async def anthropic_response(
         _usage = _blocked_response_usage(e.original_response)
 
         _anthropic_response = AnthropicMessagesResponse(
-            id=f"msg_{uuid.uuid4()!s}",
+            id=f"msg_{uuid.uuid4()}",
             type="message",
             role="assistant",
             content=[{"type": "text", "text": e.message}],
@@ -189,7 +189,7 @@ async def anthropic_response(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.anthropic_response(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.anthropic_response(): Exception occured - {e}")
 
         # Extract model_id from request metadata (same as success path)
         litellm_metadata = data.get("litellm_metadata", {}) or {}
@@ -209,7 +209,7 @@ async def anthropic_response(
             litellm_logging_obj=None,
         )
 
-        error_msg = f"{e!s}"
+        error_msg = f"{e}"
         raise ProxyException(
             message=getattr(e, "message", error_msg),
             type=getattr(e, "type", "None"),
@@ -301,8 +301,8 @@ async def count_tokens(
             detail=detail,
         )
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.anthropic_endpoints.count_tokens(): Exception occurred - {e!s}")
-        raise HTTPException(status_code=500, detail={"error": f"Internal server error: {e!s}"})
+        verbose_proxy_logger.exception(f"litellm.proxy.anthropic_endpoints.count_tokens(): Exception occurred - {e}")
+        raise HTTPException(status_code=500, detail={"error": f"Internal server error: {e}"})
 
 
 @router.post(

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -246,7 +246,7 @@ def _is_model_cost_zero(model: str | list[str] | None, llm_router: Router | None
 
         except Exception as e:
             # If we can't determine the cost, assume it has cost (conservative approach)
-            verbose_proxy_logger.debug(f"Error checking cost for model {model_name}: {e!s}, assuming it has cost")
+            verbose_proxy_logger.debug(f"Error checking cost for model {model_name}: {e}, assuming it has cost")
             return False
 
     # All models checked have zero cost
@@ -973,7 +973,7 @@ async def get_default_end_user_budget(
         return _budget_obj
 
     except Exception as e:
-        verbose_proxy_logger.error(f"Error fetching default end user budget: {e!s}")
+        verbose_proxy_logger.error(f"Error fetching default end user budget: {e}")
         return None
 
 
@@ -2238,7 +2238,7 @@ async def get_team_object_by_alias(
         verbose_proxy_logger.exception("Error looking up team by alias: %s", team_alias)
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Error looking up team by alias '{team_alias}': {e!s}"},
+            detail={"error": f"Error looking up team by alias '{team_alias}': {e}"},
         )
 
 
@@ -2324,7 +2324,7 @@ async def get_org_object_by_alias(
         verbose_proxy_logger.exception("Error looking up organization by alias: %s", org_alias)
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Error looking up organization by alias '{org_alias}': {e!s}"},
+            detail={"error": f"Error looking up organization by alias '{org_alias}': {e}"},
         )
 
 

--- a/litellm/proxy/auth/auth_exception_handler.py
+++ b/litellm/proxy/auth/auth_exception_handler.py
@@ -95,7 +95,7 @@ class UserAPIKeyAuthExceptionHandler:
                 use_x_forwarded_for=general_settings.get("use_x_forwarded_for", False),
             )
             verbose_proxy_logger.exception(
-                f"litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - {e!s}\nRequester IP Address:{requester_ip}",
+                f"litellm.proxy.proxy_server.user_api_key_auth(): Exception occured - {e}\nRequester IP Address:{requester_ip}",
                 extra={"requester_ip": requester_ip},
             )
 
@@ -150,7 +150,7 @@ class UserAPIKeyAuthExceptionHandler:
                 )
             if isinstance(e, HTTPException):
                 raise ProxyException(
-                    message=getattr(e, "detail", f"Authentication Error({e!s})"),
+                    message=getattr(e, "detail", f"Authentication Error({e})"),
                     type=ProxyErrorTypes.auth_error,
                     param=getattr(e, "param", "None"),
                     code=getattr(e, "status_code", status.HTTP_401_UNAUTHORIZED),

--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -582,7 +582,7 @@ def route_in_additonal_public_routes(current_route: str):
 
         return False
     except Exception as e:
-        verbose_proxy_logger.error(f"route_in_additonal_public_routes: {e!s}")
+        verbose_proxy_logger.error(f"route_in_additonal_public_routes: {e}")
         return False
 
 
@@ -619,7 +619,7 @@ def get_request_route(request: Request) -> str:
         return raw_path
     except Exception as e:
         verbose_proxy_logger.debug(
-            f"error on get_request_route: {e!s}, defaulting to request.url.path={request.url.path}"
+            f"error on get_request_route: {e}, defaulting to request.url.path={request.url.path}"
         )
         return str(request.url.path)
 
@@ -639,7 +639,7 @@ def get_request_route_template(request: Request) -> str | None:
         template = getattr(route, "path", None)
         return template if isinstance(template, str) and template else None
     except Exception as e:
-        verbose_proxy_logger.debug(f"error on get_request_route_template: {e!s}")
+        verbose_proxy_logger.debug(f"error on get_request_route_template: {e}")
         return None
 
 

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -777,8 +777,8 @@ class JWTHandler:
             return userinfo
 
         except Exception as e:
-            verbose_proxy_logger.error(f"Error fetching OIDC UserInfo: {e!s}")
-            raise Exception(f"Failed to fetch OIDC UserInfo: {e!s}")
+            verbose_proxy_logger.error(f"Error fetching OIDC UserInfo: {e}")
+            raise Exception(f"Failed to fetch OIDC UserInfo: {e}")
 
     _unscoped_jwt_warning_emitted = False
 
@@ -987,7 +987,7 @@ class JWTHandler:
                 code=status.HTTP_401_UNAUTHORIZED,
             )
         except Exception as e:
-            raise Exception(f"Validation fails: {e!s}")
+            raise Exception(f"Validation fails: {e}")
 
         return self._apply_issuer_claim_mappings(
             token=payload,
@@ -1032,7 +1032,7 @@ class JWTHandler:
                     code=status.HTTP_401_UNAUTHORIZED,
                 )
             except Exception as e:
-                raise Exception(f"Validation fails: {e!s}")
+                raise Exception(f"Validation fails: {e}")
 
         raise Exception("Invalid JWT Submitted")
 

--- a/litellm/proxy/auth/litellm_license.py
+++ b/litellm/proxy/auth/litellm_license.py
@@ -48,7 +48,7 @@ class LicenseCheck:
             else:
                 self.public_key = None
         except Exception as e:
-            verbose_proxy_logger.error(f"Error reading public key: {e!s}")
+            verbose_proxy_logger.error(f"Error reading public key: {e}")
 
     def _verify(self, license_str: str) -> bool:
         verbose_proxy_logger.debug(
@@ -84,7 +84,7 @@ class LicenseCheck:
             return premium
         except Exception as e:
             verbose_proxy_logger.exception(
-                f"litellm.proxy.auth.litellm_license.py::_verify - Unable to verify License={license_str} via api. - {e!s}"
+                f"litellm.proxy.auth.litellm_license.py::_verify - Unable to verify License={license_str} via api. - {e}"
             )
             return False
 
@@ -187,6 +187,6 @@ class LicenseCheck:
 
         except Exception as e:
             verbose_proxy_logger.debug(
-                f"litellm.proxy.auth.litellm_license.py::verify_license_without_api_request - Unable to verify License locally. - {e!s}"
+                f"litellm.proxy.auth.litellm_license.py::verify_license_without_api_request - Unable to verify License locally. - {e}"
             )
             return False

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1481,7 +1481,7 @@ async def _user_api_key_auth_builder(
             except Exception as e:
                 if isinstance(e, litellm.BudgetExceededError):
                     raise e
-                verbose_proxy_logger.debug(f"Unable to find user in db. Error - {e!s}")
+                verbose_proxy_logger.debug(f"Unable to find user in db. Error - {e}")
 
         ### CHECK IF ADMIN ###
         # note: never string compare api keys, this is vulenerable to a time attack. Use secrets.compare_digest instead
@@ -1729,7 +1729,7 @@ async def _user_api_key_auth_builder(
                         )
                 except Exception as e:
                     verbose_logger.debug(
-                        f"litellm.proxy.auth.user_api_key_auth.py::user_api_key_auth() - Unable to get user from db/cache. Setting user_obj to None. Exception received - {e!s}"
+                        f"litellm.proxy.auth.user_api_key_auth.py::user_api_key_auth() - Unable to get user from db/cache. Setting user_obj to None. Exception received - {e}"
                     )
                     user_obj = None
 
@@ -2754,7 +2754,7 @@ async def _lookup_end_user_and_apply_budget(
     except Exception as e:
         if isinstance(e, litellm.BudgetExceededError):
             raise e
-        verbose_proxy_logger.debug(f"Unable to find user in db. Error - {e!s}")
+        verbose_proxy_logger.debug(f"Unable to find user in db. Error - {e}")
     return valid_token, end_user_object
 
 

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -340,7 +340,7 @@ async def create_batch(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.create_batch(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.create_batch(): Exception occured - {e}")
         raise handle_exception_on_proxy(e)
 
 
@@ -592,7 +592,7 @@ async def retrieve_batch(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.retrieve_batch(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.retrieve_batch(): Exception occured - {e}")
         raise handle_exception_on_proxy(e)
 
 
@@ -773,7 +773,7 @@ async def list_batches(
             original_exception=e,
             request_data={"after": after, "limit": limit},
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.retrieve_batch(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.retrieve_batch(): Exception occured - {e}")
         raise handle_exception_on_proxy(e)
 
 
@@ -982,7 +982,7 @@ async def cancel_batch(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.create_batch(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.create_batch(): Exception occured - {e}")
         raise handle_exception_on_proxy(e)
 
 

--- a/litellm/proxy/caching_routes.py
+++ b/litellm/proxy/caching_routes.py
@@ -43,7 +43,7 @@ def _extract_cache_params() -> dict[str, Any]:
         cleaned_params = HealthCheckCacheParams(**cache_params).model_dump() if cache_params else {}
         return masker.mask_dict(cleaned_params)
     except (AttributeError, TypeError) as e:
-        verbose_proxy_logger.debug(f"Error extracting cache params: {e!s}")
+        verbose_proxy_logger.debug(f"Error extracting cache params: {e}")
         return {}
 
 
@@ -158,7 +158,7 @@ async def cache_delete(request: Request):
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Cache Delete Failed({e!s})",
+            detail=f"Cache Delete Failed({e})",
         )
 
 
@@ -173,7 +173,7 @@ def _get_redis_client_info(cache_instance) -> tuple[list, int]:
         client_list = cache_instance.client_list()
         return client_list, len(client_list)
     except Exception as e:
-        verbose_proxy_logger.warning(f"CLIENT LIST command failed (likely restricted on managed Redis): {e!s}")
+        verbose_proxy_logger.warning(f"CLIENT LIST command failed (likely restricted on managed Redis): {e}")
         return ["CLIENT LIST command not available on this Redis instance"], -1
 
 
@@ -209,7 +209,7 @@ async def cache_redis_info():
     except Exception as e:
         raise HTTPException(
             status_code=503,
-            detail=f"Service Unhealthy ({e!s})",
+            detail=f"Service Unhealthy ({e})",
         )
 
 
@@ -245,5 +245,5 @@ async def cache_flushall():
     except Exception as e:
         raise HTTPException(
             status_code=503,
-            detail=f"Service Unhealthy ({e!s})",
+            detail=f"Service Unhealthy ({e})",
         )

--- a/litellm/proxy/client/cli/commands/chat.py
+++ b/litellm/proxy/client/cli/commands/chat.py
@@ -386,5 +386,5 @@ def _stream_response(
             console.print(f"[red]{e.response.text}[/red]")
         return None
     except Exception as e:
-        console.print(f"\n[red]Error: {e!s}[/red]")
+        console.print(f"\n[red]Error: {e}[/red]")
         return None

--- a/litellm/proxy/client/cli/commands/credentials.py
+++ b/litellm/proxy/client/cli/commands/credentials.py
@@ -71,7 +71,7 @@ def create(ctx: click.Context, credential_name: str, info: str, values: str):
         credential_info = json.loads(info)
         credential_values = json.loads(values)
     except json.JSONDecodeError as e:
-        raise click.BadParameter(f"Invalid JSON: {e!s}")
+        raise click.BadParameter(f"Invalid JSON: {e}")
 
     try:
         response = client.create(credential_name, credential_info, credential_values)

--- a/litellm/proxy/client/cli/commands/keys.py
+++ b/litellm/proxy/client/cli/commands/keys.py
@@ -122,7 +122,7 @@ def generate(
         aliases_dict = json.loads(aliases) if aliases else None
         config_dict = json.loads(config) if config else None
     except json.JSONDecodeError as e:
-        raise click.BadParameter(f"Invalid JSON: {e!s}")
+        raise click.BadParameter(f"Invalid JSON: {e}")
     try:
         response = client.generate(
             models=models_list,
@@ -316,7 +316,7 @@ def _import_keys_to_destination(
         except Exception as e:
             failed_count += 1
             key_alias = key.get("key_alias", "N/A")
-            click.echo(f"Failed to import key {key_alias}: {e!s}", err=True)
+            click.echo(f"Failed to import key {key_alias}: {e}", err=True)
 
     return imported_count, failed_count
 
@@ -389,5 +389,5 @@ def import_keys(
             click.echo(e.response.text, err=True)
         raise click.Abort()
     except Exception as e:
-        click.echo(f"Error: {e!s}", err=True)
+        click.echo(f"Error: {e}", err=True)
         raise click.Abort()

--- a/litellm/proxy/client/cli/commands/teams.py
+++ b/litellm/proxy/client/cli/commands/teams.py
@@ -76,7 +76,7 @@ def list(ctx: click.Context):
         click.echo(f"Details: {error_body.get('detail', 'Unknown error')}", err=True)
         raise click.Abort()
     except Exception as e:
-        click.echo(f"Error: {e!s}", err=True)
+        click.echo(f"Error: {e}", err=True)
         raise click.Abort()
 
 
@@ -99,7 +99,7 @@ def available(ctx: click.Context):
         error_body = e.response.json()
         click.echo(f"Details: {error_body.get('detail', 'Unknown error')}", err=True)
     except Exception as e:
-        click.echo(f"Error: {e!s}", err=True)
+        click.echo(f"Error: {e}", err=True)
         raise click.Abort()
 
 
@@ -158,5 +158,5 @@ def assign_key(ctx: click.Context, team_id: str | None):
         click.echo(f"Details: {error_body.get('detail', 'Unknown error')}", err=True)
         raise click.Abort()
     except Exception as e:
-        click.echo(f"Error: {e!s}", err=True)
+        click.echo(f"Error: {e}", err=True)
         raise click.Abort()

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -908,7 +908,7 @@ def _log_llm_api_exception(e: Exception) -> None:
             "litellm.proxy.proxy_server._handle_llm_api_exception(): client disconnected, upstream LLM request cancelled"
         )
         return
-    verbose_proxy_logger.exception(f"litellm.proxy.proxy_server._handle_llm_api_exception(): Exception occured - {e!s}")
+    verbose_proxy_logger.exception(f"litellm.proxy.proxy_server._handle_llm_api_exception(): Exception occured - {e}")
 
 
 async def _cancel_llm_call_on_client_disconnect(
@@ -2696,7 +2696,7 @@ class ProxyBaseLLMRequestProcessing:
                 status_code=http_status_error.response.status_code,
                 detail={"error": error_text},
             )
-        error_msg = f"{e!s}"
+        error_msg = f"{e}"
         # Check for AttributeError in the exception chain.
         # The AttributeError may be wrapped in multiple layers
         # (e.g. AttributeError -> OpenAIException -> APIConnectionError),
@@ -2898,7 +2898,7 @@ class ProxyBaseLLMRequestProcessing:
             raise
         except Exception as e:
             verbose_proxy_logger.exception(
-                f"litellm.proxy.proxy_server.async_data_generator(): Exception occured - {e!s}"
+                f"litellm.proxy.proxy_server.async_data_generator(): Exception occured - {e}"
             )
             transformed_exception = await proxy_logging_obj.post_call_failure_hook(
                 user_api_key_dict=user_api_key_dict,
@@ -2914,7 +2914,7 @@ class ProxyBaseLLMRequestProcessing:
             if isinstance(e, HTTPException):
                 raise e
             error_traceback = _redact_string(traceback.format_exc())
-            error_msg = f"{e!s}\n\n{error_traceback}"
+            error_msg = f"{e}\n\n{error_traceback}"
             proxy_exception = ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),

--- a/litellm/proxy/common_utils/custom_openapi_spec.py
+++ b/litellm/proxy/common_utils/custom_openapi_spec.py
@@ -273,7 +273,7 @@ class CustomOpenAPISpec:
 
         except Exception as e:
             # If schema addition fails, continue without it
-            verbose_proxy_logger.debug(f"Failed to add {operation_name} request schema: {e!s}")
+            verbose_proxy_logger.debug(f"Failed to add {operation_name} request schema: {e}")
 
         return openapi_schema
 
@@ -302,7 +302,7 @@ class CustomOpenAPISpec:
                 operation_name="chat completion",
             )
         except ImportError as e:
-            verbose_proxy_logger.debug(f"Failed to import ProxyChatCompletionRequest: {e!s}")
+            verbose_proxy_logger.debug(f"Failed to import ProxyChatCompletionRequest: {e}")
             return openapi_schema
 
     @staticmethod
@@ -328,7 +328,7 @@ class CustomOpenAPISpec:
                 operation_name="embedding",
             )
         except ImportError as e:
-            verbose_proxy_logger.debug(f"Failed to import EmbeddingRequest: {e!s}")
+            verbose_proxy_logger.debug(f"Failed to import EmbeddingRequest: {e}")
             return openapi_schema
 
     @staticmethod
@@ -356,7 +356,7 @@ class CustomOpenAPISpec:
                 operation_name="responses API",
             )
         except ImportError as e:
-            verbose_proxy_logger.debug(f"Failed to import ResponsesAPIRequestParams: {e!s}")
+            verbose_proxy_logger.debug(f"Failed to import ResponsesAPIRequestParams: {e}")
             return openapi_schema
 
     @staticmethod

--- a/litellm/proxy/common_utils/debug_utils.py
+++ b/litellm/proxy/common_utils/debug_utils.py
@@ -653,7 +653,7 @@ async def configure_gc_thresholds_endpoint(
         )
     except Exception as e:
         verbose_proxy_logger.error(f"Failed to set GC thresholds: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to set GC thresholds: {e!s}")
+        raise HTTPException(status_code=500, detail=f"Failed to set GC thresholds: {e}")
 
     # Get current object count to show immediate impact
     current_count = gc.get_count()[0]
@@ -783,4 +783,4 @@ def init_verbose_loggers():
     except Exception as e:
         import logging
 
-        logging.warning(f"Failed to init verbose loggers: {e!s}")
+        logging.warning(f"Failed to init verbose loggers: {e}")

--- a/litellm/proxy/common_utils/encrypt_decrypt_utils.py
+++ b/litellm/proxy/common_utils/encrypt_decrypt_utils.py
@@ -145,7 +145,7 @@ def decrypt_value_helper(
         # if it's not str - do not decrypt it, return the value
         return value
     except Exception as e:
-        error_message = f"Error decrypting value for key: {key}, Did your master_key/salt key change recently? \nError: {e!s}\nSet permanent salt key - https://docs.litellm.ai/docs/proxy/prod#5-set-litellm-salt-key"
+        error_message = f"Error decrypting value for key: {key}, Did your master_key/salt key change recently? \nError: {e}\nSet permanent salt key - https://docs.litellm.ai/docs/proxy/prod#5-set-litellm-salt-key"
         if exception_type == "debug":
             verbose_proxy_logger.debug(error_message)
             return value if return_original_value else None

--- a/litellm/proxy/common_utils/http_parsing_utils.py
+++ b/litellm/proxy/common_utils/http_parsing_utils.py
@@ -98,9 +98,9 @@ async def _read_request_body(request: Request | None) -> dict:
                     # Above the configured size, skip the repair and raise the 400 now.
                     repair_limit_bytes = MAX_REQUEST_BODY_SIZE_TO_REPAIR_MB * 1024 * 1024
                     if repair_limit_bytes > 0 and len(body) > repair_limit_bytes:
-                        verbose_proxy_logger.error(f"Invalid JSON payload received: {e!s}")
+                        verbose_proxy_logger.error(f"Invalid JSON payload received: {e}")
                         raise ProxyException(
-                            message=f"Invalid JSON payload: {e!s}",
+                            message=f"Invalid JSON payload: {e}",
                             type="invalid_request_error",
                             param="request_body",
                             code=status.HTTP_400_BAD_REQUEST,
@@ -120,9 +120,9 @@ async def _read_request_body(request: Request | None) -> dict:
                         parsed_body = json.loads(body_str)
                     except json.JSONDecodeError:
                         # If both orjson and json.loads fail, throw a proper error
-                        verbose_proxy_logger.error(f"Invalid JSON payload received: {e!s}")
+                        verbose_proxy_logger.error(f"Invalid JSON payload received: {e}")
                         raise ProxyException(
-                            message=f"Invalid JSON payload: {e!s}",
+                            message=f"Invalid JSON payload: {e}",
                             type="invalid_request_error",
                             param="request_body",
                             code=status.HTTP_400_BAD_REQUEST,
@@ -134,7 +134,7 @@ async def _read_request_body(request: Request | None) -> dict:
 
     except (json.JSONDecodeError, orjson.JSONDecodeError, ProxyException) as e:
         # Re-raise ProxyException as-is
-        verbose_proxy_logger.error(f"Invalid JSON payload received: {e!s}")
+        verbose_proxy_logger.error(f"Invalid JSON payload received: {e}")
         raise
     except Exception as e:
         # Catch unexpected errors to avoid crashes
@@ -426,7 +426,7 @@ def extract_nested_form_metadata(form_data: dict[str, Any], prefix: str = "litel
                     verbose_proxy_logger.warning(f"Cannot set value - parent is not a dict for key: {key}")
 
         except Exception as e:
-            verbose_proxy_logger.error(f"Error parsing metadata key '{key}': {e!s}")
+            verbose_proxy_logger.error(f"Error parsing metadata key '{key}': {e}")
             continue
 
     return metadata

--- a/litellm/proxy/common_utils/load_config_utils.py
+++ b/litellm/proxy/common_utils/load_config_utils.py
@@ -34,9 +34,9 @@ def get_file_contents_from_s3(bucket_name, object_key):
 
     except ImportError as e:
         # this is most likely if a user is not using the litellm docker container
-        verbose_proxy_logger.error(f"ImportError: {e!s}")
+        verbose_proxy_logger.error(f"ImportError: {e}")
     except Exception as e:
-        verbose_proxy_logger.error(f"Error retrieving file contents: {e!s}")
+        verbose_proxy_logger.error(f"Error retrieving file contents: {e}")
         return None
 
 
@@ -57,7 +57,7 @@ async def get_config_file_contents_from_gcs(bucket_name, object_key):
         return config
 
     except Exception as e:
-        verbose_proxy_logger.error(f"Error retrieving file contents: {e!s}")
+        verbose_proxy_logger.error(f"Error retrieving file contents: {e}")
         return None
 
 
@@ -111,10 +111,10 @@ def download_python_file_from_s3(
         return True
 
     except ImportError as e:
-        verbose_proxy_logger.error(f"ImportError: {e!s}")
+        verbose_proxy_logger.error(f"ImportError: {e}")
         return False
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error downloading Python file: {e!s}")
+        verbose_proxy_logger.exception(f"Error downloading Python file: {e}")
         return False
 
 
@@ -158,7 +158,7 @@ async def download_python_file_from_gcs(
         return True
 
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error downloading Python file from GCS: {e!s}")
+        verbose_proxy_logger.exception(f"Error downloading Python file from GCS: {e}")
         return False
 
 

--- a/litellm/proxy/db/db_transaction_queue/spend_log_cleanup.py
+++ b/litellm/proxy/db/db_transaction_queue/spend_log_cleanup.py
@@ -68,7 +68,7 @@ class SpendLogCleanup:
             return True
         except ValueError as e:
             verbose_proxy_logger.warning(
-                f"Invalid maximum_spend_logs_retention_period value: {retention_setting}, error: {e!s}"
+                f"Invalid maximum_spend_logs_retention_period value: {retention_setting}, error: {e}"
             )
             return False
 

--- a/litellm/proxy/fine_tuning_endpoints/endpoints.py
+++ b/litellm/proxy/fine_tuning_endpoints/endpoints.py
@@ -199,9 +199,7 @@ async def create_fine_tuning_job(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(
-            f"litellm.proxy.proxy_server.create_fine_tuning_job(): Exception occurred - {e!s}"
-        )
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.create_fine_tuning_job(): Exception occurred - {e}")
         raise handle_exception_on_proxy(e)
 
 
@@ -340,7 +338,7 @@ async def retrieve_fine_tuning_job(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
         verbose_proxy_logger.exception(
-            f"litellm.proxy.proxy_server.retrieve_fine_tuning_job(): Exception occurred - {e!s}"
+            f"litellm.proxy.proxy_server.retrieve_fine_tuning_job(): Exception occurred - {e}"
         )
         raise handle_exception_on_proxy(e)
 
@@ -468,9 +466,7 @@ async def list_fine_tuning_jobs(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(
-            f"litellm.proxy.proxy_server.list_fine_tuning_jobs(): Exception occurred - {e!s}"
-        )
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.list_fine_tuning_jobs(): Exception occurred - {e}")
         raise handle_exception_on_proxy(e)
 
 
@@ -608,7 +604,5 @@ async def cancel_fine_tuning_job(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(
-            f"litellm.proxy.proxy_server.cancel_fine_tuning_job(): Exception occurred - {e!s}"
-        )
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.cancel_fine_tuning_job(): Exception occurred - {e}")
         raise handle_exception_on_proxy(e)

--- a/litellm/proxy/guardrails/guardrail_endpoints.py
+++ b/litellm/proxy/guardrails/guardrail_endpoints.py
@@ -1420,7 +1420,7 @@ async def get_category_yaml(category_name: str):
             "file_type": file_type,
         }
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error reading category file: {e!s}")
+        raise HTTPException(status_code=500, detail=f"Error reading category file: {e}")
 
 
 @router.get(
@@ -1452,7 +1452,7 @@ async def get_major_airlines():
             airlines = json.load(f)
         return {"airlines": airlines}
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error reading major_airlines.json: {e!s}") from e
+        raise HTTPException(status_code=500, detail=f"Error reading major_airlines.json: {e}") from e
 
 
 @router.post(
@@ -1540,10 +1540,10 @@ async def validate_blocked_words_file(request: dict[str, str]):
             "message": f"Valid YAML file with {len(blocked_words_list)} blocked word(s)",
         }
     except yaml.YAMLError as e:
-        return {"valid": False, "error": f"Invalid YAML syntax: {e!s}"}
+        return {"valid": False, "error": f"Invalid YAML syntax: {e}"}
     except Exception as e:
         verbose_proxy_logger.exception("Error validating blocked words file")
-        return {"valid": False, "error": f"Validation error: {e!s}"}
+        return {"valid": False, "error": f"Validation error: {e}"}
 
 
 def _get_field_type_from_annotation(field_annotation: Any) -> str:

--- a/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/bedrock_guardrails.py
@@ -2266,4 +2266,4 @@ class BedrockGuardrail(CustomGuardrail, BaseAWSLLM):
             raise
         except Exception as e:
             verbose_proxy_logger.error("Bedrock Guardrail: Failed to apply guardrail: %s", str(e))
-            raise Exception(f"Bedrock guardrail failed: {e!s}")
+            raise Exception(f"Bedrock guardrail failed: {e}")

--- a/litellm/proxy/guardrails/guardrail_hooks/custom_code/primitives.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/custom_code/primitives.py
@@ -480,10 +480,10 @@ async def http_request(
         return _http_success_response(e.response)
     except httpx.RequestError as e:
         verbose_proxy_logger.warning(f"Custom code http_request error: {e}")
-        return _http_error_response(f"Request failed: {e!s}")
+        return _http_error_response(f"Request failed: {e}")
     except Exception as e:
         verbose_proxy_logger.warning(f"Custom code http_request unexpected error: {e}")
-        return _http_error_response(f"Unexpected error: {e!s}")
+        return _http_error_response(f"Unexpected error: {e}")
 
 
 async def _execute_http_request(

--- a/litellm/proxy/guardrails/guardrail_hooks/deepkeep/deepkeep.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/deepkeep/deepkeep.py
@@ -228,7 +228,7 @@ class DeepKeepGuardrail(CustomGuardrail):
                 **({"http_status_code": http_status_code} if http_status_code else {}),
             )
         verbose_proxy_logger.error("DeepKeep guardrail API error: %s", str(error))
-        raise DeepKeepGuardrailAPIError(f"DeepKeep guardrail API failed: {error!s}")
+        raise DeepKeepGuardrailAPIError(f"DeepKeep guardrail API failed: {error}")
 
     @staticmethod
     def _build_return_inputs(

--- a/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
@@ -357,7 +357,7 @@ class GenericGuardrailAPI(CustomGuardrail):
                 **({"http_status_code": http_status_code} if http_status_code else {}),
             )
         verbose_proxy_logger.error("Generic Guardrail API: failed to make request: %s", str(error))
-        raise Exception(f"Generic Guardrail API failed: {error!s}")
+        raise Exception(f"Generic Guardrail API failed: {error}")
 
     @log_guardrail_information
     async def apply_guardrail(

--- a/litellm/proxy/guardrails/guardrail_hooks/lasso/lasso.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/lasso/lasso.py
@@ -299,8 +299,8 @@ class LassoGuardrail(CustomGuardrail):
                     except Exception as e:
                         if isinstance(e, HTTPException):
                             raise e
-                        verbose_proxy_logger.error(f"Error in post-call Lasso masking: {e!s}")
-                        raise LassoGuardrailAPIError(f"Failed to apply post-call masking: {e!s}")
+                        verbose_proxy_logger.error(f"Error in post-call Lasso masking: {e}")
+                        raise LassoGuardrailAPIError(f"Failed to apply post-call masking: {e}")
                 else:
                     # Use the same data for conversation_id consistency (no cache access needed)
                     await self._run_lasso_guardrail(response_data, cache=global_cache, message_type="COMPLETION")
@@ -599,7 +599,7 @@ class LassoGuardrail(CustomGuardrail):
 
         # Log error with context
         verbose_proxy_logger.error(
-            f"Error calling Lasso API: {error!s}",
+            f"Error calling Lasso API: {error}",
             extra={
                 "guardrail_name": getattr(self, "guardrail_name", "unknown"),
                 "message_type": message_type,
@@ -620,7 +620,7 @@ class LassoGuardrail(CustomGuardrail):
                     raise LassoGuardrailAPIError(f"API error: {error.response.status_code}")
 
         # Generic error handling
-        raise LassoGuardrailAPIError(f"Failed to verify request safety with Lasso API: {error!s}")
+        raise LassoGuardrailAPIError(f"Failed to verify request safety with Lasso API: {error}")
 
     def _log_masking_applied(
         self,

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -750,7 +750,7 @@ class ContentFilterGuardrail(CustomGuardrail):
         except FileNotFoundError:
             raise FileNotFoundError(f"Blocked words file not found: {file_path}")
         except Exception as e:
-            raise Exception(f"Error loading blocked words file {file_path}: {e!s}")
+            raise Exception(f"Error loading blocked words file {file_path}: {e}")
 
     def _find_pattern_spans(self, text: str, pattern_entry: dict[str, Any]) -> list[tuple[int, int]]:
         """Return all match spans for a pattern, applying contextual rules if required."""

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/patterns.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/patterns.py
@@ -168,7 +168,7 @@ def get_available_content_categories() -> list[dict[str, str]]:
                 # Skip files that can't be loaded but log the error for debugging
                 from litellm._logging import verbose_proxy_logger
 
-                verbose_proxy_logger.warning(f"Failed to load category file {filename}: {e!s}")
+                verbose_proxy_logger.warning(f"Failed to load category file {filename}: {e}")
                 continue
         elif filename.endswith(".json"):
             # JSON category files (e.g. harm_toxic_abuse.json) - no YAML header, use filename

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
@@ -163,7 +163,7 @@ class NomaGuardrail(CustomGuardrail):
         try:
             asyncio.create_task(coro)
         except Exception as e:
-            verbose_proxy_logger.error(f"Failed to create background Noma task: {e!s}")
+            verbose_proxy_logger.error(f"Failed to create background Noma task: {e}")
 
     async def _process_user_message_check(
         self,
@@ -348,7 +348,7 @@ class NomaGuardrail(CustomGuardrail):
             return "guardrail_failed_to_respond"
 
         except Exception as e:
-            verbose_proxy_logger.error(f"Error determining NOMA guardrail status: {e!s}")
+            verbose_proxy_logger.error(f"Error determining NOMA guardrail status: {e}")
             return "guardrail_failed_to_respond"
 
     def _should_only_sensitive_data_failed(self, classification_obj: dict) -> bool:
@@ -513,7 +513,7 @@ class NomaGuardrail(CustomGuardrail):
         try:
             await self._process_user_message_check(request_data, user_auth)
         except Exception as e:
-            verbose_proxy_logger.error(f"Noma background user message check failed: {e!s}")
+            verbose_proxy_logger.error(f"Noma background user message check failed: {e}")
 
     async def _check_llm_response_background(
         self,
@@ -525,7 +525,7 @@ class NomaGuardrail(CustomGuardrail):
         try:
             await self._process_llm_response_check(request_data, response, user_auth)
         except Exception as e:
-            verbose_proxy_logger.error(f"Noma background response check failed: {e!s}")
+            verbose_proxy_logger.error(f"Noma background response check failed: {e}")
 
     async def _handle_verdict_background(
         self,
@@ -547,7 +547,7 @@ class NomaGuardrail(CustomGuardrail):
                 msg = f"Noma guardrail allowed {type} message: {message}"
                 verbose_proxy_logger.info(msg)
         except Exception as e:
-            verbose_proxy_logger.error(f"Noma background verdict handling failed: {e!s}")
+            verbose_proxy_logger.error(f"Noma background verdict handling failed: {e}")
 
     async def async_pre_call_hook(
         self,
@@ -570,7 +570,7 @@ class NomaGuardrail(CustomGuardrail):
             try:
                 self._create_background_noma_check(self._check_user_message_background(data, user_api_key_dict))
             except Exception as e:
-                verbose_proxy_logger.error(f"Failed to start background Noma pre-call check: {e!s}")
+                verbose_proxy_logger.error(f"Failed to start background Noma pre-call check: {e}")
             return data
 
         try:
@@ -594,7 +594,7 @@ class NomaGuardrail(CustomGuardrail):
                 event_type=GuardrailEventHooks.pre_call,
             )
 
-            verbose_proxy_logger.error(f"Noma pre-call hook failed: {e!s}")
+            verbose_proxy_logger.error(f"Noma pre-call hook failed: {e}")
 
             if self.block_failures:
                 raise
@@ -618,7 +618,7 @@ class NomaGuardrail(CustomGuardrail):
             try:
                 self._create_background_noma_check(self._check_user_message_background(data, user_api_key_dict))
             except Exception as e:
-                verbose_proxy_logger.error(f"Failed to start background Noma moderation check: {e!s}")
+                verbose_proxy_logger.error(f"Failed to start background Noma moderation check: {e}")
             return data
 
         try:
@@ -642,7 +642,7 @@ class NomaGuardrail(CustomGuardrail):
                 event_type=GuardrailEventHooks.during_call,
             )
 
-            verbose_proxy_logger.error(f"Noma moderation hook failed: {e!s}")
+            verbose_proxy_logger.error(f"Noma moderation hook failed: {e}")
 
             if self.block_failures:
                 raise
@@ -665,7 +665,7 @@ class NomaGuardrail(CustomGuardrail):
                     self._check_llm_response_background(data, response, user_api_key_dict)
                 )
             except Exception as e:
-                verbose_proxy_logger.error(f"Failed to start background Noma post-call check: {e!s}")
+                verbose_proxy_logger.error(f"Failed to start background Noma post-call check: {e}")
             return response
 
         try:
@@ -689,7 +689,7 @@ class NomaGuardrail(CustomGuardrail):
                 event_type=GuardrailEventHooks.post_call,
             )
 
-            verbose_proxy_logger.error(f"Noma post-call hook failed: {e!s}")
+            verbose_proxy_logger.error(f"Noma post-call hook failed: {e}")
             if self.block_failures:
                 raise
             return response
@@ -828,7 +828,7 @@ class NomaGuardrail(CustomGuardrail):
             except Exception as e:
                 if self.block_failures:
                     raise
-                verbose_proxy_logger.error(f"Noma streaming post-call hook failed: {e!s}")
+                verbose_proxy_logger.error(f"Noma streaming post-call hook failed: {e}")
                 for chunk in all_chunks:
                     yield chunk
                 return

--- a/litellm/proxy/guardrails/guardrail_hooks/onyx/onyx.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/onyx/onyx.py
@@ -118,7 +118,7 @@ class OnyxGuardrail(CustomGuardrail):
                 payload = parsed.get("response", {})
             except Exception as e:
                 verbose_proxy_logger.error(
-                    f"Error in converting request_data to ModelResponse: {e!s}",
+                    f"Error in converting request_data to ModelResponse: {e}",
                     extra={
                         "conversation_id": conversation_id,
                         "input_type": input_type,
@@ -133,7 +133,7 @@ class OnyxGuardrail(CustomGuardrail):
             raise e
         except Exception as e:
             verbose_proxy_logger.error(
-                f"Error in apply_guardrail guard: {e!s}",
+                f"Error in apply_guardrail guard: {e}",
                 extra={"conversation_id": conversation_id, "input_type": input_type},
             )
             return inputs

--- a/litellm/proxy/guardrails/guardrail_hooks/ovalix/ovalix.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/ovalix/ovalix.py
@@ -250,7 +250,7 @@ class OvalixGuardrail(CustomGuardrail):
                 verbose_proxy_logger.exception("Ovalix apply_guardrail checkpoint call failed: %s", e)
                 raise GuardrailRaisedException(
                     guardrail_name=self.guardrail_name,
-                    message=f"Ovalix guardrail error: {e!s}",
+                    message=f"Ovalix guardrail error: {e}",
                     should_wrap_with_default_message=False,
                 ) from e
 

--- a/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
@@ -231,7 +231,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
 
             return " ".join(text_parts) if text_parts else ""
         except (AttributeError, IndexError) as e:
-            verbose_proxy_logger.error(f"PANW Prisma AIRS: Error extracting response text: {e!s}")
+            verbose_proxy_logger.error(f"PANW Prisma AIRS: Error extracting response text: {e}")
         return ""
 
     async def _call_panw_api(
@@ -433,7 +433,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
                 }
 
         except httpx.TimeoutException as e:
-            verbose_proxy_logger.error(f"PANW Prisma AIRS: Timeout error: {e!s}")
+            verbose_proxy_logger.error(f"PANW Prisma AIRS: Timeout error: {e}")
             return {
                 "action": "block",
                 "category": "timeout_error",
@@ -441,7 +441,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
             }
 
         except httpx.RequestError as e:
-            verbose_proxy_logger.error(f"PANW Prisma AIRS: Network/request error: {e!s}")
+            verbose_proxy_logger.error(f"PANW Prisma AIRS: Network/request error: {e}")
             return {
                 "action": "block",
                 "category": "network_error",
@@ -449,7 +449,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
             }
 
         except Exception as e:
-            verbose_proxy_logger.error(f"PANW Prisma AIRS: Unexpected error: {e!s}")
+            verbose_proxy_logger.error(f"PANW Prisma AIRS: Unexpected error: {e}")
             return {"action": "block", "category": "api_error", "_is_transient": True}
 
     @staticmethod
@@ -1056,7 +1056,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
         except HTTPException:
             raise
         except Exception as e:
-            verbose_proxy_logger.error(f"PANW Prisma AIRS scan failed: {e!s}")
+            verbose_proxy_logger.error(f"PANW Prisma AIRS scan failed: {e}")
             raise HTTPException(
                 status_code=500,
                 detail={
@@ -1170,7 +1170,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
         except HTTPException:
             raise
         except Exception as e:
-            verbose_proxy_logger.error(f"PANW Prisma AIRS scan failed: {e!s}")
+            verbose_proxy_logger.error(f"PANW Prisma AIRS scan failed: {e}")
             raise HTTPException(
                 status_code=500,
                 detail={
@@ -1366,7 +1366,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
             error_obj["code"] = e.status_code
             yield f"data: {json.dumps({'error': error_obj})}\n\n"
         except Exception as e:
-            verbose_proxy_logger.error(f"PANW Prisma AIRS streaming error: {e!s}")
+            verbose_proxy_logger.error(f"PANW Prisma AIRS streaming error: {e}")
             yield f"data: {json.dumps({'error': {'message': 'Security scan failed - streaming response blocked for safety', 'type': 'guardrail_scan_error', 'code': 500, 'guardrail': self.guardrail_name}})}\n\n"
 
     async def _scan_tool_calls_for_guardrail(

--- a/litellm/proxy/guardrails/guardrail_hooks/pillar/pillar.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/pillar/pillar.py
@@ -457,7 +457,7 @@ class PillarGuardrail(CustomGuardrail):
                 raise e
 
             # Handle API communication errors based on fallback_on_error setting
-            verbose_proxy_logger.error(f"Pillar Guardrail: API communication failed - {e!s}")
+            verbose_proxy_logger.error(f"Pillar Guardrail: API communication failed - {e}")
 
             return self._handle_api_error(e, data)
 

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -139,9 +139,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             except FileNotFoundError:
                 raise Exception(f"File not found. file_path={ad_hoc_recognizers}")
             except json.JSONDecodeError as e:
-                raise Exception(f"Error decoding JSON file: {e!s}, file_path={ad_hoc_recognizers}")
+                raise Exception(f"Error decoding JSON file: {e}, file_path={ad_hoc_recognizers}")
             except Exception as e:
-                raise Exception(f"An error occurred: {e!s}, file_path={ad_hoc_recognizers}")
+                raise Exception(f"An error occurred: {e}, file_path={ad_hoc_recognizers}")
         self.validate_environment(
             presidio_analyzer_api_base=presidio_analyzer_api_base,
             presidio_anonymizer_api_base=presidio_anonymizer_api_base,
@@ -1124,7 +1124,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             yield mock_response_stream
 
         except Exception as e:
-            verbose_proxy_logger.error(f"Error masking streaming PII output: {e!s}")
+            verbose_proxy_logger.error(f"Error masking streaming PII output: {e}")
             for chunk in all_chunks:
                 yield chunk
 
@@ -1253,7 +1253,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             yield mock_response_stream
 
         except Exception as e:
-            verbose_proxy_logger.error(f"Error in PII streaming processing: {e!s}")
+            verbose_proxy_logger.error(f"Error in PII streaming processing: {e}")
             for chunk in remaining_chunks:
                 yield chunk
 

--- a/litellm/proxy/guardrails/guardrail_hooks/prompt_security/prompt_security.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/prompt_security/prompt_security.py
@@ -326,7 +326,7 @@ class PromptSecurityGuardrail(CustomGuardrail):
                 except HTTPException:
                     raise
                 except Exception as e:
-                    verbose_proxy_logger.error(f"Error processing image: {e!s}")
+                    verbose_proxy_logger.error(f"Error processing image: {e}")
 
     @staticmethod
     def _resolve_key_alias_from_request_data(request_data: dict) -> str | None:
@@ -481,8 +481,8 @@ class PromptSecurityGuardrail(CustomGuardrail):
         except HTTPException:
             raise
         except Exception as e:
-            verbose_proxy_logger.error(f"Error sanitizing image file: {e!s}")
-            raise HTTPException(status_code=500, detail=f"File sanitization failed: {e!s}")
+            verbose_proxy_logger.error(f"Error sanitizing image file: {e}")
+            raise HTTPException(status_code=500, detail=f"File sanitization failed: {e}")
 
     async def _process_document_item(self, item: dict, user_api_key_alias: str | None) -> dict:
         """Process and sanitize document/file items."""
@@ -554,8 +554,8 @@ class PromptSecurityGuardrail(CustomGuardrail):
         except HTTPException:
             raise
         except Exception as e:
-            verbose_proxy_logger.error(f"Error sanitizing document: {e!s}")
-            raise HTTPException(status_code=500, detail=f"Document sanitization failed: {e!s}")
+            verbose_proxy_logger.error(f"Error sanitizing document: {e}")
+            raise HTTPException(status_code=500, detail=f"Document sanitization failed: {e}")
 
     async def process_message_files(self, messages: list, user_api_key_alias: str | None = None) -> list:
         """Process messages and sanitize any file content (images, documents, PDFs, etc.)."""

--- a/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/zscaler_ai_guard/zscaler_ai_guard.py
@@ -351,7 +351,7 @@ class ZscalerAIGuard(CustomGuardrail):
             return self._handle_response(response, direction)
         except Exception as e:
             verbose_proxy_logger.error(f"{e}. Blocking request.")
-            user_facing_error = self._create_user_facing_error(f"{e!s}")
+            user_facing_error = self._create_user_facing_error(f"{e}")
             raise HTTPException(status_code=500, detail=user_facing_error)
 
     @staticmethod

--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -285,7 +285,7 @@ class GuardrailRegistry:
 
             return guardrail_dict
         except Exception as e:
-            raise Exception(f"Error adding guardrail to DB: {e!s}")
+            raise Exception(f"Error adding guardrail to DB: {e}")
 
     async def delete_guardrail_from_db(self, guardrail_id: str, prisma_client: PrismaClient):
         """
@@ -297,7 +297,7 @@ class GuardrailRegistry:
 
             return {"message": f"Guardrail {guardrail_id} deleted successfully"}
         except Exception as e:
-            raise Exception(f"Error deleting guardrail from DB: {e!s}")
+            raise Exception(f"Error deleting guardrail from DB: {e}")
 
     async def update_guardrail_in_db(self, guardrail_id: str, guardrail: Guardrail, prisma_client: PrismaClient):
         """
@@ -328,7 +328,7 @@ class GuardrailRegistry:
             # Convert to dict and return
             return dict(updated_guardrail)
         except Exception as e:
-            raise Exception(f"Error updating guardrail in DB: {e!s}")
+            raise Exception(f"Error updating guardrail in DB: {e}")
 
     @staticmethod
     async def get_all_guardrails_from_db(
@@ -350,7 +350,7 @@ class GuardrailRegistry:
 
             return guardrails
         except Exception as e:
-            raise Exception(f"Error getting guardrails from DB: {e!s}")
+            raise Exception(f"Error getting guardrails from DB: {e}")
 
     async def get_guardrail_by_id_from_db(self, guardrail_id: str, prisma_client: PrismaClient) -> Guardrail | None:
         """
@@ -366,7 +366,7 @@ class GuardrailRegistry:
 
             return Guardrail(**(dict(guardrail)))  # type: ignore
         except Exception as e:
-            raise Exception(f"Error getting guardrail from DB: {e!s}")
+            raise Exception(f"Error getting guardrail from DB: {e}")
 
     async def get_guardrail_by_name_from_db(self, guardrail_name: str, prisma_client: PrismaClient) -> Guardrail | None:
         """
@@ -382,7 +382,7 @@ class GuardrailRegistry:
 
             return Guardrail(**(dict(guardrail)))  # type: ignore
         except Exception as e:
-            raise Exception(f"Error getting guardrail from DB: {e!s}")
+            raise Exception(f"Error getting guardrail from DB: {e}")
 
 
 class InMemoryGuardrailHandler:

--- a/litellm/proxy/guardrails/init_guardrails.py
+++ b/litellm/proxy/guardrails/init_guardrails.py
@@ -141,5 +141,5 @@ def initialize_guardrails(
 
         return litellm.guardrail_name_config_map
     except Exception as e:
-        verbose_proxy_logger.exception(f"error initializing guardrails {e!s}")
+        verbose_proxy_logger.exception(f"error initializing guardrails {e}")
         raise e

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -425,11 +425,11 @@ async def health_services_endpoint(
             }
 
     except Exception as e:
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.health_services_endpoint(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.health_services_endpoint(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e!s})"),
+                message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
@@ -1069,7 +1069,7 @@ async def health_endpoint(
             )
             return _post_process(router_result)
     except Exception as e:
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.py::health_endpoint(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.py::health_endpoint(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         raise e
 
@@ -1110,7 +1110,7 @@ async def health_check_history_endpoint(
         verbose_proxy_logger.error(f"Error getting health check history: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": f"Failed to retrieve health check history: {e!s}"},
+            detail={"error": f"Failed to retrieve health check history: {e}"},
         )
 
 
@@ -1142,7 +1142,7 @@ async def latest_health_checks_endpoint(
         verbose_proxy_logger.error(f"Error getting latest health checks: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": f"Failed to retrieve latest health checks: {e!s}"},
+            detail={"error": f"Failed to retrieve latest health checks: {e}"},
         )
 
 
@@ -1185,7 +1185,7 @@ async def shared_health_check_status_endpoint(
         verbose_proxy_logger.error(f"Error getting shared health check status: {e}")
         raise HTTPException(
             status_code=fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": f"Failed to retrieve shared health check status: {e!s}"},
+            detail={"error": f"Failed to retrieve shared health check status: {e}"},
         )
 
 
@@ -1473,7 +1473,7 @@ async def _get_health_readiness_details(
                 "is_detailed_debug": is_detailed_debug,
             }
     except Exception as e:
-        raise HTTPException(status_code=503, detail=f"Service Unhealthy ({e!s})")
+        raise HTTPException(status_code=503, detail=f"Service Unhealthy ({e})")
 
 
 def _allow_public_health_readiness_details() -> bool:
@@ -1897,10 +1897,8 @@ async def test_model_connection(
     except HTTPException as e:
         raise e
     except Exception as e:
-        verbose_proxy_logger.debug(
-            f"litellm.proxy.health_endpoints.test_model_connection(): Exception occurred - {e!s}"
-        )
+        verbose_proxy_logger.debug(f"litellm.proxy.health_endpoints.test_model_connection(): Exception occurred - {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": f"Failed to test connection: {e!s}"},
+            detail={"error": f"Failed to test connection: {e}"},
         )

--- a/litellm/proxy/hooks/azure_content_safety.py
+++ b/litellm/proxy/hooks/azure_content_safety.py
@@ -123,7 +123,7 @@ class _PROXY_AzureContentSafety(
             raise e
         except Exception as e:
             verbose_proxy_logger.error(
-                f"litellm.proxy.hooks.azure_content_safety.py::async_pre_call_hook(): Exception occured - {e!s}"
+                f"litellm.proxy.hooks.azure_content_safety.py::async_pre_call_hook(): Exception occured - {e}"
             )
             verbose_proxy_logger.debug(traceback.format_exc())
 

--- a/litellm/proxy/hooks/batch_rate_limiter.py
+++ b/litellm/proxy/hooks/batch_rate_limiter.py
@@ -600,7 +600,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                 )
             raise
         except Exception as e:
-            verbose_proxy_logger.error(f"Error counting input file usage for {file_id}: {e!s}")
+            verbose_proxy_logger.error(f"Error counting input file usage for {file_id}: {e}")
             raise
 
     async def _enforce_batch_file_model_access(
@@ -704,7 +704,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
                     detail={
                         "error": (
                             "Batch input file references a model the caller is "
-                            f"not authorized to use: model={model_to_check}, reason={e!s}"
+                            f"not authorized to use: model={model_to_check}, reason={e}"
                         )
                     },
                 )
@@ -734,7 +734,7 @@ class _PROXY_BatchRateLimiter(CustomLogger):
             from litellm.proxy.proxy_server import llm_router, proxy_logging_obj
         except ImportError as e:
             raise ValueError(
-                f"Cannot import proxy_server dependencies: {e!s}. Managed files require proxy_server to be initialized."
+                f"Cannot import proxy_server dependencies: {e}. Managed files require proxy_server to be initialized."
             )
 
         # Get the managed files hook
@@ -846,6 +846,6 @@ class _PROXY_BatchRateLimiter(CustomLogger):
             # Re-raise HTTP exceptions (rate limit exceeded)
             raise
         except Exception as e:
-            verbose_proxy_logger.error(f"Error in batch rate limiting: {e!s}", exc_info=True)
+            verbose_proxy_logger.error(f"Error in batch rate limiting: {e}", exc_info=True)
             # Don't block the request if rate limiting fails
             return data

--- a/litellm/proxy/hooks/batch_redis_get.py
+++ b/litellm/proxy/hooks/batch_redis_get.py
@@ -84,7 +84,7 @@ class _PROXY_BatchRedisRequests(CustomLogger):
             raise e
         except Exception as e:
             verbose_proxy_logger.error(
-                f"litellm.proxy.hooks.batch_redis_get.py::async_pre_call_hook(): Exception occured - {e!s}"
+                f"litellm.proxy.hooks.batch_redis_get.py::async_pre_call_hook(): Exception occured - {e}"
             )
             verbose_proxy_logger.debug(traceback.format_exc())
 

--- a/litellm/proxy/hooks/cache_control_check.py
+++ b/litellm/proxy/hooks/cache_control_check.py
@@ -52,5 +52,5 @@ class _PROXY_CacheControlCheck(CustomLogger):
             raise e
         except Exception as e:
             verbose_logger.exception(
-                f"litellm.proxy.hooks.cache_control_check.py::async_pre_call_hook(): Exception occured - {e!s}"
+                f"litellm.proxy.hooks.cache_control_check.py::async_pre_call_hook(): Exception occured - {e}"
             )

--- a/litellm/proxy/hooks/dynamic_rate_limiter.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter.py
@@ -68,7 +68,7 @@ class DynamicRateLimiterCache:
             await self.cache.async_set_cache_sadd(key=key_name, value=value, ttl=self.ttl)
         except Exception as e:
             verbose_proxy_logger.exception(
-                f"litellm.proxy.hooks.dynamic_rate_limiter.py::async_set_cache_sadd(): Exception occured - {e!s}"
+                f"litellm.proxy.hooks.dynamic_rate_limiter.py::async_set_cache_sadd(): Exception occured - {e}"
             )
             raise e
 
@@ -172,7 +172,7 @@ class _PROXY_DynamicRateLimitHandler(CustomLogger):
             )
         except Exception as e:
             verbose_proxy_logger.exception(
-                f"litellm.proxy.hooks.dynamic_rate_limiter.py::check_available_usage: Exception occurred - {e!s}"
+                f"litellm.proxy.hooks.dynamic_rate_limiter.py::check_available_usage: Exception occurred - {e}"
             )
             return None, None, None, None, None
 
@@ -263,6 +263,6 @@ class _PROXY_DynamicRateLimitHandler(CustomLogger):
             )
         except Exception as e:
             verbose_proxy_logger.exception(
-                f"litellm.proxy.hooks.dynamic_rate_limiter.py::async_post_call_success_hook(): Exception occured - {e!s}"
+                f"litellm.proxy.hooks.dynamic_rate_limiter.py::async_post_call_success_hook(): Exception occured - {e}"
             )
             return response

--- a/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
@@ -282,7 +282,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
             return max_saturation
 
         except Exception as e:
-            verbose_proxy_logger.error(f"Error checking saturation for {model}: {e!s}")
+            verbose_proxy_logger.error(f"Error checking saturation for {model}: {e}")
             # Fail open: assume not saturated on error
             return 0.0
 
@@ -640,7 +640,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
         except HTTPException:
             raise
         except Exception as e:
-            verbose_proxy_logger.error(f"Error in dynamic rate limiter: {e!s}, allowing request")
+            verbose_proxy_logger.error(f"Error in dynamic rate limiter: {e}, allowing request")
             # Fail open on unexpected errors
             return None
 
@@ -676,7 +676,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
             return response
 
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error in dynamic rate limiter v3 post-call hook: {e!s}")
+            verbose_proxy_logger.exception(f"Error in dynamic rate limiter v3 post-call hook: {e}")
             return response
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
@@ -791,4 +791,4 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
                 )
 
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error in dynamic rate limiter success event: {e!s}")
+            verbose_proxy_logger.exception(f"Error in dynamic rate limiter success event: {e}")

--- a/litellm/proxy/hooks/litellm_skills/main.py
+++ b/litellm/proxy/hooks/litellm_skills/main.py
@@ -587,7 +587,7 @@ class SkillsInjectionHook(CustomLogger):
 
             return result or "Code executed successfully"
         except Exception as e:
-            return f"Code execution failed: {e!s}"
+            return f"Code execution failed: {e}"
 
     async def _execute_skill_tool(
         self,
@@ -821,7 +821,7 @@ print('No executable skill module found')
 
         except Exception as e:
             verbose_proxy_logger.error(f"SkillsInjectionHook: Code execution failed: {e}")
-            return f"Code execution failed: {e!s}"
+            return f"Code execution failed: {e}"
 
     def _attach_files_to_response(
         self,

--- a/litellm/proxy/hooks/max_budget_limiter.py
+++ b/litellm/proxy/hooks/max_budget_limiter.py
@@ -75,5 +75,5 @@ class _PROXY_MaxBudgetLimiter(CustomLogger):
             raise e
         except Exception as e:
             verbose_logger.exception(
-                f"litellm.proxy.hooks.max_budget_limiter.py::async_pre_call_hook(): Exception occured - {e!s}"
+                f"litellm.proxy.hooks.max_budget_limiter.py::async_pre_call_hook(): Exception occured - {e}"
             )

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -776,7 +776,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                     litellm_parent_otel_span=litellm_parent_otel_span,
                 )  # save in cache for up to 1 min.
         except Exception as e:
-            verbose_proxy_logger.exception(f"Inside Parallel Request Limiter: An exception occurred - {e!s}")
+            verbose_proxy_logger.exception(f"Inside Parallel Request Limiter: An exception occurred - {e}")
 
     async def get_internal_user_object(
         self,

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -490,7 +490,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                     parallel_request_limiter=self,
                 )
             except Exception as e:
-                verbose_proxy_logger.debug(f"Could not load batch rate limiter: {e!s}")
+                verbose_proxy_logger.debug(f"Could not load batch rate limiter: {e}")
         return self._batch_rate_limiter
 
     def _get_current_time(self) -> datetime:
@@ -808,7 +808,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                 )
                 all_cache_values.extend(group_cache_values)
             except Exception as e:
-                verbose_proxy_logger.warning(f"Redis Lua script failed for hash tag {hash_tag}: {e!s}")
+                verbose_proxy_logger.warning(f"Redis Lua script failed for hash tag {hash_tag}: {e}")
                 # Fallback to in-memory cache for this group
                 group_cache_values = await self.in_memory_cache_sliding_window(
                     keys=group_keys,
@@ -1055,7 +1055,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                     )
                     counts = [max(0, int(value)) for value in raw_counts]
                 except Exception as e:  # noqa: BLE001 - any Redis/Lua failure degrades to the local mirror, never a 500
-                    verbose_proxy_logger.warning(f"parallel_count_script failed, using local mirror: {e!s}")
+                    verbose_proxy_logger.warning(f"parallel_count_script failed, using local mirror: {e}")
                     counts = await self._read_local_gauge_counts(gauge_keys, parent_otel_span)
             else:
                 counts = await self._read_local_gauge_counts(gauge_keys, parent_otel_span)
@@ -1085,7 +1085,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                     ],
                 )
             except Exception as e:  # noqa: BLE001 - any Redis/Lua failure degrades to in-memory enforcement, never a 500
-                verbose_proxy_logger.warning(f"parallel_acquire_script failed, falling back to in-memory gauge: {e!s}")
+                verbose_proxy_logger.warning(f"parallel_acquire_script failed, falling back to in-memory gauge: {e}")
                 async with self._check_and_increment_lock:
                     return await self._acquire_parallel_slots_in_memory(gauges, slot_id, parent_otel_span)
             if int(raw[0]) == 1:
@@ -1212,9 +1212,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                     )
                 return
             except Exception as e:  # noqa: BLE001 - any Redis/Lua failure degrades to the in-memory release, never a 500
-                verbose_proxy_logger.warning(
-                    f"parallel_release_script failed, falling back to in-memory release: {e!s}"
-                )
+                verbose_proxy_logger.warning(f"parallel_release_script failed, falling back to in-memory release: {e}")
 
         async with self._check_and_increment_lock:
             for counter_key in counter_keys:
@@ -2240,7 +2238,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             return False
 
         except Exception as e:
-            verbose_proxy_logger.debug(f"Error checking model failure status: {e!s}, defaulting to enforce limits")
+            verbose_proxy_logger.debug(f"Error checking model failure status: {e}, defaulting to enforce limits")
             # Fail safe: enforce limits if we can't check
             return True
 
@@ -2746,7 +2744,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             )
 
         except Exception as e:
-            verbose_proxy_logger.warning(f"TTL preservation failed, falling back to regular pipeline: {e!s}")
+            verbose_proxy_logger.warning(f"TTL preservation failed, falling back to regular pipeline: {e}")
             # Fallback to regular pipeline on error
             await self.internal_usage_cache.dual_cache.async_increment_cache_pipeline(
                 increment_list=pipeline_operations,
@@ -3003,7 +3001,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                 )
 
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error in rate limit success event: {e!s}")
+            verbose_proxy_logger.exception(f"Error in rate limit success event: {e}")
 
     async def async_logging_hook(
         self,
@@ -3120,7 +3118,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             if stash is not None and reserved_tokens > 0:
                 stash.reservation_released = True
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error in rate limit failure event: {e!s}")
+            verbose_proxy_logger.exception(f"Error in rate limit failure event: {e}")
 
     async def async_release_max_parallel_requests_on_disconnect(
         self,
@@ -3185,7 +3183,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
                     )
 
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error in rate limit post-call hook: {e!s}")
+            verbose_proxy_logger.exception(f"Error in rate limit post-call hook: {e}")
 
     async def async_post_call_failure_hook(
         self,

--- a/litellm/proxy/hooks/prompt_injection_detection.py
+++ b/litellm/proxy/hooks/prompt_injection_detection.py
@@ -197,7 +197,7 @@ class _OPTIONAL_PromptInjectionDetection(CustomLogger):
             raise e
         except Exception as e:
             verbose_proxy_logger.exception(
-                f"litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {e!s}"
+                f"litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {e}"
             )
 
     async def async_moderation_hook(  # type: ignore

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -308,7 +308,7 @@ class _ProxyDBLogger(CustomLogger):
                         f"Cost tracking failed for model={model}.\nDebug info - {cost_tracking_failure_debug_info}\nAdd custom pricing - https://docs.litellm.ai/docs/proxy/custom_pricing"
                     )
         except Exception as e:
-            error_msg = f"Error in tracking cost callback - {e!s}\n Traceback:{traceback.format_exc()}"
+            error_msg = f"Error in tracking cost callback - {e}\n Traceback:{traceback.format_exc()}"
             model = kwargs.get("model", "")
             metadata = get_litellm_metadata_from_kwargs(kwargs=kwargs)
             litellm_metadata = kwargs.get("litellm_params", {}).get("litellm_metadata", {})

--- a/litellm/proxy/hooks/user_management_event_hooks.py
+++ b/litellm/proxy/hooks/user_management_event_hooks.py
@@ -71,7 +71,7 @@ class UserManagementEventHooks:
                 )
             )
         except Exception as e:
-            verbose_proxy_logger.warning(f"Unable to create audit log for user on `/user/new` - {e!s}")
+            verbose_proxy_logger.warning(f"Unable to create audit log for user on `/user/new` - {e}")
 
     @staticmethod
     async def async_send_user_invitation_email(

--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -185,7 +185,7 @@ async def image_generation(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.image_generation(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.image_generation(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
@@ -195,7 +195,7 @@ async def image_generation(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),

--- a/litellm/proxy/management_endpoints/cache_settings_endpoints.py
+++ b/litellm/proxy/management_endpoints/cache_settings_endpoints.py
@@ -386,7 +386,7 @@ class CacheSettingsManager:
                 verbose_proxy_logger.info("Cache settings initialized from database")
         except Exception as e:
             verbose_proxy_logger.exception(
-                f"litellm.proxy.management_endpoints.cache_settings_endpoints.py::CacheSettingsManager::init_cache_settings_in_db - {e!s}"
+                f"litellm.proxy.management_endpoints.cache_settings_endpoints.py::CacheSettingsManager::init_cache_settings_in_db - {e}"
             )
 
     @staticmethod
@@ -480,8 +480,8 @@ async def get_cache_settings(
             redis_type_descriptions=REDIS_TYPE_DESCRIPTIONS,
         )
     except Exception as e:
-        verbose_proxy_logger.error(f"Error fetching cache settings: {e!s}")
-        raise HTTPException(status_code=500, detail=f"Error fetching cache settings: {e!s}")
+        verbose_proxy_logger.error(f"Error fetching cache settings: {e}")
+        raise HTTPException(status_code=500, detail=f"Error fetching cache settings: {e}")
 
 
 @router.post(
@@ -539,10 +539,10 @@ async def test_cache_connection(
         return CacheTestResponse(**result)
 
     except Exception as e:
-        verbose_proxy_logger.error(f"Error testing cache connection: {e!s}")
+        verbose_proxy_logger.error(f"Error testing cache connection: {e}")
         return CacheTestResponse(
             status="failed",
-            message=f"Cache connection test failed: {e!s}",
+            message=f"Cache connection test failed: {e}",
             error=str(e),
         )
 
@@ -652,5 +652,5 @@ async def update_cache_settings(
             "settings": _redact_credentials(cache_settings),
         }
     except Exception as e:
-        verbose_proxy_logger.error(f"Error updating cache settings: {e!s}")
-        raise HTTPException(status_code=500, detail=f"Error updating cache settings: {e!s}")
+        verbose_proxy_logger.error(f"Error updating cache settings: {e}")
+        raise HTTPException(status_code=500, detail=f"Error updating cache settings: {e}")

--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -993,10 +993,10 @@ async def get_daily_activity(
         )
 
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error fetching daily activity: {e!s}")
+        verbose_proxy_logger.exception(f"Error fetching daily activity: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": f"Failed to fetch analytics: {e!s}"},
+            detail={"error": f"Failed to fetch analytics: {e}"},
         )
 
 
@@ -1082,8 +1082,8 @@ async def get_daily_activity_aggregated(
         )
 
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error fetching aggregated daily activity: {e!s}")
+        verbose_proxy_logger.exception(f"Error fetching aggregated daily activity: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": f"Failed to fetch analytics: {e!s}"},
+            detail={"error": f"Failed to fetch analytics: {e}"},
         )

--- a/litellm/proxy/management_endpoints/cost_tracking_settings.py
+++ b/litellm/proxy/management_endpoints/cost_tracking_settings.py
@@ -129,7 +129,7 @@ async def get_cost_discount_config(
 
         return {"values": cost_discount_config}
     except Exception as e:
-        verbose_proxy_logger.error(f"Error fetching cost discount config: {e!s}")
+        verbose_proxy_logger.error(f"Error fetching cost discount config: {e}")
         return {"values": {}}
 
 
@@ -224,10 +224,10 @@ async def update_cost_discount_config(
             "values": cost_discount_config,
         }
     except Exception as e:
-        verbose_proxy_logger.error(f"Error updating cost discount config: {e!s}")
+        verbose_proxy_logger.error(f"Error updating cost discount config: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to update cost discount config: {e!s}"},
+            detail={"error": f"Failed to update cost discount config: {e}"},
         )
 
 
@@ -262,7 +262,7 @@ async def get_cost_margin_config(
 
         return {"values": cost_margin_config}
     except Exception as e:
-        verbose_proxy_logger.error(f"Error fetching cost margin config: {e!s}")
+        verbose_proxy_logger.error(f"Error fetching cost margin config: {e}")
         return {"values": {}}
 
 
@@ -398,10 +398,10 @@ async def update_cost_margin_config(
             "values": cost_margin_config,
         }
     except Exception as e:
-        verbose_proxy_logger.error(f"Error updating cost margin config: {e!s}")
+        verbose_proxy_logger.error(f"Error updating cost margin config: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to update cost margin config: {e!s}"},
+            detail={"error": f"Failed to update cost margin config: {e}"},
         )
 
 
@@ -484,7 +484,7 @@ async def estimate_cost(
         raise HTTPException(
             status_code=404,
             detail={
-                "error": f"Could not calculate cost for model '{request.model}' (resolved to '{resolved_model}'): {e!s}"
+                "error": f"Could not calculate cost for model '{request.model}' (resolved to '{resolved_model}'): {e}"
             },
         )
 

--- a/litellm/proxy/management_endpoints/customer_endpoints.py
+++ b/litellm/proxy/management_endpoints/customer_endpoints.py
@@ -103,7 +103,7 @@ async def block_user(data: BlockUsers):
 
         return {"blocked_users": records}
     except Exception as e:
-        verbose_proxy_logger.error(f"An error occurred - {e!s}")
+        verbose_proxy_logger.error(f"An error occurred - {e}")
         raise HTTPException(status_code=500, detail={"error": str(e)})
 
 
@@ -390,7 +390,7 @@ async def new_end_user(
         return _to_customer_response(end_user_record)
     except Exception as e:
         verbose_proxy_logger.exception(
-            f"litellm.proxy.management_endpoints.customer_endpoints.new_end_user(): Exception occured - {e!s}"
+            f"litellm.proxy.management_endpoints.customer_endpoints.new_end_user(): Exception occured - {e}"
         )
         if "Unique constraint failed on the fields: (`user_id`)" in str(e):
             raise ProxyException(
@@ -455,7 +455,7 @@ async def end_user_info(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            f"litellm.proxy.management_endpoints.customer_endpoints.end_user_info(): Exception occured - {e!s}"
+            f"litellm.proxy.management_endpoints.customer_endpoints.end_user_info(): Exception occured - {e}"
         )
         raise handle_exception_on_proxy(e)
 
@@ -636,7 +636,7 @@ async def update_end_user(
         # update based on remaining passed in values
 
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.update_end_user(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.update_end_user(): Exception occured - {e}")
         raise handle_exception_on_proxy(e)
 
 
@@ -711,7 +711,7 @@ async def delete_end_user(
 
         # update based on remaining passed in values
     except Exception as e:
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.delete_end_user(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.delete_end_user(): Exception occured - {e}")
         raise handle_exception_on_proxy(e)
 
 
@@ -767,7 +767,7 @@ async def list_end_user(
 
     except Exception as e:
         verbose_proxy_logger.exception(
-            f"litellm.proxy.management_endpoints.customer_endpoints.list_end_user(): Exception occured - {e!s}"
+            f"litellm.proxy.management_endpoints.customer_endpoints.list_end_user(): Exception occured - {e}"
         )
         raise handle_exception_on_proxy(e)
 

--- a/litellm/proxy/management_endpoints/fallback_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/fallback_management_endpoints.py
@@ -182,10 +182,10 @@ async def create_fallback(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"Error creating fallback: {e!s}", exc_info=True)
+        verbose_proxy_logger.error(f"Error creating fallback: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": f"Failed to create fallback: {e!s}"},
+            detail={"error": f"Failed to create fallback: {e}"},
         )
 
 
@@ -239,10 +239,10 @@ async def get_fallback(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"Error getting fallback: {e!s}", exc_info=True)
+        verbose_proxy_logger.error(f"Error getting fallback: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": f"Failed to get fallback: {e!s}"},
+            detail={"error": f"Failed to get fallback: {e}"},
         )
 
 
@@ -350,8 +350,8 @@ async def delete_fallback(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"Error deleting fallback: {e!s}", exc_info=True)
+        verbose_proxy_logger.error(f"Error deleting fallback: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": f"Failed to delete fallback: {e!s}"},
+            detail={"error": f"Failed to delete fallback: {e}"},
         )

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -330,7 +330,7 @@ async def _add_user_to_team(
     except HTTPException as e:
         if e.status_code == 400 and ("already exists" in str(e) or "doesn't exist" in str(e)):
             verbose_proxy_logger.debug(
-                f"litellm.proxy.management_endpoints.internal_user_endpoints.new_user(): User already exists in team - {e!s}"
+                f"litellm.proxy.management_endpoints.internal_user_endpoints.new_user(): User already exists in team - {e}"
             )
         else:
             verbose_proxy_logger.error(
@@ -348,7 +348,7 @@ async def _add_user_to_team(
             and ProxyErrorTypes.team_member_already_in_team in e.type
         ):
             verbose_proxy_logger.debug(
-                f"litellm.proxy.management_endpoints.internal_user_endpoints.new_user(): User already exists in team - {e!s}"
+                f"litellm.proxy.management_endpoints.internal_user_endpoints.new_user(): User already exists in team - {e}"
             )
         else:
             verbose_proxy_logger.error(
@@ -605,7 +605,7 @@ async def new_user(
 
         return new_user_response
     except Exception as e:
-        verbose_proxy_logger.exception(f"/user/new: Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"/user/new: Exception occured - {e}")
         raise handle_exception_on_proxy(e)
 
 
@@ -900,7 +900,7 @@ async def user_info(
 
         return response_data
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.user_info(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.user_info(): Exception occured - {e}")
         raise handle_exception_on_proxy(e)
 
 
@@ -1050,7 +1050,7 @@ async def user_info_v2(
             object_permission=user_data.get("object_permission"),
         )
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.user_info_v2(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.user_info_v2(): Exception occured - {e}")
         raise handle_exception_on_proxy(e)
 
 
@@ -1320,7 +1320,7 @@ async def _invalidate_cached_user_entitlement(user_id: str | None, object_permis
         try:
             await user_api_key_cache.async_delete_cache(key=key)
         except Exception as e:  # noqa: BLE001  # a cache we cannot clear still expires; never fail the write
-            verbose_proxy_logger.warning(f"Failed to invalidate cached entitlement key {key!r}: {e!s}")
+            verbose_proxy_logger.warning(f"Failed to invalidate cached entitlement key {key!r}: {e}")
 
 
 async def _update_single_user_helper(
@@ -1569,11 +1569,11 @@ async def user_update(
         )
         return response
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.user_update(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.user_update(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e!s})"),
+                message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
@@ -2395,7 +2395,7 @@ async def add_internal_user_to_organization(
 
         return new_membership
     except Exception as e:
-        raise Exception(f"Failed to add user to organization: {e!s}")
+        raise Exception(f"Failed to add user to organization: {e}")
 
 
 async def _resolve_org_filter_for_user_search(
@@ -2593,8 +2593,8 @@ async def ui_view_users(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error searching users: {e!s}")
-        raise HTTPException(status_code=500, detail=f"Error searching users: {e!s}")
+        verbose_proxy_logger.exception(f"Error searching users: {e}")
+        raise HTTPException(status_code=500, detail=f"Error searching users: {e}")
 
 
 # Using shared metric helper implementations from common_daily_activity
@@ -2716,10 +2716,10 @@ async def get_user_daily_activity(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.exception(f"/spend/daily/analytics: Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"/spend/daily/analytics: Exception occured - {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": f"Failed to fetch analytics: {e!s}"},
+            detail={"error": f"Failed to fetch analytics: {e}"},
         )
 
 
@@ -2808,8 +2808,8 @@ async def get_user_daily_activity_aggregated(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.exception(f"/user/daily/activity/aggregated: Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"/user/daily/activity/aggregated: Exception occured - {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail={"error": f"Failed to fetch analytics: {e!s}"},
+            detail={"error": f"Failed to fetch analytics: {e}"},
         )

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -940,7 +940,7 @@ async def _common_key_generation_helper(
         data = apply_enterprise_key_management_params(data, team_table)
     except Exception as e:
         verbose_proxy_logger.debug(
-            f"litellm.proxy.proxy_server.generate_key_fn(): Enterprise key management params not applied - {e!s}"
+            f"litellm.proxy.proxy_server.generate_key_fn(): Enterprise key management params not applied - {e}"
         )
 
     # TODO: @ishaan-jaff: Migrate all budget tracking to use LiteLLM_BudgetTable
@@ -1732,7 +1732,7 @@ async def generate_key_fn(
         )
 
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.generate_key_fn(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.generate_key_fn(): Exception occured - {e}")
         raise handle_exception_on_proxy(e)
 
 
@@ -1934,9 +1934,7 @@ def prepare_metadata_fields(data: BaseModel, non_default_values: dict, existing_
                 casted_metadata[k] = v
 
     except Exception as e:
-        verbose_proxy_logger.exception(
-            f"litellm.proxy.proxy_server.prepare_metadata_fields(): Exception occured - {e!s}"
-        )
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.prepare_metadata_fields(): Exception occured - {e}")
 
     non_default_values["metadata"] = encrypt_callback_vars(casted_metadata)
     return non_default_values
@@ -2799,10 +2797,10 @@ async def update_key_fn(
         return {"key": key, **response["data"]}
         # update based on remaining passed in values
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.update_key_fn(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.update_key_fn(): Exception occured - {e}")
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e!s})"),
+                message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
@@ -3368,7 +3366,7 @@ async def delete_key_fn(
 
         return {"deleted_keys": deleted_keys}
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.delete_key_fn(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.delete_key_fn(): Exception occured - {e}")
         raise handle_exception_on_proxy(e)
 
 
@@ -3908,7 +3906,7 @@ async def generate_key_helper_fn(
                     # If it's not valid JSON/YAML, keep as is or set to empty dict
                     key_data["router_settings"] = {}
     except Exception as e:
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.generate_key_helper_fn(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.generate_key_helper_fn(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise e
@@ -4115,7 +4113,7 @@ async def delete_verification_tokens(
             raise Exception("DB not connected. prisma_client is None")
     except Exception as e:
         verbose_proxy_logger.exception(
-            f"litellm.proxy.proxy_server.delete_verification_tokens(): Exception occured - {e!s}"
+            f"litellm.proxy.proxy_server.delete_verification_tokens(): Exception occured - {e}"
         )
         verbose_proxy_logger.debug(traceback.format_exc())
         raise e
@@ -4387,7 +4385,7 @@ async def _rotate_master_key(
                     },
                 )
             except Exception as e:
-                verbose_proxy_logger.error(f"Failed to re-encrypt credential {cred.credential_name}: {e!s}")
+                verbose_proxy_logger.error(f"Failed to re-encrypt credential {cred.credential_name}: {e}")
                 # Continue with next credential instead of failing entire rotation
                 continue
         verbose_proxy_logger.debug(f"Successfully re-encrypted {len(credentials)} credentials with new master key")
@@ -5451,7 +5449,7 @@ async def list_keys(
         verbose_proxy_logger.exception(f"Error in list_keys: {e}")
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"error({e!s})"),
+                message=getattr(e, "detail", f"error({e})"),
                 type=ProxyErrorTypes.internal_server_error,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR),
@@ -5603,7 +5601,7 @@ async def key_aliases(
         verbose_proxy_logger.exception(f"Error in key_aliases: {e}")
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"error({e!s})"),
+                message=getattr(e, "detail", f"error({e})"),
                 type=ProxyErrorTypes.internal_server_error,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
@@ -6340,7 +6338,7 @@ async def key_health(
 
     except Exception as e:
         raise ProxyException(
-            message=f"Key health check failed: {e!s}",
+            message=f"Key health check failed: {e}",
             type=ProxyErrorTypes.internal_server_error,
             param=getattr(e, "param", "None"),
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -6425,7 +6423,7 @@ async def test_key_logging(
         return LoggingCallbackStatus(
             callbacks=logging_callbacks,
             status="unhealthy",
-            details=f"Logging test failed: {e!s}",
+            details=f"Logging test failed: {e}",
         )
 
     await asyncio.sleep(2)  # wait for callbacks to run, callbacks use batching so wait for the flush event
@@ -6556,5 +6554,5 @@ def validate_model_max_budget(model_max_budget: dict | None) -> None:
                 BudgetConfig(**_info)
     except Exception as e:
         raise ValueError(
-            f"Invalid model_max_budget: {e!s}. Example of valid model_max_budget: https://docs.litellm.ai/docs/proxy/users"
+            f"Invalid model_max_budget: {e}. Example of valid model_max_budget: https://docs.litellm.ai/docs/proxy/users"
         )

--- a/litellm/proxy/management_endpoints/management_v1/budgets.py
+++ b/litellm/proxy/management_endpoints/management_v1/budgets.py
@@ -191,7 +191,7 @@ async def list_budgets(
         raise
     except Exception as e:  # noqa: BLE001  # a driver error answers as a problem document, not the OpenAI error shape
         verbose_proxy_logger.exception(
-            f"litellm.proxy.management_endpoints.management_v1.budgets.list_budgets(): Exception occured - {e!s}"
+            f"litellm.proxy.management_endpoints.management_v1.budgets.list_budgets(): Exception occured - {e}"
         )
         raise ManagementProblem(
             ProblemDetail(

--- a/litellm/proxy/management_endpoints/management_v1/spend_logs.py
+++ b/litellm/proxy/management_endpoints/management_v1/spend_logs.py
@@ -188,7 +188,7 @@ async def list_spend_log_end_users(
     except Exception as e:
         verbose_proxy_logger.exception(
             "litellm.proxy.management_endpoints.management_v1.spend_logs.list_spend_log_end_users(): "
-            f"Exception occured - {e!s}"
+            f"Exception occured - {e}"
         )
         raise ManagementProblem(
             ProblemDetail(

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -399,7 +399,7 @@ if MCP_AVAILABLE:
         try:
             encrypted_payload = encrypt_value_helper(payload_json)
         except Exception as e:
-            verbose_proxy_logger.debug(f"Failed to encrypt temporary MCP server payload for Redis cache: {e!s}")
+            verbose_proxy_logger.debug(f"Failed to encrypt temporary MCP server payload for Redis cache: {e}")
             return
 
         if not isinstance(encrypted_payload, str):
@@ -413,7 +413,7 @@ if MCP_AVAILABLE:
                 ttl=max(1, ttl_seconds),
             )
         except Exception as e:
-            verbose_proxy_logger.debug(f"Failed to write temporary MCP server to Redis cache: {e!s}")
+            verbose_proxy_logger.debug(f"Failed to write temporary MCP server to Redis cache: {e}")
 
     async def _get_temporary_mcp_server_from_redis(
         server_id: str,
@@ -435,7 +435,7 @@ if MCP_AVAILABLE:
                 key=f"{TEMPORARY_MCP_SERVER_REDIS_KEY_PREFIX}:{server_id}"
             )
         except Exception as e:
-            verbose_proxy_logger.debug(f"Failed reading temporary MCP server from Redis cache: {e!s}")
+            verbose_proxy_logger.debug(f"Failed reading temporary MCP server from Redis cache: {e}")
             return None
 
         if not isinstance(cached_server, str):
@@ -454,7 +454,7 @@ if MCP_AVAILABLE:
         try:
             loaded = json.loads(decrypted_json)
         except Exception as e:
-            verbose_proxy_logger.debug(f"Invalid decrypted temporary MCP payload in Redis cache: {e!s}")
+            verbose_proxy_logger.debug(f"Invalid decrypted temporary MCP payload in Redis cache: {e}")
             return None
         if not isinstance(loaded, dict):
             return None
@@ -463,7 +463,7 @@ if MCP_AVAILABLE:
         try:
             return MCPServer.model_validate(payload_dict)
         except Exception as e:
-            verbose_proxy_logger.debug(f"Invalid temporary MCP server payload in Redis cache: {e!s}")
+            verbose_proxy_logger.debug(f"Invalid temporary MCP server payload in Redis cache: {e}")
             return None
 
     async def get_cached_temporary_mcp_server(
@@ -1183,10 +1183,10 @@ if MCP_AVAILABLE:
                 touched_by=user_api_key_dict.user_id or user_api_key_dict.team_id,
             )
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error registering mcp server: {e!s}")
+            verbose_proxy_logger.exception(f"Error registering mcp server: {e}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail={"error": f"Error registering mcp server: {e!s}"},
+                detail={"error": f"Error registering mcp server: {e}"},
             )
         # Do NOT add to runtime registry — pending servers are not active
         return _redact_mcp_credentials(new_mcp_server)
@@ -1483,10 +1483,10 @@ if MCP_AVAILABLE:
                 touched_by=user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
             )
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error creating mcp server: {e!s}")
+            verbose_proxy_logger.exception(f"Error creating mcp server: {e}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail={"error": f"Error creating mcp server: {e!s}"},
+                detail={"error": f"Error creating mcp server: {e}"},
             )
 
         # Registry refresh is best-effort: the row is already committed, so a
@@ -1498,7 +1498,7 @@ if MCP_AVAILABLE:
             await global_mcp_server_manager.reload_servers_from_database()
         except Exception as e:
             verbose_proxy_logger.exception(
-                f"MCP server {new_mcp_server.server_id} created but in-memory registry refresh failed: {e!s}"
+                f"MCP server {new_mcp_server.server_id} created but in-memory registry refresh failed: {e}"
             )
 
         return _redact_mcp_credentials(new_mcp_server)
@@ -1559,10 +1559,10 @@ if MCP_AVAILABLE:
                 ttl_seconds=TEMPORARY_MCP_SERVER_TTL_SECONDS,
             )
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error caching temporary mcp server: {e!s}")
+            verbose_proxy_logger.exception(f"Error caching temporary mcp server: {e}")
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail={"error": f"Error caching temporary mcp server: {e!s}"},
+                detail={"error": f"Error caching temporary mcp server: {e}"},
             )
 
         return _redact_mcp_credentials(temp_record)

--- a/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_access_group_management_endpoints.py
@@ -439,10 +439,10 @@ async def create_model_group(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error creating access group '{data.access_group}': {e!s}")
+        verbose_proxy_logger.exception(f"Error creating access group '{data.access_group}': {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to create access group: {e!s}"},
+            detail={"error": f"Failed to create access group: {e}"},
         )
 
 
@@ -489,10 +489,10 @@ async def list_access_groups(
         return ListAccessGroupsResponse(access_groups=access_groups_list)
 
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error listing access groups: {e!s}")
+        verbose_proxy_logger.exception(f"Error listing access groups: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to list access groups: {e!s}"},
+            detail={"error": f"Failed to list access groups: {e}"},
         )
 
 
@@ -546,10 +546,10 @@ async def get_access_group_info(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error getting access group info for '{access_group}': {e!s}")
+        verbose_proxy_logger.exception(f"Error getting access group info for '{access_group}': {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to get access group info: {e!s}"},
+            detail={"error": f"Failed to get access group info: {e}"},
         )
 
 
@@ -627,7 +627,7 @@ async def update_access_group(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to check access group existence: {e!s}"},
+            detail={"error": f"Failed to check access group existence: {e}"},
         )
 
     # Validation: Check if all new models exist (only if using model_names path)
@@ -699,10 +699,10 @@ async def update_access_group(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error updating access group '{access_group}': {e!s}")
+        verbose_proxy_logger.exception(f"Error updating access group '{access_group}': {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to update access group: {e!s}"},
+            detail={"error": f"Failed to update access group: {e}"},
         )
 
 
@@ -759,7 +759,7 @@ async def delete_access_group(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to check access group existence: {e!s}"},
+            detail={"error": f"Failed to check access group existence: {e}"},
         )
 
     try:
@@ -800,8 +800,8 @@ async def delete_access_group(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error deleting access group '{access_group}': {e!s}")
+        verbose_proxy_logger.exception(f"Error deleting access group '{access_group}': {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to delete access group: {e!s}"},
+            detail={"error": f"Failed to delete access group: {e}"},
         )

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -355,13 +355,13 @@ async def patch_model(
         return updated_model
 
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error in patch_model: {e!s}")
+        verbose_proxy_logger.exception(f"Error in patch_model: {e}")
 
         if isinstance(e, (HTTPException, ProxyException)):
             raise e
 
         raise ProxyException(
-            message=f"Error updating model: {e!s}",
+            message=f"Error updating model: {e}",
             type=ProxyErrorTypes.internal_server_error,
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             param=None,
@@ -462,13 +462,13 @@ async def _set_model_blocked_status(
         return updated_model
 
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error in model {action}: {e!s}")
+        verbose_proxy_logger.exception(f"Error in model {action}: {e}")
 
         if isinstance(e, (HTTPException, ProxyException)):
             raise e
 
         raise ProxyException(
-            message=f"Error updating model blocked status: {e!s}",
+            message=f"Error updating model blocked status: {e}",
             type=ProxyErrorTypes.internal_server_error,
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             param=None,
@@ -1223,10 +1223,10 @@ async def delete_model(
             )
 
     except Exception as e:
-        verbose_proxy_logger.exception(f"Failed to delete model. Due to error - {e!s}")
+        verbose_proxy_logger.exception(f"Failed to delete model. Due to error - {e}")
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e!s})"),
+                message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
@@ -1429,10 +1429,10 @@ async def add_new_model(
         return model_response
 
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.add_new_model(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.add_new_model(): Exception occured - {e}")
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e!s})"),
+                message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
@@ -1582,10 +1582,10 @@ async def update_model(
 
             return model_response
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.update_model(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.update_model(): Exception occured - {e}")
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e!s})"),
+                message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
@@ -1675,13 +1675,13 @@ async def update_public_model_groups(
         }
 
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error updating public model groups: {e!s}")
+        verbose_proxy_logger.exception(f"Error updating public model groups: {e}")
 
         if isinstance(e, HTTPException):
             raise e
 
         raise ProxyException(
-            message=f"Error updating public model groups: {e!s}",
+            message=f"Error updating public model groups: {e}",
             type=ProxyErrorTypes.internal_server_error,
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             param=None,
@@ -1743,13 +1743,13 @@ async def update_useful_links(
         }
 
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error updating public model groups: {e!s}")
+        verbose_proxy_logger.exception(f"Error updating public model groups: {e}")
 
         if isinstance(e, HTTPException):
             raise e
 
         raise ProxyException(
-            message=f"Error updating public model groups: {e!s}",
+            message=f"Error updating public model groups: {e}",
             type=ProxyErrorTypes.internal_server_error,
             code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             param=None,
@@ -1970,5 +1970,5 @@ async def clear_cache() -> frozenset[str] | None:
         )
         return still_desired_ids
     except Exception as e:
-        verbose_proxy_logger.exception(f"Failed to clear cache and reload models. Due to error - {e!s}")
+        verbose_proxy_logger.exception(f"Failed to clear cache and reload models. Due to error - {e}")
         return None

--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -1261,7 +1261,7 @@ async def organization_member_add(
         verbose_proxy_logger.exception(f"Error adding member to organization: {e}")
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e!s})"),
+                message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),

--- a/litellm/proxy/management_endpoints/router_settings_endpoints.py
+++ b/litellm/proxy/management_endpoints/router_settings_endpoints.py
@@ -120,7 +120,7 @@ async def get_router_settings(
             routing_strategy_descriptions=ROUTING_STRATEGY_DESCRIPTIONS,
         )
     except Exception as e:
-        verbose_proxy_logger.error(f"Error fetching router settings: {e!s}")
+        verbose_proxy_logger.error(f"Error fetching router settings: {e}")
         raise
 
 
@@ -168,5 +168,5 @@ async def get_router_fields(
             routing_strategy_descriptions=ROUTING_STRATEGY_DESCRIPTIONS,
         )
     except Exception as e:
-        verbose_proxy_logger.error(f"Error fetching router fields: {e!s}")
+        verbose_proxy_logger.error(f"Error fetching router fields: {e}")
         raise

--- a/litellm/proxy/management_endpoints/tag_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tag_management_endpoints.py
@@ -201,7 +201,7 @@ async def _get_model_names(prisma_client: "PrismaClient", model_ids: Sequence[st
         models = await _table(ModelRepository(prisma_client)).find_many(where={"model_id": {"in": model_ids}})
         return {model.model_id: model.model_name for model in models}
     except Exception as e:
-        verbose_proxy_logger.error(f"Error getting model names: {e!s}")
+        verbose_proxy_logger.error(f"Error getting model names: {e}")
         return {}
 
 
@@ -331,7 +331,7 @@ async def new_tag(
             "tag": tag_config,
         }
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error creating tag: {e!s}")
+        verbose_proxy_logger.exception(f"Error creating tag: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -372,7 +372,7 @@ async def _add_tag_to_deployment(deployment: "Deployment", tag: str):
             data={"litellm_params": json.dumps(existing_params)},
         )
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error adding tag to deployment: {e!s}")
+        verbose_proxy_logger.exception(f"Error adding tag to deployment: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -461,7 +461,7 @@ async def update_tag(
             "tag": tag_config,
         }
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error updating tag: {e!s}")
+        verbose_proxy_logger.exception(f"Error updating tag: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -257,7 +257,7 @@ async def add_team_callbacks(
     except ProxyException as e:
         raise e
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.add_team_callbacks(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.add_team_callbacks(): Exception occured - {e}")
         raise ProxyException(
             message="Internal Server Error, " + str(e),
             type=ProxyErrorTypes.internal_server_error.value,
@@ -373,7 +373,7 @@ async def disable_team_logging(
     except ProxyException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.disable_team_logging(): Exception occurred - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.disable_team_logging(): Exception occurred - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         raise ProxyException(
             message="Internal Server Error, " + str(e),
@@ -465,11 +465,11 @@ async def get_team_callbacks(
     except ProxyException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.get_team_callbacks(): Exception occurred - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.get_team_callbacks(): Exception occurred - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"Internal Server Error({e!s})"),
+                message=getattr(e, "detail", f"Internal Server Error({e})"),
                 type=ProxyErrorTypes.internal_server_error.value,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -2411,7 +2411,7 @@ async def _process_team_members(
         except Exception as e:
             raise HTTPException(
                 status_code=500,
-                detail={"error": f"Unable to add user - {data.member}, to team - {data.team_id}, for reason - {e!s}"},
+                detail={"error": f"Unable to add user - {data.member}, to team - {data.team_id}, for reason - {e}"},
             )
         updated_users.append(updated_user)
         if updated_tm is not None:
@@ -2433,7 +2433,7 @@ async def _process_team_members(
             except Exception as e:
                 raise HTTPException(
                     status_code=500,
-                    detail={"error": f"Unable to add user - {m}, to team - {data.team_id}, for reason - {e!s}"},
+                    detail={"error": f"Unable to add user - {m}, to team - {data.team_id}, for reason - {e}"},
                 )
             updated_users.append(updated_user)
             if updated_tm is not None:
@@ -3936,7 +3936,7 @@ async def team_info(
         )
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e!s})"),
+                message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
@@ -4808,7 +4808,7 @@ async def list_team(
             )
         except Exception as e:
             team_exception = f"""Invalid team object for team_id: {team.team_id}. team_object={team.model_dump()}.
-            Error: {e!s}
+            Error: {e}
             """
             verbose_proxy_logger.exception(team_exception)
             continue
@@ -4925,7 +4925,7 @@ async def ui_view_teams(
         return teams
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error searching teams: {e!s}")
+        raise HTTPException(status_code=500, detail=f"Error searching teams: {e}")
 
 
 def add_new_models_to_team(team_obj: LiteLLM_TeamTable, new_models: list[str]) -> list[str]:

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -2197,7 +2197,7 @@ async def cli_sso_callback(
         raise
     except Exception as e:
         verbose_proxy_logger.error(f"Error with CLI SSO callback: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to process CLI SSO: {e!s}")
+        raise HTTPException(status_code=500, detail=f"Failed to process CLI SSO: {e}")
 
 
 @router.get("/sso/cli/poll/{key_id}", tags=["experimental"], include_in_schema=False)
@@ -2320,7 +2320,7 @@ async def cli_poll_key(
         raise
     except Exception as e:
         verbose_proxy_logger.error(f"Error polling for CLI JWT: {e}")
-        raise HTTPException(status_code=500, detail=f"Error checking session status: {e!s}")
+        raise HTTPException(status_code=500, detail=f"Error checking session status: {e}")
 
 
 async def insert_sso_user(
@@ -4479,7 +4479,7 @@ async def debug_sso_callback(request: Request):
                     # Try to convert to string or another JSON serializable format
                     filtered_result[key] = str(value)
                 except Exception as e:
-                    filtered_result[key] = f"Complex value (not displayable): {e!s}"
+                    filtered_result[key] = f"Complex value (not displayable): {e}"
 
     # Defense-in-depth: ensure no bearer tokens leak into the rendered HTML even if
     # a non-conforming IdP places them in its userinfo response.

--- a/litellm/proxy/management_endpoints/user_agent_analytics_endpoints.py
+++ b/litellm/proxy/management_endpoints/user_agent_analytics_endpoints.py
@@ -150,7 +150,7 @@ async def get_distinct_user_agent_tags(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to fetch distinct user agent tags: {e!s}",
+            detail=f"Failed to fetch distinct user agent tags: {e}",
         )
 
 
@@ -243,7 +243,7 @@ async def get_daily_active_users(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to fetch DAU analytics: {e!s}",
+            detail=f"Failed to fetch DAU analytics: {e}",
         )
 
 
@@ -364,7 +364,7 @@ async def get_weekly_active_users(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to fetch WAU analytics: {e!s}",
+            detail=f"Failed to fetch WAU analytics: {e}",
         )
 
 
@@ -485,7 +485,7 @@ async def get_monthly_active_users(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to fetch MAU analytics: {e!s}",
+            detail=f"Failed to fetch MAU analytics: {e}",
         )
 
 
@@ -585,12 +585,12 @@ async def get_tag_summary(
     except ValueError as e:
         raise HTTPException(
             status_code=400,
-            detail=f"Invalid date format. Use YYYY-MM-DD: {e!s}",
+            detail=f"Invalid date format. Use YYYY-MM-DD: {e}",
         )
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to fetch tag summary analytics: {e!s}",
+            detail=f"Failed to fetch tag summary analytics: {e}",
         )
 
 
@@ -740,5 +740,5 @@ async def get_per_user_analytics(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to fetch per-user analytics: {e!s}",
+            detail=f"Failed to fetch per-user analytics: {e}",
         )

--- a/litellm/proxy/ocr_endpoints/endpoints.py
+++ b/litellm/proxy/ocr_endpoints/endpoints.py
@@ -55,7 +55,7 @@ async def _parse_multipart_form(request: Request) -> dict[str, Any]:
         form = await request.form()
     except Exception as e:
         raise ValueError(
-            f"Failed to parse multipart form data: {e!s}. "
+            f"Failed to parse multipart form data: {e}. "
             "When using curl with --form/-F, do NOT set the Content-Type header "
             "manually — curl will set it automatically with the required boundary."
         )

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -549,7 +549,7 @@ async def create_file(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.create_file(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.create_file(): Exception occured - {e}")
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e.detail)),
@@ -558,7 +558,7 @@ async def create_file(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -690,7 +690,7 @@ async def get_file_content(
                         )
                     except ValueError as e:
                         raise ProxyException(
-                            message=f"Storage backend error: {e!s}",
+                            message=f"Storage backend error: {e}",
                             type="invalid_request_error",
                             param="file_id",
                             code=400,
@@ -845,7 +845,7 @@ async def get_file_content(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.retrieve_file_content(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.retrieve_file_content(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
@@ -855,7 +855,7 @@ async def get_file_content(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -1032,7 +1032,7 @@ async def get_file(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.retrieve_file(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.retrieve_file(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
@@ -1042,7 +1042,7 @@ async def get_file(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -1238,7 +1238,7 @@ async def delete_file(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.delete_file(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.delete_file(): Exception occured - {e}")
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e.detail)),
@@ -1247,7 +1247,7 @@ async def delete_file(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -1427,7 +1427,7 @@ async def list_files(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.list_files(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.list_files(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
@@ -1437,7 +1437,7 @@ async def list_files(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -857,14 +857,14 @@ async def handle_bedrock_count_tokens(
 
     except BedrockError as e:
         # Convert BedrockError to HTTPException for FastAPI
-        verbose_proxy_logger.error(f"BedrockError in handle_bedrock_count_tokens: {e!s}")
+        verbose_proxy_logger.error(f"BedrockError in handle_bedrock_count_tokens: {e}")
         raise HTTPException(status_code=e.status_code, detail={"error": e.message})
     except HTTPException:
         # Re-raise HTTP exceptions as-is
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"Error in handle_bedrock_count_tokens: {e!s}")
-        raise HTTPException(status_code=500, detail={"error": f"CountTokens processing error: {e!s}"})
+        verbose_proxy_logger.error(f"Error in handle_bedrock_count_tokens: {e}")
+        raise HTTPException(status_code=500, detail={"error": f"CountTokens processing error: {e}"})
 
 
 async def bedrock_llm_proxy_route(

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -935,7 +935,7 @@ class AnthropicPassthroughLoggingHandler:
                     index=0,
                     message={
                         "role": "assistant",
-                        "content": f"Error creating batch job: {e!s}",
+                        "content": f"Error creating batch job: {e}",
                         "tool_calls": None,
                         "function_call": None,
                         "provider_specific_fields": {

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/assembly_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/assembly_passthrough_logging_handler.py
@@ -203,7 +203,7 @@ class AssemblyAIPassthroughLoggingHandler:
 
             return response.json()
         except Exception as e:
-            verbose_proxy_logger.exception(f"[Non blocking logging error] Error getting AssemblyAI transcript: {e!s}")
+            verbose_proxy_logger.exception(f"[Non blocking logging error] Error getting AssemblyAI transcript: {e}")
             return None
 
     def _poll_assembly_for_transcript_response(
@@ -275,7 +275,7 @@ class AssemblyAIPassthroughLoggingHandler:
 
             return None
         except Exception as e:
-            verbose_proxy_logger.exception(f"[Non blocking logging error] Error getting AssemblyAI model info: {e!s}")
+            verbose_proxy_logger.exception(f"[Non blocking logging error] Error getting AssemblyAI model info: {e}")
             return None
 
     @staticmethod

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/openai_passthrough_logging_handler.py
@@ -183,7 +183,7 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
 
             return cost
         except Exception as e:
-            verbose_proxy_logger.warning(f"Error calculating image generation cost: {e!s}")
+            verbose_proxy_logger.warning(f"Error calculating image generation cost: {e}")
             return 0.0
 
     @staticmethod
@@ -217,7 +217,7 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
 
             return cost
         except Exception as e:
-            verbose_proxy_logger.warning(f"Error calculating image editing cost: {e!s}")
+            verbose_proxy_logger.warning(f"Error calculating image editing cost: {e}")
             return 0.0
 
     @staticmethod
@@ -445,7 +445,7 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
             }
 
         except Exception as e:
-            verbose_proxy_logger.error(f"Error in OpenAI passthrough cost tracking: {e!s}")
+            verbose_proxy_logger.error(f"Error in OpenAI passthrough cost tracking: {e}")
             # Fall back to base handler without cost tracking
             base_handler = OpenAIPassthroughLoggingHandler()
             return base_handler.passthrough_chat_handler(
@@ -514,7 +514,7 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
             return complete_streaming_response
 
         except Exception as e:
-            verbose_proxy_logger.error(f"Error building complete streaming response: {e!s}")
+            verbose_proxy_logger.error(f"Error building complete streaming response: {e}")
             return None
 
     @staticmethod
@@ -608,7 +608,7 @@ class OpenAIPassthroughLoggingHandler(BasePassthroughLoggingHandler):
             }
 
         except Exception as e:
-            verbose_proxy_logger.error(f"Error in OpenAI streaming passthrough cost tracking: {e!s}")
+            verbose_proxy_logger.error(f"Error in OpenAI streaming passthrough cost tracking: {e}")
             return {
                 "result": None,
                 "kwargs": {},

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
@@ -759,7 +759,7 @@ class VertexPassthroughLoggingHandler:
                     index=0,
                     message={
                         "role": "assistant",
-                        "content": f"Error creating batch prediction job: {e!s}",
+                        "content": f"Error creating batch prediction job: {e}",
                         "tool_calls": None,
                         "function_call": None,
                         "provider_specific_fields": {

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -294,8 +294,8 @@ async def chat_completion_pass_through_endpoint(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.completion(): Exception occured - {e!s}")
-        error_msg = f"{e!s}"
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.completion(): Exception occured - {e}")
+        error_msg = f"{e}"
         raise ProxyException(
             message=getattr(e, "message", error_msg),
             type=getattr(e, "type", "None"),
@@ -1502,7 +1502,7 @@ async def pass_through_request(
             )
         else:
             verbose_proxy_logger.exception(
-                f"litellm.proxy.proxy_server.pass_through_endpoint(): Exception occured - {e!s}"
+                f"litellm.proxy.proxy_server.pass_through_endpoint(): Exception occured - {e}"
             )
 
         #########################################################
@@ -1544,7 +1544,7 @@ async def pass_through_request(
                 headers=custom_headers,
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),

--- a/litellm/proxy/pass_through_endpoints/streaming_handler.py
+++ b/litellm/proxy/pass_through_endpoints/streaming_handler.py
@@ -89,7 +89,7 @@ class PassThroughStreamingHandler:
 
                     yield chunk
         except Exception as e:
-            verbose_proxy_logger.error(f"Error in chunk_processor: {e!s}")
+            verbose_proxy_logger.error(f"Error in chunk_processor: {e}")
             raise
         finally:
             # GeneratorExit (raised on client disconnect) is not caught by
@@ -115,7 +115,7 @@ class PassThroughStreamingHandler:
                         )
                     )
                 except Exception as e:
-                    verbose_proxy_logger.error(f"Error scheduling chunk_processor logging: {e!s}")
+                    verbose_proxy_logger.error(f"Error scheduling chunk_processor logging: {e}")
 
     @staticmethod
     async def _route_streaming_logging_to_handler(
@@ -165,7 +165,7 @@ class PassThroughStreamingHandler:
                 **kwargs,
             )
         except Exception as e:
-            verbose_proxy_logger.error(f"Error in _route_streaming_logging_to_handler: {e!s}")
+            verbose_proxy_logger.error(f"Error in _route_streaming_logging_to_handler: {e}")
 
     @staticmethod
     def _build_passthrough_logging_result(

--- a/litellm/proxy/policy_engine/attachment_registry.py
+++ b/litellm/proxy/policy_engine/attachment_registry.py
@@ -60,8 +60,8 @@ class AttachmentRegistry:
                 self._attachments.append(attachment)
                 verbose_proxy_logger.debug(f"Loaded attachment for policy: {attachment.policy}")
             except Exception as e:
-                verbose_proxy_logger.error(f"Error loading attachment: {e!s}")
-                raise ValueError(f"Invalid attachment: {e!s}") from e
+                verbose_proxy_logger.error(f"Error loading attachment: {e}")
+                raise ValueError(f"Invalid attachment: {e}") from e
 
         self._config_attachments = tuple(self._attachments)
         self._initialized = True
@@ -318,7 +318,7 @@ class AttachmentRegistry:
             )
         except Exception as e:
             verbose_proxy_logger.exception(f"Error adding attachment to DB: {e}")
-            raise Exception(f"Error adding attachment to DB: {e!s}")
+            raise Exception(f"Error adding attachment to DB: {e}")
 
     async def delete_attachment_from_db(
         self,
@@ -354,7 +354,7 @@ class AttachmentRegistry:
             return {"message": f"Attachment {attachment_id} deleted successfully"}
         except Exception as e:
             verbose_proxy_logger.exception(f"Error deleting attachment from DB: {e}")
-            raise Exception(f"Error deleting attachment from DB: {e!s}")
+            raise Exception(f"Error deleting attachment from DB: {e}")
 
     async def get_attachment_by_id_from_db(
         self,
@@ -394,7 +394,7 @@ class AttachmentRegistry:
             )
         except Exception as e:
             verbose_proxy_logger.exception(f"Error getting attachment from DB: {e}")
-            raise Exception(f"Error getting attachment from DB: {e!s}")
+            raise Exception(f"Error getting attachment from DB: {e}")
 
     async def get_all_attachments_from_db(
         self,
@@ -432,7 +432,7 @@ class AttachmentRegistry:
             ]
         except Exception as e:
             verbose_proxy_logger.exception(f"Error getting attachments from DB: {e}")
-            raise Exception(f"Error getting attachments from DB: {e!s}")
+            raise Exception(f"Error getting attachments from DB: {e}")
 
     async def sync_attachments_from_db(
         self,
@@ -468,7 +468,7 @@ class AttachmentRegistry:
             )
         except Exception as e:
             verbose_proxy_logger.exception(f"Error syncing attachments from DB: {e}")
-            raise Exception(f"Error syncing attachments from DB: {e!s}")
+            raise Exception(f"Error syncing attachments from DB: {e}")
 
 
 # Global singleton instance

--- a/litellm/proxy/policy_engine/init_policies.py
+++ b/litellm/proxy/policy_engine/init_policies.py
@@ -167,7 +167,7 @@ async def init_policies(
         policy_registry.load_policies(policies_config)
         verbose_proxy_logger.info(f"Successfully loaded {len(policies_config)} policies")
     except Exception as e:
-        verbose_proxy_logger.error(f"Failed to load policies: {e!s}")
+        verbose_proxy_logger.error(f"Failed to load policies: {e}")
         raise
 
     # Load attachments if provided
@@ -176,7 +176,7 @@ async def init_policies(
             attachment_registry.load_attachments(policy_attachments_config)
             verbose_proxy_logger.info(f"Successfully loaded {len(policy_attachments_config)} policy attachments")
         except Exception as e:
-            verbose_proxy_logger.error(f"Failed to load policy attachments: {e!s}")
+            verbose_proxy_logger.error(f"Failed to load policy attachments: {e}")
             raise
 
     return validation_result

--- a/litellm/proxy/policy_engine/policy_registry.py
+++ b/litellm/proxy/policy_engine/policy_registry.py
@@ -187,8 +187,8 @@ class PolicyRegistry:
                 self._policies[policy_name] = policy
                 verbose_proxy_logger.debug(f"Loaded policy: {policy_name}")
             except Exception as e:
-                verbose_proxy_logger.error(f"Error loading policy '{policy_name}': {e!s}")
-                raise ValueError(f"Invalid policy '{policy_name}': {e!s}") from e
+                verbose_proxy_logger.error(f"Error loading policy '{policy_name}': {e}")
+                raise ValueError(f"Invalid policy '{policy_name}': {e}") from e
 
         self._config_policies = dict(self._policies)
         self._sources = {policy_name: "config" for policy_name in self._policies}
@@ -433,7 +433,7 @@ class PolicyRegistry:
             return _row_to_policy_db_response(created_policy)
         except Exception as e:
             verbose_proxy_logger.exception(f"Error adding policy to DB: {e}")
-            raise Exception(f"Error adding policy to DB: {e!s}")
+            raise Exception(f"Error adding policy to DB: {e}")
 
     async def update_policy_in_db(
         self,
@@ -497,7 +497,7 @@ class PolicyRegistry:
             return _row_to_policy_db_response(updated_policy)
         except Exception as e:
             verbose_proxy_logger.exception(f"Error updating policy in DB: {e}")
-            raise Exception(f"Error updating policy in DB: {e!s}")
+            raise Exception(f"Error updating policy in DB: {e}")
 
     async def delete_policy_from_db(
         self,
@@ -547,7 +547,7 @@ class PolicyRegistry:
             return result
         except Exception as e:
             verbose_proxy_logger.exception(f"Error deleting policy from DB: {e}")
-            raise Exception(f"Error deleting policy from DB: {e!s}")
+            raise Exception(f"Error deleting policy from DB: {e}")
 
     async def get_policy_by_id_from_db(
         self,
@@ -573,7 +573,7 @@ class PolicyRegistry:
             return _row_to_policy_db_response(policy)
         except Exception as e:
             verbose_proxy_logger.exception(f"Error getting policy from DB: {e}")
-            raise Exception(f"Error getting policy from DB: {e!s}")
+            raise Exception(f"Error getting policy from DB: {e}")
 
     def get_policy_by_id_for_request(self, policy_id: str) -> tuple[str, Policy] | None:
         """
@@ -620,7 +620,7 @@ class PolicyRegistry:
             return [_row_to_policy_db_response(p) for p in policies]
         except Exception as e:
             verbose_proxy_logger.exception(f"Error getting policies from DB: {e}")
-            raise Exception(f"Error getting policies from DB: {e!s}")
+            raise Exception(f"Error getting policies from DB: {e}")
 
     async def sync_policies_from_db(
         self,
@@ -689,7 +689,7 @@ class PolicyRegistry:
             )
         except Exception as e:
             verbose_proxy_logger.exception(f"Error syncing policies from DB: {e}")
-            raise Exception(f"Error syncing policies from DB: {e!s}")
+            raise Exception(f"Error syncing policies from DB: {e}")
 
     async def resolve_guardrails_from_db(
         self,
@@ -742,7 +742,7 @@ class PolicyRegistry:
             return sorted(resolved_policy.guardrails)
         except Exception as e:
             verbose_proxy_logger.exception(f"Error resolving guardrails from DB: {e}")
-            raise Exception(f"Error resolving guardrails from DB: {e!s}")
+            raise Exception(f"Error resolving guardrails from DB: {e}")
 
     async def get_versions_by_policy_name(
         self,
@@ -772,7 +772,7 @@ class PolicyRegistry:
             )
         except Exception as e:
             verbose_proxy_logger.exception(f"Error getting versions: {e}")
-            raise Exception(f"Error getting versions: {e!s}")
+            raise Exception(f"Error getting versions: {e}")
 
     async def create_new_version(
         self,
@@ -858,7 +858,7 @@ class PolicyRegistry:
             return _row_to_policy_db_response(created)
         except Exception as e:
             verbose_proxy_logger.exception(f"Error creating new version: {e}")
-            raise Exception(f"Error creating new version: {e!s}")
+            raise Exception(f"Error creating new version: {e}")
 
     async def update_version_status(
         self,
@@ -963,7 +963,7 @@ class PolicyRegistry:
             return _row_to_policy_db_response(updated)
         except Exception as e:
             verbose_proxy_logger.exception(f"Error updating version status: {e}")
-            raise Exception(f"Error updating version status: {e!s}")
+            raise Exception(f"Error updating version status: {e}")
 
     async def compare_versions(
         self,
@@ -1016,7 +1016,7 @@ class PolicyRegistry:
             )
         except Exception as e:
             verbose_proxy_logger.exception(f"Error comparing versions: {e}")
-            raise Exception(f"Error comparing versions: {e!s}")
+            raise Exception(f"Error comparing versions: {e}")
 
     async def delete_all_versions(
         self,
@@ -1047,7 +1047,7 @@ class PolicyRegistry:
             return {"message": message}
         except Exception as e:
             verbose_proxy_logger.exception(f"Error deleting all versions: {e}")
-            raise Exception(f"Error deleting all versions: {e!s}")
+            raise Exception(f"Error deleting all versions: {e}")
 
 
 # Global singleton instance

--- a/litellm/proxy/policy_engine/policy_validator.py
+++ b/litellm/proxy/policy_engine/policy_validator.py
@@ -78,7 +78,7 @@ class PolicyValidator:
             guardrails = IN_MEMORY_GUARDRAIL_HANDLER.list_in_memory_guardrails()
             return {g.get("guardrail_name", "") for g in guardrails if g.get("guardrail_name")}
         except Exception as e:
-            verbose_proxy_logger.warning(f"Could not get guardrails from registry: {e!s}")
+            verbose_proxy_logger.warning(f"Could not get guardrails from registry: {e}")
             return set()
 
     async def check_team_alias_exists(self, team_alias: str) -> bool:
@@ -100,7 +100,7 @@ class PolicyValidator:
             )
             return team is not None
         except Exception as e:
-            verbose_proxy_logger.warning(f"Could not check team alias '{team_alias}': {e!s}")
+            verbose_proxy_logger.warning(f"Could not check team alias '{team_alias}': {e}")
             return True  # Assume valid on error
 
     async def check_key_alias_exists(self, key_alias: str) -> bool:
@@ -122,7 +122,7 @@ class PolicyValidator:
             )
             return key is not None
         except Exception as e:
-            verbose_proxy_logger.warning(f"Could not check key alias '{key_alias}': {e!s}")
+            verbose_proxy_logger.warning(f"Could not check key alias '{key_alias}': {e}")
             return True  # Assume valid on error
 
     def check_model_exists(self, model: str) -> bool:
@@ -151,7 +151,7 @@ class PolicyValidator:
 
             return False
         except Exception as e:
-            verbose_proxy_logger.warning(f"Could not check model '{model}': {e!s}")
+            verbose_proxy_logger.warning(f"Could not check model '{model}': {e}")
             return True  # Assume valid on error
 
     @staticmethod
@@ -436,7 +436,7 @@ class PolicyValidator:
                     PolicyValidationError(
                         policy_name=policy_name,
                         error_type=PolicyValidationErrorType.INVALID_SYNTAX,
-                        message=f"Failed to parse policy: {e!s}",
+                        message=f"Failed to parse policy: {e}",
                     )
                 )
 

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -1304,7 +1304,7 @@ async def convert_prompt_file_to_json(
         }
 
     except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error converting prompt file: {e!s}")
+        raise HTTPException(status_code=500, detail=f"Error converting prompt file: {e}")
 
     finally:
         # Clean up temp file

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3848,7 +3848,7 @@ class ProxyConfig:
             with open(file_path, "r") as file:
                 return yaml.safe_load(file) or {}
         except Exception as e:
-            raise Exception(f"Error loading yaml file {file_path}: {e!s}")
+            raise Exception(f"Error loading yaml file {file_path}: {e}")
 
     async def _get_config_from_file(self, config_file_path: str | None = None) -> dict:
         """
@@ -4286,7 +4286,7 @@ class ProxyConfig:
                 search_tool_typed: SearchToolTypedDict = SearchToolTypedDict(**search_tool)  # type: ignore
                 search_tools_parsed.append(search_tool_typed)
             except Exception as e:
-                verbose_proxy_logger.error(f"Error parsing search tool {search_tool_name}: {e!s}")
+                verbose_proxy_logger.error(f"Error parsing search tool {search_tool_name}: {e}")
                 continue
 
         return search_tools_parsed if search_tools_parsed else None
@@ -5499,7 +5499,7 @@ class ProxyConfig:
                 self._add_deployment(db_models=models_list)
 
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error adding/deleting model to llm_router: {e!s}")
+            verbose_proxy_logger.exception(f"Error adding/deleting model to llm_router: {e}")
 
         if llm_router is not None:
             llm_model_list = llm_router.get_model_list()
@@ -6143,7 +6143,7 @@ class ProxyConfig:
             return new_models
         except Exception as e:
             verbose_proxy_logger.exception(
-                f"litellm.proxy_server.py::add_deployment() - Error getting new models from DB - {e!s}"
+                f"litellm.proxy_server.py::add_deployment() - Error getting new models from DB - {e}"
             )
             return None
 
@@ -6200,7 +6200,7 @@ class ProxyConfig:
             await self._init_non_llm_objects_in_db(prisma_client=prisma_client)
 
         except Exception as e:
-            verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.py::ProxyConfig:add_deployment - {e!s}")
+            verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.py::ProxyConfig:add_deployment - {e}")
 
         return still_desired_ids
 
@@ -6375,9 +6375,7 @@ class ProxyConfig:
                 uppercase_sso_settings = {key.upper(): value for key, value in sso_settings.sso_settings.items()}
                 self._decrypt_and_set_db_env_variables(environment_variables=uppercase_sso_settings)
         except Exception as e:
-            verbose_proxy_logger.exception(
-                f"litellm.proxy.proxy_server.py::ProxyConfig:_init_sso_settings_in_db - {e!s}"
-            )
+            verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.py::ProxyConfig:_init_sso_settings_in_db - {e}")
 
     async def _init_hashicorp_vault_config_override(self, prisma_client: PrismaClient):
         """
@@ -6534,7 +6532,7 @@ class ProxyConfig:
                 )
 
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error in _check_and_reload_model_cost_map: {e!s}")
+            verbose_proxy_logger.exception(f"Error in _check_and_reload_model_cost_map: {e}")
 
     async def _check_and_reload_anthropic_beta_headers(self, prisma_client: PrismaClient):
         """
@@ -6631,7 +6629,7 @@ class ProxyConfig:
                 )
 
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error in _check_and_reload_anthropic_beta_headers: {e!s}")
+            verbose_proxy_logger.exception(f"Error in _check_and_reload_anthropic_beta_headers: {e}")
 
     def _get_prompt_spec_for_db_prompt(self, db_prompt):
         """
@@ -6660,7 +6658,7 @@ class ProxyConfig:
                 prompt_spec = self._get_prompt_spec_for_db_prompt(db_prompt=prompt)
                 IN_MEMORY_PROMPT_REGISTRY.initialize_prompt(prompt=prompt_spec)
         except Exception as e:
-            verbose_proxy_logger.debug(f"litellm.proxy.proxy_server.py::ProxyConfig:_init_prompts_in_db - {e!s}")
+            verbose_proxy_logger.debug(f"litellm.proxy.proxy_server.py::ProxyConfig:_init_prompts_in_db - {e}")
 
     async def _init_guardrails_in_db(self, prisma_client: PrismaClient):
         from litellm.proxy.guardrails.guardrail_registry import (
@@ -6687,7 +6685,7 @@ class ProxyConfig:
             # pod. Config-loaded entries are never touched.
             IN_MEMORY_GUARDRAIL_HANDLER.reconcile_db_guardrails(db_guardrail_ids=db_guardrail_ids)
         except Exception as e:
-            verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.py::ProxyConfig:_init_guardrails_in_db - {e!s}")
+            verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.py::ProxyConfig:_init_guardrails_in_db - {e}")
 
     async def _init_policies_in_db(self, prisma_client: PrismaClient):
         """
@@ -6711,7 +6709,7 @@ class ProxyConfig:
 
             verbose_proxy_logger.debug("Successfully synced policies and attachments from DB")
         except Exception as e:
-            verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.py::ProxyConfig:_init_policies_in_db - {e!s}")
+            verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.py::ProxyConfig:_init_policies_in_db - {e}")
 
     async def _init_tool_policy_in_db(self, prisma_client: PrismaClient):
         """
@@ -6725,9 +6723,7 @@ class ProxyConfig:
             await registry.sync_tool_policy_from_db(prisma_client=prisma_client)
             verbose_proxy_logger.debug("Successfully synced tool policy from DB")
         except Exception as e:
-            verbose_proxy_logger.exception(
-                f"litellm.proxy.proxy_server.py::ProxyConfig:_init_tool_policy_in_db - {e!s}"
-            )
+            verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.py::ProxyConfig:_init_tool_policy_in_db - {e}")
 
     async def _init_vector_stores_in_db(self, prisma_client: PrismaClient):
         from litellm.vector_stores.vector_store_registry import VectorStoreRegistry
@@ -6745,7 +6741,7 @@ class ProxyConfig:
                     litellm.vector_store_registry.add_vector_store_to_registry(vector_store=vector_store)
         except Exception as e:
             verbose_proxy_logger.exception(
-                f"litellm.proxy.proxy_server.py::ProxyConfig:_init_vector_stores_in_db - {e!s}"
+                f"litellm.proxy.proxy_server.py::ProxyConfig:_init_vector_stores_in_db - {e}"
             )
 
     async def _init_vector_store_indexes_in_db(self, prisma_client: PrismaClient):
@@ -6769,7 +6765,7 @@ class ProxyConfig:
                     litellm.vector_store_index_registry.upsert_vector_store_index(vector_store_index=vector_store_index)
         except Exception as e:
             verbose_proxy_logger.exception(
-                f"litellm.proxy.proxy_server.py::ProxyConfig:_init_vector_stores_in_db - {e!s}"
+                f"litellm.proxy.proxy_server.py::ProxyConfig:_init_vector_stores_in_db - {e}"
             )
 
     async def _init_mcp_servers_in_db(self):
@@ -6794,7 +6790,7 @@ class ProxyConfig:
                 await backfill_null_oauth2_flows(prisma_client)
         except Exception as e:  # noqa: BLE001
             verbose_proxy_logger.exception(
-                f"litellm.proxy.proxy_server.py::ProxyConfig:_init_mcp_servers_in_db backfill - {e!s}"
+                f"litellm.proxy.proxy_server.py::ProxyConfig:_init_mcp_servers_in_db backfill - {e}"
             )
 
         try:
@@ -6802,15 +6798,13 @@ class ProxyConfig:
                 await backfill_discovery_stamped_issuers(prisma_client)
         except Exception as e:  # noqa: BLE001
             verbose_proxy_logger.exception(
-                f"litellm.proxy.proxy_server.py::ProxyConfig:_init_mcp_servers_in_db issuer stamp backfill - {e!s}"
+                f"litellm.proxy.proxy_server.py::ProxyConfig:_init_mcp_servers_in_db issuer stamp backfill - {e}"
             )
 
         try:
             await global_mcp_server_manager.reload_servers_from_database()
         except Exception as e:
-            verbose_proxy_logger.exception(
-                f"litellm.proxy.proxy_server.py::ProxyConfig:_init_mcp_servers_in_db - {e!s}"
-            )
+            verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.py::ProxyConfig:_init_mcp_servers_in_db - {e}")
 
     async def init_mcp_servers_from_db(self) -> None:
         if self._should_load_db_object(object_type="mcp"):
@@ -6838,7 +6832,7 @@ class ProxyConfig:
             await global_mcp_server_manager.reload_servers_from_database()
         except Exception as e:  # noqa: BLE001  # scheduled job: a reload failure must not kill the recurring retry
             verbose_proxy_logger.exception(
-                f"litellm.proxy.proxy_server.py::ProxyConfig:reload_mcp_servers_from_db - {e!s}"
+                f"litellm.proxy.proxy_server.py::ProxyConfig:reload_mcp_servers_from_db - {e}"
             )
 
     async def _init_agents_in_db(self, prisma_client: PrismaClient):
@@ -6850,7 +6844,7 @@ class ProxyConfig:
             db_agents = await AGENT_REGISTRY.get_all_agents_from_db(prisma_client=prisma_client)
             AGENT_REGISTRY.load_agents_from_db_and_config(db_agents=db_agents)
         except Exception as e:
-            verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.py::ProxyConfig:_init_agents_in_db - {e!s}")
+            verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.py::ProxyConfig:_init_agents_in_db - {e}")
 
     async def _init_search_tools_in_db(self, prisma_client: PrismaClient):
         """
@@ -6890,9 +6884,7 @@ class ProxyConfig:
                 )
 
         except Exception as e:
-            verbose_proxy_logger.exception(
-                f"litellm.proxy.proxy_server.py::ProxyConfig:_init_search_tools_in_db - {e!s}"
-            )
+            verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.py::ProxyConfig:_init_search_tools_in_db - {e}")
 
     @staticmethod
     def _merge_config_and_db_search_tools(
@@ -6958,7 +6950,7 @@ class ProxyConfig:
             CredentialAccessor.upsert_credentials(credentials)  # upsert credentials that are in the all-up list
         except Exception as e:
             verbose_proxy_logger.exception(
-                f"litellm.proxy_server.py::get_credentials() - Error getting credentials from DB - {e!s}"
+                f"litellm.proxy_server.py::get_credentials() - Error getting credentials from DB - {e}"
             )
             return []
 
@@ -7138,14 +7130,14 @@ async def async_assistants_data_generator(response, user_api_key_dict: UserAPIKe
                 try:
                     yield f"data: {c}\n\n"
                 except Exception as e:
-                    yield f"data: {e!s}\n\n"
+                    yield f"data: {e}\n\n"
 
         # Streaming is done, yield the [DONE] chunk
         done_message = "[DONE]"
         yield f"data: {done_message}\n\n"
     except Exception as e:
         verbose_proxy_logger.exception(
-            f"litellm.proxy.proxy_server.async_assistants_data_generator(): Exception occured - {e!s}"
+            f"litellm.proxy.proxy_server.async_assistants_data_generator(): Exception occured - {e}"
         )
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict,
@@ -7586,7 +7578,7 @@ async def async_data_generator(
                 try:
                     yield _format_streaming_sse_chunk(chunk=chunk)
                 except Exception as e:
-                    yield f"data: {e!s}\n\n"
+                    yield f"data: {e}\n\n"
 
             if pending_fallback_event:
                 yield _format_fallback_metadata_sse_event(
@@ -7624,7 +7616,7 @@ async def async_data_generator(
             client_disconnected = True
         raise
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.async_data_generator(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.async_data_generator(): Exception occured - {e}")
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict,
             original_exception=e,
@@ -9375,8 +9367,8 @@ async def completion(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.completion(): Exception occured - {e!s}")
-        error_msg = f"{e!s}"
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.completion(): Exception occured - {e}")
+        error_msg = f"{e}"
         raise ProxyException(
             message=getattr(e, "message", error_msg),
             type=getattr(e, "type", "None"),
@@ -9614,7 +9606,7 @@ async def moderations(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.moderations(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.moderations(): Exception occured - {e}")
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e)),
@@ -9623,7 +9615,7 @@ async def moderations(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -9760,7 +9752,7 @@ async def audio_speech(
             original_exception=e,
             request_data=data,
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.audio_speech(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.audio_speech(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         raise e
 
@@ -9902,7 +9894,7 @@ async def audio_transcriptions(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.audio_transcription(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.audio_transcription(): Exception occured - {e}")
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e.detail)),
@@ -9911,7 +9903,7 @@ async def audio_transcriptions(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -10188,7 +10180,7 @@ async def get_assistants(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.get_assistants(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.get_assistants(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
@@ -10198,7 +10190,7 @@ async def get_assistants(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -10279,7 +10271,7 @@ async def create_assistant(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.create_assistant(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.create_assistant(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
@@ -10289,7 +10281,7 @@ async def create_assistant(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -10368,7 +10360,7 @@ async def delete_assistant(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.delete_assistant(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.delete_assistant(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
@@ -10378,7 +10370,7 @@ async def delete_assistant(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -10457,7 +10449,7 @@ async def create_threads(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.create_threads(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.create_threads(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
@@ -10467,7 +10459,7 @@ async def create_threads(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -10544,7 +10536,7 @@ async def get_thread(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.get_thread(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.get_thread(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
@@ -10554,7 +10546,7 @@ async def get_thread(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -10635,7 +10627,7 @@ async def add_messages(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.add_messages(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.add_messages(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
@@ -10645,7 +10637,7 @@ async def add_messages(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -10722,7 +10714,7 @@ async def get_messages(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.get_messages(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.get_messages(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
@@ -10732,7 +10724,7 @@ async def get_messages(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -10823,7 +10815,7 @@ async def run_thread(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.run_thread(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.run_thread(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
@@ -10833,7 +10825,7 @@ async def run_thread(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),
@@ -11760,7 +11752,7 @@ async def _apply_search_filter_to_models(
             )
             search_total_count = router_models_count + db_models_total_count
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error querying database models with search: {e!s}")
+            verbose_proxy_logger.exception(f"Error querying database models with search: {e}")
             search_total_count = router_models_count
     else:
         search_total_count = router_models_count
@@ -11895,7 +11887,7 @@ def _sort_models(
         sorted_models = sorted(all_models, key=get_sort_key, reverse=reverse)
         return sorted_models
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error sorting models by {sort_by}: {e!s}")
+        verbose_proxy_logger.exception(f"Error sorting models by {sort_by}: {e}")
         return all_models
 
 
@@ -11975,7 +11967,7 @@ async def _load_team_object_for_model_filter(team_id: str, prisma_client: Prisma
             return None
         return LiteLLM_TeamTable.model_validate(team_db_object.model_dump())
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error fetching team {team_id}: {e!s}")
+        verbose_proxy_logger.exception(f"Error fetching team {team_id}: {e}")
         return None
 
 
@@ -12025,7 +12017,7 @@ async def _gather_team_accessible_model_ids(
                 if db_model.model_id:
                     team_accessible_model_ids.add(db_model.model_id)
     except Exception as e:
-        verbose_proxy_logger.debug(f"Error querying database models for team {team_id}: {e!s}")
+        verbose_proxy_logger.debug(f"Error querying database models for team {team_id}: {e}")
 
     return team_accessible_model_ids
 
@@ -12163,7 +12155,7 @@ async def _find_model_by_id(
                 if decrypted_models:
                     found_model = decrypted_models[0]
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error querying database for modelId {model_id}: {e!s}")
+            verbose_proxy_logger.exception(f"Error querying database for modelId {model_id}: {e}")
 
     # If model found, verify search filter if provided
     if found_model is not None:
@@ -13613,7 +13605,7 @@ async def async_queue_request(
         )
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e!s})"),
+                message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
@@ -13779,7 +13771,7 @@ async def login_v2(request: Request):
         json_response.set_cookie(key="token", value=jwt_token)
         return json_response
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.login_v2(): Exception occurred - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.login_v2(): Exception occurred - {e}")
         if isinstance(e, ProxyException):
             raise e
         elif isinstance(e, HTTPException):
@@ -13790,7 +13782,7 @@ async def login_v2(request: Request):
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=error_msg,
                 type=ProxyErrorTypes.auth_error,
@@ -13856,7 +13848,7 @@ async def login_v3(request: Request):
             status_code=status.HTTP_200_OK,
         )
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.login_v3(): Exception occurred - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.login_v3(): Exception occurred - {e}")
         if isinstance(e, ProxyException):
             raise e
         elif isinstance(e, HTTPException):
@@ -13867,7 +13859,7 @@ async def login_v3(request: Request):
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=error_msg,
                 type=ProxyErrorTypes.auth_error,
@@ -13929,7 +13921,7 @@ async def login_v3_exchange(request: Request):
     except ProxyException:
         raise
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.login_v3_exchange(): Exception occurred - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.login_v3_exchange(): Exception occurred - {e}")
         raise ProxyException(
             message=str(e),
             type=ProxyErrorTypes.auth_error,
@@ -14756,11 +14748,11 @@ async def update_config(
 
         return {"message": "Config updated successfully"}
     except Exception as e:
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.update_config(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.update_config(): Exception occured - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e!s})"),
+                message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
@@ -15584,7 +15576,7 @@ async def delete_callback(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.delete_callback(): Exception occurred - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.delete_callback(): Exception occurred - {e}")
         verbose_proxy_logger.debug(traceback.format_exc())
         raise ProxyException(
             message="Error deleting callback: " + str(e),
@@ -15708,10 +15700,10 @@ async def get_config(
             "available_callbacks": all_available_callbacks,
         }
     except Exception as e:
-        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.get_config(): Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"litellm.proxy.proxy_server.get_config(): Exception occured - {e}")
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"Authentication Error({e!s})"),
+                message=getattr(e, "detail", f"Authentication Error({e})"),
                 type=ProxyErrorTypes.auth_error,
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
@@ -15826,8 +15818,8 @@ async def reload_model_cost_map(
             "timestamp": current_time.isoformat(),
         }
     except Exception as e:
-        verbose_proxy_logger.exception(f"Failed to reload model cost map: {e!s}")
-        raise HTTPException(status_code=500, detail=f"Failed to reload model cost map: {e!s}")
+        verbose_proxy_logger.exception(f"Failed to reload model cost map: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to reload model cost map: {e}")
 
 
 @router.post(
@@ -15883,10 +15875,10 @@ async def schedule_model_cost_map_reload(
             "timestamp": datetime.utcnow().isoformat(),
         }
     except Exception as e:
-        verbose_proxy_logger.exception(f"Failed to schedule model cost map reload: {e!s}")
+        verbose_proxy_logger.exception(f"Failed to schedule model cost map reload: {e}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to schedule model cost map reload: {e!s}",
+            detail=f"Failed to schedule model cost map reload: {e}",
         )
 
 
@@ -15928,8 +15920,8 @@ async def cancel_model_cost_map_reload(
             "timestamp": datetime.utcnow().isoformat(),
         }
     except Exception as e:
-        verbose_proxy_logger.exception(f"Failed to cancel model cost map reload: {e!s}")
-        raise HTTPException(status_code=500, detail=f"Failed to cancel model cost map reload: {e!s}")
+        verbose_proxy_logger.exception(f"Failed to cancel model cost map reload: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to cancel model cost map reload: {e}")
 
 
 @router.get(
@@ -16015,10 +16007,10 @@ async def get_model_cost_map_reload_status(
             "next_run": next_run,
         }
     except Exception as e:
-        verbose_proxy_logger.exception(f"Failed to get model cost map reload status: {e!s}")
+        verbose_proxy_logger.exception(f"Failed to get model cost map reload status: {e}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to get model cost map reload status: {e!s}",
+            detail=f"Failed to get model cost map reload status: {e}",
         )
 
 
@@ -16063,10 +16055,10 @@ async def get_model_cost_map_source(
             "model_count": model_count,
         }
     except Exception as e:
-        verbose_proxy_logger.exception(f"Failed to get model cost map source info: {e!s}")
+        verbose_proxy_logger.exception(f"Failed to get model cost map source info: {e}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to get model cost map source info: {e!s}",
+            detail=f"Failed to get model cost map source info: {e}",
         )
 
 
@@ -16142,8 +16134,8 @@ async def reload_anthropic_beta_headers(
             "timestamp": current_time.isoformat(),
         }
     except Exception as e:
-        verbose_proxy_logger.exception(f"Failed to reload anthropic beta headers: {e!s}")
-        raise HTTPException(status_code=500, detail=f"Failed to reload anthropic beta headers: {e!s}")
+        verbose_proxy_logger.exception(f"Failed to reload anthropic beta headers: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to reload anthropic beta headers: {e}")
 
 
 @router.post(
@@ -16199,10 +16191,10 @@ async def schedule_anthropic_beta_headers_reload(
             "timestamp": datetime.utcnow().isoformat(),
         }
     except Exception as e:
-        verbose_proxy_logger.exception(f"Failed to schedule anthropic beta headers reload: {e!s}")
+        verbose_proxy_logger.exception(f"Failed to schedule anthropic beta headers reload: {e}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to schedule anthropic beta headers reload: {e!s}",
+            detail=f"Failed to schedule anthropic beta headers reload: {e}",
         )
 
 
@@ -16244,10 +16236,10 @@ async def cancel_anthropic_beta_headers_reload(
             "timestamp": datetime.utcnow().isoformat(),
         }
     except Exception as e:
-        verbose_proxy_logger.exception(f"Failed to cancel anthropic beta headers reload: {e!s}")
+        verbose_proxy_logger.exception(f"Failed to cancel anthropic beta headers reload: {e}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to cancel anthropic beta headers reload: {e!s}",
+            detail=f"Failed to cancel anthropic beta headers reload: {e}",
         )
 
 
@@ -16336,10 +16328,10 @@ async def get_anthropic_beta_headers_reload_status(
             "next_run": next_run,
         }
     except Exception as e:
-        verbose_proxy_logger.exception(f"Failed to get anthropic beta headers reload status: {e!s}")
+        verbose_proxy_logger.exception(f"Failed to get anthropic beta headers reload status: {e}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to get anthropic beta headers reload status: {e!s}",
+            detail=f"Failed to get anthropic beta headers reload status: {e}",
         )
 
 

--- a/litellm/proxy/public_endpoints/public_endpoints.py
+++ b/litellm/proxy/public_endpoints/public_endpoints.py
@@ -364,7 +364,7 @@ async def get_litellm_model_cost_map():
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail=f"Internal Server Error ({e!s})",
+            detail=f"Internal Server Error ({e})",
         )
 
 

--- a/litellm/proxy/rerank_endpoints/endpoints.py
+++ b/litellm/proxy/rerank_endpoints/endpoints.py
@@ -103,7 +103,7 @@ async def rerank(
         await proxy_logging_obj.post_call_failure_hook(
             user_api_key_dict=user_api_key_dict, original_exception=e, request_data=data
         )
-        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.rerank(): Exception occured - {e!s}")
+        verbose_proxy_logger.error(f"litellm.proxy.proxy_server.rerank(): Exception occured - {e}")
         if isinstance(e, HTTPException):
             raise ProxyException(
                 message=getattr(e, "message", str(e)),
@@ -112,7 +112,7 @@ async def rerank(
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
         else:
-            error_msg = f"{e!s}"
+            error_msg = f"{e}"
             raise ProxyException(
                 message=getattr(e, "message", error_msg),
                 type=getattr(e, "type", "None"),

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -250,9 +250,7 @@ async def responses_api(
                             f"Stored background response {response.id} in managed objects table with unified_id={response.id}"
                         )
                     except Exception as e:
-                        verbose_proxy_logger.error(
-                            f"Failed to store background response in managed objects table: {e!s}"
-                        )
+                        verbose_proxy_logger.error(f"Failed to store background response in managed objects table: {e}")
 
         return response
     except ModifyResponseException as e:

--- a/litellm/proxy/response_polling/background_streaming.py
+++ b/litellm/proxy/response_polling/background_streaming.py
@@ -328,7 +328,7 @@ async def background_streaming_task(
         )
 
     except Exception as e:
-        verbose_proxy_logger.error(f"Error in background streaming task for {polling_id}: {e!s}")
+        verbose_proxy_logger.error(f"Error in background streaming task for {polling_id}: {e}")
         import traceback
 
         verbose_proxy_logger.error(traceback.format_exc())

--- a/litellm/proxy/search_endpoints/endpoints.py
+++ b/litellm/proxy/search_endpoints/endpoints.py
@@ -170,7 +170,7 @@ async def search(
                     team_object=team_object,
                 )
         except Exception as e:
-            verbose_proxy_logger.error(f"Search tool authorization failed for {search_tool_name_value}: {e!s}")
+            verbose_proxy_logger.error(f"Search tool authorization failed for {search_tool_name_value}: {e}")
             raise
 
         if llm_router is not None and hasattr(llm_router, "search_tools"):

--- a/litellm/proxy/search_endpoints/search_tool_registry.py
+++ b/litellm/proxy/search_endpoints/search_tool_registry.py
@@ -78,8 +78,8 @@ class SearchToolRegistry:
 
             return search_tool_dict
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error adding search tool to DB: {e!s}")
-            raise Exception(f"Error adding search tool to DB: {e!s}")
+            verbose_proxy_logger.exception(f"Error adding search tool to DB: {e}")
+            raise Exception(f"Error adding search tool to DB: {e}")
 
     async def delete_search_tool_from_db(self, search_tool_id: str, prisma_client: PrismaClient):
         """
@@ -109,8 +109,8 @@ class SearchToolRegistry:
                 "search_tool_name": existing_tool.search_tool_name,
             }
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error deleting search tool from DB: {e!s}")
-            raise Exception(f"Error deleting search tool from DB: {e!s}")
+            verbose_proxy_logger.exception(f"Error deleting search tool from DB: {e}")
+            raise Exception(f"Error deleting search tool from DB: {e}")
 
     async def update_search_tool_in_db(self, search_tool_id: str, search_tool: SearchTool, prisma_client: PrismaClient):
         """
@@ -143,8 +143,8 @@ class SearchToolRegistry:
             # Convert to dict with ISO formatted datetimes
             return self._convert_prisma_to_dict(updated_search_tool)
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error updating search tool in DB: {e!s}")
-            raise Exception(f"Error updating search tool in DB: {e!s}")
+            verbose_proxy_logger.exception(f"Error updating search tool in DB: {e}")
+            raise Exception(f"Error updating search tool in DB: {e}")
 
     @staticmethod
     async def get_all_search_tools_from_db(
@@ -176,8 +176,8 @@ class SearchToolRegistry:
 
             return search_tools
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error getting search tools from DB: {e!s}")
-            raise Exception(f"Error getting search tools from DB: {e!s}")
+            verbose_proxy_logger.exception(f"Error getting search tools from DB: {e}")
+            raise Exception(f"Error getting search tools from DB: {e}")
 
     async def get_search_tool_by_id_from_db(
         self, search_tool_id: str, prisma_client: PrismaClient
@@ -204,8 +204,8 @@ class SearchToolRegistry:
             search_tool_dict = self._convert_prisma_to_dict(search_tool)
             return SearchTool(**search_tool_dict)  # type: ignore
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error getting search tool from DB: {e!s}")
-            raise Exception(f"Error getting search tool from DB: {e!s}")
+            verbose_proxy_logger.exception(f"Error getting search tool from DB: {e}")
+            raise Exception(f"Error getting search tool from DB: {e}")
 
     async def get_search_tool_by_name_from_db(
         self, search_tool_name: str, prisma_client: PrismaClient
@@ -232,5 +232,5 @@ class SearchToolRegistry:
             search_tool_dict = self._convert_prisma_to_dict(search_tool)
             return SearchTool(**search_tool_dict)  # type: ignore
         except Exception as e:
-            verbose_proxy_logger.exception(f"Error getting search tool from DB: {e!s}")
-            raise Exception(f"Error getting search tool from DB: {e!s}")
+            verbose_proxy_logger.exception(f"Error getting search tool from DB: {e}")
+            raise Exception(f"Error getting search tool from DB: {e}")

--- a/litellm/proxy/spend_tracking/cloudzero_endpoints.py
+++ b/litellm/proxy/spend_tracking/cloudzero_endpoints.py
@@ -161,10 +161,10 @@ async def get_cloudzero_settings(
         # Re-raise HTTPExceptions as-is
         raise e
     except Exception as e:
-        verbose_proxy_logger.error(f"Error retrieving CloudZero settings: {e!s}")
+        verbose_proxy_logger.error(f"Error retrieving CloudZero settings: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to retrieve CloudZero settings: {e!s}"},
+            detail={"error": f"Failed to retrieve CloudZero settings: {e}"},
         )
 
 
@@ -238,10 +238,10 @@ async def update_cloudzero_settings(
             )
         raise e
     except Exception as e:
-        verbose_proxy_logger.error(f"Error updating CloudZero settings: {e!s}")
+        verbose_proxy_logger.error(f"Error updating CloudZero settings: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to update CloudZero settings: {e!s}"},
+            detail={"error": f"Failed to update CloudZero settings: {e}"},
         )
 
 
@@ -275,7 +275,7 @@ async def is_cloudzero_setup_in_db() -> bool:
         return cloudzero_config is not None and cloudzero_config.param_value is not None
 
     except Exception as e:
-        verbose_proxy_logger.error(f"Error checking CloudZero status: {e!s}")
+        verbose_proxy_logger.error(f"Error checking CloudZero status: {e}")
         return False
 
 
@@ -317,7 +317,7 @@ async def is_cloudzero_setup() -> bool:
         return False
 
     except Exception as e:
-        verbose_proxy_logger.error(f"Error checking CloudZero setup: {e!s}")
+        verbose_proxy_logger.error(f"Error checking CloudZero setup: {e}")
         return False
 
 
@@ -364,10 +364,10 @@ async def init_cloudzero_settings(
         return CloudZeroInitResponse(message="CloudZero settings initialized successfully", status="success")
 
     except Exception as e:
-        verbose_proxy_logger.error(f"Error initializing CloudZero settings: {e!s}")
+        verbose_proxy_logger.error(f"Error initializing CloudZero settings: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to initialize CloudZero settings: {e!s}"},
+            detail={"error": f"Failed to initialize CloudZero settings: {e}"},
         )
 
 
@@ -422,10 +422,10 @@ async def cloudzero_dry_run_export(
         )
 
     except Exception as e:
-        verbose_proxy_logger.error(f"Error performing CloudZero dry run export: {e!s}")
+        verbose_proxy_logger.error(f"Error performing CloudZero dry run export: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to perform CloudZero dry run export: {e!s}"},
+            detail={"error": f"Failed to perform CloudZero dry run export: {e}"},
         )
 
 
@@ -487,10 +487,10 @@ async def cloudzero_export(
         )
 
     except Exception as e:
-        verbose_proxy_logger.error(f"Error performing CloudZero export: {e!s}")
+        verbose_proxy_logger.error(f"Error performing CloudZero export: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to perform CloudZero export: {e!s}"},
+            detail={"error": f"Failed to perform CloudZero export: {e}"},
         )
 
 
@@ -550,8 +550,8 @@ async def delete_cloudzero_settings(
     except HTTPException as e:
         raise e
     except Exception as e:
-        verbose_proxy_logger.error(f"Error deleting CloudZero settings: {e!s}")
+        verbose_proxy_logger.error(f"Error deleting CloudZero settings: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to delete CloudZero settings: {e!s}"},
+            detail={"error": f"Failed to delete CloudZero settings: {e}"},
         )

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -440,7 +440,7 @@ async def view_spend_tags(
     except Exception as e:
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"/spend/tags Error({e!s})"),
+                message=getattr(e, "detail", f"/spend/tags Error({e})"),
                 type="internal_error",
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
@@ -1492,7 +1492,7 @@ async def global_get_all_tag_names():
     except Exception as e:
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"/spend/all_tag_names Error({e!s})"),
+                message=getattr(e, "detail", f"/spend/all_tag_names Error({e})"),
                 type="internal_error",
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
@@ -1648,7 +1648,7 @@ async def _get_spend_report_for_time_range(
 
         return response, spend_per_tag
     except Exception as e:
-        verbose_proxy_logger.error(f"Exception in _get_daily_spend_reports {e!s}")
+        verbose_proxy_logger.error(f"Exception in _get_daily_spend_reports {e}")
 
 
 @router.post(
@@ -1798,7 +1798,7 @@ async def calculate_spend(request: SpendCalculateRequest):
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_400_BAD_REQUEST),
             )
-        error_msg = f"{e!s}"
+        error_msg = f"{e}"
         raise ProxyException(
             message=getattr(e, "message", error_msg),
             type=getattr(e, "type", "None"),
@@ -2667,7 +2667,7 @@ async def view_spend_logs(
     except Exception as e:
         if isinstance(e, HTTPException):
             raise ProxyException(
-                message=getattr(e, "detail", f"/spend/logs Error({e!s})"),
+                message=getattr(e, "detail", f"/spend/logs Error({e})"),
                 type="internal_error",
                 param=getattr(e, "param", "None"),
                 code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),
@@ -2789,7 +2789,7 @@ async def global_spend_refresh():
             }
 
         except Exception as e:
-            verbose_proxy_logger.exception(f"Failed to refresh materialized view - {e!s}")
+            verbose_proxy_logger.exception(f"Failed to refresh materialized view - {e}")
             return {
                 "message": "Failed to refresh materialized view",
                 "status": "failure",
@@ -2830,7 +2830,7 @@ async def global_spend_for_internal_user(
 
         return response
     except Exception as e:
-        verbose_proxy_logger.error(f"/global/spend/logs Error: {e!s}")
+        verbose_proxy_logger.error(f"/global/spend/logs Error: {e}")
         raise e
 
 
@@ -3387,7 +3387,7 @@ async def provider_budgets() -> ProviderBudgetResponse:
             provider_budget_response_dict[_provider] = provider_budget_response_object
         return ProviderBudgetResponse(providers=provider_budget_response_dict)
     except Exception as e:
-        verbose_proxy_logger.exception(f"/provider/budgets: Exception occured - {e!s}")
+        verbose_proxy_logger.exception(f"/provider/budgets: Exception occured - {e}")
         raise handle_exception_on_proxy(e)
 
 

--- a/litellm/proxy/spend_tracking/vantage_endpoints.py
+++ b/litellm/proxy/spend_tracking/vantage_endpoints.py
@@ -166,10 +166,10 @@ async def get_vantage_settings(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"Error retrieving Vantage settings: {e!s}")
+        verbose_proxy_logger.error(f"Error retrieving Vantage settings: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to retrieve Vantage settings: {e!s}"},
+            detail={"error": f"Failed to retrieve Vantage settings: {e}"},
         )
 
 
@@ -235,10 +235,10 @@ async def update_vantage_settings(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"Error updating Vantage settings: {e!s}")
+        verbose_proxy_logger.error(f"Error updating Vantage settings: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to update Vantage settings: {e!s}"},
+            detail={"error": f"Failed to update Vantage settings: {e}"},
         )
 
 
@@ -257,7 +257,7 @@ async def is_vantage_setup_in_db() -> bool:
         return vantage_config is not None and vantage_config.param_value is not None
 
     except Exception as e:
-        verbose_proxy_logger.error(f"Error checking Vantage status: {e!s}")
+        verbose_proxy_logger.error(f"Error checking Vantage status: {e}")
         return False
 
 
@@ -280,7 +280,7 @@ async def is_vantage_setup() -> bool:
             return True
         return False
     except Exception as e:
-        verbose_proxy_logger.error(f"Error checking Vantage setup: {e!s}")
+        verbose_proxy_logger.error(f"Error checking Vantage setup: {e}")
         return False
 
 
@@ -324,10 +324,10 @@ async def init_vantage_settings(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"Error initializing Vantage settings: {e!s}")
+        verbose_proxy_logger.error(f"Error initializing Vantage settings: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to initialize Vantage settings: {e!s}"},
+            detail={"error": f"Failed to initialize Vantage settings: {e}"},
         )
 
 
@@ -415,10 +415,10 @@ async def vantage_dry_run_export(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"Error performing Vantage dry run export: {e!s}")
+        verbose_proxy_logger.error(f"Error performing Vantage dry run export: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to perform Vantage dry run export: {e!s}"},
+            detail={"error": f"Failed to perform Vantage dry run export: {e}"},
         )
 
 
@@ -488,10 +488,10 @@ async def vantage_export(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"Error performing Vantage export: {e!s}")
+        verbose_proxy_logger.error(f"Error performing Vantage export: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to perform Vantage export: {e!s}"},
+            detail={"error": f"Failed to perform Vantage export: {e}"},
         )
 
 
@@ -548,8 +548,8 @@ async def delete_vantage_settings(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.error(f"Error deleting Vantage settings: {e!s}")
+        verbose_proxy_logger.error(f"Error deleting Vantage settings: {e}")
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Failed to delete Vantage settings: {e!s}"},
+            detail={"error": f"Failed to delete Vantage settings: {e}"},
         )

--- a/litellm/proxy/types_utils/utils.py
+++ b/litellm/proxy/types_utils/utils.py
@@ -176,7 +176,7 @@ def _load_instance_from_remote_storage(remote_url: str, config_file_path: str | 
         return instance
 
     except Exception as e:
-        raise ImportError(f"Failed to load custom logger from {remote_url}: {e!s}") from e
+        raise ImportError(f"Failed to load custom logger from {remote_url}: {e}") from e
 
 
 async def _download_gcs_file_wrapper(bucket_name: str, object_key: str, local_file_path: str) -> bool:
@@ -190,7 +190,7 @@ async def _download_gcs_file_wrapper(bucket_name: str, object_key: str, local_fi
     except Exception as e:
         from litellm._logging import verbose_proxy_logger
 
-        verbose_proxy_logger.error(f"Error downloading from GCS: {e!s}")
+        verbose_proxy_logger.error(f"Error downloading from GCS: {e}")
         return False
 
 

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -966,7 +966,7 @@ async def update_sso_settings(
     except Exception as e:
         raise HTTPException(
             status_code=500,
-            detail={"error": f"Error updating environment_variables: {e!s}"},
+            detail={"error": f"Error updating environment_variables: {e}"},
         )
 
     return {

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -3341,7 +3341,7 @@ class PrismaClient:
                 reason=f"prisma_get_generic_data_{table_name}_lookup_failure",
             )
         except Exception as e:
-            error_msg = f"LiteLLM Prisma Client Exception get_generic_data: {e!s}"
+            error_msg = f"LiteLLM Prisma Client Exception get_generic_data: {e}"
             verbose_proxy_logger.error(error_msg)
             error_msg = error_msg + f"\nException Type: {type(e)}"
             error_traceback = error_msg + "\n" + traceback.format_exc()
@@ -3956,7 +3956,7 @@ class PrismaClient:
         except Exception as e:
             import traceback
 
-            error_msg = f"LiteLLM Prisma Client Exception in insert_data: {e!s}"
+            error_msg = f"LiteLLM Prisma Client Exception in insert_data: {e}"
             print_verbose(error_msg)
             error_traceback = error_msg + "\n" + traceback.format_exc()
             end_time = time.time()
@@ -4205,7 +4205,7 @@ class PrismaClient:
         except Exception as e:
             import traceback
 
-            error_msg = f"LiteLLM Prisma Client Exception - update_data: {e!s}"
+            error_msg = f"LiteLLM Prisma Client Exception - update_data: {e}"
             print_verbose(error_msg)
             error_traceback = error_msg + "\n" + traceback.format_exc()
             end_time = time.time()
@@ -4271,7 +4271,7 @@ class PrismaClient:
         except Exception as e:
             import traceback
 
-            error_msg = f"LiteLLM Prisma Client Exception - delete_data: {e!s}"
+            error_msg = f"LiteLLM Prisma Client Exception - delete_data: {e}"
             print_verbose(error_msg)
             error_traceback = error_msg + "\n" + traceback.format_exc()
             end_time = time.time()
@@ -4304,7 +4304,7 @@ class PrismaClient:
         except Exception as e:
             import traceback
 
-            error_msg = f"LiteLLM Prisma Client Exception connect(): {e!s}"
+            error_msg = f"LiteLLM Prisma Client Exception connect(): {e}"
             print_verbose(error_msg)
             error_traceback = error_msg + "\n" + traceback.format_exc()
             end_time = time.time()
@@ -4334,7 +4334,7 @@ class PrismaClient:
         except Exception as e:
             import traceback
 
-            error_msg = f"LiteLLM Prisma Client Exception disconnect(): {e!s}"
+            error_msg = f"LiteLLM Prisma Client Exception disconnect(): {e}"
             print_verbose(error_msg)
             error_traceback = error_msg + "\n" + traceback.format_exc()
             end_time = time.time()
@@ -5023,7 +5023,7 @@ class PrismaClient:
         except Exception as e:
             import traceback
 
-            error_msg = f"LiteLLM Prisma Client Exception disconnect(): {e!s}"
+            error_msg = f"LiteLLM Prisma Client Exception disconnect(): {e}"
             print_verbose(error_msg)
             error_traceback = error_msg + "\n" + traceback.format_exc()
             end_time = time.time()
@@ -5833,7 +5833,7 @@ def _raise_failed_update_spend_exception(e: Exception, start_time: float, proxy_
     """
     import traceback
 
-    error_msg = f"[Non-Blocking]LiteLLM Prisma Client Exception - update spend logs: {e!s}"
+    error_msg = f"[Non-Blocking]LiteLLM Prisma Client Exception - update spend logs: {e}"
     error_traceback = error_msg + "\n" + traceback.format_exc()
     end_time = time.time()
     _duration = end_time - start_time
@@ -6125,7 +6125,7 @@ def handle_exception_on_proxy(e: Exception) -> ProxyException:
 
     if isinstance(e, HTTPException):
         return ProxyException(
-            message=getattr(e, "detail", f"error({e!s})"),
+            message=getattr(e, "detail", f"error({e})"),
             type=ProxyErrorTypes.internal_server_error,
             param=getattr(e, "param", "None"),
             code=getattr(e, "status_code", status.HTTP_500_INTERNAL_SERVER_ERROR),

--- a/litellm/proxy/vector_store_endpoints/management_endpoints.py
+++ b/litellm/proxy/vector_store_endpoints/management_endpoints.py
@@ -211,7 +211,7 @@ def _resolve_embedding_config_from_router(embedding_model: str, llm_router) -> d
                     )
                     return embedding_config
         except Exception as e:
-            verbose_proxy_logger.debug(f"Error resolving embedding config from router for model {model_name}: {e!s}")
+            verbose_proxy_logger.debug(f"Error resolving embedding config from router for model {model_name}: {e}")
             continue
 
     return None
@@ -299,7 +299,7 @@ async def _resolve_embedding_config_from_db(embedding_model: str, prisma_client)
                     )
                     return embedding_config
         except Exception as e:
-            verbose_proxy_logger.debug(f"Error resolving embedding config for model {model_name}: {e!s}")
+            verbose_proxy_logger.debug(f"Error resolving embedding config for model {model_name}: {e}")
             continue
 
     return None
@@ -542,7 +542,7 @@ async def new_vector_store(
             "vector_store": response_vs,
         }
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error creating vector store: {e!s}")
+        verbose_proxy_logger.exception(f"Error creating vector store: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -647,7 +647,7 @@ async def list_vector_stores(
 
         return response
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error listing vector stores: {e!s}")
+        verbose_proxy_logger.exception(f"Error listing vector stores: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -727,7 +727,7 @@ async def delete_vector_store(
     except HTTPException:
         raise
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error deleting vector store: {e!s}")
+        verbose_proxy_logger.exception(f"Error deleting vector store: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -799,7 +799,7 @@ async def get_vector_store_info(
         # the catch-all below would otherwise rewrite them as 500.
         raise
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error getting vector store info: {e!s}")
+        verbose_proxy_logger.exception(f"Error getting vector store info: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -888,5 +888,5 @@ async def update_vector_store(
         # as 500 with the original status code embedded in the detail.
         raise
     except Exception as e:
-        verbose_proxy_logger.exception(f"Error updating vector store: {e!s}")
+        verbose_proxy_logger.exception(f"Error updating vector store: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/litellm/proxy/vertex_ai_endpoints/langfuse_endpoints.py
+++ b/litellm/proxy/vertex_ai_endpoints/langfuse_endpoints.py
@@ -60,7 +60,7 @@ def _normalize_langfuse_base_url(base_target_url: str) -> str:
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail={"error": f"Invalid Langfuse host: {e!s}"},
+            detail={"error": f"Invalid Langfuse host: {e}"},
         )
 
     if base_url.scheme not in ("http", "https") or not base_url.host:
@@ -137,7 +137,7 @@ def _build_langfuse_proxy_target(
         except SSRFError as e:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail={"error": f"Invalid Langfuse host: {e!s}"},
+                detail={"error": f"Invalid Langfuse host: {e}"},
             )
         custom_headers["Host"] = host_header
         return target_url, custom_headers

--- a/litellm/rerank_api/main.py
+++ b/litellm/rerank_api/main.py
@@ -534,5 +534,5 @@ def rerank(
         # Placeholder return
         return response
     except Exception as e:
-        verbose_logger.error(f"Error in rerank: {e!s}")
+        verbose_logger.error(f"Error in rerank: {e}")
         raise exception_type(model=model, custom_llm_provider=custom_llm_provider, original_exception=e)

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -313,7 +313,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
     def _default_response_created_event_data(self) -> dict:
         # Use cached response ID if available, otherwise generate a new one
         if self._cached_response_id is None:
-            self._cached_response_id = f"resp_{uuid.uuid4()!s}"
+            self._cached_response_id = f"resp_{uuid.uuid4()}"
 
         response_created_event_data = {
             "id": self._cached_response_id,
@@ -386,7 +386,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
     def create_output_item_added_event(self) -> OutputItemAddedEvent:
         if self._cached_item_id is None:
-            self._cached_item_id = f"msg_{uuid.uuid4()!s}"
+            self._cached_item_id = f"msg_{uuid.uuid4()}"
 
         self._sequence_number += 1
         event = OutputItemAddedEvent(
@@ -407,7 +407,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
     def create_content_part_added_event(self) -> ContentPartAddedEvent:
         if self._cached_item_id is None:
-            self._cached_item_id = f"msg_{uuid.uuid4()!s}"
+            self._cached_item_id = f"msg_{uuid.uuid4()}"
 
         self._sequence_number += 1
         event = ContentPartAddedEvent(
@@ -528,7 +528,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
     def create_output_text_done_event(self, litellm_complete_object: ModelResponse) -> OutputTextDoneEvent:
         if self._cached_item_id is None:
-            self._cached_item_id = f"msg_{uuid.uuid4()!s}"
+            self._cached_item_id = f"msg_{uuid.uuid4()}"
 
         return OutputTextDoneEvent(
             type=ResponsesAPIStreamEvents.OUTPUT_TEXT_DONE,
@@ -541,7 +541,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
     def create_output_content_part_done_event(self, litellm_complete_object: ModelResponse) -> ContentPartDoneEvent:
         if self._cached_item_id is None:
-            self._cached_item_id = f"msg_{uuid.uuid4()!s}"
+            self._cached_item_id = f"msg_{uuid.uuid4()}"
 
         text = getattr(litellm_complete_object.choices[0].message, "content", "") or ""  # type: ignore
         reasoning_content = getattr(litellm_complete_object.choices[0].message, "reasoning_content", "") or ""  # type: ignore
@@ -577,7 +577,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
 
     def create_output_item_done_event(self, litellm_complete_object: ModelResponse) -> OutputItemDoneEvent:
         if self._cached_item_id is None:
-            self._cached_item_id = f"msg_{uuid.uuid4()!s}"
+            self._cached_item_id = f"msg_{uuid.uuid4()}"
 
         text = self.litellm_model_response.choices[0].message.content or ""  # type: ignore
         annotations = getattr(self.litellm_model_response.choices[0].message, "annotations", None)  # type: ignore

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -844,8 +844,8 @@ class LiteLLM_Proxy_MCP_Handler:
                     request_data=logging_request_data,
                     error=e,
                 )
-                verbose_logger.error(f"BlockedPiiEntityError in MCP tool call: {e!s}")
-                error_message = f"Tool call blocked: PII entity '{getattr(e, 'entity_type', 'unknown')}' detected by guardrail '{getattr(e, 'guardrail_name', 'unknown')}'. {e!s}"
+                verbose_logger.error(f"BlockedPiiEntityError in MCP tool call: {e}")
+                error_message = f"Tool call blocked: PII entity '{getattr(e, 'entity_type', 'unknown')}' detected by guardrail '{getattr(e, 'guardrail_name', 'unknown')}'. {e}"
                 tool_results.append(
                     {
                         "tool_call_id": tool_call_id,
@@ -860,9 +860,9 @@ class LiteLLM_Proxy_MCP_Handler:
                     request_data=logging_request_data,
                     error=e,
                 )
-                verbose_logger.error(f"GuardrailRaisedException in MCP tool call: {e!s}")
+                verbose_logger.error(f"GuardrailRaisedException in MCP tool call: {e}")
                 error_message = (
-                    f"Tool call blocked: Guardrail '{getattr(e, 'guardrail_name', 'unknown')}' violation. {e!s}"
+                    f"Tool call blocked: Guardrail '{getattr(e, 'guardrail_name', 'unknown')}' violation. {e}"
                 )
                 tool_results.append(
                     {
@@ -878,7 +878,7 @@ class LiteLLM_Proxy_MCP_Handler:
                     request_data=logging_request_data,
                     error=e,
                 )
-                verbose_logger.error(f"HTTPException in MCP tool call: {e!s}")
+                verbose_logger.error(f"HTTPException in MCP tool call: {e}")
                 error_message = f"Tool call failed: {str(e.detail) if hasattr(e, 'detail') else str(e)}"
                 tool_results.append(
                     {
@@ -898,7 +898,7 @@ class LiteLLM_Proxy_MCP_Handler:
                 tool_results.append(
                     {
                         "tool_call_id": tool_call_id,
-                        "result": f"Error executing tool: {e!s}",
+                        "result": f"Error executing tool: {e}",
                         "name": tool_name,
                     }
                 )

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -1720,7 +1720,7 @@ class Router:
 
             return _deployment_copy
         except Exception as e:
-            verbose_router_logger.debug(f"Error occurred while printing deployment - {e!s}")
+            verbose_router_logger.debug(f"Error occurred while printing deployment - {e}")
             raise e
 
     ### COMPLETION, EMBEDDING, IMG GENERATION FUNCTIONS
@@ -1828,7 +1828,7 @@ class Router:
 
             return response
         except Exception as e:
-            verbose_router_logger.info(f"litellm.completion(model={model_name})\033[31m Exception {e!s}\033[0m")
+            verbose_router_logger.info(f"litellm.completion(model={model_name})\033[31m Exception {e}\033[0m")
             # Set per-deployment num_retries on exception for retry logic
             if deployment is not None:
                 self._set_deployment_num_retries_on_exception(e, deployment)
@@ -1923,7 +1923,7 @@ class Router:
             finally:
                 loop.close()
         except Exception as e:
-            verbose_router_logger.error(f"Silent experiment failed for model {silent_model}: {e!s}")
+            verbose_router_logger.error(f"Silent experiment failed for model {silent_model}: {e}")
 
     # fmt: off
 
@@ -2754,7 +2754,7 @@ class Router:
                 **silent_kwargs,
             )
         except Exception as e:
-            verbose_router_logger.error(f"Silent experiment failed for model {silent_model}: {e!s}")
+            verbose_router_logger.error(f"Silent experiment failed for model {silent_model}: {e}")
 
     async def _acompletion(
         self, model: str, messages: list[dict[str, str]], **kwargs
@@ -2907,7 +2907,7 @@ class Router:
                 self._set_failed_deployment_id_on_exception(e, deployment)
             raise e
         except Exception as e:
-            verbose_router_logger.info(f"litellm.acompletion(model={model_name})\033[31m Exception {e!s}\033[0m")
+            verbose_router_logger.info(f"litellm.acompletion(model={model_name})\033[31m Exception {e}\033[0m")
             if model_name is not None:
                 self.fail_calls[model_name] += 1
             # Set per-deployment num_retries on exception for retry logic
@@ -3696,7 +3696,7 @@ class Router:
             verbose_router_logger.info(f"litellm.image_generation(model={model_name})\033[32m 200 OK\033[0m")
             return response
         except Exception as e:
-            verbose_router_logger.info(f"litellm.image_generation(model={model_name})\033[31m Exception {e!s}\033[0m")
+            verbose_router_logger.info(f"litellm.image_generation(model={model_name})\033[31m Exception {e}\033[0m")
             if model_name is not None:
                 self.fail_calls[model_name] += 1
             raise e
@@ -3780,7 +3780,7 @@ class Router:
             verbose_router_logger.info(f"litellm.aimage_generation(model={model_name})\033[32m 200 OK\033[0m")
             return response
         except Exception as e:
-            verbose_router_logger.info(f"litellm.aimage_generation(model={model_name})\033[31m Exception {e!s}\033[0m")
+            verbose_router_logger.info(f"litellm.aimage_generation(model={model_name})\033[31m Exception {e}\033[0m")
             if model_name is not None:
                 self.fail_calls[model_name] += 1
             raise e
@@ -3884,7 +3884,7 @@ class Router:
             verbose_router_logger.info(f"litellm.atranscription(model={model_name})\033[32m 200 OK\033[0m")
             return response
         except Exception as e:
-            verbose_router_logger.info(f"litellm.atranscription(model={model_name})\033[31m Exception {e!s}\033[0m")
+            verbose_router_logger.info(f"litellm.atranscription(model={model_name})\033[31m Exception {e}\033[0m")
             if model_name is not None:
                 self.fail_calls[model_name] += 1
             raise e
@@ -3998,7 +3998,7 @@ class Router:
             verbose_router_logger.info(f"litellm.aspeech(model={model_name})\033[32m 200 OK\033[0m")
             return response
         except Exception as e:
-            verbose_router_logger.info(f"litellm.aspeech(model={model_name})\033[31m Exception {e!s}\033[0m")
+            verbose_router_logger.info(f"litellm.aspeech(model={model_name})\033[31m Exception {e}\033[0m")
             if model_name is not None:
                 self.fail_calls[model_name] += 1
             raise e
@@ -4056,7 +4056,7 @@ class Router:
             verbose_router_logger.info(f"litellm.arerank(model={model_name})\033[32m 200 OK\033[0m")
             return response
         except Exception as e:
-            verbose_router_logger.info(f"litellm.arerank(model={model_name})\033[31m Exception {e!s}\033[0m")
+            verbose_router_logger.info(f"litellm.arerank(model={model_name})\033[31m Exception {e}\033[0m")
             if model_name is not None:
                 self.fail_calls[model_name] += 1
             raise e
@@ -4190,7 +4190,7 @@ class Router:
             verbose_router_logger.info(f"litellm.atext_completion(model={model_name})\033[32m 200 OK\033[0m")
             return response
         except Exception as e:
-            verbose_router_logger.info(f"litellm.atext_completion(model={model})\033[31m Exception {e!s}\033[0m")
+            verbose_router_logger.info(f"litellm.atext_completion(model={model})\033[31m Exception {e}\033[0m")
             if model is not None:
                 self.fail_calls[model] += 1
             raise e
@@ -4280,7 +4280,7 @@ class Router:
             verbose_router_logger.info(f"litellm.aadapter_completion(model={model_name})\033[32m 200 OK\033[0m")
             return response
         except Exception as e:
-            verbose_router_logger.info(f"litellm.aadapter_completion(model={model})\033[31m Exception {e!s}\033[0m")
+            verbose_router_logger.info(f"litellm.aadapter_completion(model={model})\033[31m Exception {e}\033[0m")
             if model is not None:
                 self.fail_calls[model] += 1
             raise e
@@ -4539,9 +4539,7 @@ class Router:
 
             return response
         except Exception as e:
-            verbose_router_logger.info(
-                f"ageneric_api_call_with_fallbacks(model={model})\033[31m Exception {e!s}\033[0m"
-            )
+            verbose_router_logger.info(f"ageneric_api_call_with_fallbacks(model={model})\033[31m Exception {e}\033[0m")
             if model is not None:
                 self.fail_calls[model] += 1
             raise e
@@ -4661,7 +4659,7 @@ class Router:
             verbose_router_logger.info(f"{handler_name}(model={model_name})\033[32m 200 OK\033[0m")
             return response
         except Exception as e:
-            verbose_router_logger.info(f"{handler_name}(model={model})\033[31m Exception {e!s}\033[0m")
+            verbose_router_logger.info(f"{handler_name}(model={model})\033[31m Exception {e}\033[0m")
             if model is not None:
                 self.fail_calls[model] += 1
             raise e
@@ -4726,7 +4724,7 @@ class Router:
             verbose_router_logger.info(f"litellm.embedding(model={model_name})\033[32m 200 OK\033[0m")
             return response
         except Exception as e:
-            verbose_router_logger.info(f"litellm.embedding(model={model_name})\033[31m Exception {e!s}\033[0m")
+            verbose_router_logger.info(f"litellm.embedding(model={model_name})\033[31m Exception {e}\033[0m")
             if model_name is not None:
                 self.fail_calls[model_name] += 1
             raise e
@@ -4813,7 +4811,7 @@ class Router:
             verbose_router_logger.info(f"litellm.aembedding(model={model_name})\033[32m 200 OK\033[0m")
             return response
         except Exception as e:
-            verbose_router_logger.info(f"litellm.aembedding(model={model_name})\033[31m Exception {e!s}\033[0m")
+            verbose_router_logger.info(f"litellm.aembedding(model={model_name})\033[31m Exception {e}\033[0m")
             if model_name is not None:
                 self.fail_calls[model_name] += 1
             raise e
@@ -4966,7 +4964,7 @@ class Router:
             return returned_response
         except Exception as e:
             verbose_router_logger.exception(
-                f"litellm.acreate_file(model={model}, {kwargs})\033[31m Exception {e!s}\033[0m"
+                f"litellm.acreate_file(model={model}, {kwargs})\033[31m Exception {e}\033[0m"
             )
             if model is not None:
                 self.fail_calls[model] += 1
@@ -5061,9 +5059,7 @@ class Router:
 
             return response
         except Exception as e:
-            verbose_router_logger.exception(
-                f"litellm.avector_store_create(model={model})\033[31m Exception {e!s}\033[0m"
-            )
+            verbose_router_logger.exception(f"litellm.avector_store_create(model={model})\033[31m Exception {e}\033[0m")
             if model is not None:
                 self.fail_calls[model] += 1
             raise e
@@ -5178,7 +5174,7 @@ class Router:
             return response  # type: ignore
         except Exception as e:
             verbose_router_logger.exception(
-                f"litellm._acreate_batch(model={model}, {kwargs})\033[31m Exception {e!s}\033[0m"
+                f"litellm._acreate_batch(model={model}, {kwargs})\033[31m Exception {e}\033[0m"
             )
             if model is not None:
                 self.fail_calls[model] += 1
@@ -5400,7 +5396,7 @@ class Router:
             return response  # type: ignore
         except Exception as e:
             verbose_router_logger.exception(
-                f"litellm._acancel_batch(model={model}, {kwargs})\033[31m Exception {e!s}\033[0m"
+                f"litellm._acancel_batch(model={model}, {kwargs})\033[31m Exception {e}\033[0m"
             )
             if model is not None:
                 self.fail_calls[model] += 1
@@ -6948,7 +6944,7 @@ class Router:
 
         except Exception as e:
             verbose_router_logger.debug(
-                f"litellm.router.Router::deployment_callback_on_success(): Exception occured - {e!s}"
+                f"litellm.router.Router::deployment_callback_on_success(): Exception occured - {e}"
             )
 
     def sync_deployment_callback_on_success(
@@ -9014,7 +9010,7 @@ class Router:
                     custom_llm_provider=litellm_params.custom_llm_provider,
                 )
             except litellm.exceptions.BadRequestError as e:
-                verbose_router_logger.error(f"litellm.router.py::get_model_group_info() - {e!s}")
+                verbose_router_logger.error(f"litellm.router.py::get_model_group_info() - {e}")
 
             if model_info is None:
                 supported_openai_params = litellm.get_supported_openai_params(
@@ -10228,7 +10224,7 @@ class Router:
                             )
                         except Exception as e:
                             verbose_router_logger.error(
-                                f"litellm.router.py::_pre_call_checks: failed to count tokens. Returning initial list of deployments. Got - {e!s}"
+                                f"litellm.router.py::_pre_call_checks: failed to count tokens. Returning initial list of deployments. Got - {e}"
                             )
                             return _returned_deployments
                     if input_tokens > max_input_tokens:
@@ -10239,7 +10235,7 @@ class Router:
                         )
                         continue
             except Exception as e:
-                verbose_router_logger.exception(f"An error occurs - {e!s}")
+                verbose_router_logger.exception(f"An error occurs - {e}")
 
             model_id = _model_info.get("id", "")
             ## RPM CHECK ##
@@ -11623,7 +11619,7 @@ class Router:
                 if model_id is not None:
                     self._update_usage(model_id, parent_otel_span)  # update in-memory cache for tracking
         except Exception as e:
-            verbose_router_logger.error(f"Error in _track_deployment_metrics: {e!s}")
+            verbose_router_logger.error(f"Error in _track_deployment_metrics: {e}")
 
     def get_num_retries_from_retry_policy(self, exception: Exception, model_group: str | None = None):
         return _get_num_retries_from_retry_policy(

--- a/litellm/router_strategy/base_routing_strategy.py
+++ b/litellm/router_strategy/base_routing_strategy.py
@@ -97,7 +97,7 @@ class BaseRoutingStrategy(ABC):
                     default_sync_interval
                 )  # Wait for DEFAULT_REDIS_SYNC_INTERVAL seconds before next sync
             except Exception as e:
-                verbose_router_logger.error(f"Error in periodic sync task: {e!s}")
+                verbose_router_logger.error(f"Error in periodic sync task: {e}")
                 await asyncio.sleep(
                     default_sync_interval
                 )  # Still wait DEFAULT_REDIS_SYNC_INTERVAL seconds on error before retrying
@@ -146,7 +146,7 @@ class BaseRoutingStrategy(ABC):
                 return return_result
 
         except Exception as e:
-            verbose_router_logger.error(f"Error syncing in-memory cache with Redis: {e!s}")
+            verbose_router_logger.error(f"Error syncing in-memory cache with Redis: {e}")
             self.redis_increment_operation_queue = []
 
     def add_to_in_memory_keys_to_update(self, key: str):
@@ -226,4 +226,4 @@ class BaseRoutingStrategy(ABC):
                 await self.dual_cache.in_memory_cache.async_set_cache(key=key, value=merged)
 
         except Exception as e:
-            verbose_router_logger.exception(f"Error syncing in-memory cache with Redis: {e!s}")
+            verbose_router_logger.exception(f"Error syncing in-memory cache with Redis: {e}")

--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -514,7 +514,7 @@ class RouterBudgetLimiting(CustomLogger):
                     DEFAULT_REDIS_SYNC_INTERVAL
                 )  # Wait for DEFAULT_REDIS_SYNC_INTERVAL seconds before next sync
             except Exception as e:
-                verbose_router_logger.error(f"Error in periodic sync task: {e!s}")
+                verbose_router_logger.error(f"Error in periodic sync task: {e}")
                 await asyncio.sleep(
                     DEFAULT_REDIS_SYNC_INTERVAL
                 )  # Still wait DEFAULT_REDIS_SYNC_INTERVAL seconds on error before retrying
@@ -545,7 +545,7 @@ class RouterBudgetLimiting(CustomLogger):
             self.redis_increment_operation_queue = []
 
         except Exception as e:
-            verbose_router_logger.error(f"Error syncing in-memory cache with Redis: {e!s}")
+            verbose_router_logger.error(f"Error syncing in-memory cache with Redis: {e}")
 
     async def _sync_in_memory_spend_with_redis(self):
         """
@@ -600,7 +600,7 @@ class RouterBudgetLimiting(CustomLogger):
                         verbose_router_logger.debug(f"Updated in-memory cache for {key}: {value}")
 
         except Exception as e:
-            verbose_router_logger.error(f"Error syncing in-memory cache with Redis: {e!s}")
+            verbose_router_logger.error(f"Error syncing in-memory cache with Redis: {e}")
 
     def _get_budget_config_for_deployment(
         self,

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -91,7 +91,7 @@ class LowestCostLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                f"litellm.router_strategy.lowest_cost.py::log_success_event(): Exception occured - {e!s}"
+                f"litellm.router_strategy.lowest_cost.py::log_success_event(): Exception occured - {e}"
             )
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
@@ -170,7 +170,7 @@ class LowestCostLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                f"litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {e!s}"
+                f"litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {e}"
             )
 
     async def async_get_available_deployments(

--- a/litellm/router_strategy/lowest_latency.py
+++ b/litellm/router_strategy/lowest_latency.py
@@ -160,7 +160,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                f"litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {e!s}"
+                f"litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {e}"
             )
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
@@ -217,7 +217,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                 return
         except Exception as e:
             verbose_logger.exception(
-                f"litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {e!s}"
+                f"litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - {e}"
             )
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
@@ -350,7 +350,7 @@ class LowestLatencyLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                f"litellm.router_strategy.lowest_latency.py::async_log_success_event(): Exception occured - {e!s}"
+                f"litellm.router_strategy.lowest_latency.py::async_log_success_event(): Exception occured - {e}"
             )
 
     def _get_available_deployments(

--- a/litellm/router_strategy/lowest_tpm_rpm.py
+++ b/litellm/router_strategy/lowest_tpm_rpm.py
@@ -73,7 +73,7 @@ class LowestTPMLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_router_logger.error(
-                f"litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occured - {e!s}"
+                f"litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occured - {e}"
             )
             verbose_router_logger.debug(traceback.format_exc())
 
@@ -135,7 +135,7 @@ class LowestTPMLoggingHandler(CustomLogger):
                     self.logged_success += 1
         except Exception as e:
             verbose_router_logger.exception(
-                f"litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occured - {e!s}"
+                f"litellm.router_strategy.lowest_tpm_rpm.py::async_log_success_event(): Exception occured - {e}"
             )
             verbose_router_logger.debug(traceback.format_exc())
 

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -245,7 +245,7 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                 self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                f"litellm.proxy.hooks.lowest_tpm_rpm_v2.py::log_success_event(): Exception occured - {e!s}"
+                f"litellm.proxy.hooks.lowest_tpm_rpm_v2.py::log_success_event(): Exception occured - {e}"
             )
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
@@ -289,7 +289,7 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                 self.logged_success += 1
         except Exception as e:
             verbose_logger.exception(
-                f"litellm.proxy.hooks.lowest_tpm_rpm_v2.py::async_log_success_event(): Exception occured - {e!s}"
+                f"litellm.proxy.hooks.lowest_tpm_rpm_v2.py::async_log_success_event(): Exception occured - {e}"
             )
 
     def _return_potential_deployments(

--- a/litellm/router_utils/cooldown_cache.py
+++ b/litellm/router_utils/cooldown_cache.py
@@ -58,7 +58,7 @@ class CooldownCache:
 
             return cooldown_key, cooldown_data
         except Exception as e:
-            verbose_logger.error(f"CooldownCache::_common_add_cooldown_logic - Exception occurred - {e!s}")
+            verbose_logger.error(f"CooldownCache::_common_add_cooldown_logic - Exception occurred - {e}")
             raise e
 
     def add_deployment_to_cooldown(
@@ -92,7 +92,7 @@ class CooldownCache:
                 ttl=_cooldown_time,
             )
         except Exception as e:
-            verbose_logger.error(f"CooldownCache::add_deployment_to_cooldown - Exception occurred - {e!s}")
+            verbose_logger.error(f"CooldownCache::add_deployment_to_cooldown - Exception occurred - {e}")
             raise e
 
     @staticmethod

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -190,7 +190,7 @@ async def log_success_fallback_event(original_model_group: str, kwargs: dict, or
                 original_exception=original_exception,
             )
         except Exception as e:
-            verbose_router_logger.error(f"Error in log_success_fallback_event: {e!s}")
+            verbose_router_logger.error(f"Error in log_success_fallback_event: {e}")
 
 
 async def log_failure_fallback_event(original_model_group: str, kwargs: dict, original_exception: Exception):
@@ -218,7 +218,7 @@ async def log_failure_fallback_event(original_model_group: str, kwargs: dict, or
                 original_exception=original_exception,
             )
         except Exception as e:
-            verbose_router_logger.error(f"Error in log_failure_fallback_event: {e!s}")
+            verbose_router_logger.error(f"Error in log_failure_fallback_event: {e}")
 
 
 def _check_non_standard_fallback_format(fallbacks: list[Any] | None) -> bool:

--- a/litellm/router_utils/pattern_match_deployments.py
+++ b/litellm/router_utils/pattern_match_deployments.py
@@ -150,7 +150,7 @@ class PatternMatchRouter:
                         matched_pattern=pattern_match, deployments=llm_deployments
                     )
         except Exception as e:
-            verbose_router_logger.debug(f"Error in PatternMatchRouter.route: {e!s}")
+            verbose_router_logger.debug(f"Error in PatternMatchRouter.route: {e}")
 
         return None  # No matching pattern found
 

--- a/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
+++ b/litellm/router_utils/pre_call_checks/model_rate_limit_check.py
@@ -212,7 +212,7 @@ class ModelRateLimitingCheck(CustomLogger):
                 self._refund_io_token_reservation_if_any()
             raise
         except Exception as e:
-            verbose_router_logger.debug(f"Error in ModelRateLimitingCheck.pre_call_check: {e!s}")
+            verbose_router_logger.debug(f"Error in ModelRateLimitingCheck.pre_call_check: {e}")
             # Don't fail the request if rate limit check fails
             return deployment
 
@@ -300,7 +300,7 @@ class ModelRateLimitingCheck(CustomLogger):
                 await self._async_refund_io_token_reservation_if_any(parent_otel_span=parent_otel_span)
             raise
         except Exception as e:
-            verbose_router_logger.debug(f"Error in ModelRateLimitingCheck.async_pre_call_check: {e!s}")
+            verbose_router_logger.debug(f"Error in ModelRateLimitingCheck.async_pre_call_check: {e}")
             # Don't fail the request if rate limit check fails
             return deployment
 
@@ -360,7 +360,7 @@ class ModelRateLimitingCheck(CustomLogger):
             )
 
         except Exception as e:
-            verbose_router_logger.debug(f"Error in ModelRateLimitingCheck.async_log_success_event: {e!s}")
+            verbose_router_logger.debug(f"Error in ModelRateLimitingCheck.async_log_success_event: {e}")
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         from litellm.litellm_core_utils.core_helpers import (
@@ -418,7 +418,7 @@ class ModelRateLimitingCheck(CustomLogger):
             )
 
         except Exception as e:
-            verbose_router_logger.debug(f"Error in ModelRateLimitingCheck.log_success_event: {e!s}")
+            verbose_router_logger.debug(f"Error in ModelRateLimitingCheck.log_success_event: {e}")
 
     def log_failure_event(self, kwargs, response_obj, start_time, end_time):
         with contextlib.suppress(Exception):

--- a/litellm/router_utils/search_api_router.py
+++ b/litellm/router_utils/search_api_router.py
@@ -77,7 +77,7 @@ class SearchAPIRouter:
             verbose_router_logger.info(f"Successfully updated router with {len(router_search_tools)} search tool(s)")
 
         except Exception as e:
-            verbose_router_logger.exception(f"Error updating router with search tools: {e!s}")
+            verbose_router_logger.exception(f"Error updating router with search tools: {e}")
             raise e
 
     @staticmethod
@@ -226,6 +226,6 @@ class SearchAPIRouter:
 
         except Exception as e:
             verbose_router_logger.error(
-                f"Error in SearchAPIRouter.async_search_with_fallbacks_helper for {search_tool_name}: {e!s}"
+                f"Error in SearchAPIRouter.async_search_with_fallbacks_helper for {search_tool_name}: {e}"
             )
             raise e

--- a/litellm/secret_managers/main.py
+++ b/litellm/secret_managers/main.py
@@ -282,7 +282,7 @@ def get_secret(
                         raise ValueError("Azure OIDC provider returned None token")
                     return oidc_token
                 except Exception as e:
-                    error_msg = f"Azure OIDC provider failed: {e!s}"
+                    error_msg = f"Azure OIDC provider failed: {e}"
                     verbose_logger.error(error_msg)
                     raise ValueError(error_msg)
             with open(azure_federated_token_file, "r") as f:
@@ -335,7 +335,7 @@ def get_secret(
                 )
             except Exception as e:  # check if it's in os.environ
                 verbose_logger.error(
-                    f"Defaulting to os.environ value for key={secret_name}. An exception occurred - {e!s}.\n\n{traceback.format_exc()}"
+                    f"Defaulting to os.environ value for key={secret_name}. An exception occurred - {e}.\n\n{traceback.format_exc()}"
                 )
                 secret = os.getenv(secret_name)
             try:

--- a/litellm/secret_managers/secret_manager_handler.py
+++ b/litellm/secret_managers/secret_manager_handler.py
@@ -119,7 +119,7 @@ def get_secret_from_manager(
             if secret is None:
                 raise ValueError(f"No secret found in Google Secret Manager for {secret_name}")
         except Exception as e:
-            print_verbose(f"An error occurred - {e!s}")
+            print_verbose(f"An error occurred - {e}")
             raise e
 
     elif key_manager == KeyManagementSystem.HASHICORP_VAULT.value:
@@ -128,7 +128,7 @@ def get_secret_from_manager(
             if secret is None:
                 raise ValueError(f"No secret found in Hashicorp Secret Manager for {secret_name}")
         except Exception as e:
-            print_verbose(f"An error occurred - {e!s}")
+            print_verbose(f"An error occurred - {e}")
             raise e
 
     elif key_manager == KeyManagementSystem.CYBERARK.value:
@@ -137,7 +137,7 @@ def get_secret_from_manager(
             if secret is None:
                 raise ValueError(f"No secret found in CyberArk Secret Manager for {secret_name}")
         except Exception as e:
-            print_verbose(f"An error occurred - {e!s}")
+            print_verbose(f"An error occurred - {e}")
             raise e
 
     elif key_manager == KeyManagementSystem.CUSTOM.value:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -947,7 +947,7 @@ def function_setup(
 
                 except Exception as e:
                     # Log the error but don't fail the request
-                    verbose_logger.warning(f"Error removing thought signatures from tool call IDs: {e!s}")
+                    verbose_logger.warning(f"Error removing thought signatures from tool call IDs: {e}")
         elif call_type == CallTypes.embedding.value or call_type == CallTypes.aembedding.value:
             messages = args[1] if len(args) > 1 else kwargs.get("input", None)
         elif call_type == CallTypes.image_generation.value or call_type == CallTypes.aimage_generation.value:
@@ -1004,7 +1004,7 @@ def function_setup(
                 else:
                     messages = "default-message-value"
             except Exception as e:
-                verbose_logger.debug(f"Error extracting messages from Google contents: {e!s}")
+                verbose_logger.debug(f"Error extracting messages from Google contents: {e}")
                 messages = "default-message-value"
         else:
             messages = "default-message-value"
@@ -1410,7 +1410,7 @@ def client(original_function):
                     )
                     kwargs["max_tokens"] = modified_max_tokens
                 except Exception as e:
-                    print_verbose(f"Error while checking max token limit: {e!s}")
+                    print_verbose(f"Error while checking max token limit: {e}")
             # MODEL CALL
             result = original_function(*args, **kwargs)
             end_time = datetime.datetime.now()
@@ -1675,7 +1675,7 @@ def client(original_function):
                     )
                     kwargs["max_tokens"] = modified_max_tokens
                 except Exception as e:
-                    print_verbose(f"Error while checking max token limit: {e!s}")
+                    print_verbose(f"Error while checking max token limit: {e}")
 
             # MODEL CALL
             result = await original_function(*args, **kwargs)
@@ -2224,7 +2224,7 @@ def supports_native_streaming(model: str, custom_llm_provider: str | None) -> bo
         return supports_native_streaming
     except Exception as e:
         verbose_logger.debug(
-            f"Model not found or error in checking supports_native_streaming support. You passed model={model}, custom_llm_provider={custom_llm_provider}. Error: {e!s}"
+            f"Model not found or error in checking supports_native_streaming support. You passed model={model}, custom_llm_provider={custom_llm_provider}. Error: {e}"
         )
         return False
 
@@ -2248,7 +2248,7 @@ def supports_response_schema(model: str, custom_llm_provider: str | None = None)
         model, custom_llm_provider, _, _ = get_llm_provider(model=model, custom_llm_provider=custom_llm_provider)
     except Exception as e:
         verbose_logger.debug(
-            f"Model not found or error in checking response schema support. You passed model={model}, custom_llm_provider={custom_llm_provider}. Error: {e!s}"
+            f"Model not found or error in checking response schema support. You passed model={model}, custom_llm_provider={custom_llm_provider}. Error: {e}"
         )
         return False
 
@@ -2362,7 +2362,7 @@ def _supports_factory(model: str, custom_llm_provider: str | None, key: str) -> 
         return False
     except Exception as e:
         verbose_logger.debug(
-            f"Model not found or error in checking {key} support. You passed model={model}, custom_llm_provider={custom_llm_provider}. Error: {e!s}"
+            f"Model not found or error in checking {key} support. You passed model={model}, custom_llm_provider={custom_llm_provider}. Error: {e}"
         )
 
         supported_by_provider = _supports_provider_info_factory(model, custom_llm_provider, key)
@@ -2404,7 +2404,7 @@ def _is_explicitly_disabled_factory(model: str, custom_llm_provider: str | None,
         verbose_logger.debug(
             f"Model not found or error in checking {key} disabled state. "
             f"You passed model={model}, custom_llm_provider={custom_llm_provider}. "
-            f"Error: {e!s}"
+            f"Error: {e}"
         )
         return False
 
@@ -2537,7 +2537,7 @@ def get_supported_regions(model: str, custom_llm_provider: str | None = None) ->
             return None
     except Exception as e:
         verbose_logger.debug(
-            f"Model not found or error in checking supported_regions support. You passed model={model}, custom_llm_provider={custom_llm_provider}. Error: {e!s}"
+            f"Model not found or error in checking supported_regions support. You passed model={model}, custom_llm_provider={custom_llm_provider}. Error: {e}"
         )
         return None
 
@@ -6542,7 +6542,7 @@ class TextCompletionStreamWrapper:
 
             return response
         except Exception as e:
-            raise Exception(f"Error occurred converting to text completion object - chunk: {chunk}; Error: {e!s}")
+            raise Exception(f"Error occurred converting to text completion object - chunk: {chunk}; Error: {e}")
 
     def __next__(self):
         # model_response = ModelResponse(stream=True, model=self.model)
@@ -6868,7 +6868,7 @@ def trim_messages(
             return final_messages, response_tokens
         return final_messages
     except Exception as e:  # [NON-Blocking, if error occurs just return final_messages
-        verbose_logger.exception(f"Got exception while token trimming - {e!s}")
+        verbose_logger.exception(f"Got exception while token trimming - {e}")
         return original_messages
 
 

--- a/litellm/vector_stores/vector_store_registry.py
+++ b/litellm/vector_stores/vector_store_registry.py
@@ -235,7 +235,7 @@ class VectorStoreRegistry:
                         self.add_vector_store_to_registry(vector_store=db_vector_store)
                         return db_vector_store
             except Exception as e:
-                verbose_logger.debug(f"Error fetching vector store from database: {e!s}")
+                verbose_logger.debug(f"Error fetching vector store from database: {e}")
 
         return None
 
@@ -346,7 +346,7 @@ class VectorStoreRegistry:
                         self.delete_vector_store_from_registry(vector_store_id=vector_store_id)
                         vector_store = None
                 except Exception as e:
-                    verbose_logger.debug(f"Error verifying vector store {vector_store_id} in database: {e!s}")
+                    verbose_logger.debug(f"Error verifying vector store {vector_store_id} in database: {e}")
 
             # Fall back to database if not found in memory (or was deleted)
             if vector_store is None and prisma_client is not None:
@@ -355,7 +355,7 @@ class VectorStoreRegistry:
                         vector_store_id=vector_store_id, prisma_client=prisma_client
                     )
                 except Exception as e:
-                    verbose_logger.debug(f"Error fetching vector store {vector_store_id} from database: {e!s}")
+                    verbose_logger.debug(f"Error fetching vector store {vector_store_id} from database: {e}")
 
             if vector_store is not None:
                 # Create a copy to avoid modifying the registry


### PR DESCRIPTION
## TLDR

Problem this solves:

- the merged #35495 sweep left 1,052 noisy `{e!s}` conversions
- two `_lazy_imports.py` group comments landed on the wrong entries

How it solves it:

- drops every redundant `!s` flag, `{e!s}` becomes `{e}`
- moves the two group-header comments back above their groups

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

No new tests are added on purpose: the rewrite is machine-verified to change nothing but the conversion flag (details under Changes), and the touched paths are already covered by the existing suites run below

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured on a live proxy at this PR's `7b2d3440cb` (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml`, port 29174), hitting real provider APIs. Since the change only touches how values are stringified inside f-strings, the proof is that all three LLM endpoints and an error path still produce well-formed text

```
$ curl -s -X POST http://localhost:29174/v1/chat/completions -H 'Authorization: Bearer sk-1234' \
    -d '{"model":"gpt-5.5","messages":[{"role":"user","content":"Reply with exactly: fstrings ok"}]}'
HTTP 200  {"model": "gpt-5.5", "content": "fstrings ok", "total_tokens": 30}

$ curl -s -X POST http://localhost:29174/v1/responses -H 'Authorization: Bearer sk-1234' \
    -d '{"model":"gpt-5.5","input":"Reply with exactly: responses ok"}'
HTTP 200  {"model": "gpt-5.5", "output_text": ["responses ok"], "status": "completed"}

$ curl -s -X POST http://localhost:29174/v1/messages -H 'Authorization: Bearer sk-1234' \
    -d '{"model":"anthropic-haiku-4-5","max_tokens":50,"stream":true,"messages":[{"role":"user","content":"Reply with exactly: stream ok"}]}'
event: message_start
data: {"type":"message_start","message":{"model":"claude-haiku-4-5-20251001","id":"msg_011CdcwPLLoVFbJNLwGFwYBs",...}}

$ curl -s -X POST http://localhost:29174/v1/chat/completions -H 'Authorization: Bearer sk-1234' \
    -d '{"model":"no-such-model","messages":[{"role":"user","content":"hi"}]}'
HTTP 400  "/chat/completions: Invalid model name passed in model=no-such-model. Call `/v1/models` to view available models for your key."
```

## Type

🧹 Refactoring

## Changes

The #35495 sweep's RUF010 pass rewrote `f"{str(e)}"` into `f"{e!s}"`, which is correct but noisy; for an empty format spec, `format(x)` already falls back to `str(x)`, so the flag is redundant. This PR removes all 1,052 of them across 262 files with an AST-driven script: it finds every `FormattedValue` whose conversion is `!s`, deletes exactly that flag from the source, then re-parses and asserts the new AST is identical to the old one with only the conversion flag cleared, refusing to write the file otherwise. Nothing else in any file changed except `ruff format` collapsing 11 lines that got shorter

The stringified values are exceptions, `uuid.uuid4()`, pydantic models, and plain strings, none of which override `__format__`, so the rendered text is byte-identical

It also fixes one leftover from the sweep's import re-sort in `_lazy_imports.py`: the `# Import maps` and `# Name tuples` group headers stayed attached to the entries they happened to precede and ended up mid-list; they are moved back above their groups. A scan over every parenthesized import block in `litellm/` confirms these were the only two displaced comments

Locally green: `make pre-commit` (ruff, strict-rule gate, LIT gate, basedpyright gate, format) and 1,765 tests across `tests/test_litellm/caching`, `tests/test_litellm/litellm_core_utils`, and the internal-user endpoint suite

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> AST-verified stringification-only edits with no logic changes; risk is limited to hypothetical custom `__format__` overrides, which the PR description states are not present in touched values.
> 
> **Overview**
> This PR is a **mechanical cleanup** after the prior RUF010 sweep: it removes redundant `!s` conversion flags from f-strings (`{e!s}` → `{e}`) across **~262 files** spanning caching, cost calculation, logging integrations, provider handlers, and core utilities. For values with an empty format spec, Python already uses `str()` by default, so the flag does not change rendered output for the exceptions, UUIDs, and plain strings involved.
> 
> In **`litellm/_lazy_imports.py`**, the **`# Import maps`** and **`# Name tuples`** section comments are moved back above their respective import groups so they are not sitting mid-list after an import re-sort.
> 
> There is **no behavioral or API change** intended—only quieter f-strings and clearer import grouping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b2d3440cba3160277470f7a0180098ae9b87864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->