### PR TITLE
test(e2e): poll key spend to a deadline in budget reset advances tests

### DIFF
--- a/tests/e2e/quota_management/budgets/test_budget_reset_advances_e2e.py
+++ b/tests/e2e/quota_management/budgets/test_budget_reset_advances_e2e.py
@@ -14,6 +14,7 @@ that the happy-path "calls flow again" check alone does not pin down.
 """
 
 import time
+from collections.abc import Callable
 from datetime import datetime
 
 import pytest
@@ -29,10 +30,26 @@ pytestmark = pytest.mark.e2e
 WINDOW_SECONDS = 30
 RESET_DEADLINE_SECONDS = 150
 TINY_CAP = 3e-6
+SPEND_SETTLE_DEADLINE_SECONDS = 90
 
 
 def _call(client: BudgetClient, key: str):
     return client.chat(key, "claude-haiku-4-5", f"advance {unique_marker()}", max_tokens=16)
+
+
+def _poll_key_spend(client: BudgetClient, key: str, settled: Callable[[float], bool], problem: str) -> None:
+    """DB spend converges asynchronously: the batched spend writer flushes deltas
+    every ~60s (proxy_batch_write_at), so a delta earned before a reset can land
+    on the row after the reset zeroed it. A single read races that flush; polling
+    to a deadline longer than one flush-plus-reset cycle does not."""
+    deadline = time.monotonic() + SPEND_SETTLE_DEADLINE_SECONDS
+    while True:
+        spend = client.proxy.key_info(key).spend or 0.0
+        if settled(spend):
+            return
+        if time.monotonic() >= deadline:
+            pytest.fail(f"{problem}: spend={spend} after {SPEND_SETTLE_DEADLINE_SECONDS}s")
+        time.sleep(5)
 
 
 def _as_datetime(value: str) -> datetime:
@@ -53,9 +70,7 @@ def _drive_to_block(client: BudgetClient, key: str) -> None:
 # ---- Rung 1: scheduling exists at creation -----------------------------------
 
 
-def test_key_with_budget_duration_schedules_reset_at_creation(
-    client: BudgetClient, resources: ResourceManager
-) -> None:
+def test_key_with_budget_duration_schedules_reset_at_creation(client: BudgetClient, resources: ResourceManager) -> None:
     """Baseline: a key created with a budget_duration has budget_reset_at populated
     immediately. The reset job can only advance a timestamp that was scheduled in
     the first place; everything below depends on this."""
@@ -88,14 +103,14 @@ def test_key_spend_blocks_at_cap(client: BudgetClient, resources: ResourceManage
 
 
 @pytest.mark.covers("quota_management.budget.key.resets_after_window")
-def test_key_budget_reset_at_advances_after_window(
-    client: BudgetClient, resources: ResourceManager
-) -> None:
+def test_key_budget_reset_at_advances_after_window(client: BudgetClient, resources: ResourceManager) -> None:
     """The core #25109 guard: after the window elapses the reset job must move
     budget_reset_at strictly forward AND zero key.spend. The broken nullable-JSON
     filter left eligible rows untouched, so the timestamp stayed pinned and spend
     never cleared. Asserting before<after (not merely "a call succeeded") kills a
-    mutation that no-ops the reset while leaving enforcement intact."""
+    mutation that no-ops the reset while leaving enforcement intact. The spend
+    check polls (see _poll_key_spend): a reset that never zeroes the row keeps
+    spend pinned at the driven total and still times out."""
     key = client.generate_key(max_budget=TINY_CAP, budget_duration=f"{WINDOW_SECONDS}s")
     resources.defer(lambda: client.delete_key(key))
 
