### PR TITLE
feat(proxy): support mapping user_header_mappings to user_email (#21927)

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2170,6 +2170,15 @@ class UserHeaderMapping(LiteLLMPydanticObjectBase):
         LitellmUserRoles.INTERNAL_USER,
         LitellmUserRoles.CUSTOMER,
     ]
+    user_field: Literal["user_id", "user_email"] = Field(
+        default="user_id",
+        description=(
+            "Which UserAPIKeyAuth attribute to populate with this header's value. "
+            "Only applies to litellm_user_role='internal_user' mappings. Use 'user_email' "
+            "when the header carries the user's email (e.g. for a LiteLLM user created via SSO "
+            "and identified by email) instead of their LiteLLM user_id."
+        ),
+    )
 
     model_config = {
         "extra": "forbid",

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -2163,6 +2163,15 @@ class ConfigList(LiteLLMPydanticObjectBase):
 class UserHeaderMapping(LiteLLMPydanticObjectBase):
     """
     Map an incoming HTTP header to a LiteLLM user role.
+
+    Security note: once configured, the header value is trusted as-is - this
+    mirrors the existing behavior for litellm_user_role="internal_user"
+    mappings, which have always trusted the header to populate user_id.
+    Only map a header your edge/gateway sets and that callers cannot set or
+    override directly. When user_field="user_email", this same trust
+    boundary also flows into UserAPIKeyAuth.user_email, which some
+    downstream consumers (e.g. MCPJWTSigner token claims) treat as an
+    authoritative identity assertion, so the same caution applies there.
     """
 
     header_name: str

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -4,7 +4,7 @@ import json
 import re
 import time
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from fastapi import HTTPException, Request
 from pydantic import ValidationError as PydanticValidationError
@@ -817,7 +817,11 @@ class LiteLLMProxyRequestSetup:
             return user_api_key_dict
         header_value = LiteLLMProxyRequestSetup._get_case_insensitive_header(headers, header_name)
         if header_value:
-            user_api_key_dict.user_id = header_value
+            target_field = LiteLLMProxyRequestSetup.get_internal_user_field_from_mapping(user_header_mapping)
+            if target_field == "user_email":
+                user_api_key_dict.user_email = header_value
+            else:
+                user_api_key_dict.user_id = header_value
             return user_api_key_dict
         return user_api_key_dict
 
@@ -913,11 +917,17 @@ class LiteLLMProxyRequestSetup:
         return data
 
     @staticmethod
-    def get_internal_user_header_from_mapping(user_header_mapping) -> str | None:
+    def _iter_user_header_mapping_items(user_header_mapping) -> tuple:
+        """Normalize `user_header_mappings` (a single dict or a list of dicts) into a tuple of dicts."""
         if not user_header_mapping:
-            return None
-        items = user_header_mapping if isinstance(user_header_mapping, list) else [user_header_mapping]
-        for item in items:
+            return ()
+        if isinstance(user_header_mapping, list):
+            return tuple(user_header_mapping)
+        return (user_header_mapping,)
+
+    @staticmethod
+    def get_internal_user_header_from_mapping(user_header_mapping) -> str | None:
+        for item in LiteLLMProxyRequestSetup._iter_user_header_mapping_items(user_header_mapping):
             if not isinstance(item, dict):
                 continue
             role = item.get("litellm_user_role")
@@ -927,6 +937,22 @@ class LiteLLMProxyRequestSetup:
             if str(role).lower() == str(LitellmUserRoles.INTERNAL_USER).lower():
                 return header_name
         return None
+
+    @staticmethod
+    def get_internal_user_field_from_mapping(user_header_mapping) -> Literal["user_id", "user_email"]:
+        """Return the UserAPIKeyAuth field that the matching INTERNAL_USER mapping entry says the
+        header value should populate. Defaults to 'user_id' for backwards compatibility with
+        mappings that don't set 'user_field'.
+        """
+        for item in LiteLLMProxyRequestSetup._iter_user_header_mapping_items(user_header_mapping):
+            if not isinstance(item, dict):
+                continue
+            role = item.get("litellm_user_role")
+            if role is None:
+                continue
+            if str(role).lower() == str(LitellmUserRoles.INTERNAL_USER).lower():
+                return "user_email" if item.get("user_field") == "user_email" else "user_id"
+        return "user_id"
 
     @staticmethod
     def add_litellm_data_for_backend_llm_call(

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -819,6 +819,10 @@ class LiteLLMProxyRequestSetup:
         if header_value:
             target_field = LiteLLMProxyRequestSetup.get_internal_user_field_from_mapping(user_header_mapping)
             if target_field == "user_email":
+                # SECURITY: user_field="user_email" trusts header_value as an
+                # authoritative email for this caller, same trust model as the
+                # user_id mapping below. Only configure this for a header your
+                # edge/gateway sets - see UserHeaderMapping's docstring.
                 user_api_key_dict.user_email = header_value
             else:
                 user_api_key_dict.user_id = header_value

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -2754,6 +2754,57 @@ def test_add_internal_user_from_user_mapping_sets_user_id_when_header_present():
     assert user_api_key_dict.user_id == "internal-user-123"
 
 
+def test_add_internal_user_from_user_mapping_sets_user_email_when_configured():
+    user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+    headers = {"X-OpenWebUI-User-Email": "user@example.com"}
+    general_settings = {
+        "user_header_mappings": [
+            {
+                "header_name": "X-OpenWebUI-User-Email",
+                "litellm_user_role": "internal_user",
+                "user_field": "user_email",
+            },
+        ]
+    }
+    result = LiteLLMProxyRequestSetup.add_internal_user_from_user_mapping(
+        general_settings, user_api_key_dict, headers
+    )
+    assert result is user_api_key_dict
+    assert user_api_key_dict.user_email == "user@example.com"
+    assert user_api_key_dict.user_id is None
+
+
+def test_add_internal_user_from_user_mapping_defaults_to_user_id_without_user_field():
+    user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
+    headers = {"X-OpenWebUI-User-Id": "internal-user-123"}
+    general_settings = {
+        "user_header_mappings": [
+            {"header_name": "X-OpenWebUI-User-Id", "litellm_user_role": "internal_user"},
+        ]
+    }
+    result = LiteLLMProxyRequestSetup.add_internal_user_from_user_mapping(
+        general_settings, user_api_key_dict, headers
+    )
+    assert result.user_id == "internal-user-123"
+    assert result.user_email is None
+
+
+def test_get_internal_user_field_from_mapping_returns_user_email_when_configured():
+    mappings = [
+        {"header_name": "X-Id", "litellm_user_role": "internal_user", "user_field": "user_email"},
+    ]
+    assert LiteLLMProxyRequestSetup.get_internal_user_field_from_mapping(mappings) == "user_email"
+
+
+def test_get_internal_user_field_from_mapping_defaults_to_user_id():
+    mappings = [
+        {"header_name": "X-Id", "litellm_user_role": "internal_user"},
+    ]
+    assert LiteLLMProxyRequestSetup.get_internal_user_field_from_mapping(mappings) == "user_id"
+    assert LiteLLMProxyRequestSetup.get_internal_user_field_from_mapping(None) == "user_id"
+    assert LiteLLMProxyRequestSetup.get_internal_user_field_from_mapping([]) == "user_id"
+
+
 def test_add_internal_user_from_user_mapping_no_header_or_mapping_returns_unchanged():
     user_api_key_dict = UserAPIKeyAuth(api_key="test-key")
 

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -33650,6 +33650,15 @@ export interface components {
         /**
          * UserHeaderMapping
          * @description Map an incoming HTTP header to a LiteLLM user role.
+         *
+         *     Security note: once configured, the header value is trusted as-is - this
+         *     mirrors the existing behavior for litellm_user_role="internal_user"
+         *     mappings, which have always trusted the header to populate user_id.
+         *     Only map a header your edge/gateway sets and that callers cannot set or
+         *     override directly. When user_field="user_email", this same trust
+         *     boundary also flows into UserAPIKeyAuth.user_email, which some
+         *     downstream consumers (e.g. MCPJWTSigner token claims) treat as an
+         *     authoritative identity assertion, so the same caution applies there.
          */
         UserHeaderMapping: {
             /** Header Name */
@@ -33659,6 +33668,13 @@ export interface components {
              * @enum {string}
              */
             litellm_user_role: "internal_user" | "customer";
+            /**
+             * User Field
+             * @description Which UserAPIKeyAuth attribute to populate with this header's value. Only applies to litellm_user_role='internal_user' mappings. Use 'user_email' when the header carries the user's email (e.g. for a LiteLLM user created via SSO and identified by email) instead of their LiteLLM user_id.
+             * @default user_id
+             * @enum {string}
+             */
+            user_field: "user_id" | "user_email";
         };
         /** UserInfoResponse */
         UserInfoResponse: {


### PR DESCRIPTION
**TLDR**

**Problem this solves:**

user_header_mappings (internal_user role) always wrote the header value into user_id - no way to say "this header is actually the user's email"
Breaks per-user spend tracking for tools like OpenWebUI when the LiteLLM user was created via SSO and is keyed by email, not the external tool's internal id

**How it solves it:**

Added an optional user_field ("user_id" | "user_email", default "user_id") to each internal_user entry in user_header_mappings
add_internal_user_from_user_mapping now writes the header value to UserAPIKeyAuth.user_email when configured, user_id otherwise - existing configs are unaffected since the default is unchanged
While touching this, refactored the mapping-lookup helpers to share a single tuple-normalizing function instead of duplicating list-literal construction, so the new field-lookup method doesn't add a second copy of the same pattern

**Relevant issues**

Fixes [#21927](https://github.com/BerriAI/litellm/issues/21927)

**Pre-Submission checklist**

Please complete all items before asking a LiteLLM maintainer to review your PR

- I have added meaningful tests
- My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- My PR's scope is as isolated as possible; it only solves 1 specific problem
- I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment @greptileai to re-request a review after pushing changes)

**Delays in PR merge?**

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

**Screenshots / Proof of Fix**

Configured a single internal_user mapping with user_field: user_email and sent a request with the mapped header set to an email address.

Before this change: user_api_key_dict.user_id gets set to the raw header value regardless of what it actually represents (an email address would be misattributed as a user_id).

After this change, same header, with user_field: user_email set: user_api_key_dict.user_email is set to the header value and user_id is left untouched. With the field omitted (or set to user_id), behavior is byte-for-byte identical to before this PR.

Covered by tests/test_litellm/proxy/test_litellm_pre_call_utils.py - full suite run locally, 203 passed, including the 4 new tests (test_add_internal_user_from_user_mapping_sets_user_email_when_configured, test_add_internal_user_from_user_mapping_defaults_to_user_id_without_user_field, test_get_internal_user_field_from_mapping_returns_user_email_when_configured, test_get_internal_user_field_from_mapping_defaults_to_user_id).

**Type**

🆕 New Feature

**Changes**

Added an optional user_field: Literal["user_id", "user_email"] = "user_id" to UserHeaderMapping in litellm/proxy/_types.py, so a mapping entry can say which UserAPIKeyAuth attribute the header value should populate.

In litellm/proxy/litellm_pre_call_utils.py, add_internal_user_from_user_mapping now resolves the target field via a new get_internal_user_field_from_mapping helper and branches accordingly - user_email when configured, user_id otherwise (unchanged default). Also extracted a shared _iter_user_header_mapping_items helper so both get_internal_user_header_from_mapping and the new field-lookup method normalize the single-dict-or-list input the same way, without duplicating list-construction logic.

Added tests covering: the new user_field: user_email path setting user_email and leaving user_id untouched, the default (omitted user_field) path staying identical to prior behavior, and the field-resolution helper's default/override/empty-input cases.

**Final Attestation**

The tests check the right things, including the backward-compatibility case (omitted user_field behaves exactly as before) and the new explicit-override case, and regressions in existing user_id-based user_header_mappings configs are not possible after this PR since the default is unchanged.