### PR TITLE
fix(proxy): accept request= on cursor_data_generator (#35632)

### DIFF
--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -342,7 +342,9 @@ async def cursor_chat_completions(
 
     processor = ProxyBaseLLMRequestProcessing(data=data)
 
-    def cursor_data_generator(response, user_api_key_dict, request_data):
+    def cursor_data_generator(
+        response, user_api_key_dict, request_data, request=None
+    ):
         """
         Custom generator that transforms Responses API streaming chunks to chat completion chunks.
 
@@ -353,6 +355,9 @@ async def cursor_chat_completions(
             response: The streaming response (BaseResponsesAPIStreamingIterator or other)
             user_api_key_dict: User API key authentication dict
             request_data: Request data containing model, logging_obj, etc.
+            request: Optional FastAPI Request — accepted for parity with
+                ``select_data_generator`` / ``base_process_llm_request``, which
+                always pass ``request=`` on the streaming path (#35632).
 
         Returns:
             Async generator that yields SSE-formatted chat completion chunks
@@ -379,12 +384,14 @@ async def cursor_chat_completions(
                 response=streamwrapper,
                 user_api_key_dict=user_api_key_dict,
                 request_data=request_data,
+                request=request,
             )
         # Otherwise, use the default generator
         return async_data_generator(
             response=response,
             user_api_key_dict=user_api_key_dict,
             request_data=request_data,
+            request=request,
         )
 
     try:

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -24,6 +24,48 @@ from litellm.types.responses.main import DeleteResponseResult
 router = APIRouter()
 
 
+def _cursor_data_generator(response, user_api_key_dict, request_data, request=None):
+    """
+    Transform Responses API streaming chunks to chat-completion SSE for Cursor.
+
+    ``request`` is accepted for parity with ``select_data_generator`` /
+    ``base_process_llm_request``, which always pass ``request=`` on the
+    streaming path (#35632).
+    """
+    from litellm.completion_extras.litellm_responses_transformation.handler import (
+        responses_api_bridge,
+    )
+    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
+    from litellm.proxy.proxy_server import async_data_generator
+    from litellm.responses.streaming_iterator import BaseResponsesAPIStreamingIterator
+
+    if isinstance(response, BaseResponsesAPIStreamingIterator):
+        completion_stream = responses_api_bridge.transformation_handler.get_model_response_iterator(
+            streaming_response=cast(AsyncIterator[str], response),
+            sync_stream=False,
+            json_mode=False,
+        )
+        logging_obj = request_data.get("litellm_logging_obj")
+        streamwrapper = CustomStreamWrapper(
+            completion_stream=completion_stream,
+            model=request_data.get("model", ""),
+            custom_llm_provider=None,
+            logging_obj=logging_obj,
+        )
+        return async_data_generator(
+            response=streamwrapper,
+            user_api_key_dict=user_api_key_dict,
+            request_data=request_data,
+            request=request,
+        )
+    return async_data_generator(
+        response=response,
+        user_api_key_dict=user_api_key_dict,
+        request_data=request_data,
+        request=request,
+    )
+
+
 @router.post(
     "/v1/responses",
     dependencies=[Depends(user_api_key_auth)],
@@ -314,10 +356,8 @@ async def cursor_chat_completions(
     from litellm.completion_extras.litellm_responses_transformation.handler import (
         responses_api_bridge,
     )
-    from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
     from litellm.proxy.proxy_server import (
         _read_request_body,
-        async_data_generator,
         general_settings,
         llm_router,
         proxy_config,
@@ -329,7 +369,6 @@ async def cursor_chat_completions(
         user_temperature,
         version,
     )
-    from litellm.responses.streaming_iterator import BaseResponsesAPIStreamingIterator
     from litellm.types.llms.openai import ResponsesAPIResponse
     from litellm.types.utils import ModelResponse
 
@@ -342,58 +381,6 @@ async def cursor_chat_completions(
 
     processor = ProxyBaseLLMRequestProcessing(data=data)
 
-    def cursor_data_generator(
-        response, user_api_key_dict, request_data, request=None
-    ):
-        """
-        Custom generator that transforms Responses API streaming chunks to chat completion chunks.
-
-        This generator is used for the cursor endpoint to convert Responses API format responses
-        to chat completion format that Cursor IDE expects.
-
-        Args:
-            response: The streaming response (BaseResponsesAPIStreamingIterator or other)
-            user_api_key_dict: User API key authentication dict
-            request_data: Request data containing model, logging_obj, etc.
-            request: Optional FastAPI Request — accepted for parity with
-                ``select_data_generator`` / ``base_process_llm_request``, which
-                always pass ``request=`` on the streaming path (#35632).
-
-        Returns:
-            Async generator that yields SSE-formatted chat completion chunks
-        """
-        # If response is a BaseResponsesAPIStreamingIterator, transform it first
-        if isinstance(response, BaseResponsesAPIStreamingIterator):
-            # Transform Responses API iterator to chat completion iterator
-            # Cast to AsyncIterator[str] since BaseResponsesAPIStreamingIterator implements __aiter__/__anext__
-            completion_stream = responses_api_bridge.transformation_handler.get_model_response_iterator(
-                streaming_response=cast(AsyncIterator[str], response),
-                sync_stream=False,
-                json_mode=False,
-            )
-            # Wrap in CustomStreamWrapper to get the async generator
-            logging_obj = request_data.get("litellm_logging_obj")
-            streamwrapper = CustomStreamWrapper(
-                completion_stream=completion_stream,
-                model=request_data.get("model", ""),
-                custom_llm_provider=None,
-                logging_obj=logging_obj,
-            )
-            # Use async_data_generator to format as SSE
-            return async_data_generator(
-                response=streamwrapper,
-                user_api_key_dict=user_api_key_dict,
-                request_data=request_data,
-                request=request,
-            )
-        # Otherwise, use the default generator
-        return async_data_generator(
-            response=response,
-            user_api_key_dict=user_api_key_dict,
-            request_data=request_data,
-            request=request,
-        )
-
     try:
         response = await processor.base_process_llm_request(
             request=request,
@@ -404,7 +391,7 @@ async def cursor_chat_completions(
             llm_router=llm_router,
             general_settings=general_settings,
             proxy_config=proxy_config,
-            select_data_generator=cursor_data_generator,
+            select_data_generator=_cursor_data_generator,
             model=None,
             user_model=user_model,
             user_temperature=user_temperature,

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -82,11 +82,7 @@ class TestResponsesAPIEndpoints(unittest.TestCase):
                 ResponseOutputMessage(
                     type="message",
                     role="assistant",
-                    content=[
-                        ResponseOutputText(
-                            type="output_text", text="Hello from Cursor!"
-                        )
-                    ],
+                    content=[ResponseOutputText(type="output_text", text="Hello from Cursor!")],
                 )
             ],
         )
@@ -130,13 +126,31 @@ class TestResponsesAPIEndpoints(unittest.TestCase):
             ProxyBaseLLMRequestProcessing,
         )
         from litellm.proxy.response_api_endpoints.endpoints import (
+            _cursor_data_generator,
             cursor_chat_completions,
         )
+
+        # Direct coverage of the production helper (Codecov patch attribution).
+        mock_req = MagicMock(spec=Request)
+        with patch(
+            "litellm.proxy.proxy_server.async_data_generator",
+            return_value=MagicMock(name="async_gen"),
+        ) as mock_adg:
+            result = _cursor_data_generator(
+                response=MagicMock(),
+                user_api_key_dict=MagicMock(),
+                request_data={"model": "gpt-4o"},
+                request=mock_req,
+            )
+        assert result is mock_adg.return_value
+        mock_adg.assert_called_once()
+        assert mock_adg.call_args.kwargs["request"] is mock_req
 
         captured: dict = {}
 
         async def _capture_and_invoke_generator(self, **kwargs):
             select_data_generator = kwargs["select_data_generator"]
+            assert select_data_generator is _cursor_data_generator
             mock_fastapi_request = MagicMock(spec=Request)
             # Mirror the call shape in common_request_processing (streaming path).
             # Before the fix this raised TypeError for unexpected kwarg 'request'.
@@ -174,9 +188,9 @@ class TestResponsesAPIEndpoints(unittest.TestCase):
                 "base_process_llm_request",
                 new=_capture_and_invoke_generator,
             ),
-            patch("litellm.proxy.proxy_server.async_data_generator") as mock_adg,
+            patch("litellm.proxy.proxy_server.async_data_generator") as mock_adg_endpoint,
         ):
-            mock_adg.return_value = MagicMock(name="async_gen")
+            mock_adg_endpoint.return_value = MagicMock(name="async_gen")
             response = await cursor_chat_completions(
                 request=mock_http_request,
                 fastapi_response=mock_fastapi_response,
@@ -185,16 +199,14 @@ class TestResponsesAPIEndpoints(unittest.TestCase):
 
         assert response == {"id": "cursor_stream_ok"}
         assert captured.get("accepted_request") is True
-        mock_adg.assert_called_once()
-        assert "request" in mock_adg.call_args.kwargs
-        assert mock_adg.call_args.kwargs["request"] is not None
+        mock_adg_endpoint.assert_called_once()
+        assert "request" in mock_adg_endpoint.call_args.kwargs
+        assert mock_adg_endpoint.call_args.kwargs["request"] is not None
 
     @pytest.mark.asyncio
     @patch("litellm.proxy.proxy_server.llm_router")
     @patch("litellm.proxy.proxy_server.user_api_key_auth")
-    async def test_responses_api_key_spend_header_includes_response_cost(
-        self, mock_auth, mock_router
-    ):
+    async def test_responses_api_key_spend_header_includes_response_cost(self, mock_auth, mock_router):
         """
         Test that x-litellm-key-spend header includes the current request's response_cost
         for /v1/responses endpoint.
@@ -230,9 +242,7 @@ class TestResponsesAPIEndpoints(unittest.TestCase):
                 ResponseOutputMessage(
                     type="message",
                     role="assistant",
-                    content=[
-                        ResponseOutputText(type="output_text", text="Test response")
-                    ],
+                    content=[ResponseOutputText(type="output_text", text="Test response")],
                 )
             ],
         )
@@ -427,6 +437,7 @@ class TestWSModelExtraction:
         from litellm.proxy.response_api_endpoints.endpoints import (
             _extract_model_from_first_ws_event,
         )
+
         event = {"type": "response.create", "model": "gpt-4o", "input": "hello"}
         assert _extract_model_from_first_ws_event(event) == "gpt-4o"
 
@@ -434,6 +445,7 @@ class TestWSModelExtraction:
         from litellm.proxy.response_api_endpoints.endpoints import (
             _extract_model_from_first_ws_event,
         )
+
         event = {"type": "response.create", "response": {"model": "gpt-4o", "input": "hello"}}
         assert _extract_model_from_first_ws_event(event) == "gpt-4o"
 
@@ -441,6 +453,7 @@ class TestWSModelExtraction:
         from litellm.proxy.response_api_endpoints.endpoints import (
             _extract_model_from_first_ws_event,
         )
+
         event = {
             "type": "response.create",
             "model": "flat-model",
@@ -452,6 +465,7 @@ class TestWSModelExtraction:
         from litellm.proxy.response_api_endpoints.endpoints import (
             _extract_model_from_first_ws_event,
         )
+
         event = {"type": "response.create", "input": "hello"}
         assert _extract_model_from_first_ws_event(event) is None
 
@@ -471,9 +485,7 @@ class TestResponsesWSFirstFrameValidation:
         )
 
         ws = MagicMock()
-        ws.receive_text = AsyncMock(
-            return_value=json.dumps({"type": "session.update", "model": "gpt-4o"})
-        )
+        ws.receive_text = AsyncMock(return_value=json.dumps({"type": "session.update", "model": "gpt-4o"}))
         ws.send_text = AsyncMock()
         ws.close = AsyncMock()
 
@@ -483,10 +495,7 @@ class TestResponsesWSFirstFrameValidation:
         ws.send_text.assert_awaited_once()
         ws.close.assert_awaited_once_with(code=1008, reason="Invalid first message")
         error_payload = json.loads(ws.send_text.await_args.args[0])
-        assert (
-            error_payload["error"]["message"]
-            == "First message must be a response.create JSON object."
-        )
+        assert error_payload["error"]["message"] == "First message must be a response.create JSON object."
 
     @pytest.mark.asyncio
     async def test_rejects_non_object_json_first_frame(self):
@@ -555,16 +564,12 @@ class TestResponsesWSFirstFrameModelAuth:
         ws.url = "ws://testserver/v1/responses"
         ws.accept = AsyncMock()
         ws.receive_text = AsyncMock(
-            return_value=json.dumps(
-                {"type": "response.create", "model": "gpt-4o-mini", "input": []}
-            )
+            return_value=json.dumps({"type": "response.create", "model": "gpt-4o-mini", "input": []})
         )
         ws.close = AsyncMock()
 
         processor = MagicMock()
-        processor.common_processing_pre_call_logic = AsyncMock(
-            return_value=({"model": "gpt-4o-mini"}, MagicMock())
-        )
+        processor.common_processing_pre_call_logic = AsyncMock(return_value=({"model": "gpt-4o-mini"}, MagicMock()))
 
         async def fake_llm_call():
             return None
@@ -600,9 +605,7 @@ class TestResponsesWSFirstFrameModelAuth:
             _enforce_responses_ws_first_frame_model_auth,
         )
 
-        request = Request(
-            {"type": "http", "method": "POST", "path": "/v1/responses", "headers": []}
-        )
+        request = Request({"type": "http", "method": "POST", "path": "/v1/responses", "headers": []})
         user_api_key_dict = MagicMock()
         llm_router = MagicMock()
 
@@ -664,9 +667,7 @@ class TestReadWSModelFromFirstFrameErrors:
 
         assert result is None
         ws.send_text.assert_not_awaited()
-        ws.close.assert_awaited_once_with(
-            code=1008, reason="Timed out waiting for first message"
-        )
+        ws.close.assert_awaited_once_with(code=1008, reason="Timed out waiting for first message")
 
     @pytest.mark.asyncio
     async def test_invalid_json_sends_error_and_closes(self):
@@ -684,9 +685,7 @@ class TestReadWSModelFromFirstFrameErrors:
         assert result is None
         payload = json.loads(ws.send_text.await_args.args[0])
         assert payload["error"]["message"] == "First message is not valid JSON."
-        ws.close.assert_awaited_once_with(
-            code=1008, reason="Invalid JSON in first message"
-        )
+        ws.close.assert_awaited_once_with(code=1008, reason="Invalid JSON in first message")
 
     @pytest.mark.asyncio
     async def test_missing_model_sends_error_and_closes(self):
@@ -695,9 +694,7 @@ class TestReadWSModelFromFirstFrameErrors:
         )
 
         ws = MagicMock()
