### PR TITLE
fix(bedrock): stop forwarding no-op toolSpec.strict to Converse

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -1975,6 +1975,7 @@
         "prompt_cache_min_tokens": 2048
     },
     "anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.5e-06,
         "cache_creation_input_token_cost_above_1hr": 4e-06,
         "cache_read_input_token_cost": 2e-07,
@@ -2011,6 +2012,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "global.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.5e-06,
         "cache_creation_input_token_cost_above_1hr": 4e-06,
         "cache_read_input_token_cost": 2e-07,
@@ -2047,6 +2049,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "us.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -2083,6 +2086,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "eu.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -2119,6 +2123,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "au.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -2155,6 +2160,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "jp.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,

--- a/litellm/types/llms/bedrock.py
+++ b/litellm/types/llms/bedrock.py
@@ -301,7 +301,7 @@ class BedrockToolSpec(dict):
             "name": name,
             "description": description,
         }
-        if supports_strict_tools and strict is not None:
+        if supports_strict_tools and strict:
             tool_spec["strict"] = strict
 
         super().__init__(toolSpec=tool_spec)

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -1975,6 +1975,7 @@
         "prompt_cache_min_tokens": 2048
     },
     "anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.5e-06,
         "cache_creation_input_token_cost_above_1hr": 4e-06,
         "cache_read_input_token_cost": 2e-07,
@@ -2011,6 +2012,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "global.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.5e-06,
         "cache_creation_input_token_cost_above_1hr": 4e-06,
         "cache_read_input_token_cost": 2e-07,
