### PR TITLE
fix(anthropic): preserve tools with structured output

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -545,9 +545,6 @@ class ModelResponseIterator:
         # Generate response ID once per stream to match OpenAI-compatible behavior
         self.response_id = _generate_id()
 
-        # Anthropic content blocks can be interleaved. Keep response-format
-        # tracking per block so a json_tool_call cannot hide a real tool's
-        # argument deltas in another block.
         self._is_response_format_tool_by_content_block_index: Dict[int, bool] = {}
         # Track if we've converted any response_format tools (affects finish_reason)
         self.converted_response_format_tool: bool = False

--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -545,8 +545,10 @@ class ModelResponseIterator:
         # Generate response ID once per stream to match OpenAI-compatible behavior
         self.response_id = _generate_id()
 
-        # Track if we're currently streaming a response_format tool
-        self.is_response_format_tool: bool = False
+        # Anthropic content blocks can be interleaved. Keep response-format
+        # tracking per block so a json_tool_call cannot hide a real tool's
+        # argument deltas in another block.
+        self._is_response_format_tool_by_content_block_index: Dict[int, bool] = {}
         # Track if we've converted any response_format tools (affects finish_reason)
         self.converted_response_format_tool: bool = False
 
@@ -770,6 +772,7 @@ class ModelResponseIterator:
 
             # Always use index=0 for OpenAI choice format (fixes multi-choice errors)
             index = 0
+            content_block_index = int(chunk.get("index", 0))
             if type_chunk == "content_block_delta":
                 """
                 Anthropic content chunk
@@ -816,6 +819,9 @@ class ModelResponseIterator:
                         ),
                         index=self.tool_index,
                     )
+                    self._is_response_format_tool_by_content_block_index[
+                        content_block_index
+                    ] = _stream_tool_name == RESPONSE_FORMAT_TOOL_NAME
                     # Track server tool use inputs for code_interpreter_results.
                     # The initial input in content_block_start is typically {}
                     # for streaming; the full input arrives via input_json_delta
@@ -903,8 +909,6 @@ class ModelResponseIterator:
                             except (json.JSONDecodeError, TypeError):
                                 pass
                         self._current_server_tool_id = None
-                # Reset response_format tool tracking when block stops
-                self.is_response_format_tool = False
                 # Reset current content block type
                 self.current_content_block_type = None
             elif type_chunk == "tool_result":
@@ -956,7 +960,16 @@ class ModelResponseIterator:
                     status_code=500,  # it looks like Anthropic API does not return a status code in the chunk error - default to 500
                 )
 
-            text, tool_use = self._handle_json_mode_chunk(text=text, tool_use=tool_use)
+            text, tool_use = self._handle_json_mode_chunk(
+                text=text,
+                tool_use=tool_use,
+                content_block_index=content_block_index,
+            )
+
+            if type_chunk == "content_block_stop":
+                self._is_response_format_tool_by_content_block_index.pop(
+                    content_block_index, None
+                )
 
             returned_chunk = ModelResponseStream(
                 choices=[
@@ -982,7 +995,10 @@ class ModelResponseIterator:
             raise ValueError(f"Failed to decode JSON from chunk: {chunk}")
 
     def _handle_json_mode_chunk(
-        self, text: str, tool_use: ChatCompletionToolCallChunk | None
+        self,
+        text: str,
+        tool_use: ChatCompletionToolCallChunk | None,
+        content_block_index: int = 0,
     ) -> tuple[str, ChatCompletionToolCallChunk | None]:
         """
         If JSON mode is enabled, convert the tool call to a message.
@@ -1014,10 +1030,14 @@ class ModelResponseIterator:
             # New tool call from content_block_start - tool name is always complete here
             # (per Anthropic's fine-grained streaming pattern)
             tool_name = tool_use.get("function", {}).get("name", "")
-            self.is_response_format_tool = tool_name == RESPONSE_FORMAT_TOOL_NAME
+            self._is_response_format_tool_by_content_block_index[
+                content_block_index
+            ] = tool_name == RESPONSE_FORMAT_TOOL_NAME
 
         # Convert tool to content if we're tracking a response_format tool
-        if self.is_response_format_tool:
+        if self._is_response_format_tool_by_content_block_index.get(
+            content_block_index, False
+        ):
             message = AnthropicConfig._convert_tool_response_to_message(tool_calls=[tool_use])
             if message is not None:
                 text = message.content or ""

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1462,11 +1462,20 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     _tool = self.map_response_format_to_anthropic_tool(value, optional_params, is_thinking_enabled)
                     if _tool is None:
                         continue
