### PR TITLE
ci: extend dependabot cooldown coverage to cargo

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,3 +11,15 @@ updates:
       github-actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/litellm-rust"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 3
+      semver-major-days: 14
+    groups:
+      cargo:
+        patterns:
+          - "*"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Rust is the only ecosystem here without a dependency cooldown
- New crate versions can enter Cargo.lock with zero aging

How it solves it:

- Adds a dependabot cargo entry for litellm-rust
- 3 day cooldown, 14 for majors, matching existing policy

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests (N/A: dependabot config only, no code path to test)
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Cooldown enforcement happens server side in GitHub's dependabot service, so the observable behavior is the age of the versions in the update PRs it opens after this merges; there is nothing to demo against a local proxy. What can be verified now (at 6abbd29fb5):

```
$ python3 -c "import yaml; d = yaml.safe_load(open('.github/dependabot.yaml')); print([u['package-ecosystem'] for u in d['updates']])"
['github-actions', 'cargo']
```

The `cooldown` keys used for cargo (`default-days`, `semver-major-days`) are documented as supported for the cargo ecosystem in GitHub's dependabot options reference

## Type

🚄 Infrastructure

## Changes

One new entry in `.github/dependabot.yaml`: cargo ecosystem rooted at `/litellm-rust`, daily schedule, `cooldown` of 3 days (14 for semver majors), all updates grouped into a single PR, mirroring the shape of the existing `github-actions` entry

Context: the pip and npm lanes both have 3 day cooldowns already (`[tool.uv] exclude-newer = "3 days"` in pyproject.toml, `min-release-age=3` in both `.npmrc` files). Rust has none. CI runs `--locked` everywhere, so Cargo.lock is the single point where crate versions enter the build; today nothing gates how fresh those versions can be, and litellm-rust also gets no automated update PRs at all. This change adds the automated updates and age gates them at the same 3 day window the other ecosystems use

Two boundaries worth naming. The cooldown only governs dependabot's own PRs; a maintainer running `cargo update` by hand is not gated. Cargo's native answer, `min-publish-age` (RFC 3923), would close that client side too, but it is still nightly only (`-Zmin-publish-age`, tracking issue cargo#17009); worth adopting as a complement once it stabilizes. And as with the other lanes, git and path dependencies carry no registry timestamp, so no cooldown applies to them

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR (no tests apply; YAML config only)
