### PR TITLE
test(mcp): reload mcp_server_manager alongside utils in identity-env fixture

### DIFF
--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_identity_env.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server_identity_env.py
@@ -18,6 +18,7 @@ pytest.importorskip("mcp")
 
 UTILS_MODULE = "litellm.proxy._experimental.mcp_server.utils"
 MGMT_MODULE = "litellm.proxy.management_endpoints.mcp_management_endpoints"
+MANAGER_MODULE = "litellm.proxy._experimental.mcp_server.mcp_server_manager"
 
 
 @contextlib.contextmanager
@@ -32,8 +33,17 @@ def _env_and_reload(**env):
                 os.environ[key] = value
 
     def _reload():
+        # utils must reload first: MGMT_MODULE and MANAGER_MODULE both do
+        # ``from ...utils import X`` at module load time, so reloading them
+        # afterward re-binds those names to the fresh utils classes/values.
+        # Every module with a frozen import from utils needs to be listed
+        # here -- mcp_server_manager.py imports MCPMissingUserEnvVarsError
+        # this way, and a stale reference there causes
+        # pytest.raises(_u("MCPMissingUserEnvVarsError")) to stop matching
+        # in any test that runs after this one reloads utils.
         utils = importlib.reload(importlib.import_module(UTILS_MODULE))
         mgmt = importlib.reload(importlib.import_module(MGMT_MODULE))
+        importlib.reload(importlib.import_module(MANAGER_MODULE))
         return utils, mgmt
 
     try:


### PR DESCRIPTION
_env_and_reload() in test_mcp_server_identity_env.py reloads litellm.proxy._experimental.mcp_server.utils and litellm.proxy.management_endpoints.mcp_management_endpoints, but not litellm.proxy._experimental.mcp_server.mcp_server_manager. mcp_server_manager does `from ...utils import MCPMissingUserEnvVarsError` at module load time, so once this fixture reloads utils, mcp_server_manager keeps raising the pre-reload class object.

Any test in the same pytest worker that runs afterward and checks that exception via a fresh utils lookup (`pytest.raises(getattr(utils, "MCPMissingUserEnvVarsError"))`) fails to match, since the two class objects are no longer identical despite sharing a name -- an uncaught exception instead of a clean assertion failure.

## TLDR

- Reload mcp_server_manager alongside utils in the identity-env test fixture
- mcp_server_manager imports MCPMissingUserEnvVarsError from utils at module load time and never re-syncs
- Fixes two tests that fail nondeterministically under xdist depending on worker/ordering

Problem this solves:
- test_resolve_static_headers_raises_when_user_vars_missing and test_resolve_static_headers_empty_global_does_not_cover_user_var intermittently fail under `-n 4` with an uncaught MCPMissingUserEnvVarsError instead of the expected pytest.raises match
- Reproduced deterministically (no xdist needed) by running test_mcp_server_identity_env.py followed by the affected test in the same process

How it solves it:
- Add mcp_server_manager to the fixture's reload list, matching the pattern already used correctly in test_mcp_server_manager.py
- Confirmed via git stash: both target tests fail without this change and pass with it; full MCP suite run shows no new failures introduced

Fixes #N/A

## Relevant issues

Fixes #N/A

## Linear ticket

## Pre-Submission checklist