### PR TITLE
fix(proxy): reject or warn when budget reservation cost can't be estimated

### DIFF
--- a/litellm/proxy/spend_tracking/budget_reservation.py
+++ b/litellm/proxy/spend_tracking/budget_reservation.py
@@ -78,6 +78,38 @@ def _raise_reservation_unavailable(counter_key: str) -> NoReturn:
     )
 
 
+def _raise_cost_estimate_unavailable(route: str) -> NoReturn:
+    verbose_proxy_logger.warning(
+        "fail_closed_budget_enforcement: rejecting request — request cost for route %s could not be estimated",
+        route,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail=(
+            "Budget enforcement unavailable: this request's cost could not be "
+            "estimated before dispatch (e.g. an unpriced model or route), and "
+            "fail_closed_budget_enforcement is enabled, so the request was "
+            "rejected to avoid exceeding a configured budget."
+        ),
+    )
+
+
+def _handle_missing_cost_estimate(route: str, fail_closed_budget_enforcement: bool) -> None:
+    """A budget is configured but estimate_request_max_cost() returned no usable
+    estimate. Reject when the operator opted into fail_closed_budget_enforcement;
+    otherwise warn so the read-time-only fallback is visible instead of silent.
+    """
+    if fail_closed_budget_enforcement:
+        _raise_cost_estimate_unavailable(route=route)
+    verbose_proxy_logger.warning(
+        "reserve_budget_for_request: could not estimate a cost for route=%s; a budget is "
+        "configured for this request but no atomic reservation will be made (non-atomic, "
+        "read-time-only enforcement). Set fail_closed_budget_enforcement=true to reject "
+        "these requests instead.",
+        route,
+    )
+
+
 def get_reserved_counter_keys(budget_reservation: dict | None) -> set:
     if not budget_reservation:
         return set()
@@ -187,8 +219,10 @@ async def reserve_budget_for_request(
     )
     # estimate_request_max_cost still returns None when the model is unknown
     # to the cost map (no token-priced cost fields, e.g. image/audio routes).
-    # In that case we fall back to read-time enforcement only.
+    # A budget is configured here (counters is non-empty), so this is a real
+    # atomicity gap, not a benign no-budget request.
     if reservation_cost is None or reservation_cost <= 0:
+        _handle_missing_cost_estimate(route=route, fail_closed_budget_enforcement=fail_closed_budget_enforcement)
         return None
 
     applied_entries: list[dict[str, Any]] = []

--- a/tests/test_litellm/proxy/test_budget_reservation.py
+++ b/tests/test_litellm/proxy/test_budget_reservation.py
@@ -1621,6 +1621,98 @@ async def test_fail_closed_releases_earlier_counters_before_503(
 
 
 @pytest.mark.asyncio
+async def test_should_raise_503_when_cost_cannot_be_estimated_and_fail_closed(
+    spend_counter_state,
+):
+    """A budget is configured but the request's cost can't be estimated (e.g. an
+    unpriced model or an image/audio route). With fail_closed_budget_enforcement
+    on, this must reject instead of silently skipping the reservation and
+    falling back to non-atomic read-time-only enforcement."""
+    counter_cache, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    valid_token = UserAPIKeyAuth(
+        token="key-budget-no-estimate-fail-closed",
+        spend=0.0,
+        max_budget=1.0,
+    )
+
+    with patch(
+        "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
+        return_value=None,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await reserve_budget_for_request(
+                request_body=_request_body(),
+                route="/chat/completions",
+                llm_router=None,
+                valid_token=valid_token,
+                team_object=None,
+                user_object=None,
+                prisma_client=None,
+                user_api_key_cache=key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+                fail_closed_budget_enforcement=True,
+            )
+
+    assert exc_info.value.status_code == 503
+    assert (
+        counter_cache.in_memory_cache.get_cache(
+            key="spend:key:key-budget-no-estimate-fail-closed"
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_cost_estimate_falls_back_silently_by_default(
+    spend_counter_state,
+):
+    """Default behavior (fail_closed_budget_enforcement off) is unchanged: an
+    unestimable cost with a budget configured returns no reservation rather
+    than raising, but must now warn that enforcement fell back to non-atomic
+    read-time-only checks instead of doing so silently."""
+    counter_cache, key_cache = spend_counter_state
+    proxy_logging_obj = ProxyLogging(user_api_key_cache=key_cache)
+    valid_token = UserAPIKeyAuth(
+        token="key-budget-no-estimate-default",
+        spend=0.0,
+        max_budget=1.0,
+    )
+
+    with (
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation.estimate_request_max_cost",
+            return_value=None,
+        ),
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation.verbose_proxy_logger.warning"
+        ) as mock_warning,
+    ):
+        result = await reserve_budget_for_request(
+            request_body=_request_body(),
+            route="/chat/completions",
+            llm_router=None,
+            valid_token=valid_token,
+            team_object=None,
+            user_object=None,
+            prisma_client=None,
+            user_api_key_cache=key_cache,
+            proxy_logging_obj=proxy_logging_obj,
+            fail_closed_budget_enforcement=False,
+        )
+
+    assert result is None
+    assert (
+        counter_cache.in_memory_cache.get_cache(
+            key="spend:key:key-budget-no-estimate-default"
+        )
+        is None
+    )
+    mock_warning.assert_called_once()
+    assert "could not estimate a cost" in mock_warning.call_args.args[0]
+
+
+@pytest.mark.asyncio
 async def test_should_skip_reservation_when_counter_initialization_fails(
     spend_counter_state,
 ):


### PR DESCRIPTION


reserve_budget_for_request silently skipped the atomic reservation and fell back to non-atomic read-time-only enforcement whenever estimate_request_max_cost() couldn't price the request (unmapped models, image/audio routes). A budget is configured whenever this branch runs, so this left concurrent requests able to all pass the same stale spend check before any of their final costs committed.

Extend fail_closed_budget_enforcement (already used for the analogous counter-write-failure case) to also reject these requests, and warn when the flag is off so the non-atomic fallback is visible instead of silent. Default behavior is unchanged for operators not using the flag.


## Relevant issues

Fixes #35524 

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), include proof for every single one of them, not just one
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
