### PR TITLE
fix(ui): align SMTP settings with supported configuration

### DIFF
--- a/litellm/proxy/config_resolvers/alerting.py
+++ b/litellm/proxy/config_resolvers/alerting.py
@@ -12,6 +12,7 @@ EMAIL_DESCRIPTORS: tuple[FieldDescriptor, ...] = (
     FieldDescriptor("SMTP_HOST", "SMTP_HOST", "SMTP_HOST"),
     FieldDescriptor("SMTP_PORT", "SMTP_PORT", "SMTP_PORT", default="587"),
     FieldDescriptor("SMTP_TLS", "SMTP_TLS", "SMTP_TLS", default="True"),
+    FieldDescriptor("SMTP_USE_SSL", "SMTP_USE_SSL", "SMTP_USE_SSL", default="False"),
     FieldDescriptor("SMTP_USERNAME", "SMTP_USERNAME", "SMTP_USERNAME", is_secret=True),
     FieldDescriptor("SMTP_PASSWORD", "SMTP_PASSWORD", "SMTP_PASSWORD", is_secret=True),
     FieldDescriptor("SMTP_SENDER_EMAIL", "SMTP_SENDER_EMAIL", "SMTP_SENDER_EMAIL"),

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -1218,6 +1218,7 @@ def test_get_config_returns_email_settings_set_only_in_process_env(monkeypatch):
     monkeypatch.setenv("SMTP_HOST", "smtp.env-host.com")
     monkeypatch.setenv("SMTP_PORT", "2525")
     monkeypatch.setenv("SMTP_TLS", "False")
+    monkeypatch.setenv("SMTP_USE_SSL", "True")
     monkeypatch.setenv("SMTP_USERNAME", "env-user")
     monkeypatch.setenv("SMTP_PASSWORD", smtp_password)
     monkeypatch.setenv("SMTP_SENDER_EMAIL", "alerts@env-host.com")
@@ -1236,6 +1237,7 @@ def test_get_config_returns_email_settings_set_only_in_process_env(monkeypatch):
     assert variables["SMTP_HOST"] == "smtp.env-host.com"
     assert variables["SMTP_PORT"] == "2525"
     assert variables["SMTP_TLS"] == "False"
+    assert variables["SMTP_USE_SSL"] == "True"
     assert variables["SMTP_USERNAME"] == "env-user"
     assert variables["SMTP_SENDER_EMAIL"] == "alerts@env-host.com"
     assert variables["TEST_EMAIL_ADDRESS"] == "admin@env-host.com"
@@ -1269,7 +1271,15 @@ def test_get_config_email_settings_prefer_stored_over_process_env(monkeypatch):
 
 def test_get_config_email_settings_absent_everywhere_stay_none(monkeypatch):
     """A field set in neither source is reported unset rather than invented."""
-    for var in ("SMTP_HOST", "SMTP_PORT", "SMTP_TLS", "SMTP_USERNAME", "SMTP_PASSWORD", "SMTP_SENDER_EMAIL"):
+    for var in (
+        "SMTP_HOST",
+        "SMTP_PORT",
+        "SMTP_TLS",
+        "SMTP_USE_SSL",
+        "SMTP_USERNAME",
+        "SMTP_PASSWORD",
+        "SMTP_SENDER_EMAIL",
+    ):
         monkeypatch.delenv(var, raising=False)
 
     variables = _get_email_alert_variables(

--- a/ui/litellm-dashboard/src/components/email_settings.test.tsx
+++ b/ui/litellm-dashboard/src/components/email_settings.test.tsx
@@ -34,7 +34,8 @@ const alerts = [
   { name: "slack", variables: { SLACK_WEBHOOK_URL: "https://hooks.example.com" } },
 ];
 
-const inputNamed = (name: string) => document.querySelector<HTMLInputElement>(`input[name="${name}"]`)!;
+const fieldNamed = (name: string) =>
+  document.querySelector<HTMLInputElement | HTMLSelectElement>(`[name="${name}"]`)!;
 
 describe("EmailSettings", () => {
   beforeEach(() => {
@@ -56,17 +57,19 @@ describe("EmailSettings", () => {
   it("renders one named input per email variable and none for other alert types", () => {
     renderWithProviders(<EmailSettings accessToken="sk-test" premiumUser alerts={alerts} />);
 
-    expect(inputNamed("SMTP_HOST")).toHaveValue("smtp.example.com");
-    expect(inputNamed("SMTP_PORT")).toHaveValue("587");
-    expect(inputNamed("SMTP_PORT")).toHaveAttribute("type", "number");
-    expect(inputNamed("SMTP_HOST")).toHaveAttribute("type", "text");
-    expect(inputNamed("SMTP_TLS")).toHaveAttribute("type", "text");
-    expect(inputNamed("SMTP_USE_SSL")).toHaveAttribute("type", "text");
-    expect(inputNamed("SMTP_USERNAME")).toHaveAttribute("type", "text");
-    expect(inputNamed("SMTP_PASSWORD")).toHaveValue("********");
-    expect(inputNamed("SMTP_SENDER_EMAIL")).toHaveAttribute("type", "text");
-    expect(inputNamed("TEST_EMAIL_ADDRESS")).toHaveAttribute("type", "text");
-    expect(inputNamed("EMAIL_LOGO_URL")).toHaveAttribute("type", "text");
+    expect(fieldNamed("SMTP_HOST")).toHaveValue("smtp.example.com");
+    expect(fieldNamed("SMTP_PORT")).toHaveValue(587);
+    expect(fieldNamed("SMTP_PORT")).toHaveAttribute("type", "number");
+    expect(fieldNamed("SMTP_HOST")).toHaveAttribute("type", "text");
+    expect(fieldNamed("SMTP_TLS")).toHaveValue("True");
+    expect(fieldNamed("SMTP_TLS").tagName).toBe("SELECT");
+    expect(fieldNamed("SMTP_USE_SSL")).toHaveValue("False");
+    expect(fieldNamed("SMTP_USE_SSL").tagName).toBe("SELECT");
+    expect(fieldNamed("SMTP_USERNAME")).toHaveAttribute("type", "text");
+    expect(fieldNamed("SMTP_PASSWORD")).toHaveValue("********");
+    expect(fieldNamed("SMTP_SENDER_EMAIL")).toHaveAttribute("type", "text");
+    expect(fieldNamed("TEST_EMAIL_ADDRESS")).toHaveAttribute("type", "text");
+    expect(fieldNamed("EMAIL_LOGO_URL")).toHaveAttribute("type", "text");
     expect(document.querySelector('input[name="SLACK_WEBHOOK_URL"]')).toBeNull();
   });
 
@@ -83,22 +86,22 @@ describe("EmailSettings", () => {
   it("only requires the SMTP host and sender email", () => {
     renderWithProviders(<EmailSettings accessToken="sk-test" premiumUser alerts={alerts} />);
 
-    expect(inputNamed("SMTP_HOST")).toBeRequired();
-    expect(inputNamed("SMTP_SENDER_EMAIL")).toBeRequired();
-    expect(inputNamed("SMTP_PORT")).not.toBeRequired();
-    expect(inputNamed("SMTP_TLS")).not.toBeRequired();
-    expect(inputNamed("SMTP_USE_SSL")).not.toBeRequired();
-    expect(inputNamed("SMTP_USERNAME")).not.toBeRequired();
-    expect(inputNamed("SMTP_PASSWORD")).not.toBeRequired();
-    expect(inputNamed("TEST_EMAIL_ADDRESS")).not.toBeRequired();
+    expect(fieldNamed("SMTP_HOST")).toBeRequired();
+    expect(fieldNamed("SMTP_SENDER_EMAIL")).toBeRequired();
+    expect(fieldNamed("SMTP_PORT")).not.toBeRequired();
+    expect(fieldNamed("SMTP_TLS")).not.toBeRequired();
+    expect(fieldNamed("SMTP_USE_SSL")).not.toBeRequired();
+    expect(fieldNamed("SMTP_USERNAME")).not.toBeRequired();
+    expect(fieldNamed("SMTP_PASSWORD")).not.toBeRequired();
+    expect(fieldNamed("TEST_EMAIL_ADDRESS")).not.toBeRequired();
   });
 
   it("submits only the fields the admin actually edited", async () => {
     const user = userEvent.setup();
     renderWithProviders(<EmailSettings accessToken="sk-test" premiumUser alerts={alerts} />);
 
-    await user.clear(inputNamed("SMTP_HOST"));
-    await user.type(inputNamed("SMTP_HOST"), "smtp.changed.com");
+    await user.clear(fieldNamed("SMTP_HOST"));
+    await user.type(fieldNamed("SMTP_HOST"), "smtp.changed.com");
     await user.click(screen.getByRole("button", { name: "Save Changes" }));
 
     await waitFor(() => {
@@ -123,17 +126,33 @@ describe("EmailSettings", () => {
     });
   });
 
+  it("submits empty values when optional credentials are cleared", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<EmailSettings accessToken="sk-test" premiumUser alerts={alerts} />);
+
+    await user.clear(fieldNamed("SMTP_USERNAME"));
+    await user.clear(fieldNamed("SMTP_PASSWORD"));
+    await user.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => {
+      expect(setCallbacksCall).toHaveBeenCalledWith("sk-test", {
+        general_settings: { alerting: ["email"] },
+        environment_variables: { SMTP_USERNAME: "", SMTP_PASSWORD: "" },
+      });
+    });
+  });
+
   it("disables the premium-only fields for non-premium users", () => {
     renderWithProviders(<EmailSettings accessToken="sk-test" premiumUser={false} alerts={alerts} />);
 
-    expect(inputNamed("EMAIL_LOGO_URL")).toBeDisabled();
-    expect(inputNamed("SMTP_HOST")).not.toBeDisabled();
+    expect(fieldNamed("EMAIL_LOGO_URL")).toBeDisabled();
+    expect(fieldNamed("SMTP_HOST")).not.toBeDisabled();
   });
 
   it("leaves the premium-only fields editable for premium users", () => {
     renderWithProviders(<EmailSettings accessToken="sk-test" premiumUser alerts={alerts} />);
 
-    expect(inputNamed("EMAIL_LOGO_URL")).not.toBeDisabled();
+    expect(fieldNamed("EMAIL_LOGO_URL")).not.toBeDisabled();
   });
 
   it("triggers a live email health check", async () => {

--- a/ui/litellm-dashboard/src/components/email_settings.test.tsx
+++ b/ui/litellm-dashboard/src/components/email_settings.test.tsx
@@ -34,8 +34,7 @@ const alerts = [
   { name: "slack", variables: { SLACK_WEBHOOK_URL: "https://hooks.example.com" } },
 ];
 
-const fieldNamed = (name: string) =>
-  document.querySelector<HTMLInputElement | HTMLSelectElement>(`[name="${name}"]`)!;
+const fieldNamed = (name: string) => document.querySelector<HTMLInputElement | HTMLSelectElement>(`[name="${name}"]`)!;
 
 describe("EmailSettings", () => {
   beforeEach(() => {

--- a/ui/litellm-dashboard/src/components/email_settings.test.tsx
+++ b/ui/litellm-dashboard/src/components/email_settings.test.tsx
@@ -22,7 +22,12 @@ const alerts = [
     variables: {
       SMTP_HOST: "smtp.example.com",
       SMTP_PORT: "587",
+      SMTP_TLS: "True",
+      SMTP_USE_SSL: "False",
+      SMTP_USERNAME: "smtp-user",
       SMTP_PASSWORD: "********",
+      SMTP_SENDER_EMAIL: "alerts@example.com",
+      TEST_EMAIL_ADDRESS: "admin@example.com",
       EMAIL_LOGO_URL: "https://example.com/logo.png",
     },
   },
@@ -53,7 +58,15 @@ describe("EmailSettings", () => {
 
     expect(inputNamed("SMTP_HOST")).toHaveValue("smtp.example.com");
     expect(inputNamed("SMTP_PORT")).toHaveValue("587");
+    expect(inputNamed("SMTP_PORT")).toHaveAttribute("type", "number");
+    expect(inputNamed("SMTP_HOST")).toHaveAttribute("type", "text");
+    expect(inputNamed("SMTP_TLS")).toHaveAttribute("type", "text");
+    expect(inputNamed("SMTP_USE_SSL")).toHaveAttribute("type", "text");
+    expect(inputNamed("SMTP_USERNAME")).toHaveAttribute("type", "text");
     expect(inputNamed("SMTP_PASSWORD")).toHaveValue("********");
+    expect(inputNamed("SMTP_SENDER_EMAIL")).toHaveAttribute("type", "text");
+    expect(inputNamed("TEST_EMAIL_ADDRESS")).toHaveAttribute("type", "text");
+    expect(inputNamed("EMAIL_LOGO_URL")).toHaveAttribute("type", "text");
     expect(document.querySelector('input[name="SLACK_WEBHOOK_URL"]')).toBeNull();
   });
 
@@ -63,6 +76,21 @@ describe("EmailSettings", () => {
     expect(screen.getByText("SMTP_HOST")).toBeInTheDocument();
     expect(screen.getByText(/Enter the SMTP host address/)).toBeInTheDocument();
     expect(screen.getByText(/Enter the SMTP port number/)).toBeInTheDocument();
+    expect(screen.getByText(/Optional SMTP username/)).toBeInTheDocument();
+    expect(screen.getByText(/Optional SMTP password/)).toBeInTheDocument();
+  });
+
+  it("only requires the SMTP host and sender email", () => {
+    renderWithProviders(<EmailSettings accessToken="sk-test" premiumUser alerts={alerts} />);
+
+    expect(inputNamed("SMTP_HOST")).toBeRequired();
+    expect(inputNamed("SMTP_SENDER_EMAIL")).toBeRequired();
+    expect(inputNamed("SMTP_PORT")).not.toBeRequired();
+    expect(inputNamed("SMTP_TLS")).not.toBeRequired();
+    expect(inputNamed("SMTP_USE_SSL")).not.toBeRequired();
+    expect(inputNamed("SMTP_USERNAME")).not.toBeRequired();
+    expect(inputNamed("SMTP_PASSWORD")).not.toBeRequired();
+    expect(inputNamed("TEST_EMAIL_ADDRESS")).not.toBeRequired();
   });
 
   it("submits only the fields the admin actually edited", async () => {

--- a/ui/litellm-dashboard/src/components/email_settings.tsx
+++ b/ui/litellm-dashboard/src/components/email_settings.tsx
@@ -14,13 +14,22 @@ interface EmailSettingsProps {
 
 const REQUIRED_MARKER = <span className="text-destructive"> Required * </span>;
 
+const REQUIRED_FIELDS = new Set(["SMTP_HOST", "SMTP_SENDER_EMAIL"]);
+
+const FIELD_TYPES: Record<string, React.HTMLInputTypeAttribute> = {
+  SMTP_PORT: "number",
+  SMTP_PASSWORD: "password",
+};
+
 const FIELD_HELP: Record<string, React.ReactNode> = {
   SMTP_HOST: <>Enter the SMTP host address, e.g. `smtp.resend.com`{REQUIRED_MARKER}</>,
-  SMTP_PORT: <>Enter the SMTP port number, e.g. `587`{REQUIRED_MARKER}</>,
-  SMTP_USERNAME: <>Enter the SMTP username, e.g. `username`{REQUIRED_MARKER}</>,
-  SMTP_PASSWORD: REQUIRED_MARKER,
+  SMTP_PORT: <>Enter the SMTP port number, e.g. `587`</>,
+  SMTP_TLS: <>Use STARTTLS for the SMTP connection. Defaults to `True`</>,
+  SMTP_USE_SSL: <>Use implicit SSL for the SMTP connection. Defaults to `False`</>,
+  SMTP_USERNAME: <>Optional SMTP username for authenticated servers</>,
+  SMTP_PASSWORD: <>Optional SMTP password for authenticated servers</>,
   SMTP_SENDER_EMAIL: <>Enter the sender email address, e.g. `sender@berri.ai`{REQUIRED_MARKER}</>,
-  TEST_EMAIL_ADDRESS: <>Email Address to send `Test Email Alert` to. example: `info@berri.ai`{REQUIRED_MARKER}</>,
+  TEST_EMAIL_ADDRESS: <>Optional address for the `Test Email Alert` action</>,
   EMAIL_LOGO_URL: <>(Optional) Customize the Logo that appears in the email, pass a url to your logo</>,
   EMAIL_SUPPORT_CONTACT: (
     <>(Optional) Customize the support email address that appears in the email. Default is support@berri.ai</>
@@ -115,8 +124,9 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({ accessToken, premiumUser,
                       )}
                       <Input
                         name={key}
-                        defaultValue={value as string}
-                        type="password"
+                        defaultValue={value as string | undefined}
+                        type={FIELD_TYPES[key] ?? "text"}
+                        required={REQUIRED_FIELDS.has(key)}
                         disabled={isLocked}
                         className="max-w-100"
                       />

--- a/ui/litellm-dashboard/src/components/email_settings.tsx
+++ b/ui/litellm-dashboard/src/components/email_settings.tsx
@@ -21,6 +21,8 @@ const FIELD_TYPES: Record<string, React.HTMLInputTypeAttribute> = {
   SMTP_PASSWORD: "password",
 };
 
+const BOOLEAN_FIELDS = new Set(["SMTP_TLS", "SMTP_USE_SSL"]);
+
 const FIELD_HELP: Record<string, React.ReactNode> = {
   SMTP_HOST: <>Enter the SMTP host address, e.g. `smtp.resend.com`{REQUIRED_MARKER}</>,
   SMTP_PORT: <>Enter the SMTP port number, e.g. `587`</>,
@@ -50,18 +52,18 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({ accessToken, premiumUser,
       .filter((alert) => alert.name === "email")
       .forEach((alert) => {
         Object.entries(alert.variables ?? {}).forEach(([key, value]) => {
-          const inputElement = document.querySelector(`input[name="${key}"]`) as HTMLInputElement;
-          if (!inputElement || !inputElement.value) {
+          const fieldElement = document.querySelector(`[name="${key}"]`) as HTMLInputElement | HTMLSelectElement;
+          if (!fieldElement) {
             return;
           }
           // Only send fields the admin actually edited. Values rendered from the
           // server are masked (SMTP_PASSWORD) or sourced from the process
           // environment, so re-submitting an untouched field would persist a mask
           // or copy env-managed config into the database.
-          if (inputElement.value === (value == null ? "" : String(value))) {
+          if (fieldElement.value === (value == null ? "" : String(value))) {
             return;
           }
-          updatedVariables[key] = inputElement.value;
+          updatedVariables[key] = fieldElement.value;
         });
       });
 
@@ -122,14 +124,27 @@ const EmailSettings: React.FC<EmailSettingsProps> = ({ accessToken, premiumUser,
                       ) : (
                         <p className="text-sm">{key}</p>
                       )}
-                      <Input
-                        name={key}
-                        defaultValue={value as string | undefined}
-                        type={FIELD_TYPES[key] ?? "text"}
-                        required={REQUIRED_FIELDS.has(key)}
-                        disabled={isLocked}
-                        className="max-w-100"
-                      />
+                      {BOOLEAN_FIELDS.has(key) ? (
+                        <select
+                          name={key}
+                          defaultValue={value as string | undefined}
+                          required={REQUIRED_FIELDS.has(key)}
+                          disabled={isLocked}
+                          className="max-w-100 rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        >
+                          <option value="True">True</option>
+                          <option value="False">False</option>
+                        </select>
+                      ) : (
+                        <Input
+                          name={key}
+                          defaultValue={value as string | undefined}
+                          type={FIELD_TYPES[key] ?? "text"}
+                          required={REQUIRED_FIELDS.has(key)}
+                          disabled={isLocked}
+                          className="max-w-100"
+                        />
+                      )}
                       <div className="text-xs text-muted-foreground italic">{FIELD_HELP[key]}</div>
                     </div>
                   );


### PR DESCRIPTION
## TLDR

Problem this solves:

- SMTP fields are incorrectly rendered as password inputs
- Username and password appear required despite optional authentication
- SMTP_USE_SSL is supported by runtime but missing from Admin UI

How it solves it:

- Uses text and number inputs for non-secret SMTP fields
- Marks only SMTP host and sender email as required
- Exposes SMTP_USE_SSL through the API descriptor and GUI
- Adds regression tests for field types and configuration resolution

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [X] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [X] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before commit: `de706a35a6`

- Open the Admin UI email alert settings
- Observe that all SMTP fields are rendered as password inputs
- Observe that SMTP username, password, port, and test email address are marked required

After commit: `0c6ed09755`

- Open the Admin UI email alert settings
- Verify that SMTP host, sender email, username, TLS, SSL, and optional fields use readable inputs
- Verify that SMTP port uses a numeric input
- Verify that only SMTP host and sender email are marked required
- Verify that SMTP_USE_SSL is available in the settings returned by `/get/config/callbacks`
- Configure an SMTP server without authentication and trigger `GET /health/services?service=email`

The frontend and backend targeted tests were added, but the local environment could not complete them because `fastuuid`, frontend Node dependencies, `make`, and the project pre-commit runtime were unavailable

## Type

Bug Fix

Test

## Changes

The Admin UI now matches the SMTP runtime contract. Authentication credentials are optional, while the host and sender address remain required for sending email. Non-secret fields are no longer rendered as password inputs, and the SMTP port uses a numeric input

The API descriptor now exposes `SMTP_USE_SSL` with the same default used by the SMTP runtime, allowing the setting to be configured through the Admin UI as well as `/config/update`

Regression coverage verifies the input types, required fields, process-environment resolution, and SMTP_USE_SSL visibility

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR