### PR TITLE
test(e2e): add the gateway proxy config the suite asserts against

### DIFF
--- a/tests/e2e/gateway/litellm-config.yml
+++ b/tests/e2e/gateway/litellm-config.yml
@@ -1,0 +1,74 @@
+general_settings:
+  store_prompts_in_spend_logs: true
+  forward_client_headers_to_llm_api: false
+  maximum_spend_logs_retention_period: 3h
+  maximum_spend_logs_cleanup_cron: 0 1 * * *
+  proxy_config_reload_interval_seconds: 10
+  proxy_budget_rescheduler_min_time: 15
+  proxy_budget_rescheduler_max_time: 20
+litellm_settings:
+  drop_params: true
+  default_redis_ttl: 20
+  json_logs: true
+  store_audit_logs: true
+  cache: true
+  cache_params:
+    type: redis
+    host: os.environ/REDIS_HOST
+    port: os.environ/REDIS_PORT
+  callbacks:
+  - datadog
+  - prometheus
+  - otel
+  require_auth_for_metrics_endpoint: false
+router_settings:
+  fallbacks:
+  - gpt-5.5:
+    - gpt-5.6-luna
+    - gpt-5.2
+  - claude-haiku-4-5:
+    - gemini-2.5-flash
+    - gpt-5.6-luna
+  routing_strategy: simple-shuffle
+  num_retries: 3
+model_list:
+- model_name: gpt-5.5
+  litellm_params:
+    model: openai/gpt-5.5
+    api_key: os.environ/OPENAI_API_KEY
+- model_name: gpt-5.6-luna
+  litellm_params:
+    model: openai/gpt-5.6-luna
+    api_key: os.environ/OPENAI_API_KEY
+- model_name: gpt-5.2
+  litellm_params:
+    model: openai/gpt-5.2
+    api_key: os.environ/OPENAI_API_KEY
+- model_name: claude-haiku-4-5
+  litellm_params:
+    model: anthropic/claude-haiku-4-5
+    api_key: os.environ/ANTHROPIC_API_KEY
+- model_name: azure-foundry-claude-haiku
+  litellm_params:
+    model: azure_ai/claude-haiku-4-5
+    api_base: os.environ/AZURE_AI_API_BASE
+    api_key: os.environ/AZURE_AI_API_KEY
+- model_name: gemini-2.5-flash-vertex
+  litellm_params:
+    model: vertex_ai/gemini-2.5-flash
+    vertex_project: os.environ/VERTEXAI_PROJECT
+    vertex_location: us-central1
+    vertex_credentials: os.environ/VERTEXAI_CREDENTIALS
+- model_name: gemini-2.5-flash
+  litellm_params:
+    model: gemini/gemini-2.5-flash
+    api_key: os.environ/GEMINI_API_KEY
+- model_name: gemini-2.5-flash
+  litellm_params:
+    model: gemini/gemini-2.5-flash
+    api_key: os.environ/GEMINI_API_KEY
+mcp_servers:
+  devin:
+    url: https://mcp.devin.ai/mcp
+    auth_type: api_key
+    auth_value: os.environ/DEVIN_API_KEY


### PR DESCRIPTION
## TLDR

Problem this solves:

- `gateway/litellm-config.yml` is documented but never existed
- The config the suite needs lived in the deployment overlay
- So a run's proxy and its tests came from different commits

How it solves it:

- Adds the file where the docs already say it lives
- Every credential stays an `os.environ/` indirection
- Cache points at `REDIS_HOST`, so no environment is baked in

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

Rendering the litellm chart against this config with a bundled database and Redis, at commit 59a28ba5cf:

```
$ helm template e2e-abc123 helm/litellm-helm -f ephemeral-values.yaml
$ grep -E "^kind:" rendered.yaml | sort | uniq -c | sort -rn
   5 kind: Service
   4 kind: ConfigMap
   2 kind: StatefulSet
   2 kind: ServiceAccount
   2 kind: Secret
   2 kind: Pod
   2 kind: NetworkPolicy
   1 kind: Job
   1 kind: Deployment
```

The rendered ConfigMap resolves every model and picks up the injected coordination block:

```
coordination_redis injected: True
  -> {'host': 'os.environ/REDIS_HOST', 'password': 'os.environ/REDIS_PASSWORD', 'port': 'os.environ/REDIS_PORT'}
models: ['gpt-5.5', 'gpt-5.6-luna', 'gpt-5.2', 'claude-haiku-4-5', 'azure-foundry-claude-haiku', 'gemini-2.5-flash-vertex', 'gemini-2.5-flash', 'gemini-2.5-flash']
cache host: os.environ/REDIS_HOST
```

Bundled StatefulSets come up under the release name, so the release carries its own database and Redis rather than sharing one:

```
e2e-abc123-postgresql
e2e-abc123-redis-master
```

Scanned for anything environment-specific; the file carries none, and all 13 credentials are indirected:

```
$ grep -nE "amazonaws\.com|arn:aws|[0-9]{12}|\.internal|sk-|password:" tests/e2e/gateway/litellm-config.yml
  (no matches)
$ grep -cE "os\.environ/" tests/e2e/gateway/litellm-config.yml
13
```

This PR adds no runnable test of its own; the file is the fixture the existing `tests/e2e` suite runs against, and the proof above is that a proxy renders from it correctly.

## Type

🚄 Infrastructure
✅ Test

## Changes

Adds `tests/e2e/gateway/litellm-config.yml`, the proxy configuration the e2e suite asserts against. `tests/e2e/CLAUDE.md` already describes `gateway/` as "proxy configuration only (`litellm-config.yml`); no tests", and litellm-auto's README points operators at this path, but the file was never committed. The configuration it describes lived only in the deployment overlay, versioned independently of the tests that depend on it.

That separation is what stops an e2e run being attributable to a commit. The suite image pins to a SHA while the proxy it exercises tracks whatever was deployed most recently. Across the eight retained runs in the Buildkite Test Engine suite, the reported SHA matched the gateway actually under test once; the other seven drifted between 51 and 73 commits. Keeping the model list beside the tests that assert on it means a run can build both halves from a single commit.

The file is written to be environment-agnostic. Credentials are `os.environ/` indirections rather than values, and the response cache points at `REDIS_HOST` and `REDIS_PORT` instead of a named endpoint, so it works unchanged against a chart-bundled Redis or an external one. Nothing here is specific to a cluster, account, or region.

## QA runbook

Render the chart against the config with a bundled database and Redis, then confirm the ConfigMap lists all eight models and carries an injected `coordination_redis` block pointing at the env indirections.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
