### PR TITLE
feat(helm): make extra ingress paths configurable in the componentized chart

### DIFF
--- a/helm/litellm/templates/ingress.yaml
+++ b/helm/litellm/templates/ingress.yaml
@@ -6,6 +6,41 @@
 {{- $backendPort := .Values.backend.service.port -}}
 {{- $uiPort := .Values.ui.service.port -}}
 {{/*
+  Backends addressable from ingress.extraPaths, keyed by the `service` field.
+*/}}
+{{- $extraPathBackends := dict
+    "gateway" (dict "name" $gatewayName "port" $gatewayPort)
+    "backend" (dict "name" $backendName "port" $backendPort)
+    "ui" (dict "name" $uiName "port" $uiPort)
+-}}
+{{/*
+  UI paths (Next.js static export).
+
+  /ui/* is where the SPA serves its login + dashboard routes (e.g. /ui/login).
+  Without it, /ui/* falls into the catch-all → backend → 404.
+
+  The App Router (output: "export", basePath: "") emits the RSC/flight payload
+  for every route as a ROOT-level <route>.txt (/index.txt, /teams.txt,
+  /__next._tree.txt, ...). The client router fetches these on every soft
+  navigation / prefetch as <route>.txt?_rsc=<hash> (the query string is
+  irrelevant to path matching). They are not under /ui, /_next, or
+  /litellm-asset-prefix, so without /*.txt they fall to the backend catch-all
+  → 404 → client-side navigation never settles and the login flow spins in an
+  infinite redirect loop (/ ⇄ /ui/login). ui/nginx.conf already serves *.txt
+  from the export; the rule only routes the request to it. Needs an ingress
+  controller whose ImplementationSpecific path is a wildcard pattern
+  (AWS ALB: `*` = 0+ chars); this chart targets the AWS Load Balancer
+  Controller.
+*/}}
+{{- $uiPaths := list
+    (dict "path" "/" "pathType" "Exact")
+    (dict "path" "/favicon.ico" "pathType" "Exact")
+    (dict "path" "/litellm-asset-prefix" "pathType" "Prefix")
+    (dict "path" "/_next" "pathType" "Prefix")
+    (dict "path" "/ui" "pathType" "Prefix")
+    (dict "path" "/*.txt" "pathType" "ImplementationSpecific")
+-}}
+{{/*
   Gateway data-plane prefixes — must mirror gateway/routes/allowlist.py.
   Versioned paths are listed explicitly to avoid routing management routes
   (e.g. /v1/access_group, /v2/key/info, /v1/tool/*, /v1/agents, /v1/workflows,
@@ -39,6 +74,21 @@
   routes at startup -> 404. So /test is rendered as a standalone Exact path
   and /test/* falls through to the backend catch-all.
 */}}
