### PR TITLE
fix(anthropic): preserve tools with structured output

### DIFF
--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -548,8 +548,10 @@ class ModelResponseIterator:
         # Generate response ID once per stream to match OpenAI-compatible behavior
         self.response_id = _generate_id()
 
-        # Track if we're currently streaming a response_format tool
-        self.is_response_format_tool: bool = False
+        # Anthropic content blocks can be interleaved. Keep response-format
+        # tracking per block so a json_tool_call cannot hide a real tool's
+        # argument deltas in another block.
+        self._is_response_format_tool_by_content_block_index: Dict[int, bool] = {}
         # Track if we've converted any response_format tools (affects finish_reason)
         self.converted_response_format_tool: bool = False
 
@@ -773,6 +775,7 @@ class ModelResponseIterator:
 
             # Always use index=0 for OpenAI choice format (fixes multi-choice errors)
             index = 0
+            content_block_index = int(chunk.get("index", 0))
             if type_chunk == "content_block_delta":
                 """
                 Anthropic content chunk
@@ -819,6 +822,9 @@ class ModelResponseIterator:
                         ),
                         index=self.tool_index,
                     )
+                    self._is_response_format_tool_by_content_block_index[
+                        content_block_index
+                    ] = _stream_tool_name == RESPONSE_FORMAT_TOOL_NAME
                     # Track server tool use inputs for code_interpreter_results.
                     # The initial input in content_block_start is typically {}
                     # for streaming; the full input arrives via input_json_delta
@@ -906,8 +912,6 @@ class ModelResponseIterator:
                             except (json.JSONDecodeError, TypeError):
                                 pass
                         self._current_server_tool_id = None
-                # Reset response_format tool tracking when block stops
-                self.is_response_format_tool = False
                 # Reset current content block type
                 self.current_content_block_type = None
             elif type_chunk == "tool_result":
@@ -959,7 +963,16 @@ class ModelResponseIterator:
                     status_code=500,  # it looks like Anthropic API does not return a status code in the chunk error - default to 500
                 )
 
-            text, tool_use = self._handle_json_mode_chunk(text=text, tool_use=tool_use)
+            text, tool_use = self._handle_json_mode_chunk(
+                text=text,
+                tool_use=tool_use,
+                content_block_index=content_block_index,
+            )
+
+            if type_chunk == "content_block_stop":
+                self._is_response_format_tool_by_content_block_index.pop(
+                    content_block_index, None
+                )
 
             returned_chunk = ModelResponseStream(
                 choices=[
@@ -985,7 +998,10 @@ class ModelResponseIterator:
             raise ValueError(f"Failed to decode JSON from chunk: {chunk}")
 
     def _handle_json_mode_chunk(
-        self, text: str, tool_use: ChatCompletionToolCallChunk | None
+        self,
+        text: str,
+        tool_use: ChatCompletionToolCallChunk | None,
+        content_block_index: int = 0,
     ) -> Tuple[str, ChatCompletionToolCallChunk | None]:
         """
         If JSON mode is enabled, convert the tool call to a message.
@@ -1017,10 +1033,14 @@ class ModelResponseIterator:
             # New tool call from content_block_start - tool name is always complete here
             # (per Anthropic's fine-grained streaming pattern)
             tool_name = tool_use.get("function", {}).get("name", "")
-            self.is_response_format_tool = tool_name == RESPONSE_FORMAT_TOOL_NAME
+            self._is_response_format_tool_by_content_block_index[
+                content_block_index
+            ] = tool_name == RESPONSE_FORMAT_TOOL_NAME
 
         # Convert tool to content if we're tracking a response_format tool
-        if self.is_response_format_tool:
+        if self._is_response_format_tool_by_content_block_index.get(
+            content_block_index, False
+        ):
             message = AnthropicConfig._convert_tool_response_to_message(tool_calls=[tool_use])
             if message is not None:
                 text = message.content or ""

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -1434,11 +1434,20 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                     _tool = self.map_response_format_to_anthropic_tool(value, optional_params, is_thinking_enabled)
                     if _tool is None:
                         continue