@@ -2047,6 +2049,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "us.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -2083,6 +2086,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "eu.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -2119,6 +2123,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "au.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,
@@ -2155,6 +2160,7 @@
         "prompt_cache_min_tokens": 1024
     },
     "jp.anthropic.claude-sonnet-5": {
+        "bedrock_converse_supports_strict_tools": false,
         "cache_creation_input_token_cost": 2.75e-06,
         "cache_creation_input_token_cost_above_1hr": 4.4e-06,
         "cache_read_input_token_cost": 2.2e-07,

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
@@ -4,6 +4,11 @@ Bedrock Converse routes Claude Opus 4.7/4.8 and Claude Sonnet 4 through an
 Anthropic-compatible validator that rejects ``toolSpec.strict`` even though
 Anthropic's native API accepts ``strict`` as a top-level tool field. See
 BerriAI/litellm#31582.
+
+That per-model gate only covers models whose cost-map entry carries the flag, so a
+``strict: false`` that litellm itself synthesized still broke unflagged models. Since
+``strict: false`` is the Chat Completions default, it is now dropped for every model
+rather than forwarded as a no-op the provider can reject. See BerriAI/litellm#33193.
 """
 
 import pytest
@@ -27,6 +32,16 @@ _STRICT_TOOL = [
                 "required": ["city", "unit"],
                 "additionalProperties": False,
             },
+        },
+    }
+]
+
+_NON_STRICT_TOOL = [
+    {
+        "type": "function",
+        "function": {
+            **_STRICT_TOOL[0]["function"],
+            "strict": False,
         },
     }
 ]
@@ -79,6 +94,55 @@ def test_bedrock_tools_pt_strict_kept_for_other_anthropic(model_id: str) -> None
     assert (
         result[0]["toolSpec"]["strict"] is True
     ), f"strict missing for {model_id}: {result[0]['toolSpec']}"
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "bedrock/us.anthropic.claude-sonnet-5",
+        "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "bedrock/us.anthropic.claude-sonnet-4-6",
+        "bedrock/us.anthropic.claude-opus-4-8",
+    ],
+)
+def test_bedrock_tools_pt_falsy_strict_always_dropped(model_id: str) -> None:
+    """``strict: false`` is the Chat Completions default, so forwarding it says nothing
+    the provider does not already assume. Bedrock Converse rejects the key's presence
+    for a growing set of Claude models, so it is dropped for every model, including the
+    ones whose cost-map entry still allows ``strict: true`` through."""
+    result = _bedrock_tools_pt(_NON_STRICT_TOOL, model=model_id)
+    tool_spec = result[0]["toolSpec"]
+    assert (
+        "strict" not in tool_spec
+    ), f"no-op strict: false leaked into toolSpec for {model_id}: {tool_spec}"
+
+
+def test_responses_bridge_function_tool_does_not_reach_bedrock_with_strict() -> None:
+    """The Responses-to-Chat-Completions bridge stamps ``strict: false`` onto every
+    function tool even when the caller never sent one, which is how Codex CLI requests
+    acquired the key. Assert the fabricated value does not survive to toolSpec."""
+    from litellm.responses.litellm_completion_transformation.transformation import (
+        LiteLLMCompletionResponsesConfig,
+    )
+
+    responses_tool = {
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get the weather for a city",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    }
+    chat_tools, _ = (
+        LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
+            [responses_tool]
+        )
+    )
+    result = _bedrock_tools_pt(chat_tools, model="bedrock/us.anthropic.claude-sonnet-5")
+    assert "strict" not in result[0]["toolSpec"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
+++ b/tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py
@@ -63,12 +63,17 @@ _NON_STRICT_TOOL = [
         "bedrock/us.anthropic.claude-sonnet-4-20250514-v1:0",
         "bedrock/eu.anthropic.claude-sonnet-4-20250514-v1:0",
         "bedrock/apac.anthropic.claude-sonnet-4-20250514-v1:0",
+        # Sonnet 5 rejects it too, verified live against Bedrock in us-east-1
+        "anthropic.claude-sonnet-5",
+        "bedrock/us.anthropic.claude-sonnet-5",
+        "bedrock/eu.anthropic.claude-sonnet-5",
+        "bedrock/jp.anthropic.claude-sonnet-5",
     ],
 )
 def test_bedrock_tools_pt_strict_dropped_for_strict_unsupported_models(
     model_id: str,
 ) -> None:
-    """Opus 4.7/4.8 and Sonnet 4 reject toolSpec.strict and additionalProperties."""
+    """Opus 4.7/4.8, Sonnet 4 and Sonnet 5 reject toolSpec.strict and additionalProperties."""
     result = _bedrock_tools_pt(_STRICT_TOOL, model=model_id)
     tool_spec = result[0]["toolSpec"]
     assert (
@@ -193,6 +198,15 @@ def test_bedrock_converse_supports_strict_tools_helper() -> None:
         )
         is False
     )
+    assert bedrock_converse_supports_strict_tools("anthropic.claude-sonnet-5") is False
+    assert (
+        bedrock_converse_supports_strict_tools("bedrock/us.anthropic.claude-sonnet-5")
+        is False
+    )
+    assert (
+        bedrock_converse_supports_strict_tools("bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0")
+        is True
+    )
 
 
 @pytest.mark.parametrize(
@@ -207,6 +221,12 @@ def test_bedrock_converse_supports_strict_tools_helper() -> None:
         "us.anthropic.claude-sonnet-4-20250514-v1:0",
         "eu.anthropic.claude-sonnet-4-20250514-v1:0",
         "apac.anthropic.claude-sonnet-4-20250514-v1:0",
+        "anthropic.claude-sonnet-5",
+        "global.anthropic.claude-sonnet-5",
+        "us.anthropic.claude-sonnet-5",
+        "eu.anthropic.claude-sonnet-5",
+        "au.anthropic.claude-sonnet-5",
+        "jp.anthropic.claude-sonnet-5",
     ],
 )
 def test_strict_tools_flag_set_in_model_cost_map(cost_map_key: str) -> None:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Converse 400s with `tools.0.custom.strict: Extra inputs are not permitted` on any Claude model whose cost-map entry lacks `bedrock_converse_supports_strict_tools: false`, currently Sonnet 5
- On `/v1/responses` the caller cannot avoid it: the Responses to Chat Completions bridge stamps `strict: false` onto every function tool even when the request never mentioned `strict`, so agentic clients like Codex CLI break with no client-side workaround and `drop_params` has nothing to drop

How it solves it:

- Drop `toolSpec.strict` when it is falsy, since `strict: false` is the Chat Completions default and communicates nothing the provider does not already assume, while Bedrock rejects the key by presence rather than by value
- Leave `strict: true` on the existing per-model gate, so models that accept strict schemas keep today's behavior

## Relevant issues

- Stops litellm from synthesizing a `strict: false` that Bedrock Converse rejects, fixing tool calls on Sonnet 5, and on any future Claude model that ships before its flag does
- Makes `/v1/responses` tool calling work for agentic clients that never send `strict` at all
- Keeps `strict: true` gated per model, so no behavior changes for models that honor strict schemas

Fixes #33193

Partially addresses #34388 (the `strict: false` half; requests that genuinely send `strict: true` still depend on the per-model cost-map flag). Verified live that Haiku 4.5 accepts `strict: true`, so the Haiku symptom in that issue is the compiled-grammar-size problem, not this one

## Linear ticket

Resolves LIT-5142

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real Bedrock calls against `us.anthropic.claude-sonnet-5` in us-east-1. Config:

```yaml
model_list:
  - model_name: claude-sonnet-5
    litellm_params:
      model: bedrock/us.anthropic.claude-sonnet-5
      aws_region_name: us-east-1

  - model_name: smart-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        tiers:
          SIMPLE: claude-sonnet-5
          MEDIUM: claude-sonnet-5
          COMPLEX: claude-sonnet-5
          REASONING: claude-sonnet-5
      complexity_router_default_model: claude-sonnet-5

general_settings:
  master_key: sk-1234
```

Before, at base commit `b13e4eee5d`. Note there is no `strict` anywhere in the request; litellm adds it:

```bash
$ curl -sS http://localhost:4000/v1/responses \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"model":"claude-sonnet-5","input":"what is the weather in Prague? use the tool","tools":[{"type":"function","name":"get_weather","description":"Get the weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}]}'

{"error":{"message":"litellm.BadRequestError: BedrockException - {\"message\":\"The model returned the following errors: tools.0.custom.strict: Extra inputs are not permitted\"}. Received Model Group=claude-sonnet-5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
```

Same commit, same request through a `complexity_router` model group, failing identically:

```bash
$ curl -sS http://localhost:4000/v1/responses \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"model":"smart-router","input":"what is the weather in Prague? use the tool","tools":[{"type":"function","name":"get_weather","description":"Get the weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}}]}'

{"error":{"message":"litellm.BadRequestError: BedrockException - {\"message\":\"The model returned the following errors: tools.0.custom.strict: Extra inputs are not permitted\"}. Received Model Group=smart-router\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
```

After, at fix commit `3962201c99`, both now return a real tool call (output trimmed to the `function_call` item):

```bash
$ # direct model group
[{"arguments":"{\"city\": \"Prague\"}","call_id":"tooluse_kr62AUDTKxo2c5PzFyiU7t","name":"get_weather","type":"function_call","id":"tooluse_kr62AUDTKxo2c5PzFyiU7t","status":"completed"}]

$ # through the complexity router
[{"arguments":"{\"city\": \"Prague\"}","call_id":"tooluse_7OEw0DSJGhA1lTS95tbNcQ","name":"get_weather","type":"function_call","id":"tooluse_7OEw0DSJGhA1lTS95tbNcQ","status":"completed"}]
```

Control 1, at the fix commit; a chat completions request that explicitly sends the no-op `strict: false` also succeeds now:

```bash
$ curl -sS http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"model":"claude-sonnet-5","max_tokens":100,"messages":[{"role":"user","content":"what is the weather in Prague? use the tool"}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get the weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]},"strict":false}}]}'

[{"index":0,"function":{"arguments":"{\"city\": \"Prague\"}","name":"get_weather"},"id":"tooluse_bX6smQ1v4ALbPhXRR4soWw","type":"function"}]
```

Control 2, at the fix commit; the same request with `strict: true` is deliberately unchanged by this PR and still 400s, because a true value carries real intent and stays on the per-model cost-map gate:

```bash
{"error":{"message":"litellm.BadRequestError: BedrockException - {\"message\":\"The model returned the following errors: tools.0.custom.strict: Extra inputs are not permitted\"}. Received Model Group=claude-sonnet-5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
```

## Type

🐛 Bug Fix

## Changes

`BedrockToolSpec.__init__` is the only place that decides whether `toolSpec.strict` is emitted, and it emitted the key whenever `strict is not None`. It now emits only when `strict` is truthy.

The `bedrock_converse_supports_strict_tools` gate stays exactly as it is. It still governs `strict: true`, which is the only value that asks the provider for something, and this PR does not flip its default; the existing assertions that Sonnet 4.5/4.6 and Opus <= 4.6 keep receiving `strict: true` are untouched and still pass.

`additionalProperties` is deliberately left alone. Unlike `strict: false` it is a real JSON Schema constraint rather than a restatement of the default, so it stays on the per-model gate.

Tests extend `tests/test_litellm/litellm_core_utils/prompt_templates/test_bedrock_converse_strict_tools_opus_47_48.py`: a parametrized case asserting a falsy `strict` never reaches `toolSpec` across both flagged and unflagged models, and one integration case that runs a `/v1/responses` function tool through `transform_responses_api_tools_to_chat_completion_tools` into `_bedrock_tools_pt` to prove the bridge-synthesized value does not survive. Both fail on the parent commit and pass here. Reverting the one-line change fails 5 cases; removing the `supports_strict_tools` gate instead fails 14, so neither half of the condition can be dropped silently

## QA runbook

1. Point `config.yaml` at `bedrock/us.anthropic.claude-sonnet-5` in a region where you have access, and start the proxy: `python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug`
2. Run the `/v1/responses` curl from the proof section. Expect a `function_call` output item rather than a 400
3. Repeat with a `complexity_router` model group in front of the same deployment. Expect the same result
4. Run the chat completions curl with `"strict": false`. Expect a `tool_calls` response
5. Run the same curl with `"strict": true`. Expect the pre-existing 400; this PR does not change that path
6. Point the config at `bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0` and send `"strict": true`. Expect a successful tool call, confirming strict schemas still reach models that accept them

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow Bedrock tool-payload change with regression tests; `strict: true` behavior stays behind the existing per-model gate.
> 
> **Overview**
> Fixes Bedrock Converse **400** errors (`tools.0.custom.strict: Extra inputs are not permitted`) when tool calls include a synthesized **`strict: false`**, including **`/v1/responses`** flows where the Responses→Chat Completions bridge adds that field even though the client never sent it.
> 
> **`BedrockToolSpec`** now adds **`toolSpec.strict`** only when **`strict` is truthy** (`strict: true`), not whenever it is merely present. **`strict: false`** is omitted for every model because it is the Chat Completions default and Bedrock rejects the key by presence. The existing **`bedrock_converse_supports_strict_tools`** cost-map gate is unchanged and still controls **`strict: true`** (and **`additionalProperties`**).
> 
> Claude **Sonnet 5** regional entries in **`model_prices_and_context_window.json`** (and backup) get **`bedrock_converse_supports_strict_tools: false`**, aligned with live Bedrock behavior. Regression tests cover Sonnet 5, universal dropping of falsy **`strict`**, and the Responses bridge path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b9c706877d6d0be31f61f2295280b84f1e221c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->