### PR TITLE
Add moonshot/kimi-k3 pricing

### DIFF
--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -28288,6 +28288,22 @@
         "supports_video_input": true,
         "supports_vision": true
     },
+    "moonshot/kimi-k3": {
+        "cache_read_input_token_cost": 3e-07,
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "moonshot",
+        "max_input_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://platform.kimi.ai/docs/pricing/chat-k3",
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_video_input": true,
+        "supports_vision": true
+    },
     "moonshot/kimi-latest": {
         "cache_read_input_token_cost": 1.5e-07,
         "deprecation_date": "2026-01-28",


### PR DESCRIPTION
## Summary

Adds the missing `moonshot/kimi-k3` entry to `model_prices_and_context_window.json`. Kimi K3 is Moonshot AI's current flagship model (1M-token context window) and is not yet in the pricing table.

## Pricing (per 1M tokens, from the official pricing page)

| | |
|---|---|
| Input (cache miss) | $3.00 |
| Input (cache hit) | $0.30 |
| Output | $15.00 |
| Context window | 1,048,576 |

## Sources
- Pricing: https://platform.kimi.ai/docs/pricing/chat-k3
- Capabilities (`tool_choice`, `reasoning_effort`, image/video input): https://platform.kimi.ai/docs/api/models-overview

## Notes
- No explicit cache-write price is published, so `cache_creation_input_token_cost` is omitted (consistent with the existing `moonshot/kimi-k2.6` entry).
- `max_output_tokens` is omitted because Moonshot's docs don't publish an output cap for K3.