### PR TITLE
fix(openai): honor chat completions overrides

### DIFF
--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -11,6 +11,17 @@ from litellm.secret_managers.main import get_secret, get_secret_str
 
 from ..types.router import GenericLiteLLMParams, LiteLLM_Params
 
+_OPENAI_CHAT_COMPLETIONS_MODEL_PREFIX = "openai/chat_completions/"
+
+
+def normalize_openai_chat_completions_model(model: str) -> tuple[str, bool]:
+    if not model.startswith(_OPENAI_CHAT_COMPLETIONS_MODEL_PREFIX):
+        return model, False
+    remainder = model[len(_OPENAI_CHAT_COMPLETIONS_MODEL_PREFIX) :]
+    if not remainder:
+        return model, False
+    return f"openai/{remainder}", True
+
 
 def _endpoint_matches_api_base(endpoint: str, api_base: str) -> bool:
     """

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -86,6 +86,9 @@ from litellm.litellm_core_utils.get_litellm_params import (
     AWS_CREDENTIAL_KWARGS_KEYS,
     OPTIONAL_KWARGS_KEYS,
 )
+from litellm.litellm_core_utils.get_llm_provider_logic import (
+    normalize_openai_chat_completions_model,
+)
 from litellm.litellm_core_utils.get_provider_specific_headers import (
     ProviderSpecificHeaderUtils,
 )
@@ -4906,11 +4909,12 @@ def completion(  # type: ignore
     ######### unpacking kwargs #####################
     args = locals()
 
-    # Set by the responses->completion fallback so completion() does not bridge
-    # back to the Responses API: that round-trip mutually recurses forever for a
-    # model whose model_cost mode is "responses" but whose provider has no
-    # Responses API config (get_provider_responses_api_config -> None).
-    skip_responses_api_bridge = kwargs.pop("_skip_responses_api_bridge", False)
+    model, model_forces_chat_completions = normalize_openai_chat_completions_model(model)
+    skip_responses_api_bridge = (
+        bool(kwargs.pop("_skip_responses_api_bridge", False))
+        or bool(kwargs.get("use_chat_completions_api"))
+        or model_forces_chat_completions
+    )
 
     skip_mcp_handler = kwargs.pop("_skip_mcp_handler", False)
     if not skip_mcp_handler and tools:

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -20,6 +20,9 @@ from litellm.completion_extras.litellm_responses_transformation.transformation i
 )
 from litellm.constants import request_timeout
 from litellm.litellm_core_utils.asyncify import run_async_function
+from litellm.litellm_core_utils.get_llm_provider_logic import (
+    normalize_openai_chat_completions_model,
+)
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
 from litellm.litellm_core_utils.prompt_templates.common_utils import (
     update_responses_input_with_model_file_ids,
@@ -630,23 +633,6 @@ def _apply_prompt_management_to_responses_call(
     return input, model, custom_llm_provider
 
 
-# Opt-in via model id (mirrors the `responses/` prefix pattern on chat completions).
-_OPENAI_CHAT_COMPLETIONS_RESPONSES_MODEL_PREFIX = "openai/chat_completions/"
-
-
-def _normalize_openai_chat_completions_responses_model(model: str) -> tuple[str, bool]:
-    """
-    Strip `openai/chat_completions/<name>` → `openai/<name>` and return True when the
-    prefix was applied (same effect as use_chat_completions_api=True).
-    """
-    if not model.startswith(_OPENAI_CHAT_COMPLETIONS_RESPONSES_MODEL_PREFIX):
-        return model, False
-    remainder = model[len(_OPENAI_CHAT_COMPLETIONS_RESPONSES_MODEL_PREFIX) :]
-    if not remainder:
-        return model, False
-    return f"openai/{remainder}", True
-
-
 def _pop_use_chat_completions_api_kw(kwargs: dict[str, Any]) -> bool:
     """Pop use_chat_completions_api; True when the chat-completions bridge is requested."""
     use_cc = kwargs.pop("use_chat_completions_api", None)
@@ -933,7 +919,7 @@ def responses(
         if litellm_params.mock_response and isinstance(litellm_params.mock_response, str):
             return mock_responses_api_response(mock_response=litellm_params.mock_response)
 
-        _stripped_model, _from_chat_completions_prefix = _normalize_openai_chat_completions_responses_model(model)
+        _stripped_model, _from_chat_completions_prefix = normalize_openai_chat_completions_model(model)
         model = _stripped_model
         local_vars["model"] = model
         use_chat_completions_api = use_chat_completions_api or _from_chat_completions_prefix

--- a/tests/test_litellm/llms/openai/test_use_chat_completions_api_no_leak.py
+++ b/tests/test_litellm/llms/openai/test_use_chat_completions_api_no_leak.py
@@ -9,7 +9,7 @@ body. OpenAI/Anthropic reject unknown body params with HTTP 400.
 
 import os
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, os.path.abspath("../../../.."))
 
@@ -18,18 +18,7 @@ from litellm.types.utils import all_litellm_params
 from litellm.utils import get_non_default_completion_params
 
 
-def test_use_chat_completions_api_is_a_known_litellm_param():
-    assert "use_chat_completions_api" in all_litellm_params
-
-
-def test_use_chat_completions_api_not_forwarded_as_provider_param():
-    forwarded = get_non_default_completion_params(
-        {"use_chat_completions_api": True, "temperature": 0.5}
-    )
-    assert "use_chat_completions_api" not in forwarded
-
-
-def test_completion_does_not_leak_flag_into_provider_request_body():
+def _mock_openai_chat_client() -> MagicMock:
     mock_response = MagicMock()
     mock_response.model_dump.return_value = {
         "id": "chatcmpl-1",
@@ -55,9 +44,21 @@ def test_completion_does_not_leak_flag_into_provider_request_body():
     mock_raw_response.parse.return_value = mock_response
 
     mock_client = MagicMock()
-    mock_client.chat.completions.with_raw_response.create.return_value = (
-        mock_raw_response
-    )
+    mock_client.chat.completions.with_raw_response.create.return_value = mock_raw_response
+    return mock_client
+
+
+def test_use_chat_completions_api_is_a_known_litellm_param():
+    assert "use_chat_completions_api" in all_litellm_params
+
+
+def test_use_chat_completions_api_not_forwarded_as_provider_param():
+    forwarded = get_non_default_completion_params({"use_chat_completions_api": True, "temperature": 0.5})
+    assert "use_chat_completions_api" not in forwarded
+
+
+def test_completion_does_not_leak_flag_into_provider_request_body():
+    mock_client = _mock_openai_chat_client()
 
     litellm.completion(
         model="openai/gpt-4o-mini",
@@ -67,8 +68,63 @@ def test_completion_does_not_leak_flag_into_provider_request_body():
         client=mock_client,
     )
 
-    create_kwargs = (
-        mock_client.chat.completions.with_raw_response.create.call_args.kwargs
-    )
+    create_kwargs = mock_client.chat.completions.with_raw_response.create.call_args.kwargs
     assert "use_chat_completions_api" not in create_kwargs
     assert "use_chat_completions_api" not in (create_kwargs.get("extra_body") or {})
+
+
+def test_completion_chat_flag_overrides_gpt5_responses_auto_routing():
+    mock_client = _mock_openai_chat_client()
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "probe",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+    with patch("litellm.completion_extras.responses_api_bridge.completion") as mock_bridge:
+        litellm.completion(
+            model="openai/gpt-5.6-luna",
+            messages=[{"role": "user", "content": "probe"}],
+            tools=[tool],
+            reasoning_effort="low",
+            use_chat_completions_api=True,
+            api_base="https://example.invalid/v1",
+            api_key="sk-test",
+            client=mock_client,
+        )
+
+    mock_bridge.assert_not_called()
+    create_kwargs = mock_client.chat.completions.with_raw_response.create.call_args.kwargs
+    assert create_kwargs["model"] == "gpt-5.6-luna"
+    assert create_kwargs["tools"] == [tool]
+    assert create_kwargs["reasoning_effort"] == "low"
+
+
+def test_completion_chat_prefix_overrides_gpt5_responses_auto_routing():
+    mock_client = _mock_openai_chat_client()
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "probe",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+    with patch("litellm.completion_extras.responses_api_bridge.completion") as mock_bridge:
+        litellm.completion(
+            model="openai/chat_completions/gpt-5.6-luna",
+            messages=[{"role": "user", "content": "probe"}],
+            tools=[tool],
+            reasoning_effort="low",
+            api_base="https://example.invalid/v1",
+            api_key="sk-test",
+            client=mock_client,
+        )
+
+    mock_bridge.assert_not_called()
+    create_kwargs = mock_client.chat.completions.with_raw_response.create.call_args.kwargs
+    assert create_kwargs["model"] == "gpt-5.6-luna"
+    assert create_kwargs["tools"] == [tool]
+    assert create_kwargs["reasoning_effort"] == "low"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Explicit Chat overrides still route GPT-5 models to Responses
- OpenAI-compatible endpoints receive the wrong request shape

How it solves it:

- Skip automatic Responses bridging for explicit Chat overrides
- Normalize `openai/chat_completions/` before provider routing

## Relevant issues

Fixes #32489

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

The same live tool-call request was sent through a local path recorder that forwarded it unchanged to an OpenAI-compatible endpoint

```python
litellm.completion(
    model="openai/gpt-5.6-luna",
    messages=[{"role": "user", "content": "Call probe with no arguments"}],
    tools=[probe_tool],
    tool_choice={"type": "function", "function": {"name": "probe"}},
    reasoning_effort="low",
    use_chat_completions_api=True,
    api_base=recording_proxy_base,
    api_key=api_key,
)
```

Before, at `491eda319cd1cd1f75a2ef165c6b06ce6129c282`

```text
request_paths=['/v1/responses']
choice_count=1
finish_reason=tool_calls
tool_call_count=1
tool_name=probe
```

After, at `bfa9473795bf392e15c54646bee980480cbe0070`

```text
request_paths=['/v1/chat/completions']
choice_count=1
finish_reason=tool_calls
tool_call_count=1
tool_name=probe
```

## Type

Bug Fix

## Changes

- Share `openai/chat_completions/` model normalization across both entry points
- Treat the explicit flag and model prefix as Chat routing overrides
- Preserve automatic Responses routing when no override is supplied
- Cover flag, prefix, tools, and reasoning parameters with regression tests

Validation:

- `make pre-commit`
- Targeted regression suite: 27 passed, 43 deselected
- `make test-unit` is blocked during collection by duplicate `test_models.py` module names in the base checkout

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