-                    if not is_thinking_enabled:
-                        _tool_choice = {
-                            "name": RESPONSE_FORMAT_TOOL_NAME,
-                            "type": "tool",
-                        }
+                    # When response_format is combined with caller tools, let
+                    # the model choose between the real tools and the
+                    # internal json_tool_call. Forcing the latter locks the
+                    # first turn to the final-output tool; removing
+                    # tool_choice entirely allows an unstructured final text.
+                    has_caller_tools = bool(non_default_params.get("tools"))
+                    if not is_thinking_enabled and "tool_choice" not in optional_params:
+                        if has_caller_tools:
+                            _tool_choice = {"type": "any"}
+                        else:
+                            _tool_choice = {
+                                "name": RESPONSE_FORMAT_TOOL_NAME,
+                                "type": "tool",
+                            }
                         optional_params["tool_choice"] = _tool_choice
 
                     optional_params = self._add_tools_to_optional_params(optional_params=optional_params, tools=[_tool])
@@ -1774,6 +1783,31 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         if "tools" not in optional_params and messages is not None and has_tool_call_blocks(messages):
             optional_params["tools"], _ = self._map_tools(add_dummy_tool(custom_llm_provider="anthropic"))
+
+        # With response_format emulation, allow real caller tools on the
+        # initial turn, then require the internal output tool after a tool
+        # result has been returned. This preserves structured output without
+        # forcing a placeholder before investigation tools can run.
+        if optional_params.get("json_mode") is True:
+            response_format_tool_present = any(
+                tool.get("name") == RESPONSE_FORMAT_TOOL_NAME
+                for tool in (optional_params.get("tools") or [])
+                if isinstance(tool, dict)
+            )
+            has_tool_result = any(
+                message.get("role") == "tool"
+                or any(
+                    isinstance(block, dict) and block.get("type") == "tool_result"
+                    for block in (message.get("content") or [])
+                )
+                for message in (messages or [])
+                if isinstance(message, dict)
+            )
+            if response_format_tool_present and has_tool_result:
+                optional_params["tool_choice"] = {
+                    "name": RESPONSE_FORMAT_TOOL_NAME,
+                    "type": "tool",
+                }
 
         # Drop thinking param if thinking is enabled but thinking_blocks are missing
         # This prevents the error: "Expected thinking or redacted_thinking, but found tool_use"

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -9,9 +9,7 @@ from functools import partial
 from typing import (
     AsyncIterator,
     Callable,
-    Dict,
     Iterator,
-    List,
     Optional,
     Tuple,
     cast,
@@ -1288,8 +1286,8 @@ class AWSEventStreamDecoder:
         # Bedrock can stream multiple content blocks concurrently. Keep the
         # state keyed by contentBlockIndex so a later block start cannot change
         # how an earlier block's delta is interpreted.
-        self._content_blocks_by_content_block_index: Dict[int, List[ContentBlockDeltaEvent]] = {}
-        self._tool_names_by_content_block_index: Dict[int, str] = {}
+        self._content_blocks_by_content_block_index: dict[int, list[ContentBlockDeltaEvent]] = {}
+        self._tool_names_by_content_block_index: dict[int, str] = {}
         self.tool_calls_index: Optional[int] = None
         self.response_id: Optional[str] = None
         self.json_mode = json_mode

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -1753,10 +1753,38 @@ class MockResponseIterator:  # for returning ai21 streaming responses
         """
         tool_use: Optional[ChatCompletionToolCallChunk] = None
         if self.json_mode is True and tool_calls is not None:
-            message = litellm.AnthropicConfig()._convert_tool_response_to_message(tool_calls=tool_calls)
-            if message is not None:
-                text = message.content or ""
-                tool_use = None
+            # ``json_mode`` is also set when response_format is emulated with the
+            # internal ``json_tool_call``. A fake stream can still contain a real
+            # user tool call, so converting the first tool unconditionally loses
+            # the protocol signal needed by streaming SDK clients to execute it.
+            json_mode_tool_calls = [
+                tool_call
+                for tool_call in tool_calls
+                if tool_call["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
+            ]
+            regular_tool_calls = [
+                tool_call
+                for tool_call in tool_calls
+                if tool_call["function"].get("name") != RESPONSE_FORMAT_TOOL_NAME
+            ]
+
+            if json_mode_tool_calls:
+                message = litellm.AnthropicConfig()._convert_tool_response_to_message(
+                    tool_calls=json_mode_tool_calls
+                )
+                if message is not None:
+                    text = message.content or ""
+            if regular_tool_calls:
+                regular_tool_call = regular_tool_calls[0]
+                tool_use = ChatCompletionToolCallChunk(
+                    id=regular_tool_call.id,
+                    type="function",
+                    function=ChatCompletionToolCallFunctionChunk(
+                        name=regular_tool_call.function.name,
+                        arguments=regular_tool_call.function.arguments,
+                    ),
+                    index=0,
+                )
         elif tool_calls is not None and len(tool_calls) > 0:
             tool_use = tool_calls[0]
         return text, tool_use

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -9,7 +9,9 @@ from functools import partial
 from typing import (
     AsyncIterator,
     Callable,
+    Dict,
     Iterator,
+    List,
     Optional,
     Tuple,
     cast,
@@ -1283,27 +1285,35 @@ class AWSEventStreamDecoder:
 
         self.model = model
         self.parser = EventStreamJSONParser()
-        self.content_blocks: List[ContentBlockDeltaEvent] = []
+        # Bedrock can stream multiple content blocks concurrently. Keep the
+        # state keyed by contentBlockIndex so a later block start cannot change
+        # how an earlier block's delta is interpreted.
+        self._content_blocks_by_content_block_index: Dict[
+            int, List[ContentBlockDeltaEvent]
+        ] = {}
+        self._tool_names_by_content_block_index: Dict[int, str] = {}
         self.tool_calls_index: Optional[int] = None
         self.response_id: Optional[str] = None
         self.json_mode = json_mode
-        self._current_tool_name: Optional[str] = None
 
-    def check_empty_tool_call_args(self) -> bool:
+    def check_empty_tool_call_args(self, content_block_index: int) -> bool:
         """
         Check if the tool call block so far has been an empty string
         """
         args = ""
         # if text content block -> skip
-        if len(self.content_blocks) == 0:
+        content_blocks = self._content_blocks_by_content_block_index.get(
+            content_block_index, []
+        )
+        if len(content_blocks) == 0:
             return False
 
         if (
-            "toolUse" not in self.content_blocks[0]
+            "toolUse" not in content_blocks[0]
         ):  # be explicit - only do this if tool use block, as this is to prevent json decoding errors
             return False
 
-        for block in self.content_blocks:
+        for block in content_blocks:
             if "toolUse" in block:
                 args += block["toolUse"]["input"]
 
@@ -1357,6 +1367,7 @@ class AWSEventStreamDecoder:
     def _handle_converse_start_event(
         self,
         start_obj: ContentBlockStartEvent,
+        content_block_index: int = 0,
     ) -> Tuple[
         Optional[ChatCompletionToolCallChunk],
         dict,
@@ -1367,13 +1378,15 @@ class AWSEventStreamDecoder:
         provider_specific_fields: dict = {}
         thinking_blocks: Optional[List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]] = None
 
-        self.content_blocks = []  # reset
+        self._content_blocks_by_content_block_index[content_block_index] = []
         if start_obj is not None:
             if "toolUse" in start_obj and start_obj["toolUse"] is not None:
                 ## check tool name was formatted by litellm
                 _response_tool_name = start_obj["toolUse"]["name"]
                 response_tool_name = get_bedrock_tool_name(response_tool_name=_response_tool_name)
-                self._current_tool_name = response_tool_name
+                self._tool_names_by_content_block_index[content_block_index] = (
+                    response_tool_name
+                )
 
                 # When json_mode is True, suppress the internal json_tool_call
                 # and convert its content to text in delta events instead
@@ -1417,13 +1430,17 @@ class AWSEventStreamDecoder:
         reasoning_content: Optional[str] = None
         thinking_blocks: Optional[List[Union[ChatCompletionThinkingBlock, ChatCompletionRedactedThinkingBlock]]] = None
 
-        self.content_blocks.append(delta_obj)
+        self._content_blocks_by_content_block_index.setdefault(index, []).append(delta_obj)
         if "text" in delta_obj:
             text = delta_obj["text"]
         elif "toolUse" in delta_obj:
             # When json_mode is True and this is the internal json_tool_call,
             # convert tool input to text content instead of tool call arguments
-            if self.json_mode is True and self._current_tool_name == RESPONSE_FORMAT_TOOL_NAME:
+            if (
+                self.json_mode is True
+                and self._tool_names_by_content_block_index.get(index)
+                == RESPONSE_FORMAT_TOOL_NAME
+            ):
                 text = delta_obj["toolUse"]["input"]
             else:
                 tool_use = {
@@ -1460,14 +1477,15 @@ class AWSEventStreamDecoder:
         """Handle stop/contentBlockIndex event in converse chunk parsing."""
         tool_use: Optional[ChatCompletionToolCallChunk] = None
 
+        tool_name = self._tool_names_by_content_block_index.pop(index, None)
         # If the ending block was the internal json_tool_call, skip emitting
-        # the empty-args tool chunk and reset tracking state
-        if self.json_mode is True and self._current_tool_name == RESPONSE_FORMAT_TOOL_NAME:
-            self._current_tool_name = None
+        # the empty-args tool chunk.
+        if self.json_mode is True and tool_name == RESPONSE_FORMAT_TOOL_NAME:
+            self._content_blocks_by_content_block_index.pop(index, None)
             return tool_use
 
-        self._current_tool_name = None
-        is_empty = self.check_empty_tool_call_args()
+        is_empty = self.check_empty_tool_call_args(index)
+        self._content_blocks_by_content_block_index.pop(index, None)
         if is_empty:
             tool_use = {
                 "id": None,
@@ -1504,7 +1522,7 @@ class AWSEventStreamDecoder:
                     tool_use,
                     provider_specific_fields,
                     thinking_blocks,
-                ) = self._handle_converse_start_event(start_obj)
+                ) = self._handle_converse_start_event(start_obj, content_block_index)
             elif "delta" in chunk_data:
                 delta_obj = ContentBlockDeltaEvent(**chunk_data["delta"])
                 (

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -1283,9 +1283,7 @@ class AWSEventStreamDecoder:
 
         self.model = model
         self.parser = EventStreamJSONParser()
-        # Bedrock can stream multiple content blocks concurrently. Keep the
-        # state keyed by contentBlockIndex so a later block start cannot change
-        # how an earlier block's delta is interpreted.
+        # Bedrock associates streamed deltas with content blocks by this index.
         self._content_blocks_by_content_block_index: dict[int, list[ContentBlockDeltaEvent]] = {}
         self._tool_names_by_content_block_index: dict[int, str] = {}
         self.tool_calls_index: Optional[int] = None
@@ -1380,8 +1378,7 @@ class AWSEventStreamDecoder:
                 response_tool_name = get_bedrock_tool_name(response_tool_name=_response_tool_name)
                 self._tool_names_by_content_block_index[content_block_index] = response_tool_name
 
-                # When json_mode is True, suppress the internal json_tool_call
-                # and convert its content to text in delta events instead
+                # response_format is represented by an internal tool call.
                 if self.json_mode is True and response_tool_name == RESPONSE_FORMAT_TOOL_NAME:
                     return tool_use, provider_specific_fields, thinking_blocks
 
@@ -1426,8 +1423,6 @@ class AWSEventStreamDecoder:
         if "text" in delta_obj:
             text = delta_obj["text"]
         elif "toolUse" in delta_obj:
-            # When json_mode is True and this is the internal json_tool_call,
-            # convert tool input to text content instead of tool call arguments
             if (
                 self.json_mode is True
                 and self._tool_names_by_content_block_index.get(index) == RESPONSE_FORMAT_TOOL_NAME
@@ -1469,8 +1464,6 @@ class AWSEventStreamDecoder:
         tool_use: Optional[ChatCompletionToolCallChunk] = None
 
         tool_name = self._tool_names_by_content_block_index.pop(index, None)
-        # If the ending block was the internal json_tool_call, skip emitting
-        # the empty-args tool chunk.
         if self.json_mode is True and tool_name == RESPONSE_FORMAT_TOOL_NAME:
             self._content_blocks_by_content_block_index.pop(index, None)
             return tool_use
@@ -1744,10 +1737,7 @@ class MockResponseIterator:  # for returning ai21 streaming responses
         """
         tool_use: Optional[ChatCompletionToolCallChunk] = None
         if self.json_mode is True and tool_calls is not None:
-            # ``json_mode`` is also set when response_format is emulated with the
-            # internal ``json_tool_call``. A fake stream can still contain a real
-            # user tool call, so converting the first tool unconditionally loses
-            # the protocol signal needed by streaming SDK clients to execute it.
+            # Bedrock represents response_format as an internal json_tool_call.
             json_mode_tool_calls = [
                 tool_call for tool_call in tool_calls if tool_call["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
             ]

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -1288,9 +1288,7 @@ class AWSEventStreamDecoder:
         # Bedrock can stream multiple content blocks concurrently. Keep the
         # state keyed by contentBlockIndex so a later block start cannot change
         # how an earlier block's delta is interpreted.
-        self._content_blocks_by_content_block_index: Dict[
-            int, List[ContentBlockDeltaEvent]
-        ] = {}
+        self._content_blocks_by_content_block_index: Dict[int, List[ContentBlockDeltaEvent]] = {}
         self._tool_names_by_content_block_index: Dict[int, str] = {}
         self.tool_calls_index: Optional[int] = None
         self.response_id: Optional[str] = None
@@ -1302,9 +1300,7 @@ class AWSEventStreamDecoder:
         """
         args = ""
         # if text content block -> skip
-        content_blocks = self._content_blocks_by_content_block_index.get(
-            content_block_index, []
-        )
+        content_blocks = self._content_blocks_by_content_block_index.get(content_block_index, [])
         if len(content_blocks) == 0:
             return False
 
@@ -1384,9 +1380,7 @@ class AWSEventStreamDecoder:
                 ## check tool name was formatted by litellm
                 _response_tool_name = start_obj["toolUse"]["name"]
                 response_tool_name = get_bedrock_tool_name(response_tool_name=_response_tool_name)
-                self._tool_names_by_content_block_index[content_block_index] = (
-                    response_tool_name
-                )
+                self._tool_names_by_content_block_index[content_block_index] = response_tool_name
 
                 # When json_mode is True, suppress the internal json_tool_call
                 # and convert its content to text in delta events instead
@@ -1438,8 +1432,7 @@ class AWSEventStreamDecoder:
             # convert tool input to text content instead of tool call arguments
             if (
                 self.json_mode is True
-                and self._tool_names_by_content_block_index.get(index)
-                == RESPONSE_FORMAT_TOOL_NAME
+                and self._tool_names_by_content_block_index.get(index) == RESPONSE_FORMAT_TOOL_NAME
             ):
                 text = delta_obj["toolUse"]["input"]
             else:
@@ -1758,20 +1751,14 @@ class MockResponseIterator:  # for returning ai21 streaming responses
             # user tool call, so converting the first tool unconditionally loses
             # the protocol signal needed by streaming SDK clients to execute it.
             json_mode_tool_calls = [
-                tool_call
-                for tool_call in tool_calls
-                if tool_call["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
+                tool_call for tool_call in tool_calls if tool_call["function"].get("name") == RESPONSE_FORMAT_TOOL_NAME
             ]
             regular_tool_calls = [
-                tool_call
-                for tool_call in tool_calls
-                if tool_call["function"].get("name") != RESPONSE_FORMAT_TOOL_NAME
+                tool_call for tool_call in tool_calls if tool_call["function"].get("name") != RESPONSE_FORMAT_TOOL_NAME
             ]
 
             if json_mode_tool_calls:
-                message = litellm.AnthropicConfig()._convert_tool_response_to_message(
-                    tool_calls=json_mode_tool_calls
-                )
+                message = litellm.AnthropicConfig()._convert_tool_response_to_message(tool_calls=json_mode_tool_calls)
                 if message is not None:
                     text = message.content or ""
             if regular_tool_calls:

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_handler.py
@@ -264,6 +264,51 @@ def test_handle_json_mode_chunk_regular_tool():
     assert tool_use["function"]["name"] == "get_weather"
 
 
+def test_handle_json_mode_chunk_interleaved_tools_keep_user_tool_arguments():
+    """A response-format block must not hide deltas from an interleaved user tool."""
+    model_response_iterator = ModelResponseIterator(
+        streaming_response=MagicMock(), sync_stream=True, json_mode=True
+    )
+    response_format_tool = ChatCompletionToolCallChunk(
+        id="tool_json",
+        type="function",
+        function=ChatCompletionToolCallFunctionChunk(
+            name=RESPONSE_FORMAT_TOOL_NAME, arguments=""
+        ),
+        index=1,
+    )
+    user_tool = ChatCompletionToolCallChunk(
+        id="tool_query",
+        type="function",
+        function=ChatCompletionToolCallFunctionChunk(
+            name="query_logs", arguments=""
+        ),
+        index=0,
+    )
+    user_tool_delta = ChatCompletionToolCallChunk(
+        id=None,
+        type="function",
+        function=ChatCompletionToolCallFunctionChunk(
+            name=None, arguments='{"query_string":"executor error"}'
+        ),
+        index=0,
+    )
+
+    model_response_iterator._handle_json_mode_chunk(
+        "", user_tool, content_block_index=0
+    )
+    model_response_iterator._handle_json_mode_chunk(
+        "", response_format_tool, content_block_index=1
+    )
+    text, tool_use = model_response_iterator._handle_json_mode_chunk(
+        "", user_tool_delta, content_block_index=0
+    )
+
+    assert text == ""
+    assert tool_use is not None
+    assert tool_use["function"]["arguments"] == '{"query_string":"executor error"}'
+
+
 def test_handle_json_mode_chunk_streaming_response_format_tool():
     model_response_iterator = ModelResponseIterator(
         streaming_response=MagicMock(), sync_stream=True, json_mode=True

--- a/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
+++ b/tests/test_litellm/llms/anthropic/chat/test_anthropic_chat_transformation.py
@@ -81,6 +81,80 @@ def test_anthropic_json_mode_non_streaming_mixed_internal_and_user_tools():
     assert extra == '{"answer": 42}'
 
 
+def test_response_format_with_user_tools_allows_investigation_before_final_output():
+    """Structured output must not force the internal tool before user tools run."""
+    config = AnthropicConfig()
+    non_default_params = {
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "query_logs",
+                    "description": "Query logs for evidence.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query_string": {"type": "string"}},
+                    },
+                },
+            }
+        ],
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "FinalOutput",
+                "schema": {
+                    "type": "object",
+                    "properties": {"result": {"type": "string"}},
+                    "required": ["result"],
+                },
+            },
+        },
+        "thinking": {"type": "adaptive"},
+    }
+
+    optional_params = config.map_openai_params(
+        non_default_params=non_default_params,
+        optional_params={},
+        model="claude-sonnet-5",
+        drop_params=False,
+    )
+    assert optional_params["tool_choice"] == {"type": "any"}
+
+    config.transform_request(
+        model="claude-sonnet-5",
+        messages=[{"role": "user", "content": "Investigate the logs."}],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+    assert optional_params["tool_choice"] == {"type": "any"}
+
+    config.transform_request(
+        model="claude-sonnet-5",
+        messages=[
+            {"role": "user", "content": "Investigate the logs."},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "tool_query",
+                        "type": "function",
+                        "function": {"name": "query_logs", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tool_query", "content": "logs"},
+        ],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+    assert optional_params["tool_choice"] == {
+        "name": RESPONSE_FORMAT_TOOL_NAME,
+        "type": "tool",
+    }
+
+
 def test_calculate_usage():
     """
     Do not include cache_creation_input_tokens in the prompt_tokens

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -4517,7 +4517,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
 
 
 def test_streaming_interleaved_json_tool_call_does_not_hide_real_tool_delta():
-    """Keep each Bedrock content block's tool state separate while streaming."""
+    """Preserve a real tool delta when an internal JSON block starts later."""
     from litellm.llms.bedrock.chat.invoke_handler import AWSEventStreamDecoder
 
     decoder = AWSEventStreamDecoder(model="test-model", json_mode=True)

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_transformation.py
@@ -4475,7 +4475,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
             "name": "json_tool_call",
         }
     )
