### PR TITLE
fix(proxy): serialize model block responses

### DIFF
--- a/litellm/models/model.py
+++ b/litellm/models/model.py
@@ -29,6 +29,8 @@ class LiteLLM_ProxyModelTable(LiteLLMPydanticObjectBase):
     @model_validator(mode="before")
     @classmethod
     def check_potential_json_str(cls, values):
+        if not isinstance(values, dict):
+            return values
         if isinstance(values.get("litellm_params"), str):
             try:
                 values["litellm_params"] = json.loads(values["litellm_params"])

--- a/tests/e2e/management/test_model_tag_accessgroup_e2e.py
+++ b/tests/e2e/management/test_model_tag_accessgroup_e2e.py
@@ -180,6 +180,12 @@ class ModelBlockBody(BaseModel):
     model_id: str
 
 
+class ModelBlockResponse(BaseModel):
+    model_config = ConfigDict(protected_namespaces=())
+    model_id: str
+    blocked: bool
+
+
 class ModelInfoBlockDetail(BaseModel):
     id: str | None = None
     blocked: bool | None = None
@@ -245,11 +251,6 @@ class TestModelRoutes:
     def test_block_then_unblock_persists_to_model_info(
         self, client: ManagementClient, resources: ResourceManager
     ) -> None:
-        """The blocked flag's persistence is read back from /model/info, not from the
-        /model/block response: that route currently returns a non-2xx serialization
-        envelope even though the DB write lands, so the /model/info read-back is the
-        authoritative persistence contract and keeps this test valid once the
-        response shape is fixed."""
         model_name = f"e2e-mgmt-model-block-{unique_marker()}"
         model_id = _create_db_model(client, resources, model_name)
 
@@ -257,27 +258,25 @@ class TestModelRoutes:
             f"{model_name!r} already reports blocked in /model/info before /model/block ran"
         )
 
-        _ = client.proxy.transport.send(
-            "/model/block",
-            headers=client.proxy.transport.master,
-            json=ModelBlockBody(model_id=model_id),
-        )
-        _ = _poll(
-            client.proxy,
-            lambda: True if _model_blocked_flag(client, model_id) is True else None,
-            f"/model/info never reported {model_name!r} blocked after /model/block",
-        )
-
-        _ = client.proxy.transport.send(
-            "/model/unblock",
-            headers=client.proxy.transport.master,
-            json=ModelBlockBody(model_id=model_id),
-        )
-        _ = _poll(
-            client.proxy,
-            lambda: True if _model_blocked_flag(client, model_id) is not True else None,
-            f"/model/info never cleared blocked for {model_name!r} after /model/unblock",
-        )
+        for action, expected in (("block", True), ("unblock", False)):
+            response = unwrap(
+                client.proxy.transport.post(
+                    f"/model/{action}",
+                    headers=client.proxy.transport.master,
+                    json=ModelBlockBody(model_id=model_id),
+                    response_type=ModelBlockResponse,
+                )
+            )
+            assert response.model_id == model_id
+            assert response.blocked is expected
+            _ = _poll(
+                client.proxy,
+                lambda: True
+                if _model_blocked_flag(client, model_id) is expected
+                else None,
+                f"/model/info never reported blocked={expected} for {model_name!r} "
+                f"after /model/{action}",
+            )
 
 
 class TestTagRoutes:

--- a/tests/test_litellm/models/test_models.py
+++ b/tests/test_litellm/models/test_models.py
@@ -5,6 +5,7 @@ Tests for backend domain models.
 from datetime import datetime
 
 import pytest
+from pydantic import BaseModel, TypeAdapter
 
 from litellm.models.access_group import LiteLLM_AccessGroupTable
 from litellm.models.budget import (
@@ -128,6 +129,33 @@ class TestModel:
         )
         assert model.litellm_params == {"model": "gpt-4"}
         assert model.model_info == {"team_id": "t1"}
