### PR TITLE
fix(proxy): reset SSRF url settings when their DB config keys are rem…

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17,12 +17,15 @@ import traceback
 import warnings
 from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
+from itertools import chain
+from types import MappingProxyType
 from typing import (
     TYPE_CHECKING,
     Any,
     AsyncGenerator,
     Callable,
     Dict,
+    Final,
     List,
     Literal,
     Optional,
@@ -3654,7 +3657,63 @@ def _normalize_user_url_validation(value: object) -> Optional[bool]:
     return bool(value)
 
 
-def _apply_ssrf_general_settings(settings: Mapping[str, object]) -> None:
+_SSRF_URL_SETTING_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "user_url_allowed_hosts",
+        "user_url_validation",
+        "provider_url_destination_allowed_hosts",
+    }
+)
+
+_SSRF_URL_SETTING_DEFAULTS: Final[Mapping[str, object]] = MappingProxyType(
+    {
+        "user_url_allowed_hosts": litellm.user_url_allowed_hosts,
+        "user_url_validation": litellm.user_url_validation,
+        "provider_url_destination_allowed_hosts": litellm.provider_url_destination_allowed_hosts,
+    }
+)
+
+
+def _config_section(config: Mapping[str, object], section_name: str) -> Mapping[str, object] | None:
+    section = config.get(section_name)
+    return section if isinstance(section, Mapping) else None
+
+
+def _ssrf_url_overrides(section: Mapping[str, object] | None) -> tuple[tuple[str, object], ...]:
+    """
+    The SSRF URL-validation keys a single config section sets.
+
+    A ``user_url_validation`` of None counts as unset so an explicit null never
+    turns validation off; the allowlist keys keep None, which reads the same as
+    "no allowlist" everywhere they're consumed.
+    """
+    if section is None:
+        return ()
+    return tuple(
+        (key, value)
+        for key, value in section.items()
+        if key in _SSRF_URL_SETTING_KEYS and not (key == "user_url_validation" and value is None)
+    )
+
+
+def _resolve_ssrf_url_settings(*override_layers: tuple[tuple[str, object], ...]) -> Mapping[str, object]:
+    """
+    The SSRF settings the proxy should be running with: the values the process
+    started with, then each layer applied in precedence order (later layers win).
+    Every key is always present, so applying the result resets a setting whose
+    override went away instead of leaving the last value it was given.
+    """
+    return MappingProxyType(
+        dict(
+            chain(
+                _SSRF_URL_SETTING_DEFAULTS.items(),
+                *override_layers,
+            )
+        )
+    )
+
+
+def _apply_ssrf_url_settings(settings: Mapping[str, object]) -> None:
     if "user_url_allowed_hosts" in settings:
         litellm.user_url_allowed_hosts = cast(list[str], settings["user_url_allowed_hosts"])
 
@@ -4927,7 +4986,7 @@ class ProxyConfig:
                 ]
 
             ### SSRF URL VALIDATION SETTINGS ###
-            _apply_ssrf_general_settings(general_settings)
+            _apply_ssrf_url_settings(general_settings)
 
             ## check if user has set a premium feature in general_settings
             if general_settings.get("enforced_params") is not None and premium_user is not True:
@@ -5985,7 +6044,7 @@ class ProxyConfig:
         ):
             if key in _general_settings:
                 general_settings[key] = _general_settings[key]
-        _apply_ssrf_general_settings(_general_settings)
+        _apply_ssrf_url_settings(_general_settings)
 
     def _update_config_fields(
         self,
@@ -6076,6 +6135,16 @@ class ProxyConfig:
         config: dict,
         store_model_in_db: Optional[bool],
     ):
+        """
+        Overlay the DB config rows onto the config-file config.
+
+        The SSRF URL-validation globals are then re-applied from the merged result,
+        including the keys nothing set (which go back to the process defaults). The
+        config file is re-read on every sync, so dropping an override from the DB
+        falls back to the config-file value instead of staying live until restart.
+        Only a fully successful set of reads gets here; a DB failure raises out of
+        the gather and leaves the current restrictions in place.
+        """
         if store_model_in_db is not True:
             verbose_proxy_logger.info("'store_model_in_db' is not True, skipping db updates")
             return config
@@ -6109,6 +6178,13 @@ class ProxyConfig:
                     param_name=param_name,
                     db_param_value=param_value,
                 )
+
+        _apply_ssrf_url_settings(
+            _resolve_ssrf_url_settings(
+                _ssrf_url_overrides(_config_section(config, "litellm_settings")),
+                _ssrf_url_overrides(_config_section(config, "general_settings")),
+            )
+        )
 
         return config
 
