### PR TITLE
fix(proxy): refresh team cache after /team/block and /team/unblock (Fixes #35565)

### DIFF
--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -3809,7 +3809,11 @@ async def block_team(
 
 
     """
-    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.proxy_server import (
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+    )
 
     if prisma_client is None:
         raise Exception("No DB Connected.")
@@ -3827,9 +3831,22 @@ async def block_team(
         user_api_key_dict=user_api_key_dict,
     )
 
+    # `include` mirrors the relations the auth path consumes off the cached
+    # team object so that `_refresh_cached_team` doesn't null them out.
     record = await TeamRepository(prisma_client).table.update(
         where={"team_id": data.team_id},
         data={"blocked": True},  # type: ignore
+        include={"object_permission": True},  # pyright: ignore[reportArgumentType]  # Prisma include arg type
+    )
+
+    # Refresh the in-memory cached team so the very next auth check sees
+    # `blocked=True`. Without this, requests already in flight (and any
+    # pod with a warmed management-object cache) keep using the stale
+    # `blocked=False` row until the cache TTL expires. See #35565.
+    await _refresh_cached_team(
+        team_row=record,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
     )
 
     return record
@@ -3858,7 +3875,11 @@ async def unblock_team(
     }'
     ```
     """
-    from litellm.proxy.proxy_server import prisma_client
+    from litellm.proxy.proxy_server import (
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+    )
 
     if prisma_client is None:
         raise Exception("No DB Connected.")
@@ -3876,9 +3897,21 @@ async def unblock_team(
         user_api_key_dict=user_api_key_dict,
     )
 
+    # `include` mirrors the relations the auth path consumes off the cached
+    # team object so that `_refresh_cached_team` doesn't null them out.
     record = await TeamRepository(prisma_client).table.update(
         where={"team_id": data.team_id},
         data={"blocked": False},  # type: ignore
+        include={"object_permission": True},  # pyright: ignore[reportArgumentType]  # Prisma include arg type
+    )
+
+    # Refresh the in-memory cached team so the very next auth check sees
+    # `blocked=False`. Without this, callers see stale `Team=... is blocked`
+    # errors until the cache TTL expires. See #35565.
+    await _refresh_cached_team(
+        team_row=record,
+        user_api_key_cache=user_api_key_cache,
+        proxy_logging_obj=proxy_logging_obj,
     )
 
     return record

--- a/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py
@@ -1916,6 +1916,114 @@ async def test_team_model_add_delete_refresh_team_cache(endpoint_name):
         assert update_call_kwargs.get("include", {}).get("object_permission") is True
 
 
+@pytest.mark.parametrize("endpoint_name", ["block_team", "unblock_team"])
+@pytest.mark.asyncio
+async def test_team_block_unblock_refresh_team_cache(endpoint_name):
+    """
+    Regression pin for #35565: `/team/block` and `/team/unblock` previously
+    only updated Postgres, leaving the in-memory `team_id:{team_id}` cache
+    serving the pre-mutation `blocked` flag until the management-object
+    TTL expired. After a block, auth kept admitting calls; after an
+    unblock, auth kept rejecting them.
+
+    Pin: both endpoints must call `_cache_team_object` with the updated
+    team row so the very next auth check sees the new blocked state.
+    """
+    from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+    from fastapi import Request
+
+    from litellm.proxy._types import (
+        BlockTeamRequest,
+        LitellmUserRoles,
+        UserAPIKeyAuth,
+    )
+    from litellm.proxy.management_endpoints.team_endpoints import (
+        block_team,
+        unblock_team,
+    )
+
+    mock_request = Mock(spec=Request)
+    mock_user_api_key_dict = UserAPIKeyAuth(user_role=LitellmUserRoles.PROXY_ADMIN, user_id="test_user_id")
+
+    existing_team = MagicMock()
+    existing_team.model_dump.return_value = {
+        "team_id": "team-block-test",
+        "blocked": False,
+        "object_permission_id": "op-block",
+        "object_permission": {
+            "object_permission_id": "op-block",
+            "search_tools": ["allowed-tool-A"],
+        },
+    }
+
+    expected_blocked = endpoint_name == "block_team"
+    updated_team = MagicMock()
+    updated_team.team_id = "team-block-test"
+    updated_team.model_dump.return_value = {
+        "team_id": "team-block-test",
+        "blocked": expected_blocked,
+        "object_permission_id": "op-block",
+        "object_permission": {
+            "object_permission_id": "op-block",
+            "search_tools": ["allowed-tool-A"],
+        },
+    }
+
+    with (
+        patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma_client,
+        patch("litellm.proxy.proxy_server.user_api_key_cache") as mock_cache,
+        patch("litellm.proxy.proxy_server.proxy_logging_obj") as mock_logging,
+        patch(
+            "litellm.proxy.management_endpoints.team_endpoints._cache_team_object",
+            new_callable=AsyncMock,
+        ) as mock_cache_team,
+    ):
+        mock_prisma_client.db.litellm_teamtable.find_unique = AsyncMock(return_value=existing_team)
+        mock_prisma_client.db.litellm_teamtable.update = AsyncMock(return_value=updated_team)
+
+        if endpoint_name == "block_team":
+            await block_team(
+                data=BlockTeamRequest(team_id="team-block-test"),
+                http_request=mock_request,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+        else:
+            await unblock_team(
+                data=BlockTeamRequest(team_id="team-block-test"),
+                http_request=mock_request,
+                user_api_key_dict=mock_user_api_key_dict,
+            )
+
+        # Pin: cache refresh must run with the updated team row (#35565).
+        assert mock_cache_team.await_count == 1, (
+            f"{endpoint_name} must call _cache_team_object exactly once "
+            f"after the DB update (#35565 regression pin); "
+            f"got await_count={mock_cache_team.await_count}"
+        )
+        call_kwargs = mock_cache_team.await_args.kwargs
+        assert call_kwargs["team_id"] == "team-block-test"
+        # The cached object must carry the *post-mutation* `blocked` flag,
+        # not the pre-mutation `False` from `existing_team`. Both rows share
+        # team_id, so the only field that actually pins the update flow is
+        # `blocked`.
+        assert call_kwargs["team_table"].team_id == "team-block-test"
+        assert call_kwargs["team_table"].blocked is expected_blocked
+        # And the cached object MUST carry the `object_permission` relation
+        # (same reason as LIT-3244 follow-up): without
+        # `include={"object_permission": True}` on the Prisma update, the
+        # cached team would have object_permission=None and downstream
+        # consumers (validate_key_search_tools_against_team etc.) would
+        # stop enforcing the team's allowlist.
+        assert call_kwargs["team_table"].object_permission is not None
+        assert call_kwargs["team_table"].object_permission.search_tools == ["allowed-tool-A"]
+        # Pin the Prisma call shape too — the regression lives in *what the
+        # update asks for*, so the contract that the update includes
+        # `object_permission` belongs in this test.
+        update_call_kwargs = mock_prisma_client.db.litellm_teamtable.update.call_args.kwargs
+        assert update_call_kwargs.get("include", {}).get("object_permission") is True
+
+
 @pytest.mark.asyncio
 async def test_update_team_team_member_budget_not_passed_to_db():
     """


### PR DESCRIPTION
## Summary

`POST /team/block` and `POST /team/unblock` only wrote to Postgres and left the in-memory `team_id:{team_id}` cache untouched. The next `common_checks` auth read served the pre-mutation `blocked` flag until the management-object TTL expired, so:

- A fresh block kept admitting traffic from the team's keys.
- A fresh unblock kept rejecting traffic from the team's keys with `Team=<id> is blocked`.
- In a multi-pod deployment every pod's warmed cache extended that window independently.

This is the same multi-prefix cache-invalidation pattern that motivated `_refresh_cached_team`'s docstring, and the same cache-invalidation class as PRs #33702 (JWT key mapping delete), #34217/34218 (team delete), #34101/34103 (project budget reservation). `/team/block` and `/team/unblock` were the two stragglers on the `litellm_teamtable` mutation list.

Fixes #35565.

## Changes

### `litellm/proxy/management_endpoints/team_endpoints.py`

- `block_team` and `unblock_team` now call `await _refresh_cached_team(...)` after the Prisma `update` with `user_api_key_cache` and `proxy_logging_obj` from `litellm.proxy.proxy_server`.
- Both Prisma `update` calls now pass `include={"object_permission": True}` so the cached `LiteLLM_TeamTableCachedObj` carries the relation the auth path and downstream consumers (e.g. `validate_key_search_tools_against_team`) read off it. Without `include`, `_refresh_cached_team` would write a cached object with `object_permission=None` and the team's search-tool allowlist would silently stop being enforced. This is the same LIT-3244 follow-up pattern already applied in `team_model_add` and `team_model_delete`.
- Module imports for `user_api_key_cache` and `proxy_logging_obj` are added inside the function (matching the rest of the file's style of importing `litellm.proxy.proxy_server` symbols lazily to avoid the import-time cycle).

### `tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py`

- New parametrized regression pin `test_team_block_unblock_refresh_team_cache[block_team]` and `[unblock_team]`. It mocks `prisma_client`, the two cache handles, and `_cache_team_object` itself, then asserts:
  1. `_cache_team_object` is awaited exactly once after the DB update.
  2. The cached object carries the post-mutation `blocked` flag (not the pre-mutation `False` from `existing_team`).
  3. The cached object preserves the `object_permission` relation with its `search_tools` allowlist.
  4. The Prisma `update` call asked for `include={"object_permission": True}`.

The test mirrors the structure of `test_team_model_add_delete_refresh_team_cache` (the LIT-3244 pin) so the cache-refresh contract reads the same way for every endpoint that mutates `litellm_teamtable`.

## Verification

Local (this branch, `litellm_internal_staging` @ `2bb297efa0` base):

- `pytest tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py::test_team_block_unblock_refresh_team_cache` — 2 passed (block + unblock).
- `pytest tests/test_litellm/proxy/management_endpoints/test_team_endpoints.py::test_team_model_add_delete_refresh_team_cache` — 2 passed (the analogous LIT-3244 pin, sanity check that I didn't break the existing contract).
- `pytest tests/test_litellm/proxy/auth/test_route_checks.py -k "team_block or team_unblock or proxy_admin_viewer_blocked_management_writes"` — 16 passed (route-level permissions unchanged).
- `ruff check litellm/proxy/management_endpoints/team_endpoints.py` — clean.
- `ruff format --check litellm/proxy/management_endpoints/team_endpoints.py` — already formatted.
- `scripts/ruff_strict_gate.py` — OK (every strict rule within its codebase ceiling).
- `scripts/type_discipline_gate.py` — OK (every LIT rule within its codebase ceiling; the new `include=` suppressions use `# pyright: ignore[reportArgumentType]  # <reason>` per the LIT009 ban).
- `basedpyright litellm/proxy/management_endpoints/team_endpoints.py` — no new errors at the touched lines (the pre-existing `reportAny` cascade around the `LiteLLM_TeamTable(**existing_team.model_dump())` calls is unchanged).

CI:

- Live curl proof via the running proxy is not possible from this environment (no Docker), so verification above is the unit-level pin. Once CI lands, the `test-unit-misc` workflow should pick up the new tests on its first run.

## Design notes

- **Why include `object_permission`** — the `_refresh_cached_team` helper writes `LiteLLM_TeamTableCachedObj(**team_row.model_dump())` to the cache. If the Prisma `update` doesn't ask for `object_permission` in its `include`, the model_dump won't carry the relation, the cached object will be built with `object_permission=None`, and consumers like `validate_key_search_tools_against_team` will treat the team as having no allowlist. This is exactly the failure mode described in the LIT-3244 follow-up that was fixed in `team_model_add` / `team_model_delete`. The same `include={"object_permission": True}` shape is now applied here for consistency.
- **Why call `_refresh_cached_team` instead of just deleting the cache key** — deleting forces the next reader through `get_team_object`, which is a `cache → DB` lookup path. `_refresh_cached_team` writes the freshly-updated row directly, so the very next auth check sees the new state without a DB round-trip. The existing module-wide pattern (update_team, team_model_add, team_model_delete, etc.) all use `_refresh_cached_team`; block/unblock should match.
- **Why the test mocks `_cache_team_object` and not `_refresh_cached_team`** — the contract being pinned is "the endpoint must drive the cache write path with the post-mutation row". Mocking at the lowest layer (`_cache_team_object`) makes the assertion specific and stable; mocking at the higher layer (`_refresh_cached_team`) would also pass if someone refactored the helper to call something other than `_cache_team_object`, hiding real regressions.
- **Why both endpoints in one test, parameterized** — the two endpoints are the same shape with the only difference being `data={"blocked": True}` vs `data={"blocked": False}`. Parameterizing keeps the cache-refresh contract testable for both values without duplicating the body.

## Risks

- **Low.** The change adds one Prisma `include` and one awaited cache write to each endpoint. The include is the same one already used by `team_model_add`/`team_model_delete`, and the cache write uses the same helper.
- The cache write path (`_cache_team_object`) writes to `team_id:{team_id}` and, if a `team_alias` is set, deletes `team_alias:{team_alias}`. So the alias-keyed cache (used by JWT-by-alias auth) is also invalidated as a side effect — same behaviour as every other team-mutation endpoint.
- In a multi-pod deployment, the in-memory `DualCache` invalidation only affects the local pod. The Redis side of `DualCache` is hit by `_cache_team_object` through `proxy_logging_obj.internal_usage_cache.dual_cache.async_set_cache`, so the post-mutation row propagates to every pod that reads from Redis on its next miss. This matches the propagation semantics of every other team-mutation endpoint.

## Future improvements (not in this PR)

- The `auth_checks.py:538` blocked-team check could in theory be promoted to a route-level dependency on the `block`/`unblock` endpoints, but that's a refactor with a much larger surface than the bug itself.
- A real end-to-end test that warms the cache, fires the endpoint, and asserts the next `get_team_object` call sees the new state would be valuable — it would require a live Postgres (skipped here because the unit pin already catches the regression).
