### PR TITLE
fix(mcp): strip root_path before matching the per-server MCP route spelling

### DIFF
--- a/litellm/proxy/_experimental/mcp_server/oauth_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth_utils.py
@@ -180,6 +180,22 @@ def well_known_root_suffix() -> str:
     return "" if root == "/" else root
 
 
+def get_route_relative_request_path(scope: Scope) -> str:
+    """The request path the MCP route shapes are written against: the raw ASGI path with the
+    deployment's ``root_path`` removed.
+
+    ``scope["path"]`` and ``_original_path`` are both raw request-line paths, so on a sub-path
+    deployment they still carry the ``SERVER_ROOT_PATH`` prefix (``/litellm/{server}/mcp``) while
+    every route shape compared against them is root-relative. Mirrors the segment-boundary strip in
+    :func:`litellm.proxy.auth.auth_utils.get_request_route`, which the rest of the MCP auth path
+    already routes through, so ``/litellmfoo`` is not truncated under ``root_path=/litellm``."""
+    raw_path = str(scope.get("_original_path") or scope.get("path", "") or "")
+    root_path = str(scope.get("app_root_path") or scope.get("root_path") or "").rstrip("/")
+    if root_path and (raw_path == root_path or raw_path.startswith(f"{root_path}/")):
+        return raw_path[len(root_path) :]
+    return raw_path
+
+
 def get_passthrough_resource_metadata_url(scope: Scope, server_name: str) -> str:
     """The per-server protected-resource metadata URL matching the spelling the request
     arrived on, so a strict RFC 9728 client resolves the same route the proxy registered.
@@ -188,7 +204,7 @@ def get_passthrough_resource_metadata_url(scope: Scope, server_name: str) -> str
     the route decorators insert it (see :func:`well_known_root_suffix`)."""
     request: Final = Request(scope)
     base_url: Final = get_request_base_url(request)
-    _path: Final = scope.get("_original_path") or scope.get("path", "") or ""
+    _path: Final = get_route_relative_request_path(scope)
 
     if _path.startswith(f"/{server_name}/mcp"):
         return f"{base_url}/.well-known/oauth-protected-resource{well_known_root_suffix()}/{server_name}/mcp"

--- a/litellm/proxy/_experimental/mcp_server/oauth_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/oauth_utils.py
@@ -180,6 +180,22 @@ def well_known_root_suffix() -> str:
     return "" if root == "/" else root
 
 
+def get_route_relative_request_path(scope: Scope) -> str:
+    """The request path the MCP route shapes are written against: the raw ASGI path with the
+    deployment's ``root_path`` removed.
+
+    ``scope["path"]`` and ``_original_path`` are both raw request-line paths, so on a sub-path
+    deployment they still carry the ``SERVER_ROOT_PATH`` prefix (``/litellm/{server}/mcp``) while
+    every route shape compared against them is root-relative. Mirrors the segment-boundary strip in
+    :func:`litellm.proxy.auth.auth_utils.get_request_route`, which the rest of the MCP auth path
+    already routes through, so ``/litellmfoo`` is not truncated under ``root_path=/litellm``."""
+    raw_path = str(scope.get("_original_path") or scope.get("path", "") or "")
+    root_path = str(scope.get("app_root_path") or scope.get("root_path") or "").rstrip("/")
+    if root_path and (raw_path == root_path or raw_path.startswith(f"{root_path}/")):
+        return raw_path[len(root_path) :]
+    return raw_path
+
+
 def get_passthrough_resource_metadata_url(scope: Scope, server_name: str) -> str:
     """The per-server protected-resource metadata URL matching the spelling the request
     arrived on, so a strict RFC 9728 client resolves the same route the proxy registered.
@@ -188,7 +204,7 @@ def get_passthrough_resource_metadata_url(scope: Scope, server_name: str) -> str
     the route decorators insert it (see :func:`well_known_root_suffix`)."""
     request = Request(scope)
     base_url = get_request_base_url(request)