@@ -114,10 +129,8 @@ def test_key_budget_reset_at_advances_after_window(
             continue
         info = client.proxy.key_info(key)
         assert info.budget_reset_at is not None, "budget_reset_at cleared by reset"
-        assert _as_datetime(info.budget_reset_at) > before, (
-            "budget_reset_at did not advance past the pre-reset value"
-        )
-        assert (info.spend or 0.0) < TINY_CAP, f"spend not cleared after reset: {info.spend}"
+        assert _as_datetime(info.budget_reset_at) > before, "budget_reset_at did not advance past the pre-reset value"
+        _poll_key_spend(client, key, lambda spend: spend < TINY_CAP, "spend not cleared after reset")
         return
     pytest.fail(f"key budget never reset within {RESET_DEADLINE_SECONDS}s")
 
@@ -126,15 +139,14 @@ def test_key_budget_reset_at_advances_after_window(
 
 
 @pytest.mark.covers("quota_management.budget.key_multi_window.resets_windows_independently")
-def test_multi_window_key_resets_each_window_independently(
-    client: BudgetClient, resources: ResourceManager
-) -> None:
+def test_multi_window_key_resets_each_window_independently(client: BudgetClient, resources: ResourceManager) -> None:
     """The JSON-backed path #25109 specifically touched. A tight 30s window and a
     roomy 1m window: the tight window must reset on its own boundary while the roomy
     window keeps its accumulated spend (independent per-window reset). The
     nullable-JSON filter bug skipped these JSON-backed rows entirely, so the tight
     window never came back; a job that ERRORS on the JSON column would surface here
-    as a non-budget 5xx, which we reject throughout the wait."""
+    as a non-budget 5xx, which we reject throughout the wait. The roomy-window
+    spend read polls for the same flush-race reason as the rung above."""
     key = client.generate_key(
         budget_limits=[
             BudgetWindow(budget_duration=f"{WINDOW_SECONDS}s", max_budget=TINY_CAP),
@@ -156,8 +168,11 @@ def test_multi_window_key_resets_each_window_independently(
             assert elapsed < WINDOW_SECONDS + 90, (
                 f"tight window reset took {elapsed:.0f}s - too long for {WINDOW_SECONDS}s"
             )
-            assert (client.proxy.key_info(key).spend or 0.0) >= spend_at_block, (
-                "roomy window spend was wiped when only the tight window should reset"
+            _poll_key_spend(
+                client,
+                key,
+                lambda spend: spend >= spend_at_block,
+                "roomy window spend was wiped when only the tight window should reset",
             )
             return
         assert is_budget_block(result), f"non-budget error during reset wait: {result.body[:200]}"
@@ -168,9 +183,7 @@ def test_multi_window_key_resets_each_window_independently(
 
 
 @pytest.mark.covers("quota_management.budget.team_member.resets_after_window")
-def test_team_member_budget_reset_at_advances(
-    client: BudgetClient, resources: ResourceManager
-) -> None:
+def test_team_member_budget_reset_at_advances(client: BudgetClient, resources: ResourceManager) -> None:
     """Per-team member windows are also JSON-backed. member_budget_reset_at must
     advance after the window; the explicit before<after assertion is the #25109
     regression guard (the existing reset test only checks "it eventually moved",
@@ -181,9 +194,7 @@ def test_team_member_budget_reset_at_advances(
     resources.defer(lambda: client.delete_user(user_id))
 
     client.add_team_member(team_id, user_id, max_budget_in_team=1.0)
-    client.update_team_member(
-        team_id, user_id, max_budget_in_team=1.0, budget_duration=f"{WINDOW_SECONDS}s"
-    )
+    client.update_team_member(team_id, user_id, max_budget_in_team=1.0, budget_duration=f"{WINDOW_SECONDS}s")
 
     before_raw = client.member_budget_reset_at(team_id, user_id)
     assert before_raw, "updating the member with a budget_duration set no budget_reset_at"
@@ -205,9 +216,7 @@ def test_team_member_budget_reset_at_advances(
 # ---- Rung 6: error-path edge - resets surface as blocks, never 5xx -----------
 
 
-def test_reset_wait_never_yields_non_budget_error(
-    client: BudgetClient, resources: ResourceManager
-) -> None:
+def test_reset_wait_never_yields_non_budget_error(client: BudgetClient, resources: ResourceManager) -> None:
     """The other #25109 failure mode: a reset job that ERRORS on the nullable-JSON
     column surfaces to the caller as a non-budget 5xx. Across the whole reset wait
     every non-ok response must be a budget block (is_budget_block) and never a


### PR DESCRIPTION
## TLDR

Problem this solves:

- stage flake: budget reset tests read key spend exactly once
- the ~60s batched spend flush re-lands pre-reset deltas after the reset zeroes the row
- single read races that flush; failed Jul 30 and Aug 2 stage runs with spend ~9.7e-05 vs 3e-06 cap

How it solves it:

- new _poll_key_spend helper polls the spend read to a 90s deadline
- rung 3 (spend zeroed) and rung 4 (roomy window keeps spend) now poll instead of single-read
- a reset that never zeroes the row still fails: spend stays pinned and the poll times out

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before (the flake this kills): stage e2e runs 2026-07-30 00:45 UTC and 2026-08-02 00:52 UTC (image at ba480a619f) both failed `test_key_budget_reset_at_advances_after_window` with the identical signature while every neighbouring assertion passed, proving the reset itself worked and only the read raced the flush

```
E   AssertionError: spend not cleared after reset: 9.7e-05
E   assert ((9.7e-05)) < 3e-06
E    +  where 9.7e-05 = KeyInfo(..., spend=9.7e-05, max_budget=3e-06, budget_reset_at='2026-08-02T01:35:30+00:00', ...).spend
```

After (at ebdd854b98): both tests against a live worktree proxy on localhost:4611 backed by a real provider (groq llama-3.3-70b-versatile, x-litellm-response-cost 2.282e-05 per call), with the proxy running the stage cadence that produces the race window (`PROXY_BATCH_WRITE_AT=60`, budget rescheduler every 15-20s)

```
LITELLM_PROXY_URL=http://localhost:4611 python -m pytest \
  quota_management/budgets/test_budget_reset_advances_e2e.py::test_key_budget_reset_at_advances_after_window \
  quota_management/budgets/test_budget_reset_advances_e2e.py::test_multi_window_key_resets_each_window_independently -v

quota_management/budgets/test_budget_reset_advances_e2e.py::test_key_budget_reset_at_advances_after_window PASSED [ 50%]
quota_management/budgets/test_budget_reset_advances_e2e.py::test_multi_window_key_resets_each_window_independently PASSED [100%]

======================== 2 passed in 100.88s (0:01:40) =========================
```

## Type

✅ Test

## Changes

`tests/e2e/quota_management/budgets/test_budget_reset_advances_e2e.py` only. Adds `_poll_key_spend`, which re-reads `key_info.spend` every 5s until a predicate holds or a 90s deadline expires; 90s covers one full flush-plus-reset cycle, so a late flush delays the pass a few iterations while a reset job that never zeroes the row keeps spend pinned at the driven total and still times out. Rung 3 swaps its single `spend < cap` read for the poll, rung 4 swaps its single `spend >= spend_at_block` read (the mirror timing of the same race), and both docstrings say why. No other budget test reads spend as a single post-convergence snapshot: the reseed test already waits out the flush explicitly and the user-budget test already polls

## QA runbook

- tests/e2e/quota_management/budgets/test_budget_reset_advances_e2e.py::test_key_budget_reset_at_advances_after_window - after the budget window elapses the reset job advances budget_reset_at and zeroes spend, with the spend read now polled to a 90s deadline
  - [ ] Generate a key with max_budget 3e-06 and budget_duration 30s, then note its budget_reset_at from /key/info
  - [ ] Send chat completions with that key until one returns the budget_exceeded block
  - [ ] Keep retrying a call every 5s; within 150s one succeeds, and /key/info then shows budget_reset_at strictly later than the noted value
  - [ ] Re-read /key/info every 5s for up to 90s and expect spend to drop under the cap once the flush and the next reset settle
  - [ ] Sanity check: this test makes sense and is not hand-wavey or potentially flaky
- tests/e2e/quota_management/budgets/test_budget_reset_advances_e2e.py::test_multi_window_key_resets_each_window_independently - a tight 30s window resets on its own boundary while the roomy 1m window keeps its accumulated spend
  - [ ] Generate a key with two budget windows: 30s at 3e-06 and 1m at 1.0, then drive it to the budget block and note spend from /key/info
  - [ ] Keep retrying a call every 5s; within 150s one succeeds and well inside the tight window plus 90s
  - [ ] Re-read /key/info every 5s for up to 90s and expect spend to come back at or above the noted value, proving only the tight window reset
  - [ ] Sanity check: this test makes sense and is not hand-wavey or potentially flaky

Environment notes: needs a DB-backed proxy whose budget rescheduler runs faster than the default 10 minutes (stage runs 15-20s) and a model named claude-haiku-4-5; locally I pointed that alias at groq since this machine's .env carries no Anthropic key

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
