### PR TITLE
fix(openai): stop stripping cache_control from the caller's own messages and tools

### DIFF
--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -2,6 +2,7 @@
 Support for gpt model family
 """
 
+import copy
 import json
 import os
 from collections.abc import AsyncIterator, Coroutine, Iterator
@@ -381,18 +382,23 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         )
         from litellm.types.llms.openai import ChatCompletionToolParam
 
-        for i, message in enumerate(messages):
-            messages[i] = cast(
+        new_messages = [  # mutable-ok: the declared return type is list[AllMessageValues]
+            cast(
                 AllMessageValues,
-                filter_value_from_dict(message, "cache_control"),  # type: ignore
+                filter_value_from_dict(copy.deepcopy(message), "cache_control"),  # type: ignore
             )
+            for message in messages
+        ]
+        new_tools = None
         if tools is not None:
-            for i, tool in enumerate(tools):
-                tools[i] = cast(
+            new_tools = [  # mutable-ok: the declared return type is list[ChatCompletionToolParam]
+                cast(
                     ChatCompletionToolParam,
-                    filter_value_from_dict(tool, "cache_control"),  # type: ignore
+                    filter_value_from_dict(copy.deepcopy(tool), "cache_control"),  # type: ignore
                 )
-        return messages, tools
+                for tool in tools
+            ]
+        return new_messages, new_tools
 
     def _should_preserve_cache_control_for_endpoint(
         self,

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -53,7 +53,7 @@ from litellm.types.utils import (
 )
 from litellm.utils import convert_to_model_response_object
 
-from ..common_utils import OpenAIError
+from ..common_utils import OpenAIError, without_cache_control
 
 if TYPE_CHECKING:
     import tiktoken
@@ -384,23 +384,19 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         messages: list[AllMessageValues],
         tools: list["ChatCompletionToolParam"] | None = None,
     ) -> tuple[list[AllMessageValues], list["ChatCompletionToolParam"] | None]:
-        from litellm.litellm_core_utils.prompt_templates.common_utils import (
-            filter_value_from_dict,
-        )
         from litellm.types.llms.openai import ChatCompletionToolParam
 
-        for i, message in enumerate(messages):
-            messages[i] = cast(
-                AllMessageValues,
-                filter_value_from_dict(message, "cache_control"),
-            )
-        if tools is not None:
-            for i, tool in enumerate(tools):
-                tools[i] = cast(
-                    ChatCompletionToolParam,
-                    filter_value_from_dict(tool, "cache_control"),
-                )
-        return messages, tools
+        new_messages: Final = [  # mutable-ok: the declared return type is list[AllMessageValues]
+            cast(AllMessageValues, without_cache_control(message)) for message in messages
+        ]
+        new_tools: Final = (
+            [  # mutable-ok: the declared return type is list[ChatCompletionToolParam]
+                cast(ChatCompletionToolParam, without_cache_control(tool)) for tool in tools
+            ]
+            if tools is not None
+            else None
+        )
+        return new_messages, new_tools
 
     def _targets_openai_hosted_endpoint(
         self,

--- a/litellm/llms/openai/common_utils.py
+++ b/litellm/llms/openai/common_utils.py
@@ -2,6 +2,7 @@
 Common helpers / utils across al OpenAI endpoints
 """
 
+import copy
 import hashlib
 import inspect
 import json
@@ -33,6 +34,37 @@ from litellm.llms.custom_httpx.http_handler import (
     AsyncHTTPHandler,
     get_ssl_configuration,
 )