-    _path = scope.get("_original_path") or scope.get("path", "") or ""
+    _path = get_route_relative_request_path(scope)
 
     if _path.startswith(f"/{server_name}/mcp"):
         return f"{base_url}/.well-known/oauth-protected-resource{well_known_root_suffix()}/{server_name}/mcp"

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -51,6 +51,8 @@ from litellm.proxy._experimental.mcp_server.mcp_debug import MCPDebug
 from litellm.proxy._experimental.mcp_server.oauth_utils import (
     _redact_mcp_resource_url,
     get_passthrough_www_authenticate,
+    get_route_relative_request_path,
+    well_known_root_suffix,
 )
 from litellm.proxy._experimental.mcp_server.utils import (
     LITELLM_MCP_SERVER_DESCRIPTION,
@@ -3782,14 +3784,15 @@ if MCP_AVAILABLE:
 
                     request = StarletteRequest(scope)
                     base_url = get_request_base_url(request)
-                    _path = scope.get("_original_path") or scope.get("path", "") or ""
+                    _path = get_route_relative_request_path(scope)
 
                     # Pick the well-known AS-metadata form that matches the inbound route
                     # so strict RFC 9728 §3.2 clients can resolve it correctly.
+                    as_metadata_root = f"{base_url}/.well-known/oauth-authorization-server{well_known_root_suffix()}"
                     if _path.startswith(f"/mcp/{server_name}"):
-                        _as_url = f"{base_url}/.well-known/oauth-authorization-server/mcp/{server_name}"
+                        _as_url = f"{as_metadata_root}/mcp/{server_name}"
                     else:
-                        _as_url = f"{base_url}/.well-known/oauth-authorization-server/{server_name}"
+                        _as_url = f"{as_metadata_root}/{server_name}"
                     authorization_uri = f'Bearer authorization_uri="{_as_url}"'
 
                     raise HTTPException(

--- a/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/auth/test_user_api_key_auth_mcp.py
@@ -6314,6 +6314,49 @@ class TestAggregateGatewayDcrChallenge:
             www_authenticate = (exc_info.value.headers or {})["WWW-Authenticate"]
             assert www_authenticate == f'Bearer resource_metadata="http://testserver{expected_metadata_path}"'
 
+    async def test_per_server_challenge_keeps_spelling_under_server_root_path(self):
+        """On a sub-path deployment the challenge must still advertise the spelling the client
+        used. ``_original_path`` is a raw request-line path, so under SERVER_ROOT_PATH it reads
+        ``/litellm/{server}/mcp``; matching that against the root-relative ``/{server}/mcp`` shape
+        used to fail, silently pointing a legacy-spelling client at the standard-pattern document
+        whose ``resource`` is ``{base}/mcp/{server}`` rather than the ``{base}/{server}/mcp`` URL it
+        called, which a strict RFC 9728 section 3 client rejects."""
+        import os
+
+        from litellm.types.mcp import MCPAuth
+        from litellm.types.mcp_server.mcp_server_manager import MCPServer
+
+        server = MCPServer(
+            server_id="gh-id",
+            name="github",
+            server_name="github",
+            url="https://upstream.example/mcp",
+            transport="http",
+            auth_type=MCPAuth.oauth2,
+        )
+        for original_path, expected_metadata_path in (
+            ("/litellm/mcp/github", "/litellm/.well-known/oauth-protected-resource/litellm/mcp/github"),
+            ("/litellm/github/mcp", "/litellm/.well-known/oauth-protected-resource/litellm/github/mcp"),
+        ):
+            scope = {
+                **self._scope(path="/mcp/github"),
+                "root_path": "/litellm",
+                "_original_path": original_path,
+            }
+            with (
+                patch.dict(os.environ, {"SERVER_ROOT_PATH": "/litellm"}),
+                patch(self._AUTH_PATCH_TARGET, side_effect=self._auth_401()),
+                patch(
+                    "litellm.proxy._experimental.mcp_server.mcp_server_manager.global_mcp_server_manager"
+                ) as mock_mgr,
+            ):
+                mock_mgr.get_mcp_server_by_name.return_value = server
+                with pytest.raises(HTTPException) as exc_info:
+                    await MCPRequestHandler.process_mcp_request(scope)
+            assert exc_info.value.status_code == 401
+            www_authenticate = (exc_info.value.headers or {})["WWW-Authenticate"]
+            assert www_authenticate == f'Bearer resource_metadata="http://testserver{expected_metadata_path}"'
+
     async def test_no_per_server_challenge_for_non_gateway_managed_targets(self):
         """The per-server challenge fires only for the server set the gateway's keyless flow
         serves: an OBO server and a multi-server CSV path keep the original admission error

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextvars
+import os
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -8093,6 +8094,54 @@ class TestPreemptive401ModeAware:
             await self._run(_make_oauth2_server("interactive"), None, has_stored_token=False)
         assert exc.value.status_code == 401
         assert "www-authenticate" in {k.lower() for k in exc.value.headers}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "original_path, expected_as_path",
+        (
+            ("/litellm/mcp/interactive", "/litellm/.well-known/oauth-authorization-server/litellm/mcp/interactive"),
+            ("/litellm/interactive/mcp", "/litellm/.well-known/oauth-authorization-server/litellm/interactive"),
+        ),
+    )
+    async def test_gateway_as_metadata_challenge_under_server_root_path(self, original_path, expected_as_path):
+        """Under SERVER_ROOT_PATH the challenge must keep the spelling the client called and point at
+        a route the proxy registered, so it has to compare a route-relative path and carry the root suffix."""
+        from litellm.proxy._experimental.mcp_server import server as server_module
+
+        server = _make_oauth2_server("interactive", oauth2_flow="authorization_code")
+        scope = {
+            **self._scope(server.alias),
+            "root_path": "/litellm",
+            "_original_path": original_path,
+            "headers": [(b"host", b"testserver")],
+        }
+        with (
+            patch.dict(os.environ, {"SERVER_ROOT_PATH": "/litellm"}),
+            patch.object(
+                server_module.global_mcp_server_manager,
+                "get_mcp_server_by_name",
+                return_value=server,
+            ),
+            patch.object(
+                server_module.global_mcp_server_manager,
+                "has_user_oauth_token",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            pytest.raises(HTTPException) as exc,
+        ):
+            await server_module._raise_preemptive_401_for_unauthenticated_servers(
+                scope=scope,
+                mcp_servers=[server.alias],
+                oauth2_headers=None,
+                mcp_server_auth_headers=None,
+                user_api_key_auth=UserAPIKeyAuth(api_key="sk-litellm-virtual-key"),
+                client_ip=None,
+            )
+
+        assert exc.value.status_code == 401
+        headers = {k.lower(): v for k, v in (exc.value.headers or {}).items()}
+        assert headers["www-authenticate"] == f'Bearer authorization_uri="http://testserver{expected_as_path}"'
 
     @pytest.mark.asyncio
     async def test_gateway_managed_interactive_no_token_challenges_with_authorization_bearer(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- The per-server MCP 401 challenge decides which URL spelling the client used by matching `_original_path` against the root-relative `/{server}/mcp` shape
- `_original_path` (and `scope["path"]`) are raw request-line paths, so on a `SERVER_ROOT_PATH` deployment they still carry the prefix and that match always fails
- A client connecting on `/litellm/{server}/mcp` is therefore pointed at the standard-pattern discovery document, whose `resource` is `{base}/litellm/mcp/{server}` rather than the URL it called, and a strict RFC 9728 section 3 client aborts before the MCP request fires

The same raw-path assumption appears twice, in two different challenge shapes:

1. the pass-through `resource_metadata` challenge in `oauth_utils.py`
2. the gateway-managed `authorization_code` `authorization_uri` challenge in `server.py`, which additionally hardcoded `/.well-known/oauth-authorization-server` with no root-path segment, so the URL it advertised 404'd under a sub-path deployment regardless of which spelling branch was taken

How it solves it:

- Removes `root_path` from the path before the spelling match, on a segment boundary, the same way `litellm.proxy.auth.auth_utils.get_request_route` already does for the rest of the MCP auth path
- Routes the gateway-managed AS-metadata root through `well_known_root_suffix()`, the same helper the discovery route registrations derive their paths from, so the advertised URL cannot drift from the route that serves it
- Root-mounted deployments are unaffected; both helpers are no-ops when there is no `root_path`

## Relevant issues

- Fixes the per-server MCP OAuth 401 challenge advertising the wrong protected-resource document on a `SERVER_ROOT_PATH` (sub-path) deployment
- Restores the RFC 9728 section 3 exact-match property: the `resource` a client discovers now equals the MCP URL it connected to, in both the `/{server}/mcp` and `/mcp/{server}` spellings
- Adds a regression test that pins both spellings under `SERVER_ROOT_PATH` through the real `process_mcp_request` caller
- Fixes the same class of bug in the gateway-managed `authorization_code` challenge (raised in review by @Sanjays2402), covered by `TestPreemptive401ModeAware::test_gateway_as_metadata_challenge_under_server_root_path`

Surfaced by the discussion on #35226, which reported the same class of `resource` mismatch. That PR proposes a new opt-in env var to derive the discovery path from the request; this change instead fixes the root-path normalization the existing code already relies on, which covers the sub-path deployment without new configuration

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### Pass-through `resource_metadata` challenge

Live proxy on a sub-path deployment, config below, started with

```
SERVER_ROOT_PATH=/litellm LITELLM_MASTER_KEY=sk-1234 \
  python litellm/proxy/proxy_cli.py --config mcp_rootpath_config.yaml --port 4111
```

```yaml
mcp_servers:
  github:
    url: "https://upstream.example/mcp"
    transport: "http"
    auth_type: "oauth2"
    oauth2_flow: "authorization_code"
    client_id: "gateway-managed-client"
    client_secret: "gateway-managed-secret"
    authorization_url: "https://upstream.example/oauth/authorize"
    token_url: "https://upstream.example/oauth/token"
```

**Before (this branch's base, `ba480a619f`)** both spellings collapse onto the standard-pattern document:

```
$ for path in /litellm/github/mcp /litellm/mcp/github; do
    curl -s -i -X POST "http://localhost:4111${path}" \
      -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
      -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | grep -iE '^HTTP/|^www-authenticate'
  done

HTTP/1.1 401 Unauthorized
www-authenticate: Bearer resource_metadata="http://localhost:4111/litellm/.well-known/oauth-protected-resource/litellm/mcp/github"
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer resource_metadata="http://localhost:4111/litellm/.well-known/oauth-protected-resource/litellm/mcp/github"
```

Following the challenge a `/litellm/github/mcp` client was sent to shows the mismatch it aborts on:

```
$ curl -s "http://localhost:4111/litellm/.well-known/oauth-protected-resource/litellm/mcp/github"
{"resource": "http://localhost:4111/litellm/mcp/github", ...}
```

**After (this branch)** each spelling keeps its own document:

```
$ for path in /litellm/github/mcp /litellm/mcp/github; do
    curl -s -i -X POST "http://localhost:4111${path}" \
      -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
      -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | grep -iE '^HTTP/|^www-authenticate'
  done

HTTP/1.1 401 Unauthorized
www-authenticate: Bearer resource_metadata="http://localhost:4111/litellm/.well-known/oauth-protected-resource/litellm/github/mcp"
HTTP/1.1 401 Unauthorized
www-authenticate: Bearer resource_metadata="http://localhost:4111/litellm/.well-known/oauth-protected-resource/litellm/mcp/github"
```

and each document's `resource` is exactly the URL the client connected to:

```
$ curl -s "http://localhost:4111/litellm/.well-known/oauth-protected-resource/litellm/github/mcp"
{"resource": "http://localhost:4111/litellm/github/mcp", "authorization_servers": ["http://localhost:4111/litellm/mcp"], ...}

$ curl -s "http://localhost:4111/litellm/.well-known/oauth-protected-resource/litellm/mcp/github"
{"resource": "http://localhost:4111/litellm/mcp/github", "authorization_servers": ["http://localhost:4111/litellm/mcp"], ...}
```

### Gateway-managed `authorization_code` challenge (the second fix site)

This challenge only fires for a caller that authenticated to the proxy but has no interactive gateway session yet, so the repro needs a virtual key rather than an anonymous request. Same sub-path deployment, server named `interactive`, same `oauth2` / `authorization_code` block as the config above

```
$ SERVER_ROOT_PATH=/litellm LITELLM_MASTER_KEY=sk-1234 \
    python litellm/proxy/proxy_cli.py --config mcp_authcode_rootpath_config.yaml --port 4111

$ KEY=$(curl -s -X POST http://localhost:4111/litellm/key/generate \
    -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{}' | jq -r .key)
```

**Before (parent commit `e3869926f7`)** the advertised authorization-server document has no root-path segment, so following it 404s:

```
$ curl -s -i -X POST "http://localhost:4111/litellm/interactive/mcp" \
    -H "Authorization: Bearer $KEY" \
    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | grep -iE '^HTTP/|^www-authenticate'

HTTP/1.1 401 Unauthorized
www-authenticate: Bearer authorization_uri="http://localhost:4111/litellm/.well-known/oauth-authorization-server/interactive"

$ curl -s -o /dev/null -w '%{http_code}\n' \
    "http://localhost:4111/litellm/.well-known/oauth-authorization-server/interactive"
404
```

**After (this branch)** the challenge points at a route the proxy actually registered:

```
$ curl -s -i -X POST "http://localhost:4111/litellm/interactive/mcp" \
    -H "Authorization: Bearer $KEY" \
    -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | grep -iE '^HTTP/|^www-authenticate'

HTTP/1.1 401 Unauthorized
www-authenticate: Bearer authorization_uri="http://localhost:4111/litellm/.well-known/oauth-authorization-server/litellm/interactive"

$ curl -s "http://localhost:4111/litellm/.well-known/oauth-authorization-server/litellm/interactive"
{"issuer":"http://localhost:4111/litellm/interactive","authorization_endpoint":"http://localhost:4111/litellm/interactive/authorize","token_endpoint":"http://localhost:4111/litellm/interactive/token","response_types_supported":["code"],"grant_types_supported":["authorization_code","refresh_token"],"code_challenge_methods_supported":["S256"], ...}
```

The `/litellm/mcp/{server}` spelling cannot be shown end to end here because it never reaches this branch under a sub-path deployment: `_get_mcp_servers_in_path` splits the raw request path, reads the root segment as the server name, and the request resolves to no server and returns an empty tool list. That is a separate pre-existing bug and is left alone in this PR; the spelling selection itself is pinned by the parametrized regression test

## Type

🐛 Bug Fix

## Changes

`oauth_utils.py` gains `get_route_relative_request_path`, which reads `_original_path` (falling back to `scope["path"]`) and removes the deployment's `root_path` when the raw path is that prefix or continues past it on a `/` boundary, so `/litellmfoo` is not truncated under `root_path=/litellm`. `get_passthrough_resource_metadata_url` now compares that normalized path instead of the raw one

Nothing else changes. On a root-mounted proxy `root_path` is empty and the helper returns the raw path unchanged, so the emitted metadata URL is byte-identical to today's

The regression test lives in the existing `TestAggregateGatewayDcrChallenge` class next to the non-root-path spelling test it mirrors, and drives the real `process_mcp_request` entry point rather than the helper, so it fails if either the challenge or the spelling selection regresses. It reverts to the pre-fix assertion failure when the normalization is removed

`server.py`'s gateway-managed `authorization_code` branch gets the same treatment: `_path` now comes from `get_route_relative_request_path(scope)` instead of a raw `scope["_original_path"]` read, and the well-known root is built with `well_known_root_suffix()` so the advertised AS-metadata URL resolves to a registered route. Its regression test lives in `TestPreemptive401ModeAware`, is parametrized over both spellings, and drives `process_mcp_request` the same way

Both halves of the `server.py` fix are mutation-tested: reverting either the path normalization or the root suffix on its own fails the new test. The root suffix half is also reproduced against a live proxy in the proof section above

## QA runbook

1. `uv run --no-sync pytest tests/test_litellm/proxy/_experimental/mcp_server/auth/ tests/test_litellm/proxy/_experimental/mcp_server/test_discoverable_endpoints.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py -q`
2. Write the `mcp_servers` config above to `mcp_rootpath_config.yaml`
3. `SERVER_ROOT_PATH=/litellm LITELLM_MASTER_KEY=sk-1234 python litellm/proxy/proxy_cli.py --config mcp_rootpath_config.yaml --port 4111`
4. Run the two `curl` loops from the proof section and confirm the two spellings now advertise different `resource_metadata` URLs
5. `GET` each advertised URL and confirm `resource` equals the MCP URL from step 4
6. Restart with `SERVER_ROOT_PATH` unset and confirm the challenges are unchanged from before this PR (`/.well-known/oauth-protected-resource/github/mcp` and `/.well-known/oauth-protected-resource/mcp/github`)
7. Add an `interactive` server with the same `oauth2` / `authorization_code` block, restart under `SERVER_ROOT_PATH=/litellm`, and mint a virtual key with `POST /litellm/key/generate`
8. `POST /litellm/interactive/mcp` with that key and confirm the `authorization_uri` in the 401 carries the `/litellm` root segment
9. `GET` that URL and confirm it returns the authorization-server metadata instead of a 404

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP OAuth 401 WWW-Authenticate URLs used by strict RFC 9728 clients; wrong URLs would break login, but the change is a path-normalization fix with regression tests and no-op on root-mounted proxies.
> 
> **Overview**
> Fixes MCP OAuth 401 challenges on sub-path deployments (`SERVER_ROOT_PATH`). Previously, spelling detection used the raw request path, so `/litellm/{server}/mcp` never matched the root-relative `/{server}/mcp` shape and clients were sent to the wrong RFC 9728 metadata document (or a 404 AS-metadata URL).
> 
> Adds `get_route_relative_request_path` (segment-boundary strip, same idea as `get_request_route`) and uses it for both the pass-through `resource_metadata` challenge and the gateway-managed `authorization_uri` challenge. The latter also builds the well-known root via `well_known_root_suffix()` so advertised URLs match registered routes. Root-mounted proxies are unchanged.
> 
> Also catalogs Moonshot `moonshot/kimi-k3` pricing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91ba8994843c47a95a7d00d7879a61f4198ebe1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
