### PR TITLE
feat(provider): add AvalAI JSON-configured OpenAI-compatible provider

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -639,6 +639,7 @@ dashscope_models: Set = set()
 moonshot_models: Set = set()
 publicai_models: Set = set()
 darkbloom_models: Set = set()
+avalai_models: Set = set()
 v0_models: Set = set()
 morph_models: Set = set()
 lambda_ai_models: Set = set()
@@ -893,6 +894,8 @@ def add_known_models(model_cost_map: Optional[Dict] = None):
             publicai_models.add(key)
         elif value.get("litellm_provider") == "darkbloom":
             darkbloom_models.add(key)
+        elif value.get("litellm_provider") == "avalai":
+            avalai_models.add(key)
         elif value.get("litellm_provider") == "v0":
             v0_models.add(key)
         elif value.get("litellm_provider") == "morph":
@@ -1042,6 +1045,7 @@ model_list = list(
     | moonshot_models
     | publicai_models
     | darkbloom_models
+    | avalai_models
     | v0_models
     | morph_models
     | lambda_ai_models
@@ -1148,6 +1152,7 @@ models_by_provider: dict = {
     "moonshot": moonshot_models,
     "publicai": publicai_models,
     "darkbloom": darkbloom_models,
+    "avalai": avalai_models,
     "v0": v0_models,
     "morph": morph_models,
     "lambda_ai": lambda_ai_models,

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -728,6 +728,7 @@ openai_compatible_endpoints: List = [
     "https://api.libertai.io/v1",
     "https://pinstripes.io/v1",
     "https://api.meta.ai/v1",
+    "https://api.avalai.ir/v1",
 ]
 
 
@@ -795,6 +796,7 @@ openai_compatible_providers: List = [
     "pinstripes",  # Pinstripes - JSON-configured provider
     "darkbloom",
     "meta",  # Meta Model API (Muse Spark) - JSON-configured provider
+    "avalai",  # AvalAI - JSON-configured provider
 ]
 openai_text_completion_compatible_providers: List = [  # providers that support `/v1/completions`
     "together_ai",

--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -183,5 +183,10 @@
       "max_completion_tokens": "max_tokens"
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+  },
+  "avalai": {
+    "base_url": "https://api.avalai.ir/v1",
+    "api_key_env": "AVALAI_API_KEY",
+    "api_base_env": "AVALAI_API_BASE"
   }
 }

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -46180,6 +46180,96 @@
         "supports_reasoning": false,
         "source": "https://pinstripes.io/pricing"
     },
