### PR TITLE
fix(proxy): refresh cached project on /project/update

### DIFF
--- a/enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py
+++ b/enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
 from litellm.proxy._types import *
+from litellm.proxy.auth.auth_checks import refresh_cached_project
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.management_endpoints.common_utils import _set_object_metadata_field
 from litellm.proxy.management_helpers.utils import (
@@ -514,6 +515,8 @@ async def update_project(
         litellm_proxy_admin_name,
         premium_user,
         prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
     )
 
     try:
@@ -671,6 +674,13 @@ async def update_project(
             data=update_data,
             include={"litellm_budget_table": True, "object_permission": True},
         )
+
+        if updated_project is not None:
+            await refresh_cached_project(
+                project_row=updated_project,
+                user_api_key_cache=user_api_key_cache,
+                proxy_logging_obj=proxy_logging_obj,
+            )
 
         return updated_project
     except Exception as e:

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -4213,6 +4213,50 @@ async def _project_soft_budget_check(
             )
 
 
+def project_cache_key(project_id: str) -> str:
+    """Cache key auth resolves projects through."""
+    return f"project_id:{project_id}"
+
+
+async def _cache_project_object(
+    project_obj: LiteLLM_ProjectTableCachedObj,
+    user_api_key_cache: UserApiKeyCache,
+    proxy_logging_obj: ProxyLogging | None,
+) -> None:
+    project_obj.last_refreshed_at = time.time()
+    await _cache_management_object(
+        key=project_cache_key(project_obj.project_id),
+        value=project_obj,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
+        model_type=LiteLLM_ProjectTableCachedObj,
+    )
+
+
+async def refresh_cached_project(
+    project_row: BaseModel,
+    user_api_key_cache: UserApiKeyCache,
+    proxy_logging_obj: ProxyLogging | None = None,
+) -> None:
+    """
+    Refresh the cached project object after a DB write.
+
+    Every endpoint that mutates `litellm_projecttable` must call this so the
+    cached `LiteLLM_ProjectTableCachedObj` that `_run_project_checks` reads stays
+    in sync. Without it, auth keeps enforcing the previous `blocked`, `models`
+    and budget values until the entry expires.
+
+    `project_row` is the Prisma row returned by `update`/`find_unique` on
+    `litellm_projecttable`; include `litellm_budget_table` on that query so the
+    refreshed entry carries the same relation `get_project_object` caches.
+    """
+    await _cache_project_object(
+        project_obj=LiteLLM_ProjectTableCachedObj.model_validate(project_row.model_dump()),
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
+    )
+
+
 async def get_project_object(
     project_id: str,
     prisma_client: PrismaClient | None,
@@ -4230,9 +4274,8 @@ async def get_project_object(
         return None
 
     # Check cache first
-    cache_key = f"project_id:{project_id}"
     deserialized_project = await user_api_key_cache.async_get_cache(
-        key=cache_key,
+        key=project_cache_key(project_id),
         model_type=LiteLLM_ProjectTableCachedObj,
     )
     if deserialized_project is not None:
@@ -4246,16 +4289,12 @@ async def get_project_object(
     if project_row is None:
         return None
 
-    project_obj = LiteLLM_ProjectTableCachedObj.model_validate(project_row.model_dump())
-
     # Cache with TTL following _cache_management_object pattern
-    project_obj.last_refreshed_at = time.time()
-    await _cache_management_object(
-        key=cache_key,
-        value=project_obj,
+    project_obj = LiteLLM_ProjectTableCachedObj.model_validate(project_row.model_dump())
+    await _cache_project_object(
+        project_obj=project_obj,
         user_api_key_cache=user_api_key_cache,
         proxy_logging_obj=proxy_logging_obj,
-        model_type=LiteLLM_ProjectTableCachedObj,
     )
 
     return project_obj

--- a/tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py
+++ b/tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py
@@ -864,3 +864,45 @@ def test_litellm_project_table_has_timestamp_fields():
     fields = LiteLLM_ProjectTable.model_fields
     assert "created_at" in fields, "LiteLLM_ProjectTable must have created_at field"
     assert "updated_at" in fields, "LiteLLM_ProjectTable must have updated_at field"
+
+
+@pytest.mark.asyncio
+async def test_update_project_refreshes_cached_project():
+    """`/project/update` must refresh the cached project object.
+
+    Auth resolves projects through `project_id:{project_id}` before reading the
+    DB, and `_run_project_checks` enforces `blocked`, `models` and the budget off
+    that cached object. Writing the row without refreshing the cache lets a
+    just-blocked project keep serving traffic, and keeps rejecting a project whose
+    access was just widened, until the entry expires.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from litellm_enterprise.proxy.management_endpoints import project_endpoints
+
+    project_id = "project-cache-refresh"
+    existing = MagicMock(project_id=project_id, team_id=None, budget_id=None, object_permission_id=None)
+    updated = MagicMock(project_id=project_id)
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as pc,
+        patch("litellm.proxy.proxy_server.premium_user", True),
+        patch("litellm.proxy.proxy_server.litellm_proxy_admin_name", "admin"),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", MagicMock()),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", MagicMock()),
+        patch.object(project_endpoints, "refresh_cached_project", new=AsyncMock()) as mock_refresh,
+    ):
+        pc.db.litellm_projecttable.find_unique = AsyncMock(return_value=existing)
+        pc.db.litellm_projecttable.update = AsyncMock(return_value=updated)
+        pc.jsonify_object = MagicMock(side_effect=lambda data: data)
+
+        result = await update_project(
+            data=UpdateProjectRequest(project_id=project_id, blocked=True),
+            http_request=mock.Mock(spec=Request),
+            user_api_key_dict=UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="admin"),
+        )
+
+    assert result is updated
+    assert pc.db.litellm_projecttable.update.call_args.kwargs["data"]["blocked"] is True
+    mock_refresh.assert_awaited_once()
+    assert mock_refresh.await_args.kwargs["project_row"] is updated


### PR DESCRIPTION
## TLDR

Problem this solves:

`POST /project/update` writes the project row, its budget and its object permissions, then returns without refreshing or invalidating `project_id:{project_id}`. Authentication resolves projects through that cache entry before it reads the database, and `_run_project_checks` trusts the cached `blocked`, `models` and budget values, so a project whose traffic has already warmed the cache keeps its old authorization after an admin blocks it, narrows its allowed models, or lowers its budget

The stale direction hurts availability too. Unblocking a project or widening its model access keeps rejecting requests for the same window

How it solves it:

Added `refresh_cached_project` in `auth_checks`, right next to `get_project_object`, so the write path and the read path share one cache key and one TTL instead of the enterprise endpoint reimplementing either. `/project/update` now calls it with the row the update returns

That row already asks for `litellm_budget_table`, which is exactly the relation `get_project_object` includes when it populates the cache, so the refreshed entry has the shape auth expects rather than one with the budget relation dropped

While wiring this up I pulled the existing cache write in `get_project_object` into a small `_cache_project_object` helper and replaced the inline `f"project_id:{project_id}"` with `project_cache_key`, so there is now a single definition of the key. No behavior change on that path

## Relevant issues

Fixes #35566

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

I could not produce the curl-against-a-live-proxy proof this repo prefers; reproducing the window needs a premium-gated proxy with Postgres and a warmed cache entry, and I do not have a database or provider key to point a real proxy at. Saying that plainly rather than dressing a test run up as proof

What I do have is a regression test that fails when the refresh call is removed and passes with it. The existing project endpoint tests in that file are DB-backed and skipped, so this one mocks Prisma:

```
$ uv run --frozen pytest \
    tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py \
    -k refreshes_cached_project -q

# with the refresh call deleted (import kept, so the failure is behavioral)
E  AssertionError: Expected mock to have been awaited once. Awaited 0 times.
1 failed

# on this branch
1 passed
```

The manual runbook is below if you want to confirm against a live proxy

## Type

🐛 Bug Fix

## Changes

`auth_checks` gains `project_cache_key`, `_cache_project_object` and `refresh_cached_project`; `get_project_object` now goes through the first two

`update_project` in the enterprise project endpoints awaits `refresh_cached_project` with the updated row

Added `test_update_project_refreshes_cached_project` to the mapped enterprise test file

## QA runbook

1. Start a premium proxy with a database, create a project with `blocked=false` and a key scoped to it
2. Send one `/chat/completions` request with that key so auth warms `project_id:{project_id}`
3. `curl -X POST localhost:4000/project/update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' -d '{"project_id":"<project_id>","blocked":true}'`
4. Immediately send another `/chat/completions` request with the same key. Before this change it succeeds until the entry expires; with this change it is rejected right away
5. Repeat with `blocked:false` and confirm the next request is accepted immediately

## Note for reviewers

`/project/delete` has the same gap; it removes the row without dropping the cache entry, so a deleted project can keep authorizing traffic for the rest of the TTL. I left it out to keep this PR to the one endpoint the issue names. Happy to fold it in here or file it separately, whichever you prefer

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

An AI coding agent was used while preparing this change; I reviewed the diff, mutation-checked the new test by deleting only the refresh call, and `make pre-commit` is green. One unrelated test, `test_post_custom_auth_expired_key_returns_unauthorized`, already fails on `litellm_internal_staging` and is untouched by this change