+
+    def test_response_type_adapter_accepts_pydantic_row(self):
+        class PrismaModelRow(BaseModel):
+            model_id: str
+            model_name: str
+            litellm_params: dict[str, str]
+            model_info: dict[str, str] | None = None
+            blocked: bool = False
+
+        row = PrismaModelRow(
+            model_id="m1",
+            model_name="gpt-4",
+            litellm_params={"model": "gpt-4"},
+            model_info={"team_id": "t1"},
+            blocked=True,
+        )
+
+        model = TypeAdapter(LiteLLM_ProxyModelTable | None).validate_python(
+            row,
+            from_attributes=True,
+        )
+
+        assert model is not None
+        assert model.model_id == "m1"
+        assert model.litellm_params == {"model": "gpt-4"}
+        assert model.model_info == {"team_id": "t1"}
+        assert model.blocked is True
 
     def test_team_helpers_none_when_no_model_info(self):
         model = LiteLLM_ProxyModelTable(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Model block and unblock mutate state, then return HTTP 500.

How it solves it:

- Preserve attribute-based rows during response model validation.
- Assert successful responses and persisted blocked state.

## Relevant issues

Fixes #35597

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

The proof used a fresh PostgreSQL 17 database, `STORE_MODEL_IN_DB=True`, and
a proxy started directly from each commit. The disposable deployment used a
dummy provider key; no provider request was made.

Before, at `491eda319cd1cd1f75a2ef165c6b06ce6129c282`:

```bash
curl -X POST "${LITELLM_URL}/model/block" \
  -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
  -H "Content-Type: application/json" \
  -d "{\"model_id\":\"${MODEL_ID}\"}"

curl "${LITELLM_URL}/v2/model/info?modelId=${MODEL_ID}" \
  -H "Authorization: Bearer ${LITELLM_MASTER_KEY}"

curl -X POST "${LITELLM_URL}/model/unblock" \
  -H "Authorization: Bearer ${LITELLM_MASTER_KEY}" \
  -H "Content-Type: application/json" \
  -d "{\"model_id\":\"${MODEL_ID}\"}"
```

```text
block_status=500
{"error":{"message":"Internal server error","type":"internal_server_error"}}
state_after_block={"model_id":"00000000-0000-4000-8000-000000000358","blocked":true}

unblock_status=500
{"error":{"message":"Internal server error","type":"internal_server_error"}}
state_after_unblock={"model_id":"00000000-0000-4000-8000-000000000358","blocked":false}
```

The proxy log identifies response serialization as the failing phase:

```text
File "litellm/models/model.py", line 32, in check_potential_json_str
    if isinstance(values.get("litellm_params"), str):
AttributeError: 'LiteLLM_ProxyModelTable' object has no attribute 'get'
```

After, at `81890ca4097422e5d0712e9c1d86475d46c380fc`:

```text
block_status=200
{"model_id":"00000000-0000-4000-8000-000000000359","blocked":true}
state_after_block={"model_id":"00000000-0000-4000-8000-000000000359","blocked":true}

unblock_status=200
{"model_id":"00000000-0000-4000-8000-000000000359","blocked":false}
state_after_unblock={"model_id":"00000000-0000-4000-8000-000000000359","blocked":false}
```

The strengthened live E2E passes against the fixed proxy:

```text
$ LITELLM_PROXY_URL=http://127.0.0.1:4012 \
  uv run --no-sync pytest -q \
  tests/e2e/management/test_model_tag_accessgroup_e2e.py::TestModelRoutes::test_block_then_unblock_persists_to_model_info
.                                                                        [100%]
1 passed in 0.19s
```

Local checks:

```text
$ uv run --no-sync pytest -q \
  tests/test_litellm/models/test_models.py::TestModel::test_response_type_adapter_accepts_pydantic_row
1 passed in 1.18s

$ uv run --no-sync pytest -q \
  tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
90 passed, 4 warnings in 2.66s

$ make pre-commit
OK: every rule is within its basedpyright limit or no higher than base
1 file already formatted
tests/e2e raw HTTP client check passed
```

## Type

🐛 Bug Fix

## Changes

- Return non-dictionary inputs unchanged from the model's `mode="before"` validator.
- Keep the existing JSON-string parsing behavior for dictionary inputs.
- Add a regression test for FastAPI's attribute-based response validation path.
- Require `/model/block` and `/model/unblock` to return typed successful responses in live E2E.

## QA runbook

Prerequisites: run this commit against PostgreSQL with
`STORE_MODEL_IN_DB=True` and a valid proxy admin key. Provider credentials are
not required because the disposable deployment is never called.

- `tests/e2e/management/test_model_tag_accessgroup_e2e.py::TestModelRoutes::test_block_then_unblock_persists_to_model_info` - both routes return the requested state and persist it
  - [ ] POST `/model/new` with a unique model name, dummy `litellm_params`, and the proxy admin key; record the returned model ID
  - [ ] GET `/model/info` and confirm the new deployment is not blocked
  - [ ] POST `/model/block` with the recorded model ID and expect HTTP 200, the same model ID, and `blocked=true`
  - [ ] Poll `/model/info` until that deployment reports `blocked=true`
  - [ ] POST `/model/unblock` with the recorded model ID and expect HTTP 200, the same model ID, and `blocked=false`
  - [ ] Poll `/model/info` until that deployment reports `blocked=false`
  - [ ] POST `/model/delete` for the disposable deployment
  - [ ] Sanity check: reverting the two-line validator guard makes both mutation requests return HTTP 500 while the database changes still land

### Final Attestation

- [x] The tests check the right things, including the attribute-validation edge case and both real block-state transitions
