### PR TITLE
fix(ui): use LITELLM_UI_API_DOC_BASE_URL on MCP Connect docs

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_connect.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_connect.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MCPConnect from "./mcp_connect";
+import * as networking from "@/components/networking";
+
+vi.mock("@/components/networking", () => ({
+  getProxyBaseUrl: vi.fn().mockReturnValue("http://runtime-proxy.local:4000"),
+  getProxyUISettings: vi.fn(),
+}));
+
+function renderConnect() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MCPConnect accessToken="test-token" />
+    </QueryClientProvider>,
+  );
+}
+
+describe("MCPConnect", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(networking.getProxyBaseUrl).mockReturnValue("http://runtime-proxy.local:4000");
+  });
+
+  it("prefers LITELLM_UI_API_DOC_BASE_URL over PROXY_BASE_URL for Server URL snippets", async () => {
+    vi.mocked(networking.getProxyUISettings).mockResolvedValue({
+      PROXY_BASE_URL: "https://proxy.example.com",
+      PROXY_LOGOUT_URL: "",
+      LITELLM_UI_API_DOC_BASE_URL: "https://docs.example.com",
+    });
+
+    renderConnect();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("https://docs.example.com/mcp").length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText("https://proxy.example.com/mcp")).not.toBeInTheDocument();
+    expect(screen.queryByText("http://runtime-proxy.local:4000/mcp")).not.toBeInTheDocument();
+  });
+
+  it("falls back to PROXY_BASE_URL when docs URL is unset", async () => {
+    vi.mocked(networking.getProxyUISettings).mockResolvedValue({
+      PROXY_BASE_URL: "https://proxy.example.com",
+      PROXY_LOGOUT_URL: "",
+      LITELLM_UI_API_DOC_BASE_URL: null,
+    });
+
+    renderConnect();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("https://proxy.example.com/mcp").length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_connect.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_connect.tsx
@@ -4,8 +4,9 @@ import React, { useState } from "react";
 import { Card, Typography, Space, Alert, Button, Switch, Form, Collapse } from "antd";
 import { TabPanel, TabPanels, TabGroup, TabList, Tab, Title as TremorTitle, Text as TremorText } from "@tremor/react";
 import { CopyIcon, Code, Terminal, Globe, CheckIcon, ExternalLinkIcon, KeyIcon, ServerIcon, Zap } from "lucide-react";
-import { getProxyBaseUrl } from "@/components/networking";
+import useProxySettings from "@/app/(dashboard)/hooks/proxySettings/useProxySettings";
 import { copyToClipboard as utilCopyToClipboard } from "@/utils/dataUtils";
+import { resolveUiApiDocBaseUrl } from "@/utils/proxyUtils";
 
 const { Title, Text } = Typography;
 const { Panel } = Collapse;
@@ -111,11 +112,14 @@ const FeatureCard: React.FC<FeatureCardProps> = ({
 };
 
 interface MCPConnectProps {
+  accessToken: string | null;
   currentServerAccessGroups?: string[];
 }
 
-const MCPConnect: React.FC<MCPConnectProps> = ({ currentServerAccessGroups = [] }) => {
-  const proxyBaseUrl = getProxyBaseUrl();
+const MCPConnect: React.FC<MCPConnectProps> = ({ accessToken, currentServerAccessGroups = [] }) => {
+  const proxySettings = useProxySettings(accessToken);
+  // Prefer public docs base URL when set (LITELLM_UI_API_DOC_BASE_URL), not the runtime proxy URL.
+  const proxyBaseUrl = resolveUiApiDocBaseUrl(proxySettings);
   const [copiedStates, setCopiedStates] = useState<Record<string, boolean>>({});
   const [serverHeaders, setServerHeaders] = useState<Record<string, string[]>>({
     openai: [],

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_servers.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_servers.test.tsx
@@ -12,6 +12,11 @@ vi.mock("@/components/networking", () => ({
   fetchMCPServerHealth: vi.fn(),
   deleteMCPServer: vi.fn(),
   getProxyBaseUrl: vi.fn().mockReturnValue("http://localhost:4000"),
+  getProxyUISettings: vi.fn().mockResolvedValue({
+    PROXY_BASE_URL: "http://localhost:4000",
+    PROXY_LOGOUT_URL: "",
+    LITELLM_UI_API_DOC_BASE_URL: null,
+  }),
   fetchMCPClientIp: vi.fn().mockResolvedValue(null),
   getGeneralSettingsCall: vi.fn().mockResolvedValue([]),
   updateConfigFieldSetting: vi.fn().mockResolvedValue(undefined),

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_servers.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/mcp_servers.tsx
@@ -707,7 +707,7 @@ const MCPServers: React.FC<MCPServerProps> = ({ accessToken, userRole, userID })
             <MCPToolsetsTab accessToken={accessToken} userRole={userRole} />
           </TabsContent>
           <TabsContent value="connect">
-            <MCPConnect />
+            <MCPConnect accessToken={accessToken} />
           </TabsContent>
           {isAdminRole(userRole) && (
             <TabsContent value="semantic-filter">

--- a/ui/litellm-dashboard/src/utils/proxyUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/proxyUtils.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { fetchProxySettings } from "./proxyUtils";
-import { getProxyUISettings } from "@/components/networking";
+import { fetchProxySettings, resolveUiApiDocBaseUrl } from "./proxyUtils";
+import { getProxyBaseUrl, getProxyUISettings } from "@/components/networking";
 
 vi.mock("@/components/networking", () => ({
   getProxyUISettings: vi.fn(),
+  getProxyBaseUrl: vi.fn().mockReturnValue("http://runtime-proxy.example"),
 }));
 
 describe("fetchProxySettings", () => {
@@ -74,5 +75,34 @@ describe("fetchProxySettings", () => {
     expect(consoleSpy).toHaveBeenCalledWith("Error fetching proxy settings:", mockError);
 
     consoleSpy.mockRestore();
+  });
+});
+
+describe("resolveUiApiDocBaseUrl", () => {
+  beforeEach(() => {
+    vi.mocked(getProxyBaseUrl).mockReturnValue("http://runtime-proxy.example");
+  });
+
+  it("prefers LITELLM_UI_API_DOC_BASE_URL over PROXY_BASE_URL", () => {
+    expect(
+      resolveUiApiDocBaseUrl({
+        LITELLM_UI_API_DOC_BASE_URL: "https://docs.example.com",
+        PROXY_BASE_URL: "https://proxy.example.com",
+      }),
+    ).toBe("https://docs.example.com");
+  });
+
+  it("falls back to PROXY_BASE_URL when docs URL is empty", () => {
+    expect(
+      resolveUiApiDocBaseUrl({
+        LITELLM_UI_API_DOC_BASE_URL: "   ",
+        PROXY_BASE_URL: "https://proxy.example.com",
+      }),
+    ).toBe("https://proxy.example.com");
+  });
+
+  it("falls back to getProxyBaseUrl when settings are missing", () => {
+    expect(resolveUiApiDocBaseUrl(null)).toBe("http://runtime-proxy.example");
+    expect(getProxyBaseUrl).toHaveBeenCalled();
   });
 });

--- a/ui/litellm-dashboard/src/utils/proxyUtils.ts
+++ b/ui/litellm-dashboard/src/utils/proxyUtils.ts
@@ -16,10 +16,12 @@ export const fetchProxySettings = async (accessToken: string | null) => {
  * Resolve the base URL shown in UI docs/snippets.
  * Prefer LITELLM_UI_API_DOC_BASE_URL (public docs host) over PROXY_BASE_URL / runtime proxy.
  */
-export function resolveUiApiDocBaseUrl(proxySettings?: {
-  PROXY_BASE_URL?: string | null;
-  LITELLM_UI_API_DOC_BASE_URL?: string | null;
-} | null): string {
+export function resolveUiApiDocBaseUrl(
+  proxySettings?: {
+    PROXY_BASE_URL?: string | null;
+    LITELLM_UI_API_DOC_BASE_URL?: string | null;
+  } | null,
+): string {
   const customDocBaseUrl = proxySettings?.LITELLM_UI_API_DOC_BASE_URL?.trim();
   if (customDocBaseUrl) {
     return customDocBaseUrl;

--- a/ui/litellm-dashboard/src/utils/proxyUtils.ts
+++ b/ui/litellm-dashboard/src/utils/proxyUtils.ts
@@ -1,4 +1,4 @@
-import { getProxyUISettings } from "@/components/networking";
+import { getProxyBaseUrl, getProxyUISettings } from "@/components/networking";
 
 export const fetchProxySettings = async (accessToken: string | null) => {
   if (!accessToken) return null;
@@ -11,3 +11,22 @@ export const fetchProxySettings = async (accessToken: string | null) => {
     return null;
   }
 };
+
+/**
+ * Resolve the base URL shown in UI docs/snippets.
+ * Prefer LITELLM_UI_API_DOC_BASE_URL (public docs host) over PROXY_BASE_URL / runtime proxy.
+ */
+export function resolveUiApiDocBaseUrl(proxySettings?: {
+  PROXY_BASE_URL?: string | null;
+  LITELLM_UI_API_DOC_BASE_URL?: string | null;
+} | null): string {
+  const customDocBaseUrl = proxySettings?.LITELLM_UI_API_DOC_BASE_URL?.trim();
+  if (customDocBaseUrl) {
+    return customDocBaseUrl;
+  }
+  const proxyBaseFromSettings = proxySettings?.PROXY_BASE_URL?.trim();
+  if (proxyBaseFromSettings) {
+    return proxyBaseFromSettings;
+  }
+  return getProxyBaseUrl();
+}


### PR DESCRIPTION
## Summary
- Fixes #35583: MCP Servers **Connect** tab was using the runtime proxy base URL (`getProxyBaseUrl()`), so docs snippets ignored `LITELLM_UI_API_DOC_BASE_URL`.
- Prefer `LITELLM_UI_API_DOC_BASE_URL` → `PROXY_BASE_URL` → runtime proxy (same priority as Playground code snippets).

## Changes
- Add `resolveUiApiDocBaseUrl()` in `proxyUtils.ts` + unit tests
- Wire MCP Connect tab through proxy UI settings

## Test plan
- [x] `npx vitest run src/utils/proxyUtils.test.ts`
- [x] `npx vitest run src/app/(dashboard)/mcp-servers/_components/mcp_servers.test.tsx`
- [ ] UI: set both `PROXY_BASE_URL` and `LITELLM_UI_API_DOC_BASE_URL`, open `/ui/mcp-servers/` → Connect tab, confirm Server URL uses the docs base URL