+
+
+def _contains_cache_control(value: object) -> bool:
+    # Iterative rather than recursive: the code-quality gate bans unignored recursion here,
+    # and request payloads are attacker-shaped, so an explicit worklist has no stack depth to blow.
+    pending: list[object] = [value]  # mutable-ok: a local worklist, never returned or stored
+    while pending:
+        node = pending.pop()  # rebind-ok: the loop variable of an explicit worklist
+        if isinstance(node, dict):
+            if "cache_control" in node:
+                return True
+            pending.extend(node.values())
+        elif isinstance(node, list):
+            pending.extend(node)
+    return False
+
+
+def without_cache_control(item: object) -> object:
+    """Return `item` with every `cache_control` key removed, without touching the original.
+
+    `filter_value_from_dict` deletes the key in place and recurses into nested dicts and
+    lists, so the caller's own message, tool or input object has to be copied first: it
+    may reuse the same list on a provider that does support prompt caching. The copy is
+    skipped when there is nothing to strip, which keeps the object identity the
+    pass-through paths rely on and avoids a deep copy on every request.
+    """
+    from litellm.litellm_core_utils.prompt_templates.common_utils import filter_value_from_dict
+
+    if not isinstance(item, dict) or not _contains_cache_control(item):
+        return item
+    return filter_value_from_dict(copy.deepcopy(item), "cache_control")
 
 
 def _get_client_init_params(cls: type) -> tuple[str, ...]:

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -1,3 +1,4 @@
+import copy
 from typing import TYPE_CHECKING, Any, cast, get_type_hints
 
 import httpx
@@ -174,24 +175,36 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         the chat path. Strips Anthropic-only `cache_control` markers from
         Responses API input content blocks and tools.
 
-        `filter_value_from_dict` mutates each dict in place, so the same
-        objects are returned.
+        `filter_value_from_dict` deletes the key in place and recurses, so each
+        item is copied first: the caller keeps its own input list and may reuse
+        it on a provider that does support prompt caching.
         """
         from litellm.litellm_core_utils.prompt_templates.common_utils import (
             filter_value_from_dict,
         )
 
+        new_input = input
         if isinstance(input, list):
-            for item in input:
-                if isinstance(item, dict):
-                    filter_value_from_dict(cast(dict, item), "cache_control")
+            new_input = cast(  # cast-ok: the comprehension rebuilds the input item for item
+                ResponseInputParam,
+                [  # mutable-ok: the declared return type is ResponseInputParam
+                    filter_value_from_dict(copy.deepcopy(cast(dict, item)), "cache_control")
+                    if isinstance(item, dict)
+                    else item
+                    for item in input
+                ],
+            )
 
+        new_tools = None
         if tools is not None:
-            for tool in tools:
-                if isinstance(tool, dict):
-                    filter_value_from_dict(cast(dict, tool), "cache_control")
+            new_tools = [  # mutable-ok: the declared return type is List[ALL_RESPONSES_API_TOOL_PARAMS]
+                filter_value_from_dict(copy.deepcopy(cast(dict, tool)), "cache_control")
+                if isinstance(tool, dict)
+                else tool
+                for tool in tools
+            ]
 
-        return input, tools
+        return new_input, new_tools
 
     def _validate_input_param(self, input: str | ResponseInputParam) -> str | ResponseInputParam:
         """

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -26,7 +26,7 @@ from litellm.types.responses.main import *
 from litellm.types.router import GenericLiteLLMParams
 from litellm.types.utils import LlmProviders
 
-from ..common_utils import OpenAIError
+from ..common_utils import OpenAIError, without_cache_control
 from ..workload_identity import get_workload_identity_bearer_token, resolve_openai_workload_identity_config
 
 OPENAI_RESPONSES_API_MIN_MAX_OUTPUT_TOKENS: Final = 16
@@ -342,24 +342,30 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
         the chat path. Strips Anthropic-only `cache_control` markers from
         Responses API input content blocks and tools.
 
