### PR TITLE
fix(router): preserve disabled pre-call checks

### DIFF
--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -128,6 +128,7 @@ class UpdateRouterConfig(BaseModel):
     fallbacks: Optional[List[dict]] = None
     context_window_fallbacks: Optional[List[dict]] = None
     model_group_alias: Optional[Dict[str, Union[str, Dict]]] = {}
+    enable_pre_call_checks: Optional[bool] = None
     enable_tag_filtering: Optional[bool] = None
 
     model_config = ConfigDict(protected_namespaces=())

--- a/tests/test_litellm/test_router_retry_policy_update.py
+++ b/tests/test_litellm/test_router_retry_policy_update.py
@@ -66,6 +66,12 @@ def test_update_router_config_accepts_retry_policy_payload():
     assert dumped["retry_policy"]["TimeoutErrorRetries"] == 3
 
 
+def test_update_router_config_preserves_disabled_pre_call_checks():
+    config = UpdateRouterConfig(enable_pre_call_checks=False)
+
+    assert config.model_dump(exclude_none=True)["enable_pre_call_checks"] is False
+
+
 def test_update_router_config_rejects_malformed_retry_policy():
     """The field is typed as RetryPolicy, so /config/update validates the
     payload at the boundary and rejects non-numeric counts with a 422 instead

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -32870,6 +32870,8 @@ export interface components {
             }[] | null;
             /** Cooldown Time */
             cooldown_time?: number | null;
+            /** Enable Pre Call Checks */
+            enable_pre_call_checks?: boolean | null;
             /** Enable Tag Filtering */
             enable_tag_filtering?: boolean | null;
             /** Fallbacks */


### PR DESCRIPTION
## TLDR

Problem this solves:

- Disabling pre-call checks is dropped during config validation

How it solves it:

- Declares the setting in the router update schema
- Regenerates dashboard API types and adds regression coverage

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

## Type

Bug Fix

## Changes

`UpdateRouterConfig` now preserves `enable_pre_call_checks=false` instead of letting Pydantic discard it during `/config/update` validation

The generated dashboard API schema exposes the same optional field, and a regression test verifies that `False` survives `model_dump(exclude_none=True)`

## Validation

`uv run --no-sync pytest tests/test_litellm/test_router_retry_policy_update.py -q` passed with 11 tests

`make pre-commit` passed against `litellm_internal_staging`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
