### PR TITLE
fix(router): continue fallback chain after mid-stream failure

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6132,6 +6132,16 @@ class Router:
         if include_fallback_errors:
             input_kwargs["include_fallback_errors"] = True
 
+        remaining_fallback_model_groups: tuple[str, ...] | None = kwargs.get("_remaining_fallback_model_groups")
+        if remaining_fallback_model_groups is not None:
+            response = await run_async_fallback(
+                *args,
+                **input_kwargs,
+                fallback_model_group=remaining_fallback_model_groups,
+                original_model_group=kwargs.get("_fallback_root_model_group", original_model_group),
+            )
+            return response
+
         # ORDER-BASED FALLBACKS: prepend higher order levels to the fallback list
         # Skip for error types that have their own dedicated fallback handlers
         _skip_order_fallback = isinstance(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -126,6 +126,7 @@ from litellm.router_utils.cooldown_handlers import (
     is_advisor_orchestration_failure,
 )
 from litellm.router_utils.fallback_event_handlers import (
+    _FallbackContinuationState,
     _check_non_standard_fallback_format,
     get_fallback_model_group,
     run_async_fallback,
@@ -6134,13 +6135,17 @@ class Router:
 
         from litellm.exceptions import MidStreamFallbackError
 
-        remaining_fallback_model_groups: tuple[str, ...] | None = kwargs.get("_remaining_fallback_model_groups")
-        if isinstance(e, MidStreamFallbackError) and remaining_fallback_model_groups is not None:
+        fallback_continuation_state = (kwargs.get("metadata") or {}).get("_fallback_continuation_state")
+        if (
+            isinstance(e, MidStreamFallbackError)
+            and isinstance(fallback_continuation_state, _FallbackContinuationState)
+            and fallback_continuation_state.litellm_router is self
+        ):
             response = await run_async_fallback(
                 *args,
                 **input_kwargs,
-                fallback_model_group=remaining_fallback_model_groups,
-                original_model_group=kwargs.get("_fallback_root_model_group", original_model_group),
+                fallback_model_group=fallback_continuation_state.remaining_model_groups,
+                original_model_group=fallback_continuation_state.root_model_group,
             )
             return response
 

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6132,8 +6132,10 @@ class Router:
         if include_fallback_errors:
             input_kwargs["include_fallback_errors"] = True
 
+        from litellm.exceptions import MidStreamFallbackError
+
         remaining_fallback_model_groups: tuple[str, ...] | None = kwargs.get("_remaining_fallback_model_groups")
-        if remaining_fallback_model_groups is not None:
+        if isinstance(e, MidStreamFallbackError) and remaining_fallback_model_groups is not None:
             response = await run_async_fallback(
                 *args,
                 **input_kwargs,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -6135,7 +6135,8 @@ class Router:
 
         from litellm.exceptions import MidStreamFallbackError
 
-        fallback_continuation_state = (kwargs.get("metadata") or {}).get("_fallback_continuation_state")
+        request_metadata = kwargs.get("metadata")
+        fallback_continuation_state = request_metadata.get("_fallback_continuation_state") if request_metadata else None
         if (
             isinstance(e, MidStreamFallbackError)
             and isinstance(fallback_continuation_state, _FallbackContinuationState)

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -126,8 +126,8 @@ from litellm.router_utils.cooldown_handlers import (
     is_advisor_orchestration_failure,
 )
 from litellm.router_utils.fallback_event_handlers import (
-    _FallbackContinuationState,
     _check_non_standard_fallback_format,
+    _FallbackContinuationState,
     get_fallback_model_group,
     run_async_fallback,
 )

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -85,7 +86,7 @@ def get_fallback_model_group(fallbacks: list[Any], model_group: str) -> tuple[li
 async def run_async_fallback(
     *args: tuple[Any],
     litellm_router: LitellmRouter,
-    fallback_model_group: list[str],
+    fallback_model_group: Sequence[str],
     original_model_group: str,
     original_exception: Exception,
     max_fallbacks: int,
@@ -121,7 +122,7 @@ async def run_async_fallback(
     error_from_fallbacks = original_exception
     fallback_errors = (get_fallback_error_info(original_exception),)
 
-    for mg in fallback_model_group:
+    for fallback_index, mg in enumerate(fallback_model_group):
         if mg == original_model_group:
             continue
         try:
@@ -138,6 +139,8 @@ async def run_async_fallback(
             fallback_depth = fallback_depth + 1
             kwargs["fallback_depth"] = fallback_depth
             kwargs["max_fallbacks"] = max_fallbacks
+            kwargs["_fallback_root_model_group"] = kwargs.get("_fallback_root_model_group", original_model_group)
+            kwargs["_remaining_fallback_model_groups"] = tuple(fallback_model_group[fallback_index + 1 :])
             if include_fallback_errors:
                 kwargs["include_fallback_errors"] = include_fallback_errors
             response = await litellm_router.async_function_with_fallbacks(*args, **kwargs)

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
@@ -18,6 +19,15 @@ if TYPE_CHECKING:
     LitellmRouter = _Router
 else:
     LitellmRouter = Any
+
+
+@dataclass(frozen=True)
+class _FallbackContinuationState:
+    """Router-owned state for continuing a fallback chain after stream failure."""
+
+    litellm_router: LitellmRouter = field(repr=False, compare=False)
+    root_model_group: str
+    remaining_model_groups: tuple[Any, ...]
 
 
 def _check_stripped_model_group(model_group: str, fallback_key: str) -> bool:
@@ -86,7 +96,7 @@ def get_fallback_model_group(fallbacks: list[Any], model_group: str) -> tuple[li
 async def run_async_fallback(
     *args: tuple[Any],
     litellm_router: LitellmRouter,
-    fallback_model_group: Sequence[str],
+    fallback_model_group: Sequence[Any],
     original_model_group: str,
     original_exception: Exception,
     max_fallbacks: int,
@@ -139,8 +149,14 @@ async def run_async_fallback(
             fallback_depth = fallback_depth + 1
             kwargs["fallback_depth"] = fallback_depth
             kwargs["max_fallbacks"] = max_fallbacks
-            kwargs["_fallback_root_model_group"] = kwargs.get("_fallback_root_model_group", original_model_group)
-            kwargs["_remaining_fallback_model_groups"] = tuple(fallback_model_group[fallback_index + 1 :])
+            kwargs.pop("_fallback_root_model_group", None)
+            kwargs.pop("_remaining_fallback_model_groups", None)
+            kwargs.pop("_fallback_continuation_state", None)
+            kwargs.setdefault("metadata", {})["_fallback_continuation_state"] = _FallbackContinuationState(
+                litellm_router=litellm_router,
+                root_model_group=original_model_group,
+                remaining_model_groups=tuple(fallback_model_group[fallback_index + 1 :]),
+            )
             if include_fallback_errors:
                 kwargs["include_fallback_errors"] = include_fallback_errors
             response = await litellm_router.async_function_with_fallbacks(*args, **kwargs)

--- a/litellm/router_utils/fallback_event_handlers.py
+++ b/litellm/router_utils/fallback_event_handlers.py
@@ -152,7 +152,11 @@ async def run_async_fallback(
             kwargs.pop("_fallback_root_model_group", None)
             kwargs.pop("_remaining_fallback_model_groups", None)
             kwargs.pop("_fallback_continuation_state", None)
-            kwargs.setdefault("metadata", {})["_fallback_continuation_state"] = _FallbackContinuationState(
+            metadata = kwargs.setdefault(
+                "metadata",
+                {},  # mutable-ok: request metadata is intentionally mutable
+            )
+            metadata["_fallback_continuation_state"] = _FallbackContinuationState(
                 litellm_router=litellm_router,
                 root_model_group=original_model_group,
                 remaining_model_groups=tuple(fallback_model_group[fallback_index + 1 :]),

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1873,6 +1873,73 @@ async def test_acompletion_streaming_iterator():
 
 
 @pytest.mark.asyncio
+async def test_midstream_failure_from_fallback_continues_remaining_chain():
+    from litellm.router_utils.fallback_event_handlers import run_async_fallback
+
+    router = litellm.Router(
+        model_list=[],
+        fallbacks=[{"pool-free": ["fallback-one", "fallback-two"]}],
+    )
+    midstream_error = MidStreamFallbackError(
+        message="fallback-one stream failed",
+        model="fallback-one",
+        llm_provider="openai",
+        generated_content="partial",
+    )
+
+    class BrokenFallbackStream:
+        model = "fallback-one"
+        custom_llm_provider = "openai"
+        logging_obj = MagicMock()
+        chunks: list = []
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            raise midstream_error
+
+    async def successful_fallback_stream():
+        yield "fallback-two"
+
+    dispatched_model_groups: list[str] = []
+
+    async def dispatch_fallback(*args, **kwargs):
+        model_group = kwargs["model"]
+        dispatched_model_groups.append(model_group)
+        if model_group == "fallback-one":
+            return await router._acompletion_streaming_iterator(
+                model_response=BrokenFallbackStream(),
+                messages=kwargs["messages"],
+                initial_kwargs=dict(kwargs),
+            )
+        return successful_fallback_stream()
+
+    with patch.object(
+        router,
+        "async_function_with_fallbacks",
+        side_effect=dispatch_fallback,
+    ):
+        response = await run_async_fallback(
+            litellm_router=router,
+            fallback_model_group=["fallback-one", "fallback-two"],
+            original_model_group="pool-free",
+            original_exception=Exception("primary failed"),
+            max_fallbacks=5,
+            fallback_depth=0,
+            messages=[{"role": "user", "content": "hello"}],
+            metadata={},
+            original_function=router._acompletion,
+            stream=True,
+            fallbacks=[{"pool-free": ["fallback-one", "fallback-two"]}],
+        )
+        chunks = [chunk async for chunk in response]
+
+    assert dispatched_model_groups == ["fallback-one", "fallback-two"]
+    assert chunks == ["fallback-two"]
+
+
+@pytest.mark.asyncio
 async def test_acompletion_streaming_iterator_edge_cases():
     """Test edge cases for _acompletion_streaming_iterator."""
     from unittest.mock import MagicMock

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -1940,6 +1940,55 @@ async def test_midstream_failure_from_fallback_continues_remaining_chain():
 
 
 @pytest.mark.asyncio
+async def test_midstream_failure_ignores_caller_supplied_continuation_state():
+    router = litellm.Router(
+        model_list=[],
+        fallbacks=[{"pool-free": ["fallback-one"]}],
+    )
+    midstream_error = MidStreamFallbackError(
+        message="stream failed",
+        model="pool-free",
+        llm_provider="openai",
+        generated_content="partial",
+    )
+    attacker_fallback = {
+        "model": "unauthorized-model",
+        "api_base": "https://attacker.example",
+    }
+
+    with patch(
+        "litellm.router.run_async_fallback",
+        new_callable=AsyncMock,
+        return_value="fallback-response",
+    ) as mock_run_async_fallback:
+        response = await router.async_function_with_fallbacks_common_utils(
+            e=midstream_error,
+            disable_fallbacks=False,
+            fallbacks=router.fallbacks,
+            context_window_fallbacks=None,
+            content_policy_fallbacks=None,
+            model_group="pool-free",
+            args=(),
+            kwargs={
+                "model": "pool-free",
+                "_fallback_root_model_group": "attacker-root",
+                "_remaining_fallback_model_groups": (attacker_fallback,),
+                "metadata": {
+                    "_fallback_continuation_state": {
+                        "root_model_group": "attacker-root",
+                        "remaining_model_groups": (attacker_fallback,),
+                    }
+                },
+            },
+        )
+
+    assert response == "fallback-response"
+    fallback_call = mock_run_async_fallback.await_args.kwargs
+    assert fallback_call["fallback_model_group"] == ["fallback-one"]
+    assert fallback_call["original_model_group"] == "pool-free"
+
+
+@pytest.mark.asyncio
 async def test_acompletion_streaming_iterator_edge_cases():
     """Test edge cases for _acompletion_streaming_iterator."""
     from unittest.mock import MagicMock


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mid-stream failure on a fallback discards remaining fallbacks
- Lookup uses the current fallback instead of the requested group

How it solves it:

- Carries root group and untried fallbacks across recursive dispatch
- Resumes only the remaining chain after a stream error
- Keeps continuation state private, Router-bound, and inside LiteLLM metadata; caller-supplied legacy/dictionary state is ignored

## Relevant issues

Fixes #35578

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Pending live proof: reproducing this requires one provider to fail mid-stream while another configured fallback remains healthy. No paid provider credentials were used locally. Base commit: `491eda3`; fix tree: `a22352b`

## Type

Bug Fix

## Changes

- Preserve the root model group and untried fallback groups
- Continue with only the remaining chain after stream failure
- Cover primary failure, fallback stream failure, then success
- Reject caller-injected continuation state and use the configured fallback chain
- Local verification: 194 affected router/fallback tests passed with CI-style xdist/reruns; `ruff check`, `ruff format --check`, and `git diff --check` passed on local follow-up `967f3f3`. Earlier `make pre-commit` passed on `57c4467`.
- Security follow-up verification: 73 fallback/order/streaming tests passed; source ruff check/format, test duplicate-key check, and `git diff --check` passed locally. The strict I001 gate also passes after the import-order-only follow-up.
- Previous remote verification on `de46ce1`: 74 checks passed; one optional check skipped; Codecov covered all modified lines; CodSpeed reported no performance change.
- Latest-head status on `a22352b`: CI, Codecov, and Greptile review are in progress after the type-discipline-only follow-up.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

AI assistance was used; I reviewed the implementation, regression coverage, and verification results