### PR TITLE
fix(ui): correct grammar on login default credentials hint

### DIFF
--- a/ui/litellm-dashboard/src/app/login/LoginPage.tsx
+++ b/ui/litellm-dashboard/src/app/login/LoginPage.tsx
@@ -194,9 +194,10 @@ function LoginPageContent() {
               description={
                 <>
                   <Paragraph className="text-sm">
-                    By default, Username is <code className="bg-gray-100 px-1 py-0.5 rounded-sm text-xs">admin</code>{" "}
-                    and Password is your set LiteLLM Proxy
-                    <code className="bg-gray-100 px-1 py-0.5 rounded-sm text-xs">MASTER_KEY</code>.
+                    By default, the username is{" "}
+                    <code className="bg-gray-100 px-1 py-0.5 rounded-sm text-xs">admin</code> and the password is the
+                    LiteLLM Proxy <code className="bg-gray-100 px-1 py-0.5 rounded-sm text-xs">MASTER_KEY</code> you
+                    set.
                   </Paragraph>
                   <Paragraph className="text-sm">
                     Need to set UI credentials or SSO?{" "}


### PR DESCRIPTION
## Summary
- Fixes awkward English on the Admin UI login page "Default Credentials" hint
- Before: `By default, Username is admin and Password is your set LiteLLM Proxy MASTER_KEY.`
- After: `By default, the username is admin and the password is the LiteLLM Proxy MASTER_KEY you set.`

## Why
The previous wording ("your set LiteLLM Proxy MASTER_KEY") is ungrammatical and reads like a literal translation. This is a copy-only change with no behavior change.

## Test plan
- [x] Diff-reviewed the string change in `ui/litellm-dashboard/src/app/login/LoginPage.tsx`
- [x] Visual check on `/ui/login` Default Credentials alert after UI build
- [x] Existing LoginPage unit tests still pass (`npm run test` in `ui/litellm-dashboard`)

## Notes
- UI-only string change; no new logic or components
- CLA: I will sign the CLA-assistant prompt if required on this PR