-        ws.receive_text = AsyncMock(
-            return_value=json.dumps({"type": "response.create", "input": []})
-        )
+        ws.receive_text = AsyncMock(return_value=json.dumps({"type": "response.create", "input": []}))
         ws.send_text = AsyncMock()
         ws.close = AsyncMock()
 
@@ -750,10 +747,7 @@ class TestManagedResponsesSameProvider:
         assert self._handler("gpt-4o")._same_provider("gpt-4o-mini") is True
 
     def test_different_provider_is_not_same(self):
-        assert (
-            self._handler("gpt-4o")._same_provider("vertex_ai/gemini-2.0-flash")
-            is False
-        )
+        assert self._handler("gpt-4o")._same_provider("vertex_ai/gemini-2.0-flash") is False
 
     def test_inject_credentials_keeps_provider_for_same_provider_model(self):
         handler = self._handler("gpt-4o", custom_llm_provider="openai")
@@ -768,18 +762,14 @@ class TestManagedResponsesSameProvider:
         assert "custom_llm_provider" not in call_kwargs
 
     def test_unresolvable_connection_model_falls_back_to_custom_provider(self):
-        handler = self._handler(
-            "my-custom-deployment", custom_llm_provider="openai"
-        )
+        handler = self._handler("my-custom-deployment", custom_llm_provider="openai")
         assert handler._same_provider("gpt-4o-mini") is True
         call_kwargs: dict = {}
         handler._inject_credentials(call_kwargs, model="gpt-4o-mini")
         assert call_kwargs["custom_llm_provider"] == "openai"
 
     def test_unresolvable_connection_model_still_drops_cross_provider(self):