@@ -14980,7 +15056,7 @@ async def update_config_general_settings(
 
     if data.field_name == "plugins":
         register_plugins_from_config(general_settings)
-    _apply_ssrf_general_settings(general_settings)
+    _apply_ssrf_url_settings(general_settings)
 
     return response
 

--- a/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
+++ b/tests/test_litellm/proxy/proxy_server/test_proxy_config.py
@@ -2334,6 +2334,127 @@ async def test_ProxyConfig__update_config_from_db_does_not_log_general_settings_
     assert merged["environment_variables"]["DATABASE_URL"] == env_db_url_secret
 
 
+def _patch_config_rows(monkeypatch, rows: Dict[str, Any]) -> None:
+    async def _fake_get_config_param(prisma_client, key):
+        value = rows.get(key)
+        if value is None:
+            return None
+        return SimpleNamespace(param_name=key, param_value=value)
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.get_config_param", _fake_get_config_param)
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__update_config_from_db_resets_ssrf_settings_when_db_row_removed(monkeypatch):
+    """Regression for #35502.
+
+    A DB-backed proxy that allowlisted a host via the ``litellm_settings`` (or
+    ``general_settings``) config row kept that host allowed after the row was
+    deleted, because the sync only applied the keys it found and never unset
+    anything. Removing the override has to take effect on the next sync.
+    """
+    monkeypatch.setattr(litellm, "user_url_validation", False)
+    monkeypatch.setattr(litellm, "user_url_allowed_hosts", ["127.0.0.1:9999"])
+    monkeypatch.setattr(litellm, "provider_url_destination_allowed_hosts", ["evil.example"])
+    _patch_config_rows(monkeypatch, {})
+
+    await ProxyConfig()._update_config_from_db(
+        prisma_client=MagicMock(),
+        config={"general_settings": {}, "litellm_settings": {}},
+        store_model_in_db=True,
+    )
+
+    assert litellm.user_url_allowed_hosts == []
+    assert litellm.provider_url_destination_allowed_hosts == []
+    assert litellm.user_url_validation is True
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__update_config_from_db_ssrf_reset_falls_back_to_config_file(monkeypatch):
+    """Removing the DB override must fall back to what the config file set, not to
+    the wide-open process defaults; the config file is re-read on every sync."""
+    monkeypatch.setattr(litellm, "user_url_validation", True)
+    monkeypatch.setattr(litellm, "user_url_allowed_hosts", ["127.0.0.1:9999"])
+    monkeypatch.setattr(litellm, "provider_url_destination_allowed_hosts", ["evil.example"])
+    _patch_config_rows(monkeypatch, {})
+
+    await ProxyConfig()._update_config_from_db(
+        prisma_client=MagicMock(),
+        config={
+            "general_settings": {
+                "user_url_allowed_hosts": ["internal.corp"],
+                "user_url_validation": False,
+            },
+            "litellm_settings": {"provider_url_destination_allowed_hosts": ["api.example.com"]},
+        },
+        store_model_in_db=True,
+    )
+
+    assert litellm.user_url_allowed_hosts == ["internal.corp"]
+    assert litellm.provider_url_destination_allowed_hosts == ["api.example.com"]
+    assert litellm.user_url_validation is False
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__update_config_from_db_applies_ssrf_overrides_from_both_rows(monkeypatch):
+    """The DB rows still win over the config file while they exist, and
+    ``general_settings`` still wins over ``litellm_settings`` on a conflict."""
+    monkeypatch.setattr(litellm, "user_url_validation", True)
+    monkeypatch.setattr(litellm, "user_url_allowed_hosts", [])
+    monkeypatch.setattr(litellm, "provider_url_destination_allowed_hosts", [])
+    _patch_config_rows(
+        monkeypatch,
+        {
+            "litellm_settings": {
+                "user_url_allowed_hosts": ["from-litellm-settings"],
+                "provider_url_destination_allowed_hosts": ["provider.example"],
+            },
+            "general_settings": {
+                "user_url_allowed_hosts": ["from-general-settings"],
+                "user_url_validation": "false",
+            },
+        },
+    )
+
+    await ProxyConfig()._update_config_from_db(
+        prisma_client=MagicMock(),
+        config={
+            "general_settings": {"user_url_allowed_hosts": ["from-config-file"]},
+            "litellm_settings": {},
+        },
+        store_model_in_db=True,
+    )
+
+    assert litellm.user_url_allowed_hosts == ["from-general-settings"]
+    assert litellm.provider_url_destination_allowed_hosts == ["provider.example"]
+    assert litellm.user_url_validation is False
+
+
+@pytest.mark.asyncio
+async def test_ProxyConfig__update_config_from_db_keeps_ssrf_settings_on_db_error(monkeypatch):
+    """A transient DB failure must not be read as "the operator removed the
+    override" - the live restrictions stay in place until a read succeeds."""
+    monkeypatch.setattr(litellm, "user_url_validation", False)
+    monkeypatch.setattr(litellm, "user_url_allowed_hosts", ["127.0.0.1:9999"])
+    monkeypatch.setattr(litellm, "provider_url_destination_allowed_hosts", ["provider.example"])
+
+    async def _raise_get_config_param(prisma_client, key):
+        raise Exception("connection reset by peer")
+
+    monkeypatch.setattr("litellm.proxy.proxy_server.get_config_param", _raise_get_config_param)
+
+    with pytest.raises(Exception, match="connection reset by peer"):
+        await ProxyConfig()._update_config_from_db(
+            prisma_client=MagicMock(),
+            config={"general_settings": {}, "litellm_settings": {}},
+            store_model_in_db=True,
+        )
+
+    assert litellm.user_url_allowed_hosts == ["127.0.0.1:9999"]
+    assert litellm.provider_url_destination_allowed_hosts == ["provider.example"]
+    assert litellm.user_url_validation is False
+
+
 @pytest.mark.asyncio
 async def test_ProxyConfig_load_config_redacts_secret_litellm_setting_keeps_plain(tmp_path, monkeypatch):
     """Regression for LIT-4152 on the ``litellm_settings`` apply loop.


### PR DESCRIPTION
…oved

The DB config sync only applied the SSRF url-validation keys it found and never unset anything, so deleting user_url_allowed_hosts (or the whole config row) left the override live until the proxy restarted. Resolve all three settings from the merged config-file + DB overlay on every sync so a removed override falls back to what the config file set, and to the values the process started with when nothing sets them. Only a fully successful set of DB reads reaches the reconcile; a transient failure raises out of the gather and leaves the current restrictions in place.

## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- <blah>
- ...

How it solves it:

- <blah>
- ...

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), include proof for every single one of them, not just one
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
