### PR TITLE
fix(proxy): route DB skills to OpenAI tool format on chat completions

### DIFF
--- a/litellm/proxy/hooks/litellm_skills/main.py
+++ b/litellm/proxy/hooks/litellm_skills/main.py
@@ -121,16 +121,18 @@ class SkillsInjectionHook(CustomLogger):
                 # Native Anthropic skill - pass through
                 anthropic_skills.append(skill)
 
-        # Check if using messages API spec (anthropic_messages call type)
-        # Messages API always uses Anthropic-style tool format
-        use_anthropic_format = call_type == "anthropic_messages"
-
         if len(litellm_skills) > 0:
-            data = self._process_for_messages_api(
-                data=data,
-                litellm_skills=litellm_skills,
-                use_anthropic_format=use_anthropic_format,
-            )
+            if call_type == "anthropic_messages":
+                data = self._process_for_messages_api(
+                    data=data,
+                    litellm_skills=litellm_skills,
+                    use_anthropic_format=True,
+                )
+            else:
+                data = self._process_non_anthropic_model(
+                    data=data,
+                    litellm_skills=litellm_skills,
+                )
 
         return data
 

--- a/tests/test_litellm/proxy/hooks/litellm_skills/test_main.py
+++ b/tests/test_litellm/proxy/hooks/litellm_skills/test_main.py
@@ -2,9 +2,31 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from litellm.caching.caching import DualCache
+from litellm.proxy._types import LiteLLM_SkillsTable, UserAPIKeyAuth
 from litellm.proxy.hooks.litellm_skills.main import SkillsInjectionHook
 
 SKILL_TOOL_NAME = "litellm_skill_e2b8dca8_031a_4481_b034_b9ec7d4eb7bf"
+
+
+def _db_skill() -> LiteLLM_SkillsTable:
+    return LiteLLM_SkillsTable(
+        skill_id=SKILL_TOOL_NAME,
+        display_title="Persona Skill",
+        description="Speak politely",
+        instructions="Always address the user respectfully",
+        source="custom",
+    )
+
+
+def _skill_request_data(model: str = "gpt-4") -> dict:
+    return {
+        "model": model,
+        "messages": [{"role": "user", "content": "hello"}],
+        "container": {
+            "skills": [{"type": "custom", "skill_id": SKILL_TOOL_NAME}],
+        },
+    }
 
 
 def _request_data():
@@ -25,6 +47,68 @@ def _tool_use_response(tool_name):
             {"type": "tool_use", "id": "toolu_1", "name": tool_name, "input": {}}
         ],
     }
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("call_type", ["completion", "acompletion"])
+async def test_pre_call_chat_completions_emits_openai_tool_schema(call_type):
+    """
+    Regression: /v1/chat/completions must not emit Anthropic tool objects.
+
+    OpenAI rejects tools missing ``type`` with:
+    Missing required parameter: 'tools[0].type'
+    """
+    hook = SkillsInjectionHook()
+    data = _skill_request_data(model="gpt-4")
+
+    with patch.object(
+        hook, "_fetch_skill_from_db", new=AsyncMock(return_value=_db_skill())
+    ):
+        result = await hook.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(api_key="test"),
+            cache=DualCache(),
+            data=data,
+            call_type=call_type,
+        )
+
+    assert isinstance(result, dict)
+    assert "container" not in result
+    tools = result["tools"]
+    assert len(tools) >= 1
+    assert tools[0]["type"] == "function"
+    assert "function" in tools[0]
+    assert "name" in tools[0]["function"]
+    assert "input_schema" not in tools[0]
+
+    system_messages = [
+        m for m in result["messages"] if isinstance(m, dict) and m.get("role") == "system"
+    ]
+    assert system_messages
+    assert "Always address the user respectfully" in system_messages[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_pre_call_anthropic_messages_keeps_anthropic_tool_schema():
+    """Messages API must keep Anthropic tool shape (name + input_schema)."""
+    hook = SkillsInjectionHook()
+    data = _skill_request_data(model="claude-sonnet-4-5")
+
+    with patch.object(
+        hook, "_fetch_skill_from_db", new=AsyncMock(return_value=_db_skill())
+    ):
+        result = await hook.async_pre_call_hook(
+            user_api_key_dict=UserAPIKeyAuth(api_key="test"),
+            cache=DualCache(),
+            data=data,
+            call_type="anthropic_messages",
+        )
+
+    assert isinstance(result, dict)
+    tools = result["tools"]
+    assert len(tools) >= 1
+    assert "type" not in tools[0] or tools[0].get("type") != "function"
+    assert "name" in tools[0]
+    assert "input_schema" in tools[0]
+    assert "function" not in tools[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- DB skills break OpenAI `/v1/chat/completions`
- Proxy sent Anthropic tools missing `type`
- OpenAI returns `tools[0].type` 400 error

How it solves it:

- Route by `call_type` in skills pre-call hook
- Chat completions use OpenAI function tools
- Messages API keeps Anthropic tool schema
- Add regression tests for both tool formats

## Relevant issues

Fixes #35594

## Linear ticket


## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before 

```bash
curl -X POST "http://localhost:4000/v1/chat/completions" \
  -H "Authorization: Bearer $LITELLM_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "gpt-4",
    "messages": [{"role": "user", "content": "hello"}],
    "container": {
      "skills": [{"type": "custom", "skill_id": "litellm_skill_<id>"}]
    }
  }'
```
```
{"error":{"message":"litellm.BadRequestError: OpenAIException - Missing required parameter: 'tools[0].type'.. Received Model Group=gpt-4\nAvailable Model Group Fallbacks=None","type":"invalid_request_error","param":"tools[0].type","code":"400"}}
```

## Type
🐛 Bug Fix

## Changes
SkillsInjectionHook.async_pre_call_hook always converted LiteLLM DB skills through _process_for_messages_api, which emits Anthropic tool objects without type. That breaks OpenAI chat completions with Missing required parameter: 'tools[0].type'

For anthropic_messages keep _process_for_messages_api. For completion / acompletion call _process_non_anthropic_model so tools use {type: "function", function: {...}}

Regression coverage lives in tests/test_litellm/proxy/hooks/litellm_skills/test_main.py

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR