### PR TITLE
fix(router): count embedding input as text in pre-call checks

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10141,10 +10141,18 @@ class Router:
         The Responses payload is normalized to chat messages via the shared
         LiteLLMCompletionResponsesConfig transform so the same token_counter path covers
         both API surfaces and `instructions` tokens are included in the count.
+
+        Embeddings also arrive as `input`, but as a `list[str]` batch rather than Responses
+        input items. Those are counted as text, since the Responses transform expects
+        object-shaped items and raises on plain strings.
         """
         if messages is not None:
             return litellm.token_counter(messages=messages)
         if input is not None:
+            if isinstance(input, list) and all(isinstance(item, str) for item in input):
+                text_batch = cast(list[str], input)  # cast-ok: the isinstance guard narrows every item to str
+                return litellm.token_counter(text=text_batch)
+
             from openai.types.responses.response_create_params import ResponseInputParam
 
             from litellm.responses.litellm_completion_transformation.transformation import (

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -10142,9 +10142,7 @@ class Router:
         LiteLLMCompletionResponsesConfig transform so the same token_counter path covers
         both API surfaces and `instructions` tokens are included in the count.
 
-        Embeddings also arrive as `input`, but as a `list[str]` batch rather than Responses
-        input items. Those are counted as text, since the Responses transform expects
-        object-shaped items and raises on plain strings.
+        Embeddings send `input` as a `list[str]` batch, counted as text.
         """
         if messages is not None:
             return litellm.token_counter(messages=messages)

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -6577,10 +6577,6 @@ def test_model_info_is_active_for_environment_matrix(monkeypatch):
 
 
 def test_count_pre_call_check_tokens_counts_embedding_batches():
