### PR TITLE
feat(complexity_router): default session affinity off and expose it in the UI

### DIFF
--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -426,13 +426,13 @@ class ComplexityRouterConfig(BaseModel):
 
     # Session affinity: pin the first turn's routed model for the rest of the session
     session_affinity: bool = Field(
-        default=True,
+        default=False,
         description=(
             "When True and a session_id is resolvable on the request, pin the model chosen on the "
             "session's first turn and reuse it for every later turn, skipping re-classification. "
-            "On by default so multi-turn sessions stay on one model, preserving provider prompt "
-            "caches and avoiding cross-model conversation-history errors. Set False to reclassify "
-            "every turn."
+            "Off by default so every turn is classified on its own merits and routed to the cheapest "
+            "adequate tier. Set True to keep a multi-turn session on one model, which preserves "
+            "provider prompt caches and avoids cross-model conversation-history errors."
         ),
     )
     session_affinity_ttl_seconds: int = Field(

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2903,7 +2903,7 @@ class TestRoutingDecisionCauseLogging:
 
 
 class TestSessionAffinity:
-    """Test the session_affinity sticky-routing behavior (on by default)."""
+    """Test the session_affinity sticky-routing behavior (off by default)."""
 
     REASONING_MESSAGE = [
         {
@@ -2917,18 +2917,14 @@ class TestSessionAffinity:
     def session_affinity_config(self, basic_config) -> Dict:
         return {**basic_config, "session_affinity": True}
 
-    @pytest.fixture
-    def session_affinity_disabled_config(self, basic_config) -> Dict:
-        return {**basic_config, "session_affinity": False}
-
     @staticmethod
     def _request_kwargs(session_id: str) -> Dict:
         return {"metadata": {"session_id": session_id}}
 
     @pytest.mark.asyncio
-    async def test_enabled_by_default_pins_model(self, mock_router_instance, basic_config):
-        """Regression: session_affinity defaults to True, so a shared session_id pins the
-        first turn's model and later turns reuse it instead of reclassifying."""
+    async def test_disabled_by_default_reclassifies_every_turn(self, mock_router_instance, basic_config):
+        """Regression: session_affinity defaults to False, so a shared session_id must NOT
+        pin the first turn's model; every turn is classified on its own merits."""
         assert "session_affinity" not in basic_config
         mock_router_instance.cache = DualCache()
         router = ComplexityRouter(
@@ -2944,19 +2940,17 @@ class TestSessionAffinity:
             model="test-model", request_kwargs=request_kwargs, messages=self.SIMPLE_MESSAGE
         )
         assert first.model == "o1-preview"
-        assert second.model == "o1-preview"
+        assert second.model == "gpt-4o-mini"
 
     @pytest.mark.asyncio
-    async def test_can_be_disabled_reclassifies_every_turn(
-        self, mock_router_instance, session_affinity_disabled_config
-    ):
-        """Regression: session_affinity=False must still reclassify every turn even when a
-        shared session_id is present, so the opt-out keeps working."""
+    async def test_can_be_enabled_to_pin_every_later_turn(self, mock_router_instance, session_affinity_config):
+        """Regression: session_affinity=True is the opt-in, so a shared session_id reuses the
+        first turn's model instead of reclassifying."""
         mock_router_instance.cache = DualCache()
         router = ComplexityRouter(
             model_name="test-router",
             litellm_router_instance=mock_router_instance,
-            complexity_router_config=session_affinity_disabled_config,
+            complexity_router_config=session_affinity_config,
         )
         request_kwargs = self._request_kwargs("session-1")
         first = await router.async_pre_routing_hook(
@@ -2966,7 +2960,7 @@ class TestSessionAffinity:
             model="test-model", request_kwargs=request_kwargs, messages=self.SIMPLE_MESSAGE
         )
         assert first.model == "o1-preview"
-        assert second.model == "gpt-4o-mini"
+        assert second.model == "o1-preview"
 
     @pytest.mark.asyncio
     async def test_pins_model_after_first_turn(self, mock_router_instance, session_affinity_config):

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -14,6 +14,7 @@ export const DEFAULT_CLASSIFIER_TIMEOUT_MS = 3000;
 export const DEFAULT_TIER_DISTANCE_PENALTY = 0.5;
 export const DEFAULT_CLASSIFIER_CONTEXT_WINDOW_SIZE = 3;
 export const DEFAULT_CLASSIFIER_CONTEXT_PER_TURN_CHARS = 200;
+export const DEFAULT_SESSION_AFFINITY = true;
 
 export interface ComplexityTiers {
   SIMPLE: string[];
@@ -45,6 +46,7 @@ export interface ComplexityRouterConfigValue {
   classifier_context_window_size?: number;
   classifier_context_per_turn_chars?: number;
   classifier_context_include_assistant_turns?: boolean;
+  session_affinity?: boolean;
   adaptive?: boolean;
   adaptive_weights?: AdaptiveRouterWeights;
   tier_distance_penalty?: number;
@@ -223,6 +225,32 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
               </Text>
             ),
             children: <AdaptiveRoutingConfig value={value} onChange={onChange} />,
+          },
+          {
+            key: "session-affinity",
+            label: (
+              <Text strong style={{ color: "#374151" }}>
+                Advanced: Session Affinity
+              </Text>
+            ),
+            children: (
+              <>
+                <div className="flex items-center gap-2 mb-2">
+                  <Switch
+                    checked={value.session_affinity ?? DEFAULT_SESSION_AFFINITY}
+                    onChange={(sessionAffinity) => onChange({ ...value, session_affinity: sessionAffinity })}
+                    aria-label="Pin a session to its first model"
+                  />
+                  <Text strong>Pin a session to its first model</Text>
+                </div>
+                <Text type="secondary" style={{ display: "block", fontSize: 12 }}>
+                  On by default. The model chosen on a session&apos;s first turn is reused for every later turn, which
+                  preserves provider prompt caches and avoids cross-model conversation-history errors. Turn this off to
+                  re-classify every turn, which routes each turn to the cheapest adequate tier at the cost of losing
+                  those caches.
+                </Text>
+              </>
+            ),
           },
           {
             key: "response",

--- a/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/ComplexityRouterConfig.tsx
@@ -14,7 +14,7 @@ export const DEFAULT_CLASSIFIER_TIMEOUT_MS = 3000;
 export const DEFAULT_TIER_DISTANCE_PENALTY = 0.5;
 export const DEFAULT_CLASSIFIER_CONTEXT_WINDOW_SIZE = 3;
 export const DEFAULT_CLASSIFIER_CONTEXT_PER_TURN_CHARS = 200;
-export const DEFAULT_SESSION_AFFINITY = true;
+export const DEFAULT_SESSION_AFFINITY = false;
 
 export interface ComplexityTiers {
   SIMPLE: string[];
@@ -244,10 +244,10 @@ const ComplexityRouterConfig: React.FC<ComplexityRouterConfigProps> = ({
                   <Text strong>Pin a session to its first model</Text>
                 </div>
                 <Text type="secondary" style={{ display: "block", fontSize: 12 }}>
-                  On by default. The model chosen on a session&apos;s first turn is reused for every later turn, which
-                  preserves provider prompt caches and avoids cross-model conversation-history errors. Turn this off to
-                  re-classify every turn, which routes each turn to the cheapest adequate tier at the cost of losing
-                  those caches.
+                  Off by default: every turn is classified on its own merits and routed to the cheapest adequate tier.
+                  Turn this on to reuse the model chosen on a session&apos;s first turn for every later turn, which
+                  preserves provider prompt caches and avoids cross-model conversation-history errors, at the cost of
+                  keeping the whole session on the first turn&apos;s tier.
                 </Text>
               </>
             ),

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -111,4 +111,40 @@ describe("AddAutoRouterTab", () => {
     expect(await screen.findByText("Please select a team to continue")).toBeInTheDocument();
     expect(handleAddAutoRouterSubmit).not.toHaveBeenCalled();
   });
+
+  it("defaults a new router to session affinity on, matching the backend field default", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+
+    renderWithProviders(<Harness />);
+
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "affinity-router");
+    await user.click(screen.getByText("Advanced: Session Affinity"));
+    expect(await screen.findByRole("switch", { name: "Pin a session to its first model" })).toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+    expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).toMatchObject({
+      session_affinity: true,
+    });
+  });
+
+  it("carries session affinity turned off through to the create payload", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getMissingTiersError).mockReturnValue(null);
+
+    renderWithProviders(<Harness />);
+
+    await user.type(screen.getByPlaceholderText(/smart_router/i), "affinity-router");
+    await user.click(screen.getByText("Advanced: Session Affinity"));
+    await user.click(await screen.findByRole("switch", { name: "Pin a session to its first model" }));
+
+    await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+    await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+    expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).toMatchObject({
+      session_affinity: false,
+    });
+  });
 });

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -112,7 +112,7 @@ describe("AddAutoRouterTab", () => {
     expect(handleAddAutoRouterSubmit).not.toHaveBeenCalled();
   });
 
