### PR TITLE
fix(bedrock): drop strict/additionalProperties from toolSpec for Sonnet 4.6 and Haiku 4.5

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -725,6 +725,7 @@
         "prompt_cache_min_tokens": 2048
     },
     "anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
@@ -750,6 +751,7 @@
         "prompt_cache_min_tokens": 4096
     },
     "anthropic.claude-haiku-4-5@20251001": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
@@ -2197,6 +2199,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "anthropic.claude-sonnet-4-6": {
+        "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
@@ -2229,6 +2232,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "global.anthropic.claude-sonnet-4-6": {
+        "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
@@ -2261,6 +2265,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "us.anthropic.claude-sonnet-4-6": {
+        "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
@@ -2293,6 +2298,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "eu.anthropic.claude-sonnet-4-6": {
+        "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
@@ -2325,6 +2331,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "au.anthropic.claude-sonnet-4-6": {
+        "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
@@ -2357,6 +2364,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "jp.anthropic.claude-sonnet-4-6": {
+        "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
@@ -2682,6 +2690,7 @@
         "cache_creation_input_token_cost": 3.125e-07
     },
     "apac.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 1.1e-06,
@@ -15909,6 +15918,7 @@
         "prompt_cache_min_tokens": 2048
     },
     "eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_creation_input_token_cost_above_1hr": 2.2e-06,
         "cache_read_input_token_cost": 1.1e-07,
@@ -21908,6 +21918,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
@@ -26336,6 +26347,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_creation_input_token_cost_above_1hr": 2.2e-06,
         "cache_read_input_token_cost": 1.1e-07,
@@ -35002,6 +35014,7 @@
         "prompt_cache_min_tokens": 2048
     },
     "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_creation_input_token_cost_above_1hr": 2.2e-06,
         "cache_read_input_token_cost": 1.1e-07,
@@ -35218,6 +35231,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_creation_input_token_cost_above_1hr": 2.2e-06,
         "cache_read_input_token_cost": 1.1e-07,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -725,6 +725,7 @@
         "prompt_cache_min_tokens": 2048
     },
     "anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
@@ -750,6 +751,7 @@
         "prompt_cache_min_tokens": 4096
     },
     "anthropic.claude-haiku-4-5@20251001": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
@@ -2197,6 +2199,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "anthropic.claude-sonnet-4-6": {
+        "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
@@ -2229,6 +2232,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "global.anthropic.claude-sonnet-4-6": {
+        "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_creation_input_token_cost_above_1hr": 6e-06,
@@ -2261,6 +2265,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "us.anthropic.claude-sonnet-4-6": {
+        "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
@@ -2293,6 +2298,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "eu.anthropic.claude-sonnet-4-6": {
+        "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
@@ -2325,6 +2331,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "au.anthropic.claude-sonnet-4-6": {
+        "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
@@ -2357,6 +2364,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "jp.anthropic.claude-sonnet-4-6": {
+        "bedrock_converse_supports_strict_tools": false,
         "supports_adaptive_thinking": true,
         "cache_creation_input_token_cost": 4.125e-06,
         "cache_creation_input_token_cost_above_1hr": 6.6e-06,
@@ -2682,6 +2690,7 @@
         "cache_creation_input_token_cost": 3.125e-07
     },
     "apac.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_read_input_token_cost": 1.1e-07,
         "input_cost_per_token": 1.1e-06,
@@ -15909,6 +15918,7 @@
         "prompt_cache_min_tokens": 2048
     },
     "eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_creation_input_token_cost_above_1hr": 2.2e-06,
         "cache_read_input_token_cost": 1.1e-07,
@@ -21983,6 +21993,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.25e-06,
         "cache_creation_input_token_cost_above_1hr": 2e-06,
         "cache_read_input_token_cost": 1e-07,
@@ -26411,6 +26422,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_creation_input_token_cost_above_1hr": 2.2e-06,
         "cache_read_input_token_cost": 1.1e-07,
@@ -35093,6 +35105,7 @@
         "prompt_cache_min_tokens": 2048
     },
     "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_creation_input_token_cost_above_1hr": 2.2e-06,
         "cache_read_input_token_cost": 1.1e-07,
@@ -35309,6 +35322,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 1.375e-06,
         "cache_creation_input_token_cost_above_1hr": 2.2e-06,
         "cache_read_input_token_cost": 1.1e-07,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Claude Sonnet 4.6 and Haiku 4.5 on Bedrock Converse reject `toolSpec.strict`, producing a compiled-grammar error (>300MB) and a 504 Gateway Timeout for the caller
- LiteLLM has been forwarding `strict` and `additionalProperties` to these models since v1.90.0

How it solves it:

- Sets `bedrock_converse_supports_strict_tools: false` on all regional Bedrock Converse entries for Sonnet 4.6 and Haiku 4.5 (14 entries each file)
- Same fix pattern already applied for Opus 4.7/4.8 (#31923) and Sonnet 4 (#31943)

## Relevant issues

Closes #34388

## Type

- [x] Bug Fix

## Changes

- `model_prices_and_context_window.json` — add `bedrock_converse_supports_strict_tools: false` to 14 regional Bedrock entries for Sonnet 4.6 and Haiku 4.5
- `litellm/model_prices_and_context_window_backup.json` — same change to backup file
- `tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py` — extend existing regression tests to cover Sonnet 4.6 and Haiku 4.5; correct a wrong assertion that previously claimed Sonnet 4.6 keeps `strict` forwarded

## Testing

```bash
pytest tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py -v
# 43 passed (was 26 before this fix)
```

The 17 new test cases confirm:
- `strict` is dropped from `toolSpec` for all Sonnet 4.6 and Haiku 4.5 model IDs
- `additionalProperties` is dropped from the input schema for these models
- `bedrock_converse_supports_strict_tools` flag is correctly set in the model cost map
- The helper function `bedrock_converse_supports_strict_tools()` returns `False` for these models

## Screenshots / Proof of Fix

Before this fix, `_bedrock_tools_pt` with a strict tool and model `anthropic.claude-sonnet-4-6` returns:

```python
{'inputSchema': {'json': {'additionalProperties': False, ...}}, 'name': 'get_weather', 'strict': True}
# strict leaks through → Bedrock returns grammar-size error → 504 timeout
```

After this fix:

```python
{'inputSchema': {'json': {...}}, 'name': 'get_weather', 'description': '...'}
# strict and additionalProperties stripped → Bedrock accepts the request
```

## Pre-submission checklist

- [x] Tests added (17 new parametrized test cases in existing regression test file)
- [x] CI passes locally (`pytest` — 43 passed, 0 failed)
- [x] Scope isolated: extends existing fix pattern, no new abstractions
- [x] Both `model_prices_and_context_window.json` and backup file updated

## AI Assistance Disclosure

This contribution was AI-assisted using Hermes Agent (Nous Research).

Co-authored-by: Hermes Agent <hermes-agent@nousresearch.com>