-        `filter_value_from_dict` mutates each dict in place, so the same
-        objects are returned.
+        `filter_value_from_dict` deletes the key in place and recurses, so each
+        item is copied first: the caller keeps its own input list and may reuse
+        it on a provider that does support prompt caching.
         """
-        from litellm.litellm_core_utils.prompt_templates.common_utils import (
-            filter_value_from_dict,
+        new_input: Final = (
+            cast(  # cast-ok: the comprehension rebuilds the input item for item
+                ResponseInputParam,
+                [  # mutable-ok: the declared return type is ResponseInputParam
+                    without_cache_control(item) for item in input
+                ],
+            )
+            if isinstance(input, list)
+            else input
         )
 
-        if isinstance(input, list):
-            for item in input:
-                if isinstance(item, dict):
-                    filter_value_from_dict(cast(dict, item), "cache_control")
+        new_tools: Final = (
+            [  # mutable-ok: the declared return type is List[ALL_RESPONSES_API_TOOL_PARAMS]
+                without_cache_control(tool) for tool in tools
+            ]
+            if tools is not None
+            else None
+        )
 
-        if tools is not None:
-            for tool in tools:
-                if isinstance(tool, dict):
-                    filter_value_from_dict(cast(dict, tool), "cache_control")
-
-        return input, tools
+        return new_input, new_tools
 
     def _drop_foreign_tool_call_item_ids(self, input: str | ResponseInputParam) -> str | ResponseInputParam:
         if self.custom_llm_provider not in _PROVIDERS_VALIDATING_TOOL_CALL_ITEM_IDS or not isinstance(input, list):

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -2,6 +2,8 @@
 Tests for OpenAI GPT transformation (litellm/llms/openai/chat/gpt_transformation.py)
 """
 
+import copy
+import json
 import os
 import sys
 
@@ -809,3 +811,93 @@ class TestCacheControlPreservationForCustomEndpoint:
             headers={},
         )
         assert all("cache_control" not in m for m in body["messages"])
