### PR TITLE
fix(openai): drop undefined Union from owns_wrapped_http_client annotation

### DIFF
--- a/litellm/llms/openai/common_utils.py
+++ b/litellm/llms/openai/common_utils.py
@@ -135,7 +135,7 @@ class BaseOpenAILLM:
         return _cached_client
 
     @staticmethod
-    def owns_wrapped_http_client(http_client: Optional[Union[httpx.Client, httpx.AsyncClient]]) -> bool:
+    def owns_wrapped_http_client(http_client: httpx.Client | httpx.AsyncClient | None) -> bool:
         """Whether litellm may close an SDK client built around ``http_client``.
 
         ``_get_async_http_client`` / ``_get_sync_http_client`` hand back

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -366,7 +366,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             if cached_client:
                 if isinstance(cached_client, OpenAI) or isinstance(cached_client, AsyncOpenAI):
                     return cached_client
-            http_client: Optional[Union[httpx.Client, httpx.AsyncClient]] = (
+            http_client: httpx.Client | httpx.AsyncClient | None = (
                 OpenAIChatCompletion._get_async_http_client(shared_session=shared_session)
                 if is_async
                 else OpenAIChatCompletion._get_sync_http_client()


### PR DESCRIPTION
## TLDR

Problem this solves:

- litellm_internal_staging cannot be imported; every CI test shard fails at collection
- The proxy crashes on boot with NameError: name 'Union' is not defined

How it solves it:

- Rewrites the annotation as `httpx.Client | httpx.AsyncClient | None`, needing no typing import

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before, at staging tip 9d5984b358, the proxy exits on boot:

```
$ python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --port 4271
...
  File "litellm/llms/openai/common_utils.py", line 138, in BaseOpenAILLM
    def owns_wrapped_http_client(http_client: Optional[Union[httpx.Client, httpx.AsyncClient]]) -> bool:
                                                       ^^^^^
NameError: name 'Union' is not defined
$ echo $?
1
```

After, at 942fdc23f3, the proxy boots and serves real Groq traffic on all three LLM endpoints:

```
$ curl -s http://localhost:4271/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"groq-gpt-oss-120b","messages":[{"role":"user","content":"Say ok"}]}'
{"id":"chatcmpl-ccd2dc81-d671-42a0-b11c-1e4a76fa1383","created":1785790582,"model":"groq-gpt-oss-120b","object":"chat.completion","system_fingerprint":"fp_d81b3304b3","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Ok.","role":"assistant","reasoning":"The user says \"Say ok\". We need to respond with \"ok\". There's no disallowed content. Just comply."}}],"usage":{"completion_tokens":36,"prompt_tokens":73,"total_tokens":109,...}}

$ curl -s http://localhost:4271/v1/messages -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"groq-gpt-oss-120b","max_tokens":50,"messages":[{"role":"user","content":"Say ok"}]}'
{"id":"chatcmpl-e2274a9e-808d-4aa0-b58d-394b8556b571","type":"message","role":"assistant","model":"groq-gpt-oss-120b","stop_sequence":null,"usage":{"input_tokens":73,"output_tokens":37},"content":[{"type":"text","text":"Ok."}],"stop_reason":"end_turn"}

$ curl -s http://localhost:4271/v1/responses -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
    -d '{"model":"groq-gpt-oss-120b","input":"Say ok"}'
{"id":"resp__qbOxogn...","object":"response","model":"groq-gpt-oss-120b","status":"completed","output":[{"type":"message","id":"chatcmpl-233746ba-19bf-4ee7-bad6-1f2a8c70402b","status":"completed","role":"assistant","content":[{"type":"output_text","text":"Ok.","annotations":[]}],"phase":null}],...}
```

## Type

🐛 Bug Fix

## Changes

PR #35492 was authored before the ruff sweep (b604e2b20c) removed `Union` from the typing imports of `litellm/llms/openai/common_utils.py`, so merging it landed an annotation that references `Union` without importing it. The annotation sits on a method, so it is evaluated at class-definition time and importing litellm raises NameError, which is why every test shard on litellm_internal_staging currently fails during collection and the proxy cannot boot

This rewrites the annotation as `httpx.Client | httpx.AsyncClient | None`, matching the PEP 604 style the rest of the file uses, so no typing import is needed at all. The same latent defect existed on a local variable annotation in `litellm/llms/openai/openai.py` (harmless at runtime since local annotations are never evaluated, but flagged by F821) and is fixed the same way

No new test: the entire test suite is the regression test here, since collection itself fails while the bug exists. Ruff's F821 also catches it and `ruff check litellm/ --select F821` is clean after this change; it only slipped through because per-PR lint runs on changed files and the conflict between #35492 and the ruff sweep only materialized at merge time
