### PR TITLE
fix(vertex_ai): keep all embeddings in multimodal embedding response

### DIFF
--- a/litellm/llms/vertex_ai/multimodal_embeddings/transformation.py
+++ b/litellm/llms/vertex_ai/multimodal_embeddings/transformation.py
@@ -287,14 +287,14 @@ class VertexAIMultimodalEmbeddingConfig(BaseEmbeddingConfig):
                             object="embedding",
                         )
                         openai_embeddings.append(openai_embedding_object)
-                    elif "imageEmbedding" in _prediction:
+                    if "imageEmbedding" in _prediction:
                         openai_embedding_object = Embedding(
                             embedding=_prediction["imageEmbedding"],
                             index=idx,
                             object="embedding",
                         )
                         openai_embeddings.append(openai_embedding_object)
-                    elif "videoEmbeddings" in _prediction:
+                    if "videoEmbeddings" in _prediction:
                         for video_embedding in _prediction["videoEmbeddings"]:
                             openai_embedding_object = Embedding(
                                 embedding=video_embedding["embedding"],

--- a/tests/local_testing/test_amazing_vertex_completion.py
+++ b/tests/local_testing/test_amazing_vertex_completion.py
@@ -1880,8 +1880,9 @@ async def test_vertexai_multimodal_embedding():
 
         assert args_to_vertexai == expected_payload
         assert response.model == "multimodalembedding@001"
-        assert len(response.data) == 1
-        response_data = response.data[0]
+        assert len(response.data) == 2
+        assert response.data[0]["embedding"] == [0.4, 0.5, 0.6]
+        assert response.data[1]["embedding"] == [0.1, 0.2, 0.3]
 
         # Optional: Print for debugging
         print("Arguments passed to Vertex AI:", args_to_vertexai)

--- a/tests/test_litellm/llms/vertex_ai/multimodal_embeddings/test_vertex_ai_multimodal_embedding_transformation.py
+++ b/tests/test_litellm/llms/vertex_ai/multimodal_embeddings/test_vertex_ai_multimodal_embedding_transformation.py
@@ -179,3 +179,49 @@ class TestVertexMultimodalEmbedding:
             headers={},
         )
         assert "parameters" not in request
+
+    def test_response_keeps_both_text_and_image_embeddings(self):
+        predictions = {
+            "predictions": [
+                {
+                    "textEmbedding": [0.4, 0.5, 0.6],
+                    "imageEmbedding": [0.1, 0.2, 0.3],
+                }
+            ]
+        }
+        result = self.config.transform_embedding_response_to_openai(predictions)
+        assert [e["embedding"] for e in result] == [[0.4, 0.5, 0.6], [0.1, 0.2, 0.3]]
+        assert [e["index"] for e in result] == [0, 0]
+
+    def test_response_keeps_text_and_video_embeddings(self):
+        predictions = {
+            "predictions": [
+                {
+                    "textEmbedding": [0.4, 0.5, 0.6],
+                    "videoEmbeddings": [
+                        {
+                            "startOffsetSec": 0,
+                            "endOffsetSec": 5,
+                            "embedding": [0.7, 0.8, 0.9],
+                        }
+                    ],
+                }
+            ]
+        }
+        result = self.config.transform_embedding_response_to_openai(predictions)
+        assert [e["embedding"] for e in result] == [[0.4, 0.5, 0.6], [0.7, 0.8, 0.9]]
+
+    @pytest.mark.parametrize(
+        "prediction, expected",
+        [
+            ({"textEmbedding": [0.1, 0.2]}, [[0.1, 0.2]]),
+            ({"imageEmbedding": [0.3, 0.4]}, [[0.3, 0.4]]),
+            (
+                {"videoEmbeddings": [{"startOffsetSec": 0, "endOffsetSec": 5, "embedding": [0.5]}]},
+                [[0.5]],
+            ),
+        ],
+    )
+    def test_response_single_modality_unchanged(self, prediction, expected):
+        result = self.config.transform_embedding_response_to_openai({"predictions": [prediction]})
+        assert [e["embedding"] for e in result] == expected


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex returns `textEmbedding` and `imageEmbedding` in the same prediction
- An `elif` chain kept only the first one
- Image + caption embedding silently degrades to text-only, with HTTP 200