-    tool_use_1, _, _ = decoder._handle_converse_start_event(json_start)
+    tool_use_1, _, _ = decoder._handle_converse_start_event(json_start, 0)
     # json_tool_call start should be suppressed (return None tool_use)
     assert tool_use_1 is None
     # tool_calls_index should NOT have been incremented
@@ -4492,8 +4492,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
     # Chunk 3: json_tool_call stop
     stop_tool = decoder._handle_converse_stop_event(index=0)
     assert stop_tool is None
-    # _current_tool_name should be reset
-    assert decoder._current_tool_name is None
+    assert decoder._tool_names_by_content_block_index == {}
 
     # Chunk 4: real tool start
     real_start = ContentBlockStartEvent(
@@ -4502,7 +4501,7 @@ def test_streaming_filters_json_tool_call_with_real_tools():
             "name": "get_weather",
         }
     )
-    tool_use_4, _, _ = decoder._handle_converse_start_event(real_start)
+    tool_use_4, _, _ = decoder._handle_converse_start_event(real_start, 1)
     assert tool_use_4 is not None
     assert tool_use_4["function"]["name"] == "get_weather"
     assert decoder.tool_calls_index == 0
@@ -4515,6 +4514,51 @@ def test_streaming_filters_json_tool_call_with_real_tools():
     assert text_5 == ""
     assert tool_use_5 is not None
     assert tool_use_5["function"]["arguments"] == '{"location": "SF"}'
