### PR TITLE
feat(azure_ai): add Fireworks FW model pricing on Azure AI Foundry

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -8802,6 +8802,27 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "azure_ai/FW-Inkling": {
+        "cache_read_input_token_cost": 1.7e-07,
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 4.05e-06,
+        "source": "https://fireworks.ai/models/fireworks/inkling",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "azure_ai/FW-Kimi-K2.5": {
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 6.6e-07,
@@ -8931,6 +8952,27 @@
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": true
+    },
+    "azure_ai/FW-Nemotron-3-Ultra-NVFP4": {
+        "cache_read_input_token_cost": 1.19e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-06,
+        "source": "https://fireworks.ai/models/fireworks/nemotron-3-ultra-nvfp4",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
     },
     "azure_ai/MAI-Image-2.5": {
         "input_cost_per_image_token": 8e-06,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -8848,29 +8848,6 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "azure_ai/FW-Kimi-K2.6-Code": {
-        "cache_read_input_token_cost": 2.1e-07,
-        "input_cost_per_token": 1.05e-06,
-        "litellm_provider": "azure_ai",
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
-        "mode": "chat",
-        "output_cost_per_token": 4.4e-06,
-        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
-        "supported_modalities": [
-            "text",
-            "image"
-        ],
-        "supported_output_modalities": [
-            "text"
-        ],
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
     "azure_ai/FW-Kimi-K2.7-Code": {
         "cache_read_input_token_cost": 2.1e-07,
         "input_cost_per_token": 1.05e-06,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -8712,6 +8712,249 @@
             "/v1/images/generations"
         ]
     },
+    "azure_ai/FW-DeepSeek-V3.2": {
+        "cache_read_input_token_cost": 3.1e-07,
+        "input_cost_per_token": 6.2e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 163840,
+        "max_tokens": 163840,
+        "mode": "chat",
+        "output_cost_per_token": 1.85e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-DeepSeek-V4-Pro": {
+        "cache_read_input_token_cost": 1.65e-07,
+        "input_cost_per_token": 1.925e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 3.828e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5": {
+        "cache_read_input_token_cost": 2.2e-07,
+        "input_cost_per_token": 1.1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3.52e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.1": {
+        "cache_read_input_token_cost": 2.86e-07,
+        "input_cost_per_token": 1.54e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 202800,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.84e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.2": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 1.54e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.84e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.2-Fast": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 2.1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 6.6e-06,
+        "source": "https://docs.fireworks.ai/serverless/pricing",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-Kimi-K2.5": {
+        "cache_read_input_token_cost": 1.1e-07,
+        "input_cost_per_token": 6.6e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 3.3e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.6": {
+        "cache_read_input_token_cost": 1.76e-07,
+        "input_cost_per_token": 1.045e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.6-Code": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 1.05e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.7-Code": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 1.05e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K3": {
+        "cache_read_input_token_cost": 3.3e-07,
+        "input_cost_per_token": 3.3e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k3-through-fireworks-ai-on-microsoft-foundry/4540187",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-MiniMax-M2.5": {
+        "cache_read_input_token_cost": 3.3e-08,
+        "input_cost_per_token": 3.3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-MiniMax-M3": {
+        "cache_read_input_token_cost": 6.6e-08,
+        "input_cost_per_token": 3.3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 512000,
+        "max_output_tokens": 512000,
+        "max_tokens": 512000,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "azure_ai/MAI-Image-2.5": {
         "input_cost_per_image_token": 8e-06,
         "input_cost_per_token": 5e-06,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -8728,29 +8728,6 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "azure_ai/FW-Kimi-K2.6-Code": {
-        "cache_read_input_token_cost": 2.1e-07,
-        "input_cost_per_token": 1.05e-06,
-        "litellm_provider": "azure_ai",
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
-        "mode": "chat",
-        "output_cost_per_token": 4.4e-06,
-        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
-        "supported_modalities": [
-            "text",
-            "image"
-        ],
-        "supported_output_modalities": [
-            "text"
-        ],
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
     "azure_ai/FW-Kimi-K2.7-Code": {
         "cache_read_input_token_cost": 2.1e-07,
         "input_cost_per_token": 1.05e-06,

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -8592,6 +8592,249 @@
             "/v1/images/generations"
         ]
     },
+    "azure_ai/FW-DeepSeek-V3.2": {
+        "cache_read_input_token_cost": 3.1e-07,
+        "input_cost_per_token": 6.2e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 163840,
+        "max_tokens": 163840,
+        "mode": "chat",
+        "output_cost_per_token": 1.85e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-DeepSeek-V4-Pro": {
+        "cache_read_input_token_cost": 1.65e-07,
+        "input_cost_per_token": 1.925e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 3.828e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5": {
+        "cache_read_input_token_cost": 2.2e-07,
+        "input_cost_per_token": 1.1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3.52e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.1": {
+        "cache_read_input_token_cost": 2.86e-07,
+        "input_cost_per_token": 1.54e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 202800,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.84e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.2": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 1.54e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.84e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.2-Fast": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 2.1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 6.6e-06,
+        "source": "https://docs.fireworks.ai/serverless/pricing",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-Kimi-K2.5": {
+        "cache_read_input_token_cost": 1.1e-07,
+        "input_cost_per_token": 6.6e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 3.3e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.6": {
+        "cache_read_input_token_cost": 1.76e-07,
+        "input_cost_per_token": 1.045e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.6-Code": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 1.05e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.7-Code": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 1.05e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K3": {
+        "cache_read_input_token_cost": 3.3e-07,
+        "input_cost_per_token": 3.3e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k3-through-fireworks-ai-on-microsoft-foundry/4540187",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-MiniMax-M2.5": {
+        "cache_read_input_token_cost": 3.3e-08,
+        "input_cost_per_token": 3.3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-MiniMax-M3": {
+        "cache_read_input_token_cost": 6.6e-08,
+        "input_cost_per_token": 3.3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 512000,
+        "max_output_tokens": 512000,
+        "max_tokens": 512000,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "azure_ai/MAI-Image-2.5": {
         "input_cost_per_image_token": 8e-06,
         "input_cost_per_token": 5e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8802,6 +8802,27 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "azure_ai/FW-Inkling": {
+        "cache_read_input_token_cost": 1.7e-07,
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+        "max_tokens": 1048576,
+        "mode": "chat",
+        "output_cost_per_token": 4.05e-06,
+        "source": "https://fireworks.ai/models/fireworks/inkling",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "azure_ai/FW-Kimi-K2.5": {
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 6.6e-07,
@@ -8931,6 +8952,27 @@
         "supports_reasoning": true,
         "supports_tool_choice": true,
         "supports_vision": true
+    },
+    "azure_ai/FW-Nemotron-3-Ultra-NVFP4": {
+        "cache_read_input_token_cost": 1.19e-07,
+        "input_cost_per_token": 6e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-06,
+        "source": "https://fireworks.ai/models/fireworks/nemotron-3-ultra-nvfp4",
+        "supported_modalities": [
+            "text"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
     },
     "azure_ai/MAI-Image-2.5": {
         "input_cost_per_image_token": 8e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8848,29 +8848,6 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "azure_ai/FW-Kimi-K2.6-Code": {
-        "cache_read_input_token_cost": 2.1e-07,
-        "input_cost_per_token": 1.05e-06,
-        "litellm_provider": "azure_ai",
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
-        "mode": "chat",
-        "output_cost_per_token": 4.4e-06,
-        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
-        "supported_modalities": [
-            "text",
-            "image"
-        ],
-        "supported_output_modalities": [
-            "text"
-        ],
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
     "azure_ai/FW-Kimi-K2.7-Code": {
         "cache_read_input_token_cost": 2.1e-07,
         "input_cost_per_token": 1.05e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8712,6 +8712,249 @@
             "/v1/images/generations"
         ]
     },
+    "azure_ai/FW-DeepSeek-V3.2": {
+        "cache_read_input_token_cost": 3.1e-07,
+        "input_cost_per_token": 6.2e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 163840,
+        "max_tokens": 163840,
+        "mode": "chat",
+        "output_cost_per_token": 1.85e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-DeepSeek-V4-Pro": {
+        "cache_read_input_token_cost": 1.65e-07,
+        "input_cost_per_token": 1.925e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 3.828e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5": {
+        "cache_read_input_token_cost": 2.2e-07,
+        "input_cost_per_token": 1.1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3.52e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.1": {
+        "cache_read_input_token_cost": 2.86e-07,
+        "input_cost_per_token": 1.54e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 202800,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.84e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.2": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 1.54e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.84e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.2-Fast": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 2.1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 6.6e-06,
+        "source": "https://docs.fireworks.ai/serverless/pricing",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-Kimi-K2.5": {
+        "cache_read_input_token_cost": 1.1e-07,
+        "input_cost_per_token": 6.6e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 3.3e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.6": {
+        "cache_read_input_token_cost": 1.76e-07,
+        "input_cost_per_token": 1.045e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.6-Code": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 1.05e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.7-Code": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 1.05e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K3": {
+        "cache_read_input_token_cost": 3.3e-07,
+        "input_cost_per_token": 3.3e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k3-through-fireworks-ai-on-microsoft-foundry/4540187",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-MiniMax-M2.5": {
+        "cache_read_input_token_cost": 3.3e-08,
+        "input_cost_per_token": 3.3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-MiniMax-M3": {
+        "cache_read_input_token_cost": 6.6e-08,
+        "input_cost_per_token": 3.3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 512000,
+        "max_output_tokens": 512000,
+        "max_tokens": 512000,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "azure_ai/MAI-Image-2.5": {
         "input_cost_per_image_token": 8e-06,
         "input_cost_per_token": 5e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8728,29 +8728,6 @@
         "supports_tool_choice": true,
         "supports_vision": true
     },
-    "azure_ai/FW-Kimi-K2.6-Code": {
-        "cache_read_input_token_cost": 2.1e-07,
-        "input_cost_per_token": 1.05e-06,
-        "litellm_provider": "azure_ai",
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "max_tokens": 262144,
-        "mode": "chat",
-        "output_cost_per_token": 4.4e-06,
-        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
-        "supported_modalities": [
-            "text",
-            "image"
-        ],
-        "supported_output_modalities": [
-            "text"
-        ],
-        "supports_function_calling": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
     "azure_ai/FW-Kimi-K2.7-Code": {
         "cache_read_input_token_cost": 2.1e-07,
         "input_cost_per_token": 1.05e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -8592,6 +8592,249 @@
             "/v1/images/generations"
         ]
     },
+    "azure_ai/FW-DeepSeek-V3.2": {
+        "cache_read_input_token_cost": 3.1e-07,
+        "input_cost_per_token": 6.2e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 163840,
+        "max_output_tokens": 163840,
+        "max_tokens": 163840,
+        "mode": "chat",
+        "output_cost_per_token": 1.85e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-DeepSeek-V4-Pro": {
+        "cache_read_input_token_cost": 1.65e-07,
+        "input_cost_per_token": 1.925e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 384000,
+        "max_tokens": 384000,
+        "mode": "chat",
+        "output_cost_per_token": 3.828e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5": {
+        "cache_read_input_token_cost": 2.2e-07,
+        "input_cost_per_token": 1.1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 3.52e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.1": {
+        "cache_read_input_token_cost": 2.86e-07,
+        "input_cost_per_token": 1.54e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 202800,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.84e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.2": {
+        "cache_read_input_token_cost": 1.5e-07,
+        "input_cost_per_token": 1.54e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 4.84e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-GLM-5.2-Fast": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 2.1e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 6.6e-06,
+        "source": "https://docs.fireworks.ai/serverless/pricing",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-Kimi-K2.5": {
+        "cache_read_input_token_cost": 1.1e-07,
+        "input_cost_per_token": 6.6e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 3.3e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.6": {
+        "cache_read_input_token_cost": 1.76e-07,
+        "input_cost_per_token": 1.045e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.6-Code": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 1.05e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K2.7-Code": {
+        "cache_read_input_token_cost": 2.1e-07,
+        "input_cost_per_token": 1.05e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "max_tokens": 262144,
+        "mode": "chat",
+        "output_cost_per_token": 4.4e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-Kimi-K3": {
+        "cache_read_input_token_cost": 3.3e-07,
+        "input_cost_per_token": 3.3e-06,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 1.65e-05,
+        "source": "https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k3-through-fireworks-ai-on-microsoft-foundry/4540187",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "azure_ai/FW-MiniMax-M2.5": {
+        "cache_read_input_token_cost": 3.3e-08,
+        "input_cost_per_token": 3.3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+        "max_tokens": 1000000,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
+    "azure_ai/FW-MiniMax-M3": {
+        "cache_read_input_token_cost": 6.6e-08,
+        "input_cost_per_token": 3.3e-07,
+        "litellm_provider": "azure_ai",
+        "max_input_tokens": 512000,
+        "max_output_tokens": 512000,
+        "max_tokens": 512000,
+        "mode": "chat",
+        "output_cost_per_token": 1.32e-06,
+        "source": "https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/",
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "azure_ai/MAI-Image-2.5": {
         "input_cost_per_image_token": 8e-06,
         "input_cost_per_token": 5e-06,

--- a/tests/test_litellm/llms/azure_ai/test_azure_ai_fw_models_metadata.py
+++ b/tests/test_litellm/llms/azure_ai/test_azure_ai_fw_models_metadata.py
@@ -1,0 +1,195 @@
+"""
+Regression tests for Azure AI Foundry Fireworks (FW-*) model cost map entries.
+
+Prices for Data Zone pay-per-token meters come from the Azure retail prices API
+(product "Azure Fireworks Models"). Kimi K3 rates come from the Microsoft Foundry
+announcement. GLM-5.2-Fast uses Fireworks serverless Fast rates when Azure does
+not publish a dedicated meter yet.
+"""
+
+import json
+from importlib.resources import files
+
+import pytest
+
+FW_MODELS = {
+    "azure_ai/FW-Kimi-K2.5": {
+        "input_cost_per_token": 6.6e-07,
+        "output_cost_per_token": 3.3e-06,
+        "cache_read_input_token_cost": 1.1e-07,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "supports_vision": True,
+    },
+    "azure_ai/FW-Kimi-K2.6": {
+        "input_cost_per_token": 1.045e-06,
+        "output_cost_per_token": 4.4e-06,
+        "cache_read_input_token_cost": 1.76e-07,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "supports_vision": True,
+    },
+    "azure_ai/FW-Kimi-K2.6-Code": {
+        "input_cost_per_token": 1.05e-06,
+        "output_cost_per_token": 4.4e-06,
+        "cache_read_input_token_cost": 2.1e-07,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "supports_vision": True,
+    },
+    "azure_ai/FW-Kimi-K2.7-Code": {
+        "input_cost_per_token": 1.05e-06,
+        "output_cost_per_token": 4.4e-06,
+        "cache_read_input_token_cost": 2.1e-07,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
+        "supports_vision": True,
+    },
+    "azure_ai/FW-Kimi-K3": {
+        "input_cost_per_token": 3.3e-06,
+        "output_cost_per_token": 1.65e-05,
+        "cache_read_input_token_cost": 3.3e-07,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+        "supports_vision": True,
+    },
+    "azure_ai/FW-DeepSeek-V3.2": {
+        "input_cost_per_token": 6.2e-07,
+        "output_cost_per_token": 1.85e-06,
+        "cache_read_input_token_cost": 3.1e-07,
+        "max_input_tokens": 163840,
+        "max_output_tokens": 163840,
+    },
+    "azure_ai/FW-DeepSeek-V4-Pro": {
+        "input_cost_per_token": 1.925e-06,
+        "output_cost_per_token": 3.828e-06,
+        "cache_read_input_token_cost": 1.65e-07,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 384000,
+    },
+    "azure_ai/FW-MiniMax-M3": {
+        "input_cost_per_token": 3.3e-07,
+        "output_cost_per_token": 1.32e-06,
+        "cache_read_input_token_cost": 6.6e-08,
+        "max_input_tokens": 512000,
+        "max_output_tokens": 512000,
+        "supports_vision": True,
+    },
+    "azure_ai/FW-MiniMax-M2.5": {
+        "input_cost_per_token": 3.3e-07,
+        "output_cost_per_token": 1.32e-06,
+        "cache_read_input_token_cost": 3.3e-08,
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 1000000,
+    },
+    "azure_ai/FW-GLM-5.2-Fast": {
+        "input_cost_per_token": 2.1e-06,
+        "output_cost_per_token": 6.6e-06,
+        "cache_read_input_token_cost": 2.1e-07,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+    },
+    "azure_ai/FW-GLM-5.2": {
+        "input_cost_per_token": 1.54e-06,
+        "output_cost_per_token": 4.84e-06,
+        "cache_read_input_token_cost": 1.5e-07,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 131072,
+    },
+    "azure_ai/FW-GLM-5.1": {
+        "input_cost_per_token": 1.54e-06,
+        "output_cost_per_token": 4.84e-06,
+        "cache_read_input_token_cost": 2.86e-07,
+        "max_input_tokens": 202800,
+        "max_output_tokens": 131072,
+    },
+    "azure_ai/FW-GLM-5": {
+        "input_cost_per_token": 1.1e-06,
+        "output_cost_per_token": 3.52e-06,
+        "cache_read_input_token_cost": 2.2e-07,
+        "max_input_tokens": 200000,
+        "max_output_tokens": 128000,
+    },
+}
+
+
+@pytest.fixture(scope="module")
+def use_local_model_cost_map():
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+
+    import litellm
+    from litellm.utils import _invalidate_model_cost_lowercase_map
+
+    original_model_cost = litellm.model_cost
+    litellm.model_cost = json.loads(
+        files("litellm")
+        .joinpath("model_prices_and_context_window_backup.json")
+        .read_text(encoding="utf-8")
+    )
+    litellm.get_model_info.cache_clear()
+    _invalidate_model_cost_lowercase_map()
+    try:
+        yield litellm
+    finally:
+        litellm.model_cost = original_model_cost
+        litellm.get_model_info.cache_clear()
+        _invalidate_model_cost_lowercase_map()
+        monkeypatch.undo()
+
+
+@pytest.mark.parametrize("model_key,expected", list(FW_MODELS.items()))
+def test_azure_ai_fw_model_info(use_local_model_cost_map, model_key, expected):
+    model_info = use_local_model_cost_map.get_model_info(model=model_key)
+
+    assert model_info["litellm_provider"] == "azure_ai"
+    assert model_info["mode"] == "chat"
+    assert model_info["input_cost_per_token"] == pytest.approx(expected["input_cost_per_token"])
+    assert model_info["output_cost_per_token"] == pytest.approx(expected["output_cost_per_token"])
+    assert model_info["cache_read_input_token_cost"] == pytest.approx(
+        expected["cache_read_input_token_cost"]
+    )
+    assert model_info["max_input_tokens"] == expected["max_input_tokens"]
+    assert model_info["max_output_tokens"] == expected["max_output_tokens"]
+    assert model_info["supports_function_calling"] is True
+    assert model_info["supports_reasoning"] is True
+    assert model_info["supports_tool_choice"] is True
+    assert model_info["supports_prompt_caching"] is True
+    if expected.get("supports_vision"):
+        assert model_info["supports_vision"] is True
+
+
+@pytest.mark.parametrize(
+    "model_name,expected_prompt,expected_completion",
+    [
+        ("FW-Kimi-K2.6", 1.045, 4.4),
+        ("FW-DeepSeek-V4-Pro", 1.925, 3.828),
+        ("FW-GLM-5.2", 1.54, 4.84),
+        ("FW-Kimi-K3", 3.3, 16.5),
+        ("FW-MiniMax-M2.5", 0.33, 1.32),
+    ],
+)
+def test_azure_ai_fw_cost_per_token(
+    use_local_model_cost_map, model_name, expected_prompt, expected_completion
+):
+    from litellm.llms.azure_ai.cost_calculator import cost_per_token
+    from litellm.types.utils import Usage
+
+    usage = Usage(
+        prompt_tokens=1_000_000,
+        completion_tokens=1_000_000,
+        total_tokens=2_000_000,
+    )
+
+    prompt_cost, completion_cost = cost_per_token(model=model_name, usage=usage)
+
+    assert prompt_cost == pytest.approx(expected_prompt)
+    assert completion_cost == pytest.approx(expected_completion)
+
+
+def test_azure_ai_fw_kimi_k26_case_insensitive_lookup(use_local_model_cost_map):
+    upper = use_local_model_cost_map.get_model_info(model="azure_ai/FW-Kimi-K2.6")
+    lower = use_local_model_cost_map.get_model_info(model="azure_ai/fw-kimi-k2.6")
+
+    assert upper["input_cost_per_token"] == pytest.approx(lower["input_cost_per_token"])
+    assert upper["output_cost_per_token"] == pytest.approx(lower["output_cost_per_token"])

--- a/tests/test_litellm/llms/azure_ai/test_azure_ai_fw_models_metadata.py
+++ b/tests/test_litellm/llms/azure_ai/test_azure_ai_fw_models_metadata.py
@@ -3,8 +3,8 @@ Regression tests for Azure AI Foundry Fireworks (FW-*) model cost map entries.
 
 Prices for Data Zone pay-per-token meters come from the Azure retail prices API
 (product "Azure Fireworks Models"). Kimi K3 rates come from the Microsoft Foundry
-announcement. GLM-5.2-Fast uses Fireworks serverless Fast rates when Azure does
-not publish a dedicated meter yet.
+announcement. Models without dedicated Azure meters use published Fireworks
+serverless rates.
 """
 
 import json
@@ -45,6 +45,13 @@ FW_MODELS = {
         "max_output_tokens": 131072,
         "supports_vision": True,
     },
+    "azure_ai/FW-Inkling": {
+        "input_cost_per_token": 1e-06,
+        "output_cost_per_token": 4.05e-06,
+        "cache_read_input_token_cost": 1.7e-07,
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 1048576,
+    },
     "azure_ai/FW-DeepSeek-V3.2": {
         "input_cost_per_token": 6.2e-07,
         "output_cost_per_token": 1.85e-06,
@@ -73,6 +80,13 @@ FW_MODELS = {
         "cache_read_input_token_cost": 3.3e-08,
         "max_input_tokens": 1000000,
         "max_output_tokens": 1000000,
+    },
+    "azure_ai/FW-Nemotron-3-Ultra-NVFP4": {
+        "input_cost_per_token": 6e-07,
+        "output_cost_per_token": 2.4e-06,
+        "cache_read_input_token_cost": 1.19e-07,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 262144,
     },
     "azure_ai/FW-GLM-5.2-Fast": {
         "input_cost_per_token": 2.1e-06,
@@ -160,6 +174,8 @@ def test_azure_ai_fw_model_info(use_local_model_cost_map, model_key, expected):
         ("FW-GLM-5.2", 1.54, 4.84),
         ("FW-Kimi-K3", 3.3, 16.5),
         ("FW-MiniMax-M2.5", 0.33, 1.32),
+        ("FW-Inkling", 1.0, 4.05),
+        ("FW-Nemotron-3-Ultra-NVFP4", 0.6, 2.4),
     ],
 )
 def test_azure_ai_fw_cost_per_token(

--- a/tests/test_litellm/llms/azure_ai/test_azure_ai_fw_models_metadata.py
+++ b/tests/test_litellm/llms/azure_ai/test_azure_ai_fw_models_metadata.py
@@ -29,14 +29,6 @@ FW_MODELS = {
         "max_output_tokens": 262144,
         "supports_vision": True,
     },
-    "azure_ai/FW-Kimi-K2.6-Code": {
-        "input_cost_per_token": 1.05e-06,
-        "output_cost_per_token": 4.4e-06,
-        "cache_read_input_token_cost": 2.1e-07,
-        "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
-        "supports_vision": True,
-    },
     "azure_ai/FW-Kimi-K2.7-Code": {
         "input_cost_per_token": 1.05e-06,
         "output_cost_per_token": 4.4e-06,

--- a/tests/test_litellm/llms/azure_ai/test_azure_ai_fw_models_metadata.py
+++ b/tests/test_litellm/llms/azure_ai/test_azure_ai_fw_models_metadata.py
@@ -143,6 +143,7 @@ def test_azure_ai_fw_model_info(use_local_model_cost_map, model_key, expected):
     )
     assert model_info["max_input_tokens"] == expected["max_input_tokens"]
     assert model_info["max_output_tokens"] == expected["max_output_tokens"]
+    assert model_info["max_tokens"] == expected["max_output_tokens"]
     assert model_info["supports_function_calling"] is True
     assert model_info["supports_reasoning"] is True
     assert model_info["supports_tool_choice"] is True


### PR DESCRIPTION
## TLDR

Fixes #26618

Problem this solves:

- Azure Fireworks (`FW-*`) models lacked cost-map entries, so spend tracking was wrong or zero
- Public Azure pricing only lists a subset of Fireworks catalog models

How it solves it:

- Adds `azure_ai/FW-*` pricing for the requested Fireworks-on-Foundry models
- Uses Azure Data Zone retail meters where published; Microsoft Foundry announcements or Fireworks rates for the rest
- Adds regression tests for `model_info` lookup and `cost_per_token`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Unit coverage pins prices from the cost map (no live Azure Fireworks deployment in this environment). After merge, register a deployment whose model ID is one of the `FW-*` catalog IDs and hit chat completions; spend should match the configured rates below

```bash
python -m pytest tests/test_litellm/llms/azure_ai/test_azure_ai_fw_models_metadata.py -q
# 22 passed
```

Example cost checks (1M input + 1M output tokens):

- `FW-Kimi-K2.6` -> $1.045 input + $4.40 output
- `FW-Kimi-K2.7-Code` -> $1.05 input + $4.40 output
- `FW-DeepSeek-V4-Pro` -> $1.925 input + $3.828 output
- `FW-Kimi-K3` -> $3.30 input + $16.50 output
- `FW-Inkling` -> $1.00 input + $4.05 output
- `FW-Nemotron-3-Ultra-NVFP4` -> $0.60 input + $2.40 output

Sources:

- https://azure.microsoft.com/en-us/pricing/details/ai-foundry-models/fireworks/
- Azure retail prices API product `Azure Fireworks Models` (Data Zone token meters)
- https://learn.microsoft.com/en-us/azure/foundry/how-to/fireworks/enable-fireworks-models
- https://techcommunity.microsoft.com/blog/azure-ai-foundry-blog/introducing-kimi-k3-through-fireworks-ai-on-microsoft-foundry/4540187
- https://docs.fireworks.ai/serverless/pricing
- https://fireworks.ai/models/fireworks/inkling
- https://fireworks.ai/models/fireworks/nemotron-3-ultra-nvfp4

## Type

🆕 New Feature

## Changes

Adds cost-map entries for Fireworks models hosted on Azure AI Foundry under the Microsoft model IDs (`azure_ai/FW-...`). Rates for models with published Azure Data Zone meters come from the Azure retail prices API (per-1K token meters converted to per-token). That covers Kimi K2.5 / K2.6 / K2.7 Code, DeepSeek V3.2 / V4 Pro, MiniMax M2.5 / M3, and GLM 5 / 5.1 / 5.2

`FW-Kimi-K3` uses the Microsoft Foundry announcement Data Zone rates ($3.30 / $0.33 cached / $16.50 per 1M). Models without dedicated Azure retail meters use their published Fireworks serverless rates: `FW-GLM-5.2-Fast` ($2.10 / $0.21 / $6.60), `FW-Inkling` ($1.00 / $0.17 / $4.05), and `FW-Nemotron-3-Ultra-NVFP4` ($0.60 / $0.119 / $2.40 per 1M input / cached input / output tokens)

Native Foundry models such as `azure_ai/kimi-k2.6` (without the `FW-` prefix) are unchanged and remain separate from Fireworks-hosted deployments