-        handler = self._handler(
-            "my-custom-deployment", custom_llm_provider="openai"
-        )
+        handler = self._handler("my-custom-deployment", custom_llm_provider="openai")
         call_kwargs: dict = {}
         handler._inject_credentials(call_kwargs, model="vertex_ai/gemini-2.0-flash")
         assert "custom_llm_provider" not in call_kwargs

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -6,6 +6,7 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import Request
 from fastapi.testclient import TestClient
 
 from litellm.proxy.proxy_server import app
@@ -116,6 +117,77 @@ class TestResponsesAPIEndpoints(unittest.TestCase):
             assert "choices" in response_data or "id" in response_data
             # Should not have Responses API structure
             assert "output" not in response_data or "status" not in response_data
+
+    @pytest.mark.asyncio
+    async def test_cursor_data_generator_accepts_request_kwarg(self):
+        """
+        Regression for #35632: base_process_llm_request always passes request=
+        into select_data_generator. cursor_data_generator must accept it (and
+        forward it) so streaming /cursor/chat/completions does not 500 with
+        TypeError: unexpected keyword argument 'request'.
+        """
+        from litellm.proxy.common_request_processing import (
+            ProxyBaseLLMRequestProcessing,
+        )
+        from litellm.proxy.response_api_endpoints.endpoints import (
+            cursor_chat_completions,
+        )
+
+        captured: dict = {}
+
+        async def _capture_and_invoke_generator(self, **kwargs):
+            select_data_generator = kwargs["select_data_generator"]
+            mock_fastapi_request = MagicMock(spec=Request)
+            # Mirror the call shape in common_request_processing (streaming path).
+            # Before the fix this raised TypeError for unexpected kwarg 'request'.
+            result = select_data_generator(
+                response=MagicMock(),
+                user_api_key_dict=kwargs["user_api_key_dict"],
+                request_data=self.data,
+                request=mock_fastapi_request,
+            )
+            captured["accepted_request"] = True
+            captured["result"] = result
+            return {"id": "cursor_stream_ok"}
+
+        mock_http_request = MagicMock(spec=Request)
+        mock_http_request.headers = {}
+        mock_fastapi_response = MagicMock()
+        mock_user_api_key = MagicMock()
+        mock_user_api_key.token = "test_token"
+        mock_user_api_key.user_id = "test_user"
+        mock_user_api_key.team_id = None
+
+        with (
+            patch(
+                "litellm.proxy.proxy_server._read_request_body",
+                new=AsyncMock(
+                    return_value={
+                        "model": "gpt-4o",
+                        "input": [{"role": "user", "content": "Hello"}],
+                        "stream": True,
+                    }
+                ),
+            ),
+            patch.object(
+                ProxyBaseLLMRequestProcessing,
+                "base_process_llm_request",
+                new=_capture_and_invoke_generator,
+            ),
+            patch("litellm.proxy.proxy_server.async_data_generator") as mock_adg,
+        ):
+            mock_adg.return_value = MagicMock(name="async_gen")
+            response = await cursor_chat_completions(
+                request=mock_http_request,
+                fastapi_response=mock_fastapi_response,
+                user_api_key_dict=mock_user_api_key,
+            )
+
+        assert response == {"id": "cursor_stream_ok"}
+        assert captured.get("accepted_request") is True
+        mock_adg.assert_called_once()
+        assert "request" in mock_adg.call_args.kwargs
+        assert mock_adg.call_args.kwargs["request"] is not None
 
     @pytest.mark.asyncio
     @patch("litellm.proxy.proxy_server.llm_router")