How it solves it:

- Emit every embedding present, instead of only the first match
- `data[0]` stays the text embedding, so existing callers are unaffected
- Adds regression tests for predictions carrying two embeddings

## Relevant issues

None filed; found while smoke-testing `multimodalembedding@001`.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (5/5)

Ran locally: `pytest tests/test_litellm/llms/vertex_ai/` (38 failed / 1224 passed, identical 38 pre-existing failures on unmodified `main`, +5 from this PR), and `ruff format --check` / `ruff check` on the changed files (no new findings; two pre-existing `ruff check` findings removed). CI is green: 75 pass, 1 fail. The single failure is `osv-scan`, reporting three `cryptography 48.0.1` CVEs in `uv.lock`. `uv.lock` is byte-identical between this branch and the base, and `cryptography 48.0.1` is already pinned on the base, so the finding predates this PR and is unrelated to it.

## Screenshots / Proof of Fix

End-to-end against real Vertex AI (`multimodalembedding@001`, `us-central1`, live billed calls — project id redacted, private deployment). One instance carrying both an image and text:

```python
litellm.embedding(
    model="vertex_ai/multimodalembedding@001",
    input=[{"image": {"bytesBase64Encoded": b64}, "text": "a red and blue checkerboard"}],
    vertex_project=..., vertex_location="us-central1",
)
```

**Before** — base `litellm_internal_staging` @ `491eda3`, the image embedding is gone:

```
len(response.data) = 1
  index=0 dim=1408 head=[0.0335, -0.0447, -0.0139]
```

**After** — this PR @ `f22e9b0`, both are returned and `data[0]` is byte-for-byte the previous value:

```
len(response.data) = 2
  index=0 dim=1408 head=[0.0335, -0.0447, -0.0139]
  index=0 dim=1408 head=[0.042, 0.1063, -0.0355]
```

The raw Vertex `:predict` response for that same instance confirms both were always being sent back and then discarded:

```
prediction keys: ['imageEmbedding', 'textEmbedding']
  textEmbedding: dim=1408
  imageEmbedding: dim=1408
```

The dropped vector is not recoverable from the returned one: cosine similarity between the image and text embeddings of the same instance is `0.274`. Callers doing image + caption embedding silently receive a pure text embedding today, while `usage.prompt_tokens_details` still reports `image_count: 1`, i.e. the image is uploaded and billed before being thrown away.

## Type

🐛 Bug Fix

## Changes

`transform_embedding_response_to_openai` chained `textEmbedding` / `imageEmbedding` / `videoEmbeddings` with `elif`, so a prediction containing more than one embedding lost all but the first. `MultimodalPrediction` is a `total=False` TypedDict with all three fields optional, so carrying several at once is already the expected shape. The branches are now independent `if`s.

`index` is left as the prediction index for every embedding of that prediction, matching the existing `videoEmbeddings` branch, which already emits multiple entries sharing one index.

Tests:

- `tests/test_litellm/.../test_vertex_ai_multimodal_embedding_transformation.py`: new cases for text+image and text+video predictions, plus a parametrized check that single-modality predictions are unchanged. The two multi-embedding cases fail on `main` and pass here; the single-modality ones pass either way.
- `tests/local_testing/test_amazing_vertex_completion.py`: `test_vertexai_multimodal_embedding` mocks a prediction holding both `imageEmbedding` and `textEmbedding` but asserted `len(response.data) == 1`, pinning the bug. It is `@pytest.mark.skip`-ped, which is why this went unnoticed. Updated to assert both vectors.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)





