### PR TITLE
fix(responses): initialize completed_response on the bridge streaming iterator

### DIFF
--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -66,6 +66,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self.litellm_custom_stream_wrapper: litellm.CustomStreamWrapper = litellm_custom_stream_wrapper
         self.request_input: str | ResponseInputParam = request_input
         self.responses_api_request: ResponsesAPIOptionalRequestParams = responses_api_request
+        self.completed_response: Any | None = None
         self.custom_llm_provider: str | None = custom_llm_provider
         self.litellm_metadata: dict | None = litellm_metadata or {}
         # Store lightweight dict snapshots for stream_chunk_builder to reduce

--- a/tests/router_unit_tests/test_router_aresponses_streaming_fallback.py
+++ b/tests/router_unit_tests/test_router_aresponses_streaming_fallback.py
@@ -90,6 +90,50 @@ def test_extract_partial_responses_usage_no_completed_response():
     assert usage is None
 
 
+def test_bridge_iterator_initializes_completed_response():
+    """
+    LiteLLMCompletionStreamingIterator must expose completed_response, the
+    attribute BaseResponsesAPIStreamingIterator guarantees. It overrides
+    __init__ without calling super().__init__(), so a missing initializer
+    leaves the attribute unset (regression for #35411).
+    """
+    from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+        LiteLLMCompletionStreamingIterator,
+    )
+
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=AsyncMock(),
+        request_input="Test input",
+        responses_api_request={},
+    )
+
+    assert iterator.completed_response is None
+
+
+def test_extract_partial_responses_usage_bridge_no_chunks_returns_none():
+    """
+    Bridge iterator with no recoverable chunks must fall through to the native
+    completed_response check and return None, not raise AttributeError. Before
+    #35411 this read an uninitialized attribute and the AttributeError masked
+    the real mid-stream provider error, bypassing retry/fallback.
+    """
+    from litellm.responses.litellm_completion_transformation.streaming_iterator import (
+        LiteLLMCompletionStreamingIterator,
+    )
+
+    iterator = LiteLLMCompletionStreamingIterator(
+        model="test-model",
+        litellm_custom_stream_wrapper=AsyncMock(),
+        request_input="Test input",
+        responses_api_request={},
+    )
+    assert iterator.collected_chat_completion_chunks == []
+
+    usage = Router._extract_partial_responses_usage(iterator)
+    assert usage is None
+
+
 # -------- _combine_responses_fallback_usage --------
 
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- A mid-stream provider error on an Anthropic Responses-API stream raises `AttributeError: 'LiteLLMCompletionStreamingIterator' object has no attribute 'completed_response'`
- That AttributeError masks the real `MidStreamFallbackError`, so configured retries and model fallbacks never run and a recoverable provider overload becomes a hard failure

How it solves it:

- Initializes `completed_response` on `LiteLLMCompletionStreamingIterator`, the attribute its base `BaseResponsesAPIStreamingIterator` always sets but the subclass dropped by overriding `__init__` without calling `super().__init__()`
- The router's partial-usage recovery (`_extract_partial_responses_usage`) reads `source_iterator.completed_response` directly; with the attribute present, the bridge iterator falls through to the native check and returns None instead of raising

## Relevant issues

Fixes #35411

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Type

🐛 Bug Fix

## Changes

`LiteLLMCompletionStreamingIterator.__init__` sets `self.completed_response = None`, restoring the invariant the base class guarantees. Calling `super().__init__()` was not an option here; the base signature takes an `httpx.Response` and provider config the bridge path never has, so a targeted initializer is the correct minimal fix.

Two regression tests in `tests/router_unit_tests/test_router_aresponses_streaming_fallback.py`. One asserts a freshly constructed bridge iterator exposes `completed_response`. The other drives `Router._extract_partial_responses_usage` with a real bridge iterator that has no recoverable chunks and asserts it returns None rather than raising. Both fail before the fix with the exact AttributeError from the issue. The existing tests in that file use `MagicMock`, which auto-creates the attribute and cannot catch this, so the new tests build a real iterator.

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