-  it("defaults a new router to session affinity on, matching the backend field default", async () => {
+  it("defaults a new router to session affinity off, matching the backend field default", async () => {
     const user = userEvent.setup();
     vi.mocked(getMissingTiersError).mockReturnValue(null);
 
@@ -120,17 +120,17 @@ describe("AddAutoRouterTab", () => {
 
     await user.type(screen.getByPlaceholderText(/smart_router/i), "affinity-router");
     await user.click(screen.getByText("Advanced: Session Affinity"));
-    expect(await screen.findByRole("switch", { name: "Pin a session to its first model" })).toBeChecked();
+    expect(await screen.findByRole("switch", { name: "Pin a session to its first model" })).not.toBeChecked();
 
     await user.click(screen.getByRole("button", { name: /add auto router/i }));
 
     await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
     expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).toMatchObject({
-      session_affinity: true,
+      session_affinity: false,
     });
   });
 
-  it("carries session affinity turned off through to the create payload", async () => {
+  it("carries session affinity turned on through to the create payload", async () => {
     const user = userEvent.setup();
     vi.mocked(getMissingTiersError).mockReturnValue(null);
 
@@ -144,7 +144,7 @@ describe("AddAutoRouterTab", () => {
 
     await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
     expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).toMatchObject({
-      session_affinity: false,
+      session_affinity: true,
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -10,6 +10,7 @@ import { fetchAvailableModels, ModelGroup } from "@/components/llm_calls/fetch_m
 import ComplexityRouterConfig, {
   ComplexityRouterConfigValue,
   DEFAULT_ADAPTIVE_WEIGHTS,
+  DEFAULT_SESSION_AFFINITY,
   DEFAULT_TIER_DISTANCE_PENALTY,
 } from "./ComplexityRouterConfig";
 import { KeywordTierRule } from "./KeywordTierRules";
@@ -102,6 +103,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
       classifier_context_window_size: classifierContextWindowSize,
       classifier_context_per_turn_chars: classifierContextPerTurnChars,
       classifier_context_include_assistant_turns: classifierContextIncludeAssistantTurns,
+      session_affinity: sessionAffinity = DEFAULT_SESSION_AFFINITY,
       adaptive = false,
       adaptive_weights: adaptiveWeights = DEFAULT_ADAPTIVE_WEIGHTS,
       tier_distance_penalty: tierDistancePenalty = DEFAULT_TIER_DISTANCE_PENALTY,
@@ -148,6 +150,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
           classifierContextWindowSize,
           classifierContextPerTurnChars,
           classifierContextIncludeAssistantTurns,
+          sessionAffinity,
           customTechnicalKeywords,
           keywordTierRules,
           semanticMatchingEnabled,

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
@@ -19,6 +19,7 @@ const baseParams: BuildComplexityRouterConfigParams = {
   classifierContextWindowSize: undefined,
   classifierContextPerTurnChars: undefined,
   classifierContextIncludeAssistantTurns: undefined,
+  sessionAffinity: true,
   customTechnicalKeywords: [],
   keywordTierRules: [],
   semanticMatchingEnabled: false,
@@ -35,7 +36,12 @@ const baseParams: BuildComplexityRouterConfigParams = {
 describe("buildComplexityRouterConfig", () => {
   it("emits tiers, classifier_type, and escalation_keywords when nothing else is configured", () => {
     const config = buildComplexityRouterConfig(baseParams);
-    expect(config).toEqual({ tiers, classifier_type: "heuristic", escalation_keywords: ["LITELLM ESCALATE"] });
+    expect(config).toEqual({
+      tiers,
+      classifier_type: "heuristic",
+      session_affinity: true,
+      escalation_keywords: ["LITELLM ESCALATE"],
+    });
   });
 
   it("trims escalation keywords and drops blank entries", () => {
@@ -217,6 +223,16 @@ describe("buildComplexityRouterConfig", () => {
   it("omits return_raw_model_name when disabled", () => {
     const config = buildComplexityRouterConfig({ ...baseParams, returnRawModelName: false });
     expect(config.return_raw_model_name).toBeUndefined();
+  });
+
+  it("writes session_affinity=false so turning the toggle off overrides the backend's on-by-default", () => {
+    const config = buildComplexityRouterConfig({ ...baseParams, sessionAffinity: false });
+    expect(config.session_affinity).toBe(false);
+  });
+
+  it("writes session_affinity explicitly when on, so the stored config never relies on the backend default", () => {
+    const config = buildComplexityRouterConfig({ ...baseParams, sessionAffinity: true });
+    expect(config.session_affinity).toBe(true);
   });
 
   it("includes return_raw_model_name when enabled", () => {

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.test.ts
@@ -19,7 +19,7 @@ const baseParams: BuildComplexityRouterConfigParams = {
   classifierContextWindowSize: undefined,
   classifierContextPerTurnChars: undefined,
   classifierContextIncludeAssistantTurns: undefined,
-  sessionAffinity: true,
+  sessionAffinity: false,
   customTechnicalKeywords: [],
   keywordTierRules: [],
   semanticMatchingEnabled: false,
@@ -39,7 +39,7 @@ describe("buildComplexityRouterConfig", () => {
     expect(config).toEqual({
       tiers,
       classifier_type: "heuristic",
-      session_affinity: true,
+      session_affinity: false,
       escalation_keywords: ["LITELLM ESCALATE"],
     });
   });
@@ -225,14 +225,14 @@ describe("buildComplexityRouterConfig", () => {
     expect(config.return_raw_model_name).toBeUndefined();
   });
 
-  it("writes session_affinity=false so turning the toggle off overrides the backend's on-by-default", () => {
-    const config = buildComplexityRouterConfig({ ...baseParams, sessionAffinity: false });
-    expect(config.session_affinity).toBe(false);
-  });
-
-  it("writes session_affinity explicitly when on, so the stored config never relies on the backend default", () => {
+  it("writes session_affinity=true so turning the toggle on overrides the backend's off-by-default", () => {
     const config = buildComplexityRouterConfig({ ...baseParams, sessionAffinity: true });
     expect(config.session_affinity).toBe(true);
+  });
+
+  it("writes session_affinity explicitly when off, so the stored config never relies on the backend default", () => {
+    const config = buildComplexityRouterConfig({ ...baseParams, sessionAffinity: false });
+    expect(config.session_affinity).toBe(false);
   });
 
   it("includes return_raw_model_name when enabled", () => {

--- a/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
+++ b/ui/litellm-dashboard/src/components/add_model/build_complexity_router_config.ts
@@ -15,6 +15,7 @@ export interface BuildComplexityRouterConfigParams {
   classifierContextWindowSize: number | undefined;
   classifierContextPerTurnChars: number | undefined;
   classifierContextIncludeAssistantTurns: boolean | undefined;
+  sessionAffinity: boolean;
   customTechnicalKeywords: string[];
   keywordTierRules: KeywordTierRule[];
   semanticMatchingEnabled: boolean;
@@ -35,6 +36,7 @@ export interface ComplexityRouterConfigPayload {
   classifier_context_window_size?: number;
   classifier_context_per_turn_chars?: number;
   classifier_context_include_assistant_turns?: boolean;
+  session_affinity: boolean;
   custom_technical_keywords?: string[];
   keyword_tier_rules?: { keywords: string[]; tier: KeywordTierRule["tier"] }[];
   semantic_keyword_matching?: boolean;
@@ -78,6 +80,7 @@ export const buildComplexityRouterConfig = ({
   classifierContextWindowSize,
   classifierContextPerTurnChars,
   classifierContextIncludeAssistantTurns,
+  sessionAffinity,
   customTechnicalKeywords,
   keywordTierRules,
   semanticMatchingEnabled,
@@ -110,6 +113,7 @@ export const buildComplexityRouterConfig = ({
       classifierContextIncludeAssistantTurns !== undefined && {
         classifier_context_include_assistant_turns: classifierContextIncludeAssistantTurns,
       }),
+    session_affinity: sessionAffinity,
     ...(customTechnicalKeywords.length > 0 && { custom_technical_keywords: customTechnicalKeywords }),
     ...(cleanedKeywordTierRules.length > 0 && { keyword_tier_rules: cleanedKeywordTierRules }),
     escalation_keywords: cleanedEscalationKeywords,

--- a/ui/litellm-dashboard/src/components/edit_auto_router/build_updated_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/build_updated_complexity_router_config.test.ts
@@ -211,16 +211,16 @@ describe("buildUpdatedComplexityRouterConfig session affinity", () => {
     expect(result.session_affinity).toBe(true);
   });
 
-  it("re-asserts the backend's on-by-default when the form value is absent, rather than dropping the key", () => {
-    const result = buildUpdatedComplexityRouterConfig({ ...STORED, session_affinity: false }, FORM_VALUE);
-    expect(result.session_affinity).toBe(true);
+  it("re-asserts the backend's off-by-default when the form value is absent, rather than dropping the key", () => {
+    const result = buildUpdatedComplexityRouterConfig({ ...STORED, session_affinity: true }, FORM_VALUE);
+    expect(result.session_affinity).toBe(false);
   });
 
-  it("stops a stored session_affinity=false from surviving a save that turned the toggle back on", () => {
+  it("stops a stored session_affinity=true from surviving a save that turned the toggle back off", () => {
     const result = buildUpdatedComplexityRouterConfig(
-      { ...STORED, session_affinity: false },
-      { ...FORM_VALUE, session_affinity: true },
+      { ...STORED, session_affinity: true },
+      { ...FORM_VALUE, session_affinity: false },
     );
-    expect(result.session_affinity).toBe(true);
+    expect(result.session_affinity).toBe(false);
   });
 });

--- a/ui/litellm-dashboard/src/components/edit_auto_router/build_updated_complexity_router_config.test.ts
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/build_updated_complexity_router_config.test.ts
@@ -199,3 +199,28 @@ describe("buildUpdatedComplexityRouterConfig assistant turns", () => {
     expect(result.classifier_context_include_assistant_turns).toBeUndefined();
   });
 });
+
+describe("buildUpdatedComplexityRouterConfig session affinity", () => {
+  it("writes session_affinity=false when the toggle is off", () => {
+    const result = buildUpdatedComplexityRouterConfig(STORED, { ...FORM_VALUE, session_affinity: false });
+    expect(result.session_affinity).toBe(false);
+  });
+
+  it("writes session_affinity=true when the toggle is on", () => {
+    const result = buildUpdatedComplexityRouterConfig(STORED, { ...FORM_VALUE, session_affinity: true });
+    expect(result.session_affinity).toBe(true);
+  });
+
+  it("re-asserts the backend's on-by-default when the form value is absent, rather than dropping the key", () => {
+    const result = buildUpdatedComplexityRouterConfig({ ...STORED, session_affinity: false }, FORM_VALUE);
+    expect(result.session_affinity).toBe(true);
+  });
+
+  it("stops a stored session_affinity=false from surviving a save that turned the toggle back on", () => {
+    const result = buildUpdatedComplexityRouterConfig(
+      { ...STORED, session_affinity: false },
+      { ...FORM_VALUE, session_affinity: true },
+    );
+    expect(result.session_affinity).toBe(true);
+  });
+});

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.ts
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.ts
@@ -47,7 +47,7 @@ const expectedClassifiedTierConfig = {
   semantic_keyword_matching: true,
   embedding_model: "voyage-4-large",
   match_threshold: 0.65,
-  session_affinity: true,
+  session_affinity: false,
   adaptive: true,
   adaptive_weights: { quality: 0.4, cost: 0.6 },
   adaptive_eligible: "classified_tier",
@@ -67,7 +67,7 @@ const expectedAdaptiveDisabledConfig = {
   semantic_keyword_matching: true,
   embedding_model: "voyage-4-large",
   match_threshold: 0.65,
-  session_affinity: true,
+  session_affinity: false,
 };
 
 describe("buildUpdatedComplexityRouterConfig", () => {

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.ts
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.ts
@@ -47,6 +47,7 @@ const expectedClassifiedTierConfig = {
   semantic_keyword_matching: true,
   embedding_model: "voyage-4-large",
   match_threshold: 0.65,
+  session_affinity: true,
   adaptive: true,
   adaptive_weights: { quality: 0.4, cost: 0.6 },
   adaptive_eligible: "classified_tier",
@@ -66,6 +67,7 @@ const expectedAdaptiveDisabledConfig = {
   semantic_keyword_matching: true,
   embedding_model: "voyage-4-large",
   match_threshold: 0.65,
+  session_affinity: true,
 };
 
 describe("buildUpdatedComplexityRouterConfig", () => {

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
@@ -261,25 +261,12 @@ describe("EditAutoRouterModal session affinity", () => {
       />,
     );
 
-  // Every router created before the toggle existed stores no session_affinity key and is running
-  // with affinity ON, because the backend field defaults to True. Rendering that as OFF would
-  // tell the user the opposite of what their router does, and saving would then write the lie.
-  it("shows a stored config with no session_affinity key as on", async () => {
+  // A stored config with no session_affinity key now runs with affinity OFF, because the backend
+  // field defaults to False. The toggle has to render what the router actually does, and an
+  // untouched save must not flip it.
+  it("shows a stored config with no session_affinity key as off", async () => {
     const user = userEvent.setup();
     renderWithStoredConfig(STORED_CONFIG);
-
-    await user.click(await screen.findByText("Advanced: Session Affinity"));
-    expect(await screen.findByRole("switch", { name: "Pin a session to its first model" })).toBeChecked();
-
-    await user.click(screen.getByRole("button", { name: /save changes/i }));
-
-    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
-    expect(savedConfig().session_affinity).toBe(true);
-  });
-
-  it("shows a stored session_affinity=false as off and preserves it through an untouched save", async () => {
-    const user = userEvent.setup();
-    renderWithStoredConfig({ ...STORED_CONFIG, session_affinity: false });
 
     await user.click(await screen.findByText("Advanced: Session Affinity"));
     expect(await screen.findByRole("switch", { name: "Pin a session to its first model" })).not.toBeChecked();
@@ -290,7 +277,20 @@ describe("EditAutoRouterModal session affinity", () => {
     expect(savedConfig().session_affinity).toBe(false);
   });
 
-  it("persists turning session affinity off", async () => {
+  it("shows a stored session_affinity=true as on and preserves it through an untouched save", async () => {
+    const user = userEvent.setup();
+    renderWithStoredConfig({ ...STORED_CONFIG, session_affinity: true });
+
+    await user.click(await screen.findByText("Advanced: Session Affinity"));
+    expect(await screen.findByRole("switch", { name: "Pin a session to its first model" })).toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().session_affinity).toBe(true);
+  });
+
+  it("persists turning session affinity on", async () => {
     const user = userEvent.setup();
     renderWithStoredConfig(STORED_CONFIG);
 
@@ -300,12 +300,12 @@ describe("EditAutoRouterModal session affinity", () => {
     await user.click(screen.getByRole("button", { name: /save changes/i }));
 
     await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
-    expect(savedConfig().session_affinity).toBe(false);
+    expect(savedConfig().session_affinity).toBe(true);
   });
 
-  it("persists turning session affinity back on", async () => {
+  it("persists turning session affinity back off", async () => {
     const user = userEvent.setup();
-    renderWithStoredConfig({ ...STORED_CONFIG, session_affinity: false });
+    renderWithStoredConfig({ ...STORED_CONFIG, session_affinity: true });
 
     await user.click(await screen.findByText("Advanced: Session Affinity"));
     await user.click(await screen.findByRole("switch", { name: "Pin a session to its first model" }));
@@ -313,6 +313,6 @@ describe("EditAutoRouterModal session affinity", () => {
     await user.click(screen.getByRole("button", { name: /save changes/i }));
 
     await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
-    expect(savedConfig().session_affinity).toBe(true);
+    expect(savedConfig().session_affinity).toBe(false);
   });
 });

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.test.tsx
@@ -243,3 +243,76 @@ describe("EditAutoRouterModal assistant turns", () => {
     expect(savedConfig().classifier_context_include_assistant_turns).toBe(false);
   });
 });
+
+describe("EditAutoRouterModal session affinity", () => {
+  beforeEach(() => {
+    modelPatchUpdateCall.mockClear();
+  });
+
+  const renderWithStoredConfig = (complexity_router_config: Record<string, unknown>) =>
+    renderWithProviders(
+      <EditAutoRouterModal
+        isVisible
+        onCancel={vi.fn()}
+        onSuccess={vi.fn()}
+        modelData={{ ...MODEL_DATA, litellm_params: { ...MODEL_DATA.litellm_params, complexity_router_config } }}
+        accessToken="token"
+        userRole="Admin"
+      />,
+    );
+
+  // Every router created before the toggle existed stores no session_affinity key and is running
+  // with affinity ON, because the backend field defaults to True. Rendering that as OFF would
+  // tell the user the opposite of what their router does, and saving would then write the lie.
+  it("shows a stored config with no session_affinity key as on", async () => {
+    const user = userEvent.setup();
+    renderWithStoredConfig(STORED_CONFIG);
+
+    await user.click(await screen.findByText("Advanced: Session Affinity"));
+    expect(await screen.findByRole("switch", { name: "Pin a session to its first model" })).toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().session_affinity).toBe(true);
+  });
+
+  it("shows a stored session_affinity=false as off and preserves it through an untouched save", async () => {
+    const user = userEvent.setup();
+    renderWithStoredConfig({ ...STORED_CONFIG, session_affinity: false });
+
+    await user.click(await screen.findByText("Advanced: Session Affinity"));
+    expect(await screen.findByRole("switch", { name: "Pin a session to its first model" })).not.toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().session_affinity).toBe(false);
+  });
+
+  it("persists turning session affinity off", async () => {
+    const user = userEvent.setup();
+    renderWithStoredConfig(STORED_CONFIG);
+
+    await user.click(await screen.findByText("Advanced: Session Affinity"));
+    await user.click(await screen.findByRole("switch", { name: "Pin a session to its first model" }));
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().session_affinity).toBe(false);
+  });
+
+  it("persists turning session affinity back on", async () => {
+    const user = userEvent.setup();
+    renderWithStoredConfig({ ...STORED_CONFIG, session_affinity: false });
+
+    await user.click(await screen.findByText("Advanced: Session Affinity"));
+    await user.click(await screen.findByRole("switch", { name: "Pin a session to its first model" }));
+
+    await user.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() => expect(modelPatchUpdateCall).toHaveBeenCalled());
+    expect(savedConfig().session_affinity).toBe(true);
+  });
+});

--- a/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
+++ b/ui/litellm-dashboard/src/components/edit_auto_router/edit_auto_router_modal.tsx
@@ -13,6 +13,7 @@ import { hydrateKeywordTierRules, serializeKeywordTierRules } from "../add_model
 import ComplexityRouterConfig, {
   ComplexityRouterConfigValue,
   DEFAULT_ADAPTIVE_WEIGHTS,
+  DEFAULT_SESSION_AFFINITY,
   DEFAULT_TIER_DISTANCE_PENALTY,
 } from "../add_model/ComplexityRouterConfig";
 import NotificationsManager from "../molecules/notifications_manager";
@@ -36,6 +37,7 @@ const MANAGED_COMPLEXITY_ROUTER_KEYS = new Set([
   "classifier_context_window_size",
   "classifier_context_per_turn_chars",
   "classifier_context_include_assistant_turns",
+  "session_affinity",
   "adaptive",
   "adaptive_weights",
   "tier_distance_penalty",
@@ -101,6 +103,7 @@ export const buildUpdatedComplexityRouterConfig = (
       value.classifier_context_include_assistant_turns !== undefined && {
         classifier_context_include_assistant_turns: value.classifier_context_include_assistant_turns,
       }),
+    session_affinity: value.session_affinity ?? DEFAULT_SESSION_AFFINITY,
     ...(customTechnicalKeywords &&
       customTechnicalKeywords.length > 0 && {
         custom_technical_keywords: customTechnicalKeywords,
@@ -218,6 +221,10 @@ const EditAutoRouterModal: React.FC<EditAutoRouterModalProps> = ({
             typeof parsedConfig.classifier_context_include_assistant_turns === "boolean"
               ? parsedConfig.classifier_context_include_assistant_turns
               : undefined,
+          session_affinity:
+            typeof parsedConfig.session_affinity === "boolean"
+              ? parsedConfig.session_affinity
+              : DEFAULT_SESSION_AFFINITY,
           adaptive: parsedConfig.adaptive || false,
           adaptive_weights: parsedConfig.adaptive_weights,
           tier_distance_penalty: parsedConfig.tier_distance_penalty,


### PR DESCRIPTION
## TLDR

Problem this solves:

- `session_affinity` defaulted to true, pinning every session for an hour
- The Auto-Router UI never emitted the key, so that default always won
- No way to see or change the pin outside config.yaml

How it solves it:

- Flips the field default to false; pinning becomes opt-in
- Adds an Advanced > Session Affinity toggle to the create tab and edit modal
- Both paths write the key explicitly instead of inheriting a default

## Relevant issues

- Auto-Router session affinity was on by default and silently pinned every router built in the UI
- Flips the `session_affinity` default to false, so each turn is classified on its own merits and routes to the cheapest adequate tier
- Adds an Advanced > Session Affinity toggle to the Auto-Router create tab and edit modal

## Linear ticket

Resolves LIT-5134

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

On the CI box: `make lint-format-changed`, `lint-ruff-dev`, `lint-gate` and `lint-type-discipline` all pass, and the vitest and pytest suites are green. Full `make pre-commit` cannot complete on current staging, because `npm run gen:api` boots the FastAPI app and `litellm/llms/openai/common_utils.py:138` uses `Union` without importing it (introduced in #35492), so any `import litellm` raises `NameError`. That is unrelated to this diff and needs its own one-line fix. No regeneration is owed here regardless: `complexity_router_config` is typed `{[key: string]: unknown}` in `schema.d.ts`, so changing a router-strategy pydantic model cannot move the OpenAPI schema.

## Screenshots / Proof of Fix

Steps to capture, against a proxy on :4000 and the Admin UI dev server on :3000.

1. Add an auto router to `litellm/proxy/dev_config.yaml`:

```yaml
  - model_name: affinity-demo
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_default_model: gpt-4o-mini
      complexity_router_config:
        tiers:
          SIMPLE:    gpt-4o-mini
          MEDIUM:    gpt-4o
          COMPLEX:   claude-sonnet-4-20250514
          REASONING: o1-preview
```

2. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`

3. Turn 1 of a session, a REASONING prompt. Expect it to route to `o1-preview`:

```bash
curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"affinity-demo","messages":[{"role":"user","content":"Let'"'"'s think step by step and reason through this problem carefully."}],"metadata":{"session_id":"demo-1"}}' | jq -r .model
```

4. Turn 2 of the same session, a trivial prompt. This is the behavior change: expect `gpt-4o-mini`, where before this PR it stayed on `o1-preview`:

```bash
curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"affinity-demo","messages":[{"role":"user","content":"thanks!"}],"metadata":{"session_id":"demo-1"}}' | jq -r .model
```

5. Add `session_affinity: true` under `complexity_router_config`, let the proxy reload, then repeat steps 3 and 4 with a fresh `session_id`. Turn 2 should now stay on `o1-preview`, showing the opt-in still works.

6. `grep 'routing decision cause=' litellm.log` to show `cause=complexity_scorer` on both turns in step 4 and `cause=session_affinity_pin` on the pinned turn in step 5.

7. UI, with `npm run dev` in `ui/litellm-dashboard`: go to http://localhost:3000/ui/?page=models, Add Model > Auto Router, fill the four tiers, expand **Advanced: Session Affinity**, and screenshot the toggle rendering off.

8. Create that router, reopen it from the Auto-Routers tab, expand the same section, and screenshot the toggle round-tripping.

## Type

🆕 New Feature

## Changes

`litellm/router_strategy/complexity_router/config.py` flips the `session_affinity` default to `False` and rewrites the field description around pinning as the opt-in. Nothing else in the routing path changes; the pin still works exactly as before when it is turned on, and it is still suppressed when `plugins` are configured.

On the UI side, `ComplexityRouterConfig.tsx` gains an "Advanced: Session Affinity" panel with a `DEFAULT_SESSION_AFFINITY` constant kept in lockstep with the pydantic default. The create path threads it through `build_complexity_router_config.ts` and `add_auto_router_tab.tsx`; the edit path adds it to `MANAGED_COMPLEXITY_ROUTER_KEYS`, hydrates it in `initializeForm`, and writes it in `buildUpdatedComplexityRouterConfig`. Both paths emit the key explicitly rather than omitting it when it matches the default, so a stored config states what its router does instead of inheriting a value that can move underneath it.

Hydration reads a missing key as off, which is what those routers now actually do once this ships.

### Behavior change

Routers created before this have no `session_affinity` key stored, so they pick up the new default and start reclassifying every turn. That gives up the provider prompt cache the pin was preserving, and lets a multi-turn session move between models. Adding `session_affinity: true` restores the old behavior. `ComplexityRouterConfig` sets `extra="allow"`, so configs that already carry the key keep validating untouched and no migration is needed.

Docs are in BerriAI/litellm-docs#746, which rewrites the Auto Routing page's session affinity section, corrects a "When to use" table row that already described the field as opt-in while it was on by default, and adds a callout for the default change.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default routing behavior changes for existing UI-built routers missing the key (per-turn classification vs pinned model), which affects cost, model choice, and provider caches, though explicit `session_affinity: true` is unchanged.
> 
> **Overview**
> **Complexity router session affinity is now opt-in instead of the default.** `session_affinity` on `ComplexityRouterConfig` defaults to `false`, so multi-turn traffic with a `session_id` is reclassified each turn unless the config explicitly enables pinning. Field docs and pytest coverage were updated to match (default-off regression test; opt-in pin test).
> 
> The **Auto Router dashboard** adds **Advanced: Session Affinity** on create and edit, wired through `DEFAULT_SESSION_AFFINITY` and `buildComplexityRouterConfig` / `buildUpdatedComplexityRouterConfig` so **`session_affinity` is always persisted** (`true` or `false`) rather than omitted and left to backend defaults.
> 
> **Deploy impact:** stored router configs with no `session_affinity` key will behave as off after upgrade—later turns may move to cheaper tiers and lose prompt-cache stickiness until operators set `session_affinity: true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59208fa18267c8b45d9143efe3554414aef0cb28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->