### PR TITLE
fix(ui): honor LITELLM_UI_API_DOC_BASE_URL on the MCP Servers Connect and Toolsets tabs

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxySettings/useDocBaseUrl.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxySettings/useDocBaseUrl.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { resolveDocBaseUrl } from "./useDocBaseUrl";
+
+const FALLBACK = "http://proxy.internal:4000";
+const DOC_BASE = "https://gateway.public.example.com";
+
+describe("resolveDocBaseUrl", () => {
+  it("prefers the doc base url over the fallback when it is set", () => {
+    expect(resolveDocBaseUrl(DOC_BASE, FALLBACK)).toBe(DOC_BASE);
+  });
+
+  it("falls back when the doc base url is undefined", () => {
+    expect(resolveDocBaseUrl(undefined, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("falls back when the doc base url is null", () => {
+    expect(resolveDocBaseUrl(null, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("falls back when the doc base url is an empty string", () => {
+    expect(resolveDocBaseUrl("", FALLBACK)).toBe(FALLBACK);
+  });
+
+  it("falls back when the doc base url is whitespace only", () => {
+    expect(resolveDocBaseUrl("   ", FALLBACK)).toBe(FALLBACK);
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxySettings/useDocBaseUrl.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/proxySettings/useDocBaseUrl.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { getProxyBaseUrl } from "@/components/networking";
+import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
+import useProxySettings from "@/app/(dashboard)/hooks/proxySettings/useProxySettings";
+
+export function resolveDocBaseUrl(docBaseUrl: string | null | undefined, fallback: string): string {
+  return docBaseUrl && docBaseUrl.trim() ? docBaseUrl : fallback;
+}
+
+export default function useDocBaseUrl(): string {
+  const { accessToken } = useAuthorized();
+  const { LITELLM_UI_API_DOC_BASE_URL } = useProxySettings(accessToken);
+  return resolveDocBaseUrl(LITELLM_UI_API_DOC_BASE_URL, getProxyBaseUrl());
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPToolsetTableColumns.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPToolsetTableColumns.test.tsx
@@ -5,9 +5,7 @@ import { DataTable } from "@/components/shared/DataTable";
 import { MCPToolset } from "@/components/mcp_tools/types";
 import { getMCPToolsetTableColumns } from "./MCPToolsetTableColumns";
 
-vi.mock("@/components/networking", () => ({
-  getProxyBaseUrl: () => "http://localhost:4000",
-}));
+const DOC_BASE_URL = "https://gateway.public.example.com";
 
 const mockToolset: MCPToolset = {
   toolset_id: "ts-1",
@@ -29,7 +27,7 @@ const serverPrefixById = new Map([
 ]);
 
 function renderTable({ isAdmin = true, onEditClick = vi.fn(), onDeleteClick = vi.fn() } = {}) {
-  const deps = { isAdmin, serverPrefixById, onEditClick, onDeleteClick };
+  const deps = { isAdmin, serverPrefixById, docBaseUrl: DOC_BASE_URL, onEditClick, onDeleteClick };
   render(
     <DataTable
       data={[mockToolset]}
@@ -46,7 +44,7 @@ describe("getMCPToolsetTableColumns", () => {
   it("renders the toolset with its endpoint url as subtitle", () => {
     renderTable();
     expect(screen.getByText("github-tools")).toBeInTheDocument();
-    expect(screen.getByText("http://localhost:4000/toolset/github-tools/mcp")).toBeInTheDocument();
+    expect(screen.getByText(`${DOC_BASE_URL}/toolset/github-tools/mcp`)).toBeInTheDocument();
   });
 
   it("renders server-prefixed tool chips capped at four with an overflow count", () => {
@@ -77,7 +75,7 @@ describe("getMCPToolsetTableColumns", () => {
 
     await user.click(screen.getByTestId("toolset-actions-ts-1"));
     await user.click(await screen.findByTestId("toolset-action-copy-url"));
-    expect(await window.navigator.clipboard.readText()).toBe("http://localhost:4000/toolset/github-tools/mcp");
+    expect(await window.navigator.clipboard.readText()).toBe(`${DOC_BASE_URL}/toolset/github-tools/mcp`);
 
     await user.click(screen.getByTestId("toolset-actions-ts-1"));
     await user.click(await screen.findByTestId("toolset-action-copy-id"));

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPToolsetTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPToolsetTableColumns.tsx
@@ -14,7 +14,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/cva.config";
-import { getProxyBaseUrl } from "@/components/networking";
 import { MCPToolset } from "@/components/mcp_tools/types";
 import { copyToClipboard } from "@/utils/dataUtils";
 
@@ -29,18 +28,19 @@ export function displayToolName(serverPrefix: string | undefined, toolName: stri
   return serverPrefix ? `${serverPrefix}${MCP_TOOL_PREFIX_SEPARATOR}${toolName}` : toolName;
 }
 
-export function toolsetEndpointUrl(toolsetName: string): string {
-  return `${getProxyBaseUrl()}/toolset/${toolsetName}/mcp`;
+export function toolsetEndpointUrl(baseUrl: string, toolsetName: string): string {
+  return `${baseUrl}/toolset/${toolsetName}/mcp`;
 }
 
 interface ToolsetRowActionsProps {
   toolset: MCPToolset;
   isAdmin: boolean;
+  docBaseUrl: string;
   onEditClick: (toolset: MCPToolset) => void;
   onDeleteClick: (toolsetId: string) => void;
 }
 
-function ToolsetRowActions({ toolset, isAdmin, onEditClick, onDeleteClick }: ToolsetRowActionsProps) {
+function ToolsetRowActions({ toolset, isAdmin, docBaseUrl, onEditClick, onDeleteClick }: ToolsetRowActionsProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
@@ -53,7 +53,9 @@ function ToolsetRowActions({ toolset, isAdmin, onEditClick, onDeleteClick }: Too
       <DropdownMenuContent align="end" className="w-52">
         <DropdownMenuItem
           data-testid="toolset-action-copy-url"
-          onClick={() => void copyToClipboard(toolsetEndpointUrl(toolset.toolset_name), "Endpoint URL copied")}
+          onClick={() =>
+            void copyToClipboard(toolsetEndpointUrl(docBaseUrl, toolset.toolset_name), "Endpoint URL copied")
+          }
         >
           <Link2 />
           Copy endpoint URL
@@ -90,6 +92,7 @@ function ToolsetRowActions({ toolset, isAdmin, onEditClick, onDeleteClick }: Too
 interface MCPToolsetTableColumnsDeps {
   isAdmin: boolean;
   serverPrefixById: Map<string, string>;
+  docBaseUrl: string;
   onEditClick: (toolset: MCPToolset) => void;
   onDeleteClick: (toolsetId: string) => void;
 }
@@ -97,6 +100,7 @@ interface MCPToolsetTableColumnsDeps {
 export const getMCPToolsetTableColumns = ({
   isAdmin,
   serverPrefixById,
+  docBaseUrl,
   onEditClick,
   onDeleteClick,
 }: MCPToolsetTableColumnsDeps): ColumnDef<MCPToolset>[] => [
@@ -120,7 +124,7 @@ export const getMCPToolsetTableColumns = ({
     cell: ({ row }) => (
       <IdentityCell
         title={row.original.toolset_name}
-        subtitle={toolsetEndpointUrl(row.original.toolset_name)}
+        subtitle={toolsetEndpointUrl(docBaseUrl, row.original.toolset_name)}
         className="max-w-80"
         onClick={isAdmin ? () => onEditClick(row.original) : undefined}
       />
@@ -185,6 +189,7 @@ export const getMCPToolsetTableColumns = ({
         <ToolsetRowActions
           toolset={row.original}
           isAdmin={isAdmin}
+          docBaseUrl={docBaseUrl}
           onEditClick={onEditClick}
           onDeleteClick={onDeleteClick}
         />

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPToolsetsTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPToolsetsTab.test.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MCPToolsetsTab } from "./MCPToolsetsTab";
+import useProxySettings from "@/app/(dashboard)/hooks/proxySettings/useProxySettings";
+
+const DOC_BASE_URL = "https://gateway.public.example.com";
+const PROXY_BASE_URL = "http://proxy.internal:4000";
+
+vi.mock("@/components/networking", () => ({
+  getProxyBaseUrl: () => PROXY_BASE_URL,
+  createMCPToolset: vi.fn(),
+  updateMCPToolset: vi.fn(),
+  deleteMCPToolset: vi.fn(),
+  listMCPTools: vi.fn(),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => ({ accessToken: "sk-test" }),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/proxySettings/useProxySettings", () => ({
+  default: vi.fn(),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/mcpServers/useMCPToolsets", () => ({
+  useMCPToolsets: () => ({
+    data: [
+      {
+        toolset_id: "ts-1",
+        toolset_name: "github-tools",
+        description: "GitHub helpers",
+        tools: [{ server_id: "srv-1", tool_name: "create_issue" }],
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ],
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/mcpServers/useMCPServers", () => ({
+  useMCPServers: () => ({ data: [{ server_id: "srv-1", alias: "github", server_name: "github" }] }),
+}));
+
+const mockedUseProxySettings = vi.mocked(useProxySettings);
+
+function renderTab(docBaseUrl: string | null) {
+  mockedUseProxySettings.mockReturnValue({
+    PROXY_BASE_URL,
+    PROXY_LOGOUT_URL: "",
+    LITELLM_UI_API_DOC_BASE_URL: docBaseUrl,
+  });
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <MCPToolsetsTab accessToken="sk-test" userRole="Admin" />
+    </QueryClientProvider>,
+  );
+}
+
+describe("MCPToolsetsTab", () => {
+  it("builds the usage guide and row endpoint urls from LITELLM_UI_API_DOC_BASE_URL when set", () => {
+    renderTab(DOC_BASE_URL);
+
+    expect(screen.getByText(new RegExp(`${DOC_BASE_URL}/toolset/<toolset-name>/mcp`))).toBeInTheDocument();
+    expect(screen.getByText(`${DOC_BASE_URL}/toolset/github-tools/mcp`)).toBeInTheDocument();
+    expect(screen.queryAllByText(/proxy\.internal/)).toHaveLength(0);
+  });
+
+  it("falls back to the proxy base url when LITELLM_UI_API_DOC_BASE_URL is unset", () => {
+    renderTab(null);
+
+    expect(screen.getByText(new RegExp(`${PROXY_BASE_URL}/toolset/<toolset-name>/mcp`))).toBeInTheDocument();
+    expect(screen.getByText(`${PROXY_BASE_URL}/toolset/github-tools/mcp`)).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPToolsetsTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPToolsetsTab.tsx
@@ -8,13 +8,8 @@ import { useMCPToolsets } from "@/app/(dashboard)/hooks/mcpServers/useMCPToolset
 import { useMCPServers } from "@/app/(dashboard)/hooks/mcpServers/useMCPServers";
 import { useQueryClient } from "@tanstack/react-query";
 import { DataTable } from "@/components/shared/DataTable";
-import {
-  createMCPToolset,
-  updateMCPToolset,
-  deleteMCPToolset,
-  listMCPTools,
-  getProxyBaseUrl,
-} from "@/components/networking";
+import { createMCPToolset, updateMCPToolset, deleteMCPToolset, listMCPTools } from "@/components/networking";
+import useDocBaseUrl from "@/app/(dashboard)/hooks/proxySettings/useDocBaseUrl";
 import { MCPToolset, MCPToolsetTool } from "@/components/mcp_tools/types";
 import { displayToolName, getMCPToolsetTableColumns } from "./MCPToolsetTableColumns";
 
@@ -302,12 +297,12 @@ function ToolsetsEmptyState() {
 
 function ToolsetUsageGuide() {
   const [copied, setCopied] = useState(false);
-  const proxyBaseUrl = getProxyBaseUrl();
+  const docBaseUrl = useDocBaseUrl();
 
   const snippet = `{
   "mcpServers": {
     "my-toolset": {
-      "url": "${proxyBaseUrl}/toolset/<toolset-name>/mcp",
+      "url": "${docBaseUrl}/toolset/<toolset-name>/mcp",
       "headers": { "x-litellm-api-key": "Bearer <your-api-key>" }
     }
   }
@@ -358,6 +353,7 @@ export function MCPToolsetsTab({ accessToken, userRole }: MCPToolsetsTabProps) {
   const [deleting, setDeleting] = useState(false);
 
   const isAdmin = userRole === "Admin" || userRole === "proxy_admin";
+  const docBaseUrl = useDocBaseUrl();
 
   const handleCreate = async (name: string, description: string | undefined, tools: MCPToolsetTool[]) => {
     if (!accessToken) return;
@@ -396,11 +392,12 @@ export function MCPToolsetsTab({ accessToken, userRole }: MCPToolsetsTabProps) {
     const deps = {
       isAdmin,
       serverPrefixById,
+      docBaseUrl,
       onEditClick: setEditToolset,
       onDeleteClick: setDeleteId,
     };
     return getMCPToolsetTableColumns(deps);
-  }, [isAdmin, serverPrefixById]);
+  }, [isAdmin, serverPrefixById, docBaseUrl]);
 
   return (
     <div className="mt-4">

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_connect.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_connect.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import MCPConnect from "./mcp_connect";
+import useProxySettings from "@/app/(dashboard)/hooks/proxySettings/useProxySettings";
+
+vi.mock("@/components/networking", () => ({
+  getProxyBaseUrl: () => "http://proxy.internal:4000",
+}));
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => ({ accessToken: "sk-test" }),
+}));
+
+vi.mock("@/app/(dashboard)/hooks/proxySettings/useProxySettings", () => ({
+  default: vi.fn(),
+}));
+
+const mockedUseProxySettings = vi.mocked(useProxySettings);
+
+const proxySettings = (docBaseUrl: string | null) => ({
+  PROXY_BASE_URL: "http://proxy.internal:4000",
+  PROXY_LOGOUT_URL: "",
+  LITELLM_UI_API_DOC_BASE_URL: docBaseUrl,
+});
+
+describe("MCPConnect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the Server URL from LITELLM_UI_API_DOC_BASE_URL when it is set", () => {
+    mockedUseProxySettings.mockReturnValue(proxySettings("https://gateway.public.example.com"));
+
+    render(<MCPConnect />);
+
+    expect(screen.getAllByText("https://gateway.public.example.com/mcp").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText(/proxy\.internal/)).toHaveLength(0);
+  });
+
+  it("renders the Server URL from the proxy base url when LITELLM_UI_API_DOC_BASE_URL is unset", () => {
+    mockedUseProxySettings.mockReturnValue(proxySettings(null));
+
+    render(<MCPConnect />);
+
+    expect(screen.getAllByText("http://proxy.internal:4000/mcp").length).toBeGreaterThan(0);
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_connect.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_connect.tsx
@@ -4,7 +4,7 @@ import React, { useState } from "react";
 import { Card, Typography, Space, Alert, Button, Switch, Form, Collapse } from "antd";
 import { TabPanel, TabPanels, TabGroup, TabList, Tab, Title as TremorTitle, Text as TremorText } from "@tremor/react";
 import { CopyIcon, Code, Terminal, Globe, CheckIcon, ExternalLinkIcon, KeyIcon, ServerIcon, Zap } from "lucide-react";
-import { getProxyBaseUrl } from "@/components/networking";
+import useDocBaseUrl from "@/app/(dashboard)/hooks/proxySettings/useDocBaseUrl";
 import { copyToClipboard as utilCopyToClipboard } from "@/utils/dataUtils";
 
 const { Title, Text } = Typography;
@@ -115,7 +115,7 @@ interface MCPConnectProps {
 }
 
 const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] }) => {
-  const proxyBaseUrl = getProxyBaseUrl();
+  const docBaseUrl = useDocBaseUrl();
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
   const [serverHeaders, setServerHeaders] = useState<Record<string, string[]>>({
     openai: [],
@@ -236,7 +236,7 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
           title="MCP Server Information"
           description="Connection details for your LiteLLM MCP server"
         >
-          <CodeBlock title="Server URL" code={`${proxyBaseUrl}/mcp`} copyKey="litellm-server-url" />
+          <CodeBlock title="Server URL" code={`${docBaseUrl}/mcp`} copyKey="litellm-server-url" />
         </FeatureCard>
 
         <FeatureCard
@@ -247,7 +247,7 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
           accessGroups={["dev-group"]}
         >
           <CodeBlock
-            code={`curl --location '${proxyBaseUrl}/v1/responses' \\
+            code={`curl --location '${docBaseUrl}/v1/responses' \\
 --header 'Content-Type: application/json' \\
 --header "Authorization: Bearer $LITELLM_VIRTUAL_KEY" \\
 --data '{
@@ -319,7 +319,7 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
           title="MCP Server Information"
           description="Connection details for your LiteLLM MCP server"
         >
-          <CodeBlock title="Server URL" code={`${proxyBaseUrl}/mcp`} copyKey="openai-server-url" />
+          <CodeBlock title="Server URL" code={`${docBaseUrl}/mcp`} copyKey="openai-server-url" />
         </FeatureCard>
 
         <FeatureCard
@@ -339,7 +339,7 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
         {
             "type": "mcp",
             "server_label": "litellm",
-            "server_url": "${proxyBaseUrl}/mcp",
+            "server_url": "${docBaseUrl}/mcp",
             "require_approval": "never",
             "headers": {
                 "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
@@ -406,7 +406,7 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
                 code={`{
   "mcpServers": {
     "Zapier_MCP": {
-      "url": "${proxyBaseUrl}/mcp",
+      "url": "${docBaseUrl}/mcp",
       "headers": {
         "x-litellm-api-key": "Bearer YOUR_LITELLM_API_KEY",
         "x-mcp-servers": "Zapier_MCP,dev-group"
@@ -450,7 +450,7 @@ const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] 
               appropriate transport method.
             </Text>
           </div>
-          <CodeBlock title="Server URL" code={`${proxyBaseUrl}/mcp`} copyKey="http-server-url" />
+          <CodeBlock title="Server URL" code={`${docBaseUrl}/mcp`} copyKey="http-server-url" />
           <CodeBlock
             title="Headers Configuration"
             code={JSON.stringify(


### PR DESCRIPTION
## TLDR

Problem this solves:

- MCP Connect tab prints PROXY_BASE_URL, ignoring LITELLM_UI_API_DOC_BASE_URL
- Toolset endpoint URLs on the sibling tab have the same bug
- Users copy snippets pointing at the wrong host

How it solves it:

- New useDocBaseUrl hook prefers a non-blank LITELLM_UI_API_DOC_BASE_URL
- Falls back to getProxyBaseUrl(), so unset behaves exactly as today
- Connect snippets and toolset URLs read that single resolved base

## Relevant issues

Fixes #35583

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Steps to capture before/after, with PROXY_BASE_URL and LITELLM_UI_API_DOC_BASE_URL deliberately pointed at different hosts:

1. Export both, then start the proxy: `export PROXY_BASE_URL=http://localhost:4000` and `export LITELLM_UI_API_DOC_BASE_URL=https://gateway.example.com`, then `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
2. Start the dashboard with `npm run dev` in `ui/litellm-dashboard`
3. Open http://localhost:4000/ui/?page=mcp-servers and click the Connect tab; screenshot the Server URL and the OpenAI / LiteLLM Proxy / Cursor / Streamable HTTP snippets. Before this PR they read `http://localhost:4000/mcp`; after, `https://gateway.example.com/mcp`
4. Click the Toolsets tab; screenshot the "Claude Code / Cursor config" block and a toolset row's endpoint subtitle, then use the row's three-dot menu -> Copy endpoint URL and paste it. All three should show `https://gateway.example.com/toolset/...`
5. Unset LITELLM_UI_API_DOC_BASE_URL, restart both, and repeat steps 3 and 4 to confirm everything reverts to `http://localhost:4000`

## Type

🐛 Bug Fix

## Changes

`useDocBaseUrl` lives at `app/(dashboard)/hooks/proxySettings/useDocBaseUrl.ts` next to `useProxySettings`. It exports a pure `resolveDocBaseUrl(docBaseUrl, fallback)` that trims and prefers the doc base, plus the hook that composes `useAuthorized`, `useProxySettings` and `getProxyBaseUrl`. Taking the fallback as a parameter keeps the trim-and-prefer semantics shareable without forcing one chain on every caller

Falling back to `getProxyBaseUrl()` rather than straight to `PROXY_BASE_URL` preserves the worker-url override in `networking.tsx`, so the only behavior change is the one the issue asks for

`toolsetEndpointUrl` now takes its base as a parameter because it is called from a TanStack column `cell` renderer where calling a hook is unsafe; the resolved base is injected through the existing `MCPToolsetTableColumnsDeps` object, matching how that file already receives its dependencies

`chat_ui/CodeSnippets.tsx` keeps its own inlined chain (`LITELLM_UI_API_DOC_BASE_URL > PROXY_BASE_URL > window.location.origin`). Those snippets are not worker-aware today and making them so is a separate change

Tests were written first and each was watched fail against the unfixed code: `useDocBaseUrl.test.ts` pins the resolution order and the blank/whitespace/null guards, `mcp_connect.test.tsx` asserts the rendered Server URL follows the doc base when set and the proxy base when not, `MCPToolsetsTab.test.tsx` covers the usage-guide snippet and the per-row endpoint URL, and the existing `MCPToolsetTableColumns.test.tsx` was updated to inject a doc base distinct from the mocked proxy base so an inverted priority fails it

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
