### PR TITLE
fix(router): handle embedding batches in token checks

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10145,6 +10145,9 @@ class Router:
         if messages is not None:
             return litellm.token_counter(messages=messages)
         if input is not None:
+            if isinstance(input, list) and all(isinstance(item, str) for item in input):
+                return litellm.token_counter(text=input)
+
             from openai.types.responses.response_create_params import ResponseInputParam
 
             from litellm.responses.litellm_completion_transformation.transformation import (

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -2977,10 +2977,14 @@ def test_count_pre_call_check_tokens_across_api_surfaces():
     list_input_tokens = router._count_pre_call_check_tokens(
         messages=None, input=[{"role": "user", "content": "hello world"}]
     )
+    embedding_batch_tokens = router._count_pre_call_check_tokens(
+        messages=None, input=["first document", "second document"]
+    )
 
     assert messages_tokens > 0
     assert string_input_tokens > 0
     assert list_input_tokens > 0
+    assert embedding_batch_tokens > 0
 
     with pytest.raises(ValueError):
         router._count_pre_call_check_tokens(messages=None, input=None)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Embedding batches pass through Responses message transformation
- `list[str]` input can fail before token counting

How it solves it:

- Count string batches through LiteLLM text tokenization
- Preserve Responses-item transformation for structured input

## Relevant issues

Fixes #35626

## Linear ticket


## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks; bootstrap was blocked by disk space while downloading Playwright
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5

## Screenshots / Proof of Fix

`python3 -m py_compile litellm/router.py tests/test_litellm/test_router.py` passed
`git diff --check` passed
The focused pytest suite could not run because the repository bootstrap exhausted the host filesystem while downloading Playwright

## Type

🐛 Bug Fix

## Changes

`Router._count_pre_call_check_tokens` now sends embedding-style `list[str]` input directly to the existing text token counter instead of treating it as Responses API items. Added regression coverage for a string batch.

## Final Attestation

- [x] The regression test exercises the reported list-of-strings input shape
