### PR TITLE
feat(infersia): add Infersia via providers.json

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -183,5 +183,9 @@
       "max_completion_tokens": "max_tokens"
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+  },
+  "infersia": {
+    "base_url": "https://api.infersia.com/v1",
+    "api_key_env": "INFERSIA_API_KEY"
   }
 }

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -509,6 +509,23 @@
         "a2a": false
       }
     },
+    "infersia": {
+      "display_name": "Infersia (`infersia`)",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false,
+        "interactions": false
+      }
+    },
     "clarifai": {
       "display_name": "Clarifai (`clarifai`)",
       "url": "https://docs.litellm.ai/docs/providers/clarifai",


### PR DESCRIPTION
Adds [Infersia](https://infersia.com) as an OpenAI-compatible provider via `providers.json`.

```json
"infersia": {
  "base_url": "https://api.infersia.com/v1",
  "api_key_env": "INFERSIA_API_KEY"
}
```

**Disclosure:** I work on Infersia.

### Why JSON-only

The API follows the OpenAI spec without deviation, so no `param_mappings`, `constraints` or `base_class` override is needed — standard bearer auth, standard SSE streaming, standard `max_tokens`. Verified against the official `openai` Python and JS SDKs in our CI (streaming, tool calls, structured output, prefix caching).

### Usage

```python
import litellm
litellm.completion(
    model="infersia/deepseek/deepseek-v4-flash-0731",
    messages=[{"role": "user", "content": "hi"}],
)
```

Note our model IDs contain a slash (`deepseek/deepseek-v4-flash-0731`), giving a three-segment string. This works correctly today — `get_llm_provider_logic` splits with `split("/", 1)`, so the provider prefix is stripped and `deepseek/deepseek-v4-flash-0731` is forwarded intact. Flagging it only because it is unusual, not because it needs handling.

### What's served

Open-weight models on our own GPUs — DeepSeek V4 Flash 0731 (1M context), StepFun Step 3.7 Flash (262K, vision), Qwen3.6 35B-A3B, Qwen3 14B, Qwen3 8B, plus a free tier (`qwen/qwen3-8b:free`). Each endpoint publishes the exact quantisation served, measured latency and 30-day uptime. Catalogue: https://infersia.com/models — keys: https://infersia.com/dashboard/keys

`/v1/models` exposes per-model `pricing` and `context_length` in the OpenAI shape, so cost-aware routing works without extra configuration.
