### PR TITLE
fix(fireworks-ai): handle dict-form reasoning_effort from Anthropic adapter

### DIFF
--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -269,6 +269,8 @@ class FireworksAIConfig(FireworksAIMixin, OpenAIGPTConfig):
                     optional_params["reasoning_effort"] = "medium"
                 elif value is False:
                     optional_params["reasoning_effort"] = "none"
+                elif isinstance(value, dict):
+                    optional_params["reasoning_effort"] = value.get("effort", "medium")
                 else:
                     optional_params["reasoning_effort"] = value
             elif param in supported_openai_params:

--- a/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
+++ b/tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py
@@ -1141,6 +1141,30 @@ def test_reasoning_effort_string_passthrough():
     assert result["reasoning_effort"] == "high"
 
 
+def test_reasoning_effort_dict_extracts_effort_key():
+    config = FireworksAIConfig()
+    result = config.map_openai_params(
+        {"reasoning_effort": {"effort": "high", "summary": "detailed"}},
+        {},
+        _REASONING_MODEL,
+        drop_params=False,
+    )
+    assert result["reasoning_effort"] == "high"
+    assert isinstance(result["reasoning_effort"], str)
+
+
+def test_reasoning_effort_dict_without_effort_key_defaults_to_medium():
+    config = FireworksAIConfig()
+    result = config.map_openai_params(
+        {"reasoning_effort": {"summary": "detailed"}},
+        {},
+        _REASONING_MODEL,
+        drop_params=False,
+    )
+    assert result["reasoning_effort"] == "medium"
+    assert isinstance(result["reasoning_effort"], str)
+
+
 def test_reasoning_effort_integer_passthrough():
     config = FireworksAIConfig()
     result = config.map_openai_params(


### PR DESCRIPTION
## TLDR

Problem this solves:

- Fireworks AI transformer passes dict-form `reasoning_effort` to the API, causing a 400
- Dict shape `{"effort": "medium", "summary": "detailed"}` comes from the Anthropic adapter; Fireworks only accepts a plain string

How it solves it:

- Adds an `isinstance(value, dict)` branch in the Fireworks transformer that extracts the `effort` key, defaulting to `"medium"` if absent

## Relevant issues

Fixes #35649

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Before (at commit `6753639325`):

```
curl -s -X POST http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -d '{
    "model": "accounts/fireworks/models/deepseek-v4-0709",
    "messages": [{"role": "user", "content": "hi"}],
    "reasoning_effort": {"effort": "medium", "summary": "detailed"}
  }'

{"error":{"message":"Fireworks_aiException - reasoning_effort is of type '\''object'\'', expected '\''string'\''","type":"invalid_request_error","param":null,"code":"400"}}
```

After (at commit `ab932530e1`):

```
curl -s -X POST http://localhost:4000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -d '{
    "model": "accounts/fireworks/models/deepseek-v4-0709",
    "messages": [{"role": "user", "content": "hi"}],
    "reasoning_effort": {"effort": "medium", "summary": "detailed"}
  }'

{"id":"...","choices":[{"message":{"role":"assistant","content":"Hello! How can I assist you today?"},...}],...}
```

## Type

🐛 Bug Fix

## Changes

`litellm/llms/fireworks_ai/chat/transformation.py`: add `elif isinstance(value, dict)` branch under the `reasoning_effort` param handler to extract the string `effort` key from dict-form values produced by the Anthropic adapter.

`tests/test_litellm/llms/fireworks_ai/chat/test_fireworks_ai_chat_transformation.py`: two regression tests — one for a dict with an `effort` key, one for a dict missing it (should default to `"medium"`).

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR