### PR TITLE
fix(proxy): refresh cached team on /team/block and /team/unblock

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -15,6 +15,7 @@ import math
 import traceback
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
+from types import MappingProxyType
 from typing import (
     Annotated,
     Protocol,
@@ -217,6 +218,9 @@ class _PrismaTableActions(Protocol[_DbRecordT]):
         self,
         where: Mapping[str, object] | None = None,
     ) -> int: ...
+
+
+_INCLUDE_OBJECT_PERMISSION: Mapping[str, bool] = MappingProxyType({"object_permission": True})
 
 
 def _team_db(prisma_client: PrismaClient | None) -> "_PrismaTableActions[LiteLLM_TeamTable]":
@@ -4094,7 +4098,11 @@ async def block_team(
 
 
     """
-    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.proxy_server import (
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+    )
 
     if prisma_client is None:
         raise Exception("No DB Connected.")
@@ -4115,6 +4123,13 @@ async def block_team(
     record = await _team_db(prisma_client).update(
         where={"team_id": data.team_id},
         data={"blocked": True},  # type: ignore
+        include=_INCLUDE_OBJECT_PERMISSION,
+    )
+
+    await _refresh_cached_team(
+        team_row=record,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
     )
 
     return record
@@ -4143,7 +4158,11 @@ async def unblock_team(
     }'
     ```
     """
-    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.proxy_server import (
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+    )
 
     if prisma_client is None:
         raise Exception("No DB Connected.")
@@ -4164,6 +4183,13 @@ async def unblock_team(
     record = await _team_db(prisma_client).update(
         where={"team_id": data.team_id},
         data={"blocked": False},  # type: ignore
+        include=_INCLUDE_OBJECT_PERMISSION,
+    )
+
+    await _refresh_cached_team(
+        team_row=record,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
     )
 
     return record

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -10617,3 +10617,55 @@ def test_validate_member_user_id_provisioning_caps_the_ids_it_echoes_back():
     assert f"u{_MAX_REPORTED_UNKNOWN_USER_IDS}" not in detail
     assert f"and {500 - _MAX_REPORTED_UNKNOWN_USER_IDS} more" in detail
     assert len(detail) < 1000
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "endpoint_name, expected_blocked",
+    [("block_team", True), ("unblock_team", False)],
+)
+async def test_block_unblock_team_refreshes_cached_team(endpoint_name, expected_blocked):
+    """`/team/block` and `/team/unblock` must refresh the cached team object.
+
+    Auth resolves teams through `team_id:{team_id}` before hitting the DB, and
+    `common_checks` enforces `blocked` off that cached object. Writing the DB row
+    without refreshing the cache lets a blocked team keep serving traffic (and a
+    just-unblocked team keep getting rejected) until the entry expires.
+    """
+    from unittest.mock import Mock
+
+    from fastapi import Request
+
+    from litellm.proxy._types import BlockTeamRequest
+    from litellm.proxy.management_endpoints import team_endpoints
+
+    team_id = "team-block-cache-refresh"
+    existing = LiteLLM_TeamTable(team_id=team_id, team_alias="t", blocked=not expected_blocked)
+    updated = LiteLLM_TeamTable(team_id=team_id, team_alias="t", blocked=expected_blocked)
+    endpoint = getattr(team_endpoints, endpoint_name)
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as pc,
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch.object(team_endpoints, "_refresh_cached_team", new=AsyncMock()) as mock_refresh,
+    ):
+        pc.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing)
+        pc.db.litellm_teamtable.update = AsyncMock(return_value=updated)
+
+        result = await endpoint(
+            data=BlockTeamRequest(team_id=team_id),
+            http_request=Mock(spec=Request),
+            user_api_key_dict=UserAPIKeyAuth(
+                user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin"
+            ),
+        )
+
+    assert result is updated
+    update_kwargs = pc.db.litellm_teamtable.update.call_args.kwargs
+    assert update_kwargs["data"] == {"blocked": expected_blocked}
+    mock_refresh.assert_awaited_once()
+    assert mock_refresh.await_args.kwargs["team_row"] is updated
+    # Without `object_permission`, the refresh caches the team with the relation
+    # nulled out.
+    assert update_kwargs.get("include") == {"object_permission": True}


### PR DESCRIPTION
## TLDR

Problem this solves:

`POST /team/block` and `POST /team/unblock` write `blocked` to Postgres and return without touching the management-object cache. Authentication resolves teams through the `team_id:{team_id}` cache entry before it reads the database, and `common_checks` enforces `blocked` off that cached object, so blocking a team whose traffic has already warmed the cache does not actually stop the traffic; it keeps flowing until the entry expires. The inverse is just as bad for availability: unblocking a team keeps rejecting its requests for the same window

How it solves it:

`_refresh_cached_team` already exists for this, and its docstring states that every endpoint mutating `litellm_teamtable` must call it so auth does not keep granting revoked permissions. Block and unblock were the only mutating team endpoints that skipped it. Both now call it with the row the update returned

The update also asks for `object_permission` now, because the refresh writes the returned row straight into the cache and Prisma leaves unrequested relations null; caching a team with the relation dropped is what `team_model_add` and `team_model_delete` already avoid the same way. That include is a frozen module-level `MappingProxyType` constant rather than a literal at each call site, so it does not add mutable-construction violations

## Relevant issues

Fixes #35565

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

I could not produce the curl-against-a-live-proxy proof this repo asks for, because reproducing the stale-cache window needs a running proxy with Postgres plus a warmed cache entry and I do not have a provider key or database to point a real proxy at. Flagging that plainly rather than passing a test run off as proof

What I can offer instead is the regression coverage, which fails on `litellm_internal_staging` and passes here. It is parametrized over both endpoints and asserts the refresh actually happens rather than mocking the contract away:

```
$ uv run --frozen pytest tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py \
    -k block_unblock_team_refreshes -q

# on litellm_internal_staging
E  AssertionError: Expected mock to have been awaited once. Awaited 0 times.
2 failed

# on this branch
2 passed
```

The manual QA runbook is below if you would like to confirm it against a live proxy

## Type

🐛 Bug Fix

## Changes

`block_team` and `unblock_team` in `litellm/proxy/management_endpoints/team_endpoints.py` now import `proxy_logging_obj` and `user_api_key_cache`, request `object_permission` on the update, and await `_refresh_cached_team` with the updated row

Added `_INCLUDE_OBJECT_PERMISSION`, a frozen `Mapping[str, bool]` constant for that include

Extended the mapped test file with `test_block_unblock_team_refreshes_cached_team`, parametrized over block and unblock

## QA runbook

1. Start a proxy with a database and Redis or in-memory caching, create a team with `blocked=false`, and create a key on that team
2. Send one `/chat/completions` request with that key so auth warms `team_id:{team_id}`
3. `curl -X POST localhost:4000/team/block -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"team_id":"<team_id>"}'`
4. Immediately send another `/chat/completions` request with the same key. Before this change it succeeds until the cache entry expires; with this change it is rejected right away
5. Repeat with `/team/unblock` and confirm the next request is accepted immediately instead of staying rejected

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

An AI coding agent was used while preparing this change; I reviewed the diff, confirmed the new tests fail on the base branch and pass here, and `make pre-commit` is green