-                    if not is_thinking_enabled:
-                        _tool_choice = {
-                            "name": RESPONSE_FORMAT_TOOL_NAME,
-                            "type": "tool",
-                        }
+                    # When response_format is combined with caller tools, let
+                    # the model choose between the real tools and the
+                    # internal json_tool_call. Forcing the latter locks the
+                    # first turn to the final-output tool; removing
+                    # tool_choice entirely allows an unstructured final text.
+                    has_caller_tools = bool(non_default_params.get("tools"))
+                    if not is_thinking_enabled and "tool_choice" not in optional_params:
+                        if has_caller_tools:
+                            _tool_choice = {"type": "any"}
+                        else:
+                            _tool_choice = {
+                                "name": RESPONSE_FORMAT_TOOL_NAME,
+                                "type": "tool",
+                            }
                         optional_params["tool_choice"] = _tool_choice
 
                     optional_params = self._add_tools_to_optional_params(optional_params=optional_params, tools=[_tool])
@@ -1802,6 +1811,31 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         if "tools" not in optional_params and messages is not None and has_tool_call_blocks(messages):
             optional_params["tools"], _ = self._map_tools(add_dummy_tool(custom_llm_provider="anthropic"))
+
+        # With response_format emulation, allow real caller tools on the
+        # initial turn, then require the internal output tool after a tool
+        # result has been returned. This preserves structured output without
+        # forcing a placeholder before investigation tools can run.
+        if optional_params.get("json_mode") is True:
+            response_format_tool_present = any(
+                tool.get("name") == RESPONSE_FORMAT_TOOL_NAME
+                for tool in (optional_params.get("tools") or [])
+                if isinstance(tool, dict)
+            )
+            has_tool_result = any(
+                message.get("role") == "tool"
+                or any(
+                    isinstance(block, dict) and block.get("type") == "tool_result"
+                    for block in (message.get("content") or [])
+                )
+                for message in (messages or [])
+                if isinstance(message, dict)
+            )
+            if response_format_tool_present and has_tool_result:
+                optional_params["tool_choice"] = {
+                    "name": RESPONSE_FORMAT_TOOL_NAME,
+                    "type": "tool",
+                }
 
         # Drop thinking param if thinking is enabled but thinking_blocks are missing
         # This prevents the error: "Expected thinking or redacted_thinking, but found tool_use"

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1462,11 +1462,6 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     _tool = self.map_response_format_to_anthropic_tool(value, optional_params, is_thinking_enabled)
                     if _tool is None:
                         continue
-                    # When response_format is combined with caller tools, let
-                    # the model choose between the real tools and the
-                    # internal json_tool_call. Forcing the latter locks the
-                    # first turn to the final-output tool; removing
-                    # tool_choice entirely allows an unstructured final text.
                     has_caller_tools = bool(non_default_params.get("tools"))
                     if not is_thinking_enabled and "tool_choice" not in optional_params:
                         if has_caller_tools:
@@ -1812,31 +1807,6 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         if "tools" not in optional_params and messages is not None and has_tool_call_blocks(messages):
             optional_params["tools"], _ = self._map_tools(add_dummy_tool(custom_llm_provider="anthropic"))
 
-        # With response_format emulation, allow real caller tools on the
-        # initial turn, then require the internal output tool after a tool
-        # result has been returned. This preserves structured output without
-        # forcing a placeholder before investigation tools can run.
-        if optional_params.get("json_mode") is True:
-            response_format_tool_present = any(
-                tool.get("name") == RESPONSE_FORMAT_TOOL_NAME
-                for tool in (optional_params.get("tools") or [])
-                if isinstance(tool, dict)
-            )
-            has_tool_result = any(
-                message.get("role") == "tool"
-                or any(
-                    isinstance(block, dict) and block.get("type") == "tool_result"
-                    for block in (message.get("content") or [])
-                )
-                for message in (messages or [])
-                if isinstance(message, dict)
-            )
-            if response_format_tool_present and has_tool_result:
-                optional_params["tool_choice"] = {
-                    "name": RESPONSE_FORMAT_TOOL_NAME,
-                    "type": "tool",
-                }
-
         # Drop thinking param if thinking is enabled but thinking_blocks are missing
         # This prevents the error: "Expected thinking or redacted_thinking, but found tool_use"
         #
@@ -1856,6 +1826,16 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     "Dropping 'thinking' param because the last assistant message with tool_calls "
                     "has no thinking_blocks. The model won't use extended thinking for this turn."
                 )