+
+
+def test_streaming_interleaved_json_tool_call_does_not_hide_real_tool_delta():
+    """Keep each Bedrock content block's tool state separate while streaming."""
+    from litellm.llms.bedrock.chat.invoke_handler import AWSEventStreamDecoder
+
+    decoder = AWSEventStreamDecoder(model="test-model", json_mode=True)
+
+    real_start = decoder.converse_chunk_parser(
+        {
+            "contentBlockIndex": 0,
+            "start": {
+                "toolUse": {
+                    "toolUseId": "tooluse_metrics_001",
+                    "name": "query_metrics",
+                }
+            },
+        }
+    )
+    assert (
+        real_start.choices[0].delta.tool_calls[0]["function"]["name"]
+        == "query_metrics"
+    )
+
+    decoder.converse_chunk_parser(
+        {
+            "contentBlockIndex": 1,
+            "start": {
+                "toolUse": {
+                    "toolUseId": "tooluse_json_001",
+                    "name": "json_tool_call",
+                }
+            },
+        }
+    )
+
+    real_delta = decoder.converse_chunk_parser(
+        {
+            "contentBlockIndex": 0,
+            "delta": {"toolUse": {"input": '{"prefix":"trace.grpc.server"}'}},
+        }
+    )
+    delta = real_delta.choices[0].delta
+    assert delta.content == ""
+    assert delta.tool_calls[0]["function"]["arguments"] == '{"prefix":"trace.grpc.server"}'
 
 
 def test_streaming_without_json_mode_passes_all_tools():

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -12,10 +12,18 @@ import litellm
 from litellm.llms.bedrock.chat.invoke_handler import (
     AWSEventStreamDecoder,
     BedrockLLM,
+    MockResponseIterator,
     make_call,
     make_sync_call,
 )
 from litellm.llms.custom_httpx.http_handler import HTTPHandler
