### PR TITLE
fix: map Cohere params with the config that transforms the request

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -3894,8 +3894,9 @@ def get_optional_params(
         )
 
     elif custom_llm_provider == "cohere_chat" or custom_llm_provider == "cohere":
-        # handle cohere params
-        optional_params = litellm.CohereChatConfig().map_openai_params(
+        # handle cohere params - pick the same config the request transform will
+        # use, so v2 (the default route) maps its own params rather than v1's
+        optional_params = ProviderConfigManager._get_cohere_config(model=model).map_openai_params(
             non_default_params=non_default_params,
             optional_params=optional_params,
             model=model,

--- a/tests/test_litellm/llms/cohere/chat/test_cohere_v2_param_routing.py
+++ b/tests/test_litellm/llms/cohere/chat/test_cohere_v2_param_routing.py
@@ -1,0 +1,55 @@
+"""`get_optional_params` must map Cohere params with the config that will
+actually transform the request.
+
+`CohereModelInfo.get_cohere_route` sends every model to v2 unless the id asks
+for v1, and `ProviderConfigManager` hands the v2 config to the transform. Param
+mapping used to be pinned to the v1 config regardless, so a request could be
+built by v2 while its params were mapped by v1.
+
+The two configs happen to agree today, so this is not a behaviour change. It
+stops them silently disagreeing the moment either one grows a param the other
+does not have.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+import pytest
+
+from litellm.llms.cohere.chat.transformation import CohereChatConfig
+from litellm.llms.cohere.chat.v2_transformation import CohereV2ChatConfig
+from litellm.utils import ProviderConfigManager
+
+
+@pytest.mark.parametrize("custom_llm_provider", ["cohere", "cohere_chat"])
+@pytest.mark.parametrize(
+    "model, expected_config",
+    [
+        ("command-a-03-2025", CohereV2ChatConfig),
+        ("cohere_chat/v1/command-r", CohereChatConfig),
+    ],
+)
+def test_param_mapping_uses_the_route_config(model, expected_config, custom_llm_provider, monkeypatch):
+    """The config that maps params must be the one that transforms the request."""
+    seen = {}
+
+    def record(self, non_default_params, optional_params, model, drop_params):
+        seen["config"] = type(self)
+        return optional_params
+
+    monkeypatch.setattr(CohereChatConfig, "map_openai_params", record)
+    monkeypatch.setattr(CohereV2ChatConfig, "map_openai_params", record)
+
+    from litellm.utils import get_optional_params
+
+    get_optional_params(
+        model=model,
+        custom_llm_provider=custom_llm_provider,
+        drop_params=True,
+        temperature=0.5,
+    )
+
+    assert seen["config"] is expected_config
+    assert seen["config"] is type(ProviderConfigManager._get_cohere_config(model=model))


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cohere requests transform with the v2 config
- Their params map with the v1 config
- The two can silently disagree

How it solves it:

- `get_optional_params` picks the config via the same route selector

## Relevant issues

None. Found while auditing Cohere param handling.

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5**

## Screenshots / Proof of Fix

`CohereModelInfo.get_cohere_route` sends every model to v2 unless the id asks for v1, and `ProviderConfigManager._get_cohere_config` hands that config to the request transform. `get_optional_params` was pinned to `CohereChatConfig` (v1) regardless:

```python
elif custom_llm_provider == "cohere_chat" or custom_llm_provider == "cohere":
    optional_params = litellm.CohereChatConfig().map_openai_params(...)
```

The new test records which config actually maps the params. On `main` it fails for the v2 route:

```
FAILED test_param_mapping_uses_the_route_config[command-a-03-2025-CohereV2ChatConfig-cohere]
FAILED test_param_mapping_uses_the_route_config[command-a-03-2025-CohereV2ChatConfig-cohere_chat]
2 failed, 2 passed
```

With the fix, all four pass, and the explicit `cohere_chat/v1/...` route still resolves to v1.

**This is not a behaviour change on its own.** v1 and v2 produce identical output for every param they both handle today, so merging this alone shifts nothing for users.

It becomes load-bearing the moment v2 grows a param v1 lacks. #35217 does exactly that, adding `response_format`, `logprobs`, `thinking` and `tool_choice` mapping from Cohere's v2 reference. Without this PR, 5 of those behaviours are silently dropped, because v1 does the mapping:

```
FAILED TestCohereV2::test_response_format_and_logprobs_survive_drop_params
FAILED TestCohereV2::test_tool_choice_is_mapped_to_cohere_casing[required-REQUIRED]
FAILED TestCohereV2::test_tool_choice_is_mapped_to_cohere_casing[none-NONE]
FAILED TestCohereV2::test_reasoning_effort_maps_to_thinking
FAILED TestCohereV2::test_reasoning_effort_none_disables_thinking
```

So this is worth merging on its own terms (the two configs should not be able to disagree), and it is a prerequisite for #35217.

I don't hold a paid Cohere key, so I have not run a live billed call.