+
+        if (
+            optional_params.get("json_mode") is True
+            and optional_params.get("thinking") is None
+            and self._last_tool_result_is_response_format_tool(messages)
+        ):
+            optional_params["tool_choice"] = {
+                "name": RESPONSE_FORMAT_TOOL_NAME,
+                "type": "tool",
+            }
 
         AnthropicConfig._maybe_drop_speed_param(
             model=model,
@@ -1985,6 +1965,62 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         self._apply_output_config(data=data, model=model, optional_params=optional_params)
 
         return data
+
+    @staticmethod
+    def _last_tool_result_is_response_format_tool(
+        messages: list[AllMessageValues],
+    ) -> bool:
+        last_regular_user_index = -1
+        last_tool_result_index = -1
+        for index, message in enumerate(messages or []):
+            if not isinstance(message, dict):
+                continue
+            content = message.get("content") or []
+            has_tool_result = message.get("role") == "tool" or any(
+                isinstance(block, dict) and block.get("type") == "tool_result"
+                for block in content
+            )
+            if has_tool_result:
+                last_tool_result_index = index
+            elif message.get("role") == "user":
+                last_regular_user_index = index
+
+        if last_tool_result_index <= last_regular_user_index:
+            return False
+
+        tool_names_by_id: dict[str, str] = {}
+        for message in messages[last_regular_user_index + 1 : last_tool_result_index + 1]:
+            if not isinstance(message, dict):
+                continue
+            for tool_call in message.get("tool_calls") or []:
+                if not isinstance(tool_call, dict):
+                    continue
+                function = tool_call.get("function") or {}
+                tool_id = tool_call.get("id")
+                tool_name = function.get("name")
+                if tool_id and tool_name:
+                    tool_names_by_id[tool_id] = tool_name
+            for block in message.get("content") or []:
+                if not isinstance(block, dict) or block.get("type") != "tool_use":
+                    continue
+                tool_id = block.get("id")
+                tool_name = block.get("name")
+                if tool_id and tool_name:
+                    tool_names_by_id[tool_id] = tool_name
+
+        last_result_name = None
+        result_message = messages[last_tool_result_index]
+        if isinstance(result_message, dict):
+            if result_message.get("role") == "tool":
+                last_result_name = tool_names_by_id.get(result_message.get("tool_call_id"))
+            for block in result_message.get("content") or []:
+                if not isinstance(block, dict) or block.get("type") != "tool_result":
+                    continue
+                last_result_name = block.get("name") or tool_names_by_id.get(
+                    block.get("tool_use_id")
+                )
+
+        return last_result_name == RESPONSE_FORMAT_TOOL_NAME
 
     def _apply_output_config(self, data: dict, model: str, optional_params: dict) -> None:
         """Validate and apply output_config to the request data."""

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -264,6 +264,51 @@ def test_handle_json_mode_chunk_regular_tool():
     assert tool_use["function"]["name"] == "get_weather"
 
 
+def test_handle_json_mode_chunk_interleaved_tools_keep_user_tool_arguments():
+    """A response-format block must not hide deltas from an interleaved user tool."""
+    model_response_iterator = ModelResponseIterator(
+        streaming_response=MagicMock(), sync_stream=True, json_mode=True
+    )
+    response_format_tool = ChatCompletionToolCallChunk(
+        id="tool_json",
+        type="function",
+        function=ChatCompletionToolCallFunctionChunk(
+            name=RESPONSE_FORMAT_TOOL_NAME, arguments=""
+        ),
+        index=1,
+    )
+    user_tool = ChatCompletionToolCallChunk(
+        id="tool_query",
+        type="function",
+        function=ChatCompletionToolCallFunctionChunk(
+            name="query_logs", arguments=""
+        ),
+        index=0,
+    )
+    user_tool_delta = ChatCompletionToolCallChunk(
+        id=None,
+        type="function",
+        function=ChatCompletionToolCallFunctionChunk(
+            name=None, arguments='{"query_string":"executor error"}'
+        ),
+        index=0,
+    )
+
+    model_response_iterator._handle_json_mode_chunk(
+        "", user_tool, content_block_index=0
+    )
+    model_response_iterator._handle_json_mode_chunk(
+        "", response_format_tool, content_block_index=1
+    )
+    text, tool_use = model_response_iterator._handle_json_mode_chunk(
+        "", user_tool_delta, content_block_index=0
+    )
+
+    assert text == ""
+    assert tool_use is not None
+    assert tool_use["function"]["arguments"] == '{"query_string":"executor error"}'
+
+
 def test_handle_json_mode_chunk_streaming_response_format_tool():
     model_response_iterator = ModelResponseIterator(
         streaming_response=MagicMock(), sync_stream=True, json_mode=True

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -149,10 +149,110 @@ def test_response_format_with_user_tools_allows_investigation_before_final_outpu
         litellm_params={},
         headers={},
     )
+    assert optional_params["tool_choice"] == {"type": "any"}
+
+
+def test_response_format_tool_result_forces_final_output_tool():
+    config = AnthropicConfig()
+    optional_params = {
+        "json_mode": True,
+        "tools": [
+            {"name": "query_logs"},
+            {"name": RESPONSE_FORMAT_TOOL_NAME},
+        ],
+        "thinking": None,
+    }
+
+    config.transform_request(
+        model="claude-sonnet-5",
+        messages=[
+            {"role": "user", "content": "Investigate the logs."},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "tool_query",
+                        "function": {"name": RESPONSE_FORMAT_TOOL_NAME},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tool_query", "content": "done"},
+        ],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
     assert optional_params["tool_choice"] == {
         "name": RESPONSE_FORMAT_TOOL_NAME,
         "type": "tool",
     }
+
+
+def test_response_format_does_not_force_tool_after_caller_tool_result():
+    config = AnthropicConfig()
+    optional_params = {
+        "json_mode": True,
+        "tools": [
+            {"name": "query_logs"},
+            {"name": RESPONSE_FORMAT_TOOL_NAME},
+        ],
+        "tool_choice": {"type": "any"},
+    }
+
+    config.transform_request(
+        model="claude-sonnet-5",
+        messages=[
+            {"role": "user", "content": "Investigate the logs."},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "tool_query",
+                        "function": {"name": "query_logs"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tool_query", "content": "logs"},
+        ],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+    assert optional_params["tool_choice"] == {"type": "any"}
+
+
+def test_response_format_does_not_force_tool_when_thinking_is_enabled():
+    config = AnthropicConfig()
+    optional_params = {
+        "json_mode": True,
+        "tools": [
+            {"name": "query_logs"},
+            {"name": RESPONSE_FORMAT_TOOL_NAME},
+        ],
+        "thinking": {"type": "enabled", "budget_tokens": 1024},
+    }
+
+    config.transform_request(
+        model="claude-sonnet-5",
+        messages=[
+            {"role": "user", "content": "Investigate the logs."},
+            {
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": "Checking logs"}],
+                "tool_calls": [
+                    {
+                        "id": "tool_json",
+                        "function": {"name": RESPONSE_FORMAT_TOOL_NAME},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tool_json", "content": "done"},
+        ],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+    assert "tool_choice" not in optional_params
 
 
 def test_calculate_usage():

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -81,6 +81,80 @@ def test_anthropic_json_mode_non_streaming_mixed_internal_and_user_tools():
     assert extra == '{"answer": 42}'
 
 
+def test_response_format_with_user_tools_allows_investigation_before_final_output():
+    """Structured output must not force the internal tool before user tools run."""
+    config = AnthropicConfig()
+    non_default_params = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "query_logs",
+                    "description": "Query logs for evidence.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query_string": {"type": "string"}},
+                    },
+                },
+            }
+        ],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "FinalOutput",
+                "schema": {
+                    "type": "object",
+                    "properties": {"result": {"type": "string"}},
+                    "required": ["result"],
+                },
+            },
+        },
+        "thinking": {"type": "adaptive"},
+    }
+
+    optional_params = config.map_openai_params(
+        non_default_params=non_default_params,
+        optional_params={},
+        model="claude-sonnet-5",
+        drop_params=False,
+    )
+    assert optional_params["tool_choice"] == {"type": "any"}
+
+    config.transform_request(
+        model="claude-sonnet-5",
+        messages=[{"role": "user", "content": "Investigate the logs."}],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+    assert optional_params["tool_choice"] == {"type": "any"}
+
+    config.transform_request(
+        model="claude-sonnet-5",
+        messages=[
+            {"role": "user", "content": "Investigate the logs."},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "tool_query",
+                        "type": "function",
+                        "function": {"name": "query_logs", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tool_query", "content": "logs"},
+        ],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+    assert optional_params["tool_choice"] == {
+        "name": RESPONSE_FORMAT_TOOL_NAME,
+        "type": "tool",
+    }
+
+
 def test_calculate_usage():
     """
     Do not include cache_creation_input_tokens in the prompt_tokens


### PR DESCRIPTION
Fixes Anthropic structured-output requests that also expose caller tools. The old path forced the internal json_tool_call before investigation tools could run, producing placeholder output. This changes the initial choice to any when caller tools exist, forces json_tool_call only after a tool result, and tracks response-format state by content-block index in streaming. Added regression tests for interleaved streaming tools and the two-phase tool-choice behavior. Five targeted tests pass.