+{{/*
+  Every "<path>|<pathType>" this template renders on its own. An
+  ingress.extraPaths entry that repeats one of these is rejected: duplicates
+  in a single rule are resolved by position or by controller-specific tie
+  breaking, so the operator entry could take over a built-in route (an entry
+  at "/" Prefix would swallow the whole backend management API) instead of
+  adding to it.
+*/}}
+{{- $builtinPathKeys := list "/test|Exact" "/|Prefix" -}}
+{{- range $uiPaths }}
+{{- $builtinPathKeys = append $builtinPathKeys (printf "%s|%s" .path .pathType) }}
+{{- end }}
+{{- range $gatewayPrefixes }}
+{{- $builtinPathKeys = append $builtinPathKeys (printf "%s|Prefix" .) }}
+{{- end }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -64,65 +114,15 @@ spec:
       http:
         paths:
           # --- UI (Next.js static export) ---
-          - path: /
-            pathType: Exact
+          {{- range $uiPaths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
               service:
                 name: {{ $uiName }}
                 port:
                   number: {{ $uiPort }}
-          - path: /favicon.ico
-            pathType: Exact
-            backend:
-              service:
-                name: {{ $uiName }}
-                port:
-                  number: {{ $uiPort }}
-          - path: /litellm-asset-prefix
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ $uiName }}
-                port:
-                  number: {{ $uiPort }}
-          - path: /_next
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ $uiName }}
-                port:
-                  number: {{ $uiPort }}
-          # /ui/* is where the Next.js SPA serves its login + dashboard
-          # routes (e.g. /ui/login). Without this, /ui/* falls into the
-          # catch-all → backend → 404.
-          - path: /ui
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ $uiName }}
-                port:
-                  number: {{ $uiPort }}
-          # Next.js App Router (output: "export", basePath: "") emits the
-          # RSC/flight payload for every route as a ROOT-level <route>.txt
-          # (/index.txt, /teams.txt, /__next._tree.txt, ...). The client
-          # router fetches these on every soft navigation / prefetch as
-          # <route>.txt?_rsc=<hash> (the query string is irrelevant to path
-          # matching). They are not under /ui, /_next, or
-          # /litellm-asset-prefix, so without this rule they fall to the
-          # backend catch-all → 404 → client-side navigation never settles
-          # and the login flow spins in an infinite redirect loop
-          # (/ ⇄ /ui/login). ui/nginx.conf already serves *.txt from the
-          # export; this rule only routes the request to it. Needs an
-          # ingress controller whose ImplementationSpecific path is a
-          # wildcard pattern (AWS ALB: `*` = 0+ chars); this chart targets
-          # the AWS Load Balancer Controller.
-          - path: /*.txt
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: {{ $uiName }}
-                port:
-                  number: {{ $uiPort }}
+          {{- end }}
           # --- Gateway data plane ---
           # Exact /test only (see the $gatewayPrefixes comment above);
           # /test/* MCP management endpoints fall to the backend catch-all.
@@ -141,6 +141,46 @@ spec:
                 name: {{ $gatewayName }}
                 port:
                   number: {{ $gatewayPort }}
+          {{- end }}
+          {{- /*
+            --- Operator-supplied extra paths (ingress.extraPaths) ---
+            Rendered after every built-in path so an entry can never take
+            precedence over a default, and before the backend catch-all.
+            Position only decides the match on controllers that honour manifest
+            order: the AWS Load Balancer Controller this chart targets sorts
+            Exact paths first and Prefix paths longest-first, but keeps
+            ImplementationSpecific paths in manifest order, which is what the
+            /*.txt rule above already depends on.
+          */}}
+          {{- range $idx, $extra := .Values.ingress.extraPaths }}
+          {{- if not (kindIs "map" $extra) }}
+          {{- fail (printf "ingress.extraPaths[%d]: each entry must be a mapping with a 'path' key" $idx) }}
+          {{- end }}
+          {{- if not $extra.path }}
+          {{- fail (printf "ingress.extraPaths[%d]: 'path' is required" $idx) }}
+          {{- end }}
+          {{- $service := $extra.service | default "gateway" }}
+          {{- $target := get $extraPathBackends $service }}
+          {{- if not $target }}
+          {{- fail (printf "ingress.extraPaths[%d] (path %s): unknown service %q, expected one of backend, gateway, ui" $idx $extra.path $service) }}
+          {{- end }}
+          {{- $pathType := $extra.pathType | default "Prefix" }}
+          {{- if not (has $pathType (list "Prefix" "Exact" "ImplementationSpecific")) }}
+          {{- fail (printf "ingress.extraPaths[%d] (path %s): unknown pathType %q, expected one of Exact, ImplementationSpecific, Prefix" $idx $extra.path $pathType) }}
+          {{- end }}
+          {{- if eq $extra.path "/" }}
+          {{- fail (printf "ingress.extraPaths[%d]: path / is already routed in both directions, Exact to ui and Prefix to backend, so no pathType leaves a request for an entry here to capture" $idx) }}
+          {{- end }}
+          {{- if has (printf "%s|%s" $extra.path $pathType) $builtinPathKeys }}
+          {{- fail (printf "ingress.extraPaths[%d]: path %s with pathType %s is already routed by this chart, and a duplicate would take it over rather than add to it" $idx $extra.path $pathType) }}
+          {{- end }}
+          - path: {{ $extra.path | quote }}
+            pathType: {{ $pathType }}
+            backend:
+              service:
+                name: {{ $target.name }}
+                port:
+                  number: {{ $target.port }}
           {{- end }}
           # --- Catch-all → backend (management API: /key/*, /user/*, /team/*, ...) ---
           - path: /

