### PR TITLE
fix(ui): reject an auto-router keyword rule left empty instead of dropping it

### DIFF
--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -61,6 +61,7 @@ from litellm.repositories.team_repository import TeamRepository
 from litellm.router import Router
 from litellm.router_utils.auto_router_model_naming import (
     STRATEGY_ROUTER_PARAM_FIELDS,
+    validate_complexity_router_config_write,
     validate_strategy_router_model_write,
 )
 from litellm.types.proxy.management_endpoints.model_management_endpoints import (
@@ -117,11 +118,20 @@ def _strategy_router_write_violation(
     An auto-router deployment's ``litellm_params.model`` (``auto_router/...``) is
     the discriminator the router loads it by; a write that mangles it makes the
     router drop the deployment silently under ``ignore_invalid_deployments``.
-    Only writes that supply ``litellm_params.model`` are judged, against the
-    merged (stored + incoming) params, so partial patches and restores of an
-    already-corrupted row stay legal. Returns the violation, or None.
+    Only writes that supply ``litellm_params.model`` are judged on the naming
+    contract, against the merged (stored + incoming) params, so partial patches
+    and restores of an already-corrupted row stay legal. A config is judged only
+    when the write carries one, for the same reason: a rename must not be held
+    hostage by a stored config it does not touch. Returns the violation, or None.
     """
-    if incoming_params is None or incoming_params.model is None:
+    if incoming_params is None:
+        return None
+    config_violation = validate_complexity_router_config_write(
+        complexity_router_config=incoming_params.complexity_router_config
+    )
+    if config_violation is not None:
+        return config_violation
+    if incoming_params.model is None:
         return None
     present_fields = frozenset(
         field

--- a/litellm/router_utils/auto_router_model_naming.py
+++ b/litellm/router_utils/auto_router_model_naming.py
@@ -62,12 +62,42 @@ def classify_strategy_router_model(model: str) -> StrategyRouterKind | None:
     return "semantic"
 
 
+def validate_complexity_router_config_write(complexity_router_config: Mapping[str, object] | None) -> str | None:
+    """Reject a complexity config the router would refuse to build a deployment from.
+
+    Parsed with the router's own ``ComplexityRouterConfig`` rather than a copy of
+    its rules, so the boundary rejects exactly what the load would. Plugins are
+    resolved from dotted paths only on the config.yaml path, so a written config
+    reaches this function in the same shape the load hands to the same model.
+    Judged on the config alone: a patch may write one without naming a model, and
+    the stored model is encrypted at rest, so it cannot be classified here.
+    """
+    from pydantic import ValidationError
+
+    from litellm.router_strategy.complexity_router.config import ComplexityRouterConfig
+
+    if complexity_router_config is None:
+        return None
+    try:
+        _ = ComplexityRouterConfig.model_validate(complexity_router_config)
+    except ValidationError as exc:
+        first = exc.errors()[0]
+        location = ".".join(str(part) for part in first.get("loc", ())) or "complexity_router_config"
+        return (
+            f"complexity_router_config is invalid at {location}: {first.get('msg', 'invalid value')}. "
+            "The router would drop this deployment at load time, so the write is rejected instead."
+        )
+    return None
+
+
 def validate_strategy_router_model_write(model: str, present_fields: frozenset[str]) -> str | None:
     """Check that writing ``model`` leaves a deployment the router can load.
 
     ``present_fields`` is the set of strategy-router param fields that are
     non-None on the deployment after the write (stored fields merged with the
     incoming ones). Returns a human-readable violation, or None when coherent.
+    A config's contents are ``validate_complexity_router_config_write``'s to
+    judge, since a write may carry one without naming a model at all.
     """
     kind = classify_strategy_router_model(model)
     if kind is None:

--- a/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py
@@ -3477,6 +3477,140 @@ class TestStrategyRouterWriteValidation:
             is None
         )
 
+    def test_create_with_empty_keyword_rule_rejected(self):
+        """LIT-5133: the router refuses to build a rule with no keyword, but only at load time.
+        Without this the row is written, dropped on reload, and the caller gets a 500 plus a
+        deployment that can never come back."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+
+        violation = _strategy_router_write_violation(
+            incoming_params=LiteLLM_Params(
+                model="auto_router/complexity_router",
+                complexity_router_default_model="gpt-4o-mini",
+                complexity_router_config={
+                    "tiers": {"SIMPLE": ["gpt-4o-mini"]},
+                    "keyword_tier_rules": [{"keywords": [], "tier": "COMPLEX"}],
+                },
+            ),
+            existing_params=None,
+        )
+        assert violation is not None
+        assert "complexity_router_config is invalid" in violation
+        assert "keyword_tier_rules" in violation
+
+    def test_patch_that_only_renames_does_not_judge_the_stored_config(self):
+        """Only a config the write actually carries is judged. A row stored before this validation
+        existed is already unloadable, and holding its rename hostage would break the restore path
+        this function documents; the repair is a write that supplies a good config."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        stored_bad = LiteLLM_Params(
+            model="auto_router/complexity_router",
+            complexity_router_config={
+                "tiers": {"SIMPLE": ["gpt-4o-mini"]},
+                "keyword_tier_rules": [{"keywords": ["  "], "tier": "COMPLEX"}],
+            },
+        )
+        assert (
+            _strategy_router_write_violation(
+                incoming_params=updateLiteLLMParams(model="auto_router/complexity_router"),
+                existing_params=stored_bad,
+            )
+            is None
+        )
+
+    def test_incoming_config_replaces_stored_rather_than_merging(self):
+        """The field is written wholesale, so a good incoming config must clear a bad stored one."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        stored_bad = LiteLLM_Params(
+            model="auto_router/complexity_router",
+            complexity_router_config={
+                "tiers": {"SIMPLE": ["gpt-4o-mini"]},
+                "keyword_tier_rules": [{"keywords": [], "tier": "COMPLEX"}],
+            },
+        )
+        assert (
+            _strategy_router_write_violation(
+                incoming_params=updateLiteLLMParams(
+                    model="auto_router/complexity_router",
+                    complexity_router_config={
+                        "tiers": {"SIMPLE": ["gpt-4o-mini"]},
+                        "keyword_tier_rules": [{"keywords": ["invoice"], "tier": "COMPLEX"}],
+                    },
+                ),
+                existing_params=stored_bad,
+            )
+            is None
+        )
+
+    def test_config_only_patch_is_judged_without_a_model_in_the_payload(self):
+        """A patch may carry a config and no model, which is what a caller updating only the
+        routing rules sends. That path skipped the naming contract, so it has to be judged on the
+        config alone against the stored model, or it overwrites a working router with one that
+        cannot load and takes it out of service."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        violation = _strategy_router_write_violation(
+            incoming_params=updateLiteLLMParams(
+                complexity_router_config={
+                    "tiers": {"SIMPLE": ["gpt-4o-mini"]},
+                    "keyword_tier_rules": [{"keywords": [], "tier": "COMPLEX"}],
+                }
+            ),
+            existing_params=self._stored_complexity_params(),
+        )
+        assert violation is not None
+        assert "complexity_router_config is invalid" in violation
+
+    def test_config_only_patch_with_a_loadable_config_is_allowed(self):
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        assert (
+            _strategy_router_write_violation(
+                incoming_params=updateLiteLLMParams(
+                    complexity_router_config={
+                        "tiers": {"SIMPLE": ["gpt-4o-mini"]},
+                        "keyword_tier_rules": [{"keywords": ["invoice"], "tier": "COMPLEX"}],
+                    }
+                ),
+                existing_params=self._stored_complexity_params(),
+            )
+            is None
+        )
+
+    def test_config_only_patch_is_judged_on_the_config_alone(self):
+        """The stored model is encrypted at rest, so a patch that names no model cannot be
+        classified from the row. An unloadable config is rejected on its own merits instead,
+        which is also the only reading that closes the path regardless of what is stored."""
+        from litellm.proxy.management_endpoints.model_management_endpoints import (
+            _strategy_router_write_violation,
+        )
+        from litellm.types.router import updateLiteLLMParams
+
+        violation = _strategy_router_write_violation(
+            incoming_params=updateLiteLLMParams(
+                complexity_router_config={"keyword_tier_rules": [{"keywords": [], "tier": "COMPLEX"}]}
+            ),
+            existing_params=LiteLLM_Params(model="c2VjcmV0-encrypted-at-rest"),
+        )
+        assert violation is not None
+        assert "complexity_router_config is invalid" in violation
+
     def test_create_semantic_router_missing_embedding_rejected(self):
         from litellm.proxy.management_endpoints.model_management_endpoints import (
             _strategy_router_write_violation,

--- a/tests/test_litellm/router_utils/test_auto_router_model_naming.py
+++ b/tests/test_litellm/router_utils/test_auto_router_model_naming.py
@@ -2,6 +2,7 @@ import pytest
 
 from litellm.router_utils.auto_router_model_naming import (
     classify_strategy_router_model,
+    validate_complexity_router_config_write,
     validate_strategy_router_model_write,
 )
 
@@ -75,3 +76,74 @@ def test_validate_rejects_incoherent_writes(model, present_fields, expected_frag
 )
 def test_validate_accepts_coherent_writes(model, present_fields):
     assert validate_strategy_router_model_write(model=model, present_fields=present_fields) is None
+
+
+VALID_TIERS = {
+    "SIMPLE": ["gpt-4o-mini"],
+    "MEDIUM": ["gpt-4o-mini"],
+    "COMPLEX": ["gpt-4o"],
+    "REASONING": ["gpt-4o"],
+}
+
+
+@pytest.mark.parametrize(
+    "keyword_tier_rules,expected_fragment",
+    [
+        ([{"keywords": [], "tier": "COMPLEX"}], "at least 1 item"),
+        ([{"keywords": ["   "], "tier": "COMPLEX"}], "non-empty keyword"),
+        (
+            [{"keywords": ["invoice"], "tier": "MEDIUM"}, {"keywords": [], "tier": "COMPLEX"}],
+            "at least 1 item",
+        ),
+    ],
+)
+def test_validate_rejects_unloadable_complexity_config(keyword_tier_rules, expected_fragment):
+    """A rule with no keyword makes ComplexityRouterConfig unbuildable, so the row must never be
+    written: without this the deployment is persisted, dropped at load, and the caller gets a 500."""
+    violation = validate_complexity_router_config_write(
+        complexity_router_config={
+            "tiers": VALID_TIERS,
+            "classifier_type": "heuristic",
+            "keyword_tier_rules": keyword_tier_rules,
+        }
+    )
+    assert violation is not None
+    assert "complexity_router_config is invalid" in violation
+    assert expected_fragment in violation
+
+
+@pytest.mark.parametrize(
+    "complexity_router_config",
+    [
+        {"tiers": VALID_TIERS, "classifier_type": "heuristic"},
+        {
+            "tiers": VALID_TIERS,
+            "classifier_type": "heuristic",
+            "keyword_tier_rules": [{"keywords": ["invoice", "refund"], "tier": "MEDIUM"}],
+        },
+        # extra="allow" on the model, so an unrecognised key is not this gate's business
+        {"tiers": VALID_TIERS, "classifier_type": "heuristic", "some_future_key": "value"},
+    ],
+)
+def test_validate_accepts_loadable_complexity_config(complexity_router_config):
+    assert validate_complexity_router_config_write(complexity_router_config=complexity_router_config) is None
+
+
+def test_naming_check_ignores_the_config_entirely():
+    """The naming contract and the config's contents are separate questions with separate owners;
+    a write may carry a config without naming a model, so neither can stand in for the other."""
+    violation = validate_strategy_router_model_write(
+        model="auto_router/complexity_router", present_fields=frozenset()
+    )
+    assert violation is not None
+    assert "requires" in violation
+
+
+def test_config_check_ignores_the_model_entirely():
+    assert validate_complexity_router_config_write(complexity_router_config=None) is None
+    assert (
+        validate_complexity_router_config_write(
+            complexity_router_config={"tiers": VALID_TIERS, "keyword_tier_rules": [{"keywords": [], "tier": "COMPLEX"}]}
+        )
+        is not None
+    )

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.test.tsx
@@ -310,6 +310,26 @@ describe("ComplexityRouterConfig", () => {
     expect(newRules[0]).toMatchObject({ keywords: [], tier: "COMPLEX" });
   });
 
+  // The dropdown is closed, so antd has nothing for Enter to select and the word would only land
+  // on blur. Submitting used to provide that blur; it no longer can while the row reads as empty.
+  it("commits a typed keyword on Enter, with the dropdown closed", async () => {
+    const user = userEvent.setup();
+    const onKeywordTierRulesChange = vi.fn();
+    renderWithProviders(
+      <ComplexityRouterConfig
+        {...baseProps}
+        keywordTierRules={[{ id: "rule-1", keywords: [], tier: "COMPLEX" }]}
+        onKeywordTierRulesChange={onKeywordTierRulesChange}
+      />,
+    );
+    fireEvent.click(screen.getByText("Advanced: Keyword/Semantic Matching"));
+
+    const field = screen.getByText("Keywords 1").closest("div") as HTMLElement;
+    await user.type(within(field).getByRole("combobox"), "invoice{enter}");
+
+    expect(onKeywordTierRulesChange).toHaveBeenCalledWith([{ id: "rule-1", keywords: ["invoice"], tier: "COMPLEX" }]);
+  });
+
   it("should render an existing keyword tier rule and remove it when the delete button is clicked", async () => {
     const user = userEvent.setup();
     const onKeywordTierRulesChange = vi.fn();

--- a/ui/litellm-dashboard/src/components/add_model/KeywordTierRules.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/KeywordTierRules.tsx
@@ -2,6 +2,8 @@ import { DeleteOutlined, InfoCircleOutlined, PlusOutlined } from "@ant-design/ic
 import { Button, Card, Empty, Select as AntdSelect, Tooltip, Typography } from "antd";
 import React from "react";
 
+import { emptyKeywordTierRuleIndexes } from "./complexity_router_keywords";
+
 const { Text } = Typography;
 
 export type ComplexityTier = "SIMPLE" | "MEDIUM" | "COMPLEX" | "REASONING";
@@ -24,7 +26,36 @@ const TIER_OPTIONS: { value: ComplexityTier; label: string }[] = [
   { value: "REASONING", label: "Reasoning" },
 ];
 
+// A row exists only because the caller asked for it, so it reports its own gap straight away
+// rather than waiting for a submit; the submit button is disabled while one is outstanding, so
+// there is no failed attempt left to surface it.
 const KeywordTierRules: React.FC<KeywordTierRulesProps> = ({ rules, onChange }) => {
+  const emptyRuleIndexes = new Set(emptyKeywordTierRuleIndexes(rules));
+  const [drafts, setDrafts] = React.useState<Record<string, string>>({});
+
+  const setDraft = (id: string, text: string) => setDrafts((current) => ({ ...current, [id]: text }));
+
+  // The dropdown is kept closed, which leaves antd nothing for Enter to select, so a typed keyword
+  // would only become a tag on blur. Submitting used to supply that blur; the button is disabled
+  // while the row reads as empty, so Enter has to commit the word itself or the row cannot be filled.
+  const commitDraft = (rule: KeywordTierRule) => {
+    const keyword = (drafts[rule.id] ?? "").trim();
+    if (!keyword) return;
+    updateRule(rule.id, { keywords: [...rule.keywords, keyword] });
+    setDraft(rule.id, "");
+  };
+
+  const commitDraftOnEnter = (rule: KeywordTierRule) => (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    commitDraft(rule);
+  };
+
+  const replaceKeywords = (rule: KeywordTierRule) => (keywords: string[]) => {
+    updateRule(rule.id, { keywords });
+    setDraft(rule.id, "");
+  };
+
   const addRule = () => {
     onChange([...rules, { id: `${Date.now()}`, keywords: [], tier: "COMPLEX" }]);
   };
@@ -73,14 +104,24 @@ const KeywordTierRules: React.FC<KeywordTierRulesProps> = ({ rules, onChange }) 
                   <AntdSelect
                     mode="tags"
                     value={rule.keywords}
-                    onChange={(keywords: string[]) => updateRule(rule.id, { keywords })}
+                    onChange={replaceKeywords(rule)}
+                    searchValue={drafts[rule.id] ?? ""}
+                    onSearch={(text) => setDraft(rule.id, text)}
+                    onInputKeyDown={commitDraftOnEnter(rule)}
+                    onBlur={() => commitDraft(rule)}
                     placeholder="e.g., invoice, refund, billing"
                     tokenSeparators={[","]}
                     open={false}
                     suffixIcon={null}
                     style={{ width: "100%" }}
                     allowClear
+                    status={emptyRuleIndexes.has(index) ? "error" : undefined}
                   />
+                  {emptyRuleIndexes.has(index) && (
+                    <Text type="danger" style={{ fontSize: 12 }}>
+                      At least one keyword is required
+                    </Text>
+                  )}
                 </div>
                 <div style={{ width: 220 }}>
                   <Text strong style={{ display: "block", marginBottom: 8 }}>

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -1,4 +1,4 @@
-import { renderWithProviders, screen, waitFor } from "../../../tests/test-utils";
+import { renderWithProviders, screen, waitFor, within } from "../../../tests/test-utils";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import AddAutoRouterTab from "./add_auto_router_tab";
@@ -52,14 +52,22 @@ describe("AddAutoRouterTab", () => {
     vi.clearAllMocks();
   });
 
-  it("flags every mandatory field when Add Auto Router is clicked with nothing filled", async () => {
+  // Nothing is filled in, so there is nothing to submit. The button reports that itself instead of
+  // accepting a click and answering with a toast.
+  it("offers no submit at all until every tier has a model", async () => {
+    renderWithProviders(<Harness />);
+
+    expect(screen.getByRole("button", { name: /add auto router/i })).toBeDisabled();
+  });
+
+  it("still flags the router name once the config no longer blocks the submit", async () => {
     const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
     renderWithProviders(<Harness />);
 
     await user.click(screen.getByRole("button", { name: /add auto router/i }));
 
     expect(await screen.findByText("Auto router name is required")).toBeInTheDocument();
-    expect(screen.getAllByText("This tier is required")).toHaveLength(4);
     expect(NotificationManager.fromBackend).toHaveBeenCalledWith("Please enter an Auto Router Name");
   });
 
@@ -95,6 +103,83 @@ describe("AddAutoRouterTab", () => {
 
     await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
     expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0]).toMatchObject({ team_id: "team-1" });
+  });
+
+  // LIT-5133: "Add keyword rule" seeds a row with no keywords, and the semantic toggle that used
+  // to be the only thing checking them is off by default. The row was dropped on the way to the
+  // payload, so the create succeeded and the caller's rule was gone with nothing said about it.
+  it("takes the submit away while a keyword rule is left empty", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+
+    renderWithProviders(<Harness />);
+
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "keyword-router");
+    await user.click(screen.getByText("Advanced: Keyword/Semantic Matching"));
+    await user.click(screen.getByRole("button", { name: /add keyword rule/i }));
+
+    expect(screen.getByRole("button", { name: /add auto router/i })).toBeDisabled();
+    // The row says so on its own; there is no failed submit left to surface it.
+    expect(await screen.findByText("At least one keyword is required")).toBeInTheDocument();
+    expect(handleAddAutoRouterSubmit).not.toHaveBeenCalled();
+  });
+
+  it("gives the submit back once that keyword rule is filled", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+
+    renderWithProviders(<Harness />);
+
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "keyword-router");
+    await user.click(screen.getByText("Advanced: Keyword/Semantic Matching"));
+    await user.click(screen.getByRole("button", { name: /add keyword rule/i }));
+    expect(screen.getByRole("button", { name: /add auto router/i })).toBeDisabled();
+
+    await user.type(
+      within(screen.getByText("Keywords 1").closest("div") as HTMLElement).getByRole("combobox"),
+      "invoice{enter}",
+    );
+
+    expect(screen.getByRole("button", { name: /add auto router/i })).toBeEnabled();
+    expect(screen.queryByText("At least one keyword is required")).not.toBeInTheDocument();
+  });
+
+  it("marks only the offending keyword row, leaving a filled one alone", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+
+    renderWithProviders(<Harness />);
+
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "keyword-router");
+    await user.click(screen.getByText("Advanced: Keyword/Semantic Matching"));
+    await user.click(screen.getByRole("button", { name: /add keyword rule/i }));
+    await user.type(
+      within(screen.getByText("Keywords 1").closest("div") as HTMLElement).getByRole("combobox"),
+      "invoice{enter}",
+    );
+    await user.click(screen.getByRole("button", { name: /add keyword rule/i }));
+
+    expect(await screen.findAllByText("At least one keyword is required")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: /add auto router/i })).toBeDisabled();
+  });
+
+  it("creates the router once that keyword rule is filled in", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+
+    renderWithProviders(<Harness />);
+
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "keyword-router");
+    await user.click(screen.getByText("Advanced: Keyword/Semantic Matching"));
+    await user.click(screen.getByRole("button", { name: /add keyword rule/i }));
+    const keywordsField = screen.getByText("Keywords 1").closest("div") as HTMLElement;
+    await user.type(within(keywordsField).getByRole("combobox"), "invoice{enter}");
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+    expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0]).toMatchObject({
+      complexity_router_config: { keyword_tier_rules: [{ keywords: ["invoice"], tier: "COMPLEX" }] },
+    });
   });
 
   it("blocks the submit when a team admin has not picked a team", async () => {

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -17,6 +17,7 @@ import { DEFAULT_ESCALATION_KEYWORDS } from "./EscalationKeywords";
 import { DEFAULT_MATCH_THRESHOLD } from "./SemanticKeywordMatching";
 import {
   buildComplexityRouterConfig,
+  getKeywordTierRulesError,
   getMissingTiersError,
   getSemanticConfigError,
 } from "./build_complexity_router_config";
@@ -94,6 +95,11 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     label: model_group,
   }));
 
+  // Why the submit is unavailable, or null when it is available. The button reads this to disable
+  // itself and to say what is missing, so the two can never give different answers.
+  const submitBlockedReason =
+    getMissingTiersError(complexityRouterConfig.tiers) ?? getKeywordTierRulesError(keywordTierRules);
+
   const submitRecommendedRouter = (name: string) => {
     const {
       tiers,
@@ -119,6 +125,13 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     if (classifierType === "llm" && !classifierLlmConfig?.model) {
       setShowValidationErrors(true);
       NotificationManager.fromBackend("Please select a classifier model, or switch back to Heuristic");
+      return;
+    }
+
+    const keywordRulesError = getKeywordTierRulesError(keywordTierRules);
+    if (keywordRulesError) {
+      setShowValidationErrors(true);
+      NotificationManager.fromBackend(keywordRulesError);
       return;
     }
 
@@ -307,14 +320,17 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                   Test Connection
                 </Button>
               }
-              <Button
-                type="primary"
-                onClick={() => {
-                  handleAutoRouterSubmit();
-                }}
-              >
-                Add Auto Router
-              </Button>
+              <Tooltip title={submitBlockedReason}>
+                <Button
+                  type="primary"
+                  disabled={submitBlockedReason !== null}
+                  onClick={() => {
+                    handleAutoRouterSubmit();
+                  }}
+                >
+                  Add Auto Router
+                </Button>
+              </Tooltip>
             </div>
           </div>
         </Form>

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
@@ -1,5 +1,6 @@
 import {
   buildComplexityRouterConfig,
+  getKeywordTierRulesError,
   getMissingTiersError,
   getSemanticConfigError,
   BuildComplexityRouterConfigParams,
@@ -177,7 +178,7 @@ describe("buildComplexityRouterConfig", () => {
     expect(config.keyword_tier_rules).toBeUndefined();
   });
 
-  it("trims keywords and drops rules left empty, so unfilled rows never 400 the backend", () => {
+  it("trims keywords but keeps rules left empty, so a dropped row can never pass for a saved one", () => {
     const params: BuildComplexityRouterConfigParams = {
       ...baseParams,
       keywordTierRules: [
@@ -187,17 +188,13 @@ describe("buildComplexityRouterConfig", () => {
       ],
     };
     const config = buildComplexityRouterConfig(params);
-    // r1 keeps only its real keyword (trimmed); r2 and r3 are dropped entirely.
-    expect(config.keyword_tier_rules).toEqual([{ keywords: ["deploy to k8s"], tier: "REASONING" }]);
-  });
-
-  it("omits keyword_tier_rules entirely when every rule is empty", () => {
-    const params: BuildComplexityRouterConfigParams = {
-      ...baseParams,
-      keywordTierRules: [{ id: "r1", keywords: ["", "  "], tier: "COMPLEX" }],
-    };
-    const config = buildComplexityRouterConfig(params);
-    expect(config.keyword_tier_rules).toBeUndefined();
+    // getKeywordTierRulesError blocks this submit; r2 and r3 survive here so the backend rejects
+    // them loudly rather than the caller's rows vanishing on a successful save.
+    expect(config.keyword_tier_rules).toEqual([
+      { keywords: ["deploy to k8s"], tier: "REASONING" },
+      { keywords: [], tier: "COMPLEX" },
+      { keywords: [], tier: "SIMPLE" },
+    ]);
   });
 
   it("omits adaptive fields when adaptive is disabled even if weights linger in state", () => {
@@ -302,21 +299,56 @@ describe("getSemanticConfigError", () => {
     ).toMatch(/keyword tier rule/i);
   });
 
-  it("errors when a rule has no non-empty keywords", () => {
-    const emptyRule = { id: "r2", keywords: ["", "  "], tier: "SIMPLE" as const };
-    expect(
-      getSemanticConfigError({
-        semanticMatchingEnabled: true,
-        embeddingModel: "voyage-3-5",
-        keywordTierRules: [emptyRule],
-      }),
-    ).toMatch(/at least one keyword/i);
-  });
-
   it("returns null when enabled with both an embedding model and rules", () => {
     expect(
       getSemanticConfigError({ semanticMatchingEnabled: true, embeddingModel: "voyage-3-5", keywordTierRules: [rule] }),
     ).toBeNull();
+  });
+});
+
+describe("getKeywordTierRulesError", () => {
+  it("returns null when every rule carries a keyword", () => {
+    expect(
+      getKeywordTierRulesError([
+        { id: "r1", keywords: ["invoice"], tier: "MEDIUM" },
+        { id: "r2", keywords: ["deploy to k8s"], tier: "REASONING" },
+      ]),
+    ).toBeNull();
+  });
+
+  it("returns null when there are no rules at all, since the section is optional", () => {
+    expect(getKeywordTierRulesError([])).toBeNull();
+  });
+
+  // The whole point of the ticket: the semantic toggle is off by default, and an unfilled row
+  // used to be discarded silently on an otherwise successful create.
+  it("rejects a row left empty while semantic matching is off", () => {
+    expect(getKeywordTierRulesError([{ id: "r1", keywords: [], tier: "COMPLEX" }])).toBe(
+      "Add at least one keyword to keyword rule(s): 1",
+    );
+  });
+
+  it.each([
+    ["whitespace only", ["   "]],
+    ["blank strings, as an unfilled row between filled ones leaves behind", ["", " ", ""]],
+  ])("treats %s as empty rather than as a keyword", (_label, keywords) => {
+    expect(getKeywordTierRulesError([{ id: "r1", keywords, tier: "SIMPLE" }])).toMatch(/keyword rule\(s\): 1/);
+  });
+
+  // Row numbers have to survive rules that are fine, or the message points at the wrong input.
+  it("names each offending row by its position among all rules", () => {
+    expect(
+      getKeywordTierRulesError([
+        { id: "r1", keywords: ["invoice"], tier: "MEDIUM" },
+        { id: "r2", keywords: [], tier: "COMPLEX" },
+        { id: "r3", keywords: ["billing"], tier: "SIMPLE" },
+        { id: "r4", keywords: ["  "], tier: "REASONING" },
+      ]),
+    ).toBe("Add at least one keyword to keyword rule(s): 2, 4");
+  });
+
+  it("keeps a keyword whose surrounding whitespace is the only thing trimmed", () => {
+    expect(getKeywordTierRulesError([{ id: "r1", keywords: ["  invoice  "], tier: "MEDIUM" }])).toBeNull();
   });
 });
 

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
@@ -1,5 +1,5 @@
 import { KeywordTierRule } from "./KeywordTierRules";
-import { serializeKeywordTierRules } from "./complexity_router_keywords";
+import { emptyKeywordTierRuleIndexes, serializeKeywordTierRules } from "./complexity_router_keywords";
 import {
   AdaptiveEligible,
   AdaptiveRouterWeights,
@@ -56,6 +56,12 @@ export const getMissingTiersError = (tiers: ComplexityTiers): string | null => {
   return `Select a model for the following tier(s): ${missing.join(", ")}`;
 };
 
+export const getKeywordTierRulesError = (keywordTierRules: KeywordTierRule[]): string | null => {
+  const emptyRows = emptyKeywordTierRuleIndexes(keywordTierRules);
+  if (emptyRows.length === 0) return null;
+  return `Add at least one keyword to keyword rule(s): ${emptyRows.map((index) => index + 1).join(", ")}`;
+};
+
 export const getSemanticConfigError = ({
   semanticMatchingEnabled,
   embeddingModel,
@@ -66,8 +72,6 @@ export const getSemanticConfigError = ({
   if (!semanticMatchingEnabled) return null;
   if (!embeddingModel) return "Select an embedding model to use semantic keyword matching";
   if (keywordTierRules.length === 0) return "Add at least one keyword tier rule to use semantic keyword matching";
-  if (keywordTierRules.some((rule) => !rule.keywords.some((keyword) => keyword.trim())))
-    return "Every keyword tier rule needs at least one keyword";
   return null;
 };
 
@@ -91,7 +95,6 @@ export const buildComplexityRouterConfig = ({
   returnRawModelName,
 }: BuildComplexityRouterConfigParams): ComplexityRouterConfigPayload => {
   const cleanedEscalationKeywords = escalationKeywords.map((keyword) => keyword.trim()).filter(Boolean);
-  // Trim keywords and drop empty ones; drop any rule left with no keywords. Clicking
   const cleanedKeywordTierRules = serializeKeywordTierRules(keywordTierRules);
 
   return {

--- a/ui/litellm-dashboard/src/components/add_model/complexity_router_keywords.ts
+++ b/ui/litellm-dashboard/src/components/add_model/complexity_router_keywords.ts
@@ -19,13 +19,19 @@ const asKeywords = (value: unknown): string[] =>
     : [];
 
 /**
- * Drop the React-only id, trim keywords, and discard rules left empty. "Add keyword rule"
- * seeds a row with no keywords, and the backend validator rejects those with a 400.
+ * Drop the React-only id and trim keywords, leaving one entry per rule. A rule left empty stays
+ * empty rather than disappearing, so getKeywordTierRulesError can name the row it came from.
  */
 export const serializeKeywordTierRules = (rules: KeywordTierRule[]): StoredKeywordTierRule[] =>
-  rules
-    .map((rule) => ({ keywords: asKeywords(rule.keywords).filter(Boolean), tier: rule.tier }))
-    .filter((rule) => rule.keywords.length > 0);
+  rules.map((rule) => ({ keywords: asKeywords(rule.keywords).filter(Boolean), tier: rule.tier }));
+
+/**
+ * Positions of the rules left without a keyword, as indexes into the caller's own array. The
+ * submit-time message and the inline error on the row both read this, so the row the message
+ * names is always the row that lights up.
+ */
+export const emptyKeywordTierRuleIndexes = (rules: KeywordTierRule[]): number[] =>
+  serializeKeywordTierRules(rules).flatMap((rule, index) => (rule.keywords.length === 0 ? [index] : []));
 
 export const hydrateKeywordTierRules = (value: unknown): KeywordTierRule[] => {
   if (!Array.isArray(value)) return [];

--- a/ui/litellm-dashboard/src/components/edit_auto_router/build_updated_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/build_updated_complexity_router_config.test.ts
@@ -54,13 +54,16 @@ describe("buildUpdatedComplexityRouterConfig keyword matching", () => {
     expect(result.keyword_tier_rules).toEqual([{ keywords: ["chargeback"], tier: "COMPLEX" }]);
   });
 
-  it("drops a rule left empty rather than shipping one the backend 400s on", () => {
+  // getKeywordTierRulesError blocks this save, so the builder never runs on a real edit. Keeping
+  // the rule here means that if a caller ever reaches it anyway, the stored rules are replaced by
+  // something the backend rejects out loud rather than by silence that reads as a clean save.
+  it("keeps a rule left empty rather than quietly dropping the caller's row", () => {
     const result = buildUpdatedComplexityRouterConfig(STORED, FORM_VALUE, undefined, {
       ...hydratedState,
       keywordTierRules: [{ id: "new-1", keywords: ["   "], tier: "SIMPLE" }],
     });
 
-    expect(result.keyword_tier_rules).toBeUndefined();
+    expect(result.keyword_tier_rules).toEqual([{ keywords: [], tier: "SIMPLE" }]);
   });
 
   it("removes the semantic trio when the toggle is turned off", () => {

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
@@ -118,6 +118,80 @@ describe("EditAutoRouterModal keyword matching", () => {
     await waitFor(() => expect(NotificationsManager.fromBackend).toHaveBeenCalled());
     expect(modelPatchUpdateCall).not.toHaveBeenCalled();
   });
+
+  // LIT-5133, edit side. Semantic matching is off here on purpose: it used to be the only thing
+  // that checked a rule for keywords, so with it on this save was already blocked and the test
+  // would pass without the fix. Off, the unfilled row was dropped and the save reported success.
+  it("blocks a save that adds a keyword rule and leaves it empty", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <EditAutoRouterModal
+        isVisible
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        modelData={{
+          ...MODEL_DATA,
+          litellm_params: {
+            ...MODEL_DATA.litellm_params,
+            complexity_router_config: {
+              ...STORED_CONFIG,
+              semantic_keyword_matching: false,
+              embedding_model: undefined,
+            },
+          },
+        }}
+        accessToken="token"
+        userRole="Admin"
+      />,
+    );
+
+    await screen.findByText(/Escalation Keywords/i);
+    fireEvent.click(screen.getByText("Advanced: Keyword/Semantic Matching"));
+    await user.click(screen.getByRole("button", { name: /add keyword rule/i }));
+
+    // The modal renders the same controls as the create form, so it owes the same treatment:
+    // the row says what is missing and the save is not offered while it is.
+    expect(await screen.findByText("At least one keyword is required")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled();
+    expect(modelPatchUpdateCall).not.toHaveBeenCalled();
+  });
+
+  it("gives the save back once the added keyword rule is filled", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <EditAutoRouterModal
+        isVisible
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        modelData={{
+          ...MODEL_DATA,
+          litellm_params: {
+            ...MODEL_DATA.litellm_params,
+            complexity_router_config: {
+              ...STORED_CONFIG,
+              semantic_keyword_matching: false,
+              embedding_model: undefined,
+            },
+          },
+        }}
+        accessToken="token"
+        userRole="Admin"
+      />,
+    );
+
+    await screen.findByText(/Escalation Keywords/i);
+    fireEvent.click(screen.getByText("Advanced: Keyword/Semantic Matching"));
+    await user.click(screen.getByRole("button", { name: /add keyword rule/i }));
+    expect(screen.getByRole("button", { name: /save changes/i })).toBeDisabled();
+
+    await user.type(
+      within(screen.getByText("Keywords 2").closest("div") as HTMLElement).getByRole("combobox"),
+      "chargeback{enter}",
+    );
+
+    expect(screen.getByRole("button", { name: /save changes/i })).toBeEnabled();
+    expect(screen.queryByText("At least one keyword is required")).not.toBeInTheDocument();
+  });
 });
 
 describe("EditAutoRouterModal classifier context window", () => {

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { Modal, Form, Button, Select as AntdSelect } from "antd";
+import { Modal, Form, Button, Select as AntdSelect, Tooltip } from "antd";
 import { Text, TextInput } from "@tremor/react";
 import { modelAvailableCall, modelPatchUpdateCall } from "../networking";
 import { fetchAvailableModels, ModelGroup } from "@/components/llm_calls/fetch_models";
 import RouterConfigBuilder from "../add_model/RouterConfigBuilder";
 import { normalizeTierModels } from "../add_model/complexity_router_tiers";
 import { isComplexityRouter } from "../add_model/auto_router_strategies";
-import { getSemanticConfigError } from "../add_model/build_complexity_router_config";
+import { getKeywordTierRulesError, getSemanticConfigError } from "../add_model/build_complexity_router_config";
 import { KeywordTierRule } from "../add_model/KeywordTierRules";
 import { DEFAULT_MATCH_THRESHOLD } from "../add_model/SemanticKeywordMatching";
 import { hydrateKeywordTierRules, serializeKeywordTierRules } from "../add_model/complexity_router_keywords";
@@ -115,8 +115,8 @@ export const buildUpdatedComplexityRouterConfig = (
     }),
     ...(value.return_raw_model_name && { return_raw_model_name: true }),
     ...(keywordMatching && {
-      // Mirrors buildComplexityRouterConfig: rules only when non-empty (the backend rejects
-      // an empty rule with a 400), escalation keywords always, semantic trio only when on.
+      // Mirrors buildComplexityRouterConfig: the key only when there is a rule to write,
+      // escalation keywords always, semantic trio only when on.
       ...(storedKeywordRules.length > 0 && { keyword_tier_rules: storedKeywordRules }),
       escalation_keywords: keywordMatching.escalationKeywords.map((k) => k.trim()).filter(Boolean),
       ...(keywordMatching.semanticMatchingEnabled && {
@@ -142,6 +142,7 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
   const [modelInfo, setModelInfo] = useState<ModelGroup[]>([]);
   const [showCustomDefaultModel, setShowCustomDefaultModel] = useState<boolean>(false);
   const [showCustomEmbeddingModel, setShowCustomEmbeddingModel] = useState<boolean>(false);
+  const [showValidationErrors, setShowValidationErrors] = useState<boolean>(false);
   const [routerConfig, setRouterConfig] = useState<any>(null);
   const [customTechnicalKeywords, setCustomTechnicalKeywords] = useState<string[]>([]);
   const [keywordTierRules, setKeywordTierRules] = useState<KeywordTierRule[]>([]);
@@ -154,6 +155,15 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
     classifier_type: "heuristic",
   });
   const isComplexityRouterModel = isComplexityRouter(modelData?.litellm_params);
+
+  // Mirrors the create form: the button says why it is unavailable and disables on the same
+  // answer. Tiers use this modal's own rule, which allows a partly filled router, so an edit that
+  // is legal today stays legal.
+  const submitBlockedReason = !isComplexityRouterModel
+    ? null
+    : (Object.values(complexityRouterConfig.tiers).every((models) => models.length === 0)
+        ? "Please select at least one model for a complexity tier"
+        : null) ?? getKeywordTierRulesError(keywordTierRules);
 
   useEffect(() => {
     if (isVisible && modelData) {
@@ -288,24 +298,29 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
       if (isComplexityRouterModel) {
         const { tiers, classifier_type, classifier_llm_config } = complexityRouterConfig;
         if (Object.values(tiers).every((models) => models.length === 0)) {
+          setShowValidationErrors(true);
           NotificationsManager.fromBackend("Please select at least one model for a complexity tier");
           return;
         }
         if (classifier_type === "llm" && !classifier_llm_config?.model) {
+          setShowValidationErrors(true);
           NotificationsManager.fromBackend("Please select a classifier model, or switch back to Heuristic");
           return;
         }
-        // Same guard the create form applies (add_auto_router_tab.tsx). The backend rejects
-        // semantic_keyword_matching without an embedding model or keyword rules
-        // (complexity_router/config.py), so without this a save fails as a raw 400 instead of
-        // an inline message.
+        // Same guards the create form applies (add_auto_router_tab.tsx). The backend rejects a
+        // keyword rule with no keyword, and semantic_keyword_matching without an embedding model
+        // or keyword rules (complexity_router/config.py), so without these a save fails as a raw
+        // 400 instead of an inline message.
+        const keywordRulesError = getKeywordTierRulesError(keywordTierRules);
+        if (keywordRulesError) {
+          setShowValidationErrors(true);
+          NotificationsManager.fromBackend(keywordRulesError);
+          return;
+        }
 
-        // Same guard the create form applies (add_auto_router_tab.tsx). The backend rejects
-        // semantic_keyword_matching without an embedding model or keyword rules
-        // (complexity_router/config.py), so without this a save fails as a raw 400 instead of
-        // an inline message.
         const semanticError = getSemanticConfigError({ semanticMatchingEnabled, embeddingModel, keywordTierRules });
         if (semanticError) {
+          setShowValidationErrors(true);
           NotificationsManager.fromBackend(semanticError);
           return;
         }
@@ -403,9 +418,11 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
         <Button key="cancel" onClick={onCancel}>
           Cancel
         </Button>,
-        <Button key="submit" loading={loading} onClick={handleSubmit}>
-          Save Changes
-        </Button>,
+        <Tooltip key="submit" title={submitBlockedReason}>
+          <Button loading={loading} disabled={submitBlockedReason !== null} onClick={handleSubmit}>
+            Save Changes
+          </Button>
+        </Tooltip>,
       ]}
       width={1000}
       destroyOnHidden
@@ -429,6 +446,7 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
             /* Complexity Router Configuration */
             <div className="w-full">
               <ComplexityRouterConfig
+                showValidationErrors={showValidationErrors}
                 modelInfo={modelInfo}
                 value={complexityRouterConfig}
                 onChange={(config) => {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Adding a keyword tier override and leaving the keywords box empty created the auto router anyway, with the rule silently discarded
- Sending that same rule straight to the API wrote the row, then dropped the deployment on reload and returned a 500, leaving a model that can never load

How it solves it:

- The check that a rule carries at least one keyword now runs on every submit instead of only when semantic matching is on
- The write endpoints parse the config with the router's own model, so an unloadable one is a 400 and nothing is persisted

## Relevant issues

- An unfilled keyword rule marks its own row and withholds the submit button, so the router cannot be created while one is outstanding, on both the create form and the edit modal
- `serializeKeywordTierRules` stops discarding empty rules, so an unfilled row can never pass for a saved one
- The management write paths now judge `complexity_router_config` content, closing the gap `auto_router_model_naming` documents as its own purpose

## Linear ticket

Resolves LIT-5133

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix
<img width="725" height="541" alt="image" src="https://github.com/user-attachments/assets/3572e2d1-0dbb-4517-8ea1-116da3a94fdc" />


Live proxy on localhost:4000 against a real Postgres. First, what the two halves looked like before

```bash
# the dashboard stripped the empty rule client-side, so the router was created without it
$ curl -s -o /dev/null -w "HTTP %{http_code}\n" -X POST http://localhost:4000/model/new -H "Authorization: Bearer $KEY" \
  -H "Content-Type: application/json" -d '{"model_name":"router-old-ui","litellm_params":{...no keyword_tier_rules...}}'
HTTP 200

# the rule the operator actually configured, sent intact
$ curl -s -X POST http://localhost:4000/model/new -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model_name":"router-empty-rule","litellm_params":{"model":"auto_router/complexity_router",
       "complexity_router_default_model":"gpt-4o-mini","complexity_router_config":{
       "tiers":{"SIMPLE":["gpt-4o-mini"],"MEDIUM":["gpt-4o-mini"],"COMPLEX":["gpt-4o"],"REASONING":["gpt-4o"]},
       "classifier_type":"heuristic","keyword_tier_rules":[{"keywords":[],"tier":"COMPLEX"}]}},"model_info":{}}'
HTTP 500
{"error": {"message": "Model create was saved to the database, but the model id(s) ['e2afc484-...'] are not
 live in this pod's router after the reload and are not being served by this pod. ...",
 "type": "internal_server_error"}}
```

That 500 leaves a durable row the router will never load, which is what the client-side strip was avoiding by throwing the rule away instead

```bash
$ psql -U tin -d lit5133qa -tA -c "select model_name, litellm_params::json->'complexity_router_config'->'keyword_tier_rules' from \"LiteLLM_ProxyModelTable\";"
router-old-ui|
router-empty-rule|[{"tier": "COMPLEX", "keywords": []}]

$ curl -s http://localhost:4000/v1/models -H "Authorization: Bearer $KEY" | jq -r '.data[].id'
gpt-4o-mini
gpt-4o
router-old-ui          # created, with the operator's rule gone
                       # router-empty-rule is absent: written, never served
```

```
LiteLLM Router:WARNING: router.py:8437 - Error upserting deployment router-empty-rule (id=e2afc484-...):
  1 validation error for ComplexityRouterConfig
  List should have at least 1 item after validation, not 0 [type=too_short, input_value=[], input_type=list]
  Dropping it and continuing with other deployments.
```

After the change, on a fresh database. The same payload is refused at the boundary

```bash
$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://localhost:4000/model/new ... same body as above ...
{
  "error": {
    "message": "complexity_router_config is invalid at keyword_tier_rules.0.keywords: List should have at
     least 1 item after validation, not 0. The router would drop this deployment at load time, so the write
     is rejected instead.",
    "type": "validation_error",
    "param": "litellm_params.model",
    "code": "400"
  }
}
HTTP 400

$ psql -U tin -d lit5133qa -tA -c "select count(*) || ' rows' from \"LiteLLM_ProxyModelTable\";"
0 rows
```

Whitespace-only keywords hit the router's own normalizer, and a valid rule still creates and serves

```bash
$ curl -s -X POST http://localhost:4000/model/new ... "keyword_tier_rules":[{"keywords":["   "],"tier":"COMPLEX"}] ...
"... complexity_router_config is invalid at keyword_tier_rules.0: Value error, keyword_tier_rules entries
 must contain at least one non-empty keyword. ..."

$ curl -s -o /dev/null -w "HTTP %{http_code}\n" -X POST http://localhost:4000/model/new ... "keywords":["invoice","refund","billing"] ...
HTTP 200
$ curl -s http://localhost:4000/v1/models -H "Authorization: Bearer $KEY" | jq -r '.data[].id'
gpt-4o-mini
gpt-4o
router-valid-rule
```

Every write shape, against a fresh database. A patch that carries only a config is covered too, which is what the dashboard's edit modal and any caller updating just the routing rules send

```
1. create valid:                       HTTP 200
2. create with empty rule:             HTTP 400
3. patch model + empty rule:           HTTP 400
4. patch config-only, no model:        HTTP 400
5. patch config-only, valid:           HTTP 200
6. patch unrelated field (rpm):        HTTP 200
7. rename only, against a bad stored config:  HTTP 200

$ psql -U tin -d lit5133qa -tA -c "select litellm_params::json->'complexity_router_config'->'keyword_tier_rules' from \"LiteLLM_ProxyModelTable\";"
[{"tier": "COMPLEX", "keywords": ["invoice"]}]
```

Case 4 is the one worth calling out: before it was closed, that patch overwrote a serving router with a config it could not build and took it out of service on the way to the 500. Case 7 is why a stored config is never judged on a write that does not carry one

The inference leg is not included because both shared provider accounts are out of credit right now; routing behaviour is untouched by this PR either way

### UI runbook

Start the proxy and `npm run dev` in `ui/litellm-dashboard`, then

1. Go to http://localhost:3000/?page=llm-model-hub, open Auto Routers, click Add Auto Router
2. Name it, pick a model for all four tiers
3. Expand "Advanced: Keyword/Semantic Matching", click "+ Add keyword rule", leave Keywords 1 empty, leave the tier on Complex
4. The Keywords 1 box turns red with "At least one keyword is required" under it, and Add Auto Router greys out. Hover it and the tooltip names the row. Before this PR the button was clickable and the router was created with the rule gone
5. Type `invoice` into Keywords 1 and press enter. The error clears and the button comes back; click it and the rule is on the saved config
6. Reopen that router, click "+ Add keyword rule", leave it empty. Save Changes greys out the same way, with the error on the second row

## Type

🐛 Bug Fix

## Changes

- `getKeywordTierRulesError` rejects any rule whose keywords are empty after trimming and names each offending row; `getSemanticConfigError` drops the per-rule check it now subsumes, which only ever ran with the semantic toggle on
- `serializeKeywordTierRules` returns one entry per rule instead of filtering empties out, so validation and the payload agree on what a keyword is and row numbers line up with the "Keywords N" labels
- Both `add_auto_router_tab.tsx` and `edit_auto_router_modal.tsx` call the new check before building their payload
- `KeywordTierRules` marks an offending row with `status="error"` and "At least one keyword is required", driven by the same `emptyKeywordTierRuleIndexes` the submit message uses, so the row named and the row marked cannot diverge
- Both submit buttons are disabled while a tier is unfilled or a keyword row is empty, with the reason in a tooltip. Disable state and tooltip read one value, so a greyed button always explains itself
- Enter commits a typed keyword. `open={false}` leaves antd nothing for Enter to select, so the word previously only became a tag on blur, and clicking submit was what supplied that blur; with the button withheld that route is gone and the row could not be filled
- The edit modal gains the `showValidationErrors` state it was missing, so its classifier error renders at all
- `validate_complexity_router_config_write` parses a written `complexity_router_config` with `ComplexityRouterConfig`, so `/model/new`, `/model/{id}/update` and the legacy `/model/update` all reject an unloadable one with a 400 and persist nothing

### Things a reviewer will ask about

Whether parsing at the write boundary can reject a config that works today. It cannot: `resolve_complexity_router_plugins` runs only on the config.yaml path, so a written config already reaches `ComplexityRouterConfig.model_validate` unchanged moments later at load time. The boundary calls that same model rather than a copy of its rules, and the model is `extra="allow"`, so unknown keys stay the caller's business

Why the row reports itself instead of waiting for a failed submit. With the button withheld there is no failed submit left to surface anything, so a row that only spoke up after one would never speak at all. A row exists only because the caller clicked "Add keyword rule", so it is safe to have it report straight away; tiers keep their existing behaviour and rely on the tooltip, since a blank form turning red on load helps nobody

Why the serializer no longer drops empty rules. Dropping them is what made the bug invisible, and it breaks the row numbering the message depends on. Reverting the serializer alone fails five of the new tests, including the validator ones, which is the check that the call into it is real

Why the config is judged on its own rather than by classifying the deployment's model. A patch may write a config without naming a model, and the stored model is encrypted at rest, so it cannot be classified from the row. Judging the config alone is the only reading that covers that path

Why a write that carries no config is never rejected for a stored one. A row stored before this validation existed is already unloadable, and blocking its rename would break the restore path `_strategy_router_write_violation` documents. The repair is a write that supplies a good config, which is covered

## QA runbook

Follow the UI runbook above for the dashboard half, and the curl block for the API half

- `npx vitest run src/components/add_model src/components/edit_auto_router` is green; the full dashboard suite passes at 5906 tests
- `pytest tests/test_litellm/router_utils/test_auto_router_model_naming.py tests/test_litellm/proxy/management_endpoints/test_model_management_endpoints.py tests/test_litellm/router_strategy/test_complexity_router.py` passes at 397

Mutation checks run against this diff:

- reverting the two UI guard call sites fails exactly the two new workflow tests and nothing else
- reverting the inline row error fails the tests that assert it, on both forms
- forcing either submit button back to always-enabled fails six tests across both forms
- restoring the serializer's empty-rule filter fails six tests across both the create and edit payload builders
- disabling the new backend config check fails exactly the new backend tests, with the pre-existing ones still passing

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proxy model create/update validation for auto-router deployments; behavior is aligned with existing router load rules and mainly prevents bad writes, but incorrect validation could block legitimate configs.
> 
> **Overview**
> Fixes **LIT-5133**: empty keyword tier rules could be saved (or stripped client-side) and leave deployments that fail at router reload with a 500 instead of a clear validation error.
> 
> **Proxy:** Model create/update now runs **`validate_complexity_router_config_write`** on any incoming `complexity_router_config`, using the same **`ComplexityRouterConfig`** the router loads. Invalid configs (e.g. `keyword_tier_rules` with no keywords) return **400** before persistence. **`_strategy_router_write_violation`** validates config-only patches without requiring `litellm_params.model`, and does not judge stored config on renames that omit config.
> 
> **Dashboard:** **`getKeywordTierRulesError`** and **`emptyKeywordTierRuleIndexes`** block submit whenever a keyword rule has no non-empty keyword, including when semantic matching is off. **`serializeKeywordTierRules`** keeps empty rules in the payload instead of dropping them. **`KeywordTierRules`** shows per-row errors, disables submit via shared **`submitBlockedReason`** (tooltip on create/edit), and commits typed keywords on **Enter**/**blur** so rows can be filled with the button disabled. Create and edit flows both call the new checks before building the config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b647947b3402e238f4180b6b046ca2af1c4098e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->