### PR DESCRIPTION
## TLDR

Problem this solves:

- Streaming `POST /cursor/chat/completions` returns 500 on every request
- Cursor always sends `stream: true`, so the endpoint is unusable for its client
- Root cause: `cursor_data_generator` rejected the `request=` kwarg that `base_process_llm_request` always passes

How it solves it:

- Accept optional `request=` on `cursor_data_generator` (same contract as default `select_data_generator`)
- Forward `request` into `async_data_generator`
- Add a hermetic regression test that invokes the generator with `request=` and asserts no `TypeError`

## Relevant issues

Fixes #35632

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Failure is in the proxy endpoint layer before provider I/O: `base_process_llm_request` calls `select_data_generator(..., request=request)` and the Cursor closure raised `TypeError: got an unexpected keyword argument 'request'`.

Regression covered by:

```bash
.venv/bin/pytest tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py::TestResponsesAPIEndpoints::test_cursor_data_generator_accepts_request_kwarg -q
# 1 passed
```

Manual shape (any local proxy; crash is upstream of provider selection):

```bash
curl -N -X POST http://localhost:4000/cursor/chat/completions \
  -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" \
  -d '{"model":"<any-model>","stream":true,"input":[{"role":"user","content":"hi"}]}'
```

Before: 500 with unexpected kwarg `request`. After: generator selection succeeds (auth/model errors may still surface, but not this TypeError).

## Type

🐛 Bug Fix
✅ Test

## Changes

- `litellm/proxy/response_api_endpoints/endpoints.py`: add `request=None` to `cursor_data_generator` and forward it
- `tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py`: regression that mirrors the streaming call site