-    """An embedding `input` is a `list[str]`, not Responses API input items. Routing it through the
-    Responses transform raised `AttributeError: 'str' object has no attribute 'get'`, which
-    `_pre_call_checks` swallowed, so context-window filtering was silently skipped and an error was
-    logged per request."""
     from litellm.router import Router
 
     router = Router(
@@ -6599,8 +6595,6 @@ def test_count_pre_call_check_tokens_counts_embedding_batches():
 
 
 def test_pre_call_checks_filters_embedding_over_context_window():
-    """The consequence the bug hid: with the count raising, every deployment survived the filter.
-    A batch over `max_input_tokens` must now be dropped."""
     from litellm.router import Router
 
     over_limit = ["token " * 50, "token " * 50]

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -6574,3 +6574,57 @@ def test_model_info_is_active_for_environment_matrix(monkeypatch):
     monkeypatch.delenv("LITELLM_ENVIRONMENT")
     with pytest.raises(ValueError, match="LITELLM_ENVIRONMENT"):
         model_info_is_active_for_environment(model_info={"supported_environments": ["production"]})
+
+
+def test_count_pre_call_check_tokens_counts_embedding_batches():
+    """An embedding `input` is a `list[str]`, not Responses API input items. Routing it through the
+    Responses transform raised `AttributeError: 'str' object has no attribute 'get'`, which
+    `_pre_call_checks` swallowed, so context-window filtering was silently skipped and an error was
+    logged per request."""
+    from litellm.router import Router
+
+    router = Router(
+        model_list=[
+            {"model_name": "embed-test", "litellm_params": {"model": "vertex_ai/text-embedding-005"}}
+        ]
+    )
+
+    batch = router._count_pre_call_check_tokens(messages=None, input=["hello world", "second string"])
+    single = router._count_pre_call_check_tokens(messages=None, input=["hello world"])
+    assert batch > single > 0, "a batch must cost more than one of its own entries"
+
+    assert router._count_pre_call_check_tokens(messages=None, input="single string") > 0
+    assert router._count_pre_call_check_tokens(messages=None, input=[{"role": "user", "content": "hi"}]) > 0
+    assert router._count_pre_call_check_tokens(messages=[{"role": "user", "content": "hi"}], input=None) > 0
+
+
+def test_pre_call_checks_filters_embedding_over_context_window():
+    """The consequence the bug hid: with the count raising, every deployment survived the filter.
+    A batch over `max_input_tokens` must now be dropped."""
+    from litellm.router import Router
+
+    over_limit = ["token " * 50, "token " * 50]
+    router = Router(
+        model_list=[
+            {
+                "model_name": "embed-test",
+                "litellm_params": {"model": "vertex_ai/text-embedding-005"},
+                "model_info": {"id": "small", "base_model": "vertex_ai/text-embedding-005", "max_input_tokens": 8},
+            }
+        ],
+        enable_pre_call_checks=True,
+    )
+    deployments = router.model_list
+
+    with pytest.raises(litellm.exceptions.ContextWindowExceededError):
+        router._pre_call_checks(
+            model="embed-test",
+            healthy_deployments=deployments,
+            messages=None,
+            input=over_limit,
+        )
+
+    kept = router._pre_call_checks(
+        model="embed-test", healthy_deployments=deployments, messages=None, input=["hi"]
+    )
+    assert len(kept) == 1, "a batch inside the limit must survive the filter"


### PR DESCRIPTION
## TLDR

Problem this solves:

- With router pre-call checks enabled, every `/embeddings` request whose `input` is a `list[str]` logged `AttributeError: 'str' object has no attribute 'get'`, and context-window filtering was silently skipped for that request
- The same held for the two pre-tokenized shapes `AllEmbeddingInputValues` allows, `list[int]` and `list[list[int]]`, which raised `'int' object has no attribute 'get'` and `'list' object has no attribute 'get'`

How it solves it:

- A `list[str]` batch is counted with `litellm.token_counter(text=...)`, which already accepts `str | list[str]`, instead of being pushed through the Responses API input transform that expects object-shaped items
- Token IDs are counted by length, since they are already tokens. `token_counter(text=[1, 2, 3])` returns `0`, so counting them as text would have replaced a logged error with a silent undercount to zero
- The shape dispatch lives in one module-level helper that returns `None` when `input` is not an embedding shape, so Responses items and plain strings keep the existing transform path

## Relevant issues

Fixes #35626

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Two deployments of `bedrock/amazon.titan-embed-text-v2:0` in one model group with `router_settings.enable_pre_call_checks: true`, against live Bedrock in us-west-2. Two deployments matter: with a single one, `async_get_available_deployment` returns before pre-call checks ever run, so the bug does not surface. Each deployment needs `model_info.base_model` and `model_info.max_input_tokens`, otherwise `get_router_model_info` yields no limit and the counting branch is skipped entirely

Before, on `litellm_internal_staging`:

```
$ curl -s -X POST http://localhost:4005/v1/embeddings \
    -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
    -d '{"model":"titan-embed","input":[15496,2159,995]}' \
    -o /dev/null -w "HTTP %{http_code}\n"
HTTP 400

$ grep -c "failed to count tokens" litellm.log
1
$ grep -o "'int' object has no attribute 'get'" litellm.log
'int' object has no attribute 'get'
```

After, same config, all four input shapes:

```
$ for body in '{"model":"titan-embed","input":[15496,2159,995]}' \
              '{"model":"titan-embed","input":[[15496,2159],[995,1,2]]}' \
              '{"model":"titan-embed","input":["hello world","second string"]}' \
              '{"model":"titan-embed","input":"single string"}'; do
    curl -s -X POST http://localhost:4006/v1/embeddings \
      -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
      -d "$body" -o /dev/null -w "HTTP %{http_code}\n"
  done
HTTP 400
HTTP 200
HTTP 200
HTTP 200

$ grep -c "failed to count tokens" litellm.log
0
$ grep -c "has no attribute 'get'" litellm.log
0
```

The `HTTP 400` on `[15496, 2159, 995]` is Bedrock, not the router: Titan does not accept token IDs (`Malformed input request: expected type: String, found: Integer`). The point is that the request now reaches the provider and gets its real answer instead of dying in the token count

Context-window filtering now actually applies to token IDs. Same model group with `max_input_tokens: 4`:

```
$ curl -s -X POST http://localhost:4007/v1/embeddings \
    -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
    -d '{"model":"titan-embed","input":[1,2,3,4,5,6,7,8,9,10]}'
litellm.ContextWindowExceededError: ... No models have context window large enough
for this call. Model=bedrock/amazon.titan-embed-text-v2:0, Max Input Tokens=4, Got=10
```

`Got=10` is the count coming from the new path. Before this change that request was routed with no check at all

## Type

🐛 Bug Fix

## Changes

`Router._count_pre_call_check_tokens` treated every non-null `input` as Responses API input and ran it through `LiteLLMCompletionResponsesConfig.transform_responses_api_input_to_messages`, which calls `.get()` on each item. `AllEmbeddingInputValues` is `str | list[str] | list[int] | list[list[int]]`, so three of its four shapes raised there. `_pre_call_checks` caught the exception and returned the unfiltered deployment list, so the request proceeded with no context-window check and one error logged per request

A new `_count_embedding_input_tokens` helper dispatches on the element type and returns `None` for anything that is not an embedding shape, leaving the transform path untouched for Responses items and plain strings. Strings go to `token_counter(text=...)`; `list[int]` counts as its length; `list[list[int]]` as the sum of its rows

The string branch is checked first, which matters because `str` is itself a `Sequence`: `["ab"]` is a text batch, not a row of token IDs

## Caveats (if any)

- Token IDs count as their length, not through a tokenizer
- `to_fp8`-style saturation is not involved; no provider validates these shapes
- Titan rejects token IDs itself, so the 400 above is expected

## QA runbook

1. Put two deployments of the same embedding model in one model group, each with `model_info.base_model` and `model_info.max_input_tokens`, and set `router_settings.enable_pre_call_checks: true`
2. Start the proxy and `POST /v1/embeddings` with `"input": [15496, 2159, 995]`, then with `"input": [[15496, 2159], [995, 1, 2]]`
3. Grep the proxy log for `failed to count tokens`; there should be no match
4. Set `max_input_tokens: 4` and send ten token IDs; confirm `ContextWindowExceededError` with `Got=10`
5. Send `"input": ["hello world", "second string"]`, a plain string, and a Responses API request to confirm none of those paths regressed

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

Three regression tests in `tests/test_litellm/test_router.py`, all of which fail on `litellm_internal_staging` and pass here. A fourth test calls `_count_embedding_input_tokens` directly, which the router coverage gate requires and which also pins the contract the caller depends on: `None` for any non-embedding shape, and the string branch winning over the token-id branch since `str` is itself a `Sequence`. The first pins counting across all five input shapes and asserts a batch costs more than one of its own entries, so a mutation counting only the first entry fails. The second pins the two token-ID shapes to exact counts (3 and 5) plus the empty list, so counting them as text would fail with 0 rather than pass quietly. The third covers the consequence the exception hid rather than the exception itself: a batch over `max_input_tokens` must raise `ContextWindowExceededError`, since before the fix the swallowed error meant every deployment survived the filter

`tests/test_litellm/test_router.py` is 200 passed, 2 skipped. `make check` is green end to end, and this adds no lint or type-budget headroom: an earlier version of the patch needed a `cast` that tripped LIT001 and LIT006 and added one `reportUnknownArgumentType`, so the helper takes `Sequence[object]` and re-narrows instead of asserting