+from litellm.types.utils import (
+    ChatCompletionMessageToolCall,
+    Choices,
+    Function,
+    Message,
+    Usage,
+)
 
 
 def test_transform_thinking_blocks_with_redacted_content():
@@ -25,6 +33,85 @@ def test_transform_thinking_blocks_with_redacted_content():
     assert len(transformed_thinking_blocks) == 1
     assert transformed_thinking_blocks[0]["type"] == "redacted_thinking"
     assert transformed_thinking_blocks[0]["data"] == "This is a redacted content"
+
+
+def test_fake_stream_json_mode_preserves_regular_tool_use():
+    """A fake stream must not turn a user tool call into JSON text."""
+    response = litellm.ModelResponse(
+        id="chatcmpl-test",
+        created=0,
+        model="test",
+        object="chat.completion",
+        choices=[
+            Choices(
+                finish_reason="tool_calls",
+                index=0,
+                message=Message(
+                    content=None,
+                    role="assistant",
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            function=Function(
+                                arguments='{"prefix":"service.request"}',
+                                name="get_metrics_by_prefix",
+                            ),
+                            id="call_metrics",
+                            type="function",
+                        )
+                    ],
+                    function_call=None,
+                ),
+            )
+        ],
+        usage=Usage(completion_tokens=1, prompt_tokens=1, total_tokens=2),
+    )
+
+    response_chunk = MockResponseIterator(
+        model_response=response, json_mode=True
+    )._chunk_parser(chunk_data=response)
+
+    assert response_chunk["text"] == ""
+    assert response_chunk["tool_use"] is not None
+    assert response_chunk["tool_use"]["function"]["name"] == "get_metrics_by_prefix"
+
+
+def test_fake_stream_json_mode_converts_only_response_format_tool():
+    """The internal response-format tool remains regular JSON text."""
+    response = litellm.ModelResponse(
+        id="chatcmpl-test",
+        created=0,
+        model="test",
+        object="chat.completion",
+        choices=[
+            Choices(
+                finish_reason="tool_calls",
+                index=0,
+                message=Message(
+                    content=None,
+                    role="assistant",
+                    tool_calls=[
+                        ChatCompletionMessageToolCall(
+                            function=Function(
+                                arguments='{"values":{"result":"ok"}}',
+                                name="json_tool_call",
+                            ),
+                            id="call_response_format",
+                            type="function",
+                        )
+                    ],
+                    function_call=None,
+                ),
+            )
+        ],
+        usage=Usage(completion_tokens=1, prompt_tokens=1, total_tokens=2),
+    )
+
+    response_chunk = MockResponseIterator(
+        model_response=response, json_mode=True
+    )._chunk_parser(chunk_data=response)
+
+    assert response_chunk["text"] == '{"result": "ok"}'
+    assert response_chunk["tool_use"] is None
 
 
 def test_transform_tool_calls_index():

--- a/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_invoke_handler.py
@@ -36,7 +36,7 @@ def test_transform_thinking_blocks_with_redacted_content():
 
 
 def test_fake_stream_json_mode_preserves_regular_tool_use():
-    """A fake stream must not turn a user tool call into JSON text."""
+    """Preserve a regular tool call in a fake stream with JSON mode enabled."""
     response = litellm.ModelResponse(
         id="chatcmpl-test",
         created=0,
@@ -76,7 +76,7 @@ def test_fake_stream_json_mode_preserves_regular_tool_use():
 
 
 def test_fake_stream_json_mode_converts_only_response_format_tool():
-    """The internal response-format tool remains regular JSON text."""
+    """Convert only the response-format helper tool to JSON content."""
     response = litellm.ModelResponse(
         id="chatcmpl-test",
         created=0,


### PR DESCRIPTION
Combined validation branch for Bedrock PR #34230 and Vertex/Anthropic PR #35637. This branch is based on the same base branch as #34230: litellm_internal_staging. It contains the Bedrock content-block/fake-stream fixes plus the shared Anthropic structured-output tool-choice and streaming-state fixes. Targeted Bedrock and Anthropic regression tests pass: 6 passed.