### PR TITLE
fix: correct Bedrock Claude 3.5 Sonnet context window (1M -> 200k)

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -778,7 +778,7 @@
     "anthropic.claude-3-5-sonnet-20240620-v1:0": {
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
-        "max_input_tokens": 1000000,
+        "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
@@ -788,10 +788,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "input_cost_per_token_above_200k_tokens": 6e-06,
-        "output_cost_per_token_above_200k_tokens": 3e-05,
-        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
-        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07
     },
@@ -800,7 +796,7 @@
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
-        "max_input_tokens": 1000000,
+        "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
@@ -812,11 +808,7 @@
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "input_cost_per_token_above_200k_tokens": 6e-06,
-        "output_cost_per_token_above_200k_tokens": 3e-05,
-        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
-        "cache_read_input_token_cost_above_200k_tokens": 6e-07
+        "supports_vision": true
     },
     "anthropic.claude-3-7-sonnet-20240620-v1:0": {
         "cache_creation_input_token_cost": 4.5e-06,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -778,7 +778,7 @@
     "anthropic.claude-3-5-sonnet-20240620-v1:0": {
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
-        "max_input_tokens": 1000000,
+        "max_input_tokens": 200000,
         "max_output_tokens": 4096,
         "max_tokens": 4096,
         "mode": "chat",
@@ -788,10 +788,6 @@
         "supports_response_schema": true,
         "supports_tool_choice": true,
         "supports_vision": true,
-        "input_cost_per_token_above_200k_tokens": 6e-06,
-        "output_cost_per_token_above_200k_tokens": 3e-05,
-        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
-        "cache_read_input_token_cost_above_200k_tokens": 6e-07,
         "cache_creation_input_token_cost": 3.75e-06,
         "cache_read_input_token_cost": 3e-07
     },
@@ -800,7 +796,7 @@
         "cache_read_input_token_cost": 3e-07,
         "input_cost_per_token": 3e-06,
         "litellm_provider": "bedrock",
-        "max_input_tokens": 1000000,
+        "max_input_tokens": 200000,
         "max_output_tokens": 8192,
         "max_tokens": 8192,
         "mode": "chat",
@@ -812,11 +808,7 @@
         "supports_prompt_caching": true,
         "supports_response_schema": true,
         "supports_tool_choice": true,
-        "supports_vision": true,
-        "input_cost_per_token_above_200k_tokens": 6e-06,
-        "output_cost_per_token_above_200k_tokens": 3e-05,
-        "cache_creation_input_token_cost_above_200k_tokens": 7.5e-06,
-        "cache_read_input_token_cost_above_200k_tokens": 6e-07
+        "supports_vision": true
     },
     "anthropic.claude-3-7-sonnet-20240620-v1:0": {
         "cache_creation_input_token_cost": 4.5e-06,

--- a/tests/test_litellm/test_bedrock_claude_3_5_sonnet_model_metadata.py
+++ b/tests/test_litellm/test_bedrock_claude_3_5_sonnet_model_metadata.py
@@ -1,0 +1,78 @@
+import json
+from pathlib import Path
+
+import pytest
+
+BEDROCK_CLAUDE_3_5_SONNET_MODELS = [
+    "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "anthropic.claude-3-5-sonnet-20241022-v2:0",
+]
+
+REGIONAL_PREFIXES = ["us.", "eu.", "apac."]
+
+ABOVE_200K_FIELDS = [
+    "input_cost_per_token_above_200k_tokens",
+    "output_cost_per_token_above_200k_tokens",
+    "cache_creation_input_token_cost_above_200k_tokens",
+    "cache_read_input_token_cost_above_200k_tokens",
+]
+
+
+def _load(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+@pytest.mark.parametrize("model", BEDROCK_CLAUDE_3_5_SONNET_MODELS)
+def test_bedrock_claude_3_5_sonnet_context_window(model):
+    """Claude 3.5 Sonnet has a 200k context window on Bedrock."""
+    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    model_cost = _load(json_path)
+
+    info = model_cost.get(model)
+    assert (
+        info is not None
+    ), f"{model} not found in model_prices_and_context_window.json"
+
+    assert info["litellm_provider"] == "bedrock"
+    assert info["max_input_tokens"] == 200000
+
+
+@pytest.mark.parametrize("model", BEDROCK_CLAUDE_3_5_SONNET_MODELS)
+def test_bedrock_claude_3_5_sonnet_has_no_long_context_tier(model):
+    """There is no >200k pricing tier for Claude 3.5 Sonnet."""
+    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    info = _load(json_path)[model]
+
+    present = [field for field in ABOVE_200K_FIELDS if field in info]
+    assert not present, f"{model} should not carry >200k pricing fields: {present}"
+
+
+@pytest.mark.parametrize("model", BEDROCK_CLAUDE_3_5_SONNET_MODELS)
+def test_bedrock_claude_3_5_sonnet_matches_regional_profiles(model):
+    """The base entry and its regional copies describe the same model."""
+    json_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    model_cost = _load(json_path)
+    info = model_cost[model]
+
+    for prefix in REGIONAL_PREFIXES:
+        regional = model_cost.get(prefix + model)
+        if regional is None:
+            continue
+        assert (
+            regional["max_input_tokens"] == info["max_input_tokens"]
+        ), f"{prefix + model} and {model} disagree on max_input_tokens"
+
+
+@pytest.mark.parametrize("model", BEDROCK_CLAUDE_3_5_SONNET_MODELS)
+def test_bedrock_claude_3_5_sonnet_backup_matches_main(model):
+    """Ensure the bundled model cost map stays in sync with the canonical file."""
+    repo_root = Path(__file__).parents[2]
+    main_cost = _load(repo_root / "model_prices_and_context_window.json")
+    backup_cost = _load(
+        repo_root / "litellm" / "model_prices_and_context_window_backup.json"
+    )
+
+    assert backup_cost.get(model) == main_cost.get(
+        model
+    ), f"{model} differs between main and backup model cost maps"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Claude 3.5 Sonnet is listed with a 1M context window
- Claude 3.5 Sonnet is 200k; the regional copies of the same model say 200k
- It also carries a >200k pricing tier the model has no access to

How it solves it:

- Set `max_input_tokens` back to 200000 on both `anthropic.claude-3-5-sonnet-*` entries
- Dropped the four `*_above_200k_tokens` fields from those entries
- Added metadata tests pinning the value and the base/regional agreement

## Relevant issues

<!-- none filed -->

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Two entries claim a 1M context window for Claude 3.5 Sonnet:

```
anthropic.claude-3-5-sonnet-20240620-v1:0             1000000
anthropic.claude-3-5-sonnet-20241022-v2:0             1000000
```

Every other entry in the file for the same two models says 200000, including the regional
copies that are otherwise byte-for-byte equivalent:

```
apac.anthropic.claude-3-5-sonnet-20240620-v1:0         200000
eu.anthropic.claude-3-5-sonnet-20240620-v1:0           200000
us.anthropic.claude-3-5-sonnet-20240620-v1:0           200000
bedrock/invoke/anthropic.claude-3-5-sonnet-20240620-v1:0   200000
bedrock/us-gov-east-1/anthropic.claude-3-5-sonnet-20240620-v1:0  200000
vertex_ai/claude-3-5-sonnet@20240620                   200000
openrouter/anthropic/claude-3.5-sonnet                 200000
... (19 entries in total, all 200000)
```

Alongside the inflated window, both entries picked up `input_cost_per_token_above_200k_tokens`,
`output_cost_per_token_above_200k_tokens` and the two matching cache fields. Claude 3.5 Sonnet
has no long-context tier, and none of the 19 other entries for it carry those fields — this
looks like the 1M tier from a Sonnet 4 entry landing on the wrong two keys.

The practical effect is on context-window handling: with `max_input_tokens` at 1M, a proxy or
router using `context_window_fallbacks` believes it can send 1M tokens to Claude 3.5 Sonnet on
Bedrock, so oversized requests go out and fail at Bedrock instead of falling back — but only
if the caller used the bare `anthropic.` id, since `us.`/`eu.`/`apac.` behave correctly.

**Before** (`491eda3`):

```
$ LITELLM_LOCAL_MODEL_COST_MAP=True python -c "..."
bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0     max_input_tokens=1,000,000  >200k tiers=4
bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0     max_input_tokens=1,000,000  >200k tiers=4
bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0  max_input_tokens=  200,000  >200k tiers=0
bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0  max_input_tokens=  200,000  >200k tiers=0
```

**After** (`491eda3` + this PR):

```
bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0     max_input_tokens=  200,000  >200k tiers=0
bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0     max_input_tokens=  200,000  >200k tiers=0
bedrock/us.anthropic.claude-3-5-sonnet-20240620-v1:0  max_input_tokens=  200,000  >200k tiers=0
bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0  max_input_tokens=  200,000  >200k tiers=0
```

The phantom tier is live in cost calculation too — two ids for the same model disagree by 2x
once a request is priced above 200k:

```python
from litellm import cost_per_token
cost_per_token(model=..., prompt_tokens=300_000, completion_tokens=1_000)
```

```
before  bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0     $1.8000
        bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0  $0.9000
after   both                                                  $0.9000
```

(That call can't happen against the real model at 300k tokens — it's there to show the tier is
reachable in the pricing path, not just inert metadata.)

Both `model_prices_and_context_window.json` and
`litellm/model_prices_and_context_window_backup.json` are updated; the two entries were already
identical between the files and still are.

Tests (`tests/test_litellm/test_bedrock_claude_3_5_sonnet_model_metadata.py`):

```
8 passed
```

With the test file kept and the two JSON files reverted, 6 of the 8 fail (the two that pass
either way are the main/backup sync checks).

## Type

🐛 Bug Fix

---

Written with AI assistance (Claude Code); I reviewed the change and ran everything above.
