### PR TITLE
fix(databricks): delegate cost_per_token to generic_cost_per_token so cached tokens are discounted

### DIFF
--- a/litellm/llms/databricks/cost_calculator.py
+++ b/litellm/llms/databricks/cost_calculator.py
@@ -5,8 +5,8 @@ Helper util for handling databricks-specific cost calculation
 
 from typing import Tuple
 
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
 from litellm.types.utils import Usage
-from litellm.utils import get_model_info
 
 
 def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
@@ -39,14 +39,5 @@ def cost_per_token(model: str, usage: Usage) -> Tuple[float, float]:
         base_model = "databricks-gte-large-en"
     elif model.startswith("databricks/llama-2-70b-chat") or model.startswith("llama-2-70b-chat"):
         base_model = "databricks-llama-2-70b-chat"
-    ## GET MODEL INFO
-    model_info = get_model_info(model=base_model, custom_llm_provider="databricks")
 
-    ## CALCULATE INPUT COST
-
-    prompt_cost: float = usage["prompt_tokens"] * model_info["input_cost_per_token"]
-
-    ## CALCULATE OUTPUT COST
-    completion_cost = usage["completion_tokens"] * model_info["output_cost_per_token"]
-
-    return prompt_cost, completion_cost
+    return generic_cost_per_token(model=base_model, usage=usage, custom_llm_provider="databricks")

--- a/tests/test_litellm/llms/databricks/test_databricks_pricing.py
+++ b/tests/test_litellm/llms/databricks/test_databricks_pricing.py
@@ -49,3 +49,41 @@ def test_databricks_pricing_integrity():
                     )
 
     assert not errors, "\n" + "\n".join(errors)
+
+
+def test_databricks_cost_per_token_honors_cached_tokens():
+    """
+    Regression for the hand-rolled databricks cost calculator that multiplied every prompt
+    token by input_cost_per_token and ignored prompt_tokens_details.cached_tokens. After
+    delegating to generic_cost_per_token, cached tokens must bill at cache_read_input_token_cost
+    (mirrors deepseek / xai / fireworks). A cache-priced databricks model is registered for the
+    test since no bundled databricks entry publishes cache rates yet.
+    """
+    import litellm
+    from litellm.llms.databricks.cost_calculator import cost_per_token
+    from litellm.types.utils import PromptTokensDetailsWrapper, Usage
+
+    litellm.register_model(
+        {
+            "databricks/test-cache-model": {
+                "litellm_provider": "databricks",
+                "input_cost_per_token": 1e-6,
+                "output_cost_per_token": 2e-6,
+                "cache_read_input_token_cost": 1e-7,
+                "mode": "chat",
+            }
+        }
+    )
+
+    usage = Usage(
+        prompt_tokens=1000,
+        completion_tokens=200,
+        total_tokens=1200,
+        prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=800),
+    )
+
+    prompt_cost, completion_cost = cost_per_token("databricks/test-cache-model", usage)
+
+    # non-cached 200 * 1e-6 + cached 800 * 1e-7 = 0.0002 + 0.00008 = 0.00028
+    assert abs(prompt_cost - 0.00028) < 1e-12
+    assert abs(completion_cost - 200 * 2e-6) < 1e-12


### PR DESCRIPTION
## TLDR

Problem this solves:

- The databricks cost calculator hand-rolls `prompt_tokens * input_cost_per_token` and ignores cached / audio / reasoning tokens, the same shape as the Fireworks bug fixed in #33714

How it solves it:

- Delegate to `generic_cost_per_token` (as deepseek / xai / perplexity / fireworks already do), keeping the existing dbrx-instruct / meta-llama base-model name resolution

## Relevant issues

Fixes #35608

## Type

🐛 Bug Fix

## Changes

`litellm/llms/databricks/cost_calculator.py` computed cost as `usage["prompt_tokens"] * model_info["input_cost_per_token"]` plus the equivalent for completion, dropping `prompt_tokens_details.cached_tokens`, cache-creation, audio and reasoning tokens. The other OpenAI-compatible providers delegate to `generic_cost_per_token`, which prices each token type against the fields already on `model_info`. This keeps the databricks base-model resolution (dbrx-instruct, meta-llama, mixtral, bge/gte, llama-2) and hands the resolved model to `generic_cost_per_token`.

Latent today since no bundled databricks entry publishes cache_read rates, but Databricks serves models that report cached tokens, so a future cache-priced entry would have silently billed cached tokens at the full input rate.

## QA runbook

Added `test_databricks_cost_per_token_honors_cached_tokens` in `tests/test_litellm/llms/databricks/test_databricks_pricing.py`: it registers a cache-priced databricks model, sends usage with 800 of 1000 prompt tokens cached, and asserts the prompt cost is `200 * 1e-6 + 800 * 1e-7 = 0.00028`. Before this change the calculator billed `1000 * 1e-6 = 0.001`; the test fails on the old code and passes on the new.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