--- a/helm/litellm/tests/ingress_extra_paths_tests.yaml
+++ b/helm/litellm/tests/ingress_extra_paths_tests.yaml
@@ -1,0 +1,317 @@
+suite: test ingress.extraPaths
+templates:
+  - ingress.yaml
+values:
+  - ./values/required.yaml
+tests:
+  - it: renders nothing extra between the built-in gateway prefixes and the backend catch-all when unset
+    set:
+      ingress.enabled: true
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[-1]
+          value:
+            path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-backend
+                port:
+                  number: 4001
+      - equal:
+          path: spec.rules[0].http.paths[-2]
+          value:
+            path: /metrics
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-gateway
+                port:
+                  number: 4000
+
+  - it: routes an extra path to the gateway by default, immediately before the backend catch-all
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /watsonx
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[-2]
+          value:
+            path: /watsonx
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-gateway
+                port:
+                  number: 4000
+      - equal:
+          path: spec.rules[0].http.paths[-1]
+          value:
+            path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-backend
+                port:
+                  number: 4001
+
+  - it: keeps every built-in path when extra paths are supplied
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /watsonx
+    asserts:
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /
+            pathType: Exact
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-ui
+                port:
+                  number: 3000
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /ui
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-ui
+                port:
+                  number: 3000
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /test
+            pathType: Exact
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-gateway
+                port:
+                  number: 4000
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /v1/chat
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-gateway
+                port:
+                  number: 4000
+      - contains:
+          path: spec.rules[0].http.paths
+          content:
+            path: /vertex_ai
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-gateway
+                port:
+                  number: 4000
+
+  - it: renders every entry in order and honours the service and pathType selectors
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /watsonx
+          service: gateway
+        - path: /my-passthrough
+          pathType: Exact
+          service: backend
+        - path: /brand.txt
+          pathType: ImplementationSpecific
+          service: ui
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[-4]
+          value:
+            path: /watsonx
+            pathType: Prefix
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-gateway
+                port:
+                  number: 4000
+      - equal:
+          path: spec.rules[0].http.paths[-3]
+          value:
+            path: /my-passthrough
+            pathType: Exact
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-backend
+                port:
+                  number: 4001
+      - equal:
+          path: spec.rules[0].http.paths[-2]
+          value:
+            path: /brand.txt
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-ui
+                port:
+                  number: 3000
+
+  - it: addresses the component services by their configured ports
+    set:
+      ingress.enabled: true
+      gateway.service.port: 8000
+      backend.service.port: 8001
+      ui.service.port: 8080
+      ingress.extraPaths:
+        - path: /watsonx
+        - path: /my-passthrough
+          service: backend
+        - path: /brand.txt
+          service: ui
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[-4].backend.service.port.number
+          value: 8000
+      - equal:
+          path: spec.rules[0].http.paths[-3].backend.service.port.number
+          value: 8001
+      - equal:
+          path: spec.rules[0].http.paths[-2].backend.service.port.number
+          value: 8080
+
+  - it: rejects an entry naming a service the chart does not deploy
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /watsonx
+          service: proxy
+    asserts:
+      - failedTemplate:
+          errorMessage: 'ingress.extraPaths[0] (path /watsonx): unknown service "proxy", expected one of backend, gateway, ui'
+
+  - it: rejects an entry whose pathType is not a kubernetes pathType
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /watsonx
+          pathType: prefix
+    asserts:
+      - failedTemplate:
+          errorMessage: 'ingress.extraPaths[0] (path /watsonx): unknown pathType "prefix", expected one of Exact, ImplementationSpecific, Prefix'
+
+  - it: rejects an entry with no path
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - service: gateway
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.extraPaths[0]: 'path' is required"
+
+
+  - it: rejects a root entry that would take over the backend catch-all
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /
+          service: gateway
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.extraPaths[0]: path / is already routed in both directions, Exact to ui and Prefix to backend, so no pathType leaves a request for an entry here to capture"
+
+  - it: rejects a root entry that would take over the UI root
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /
+          pathType: Exact
+          service: gateway
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.extraPaths[0]: path / is already routed in both directions, Exact to ui and Prefix to backend, so no pathType leaves a request for an entry here to capture"
+
+  # A root ImplementationSpecific entry duplicates no built-in pair, so the
+  # duplicate check alone would admit it. It is still dead: the built-in
+  # Exact / sorts ahead of it on the AWS Load Balancer Controller and claims
+  # the only request its pattern matches, so it renders and never routes.
+  - it: rejects a root entry that would render but never match
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /
+          pathType: ImplementationSpecific
+          service: gateway
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.extraPaths[0]: path / is already routed in both directions, Exact to ui and Prefix to backend, so no pathType leaves a request for an entry here to capture"
+
+  - it: rejects an entry that would take over a UI prefix
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /ui
+          service: gateway
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.extraPaths[0]: path /ui with pathType Prefix is already routed by this chart, and a duplicate would take it over rather than add to it"
+
+  - it: rejects an entry that would take over the UI RSC payload rule
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /*.txt
+          pathType: ImplementationSpecific
+          service: backend
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.extraPaths[0]: path /*.txt with pathType ImplementationSpecific is already routed by this chart, and a duplicate would take it over rather than add to it"
+
+  - it: rejects an entry that would take over a gateway data-plane prefix
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /v1/chat
+          service: backend
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.extraPaths[0]: path /v1/chat with pathType Prefix is already routed by this chart, and a duplicate would take it over rather than add to it"
+
+  - it: rejects an entry that would take over the exact /test route
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /test
+          pathType: Exact
+          service: backend
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.extraPaths[0]: path /test with pathType Exact is already routed by this chart, and a duplicate would take it over rather than add to it"
+
+  - it: allows a built-in path under a different pathType, which is a distinct rule
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - path: /ui
+          pathType: Exact
+          service: ui
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[-2]
+          value:
+            path: /ui
+            pathType: Exact
+            backend:
+              service:
+                name: RELEASE-NAME-litellm-ui
+                port:
+                  number: 3000
+
+  - it: rejects a bare string entry instead of failing on template internals
+    set:
+      ingress.enabled: true
+      ingress.extraPaths:
+        - /watsonx
+    asserts:
+      - failedTemplate:
+          errorMessage: "ingress.extraPaths[0]: each entry must be a mapping with a 'path' key"

--- a/helm/litellm/values.yaml
+++ b/helm/litellm/values.yaml
@@ -13,6 +13,27 @@ ingress:
   annotations: {}
   host: ""        # optional; if set, becomes the rule's host
   tls: []
+  # Extra HTTP paths appended to the ingress rule. Additive: every built-in
+  # UI / gateway / backend path is still rendered, these entries are placed
+  # after them and before the backend catch-all, and an entry that repeats a
+  # path the chart already routes is rejected at render time rather than
+  # silently taking it over.
+  #
+  # The chart's built-in gateway prefix list is a snapshot of the data-plane
+  # surface at release time. Use extraPaths for passthrough routes it does not
+  # cover: a provider prefix added upstream after this chart version, or a
+  # custom general_settings.pass_through_endpoints route.
+  #
+  #   path      required; the HTTP path to route
+  #   service   which component serves it: gateway (default), backend, or ui
+  #   pathType  Prefix (default), Exact, or ImplementationSpecific
+  #
+  # The target component only answers paths its own route allowlist keeps, so
+  # a path here still has to be one that component serves.
+  extraPaths: []
+  # - path: /watsonx
+  #   pathType: Prefix
+  #   service: gateway
 
 # Per-component ServiceAccounts for gateway, backend, and ui.
 #


### PR DESCRIPTION
## TLDR

Problem this solves:

- Chart's ingress path list is hardcoded; no values knob
- Passthrough routes it omits 404 at the backend catch-all
- `/watsonx` is unreachable through this chart today
- Custom `pass_through_endpoints` paths can never ship a rule
- Only workaround is forking the ingress template

How it solves it:

- New `ingress.extraPaths` list in `values.yaml`
- Entries render after every built-in path, never in place of one
- An entry repeating a path the chart routes is rejected
- `service` picks gateway (default), backend, or ui
- `pathType` defaults to Prefix

## Relevant issues

## Linear ticket

Resolves LIT-5135

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### Live cluster: the routing actually changes

kind + ingress-nginx, running this chart with `ealen/echo-server` standing in for the three component images so the pods come up and answer the chart's own probes. echo-server echoes `environment.HOSTNAME`, which is the pod name, and pod names carry `-gateway-` / `-backend-` / `-ui-`, so the response says which component served the request.

Cluster legs were captured at `a16d553bf3`; the head is now `fe451d70aa`, which changed only the extra-path validation and moved the built-in UI paths from six literal blocks into one range. The Ingress object rendered from these values is identical at every commit on the branch, verified by parsing each render and comparing the objects, so the capture stands at the head.

`values-base.yaml` (`PORT` matches each chart containerPort: gateway 4000, backend 4001, ui 3000):

```yaml
migrationJob: { enabled: false }
database:
  writer: { host: postgres.example.com, dbname: litellm }
ingress:
  enabled: true
  className: nginx
  host: litellm.local
gateway:
  image: { repository: ealen/echo-server, tag: latest }
  extraEnv: [{ name: PORT, value: "4000" }]
  resources: { requests: { cpu: 50m, memory: 64Mi }, limits: { cpu: 500m, memory: 256Mi } }
  hpa: { enabled: false }
backend:
  image: { repository: ealen/echo-server, tag: latest }
  extraEnv: [{ name: PORT, value: "4001" }]
  resources: { requests: { cpu: 50m, memory: 64Mi }, limits: { cpu: 500m, memory: 256Mi } }
  hpa: { enabled: false }
ui:
  image: { repository: ealen/echo-server, tag: latest }
  extraEnv: [{ name: PORT, value: "3000" }]
  resources: { requests: { cpu: 50m, memory: 64Mi }, limits: { cpu: 500m, memory: 256Mi } }
  hpa: { enabled: false }
```

`values-extrapaths.yaml`, exercising all three selectors, with `/watsonx` deliberately omitting `pathType` so the run also proves the `Prefix` default:

```yaml
ingress:
  extraPaths:
    - path: /watsonx
      service: gateway
    - path: /my-passthrough
      pathType: Prefix
      service: backend
    - path: /brand.txt
      pathType: ImplementationSpecific
      service: ui
```

**1. Cluster and controller**

```console
$ kind create cluster --name litellm-ingress-extrapaths --config kind-cluster.yaml
$ export KUBECONFIG=$PWD/kubeconfig && kind get kubeconfig --name litellm-ingress-extrapaths > "$KUBECONFIG"
$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.11.2/deploy/static/provider/kind/deploy.yaml
$ kubectl wait -n ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=300s
pod/ingress-nginx-controller-6b7cdd4bf6-l8qgb condition met
```

**2. Install without `extraPaths`**

```console
$ git log --oneline -1
a16d553bf3 feat(helm): make extra ingress paths configurable in the componentized chart

$ kubectl create namespace litellm-extrapaths
$ kubectl -n litellm-extrapaths create secret generic litellm-master-key-secret --from-literal=master-key=sk-proof-1234
$ kubectl -n litellm-extrapaths create secret generic litellm-writer-secret --from-literal=username=litellm --from-literal=password=dummy
$ helm install litellm ./helm/litellm -n litellm-extrapaths -f values-base.yaml --wait --timeout 5m

$ kubectl -n litellm-extrapaths get ingress litellm-litellm -o yaml | grep -cE 'watsonx|my-passthrough|brand\.txt'
0

$ for p in / /ui/login /v1/chat/completions /v1/messages /key/generate /user/info /watsonx /my-passthrough /brand.txt; do
    code=$(curl -s -o /dev/null -w '%{http_code}' -H "Host: litellm.local" "http://localhost:18080$p")
    pod=$(curl -s -H "Host: litellm.local" "http://localhost:18080$p" | jq -r .environment.HOSTNAME)
    printf '%-24s %s  %s\n' "$p" "$code" "$pod"
  done
/                        200  litellm-litellm-ui-5d5c6fd5f4-7n62p
/ui/login                200  litellm-litellm-ui-5d5c6fd5f4-7n62p
/v1/chat/completions     200  litellm-litellm-gateway-69988d8bd6-pkbdk
/v1/messages             200  litellm-litellm-gateway-69988d8bd6-pkbdk
/key/generate            200  litellm-litellm-backend-7c5dfb7b96-xzftt
/user/info               200  litellm-litellm-backend-7c5dfb7b96-xzftt
/watsonx                 200  litellm-litellm-backend-7c5dfb7b96-xzftt
/my-passthrough          200  litellm-litellm-backend-7c5dfb7b96-xzftt
/brand.txt               200  litellm-litellm-backend-7c5dfb7b96-xzftt
```

All three target paths fall into the `/` catch-all and land on the backend, which serves none of them

**3. Upgrade with `extraPaths`**

```console
$ helm upgrade litellm ./helm/litellm -n litellm-extrapaths -f values-base.yaml -f values-extrapaths.yaml --wait --timeout 5m
Release "litellm" has been upgraded. Happy Helming!
STATUS: deployed
REVISION: 2

$ kubectl -n litellm-extrapaths get ingress litellm-litellm -o yaml | grep -B5 -A1 -E 'path: /(watsonx|my-passthrough|brand\.txt)$'
      - backend:
          service:
            name: litellm-litellm-gateway
            port:
              number: 4000
        path: /watsonx
        pathType: Prefix
      - backend:
          service:
            name: litellm-litellm-backend
            port:
              number: 4001
        path: /my-passthrough
        pathType: Prefix
      - backend:
          service:
            name: litellm-litellm-ui
            port:
              number: 3000
        path: /brand.txt
        pathType: ImplementationSpecific
```

`/watsonx` rendered `pathType: Prefix` without being asked, which is the documented default

**4. Same matrix, after**

```console
$ for p in / /ui/login /v1/chat/completions /v1/messages /key/generate /user/info /watsonx /my-passthrough /brand.txt; do ... done
/                        200  litellm-litellm-ui-5d5c6fd5f4-7n62p
/ui/login                200  litellm-litellm-ui-5d5c6fd5f4-7n62p
/v1/chat/completions     200  litellm-litellm-gateway-69988d8bd6-pkbdk
/v1/messages             200  litellm-litellm-gateway-69988d8bd6-pkbdk
/key/generate            200  litellm-litellm-backend-7c5dfb7b96-xzftt
/user/info               200  litellm-litellm-backend-7c5dfb7b96-xzftt
/watsonx                 200  litellm-litellm-gateway-69988d8bd6-pkbdk
/my-passthrough          200  litellm-litellm-backend-7c5dfb7b96-xzftt
/brand.txt               200  litellm-litellm-ui-5d5c6fd5f4-7n62p
```

`/watsonx` moved backend to gateway and `/brand.txt` moved backend to ui. Every built-in path is identical to the before state, on the same pods, which never restarted (`0 restarts, 38s` after the upgrade)

**5. The backend selector needs a second form of evidence**

`service: backend` targets the same component the catch-all already targets, so a response cannot tell "matched my rule" from "fell through". The controller's generated config can: each entry gets its own location block with the right upstream.

```console
$ NGINX=$(kubectl -n ingress-nginx get pod -l app.kubernetes.io/component=controller -o name | head -1)
$ kubectl -n ingress-nginx exec "$NGINX" -- cat /etc/nginx/nginx.conf > nginx.conf
$ for n in my-passthrough watsonx brand.txt; do
    awk -v pat="location = /$n {" 'index($0,pat){f=1} f&&/set \$proxy_upstream_name/{print; exit}' nginx.conf
  done
			set $proxy_upstream_name "litellm-extrapaths-litellm-litellm-backend-4001";
			set $proxy_upstream_name "litellm-extrapaths-litellm-litellm-gateway-4000";
			set $proxy_upstream_name "litellm-extrapaths-litellm-litellm-ui-3000";
```

Combined with the before-leg `grep -c` returning 0, that is the backend entry demonstrably taking effect rather than being absorbed by the catch-all

**6. Cleanup**

```console
$ kind delete cluster --name litellm-ingress-extrapaths
```

### What this run does not prove

ingress-nginx matches by longest prefix, so `/watsonx` Prefix beats the `/` catch-all wherever it sits in the list. This run proves the routing delta and all three service selectors; it does not prove the manifest-position argument, which is specific to controllers that honour manifest order and is covered by the helm-unittest ordering assertions instead.

### Render aborts on a bad entry

Captured at `fe451d70aa`:

```console
$ helm template litellm helm/litellm -f values.yaml --set-json 'ingress.extraPaths=["/watsonx"]' -s templates/ingress.yaml
Error: execution error at (litellm/templates/ingress.yaml:157:14): ingress.extraPaths[0]: each entry must be a mapping with a 'path' key

$ helm template litellm helm/litellm -f values.yaml --set-json 'ingress.extraPaths=[{"service":"gateway"}]' -s templates/ingress.yaml
Error: execution error at (litellm/templates/ingress.yaml:160:14): ingress.extraPaths[0]: 'path' is required

$ helm template litellm helm/litellm -f values.yaml --set-json 'ingress.extraPaths=[{"path":"/watsonx","service":"proxy"}]' -s templates/ingress.yaml
Error: execution error at (litellm/templates/ingress.yaml:165:14): ingress.extraPaths[0] (path /watsonx): unknown service "proxy", expected one of backend, gateway, ui

$ helm template litellm helm/litellm -f values.yaml --set-json 'ingress.extraPaths=[{"path":"/watsonx","pathType":"prefix"}]' -s templates/ingress.yaml
Error: execution error at (litellm/templates/ingress.yaml:169:14): ingress.extraPaths[0] (path /watsonx): unknown pathType "prefix", expected one of Exact, ImplementationSpecific, Prefix

$ helm template litellm helm/litellm -f values.yaml --set-json 'ingress.extraPaths=[{"path":"/","pathType":"ImplementationSpecific","service":"gateway"}]' -s templates/ingress.yaml
Error: execution error at (litellm/templates/ingress.yaml:172:14): ingress.extraPaths[0]: path / is already routed in both directions, Exact to ui and Prefix to backend, so no pathType leaves a request for an entry here to capture

$ helm template litellm helm/litellm -f values.yaml --set-json 'ingress.extraPaths=[{"path":"/ui","service":"gateway"}]' -s templates/ingress.yaml
Error: execution error at (litellm/templates/ingress.yaml:175:14): ingress.extraPaths[0]: path /ui with pathType Prefix is already routed by this chart, and a duplicate would take it over rather than add to it
```

## Type

🆕 New Feature

## Changes

`helm/litellm/templates/ingress.yaml` renders a fixed path set: the UI paths, a hardcoded `$gatewayPrefixes` list mirroring `gateway/routes/allowlist.py`, and a `/` Prefix catch-all to the backend. `values.yaml` exposed no path knob, so an operator needing a route the chart does not know about had to fork the template.

That prefix list is a snapshot of the data plane at chart release time and drifts from it. `/watsonx` is in `GATEWAY_PATH_PREFIXES` (`gateway/routes/allowlist.py:110`, backing the real `/watsonx/{endpoint:path}` passthrough route) but has no ingress rule and no backend prefix, so `/watsonx/*` falls into the catch-all, reaches the backend, and 404s. A provider passthrough prefix added upstream after the chart version an operator runs has the same shape, and a custom `general_settings.pass_through_endpoints` route has a path only the operator knows, so the chart can never ship a rule for it at all.

`ingress.extraPaths` takes a list of `{path, service, pathType}` entries rendered in addition to the built-in paths, never in place of them. They render after every built-in path and before the backend catch-all, and two classes of entry are rejected at render time rather than shipped. An entry repeating a `path` + `pathType` the chart already routes would be resolved by position or by controller-specific tie breaking, so an entry at `/` Prefix would swallow the whole backend management API rather than add to it. And any entry at `/` is rejected whatever its `pathType`, because the chart routes the root in both directions already (Exact to ui, Prefix to backend): every request either matches the Exact rule or falls into the Prefix one, and no rule at `/` can be longer or more specific than those, so such an entry renders and can never capture a request. An entry that differs from a built-in only by `pathType` is still allowed elsewhere, since that is a distinct Kubernetes rule.

`service` picks the component Service (`gateway` by default, or `backend` or `ui`) so an operator does not have to reconstruct release-templated Service names, and `pathType` defaults to `Prefix`. A non-mapping entry, an entry with no path, an unknown service, an unknown pathType, and a duplicate each abort the render naming the offending index rather than emitting an Ingress that misroutes traffic. Leading-slash validation is deliberately left to the API server, which enforces it per pathType and would be the authority a chart-side copy could drift from.

The duplicate check needs the built-in paths as data, so the six UI paths move from literal YAML blocks into a `$uiPaths` list rendered by one range, and their explanatory comments move from the rendered manifest into template comments. The key set derives from that list plus `$gatewayPrefixes` plus `/test|Exact` and `/|Prefix`, so a built-in path added later extends the check automatically. The Ingress object is unchanged: the same 92 paths in the same order with the same backends, verified by parsing the render at every commit on this branch and comparing the objects.

Where position matters at all: the AWS Load Balancer Controller this chart targets [sorts Exact paths first and Prefix paths longest-first, and keeps ImplementationSpecific paths in manifest order](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2409), which is what the existing `/*.txt` rule already depends on.

The target component still answers only the paths its own route allowlist keeps, so this makes a route routable, not servable. Wiring a custom `pass_through_endpoints` path through the gateway's route trim is separate work.

Tests are `helm/litellm/tests/ingress_extra_paths_tests.yaml`, run by the existing `helm_unit_test` workflow. Seventeen cases covering the additive contract, position relative to the catch-all, both selectors and their defaults, the component ports, every render abort, one built-in path per family rejected as a duplicate, the root rejected under all three pathTypes, and the different-pathType case that must still be allowed. Fifteen mutants were run against them and each was killed: flipping the default `service`, flipping the default `pathType`, dropping each of the six guards, exempting `ImplementationSpecific` from the root guard, emptying the built-in key seed, skipping the UI paths or the gateway prefixes when building the key set, two forms of keying on `path` alone, moving the extras below the catch-all, and reverting the template to the branch point. The chart's other 71 tests still pass unchanged

`osv-scan` is red on a file this diff does not touch: `cryptography 48.0.1` in `uv.lock`, where `git diff base...HEAD -- uv.lock` is empty. It is a newly published advisory against the version pinned on staging, it fails the same way on #35690, and #35686 merged with it red. It needs a dependency bump of its own rather than anything here

Docs companion: BerriAI/litellm-docs#745, to merge after this

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