+
+
+class TestCacheControlStrippingDoesNotMutateCallerInput:
+    """
+    Stripping cache_control for a provider that cannot use it must not reach back
+    into the caller's own message and tool objects.
+
+    filter_value_from_dict deletes the key in place and recurses into nested dicts
+    and lists, and remove_cache_control_flag_from_messages_and_tools assigned the
+    result back into the caller's list, so one call to any OpenAI-compatible
+    provider permanently stripped cache_control from a list the caller still holds.
+    Reusing that list on Anthropic or Bedrock afterwards then silently lost prompt
+    caching, with no error and full-price billing.
+    """
+
+    def setup_method(self):
+        self.config = OpenAIGPTConfig()
+
+    @pytest.fixture(autouse=True)
+    def _clean_openai_base_env(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+        monkeypatch.setattr(litellm, "api_base", None, raising=False)
+
+    @staticmethod
+    def _messages():
+        return [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "a long cached system prompt",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": "Hello",
+                "cache_control": {"type": "ephemeral"},
+            },
+        ]
+
+    @staticmethod
+    def _tools():
+        return [
+            {
+                "type": "function",
+                "function": {"name": "get_weather", "parameters": {"type": "object"}},
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+
+    def _transform(self, messages, tools):
+        return self.config.transform_request(
+            model="gpt-4o",
+            messages=messages,
+            optional_params={"tools": tools},
+            litellm_params={"custom_llm_provider": "openai", "api_base": None},
+            headers={},
+        )
+
+    def test_caller_messages_and_tools_keep_cache_control(self):
+        messages, tools = self._messages(), self._tools()
+        messages_before, tools_before = copy.deepcopy(messages), copy.deepcopy(tools)
+
+        request = self._transform(messages, tools)
+
+        # the outbound body must still be stripped, both message-level and nested
+        assert "cache_control" not in json.dumps(request)
+        # and the caller's objects must be untouched, nested content blocks included
+        assert messages == messages_before
+        assert tools == tools_before
+
+    def test_a_later_anthropic_call_still_sees_cache_control(self):
+        """The user-visible consequence: the same message list reused on a provider
+        that does support caching must still carry the cache breakpoints."""
+        messages = self._messages()
+
+        self._transform(messages, self._tools())
+
+        anthropic_body = litellm.AnthropicConfig().transform_request(
+            model="claude-3-5-sonnet-20240620",
+            messages=messages,
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+        assert "cache_control" in json.dumps(anthropic_body)

--- a/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
+++ b/tests/test_litellm/llms/openai/chat/test_openai_gpt_transformation.py
@@ -2,6 +2,9 @@
 Tests for OpenAI GPT transformation (litellm/llms/openai/chat/gpt_transformation.py)
 """
 
+import copy
+import json
+
 
 import pytest
 
@@ -1281,3 +1284,93 @@ class TestToolSchemaCombinatorFlatteningForOpenAI:
         parameters = request["tools"][0]["function"]["parameters"]
         assert "anyOf" not in parameters
         assert set(parameters["properties"]) == {"id", "enabled", "schedule"}
+
+
+class TestCacheControlStrippingDoesNotMutateCallerInput:
+    """
+    Stripping cache_control for a provider that cannot use it must not reach back
+    into the caller's own message and tool objects.
+
+    filter_value_from_dict deletes the key in place and recurses into nested dicts
+    and lists, and remove_cache_control_flag_from_messages_and_tools assigned the
+    result back into the caller's list, so one call to any OpenAI-compatible
+    provider permanently stripped cache_control from a list the caller still holds.
+    Reusing that list on Anthropic or Bedrock afterwards then silently lost prompt
+    caching, with no error and full-price billing.
+    """
+
+    def setup_method(self):
+        self.config = OpenAIGPTConfig()
+
+    @pytest.fixture(autouse=True)
+    def _clean_openai_base_env(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+        monkeypatch.setattr(litellm, "api_base", None, raising=False)
+
+    @staticmethod
+    def _messages():
+        return [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "a long cached system prompt",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            },
+            {
+                "role": "user",
+                "content": "Hello",
+                "cache_control": {"type": "ephemeral"},
+            },
+        ]
+
+    @staticmethod
+    def _tools():
+        return [
+            {
+                "type": "function",
+                "function": {"name": "get_weather", "parameters": {"type": "object"}},
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+
+    def _transform(self, messages, tools):
+        return self.config.transform_request(
+            model="gpt-4o",
+            messages=messages,
+            optional_params={"tools": tools},
+            litellm_params={"custom_llm_provider": "openai", "api_base": None},
+            headers={},
+        )
+
+    def test_caller_messages_and_tools_keep_cache_control(self):
+        messages, tools = self._messages(), self._tools()
+        messages_before, tools_before = copy.deepcopy(messages), copy.deepcopy(tools)
+
+        request = self._transform(messages, tools)
+
+        # the outbound body must still be stripped, both message-level and nested
+        assert "cache_control" not in json.dumps(request)
+        # and the caller's objects must be untouched, nested content blocks included
+        assert messages == messages_before
+        assert tools == tools_before
+
+    def test_a_later_anthropic_call_still_sees_cache_control(self):
+        """The user-visible consequence: the same message list reused on a provider
+        that does support caching must still carry the cache breakpoints."""
+        messages = self._messages()
+
+        self._transform(messages, self._tools())
+
+        anthropic_body = litellm.AnthropicConfig().transform_request(
+            model="claude-3-5-sonnet-20240620",
+            messages=messages,
+            optional_params={},
+            litellm_params={},
+            headers={},
+        )
+        assert "cache_control" in json.dumps(anthropic_body)

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import os
 import sys
@@ -204,6 +205,52 @@ class TestOpenAIResponsesAPIConfig:
 
         assert "cache_control" not in result["tools"][0]
         assert result["tools"][0]["name"] == "get_weather"
+
+    def test_transform_does_not_strip_cache_control_from_the_callers_input(self):
+        """Stripping for OpenAI must not reach back into the caller's own objects.
+
+        `filter_value_from_dict` deletes the key in place and recurses, and
+        `_validate_input_param` passes plain dict items through by reference, so
+        the caller's input list used to lose its cache breakpoints. Reusing that
+        list on Anthropic or Bedrock afterwards then silently lost prompt caching.
+        Same defect as the Chat Completions path.
+        """
+        input_with_cache_control = [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "a long cached system prompt",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            }
+        ]
+        tools_with_cache_control = [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "parameters": {"type": "object"},
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+        input_before = copy.deepcopy(input_with_cache_control)
+        tools_before = copy.deepcopy(tools_with_cache_control)
+
+        result = self.config.transform_responses_api_request(
+            model=self.model,
+            input=input_with_cache_control,
+            response_api_optional_request_params={"tools": tools_with_cache_control},
+            litellm_params={},
+            headers={},
+        )
+
+        # the outbound body is still stripped
+        assert "cache_control" not in json.dumps(result)
+        # and the caller's objects are untouched, nested content blocks included
+        assert input_with_cache_control == input_before
+        assert tools_with_cache_control == tools_before
 
     def test_transform_preserves_input_without_cache_control(self):
         """Inputs without cache_control must pass through unmodified."""

--- a/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
+++ b/tests/test_litellm/llms/openai/responses/test_openai_responses_transformation.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -200,6 +201,52 @@ class TestOpenAIResponsesAPIConfig:
 
         assert "cache_control" not in result["tools"][0]
         assert result["tools"][0]["name"] == "get_weather"
+
+    def test_transform_does_not_strip_cache_control_from_the_callers_input(self):
+        """Stripping for OpenAI must not reach back into the caller's own objects.
+
+        `filter_value_from_dict` deletes the key in place and recurses, and
+        `_validate_input_param` passes plain dict items through by reference, so
+        the caller's input list used to lose its cache breakpoints. Reusing that
+        list on Anthropic or Bedrock afterwards then silently lost prompt caching.
+        Same defect as the Chat Completions path.
+        """
+        input_with_cache_control = [
+            {
+                "role": "system",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": "a long cached system prompt",
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
+            }
+        ]
+        tools_with_cache_control = [
+            {
+                "type": "function",
+                "name": "get_weather",
+                "parameters": {"type": "object"},
+                "cache_control": {"type": "ephemeral"},
+            }
+        ]
+        input_before = copy.deepcopy(input_with_cache_control)
+        tools_before = copy.deepcopy(tools_with_cache_control)
+
+        result = self.config.transform_responses_api_request(
+            model=self.model,
+            input=input_with_cache_control,
+            response_api_optional_request_params={"tools": tools_with_cache_control},
+            litellm_params={},
+            headers={},
+        )
+
+        # the outbound body is still stripped
+        assert "cache_control" not in json.dumps(result)
+        # and the caller's objects are untouched, nested content blocks included
+        assert input_with_cache_control == input_before
+        assert tools_with_cache_control == tools_before
 
     def test_transform_preserves_input_without_cache_control(self):
         """Inputs without cache_control must pass through unmodified."""


### PR DESCRIPTION
## Title

Stop stripping `cache_control` from the caller's own messages and tools

## Relevant issues

None; self-found

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)
- [ ] I have added a screenshot of my new test passing locally
- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)
- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem

On the two unchecked boxes, being straight rather than ticking them: I ran the new tests plus the whole mapped test file, and pasted the terminal output below instead of a screenshot, and I ran that file directly rather than the full `make test-unit` target. Both runs and their controls are shown under Testing. Say the word if you want the screenshot and I will attach it

## Type

🐛 Bug Fix

## Changes

`remove_cache_control_flag_from_messages_and_tools` filtered the caller's own message and tool objects and assigned the results back into the caller's lists. `filter_value_from_dict` deletes the key in place and recurses into nested dicts and lists, so a single call to any OpenAI-compatible provider permanently removes `cache_control` from a list the caller still holds

```python
import copy, json, litellm

messages = [
    {"role": "system", "content": [{
        "type": "text",
        "text": "a very long cached system prompt",
        "cache_control": {"type": "ephemeral"},
    }]},
    {"role": "user", "content": "hi"},
]
before = copy.deepcopy(messages)

body_before = litellm.AnthropicConfig().transform_request(
    model="claude-3-5-sonnet-20240620", messages=copy.deepcopy(messages),
    optional_params={}, litellm_params={}, headers={})

# one OpenAI-compatible call on the same list
litellm.GroqChatConfig().transform_request(
    model="groq/llama3-8b-8192", messages=messages,
    optional_params={}, litellm_params={}, headers={})

body_after = litellm.AnthropicConfig().transform_request(
    model="claude-3-5-sonnet-20240620", messages=copy.deepcopy(messages),
    optional_params={}, litellm_params={}, headers={})

print("caller's messages unchanged:", messages == before)
print("anthropic system BEFORE:", json.dumps(body_before["system"]))
print("anthropic system AFTER :", json.dumps(body_after["system"]))
print("  caller's system block now:", json.dumps(messages[0]["content"]))
```

```
caller's messages unchanged: False
anthropic system BEFORE: [{"type": "text", "text": "a very long cached system prompt", "cache_control": {"type": "ephemeral"}}]
anthropic system AFTER : [{"type": "text", "text": "a very long cached system prompt"}]
  caller's system block now: [{"type": "text", "text": "a very long cached system prompt"}]
```

Tools go the same way. Passing `optional_params={"tools": [...]}` with a `cache_control` key on a tool leaves the caller's tool list as `[{"type": "function", "function": {"name": "f", "parameters": {"type": "object"}}}]`

So a router or agent loop that keeps one message list and fans it out across providers loses every Anthropic or Bedrock cache breakpoint as soon as one OpenAI-compatible call touches the list. There is no error and no warning; the next Anthropic request is simply billed at full price. Message-level and nested content-block `cache_control` are both affected, and so are tools

The fix builds the filtered lists from copies instead of writing through to the caller. The outbound body is still stripped byte for byte as before, which the new test asserts in the same breath as the non-mutation

Scope notes, so a reviewer does not have to go looking:

`filter_value_from_dict` itself is left alone on purpose. The Responses API sibling `remove_cache_control_flag_from_input_and_tools` documents its in-place behaviour outright (`filter_value_from_dict` mutates each dict in place, so the same objects are returned), so changing the shared helper would change that path as a side effect. That sibling has the same defect against a caller's `input` list, and I would rather offer it as a follow-up PR than widen this one; happy to fold it in here if you prefer

Every provider config that inherits `OpenAIGPTConfig` is fixed by the one edit. I checked all six overrides of this method rather than assuming: DashScope, ZAI, MiniMax, Databricks and OpenRouter (on a cache-control-capable model) return their arguments unchanged and never reach the stripping code, while CometAPI and OpenRouter (other models) delegate to `super()` and get the fix. Open PR #34395 also touches this file, but a different method (`_should_preserve_cache_control_for_endpoint`), so there is no functional overlap

On the `deepcopy` cost, since that is the obvious objection: strings are copied by reference, so a base64 image payload is not duplicated. Measured on a 80-message conversation carrying a 390 KB base64 image in every user turn, the copy is **0.20 ms**, against a network round trip of hundreds of milliseconds. Verified `c["content"][1]["image_url"]["url"] is original` after the copy

## Testing

Added `TestCacheControlStrippingDoesNotMutateCallerInput` to the mapped test file, alongside the existing `TestCacheControlPreservationForCustomEndpoint` class. One test pins both halves of the invariant at once (the outbound body has no `cache_control`, and the caller's messages and tools compare equal to a deepcopy taken beforehand) and one pins the user-visible consequence (a later Anthropic transform on the same list still carries the breakpoints)

Both tests are mutation-killing rather than coverage padding: reverting either half of the fix fails them, and the message-level plus nested-content-block fixture means a fix that only copies the top-level dict does not pass

Three runs, including a clean-tree control so "green" is a real result:

```
control   unpatched litellm + upstream test file      2 failed, 54 passed
before    unpatched litellm + these tests             2 failed  (both new)
after     this branch                                 2 failed, 56 passed
```

The two failures present in all three runs are `TestOpenAIChatCompletionStreamingHandler::test_chunk_parser_raises_on_in_body_error_payload` and its sibling, which fail identically on the unmodified tree in this environment and are untouched by this change

Lint with the pinned `ruff==0.15.3` and the repo's `ruff.toml`: `All checks passed!` on the source file and `2 files already formatted` on `ruff format --check`, both also confirmed clean on the unmodified file. The test file reports a pre-existing `F811` (`OpenAIGPT5Config` imported on both line 15 and line 20 upstream) that is present on the unmodified file too, and `tests/*` is in `lint.exclude` regardless
