### PR TITLE
fix(ui): block Playground page for viewer roles on direct URL access

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.tsx
@@ -22,7 +22,7 @@ import {
   UserOutlined,
 } from "@ant-design/icons";
 import { Card, Text, TextInput, Title, Button as TremorButton } from "@tremor/react";
-import { Button, Input, Modal, Popover, Select, Spin, Tooltip, Typography, Upload } from "antd";
+import { Button, Input, Modal, Popover, Select, Spin, Tooltip, Upload } from "antd";
 import React, { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -1005,16 +1005,6 @@ const ChatUI: React.FC<ChatUIProps> = ({
     handleRemoveAudio();
     NotificationsManager.success("Chat history cleared.");
   };
-
-  if (userRole && userRole === "Admin Viewer") {
-    const { Title, Paragraph } = Typography;
-    return (
-      <div>
-        <Title level={1}>Access Denied</Title>
-        <Paragraph>Ask your proxy admin for access to test models</Paragraph>
-      </div>
-    );
-  }
 
   const onModelChange = (value: string) => {
     setSelectedModel(value);

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/page.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/page.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import PlaygroundPage from "./page";
+
+const authState = { userRole: "Admin" };
+
+vi.mock("@/app/(dashboard)/hooks/useAuthorized", () => ({
+  default: () => ({
+    token: "token-1",
+    accessToken: "sk-test",
+    userId: "user-1",
+    userRole: authState.userRole,
+    disabledPersonalKeyCreation: false,
+  }),
+}));
+
+vi.mock("@/utils/proxyUtils", () => ({
+  fetchProxySettings: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/app/(dashboard)/playground/components/chat_ui/ChatUI", () => ({
+  default: () => <div data-testid="chat-ui" />,
+}));
+
+vi.mock("@/app/(dashboard)/playground/components/compareUI/CompareUI", () => ({
+  default: () => <div data-testid="compare-ui" />,
+}));
+
+vi.mock("@/app/(dashboard)/playground/components/complianceUI/ComplianceUI", () => ({
+  default: () => <div data-testid="compliance-ui" />,
+}));
+
+vi.mock("@/app/(dashboard)/playground/components/chat_ui/AgentBuilderView", () => ({
+  default: () => <div data-testid="agent-builder" />,
+}));
+
+describe("PlaygroundPage role guard", () => {
+  beforeEach(() => {
+    authState.userRole = "Admin";
+  });
+
+  it.each(["Internal Viewer", "Admin Viewer"])("blocks the entire playground for %s", (role) => {
+    authState.userRole = role;
+    render(<PlaygroundPage />);
+
+    expect(screen.getByText("Access Denied")).toBeInTheDocument();
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("chat-ui")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("compare-ui")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("compliance-ui")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("agent-builder")).not.toBeInTheDocument();
+  });
+
+  it.each(["Admin", "Internal User", "Org Admin"])("renders the playground for %s", (role) => {
+    authState.userRole = role;
+    render(<PlaygroundPage />);
+
+    expect(screen.queryByText("Access Denied")).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Chat" })).toBeInTheDocument();
+    expect(screen.getByTestId("chat-ui")).toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/page.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/page.tsx
@@ -9,6 +9,7 @@ import { TabGroup, TabList, Tab, TabPanels, TabPanel } from "@tremor/react";
 import { DeprecationBanner } from "@/components/DeprecationBanner";
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
 import { fetchProxySettings } from "@/utils/proxyUtils";
+import { isViewOnlyRole } from "@/utils/roles";
 
 interface ProxySettings {
   PROXY_BASE_URL?: string;
@@ -34,6 +35,17 @@ export default function PlaygroundPage() {
 
     initializeProxySettings();
   }, [accessToken]);
+
+  if (isViewOnlyRole(userRole)) {
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2 p-8 text-center">
+        <h1 className="text-2xl font-semibold">Access Denied</h1>
+        <p className="text-muted-foreground">
+          Your role does not have access to the Playground. Ask your proxy admin for access to test models.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="h-full w-full flex flex-col">

--- a/ui/litellm-dashboard/src/utils/roles.ts
+++ b/ui/litellm-dashboard/src/utils/roles.ts
@@ -13,6 +13,8 @@ export const rolesWithWriteAccess = ["Internal User", "Admin", "proxy_admin"];
 // Per the Admin Viewer principle: read parity with Proxy Admin, no writes,
 // no cost-incurring actions (Playground stays gated by `rolesWithWriteAccess`).
 export const rolesAllowedToViewWriteScopedPages = [...rolesWithWriteAccess, "Admin Viewer", "proxy_admin_viewer"];
+export const viewOnlyRoles = ["Admin Viewer", "Internal Viewer"];
+export const isViewOnlyRole = (role: string): boolean => viewOnlyRoles.includes(role);
 
 // Helper function to check if a role is in all_admin_roles
 export const isAdminRole = (role: string): boolean => {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Playground is hidden from viewer roles only in the sidebar
- Direct navigation to /ui/playground still renders the full playground
- Internal Viewer and Admin Viewer can trigger real, cost-incurring model calls

How it solves it:

- Page-level role guard on the Playground route itself
- Internal Viewer and Admin Viewer now get an Access Denied panel
- Guard covers all four tabs, not just Chat

## Relevant issues

Fixes #35668

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Repro before the fix (captured at 2d5754d928, whose playground code is identical to litellm_internal_staging). Created an `internal_user_viewer` user via `/user/new` with the master key, logged in through `/login` with that user's email and password, then navigated straight to `/ui/playground`. The sidebar hides Playground for this role, but the page renders fully

![internal viewer sees the full playground](https://raw.githubusercontent.com/BerriAI/litellm/6da7980bf18f78ea38898b4cfde1027af42ff4a3/repro-internal-viewer-playground-before.png)

From that page the Internal Viewer sent a real chat completion through a live Groq deployment (`groq/qwen/qwen3.6-27b`, 407 tokens billed), proving the cost-incurring bypass end to end. The same page as `proxy_admin_viewer` showed Access Denied on the Chat tab only; the Compare tab was fully usable for model calls

![internal viewer completes a real model call](https://raw.githubusercontent.com/BerriAI/litellm/6da7980bf18f78ea38898b4cfde1027af42ff4a3/repro-internal-viewer-model-call-before.png)

After the fix (captured at 77a91635c9), the same sessions hitting the same URL get an Access Denied panel with no tabs, no model picker, and no message box

![internal viewer blocked](https://raw.githubusercontent.com/BerriAI/litellm/6da7980bf18f78ea38898b4cfde1027af42ff4a3/fix-internal-viewer-access-denied-after.png)

![admin viewer blocked](https://raw.githubusercontent.com/BerriAI/litellm/6da7980bf18f78ea38898b4cfde1027af42ff4a3/fix-admin-viewer-access-denied-after.png)

Positive control at 77a91635c9: a `proxy_admin` login on the same URL still sees the Playground entry in the sidebar, renders all tabs, and completed the same live Groq call successfully

## Type

🐛 Bug Fix

## Changes

`utils/roles.ts` gains `viewOnlyRoles` and `isViewOnlyRole` covering the two view-only display roles (Admin Viewer, Internal Viewer; `useAuthorized` always normalizes raw roles like `proxy_admin_viewer` and `internal_user_viewer` to these via `formatUserRole`)

`playground/page.tsx` returns an Access Denied panel for those roles before rendering any tab. This is the single entry point for the playground: the sidebar links here and the legacy `?page=llm-playground` deep link redirects here through `MIGRATED_PAGES`

The old inline Admin Viewer check inside `ChatUI.tsx` is removed; it only covered one of the four tabs, missed Internal Viewer entirely, and its sole consumer is the now-guarded page

`page.test.tsx` locks the contract: Internal Viewer and Admin Viewer get Access Denied with zero tabs mounted, while Admin, Internal User, and Org Admin render the playground. These tests fail if the guard is removed, widened, or narrowed

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
