### PR TITLE
fix(ui): stable AI Hub feature pill colors by capability

### DIFF
--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.test.tsx
@@ -1,6 +1,8 @@
 import * as networking from "@/components/networking";
+import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen, waitFor } from "../../../tests/test-utils";
+import { getCapabilityBadgeColor } from "./capabilityColors";
 import ModelHubTable from "./ModelHubTable";
 
 const mockUseUISettings = vi.hoisted(() => vi.fn());
@@ -166,6 +168,48 @@ describe("ModelHubTable", () => {
 
     expect(await screen.findByText("No models yet")).toBeInTheDocument();
     expect(networking.modelHubCall).not.toHaveBeenCalled();
+  });
+
+  it("applies stable capability colors in the model detail modal", async () => {
+    const user = userEvent.setup();
+    const model = {
+      model_group: "gpt-4o",
+      providers: ["openai"],
+      supports_function_calling: true,
+      supports_vision: true,
+      supports_parallel_function_calling: false,
+      is_public_model_group: true,
+    };
+    vi.mocked(networking.modelHubCall).mockResolvedValue({ data: [model] });
+    vi.mocked(networking.getConfigFieldSetting).mockResolvedValue({ field_value: false });
+    vi.mocked(networking.getAgentsList).mockResolvedValue({ agents: [] });
+    vi.mocked(networking.fetchMCPServers).mockResolvedValue([]);
+    vi.mocked(networking.getUiSettings).mockResolvedValue({ values: {} });
+    mockUseUISettings.mockReturnValue({
+      data: { values: {} },
+      isLoading: false,
+    });
+
+    renderWithProviders(
+      <ModelHubTable accessToken="test-token" publicPage={false} premiumUser={false} userRole="proxy_admin" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("gpt-4o")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "gpt-4o" }));
+
+    const visionBadge = await screen.findByTestId("model-detail-capability-supports_vision");
+    const functionBadge = screen.getByTestId("model-detail-capability-supports_function_calling");
+    expect(visionBadge).toHaveAttribute("data-capability-color", getCapabilityBadgeColor("supports_vision"));
+    expect(functionBadge).toHaveAttribute(
+      "data-capability-color",
+      getCapabilityBadgeColor("supports_function_calling"),
+    );
+    expect(visionBadge.getAttribute("data-capability-color")).not.toBe(
+      functionBadge.getAttribute("data-capability-color"),
+    );
   });
 
   it("should call getUiConfig before modelHubPublicModelsCall when publicPage is true", async () => {

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
@@ -3,6 +3,7 @@ import MakeAgentPublicForm from "@/components/AIHub/forms/MakeAgentPublicForm";
 import MakeMCPPublicForm from "@/components/AIHub/forms/MakeMCPPublicForm";
 import MakeModelPublicForm from "@/components/AIHub/forms/MakeModelPublicForm";
 import { getMCPHubTableColumns, MCPServerData } from "@/components/AIHub/MCPHubTableColumns";
+import { getCapabilityBadgeColor } from "@/components/AIHub/capabilityColors";
 import { getModelHubTableColumns, ModelHubData } from "@/components/AIHub/ModelHubTableColumns";
 import UsefulLinksManagement from "@/components/AIHub/UsefulLinksManagement";
 import { getClaudeCodePluginsList } from "@/components/networking";
@@ -674,14 +675,13 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
               <div className="flex flex-wrap gap-2">
                 {(() => {
                   const capabilities = getModelCapabilities(selectedModel);
-                  const colors = ["green", "blue", "purple", "orange", "red", "yellow"];
 
                   if (capabilities.length === 0) {
                     return <Text className="text-gray-500">No special capabilities listed</Text>;
                   }
 
-                  return capabilities.map((capability, index) => (
-                    <Badge key={capability} color={colors[index % colors.length]}>
+                  return capabilities.map((capability) => (
+                    <Badge key={capability} color={getCapabilityBadgeColor(capability)}>
                       {formatCapabilityName(capability)}
                     </Badge>
                   ));

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTable.tsx
@@ -681,7 +681,12 @@ const ModelHubTable: React.FC<ModelHubTableProps> = ({ accessToken, publicPage, 
                   }
 
                   return capabilities.map((capability) => (
-                    <Badge key={capability} color={getCapabilityBadgeColor(capability)}>
+                    <Badge
+                      key={capability}
+                      color={getCapabilityBadgeColor(capability)}
+                      data-testid={`model-detail-capability-${capability}`}
+                      data-capability-color={getCapabilityBadgeColor(capability)}
+                    >
                       {formatCapabilityName(capability)}
                     </Badge>
                   ));

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTableColumns.test.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTableColumns.test.tsx
@@ -59,6 +59,23 @@ describe("getModelHubTableColumns", () => {
     expect(screen.queryByText("Parallel Function Calling")).not.toBeInTheDocument();
   });
 
+  it("uses the same color class for the same capability across rows", () => {
+    renderTable([
+      mockModel,
+      {
+        ...mockModel,
+        model_group: "gpt-4o-mini",
+        supports_vision: true,
+        supports_function_calling: false,
+      },
+    ]);
+    const visionBadges = screen.getAllByText("Vision");
+    expect(visionBadges.length).toBeGreaterThanOrEqual(2);
+    const classes = visionBadges.map((el) => el.getAttribute("class") || "");
+    expect(classes[0]).toBe(classes[1]);
+    expect(classes[0]).toContain("purple");
+  });
+
   it("shows the public status badge", () => {
     renderTable([mockModel]);
     expect(screen.getByText("Yes")).toBeInTheDocument();

--- a/ui/litellm-dashboard/src/components/AIHub/ModelHubTableColumns.tsx
+++ b/ui/litellm-dashboard/src/components/AIHub/ModelHubTableColumns.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/cva.config";
 import { copyToClipboard } from "@/utils/dataUtils";
+import { getCapabilityBadgeClassName } from "./capabilityColors";
 
 export interface ModelHubData {
   model_group: string;
@@ -200,7 +201,12 @@ export const getModelHubTableColumns = ({ onModelClick }: ModelHubTableColumnsDe
       return (
         <div className="flex flex-wrap gap-1">
           {capabilities.map((capability) => (
-            <Badge key={capability} variant="outline">
+            <Badge
+              key={capability}
+              variant="outline"
+              className={getCapabilityBadgeClassName(capability)}
+              data-capability={capability}
+            >
               {formatCapabilityName(capability)}
             </Badge>
           ))}

--- a/ui/litellm-dashboard/src/components/AIHub/capabilityColors.test.ts
+++ b/ui/litellm-dashboard/src/components/AIHub/capabilityColors.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { getCapabilityBadgeClassName, getCapabilityBadgeColor } from "./capabilityColors";
+
+describe("getCapabilityBadgeColor", () => {
+  it("maps the same capability to the same color regardless of order", () => {
+    const a = getCapabilityBadgeColor("supports_function_calling");
+    const b = getCapabilityBadgeColor("supports_function_calling");
+    expect(a).toBe(b);
+    expect(a).toBe("blue");
+  });
+
+  it("uses different stable colors for different known capabilities", () => {
+    expect(getCapabilityBadgeColor("supports_function_calling")).not.toBe(
+      getCapabilityBadgeColor("supports_vision"),
+    );
+  });
+
+  it("is stable for unknown capability keys (hash-based)", () => {
+    const key = "supports_custom_feature_xyz";
+    expect(getCapabilityBadgeColor(key)).toBe(getCapabilityBadgeColor(key));
+  });
+});
+
+describe("getCapabilityBadgeClassName", () => {
+  it("returns matching tailwind classes for a capability", () => {
+    const className = getCapabilityBadgeClassName("supports_vision");
+    expect(className).toContain("purple");
+  });
+});

--- a/ui/litellm-dashboard/src/components/AIHub/capabilityColors.test.ts
+++ b/ui/litellm-dashboard/src/components/AIHub/capabilityColors.test.ts
@@ -10,9 +10,7 @@ describe("getCapabilityBadgeColor", () => {
   });
 
   it("uses different stable colors for different known capabilities", () => {
-    expect(getCapabilityBadgeColor("supports_function_calling")).not.toBe(
-      getCapabilityBadgeColor("supports_vision"),
-    );
+    expect(getCapabilityBadgeColor("supports_function_calling")).not.toBe(getCapabilityBadgeColor("supports_vision"));
   });
 
   it("is stable for unknown capability keys (hash-based)", () => {

--- a/ui/litellm-dashboard/src/components/AIHub/capabilityColors.ts
+++ b/ui/litellm-dashboard/src/components/AIHub/capabilityColors.ts
@@ -1,0 +1,54 @@
+/** Stable Tremor badge colors for AI Hub capability pills. */
+export const CAPABILITY_BADGE_COLORS = ["blue", "purple", "orange", "green", "rose", "amber", "cyan", "indigo"] as const;
+
+export type CapabilityBadgeColor = (typeof CAPABILITY_BADGE_COLORS)[number];
+
+/** Preferred colors for well-known capabilities (stable across rows). */
+const KNOWN_CAPABILITY_COLORS: Record<string, CapabilityBadgeColor> = {
+  supports_function_calling: "blue",
+  supports_parallel_function_calling: "indigo",
+  supports_vision: "purple",
+  supports_prompt_caching: "green",
+  supports_response_schema: "cyan",
+  supports_system_messages: "amber",
+  supports_tool_choice: "blue",
+  supports_assistant_prefill: "orange",
+  supports_audio_input: "rose",
+  supports_audio_output: "rose",
+  supports_pdf_input: "orange",
+  supports_reasoning: "amber",
+  supports_web_search: "cyan",
+};
+
+function hashCapability(key: string): number {
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+/** Same capability key always maps to the same color (not position-based). */
+export function getCapabilityBadgeColor(capabilityKey: string): CapabilityBadgeColor {
+  const known = KNOWN_CAPABILITY_COLORS[capabilityKey];
+  if (known) {
+    return known;
+  }
+  return CAPABILITY_BADGE_COLORS[hashCapability(capabilityKey) % CAPABILITY_BADGE_COLORS.length];
+}
+
+/** Tailwind classes for shadcn/ui Badge when Tremor color props are unavailable. */
+export const CAPABILITY_BADGE_CLASS: Record<CapabilityBadgeColor, string> = {
+  blue: "border-blue-200 bg-blue-50 text-blue-800",
+  purple: "border-purple-200 bg-purple-50 text-purple-800",
+  orange: "border-orange-200 bg-orange-50 text-orange-800",
+  green: "border-green-200 bg-green-50 text-green-800",
+  rose: "border-rose-200 bg-rose-50 text-rose-800",
+  amber: "border-amber-200 bg-amber-50 text-amber-900",
+  cyan: "border-cyan-200 bg-cyan-50 text-cyan-800",
+  indigo: "border-indigo-200 bg-indigo-50 text-indigo-800",
+};
+
+export function getCapabilityBadgeClassName(capabilityKey: string): string {
+  return CAPABILITY_BADGE_CLASS[getCapabilityBadgeColor(capabilityKey)];
+}

--- a/ui/litellm-dashboard/src/components/AIHub/capabilityColors.ts
+++ b/ui/litellm-dashboard/src/components/AIHub/capabilityColors.ts
@@ -1,5 +1,14 @@
 /** Stable Tremor badge colors for AI Hub capability pills. */
-export const CAPABILITY_BADGE_COLORS = ["blue", "purple", "orange", "green", "rose", "amber", "cyan", "indigo"] as const;
+export const CAPABILITY_BADGE_COLORS = [
+  "blue",
+  "purple",
+  "orange",
+  "green",
+  "rose",
+  "amber",
+  "cyan",
+  "indigo",
+] as const;
 
 export type CapabilityBadgeColor = (typeof CAPABILITY_BADGE_COLORS)[number];
 


### PR DESCRIPTION
## Summary
- Fixes #34231: AI Hub Features pills used position-based colors, so the same capability looked different across model rows.
- Color is now derived from the capability key (known map + stable hash fallback).

## Changes
- `capabilityColors.ts` helper + unit tests
- Features column in model hub table
- Capabilities section in model detail modal

## Test plan
- [x] `npx vitest run src/components/AIHub/capabilityColors.test.ts src/components/AIHub/ModelHubTableColumns.test.tsx`
- [ ] UI: open `/ui/model-hub-table/`, confirm Function calling / Vision / Reasoning keep the same pill color on every row