### PR TITLE
build(makefile): run bootstrap before pre-commit lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ lint-dev: lint-format-changed check-circular-imports check-import-safety
 # test-linting.yml (Python), test-litellm-ui-build.yml's frontend-lint (dashboard), and
 # check-ui-api-types.yml (API-type drift), skipping any whose files you didn't stage.
 # Not auto-installed as a git hook so it never slows an unrelated human commit.
-pre-commit:
+pre-commit: bootstrap
 	./scripts/pre_commit_lint.sh
 
 # Testing targets


### PR DESCRIPTION
## TLDR

Problem this solves:

- `make pre-commit` assumes deps are already provisioned
- stale venv, prisma client, or dashboard deps cause confusing lint failures

How it solves it:

- `pre-commit` now runs `bootstrap` first
- a warm bootstrap no-ops in ~1.5s since #35509

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before, at base b1fd20f4cd: `make pre-commit` goes straight to the lint script, so it inherits whatever state the venv and node_modules happen to be in

```
$ time make pre-commit
./scripts/pre_commit_lint.sh
make pre-commit  0.12s user 0.38s system 72% cpu 0.684 total
```

After, at 28d56efb89: bootstrap runs first and a warm run adds about 1.5 seconds before the lint script starts

```
$ time make pre-commit
uv sync --inexact --frozen --extra proxy --group proxy-dev --group e2e-dev
Audited 228 packages in 51ms
uv run --no-sync python scripts/prisma_generate_if_needed.py
Prisma client already generated for litellm/proxy/schema.prisma (prisma 0.11.0); skipping prisma generate
cd ui/litellm-dashboard && npm install --no-audit --no-fund

up to date in 519ms
bootstrap: .env left untouched
bootstrap: done
./scripts/pre_commit_lint.sh
make pre-commit  0.78s user 0.60s system 88% cpu 1.561 total
```

## Type

🚄 Infrastructure

## Changes

`pre-commit` gains `bootstrap` as a make prerequisite (both are already `.PHONY`), so the environment is synced right before the gating lint checks run. Since #35509 made the dashboard install incremental, the fully warm case costs about 1.5 seconds, dominated by npm confirming node_modules is up to date; when deps actually drifted, that is exactly the case where you want bootstrap to run before linting