+    "avalai/gpt-4o": {
+        "input_cost_per_token": 2.5e-06,
+        "litellm_provider": "avalai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "source": "https://docs.avalai.ir/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "avalai/gpt-4o-mini": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "avalai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "source": "https://docs.avalai.ir/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "avalai/gpt-4.1": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "avalai",
+        "max_input_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 8e-06,
+        "source": "https://docs.avalai.ir/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "avalai/claude-sonnet-4-5": {
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "avalai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://docs.avalai.ir/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "avalai/gemini-2.5-flash": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "avalai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://docs.avalai.ir/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "fallback_generalizations": {
         "rules": [
             {

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -229,6 +229,23 @@
         "interactions": true
       }
     },
+    "avalai": {
+      "display_name": "AvalAI (`avalai`)",
+      "url": "https://docs.litellm.ai/docs/providers/avalai",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "bedrock": {
       "display_name": "AWS - Bedrock (`bedrock`)",
       "url": "https://docs.litellm.ai/docs/providers/bedrock",

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3597,6 +3597,7 @@ class LlmProviders(str, Enum):
     PINSTRIPES = "pinstripes"
     DARKBLOOM = "darkbloom"
     META = "meta"
+    AVALAI = "avalai"
     LITELLM_AGENT = "litellm_agent"
     CURSOR = "cursor"
     BEDROCK_MANTLE = "bedrock_mantle"

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -46302,6 +46302,96 @@
         "supports_system_messages": true,
         "supports_tool_choice": true
     },
+    "avalai/gpt-4o": {
+        "input_cost_per_token": 2.5e-06,
+        "litellm_provider": "avalai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 1e-05,
+        "source": "https://docs.avalai.ir/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "avalai/gpt-4o-mini": {
+        "input_cost_per_token": 1.5e-07,
+        "litellm_provider": "avalai",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 16384,
+        "max_tokens": 16384,
+        "mode": "chat",
+        "output_cost_per_token": 6e-07,
+        "source": "https://docs.avalai.ir/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "avalai/gpt-4.1": {
+        "input_cost_per_token": 2e-06,
+        "litellm_provider": "avalai",
+        "max_input_tokens": 1047576,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 8e-06,
+        "source": "https://docs.avalai.ir/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "avalai/claude-sonnet-4-5": {
+        "input_cost_per_token": 3e-06,
+        "litellm_provider": "avalai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "mode": "chat",
+        "output_cost_per_token": 1.5e-05,
+        "source": "https://docs.avalai.ir/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "avalai/gemini-2.5-flash": {
+        "input_cost_per_token": 3e-07,
+        "litellm_provider": "avalai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65535,
+        "max_tokens": 65535,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "source": "https://docs.avalai.ir/",
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "supports_function_calling": true,
+        "supports_native_streaming": true,
+        "supports_system_messages": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "fallback_generalizations": {
         "rules": [
             {

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -246,6 +246,23 @@
         "interactions": true
       }
     },
+    "avalai": {
+      "display_name": "AvalAI (`avalai`)",
+      "url": "https://docs.litellm.ai/docs/providers/avalai",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
+    },
     "bedrock": {
       "display_name": "AWS - Bedrock (`bedrock`)",
       "url": "https://docs.litellm.ai/docs/providers/bedrock",

--- a/tests/test_litellm/llms/openai_like/test_json_providers.py
+++ b/tests/test_litellm/llms/openai_like/test_json_providers.py
@@ -338,6 +338,99 @@ class TestDarkbloom:
             assert model_cost[model]["output_cost_per_token"] == output_cost
 
 
+class TestAvalAI:
+    def test_avalai_json_config_exists(self):
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        avalai = JSONProviderRegistry.get("avalai")
+        assert avalai is not None
+        assert avalai.base_url == "https://api.avalai.ir/v1"
+        assert avalai.api_key_env == "AVALAI_API_KEY"
+        assert avalai.api_base_env == "AVALAI_API_BASE"
+
+    def test_avalai_provider_resolution(self):
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="avalai/gpt-4o",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+
+        assert model == "gpt-4o"
+        assert provider == "avalai"
+        assert api_key is None
+        assert api_base == "https://api.avalai.ir/v1"
+
+    def test_avalai_dynamic_config(self):
+        from litellm.llms.openai_like.dynamic_config import create_config_class
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        provider = JSONProviderRegistry.get("avalai")
+        config_class = create_config_class(provider)
+        config = config_class()
+
+        api_base, api_key = config._get_openai_compatible_provider_info(None, None)
+        assert api_base == "https://api.avalai.ir/v1"
+
+        api_base, api_key = config._get_openai_compatible_provider_info(
+            "https://custom.avalai.ir/v1", "test-key"
+        )
+        assert api_base == "https://custom.avalai.ir/v1"
+        assert api_key == "test-key"
+
+    def test_avalai_complete_url_appends_endpoint(self):
+        from litellm.llms.openai_like.dynamic_config import create_config_class
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        provider = JSONProviderRegistry.get("avalai")
+        config_class = create_config_class(provider)
+        config = config_class()
+
+        url = config.get_complete_url(
+            api_base="https://api.avalai.ir/v1",
+            api_key="test-key",
+            model="avalai/gpt-4o",
+            optional_params={},
+            litellm_params={},
+            stream=True,
+        )
+
+        assert url == "https://api.avalai.ir/v1/chat/completions"
+
+    def test_avalai_provider_config_manager(self):
+        from litellm import LlmProviders
+        from litellm.utils import ProviderConfigManager
+
+        config = ProviderConfigManager.get_provider_chat_config(
+            model="gpt-4o", provider=LlmProviders.AVALAI
+        )
+
+        assert config is not None
+        assert config.custom_llm_provider == "avalai"
+
+    def test_avalai_model_cost_map(self):
+        with open(
+            os.path.join(workspace_path, "model_prices_and_context_window.json")
+        ) as f:
+            model_cost = json.load(f)
+
+        expected_models = (
+            "avalai/gpt-4o",
+            "avalai/gpt-4o-mini",
+            "avalai/gpt-4.1",
+            "avalai/claude-sonnet-4-5",
+            "avalai/gemini-2.5-flash",
+        )
+        for model in expected_models:
+            assert model in model_cost
+            assert model_cost[model]["litellm_provider"] == "avalai"
+            assert model_cost[model]["mode"] == "chat"
+            assert model_cost[model]["supports_function_calling"] is True
+            assert model_cost[model]["supports_tool_choice"] is True
+
+
 class TestPublicAIIntegration:
     """Integration tests for PublicAI provider"""
 


### PR DESCRIPTION
## Summary

Adds [AvalAI](https://avalai.ir) as an OpenAI-compatible provider — an AI gateway fronting OpenAI, Anthropic, Google and other vendor models behind a single API key and endpoint (`https://api.avalai.ir/v1`).

Registered via the existing JSON-configured provider path (`litellm/llms/openai_like/providers.json`), the same mechanism used by darkbloom/publicai/meta, rather than a bespoke `transformation.py`:

- `litellm/llms/openai_like/providers.json` — base_url + env vars (`AVALAI_API_KEY`, `AVALAI_API_BASE`)
- `litellm/constants.py` — `openai_compatible_providers` / `openai_compatible_endpoints`
- `litellm/types/utils.py` — `LlmProviders.AVALAI`
- `litellm/__init__.py` — model set registration
- `model_prices_and_context_window.json` (+ backup) — 5 representative models: gpt-4o, gpt-4o-mini, gpt-4.1, claude-sonnet-4-5, gemini-2.5-flash, with pricing
- `tests/test_litellm/llms/openai_like/test_json_providers.py` — `TestAvalAI` covering config resolution, provider routing, and dynamic config

Usage: `litellm.completion(model="avalai/gpt-4o", ...)`

## Known gaps — please advise

- No dedicated docs page under `docs/my-website/docs/providers/` was added — happy to add one if maintainers confirm the convention for JSON-configured providers.
- Full `pytest` run wasn't completed locally (heavy monorepo dependency install wasn't feasible in the prep environment) — JSON files were validated and touched `.py` files were syntax-checked (`py_compile`), but please let CI run the full suite including `TestAvalAI`.

## Test plan

- [ ] CI passes, including `tests/test_litellm/llms/openai_like/test_json_providers.py::TestAvalAI`
- [ ] Manual check: `litellm.completion(model="avalai/gpt-4o-mini", messages=[...])` resolves to `https://api.avalai.ir/v1`