### PR TITLE
fix(ui): ignore IME composition Enter in Playground inputs

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -77,6 +77,7 @@ import { A2ATaskMetadata, MessageType } from "@/components/chat_ui/types";
 import { useCodeInterpreter } from "../../hooks/useCodeInterpreter";
 import { useChatHistory } from "../../hooks/useChatHistory";
 import { getSecureItem, setSecureItem } from "@/utils/secureStorage";
+import { isSubmitEnterKey } from "@/utils/keyboardUtils";
 import { useDebouncedCallback } from "@tanstack/react-pacer/debouncer";
 
 const { TextArea } = Input;
@@ -485,7 +486,8 @@ const ChatUI: React.FC<ChatUIProps> = ({
   }, [chatHistory]);
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key === "Enter" && !event.shiftKey) {
+    // Skip while IME is composing (CJK candidate confirm also sends Enter)
+    if (isSubmitEnterKey(event)) {
       event.preventDefault(); // Prevent default to avoid newline
       handleSendMessage();
     }

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/RealtimePlayground.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/RealtimePlayground.tsx
@@ -4,6 +4,7 @@ import { AudioMutedOutlined, AudioOutlined, CloseCircleOutlined, SendOutlined, S
 import { Button, Input, Select, Typography } from "antd";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { getProxyBaseUrl } from "@/components/networking";
+import { isSubmitEnterKey } from "@/utils/keyboardUtils";
 import { OPEN_AI_VOICE_SELECT_OPTIONS } from "./chatConstants";
 
 const { Text } = Typography;
@@ -448,7 +449,11 @@ const RealtimePlayground: React.FC<RealtimePlaygroundProps> = ({
               placeholder="Type a message or use the mic..."
               value={inputText}
               onChange={(e) => setInputText(e.target.value)}
-              onPressEnter={sendTextMessage}
+              onPressEnter={(e) => {
+                if (isSubmitEnterKey(e)) {
+                  sendTextMessage();
+                }
+              }}
               className="flex-1"
               size="large"
             />

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/compareUI/components/MessageInput.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/compareUI/components/MessageInput.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Input, Button } from "antd";
 import { ArrowUpOutlined } from "@ant-design/icons";
+import { isSubmitEnterKey } from "@/utils/keyboardUtils";
 
 const { TextArea } = Input;
 
@@ -17,7 +18,7 @@ export function MessageInput({ value, onChange, onSend, disabled, hasAttachment,
   const canSend = !disabled && (value.trim().length > 0 || Boolean(hasAttachment));
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (isSubmitEnterKey(e)) {
       e.preventDefault();
       if (canSend) {
         onSend();

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/compareUI/components/ModelSelector.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/compareUI/components/ModelSelector.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { Select } from "antd";
 import { TextInput } from "@tremor/react";
+import { isSubmitEnterKey } from "@/utils/keyboardUtils";
 interface ModelSelectorProps {
   value: string;
   onChange: (value: string) => void;
@@ -74,7 +75,7 @@ export function ModelSelector({ value, onChange, models, loading, disabled }: Mo
           value={customValue}
           onValueChange={setCustomValue}
           onKeyDown={(event) => {
-            if (event.key === "Enter") {
+            if (isSubmitEnterKey(event)) {
               event.preventDefault();
               commitCustomValue();
             }

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/complianceUI/ComplianceUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/complianceUI/ComplianceUI.tsx
@@ -45,6 +45,7 @@ import {
 } from "lucide-react";
 import Papa from "papaparse";
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { isSubmitEnterKey } from "@/utils/keyboardUtils";
 
 const CATEGORY_ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
   lock: Lock,
@@ -522,7 +523,7 @@ export default function ComplianceUI({
   }, [accessToken, quickTestInput, selectedPolicies, selectedGuardrails, backendMode, fixedModel, requestProxyBaseUrl]);
 
   const handleQuickTestKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (isSubmitEnterKey(e)) {
       e.preventDefault();
       runQuickTest();
     }

--- a/ui/litellm-dashboard/src/utils/keyboardUtils.test.ts
+++ b/ui/litellm-dashboard/src/utils/keyboardUtils.test.ts
@@ -1,0 +1,39 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import { describe, expect, it } from "vitest";
+import { isSubmitEnterKey } from "./keyboardUtils";
+
+function makeEvent(overrides: {
+  key?: string;
+  shiftKey?: boolean;
+  isComposing?: boolean;
+  keyCode?: number;
+}): ReactKeyboardEvent {
+  return {
+    key: overrides.key ?? "Enter",
+    shiftKey: overrides.shiftKey ?? false,
+    keyCode: overrides.keyCode ?? 13,
+    nativeEvent: { isComposing: overrides.isComposing ?? false },
+  } as ReactKeyboardEvent;
+}
+
+describe("isSubmitEnterKey", () => {
+  it("returns true for plain Enter", () => {
+    expect(isSubmitEnterKey(makeEvent({}))).toBe(true);
+  });
+
+  it("returns false for Shift+Enter", () => {
+    expect(isSubmitEnterKey(makeEvent({ shiftKey: true }))).toBe(false);
+  });
+
+  it("returns false while IME is composing", () => {
+    expect(isSubmitEnterKey(makeEvent({ isComposing: true }))).toBe(false);
+  });
+
+  it("returns false for legacy IME Process keyCode 229", () => {
+    expect(isSubmitEnterKey(makeEvent({ keyCode: 229 }))).toBe(false);
+  });
+
+  it("returns false for non-Enter keys", () => {
+    expect(isSubmitEnterKey(makeEvent({ key: "a" }))).toBe(false);
+  });
+});

--- a/ui/litellm-dashboard/src/utils/keyboardUtils.ts
+++ b/ui/litellm-dashboard/src/utils/keyboardUtils.ts
@@ -1,0 +1,19 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+
+/**
+ * True when Enter should submit (not newline / not IME candidate confirm).
+ * IME composition uses Enter to accept candidates; treating that as submit
+ * breaks CJK input (Chinese / Japanese / Korean).
+ */
+export function isSubmitEnterKey(
+  event: Pick<ReactKeyboardEvent, "key" | "shiftKey" | "nativeEvent" | "keyCode">,
+): boolean {
+  if (event.key !== "Enter" || event.shiftKey) {
+    return false;
+  }
+  // During IME composition (or legacy keyCode 229 for Process key)
+  if (event.nativeEvent.isComposing || event.keyCode === 229) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- Fixes #33932: Playground treated IME candidate confirmation (Enter) as message submit for CJK input methods.
- Shared helper `isSubmitEnterKey` checks `nativeEvent.isComposing` and legacy `keyCode === 229`.

## Touched surfaces
- ChatUI message box
- Compare UI `MessageInput` + custom model name
- Compliance UI quick test
- Realtime playground text input

## Test plan
- [x] `npx vitest run src/utils/keyboardUtils.test.ts`
- [ ] Manual: Chinese Zhuyin/Pinyin IME — Enter confirms candidate without sending; second Enter (not composing) sends
- [ ] Shift+Enter still inserts newline where applicable