### PR TITLE
fix(ui): render Responses API request and response in the logs drawer

### DIFF
--- a/ui/litellm-dashboard/eslint-suppressions.json
+++ b/ui/litellm-dashboard/eslint-suppressions.json
@@ -4142,11 +4142,6 @@
       "count": 1
     }
   },
-  "src/components/view_logs/LogDetailsDrawer/prettyMessagesUtils.ts": {
-    "no-nested-ternary": {
-      "count": 1
-    }
-  },
   "src/components/view_logs/LogDetailsDrawer/useKeyboardNavigation.ts": {
     "react-hooks/immutability": {
       "count": 2

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/PrettyMessagesView.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/PrettyMessagesView.test.tsx
@@ -76,6 +76,126 @@ describe("PrettyMessagesView", () => {
     expect(modelElements.length).toBeGreaterThanOrEqual(1);
   });
 
+  it("renders a Responses API log, whose body uses input/output instead of messages/choices", () => {
+    const request = {
+      model: "gpt-5.6",
+      input: [{ role: "user", content: "Reply with exactly: hello from responses api" }],
+    };
+    const response = {
+      output: [
+        {
+          id: "msg_070989277645d4ae",
+          role: "assistant",
+          type: "message",
+          status: "completed",
+          content: [{ text: "hello from responses api", type: "output_text", annotations: [] }],
+        },
+      ],
+    };
+
+    render(<PrettyMessagesView request={request} response={response} />);
+    expect(screen.getByText("Reply with exactly: hello from responses api")).toBeInTheDocument();
+    expect(screen.getByText("hello from responses api")).toBeInTheDocument();
+    expect(screen.queryByText("No response data available")).not.toBeInTheDocument();
+  });
+
+  it("renders a Responses API tool call, whose output item is a function_call", () => {
+    const request = {
+      model: "gpt-5.6",
+      input: [{ role: "user", content: "What is the weather in San Francisco? Use the tool." }],
+    };
+    const response = {
+      output: [
+        {
+          id: "fc_08edf6c2312f1485",
+          name: "get_weather",
+          type: "function_call",
+          status: "completed",
+          call_id: "call_AtO0J9eNy5jgECXzBicMJM8W",
+          arguments: '{"city":"San Francisco"}',
+        },
+      ],
+    };
+
+    render(<PrettyMessagesView request={request} response={response} />);
+    expect(screen.getByText("What is the weather in San Francisco? Use the tool.")).toBeInTheDocument();
+    expect(screen.getByText("get_weather")).toBeInTheDocument();
+    expect(screen.queryByText("No response data available")).not.toBeInTheDocument();
+  });
+
+  it("renders instructions as the system turn and a bare string input", () => {
+    const request = { model: "gpt-5.6", instructions: "You are terse.", input: "Say A" };
+    const response = {
+      output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "A" }] }],
+    };
+
+    render(<PrettyMessagesView request={request} response={response} />);
+    expect(screen.getByText("You are terse.")).toBeInTheDocument();
+    expect(screen.getByText("Say A")).toBeInTheDocument();
+    expect(screen.getByText("A")).toBeInTheDocument();
+  });
+
+  it("skips reasoning output items rather than rendering them as empty turns", () => {
+    const request = { input: [{ role: "user", content: "Think then answer" }] };
+    const response = {
+      output: [
+        { type: "reasoning", id: "rs_1", summary: [] },
+        { type: "message", role: "assistant", content: [{ type: "output_text", text: "answered" }] },
+      ],
+    };
+
+    render(<PrettyMessagesView request={request} response={response} />);
+    expect(screen.getByText("answered")).toBeInTheDocument();
+    expect(screen.queryByText("No response data available")).not.toBeInTheDocument();
+  });
+
+  it("renders a Responses API follow-up turn carrying a prior function_call and its output", () => {
+    const request = {
+      input: [
+        { role: "user", content: "What is the weather in San Francisco? Use the tool." },
+        {
+          type: "function_call",
+          name: "get_weather",
+          call_id: "call_AtO0J9eNy5jgECXzBicMJM8W",
+          arguments: '{"city":"San Francisco"}',
+        },
+        { type: "function_call_output", call_id: "call_AtO0J9eNy5jgECXzBicMJM8W", output: '{"temp":18}' },
+      ],
+    };
+    const response = {
+      output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "It is 18 degrees." }] }],
+    };
+
+    render(<PrettyMessagesView request={request} response={response} />);
+    expect(screen.getByText("It is 18 degrees.")).toBeInTheDocument();
+    expect(screen.getByText('{"temp":18}')).toBeInTheDocument();
+    expect(screen.getByText("TOOL")).toBeInTheDocument();
+  });
+
+  it("maps the developer and legacy function roles onto the roles the drawer renders", () => {
+    const request = {
+      messages: [
+        { role: "developer", content: "Stay terse." },
+        { role: "user", content: "Weather?" },
+        { role: "function", name: "get_weather", content: '{"temp":18}' },
+      ],
+    };
+    const response = { choices: [{ message: { role: "assistant", content: "18 degrees." } }] };
+
+    render(<PrettyMessagesView request={request} response={response} />);
+    expect(screen.getByText("Stay terse.")).toBeInTheDocument();
+    expect(screen.getByText("TOOL")).toBeInTheDocument();
+    expect(screen.queryByText("FUNCTION")).not.toBeInTheDocument();
+  });
+
+  it("still reports missing output when a Responses API log has an empty output array", () => {
+    const request = { input: [{ role: "user", content: "Hello" }] };
+
+    render(<PrettyMessagesView request={request} response={{ output: [] }} />);
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+    expect(screen.getByText("No response data available")).toBeInTheDocument();
+  });
+
   it("should render standard view when response has results but no realtime events", () => {
     const request = {
       messages: [{ role: "user", content: "Test" }],

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/prettyMessagesTypes.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/prettyMessagesTypes.ts
@@ -2,17 +2,29 @@
  * Type definitions for pretty messages view
  */
 
+export type MessageRole = "system" | "user" | "assistant" | "tool";
+
 export interface ParsedMessage {
-  role: "system" | "user" | "assistant" | "tool";
+  role: MessageRole;
   content: string;
   toolCalls?: ToolCall[];
   toolCallId?: string;
 }
 
+export type RequestPayload =
+  | { kind: "chat"; messages: readonly unknown[] }
+  | { kind: "responses"; instructions: string; input: string | readonly unknown[] }
+  | { kind: "unknown" };
+
+export type ResponsePayload =
+  | { kind: "chat"; choices: readonly unknown[] }
+  | { kind: "responses"; output: readonly unknown[] }
+  | { kind: "unknown" };
+
 export interface ToolCall {
   id: string;
   name: string;
-  arguments: Record<string, any>;
+  arguments: Record<string, unknown>;
 }
 
 export interface ParsedMessages {

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/prettyMessagesUtils.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/prettyMessagesUtils.ts
@@ -2,7 +2,15 @@
  * Utility functions for parsing and formatting messages for pretty view
  */
 
-import { ParsedMessage, ParsedMessages, RoleStyle } from "./prettyMessagesTypes";
+import {
+  MessageRole,
+  ParsedMessage,
+  ParsedMessages,
+  RequestPayload,
+  ResponsePayload,
+  RoleStyle,
+  ToolCall,
+} from "./prettyMessagesTypes";
 
 /**
  * Role color styles for message cards - minimal, professional design
@@ -35,102 +43,188 @@ export const ROLE_STYLES: Record<string, RoleStyle> = {
   },
 };
 
+type UnknownRecord = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const asString = (value: unknown): string => (typeof value === "string" ? value : "");
+
+const ROLES: readonly MessageRole[] = ["system", "user", "assistant", "tool"];
+
+const toRole = (value: unknown, fallback: MessageRole): MessageRole => {
+  if (value === "developer") return "system";
+  if (value === "function") return "tool";
+  return ROLES.includes(value as MessageRole) ? (value as MessageRole) : fallback;
+};
+
+const classifyRequest = (request: unknown): RequestPayload => {
+  if (Array.isArray(request)) return { kind: "chat", messages: request };
+  if (!isRecord(request)) return { kind: "unknown" };
+  if (Array.isArray(request.messages)) return { kind: "chat", messages: request.messages };
+  const { input } = request;
+  if (typeof input === "string" || Array.isArray(input)) {
+    return { kind: "responses", instructions: asString(request.instructions), input };
+  }
+  return { kind: "unknown" };
+};
+
+const classifyResponse = (response: unknown): ResponsePayload => {
+  if (!isRecord(response)) return { kind: "unknown" };
+  if (Array.isArray(response.choices)) return { kind: "chat", choices: response.choices };
+  if (Array.isArray(response.output)) return { kind: "responses", output: response.output };
+  return { kind: "unknown" };
+};
+
 /**
  * Parse request messages and response message from log data
  */
-export const parseMessages = (request: any, response: any): ParsedMessages => {
-  // Parse request messages. `request` is either the raw request body
-  // ({ messages: [...] }) or, when prompts come from cold storage, the bare
-  // messages array itself.
-  const requestMessages: ParsedMessage[] = [];
+export const parseMessages = (request: unknown, response: unknown): ParsedMessages => ({
+  requestMessages: parseRequestMessages(classifyRequest(request)),
+  responseMessage: parseResponseMessage(classifyResponse(response)),
+});
 
-  const requestMessageList = Array.isArray(request)
-    ? request
-    : Array.isArray(request?.messages)
-      ? request.messages
-      : [];
-
-  requestMessageList.forEach((msg: any) => {
-    requestMessages.push({
-      role: msg.role || "user",
-      content: parseMessageContent(msg.content),
-      toolCallId: msg.tool_call_id,
-    });
-  });
-
-  // Parse response message
-  let responseMessage: ParsedMessage | null = null;
-  const responseMsg = response?.choices?.[0]?.message;
-
-  if (responseMsg) {
-    responseMessage = {
-      role: responseMsg.role || "assistant",
-      content: responseMsg.content || "",
-      toolCalls: parseToolCalls(responseMsg.tool_calls),
-    };
+const parseRequestMessages = (payload: RequestPayload): ParsedMessage[] => {
+  switch (payload.kind) {
+    case "chat":
+      return payload.messages.map(parseChatMessage);
+    case "responses": {
+      const instructions: ParsedMessage[] = payload.instructions
+        ? [{ role: "system", content: payload.instructions }]
+        : [];
+      const input: ParsedMessage[] =
+        typeof payload.input === "string"
+          ? [{ role: "user", content: payload.input }]
+          : payload.input.flatMap(parseResponsesInputItem);
+      return [...instructions, ...input];
+    }
+    case "unknown":
+      return [];
   }
-
-  return { requestMessages, responseMessage };
 };
+
+const parseResponseMessage = (payload: ResponsePayload): ParsedMessage | null => {
+  switch (payload.kind) {
+    case "chat": {
+      const choice = payload.choices[0];
+      const message = isRecord(choice) ? choice.message : undefined;
+      if (!isRecord(message)) return null;
+      return {
+        role: toRole(message.role, "assistant"),
+        content: parseMessageContent(message.content),
+        toolCalls: parseChatToolCalls(message.tool_calls),
+      };
+    }
+    case "responses": {
+      const content = payload.output
+        .filter((item): item is UnknownRecord => isRecord(item) && item.type === "message")
+        .map((item) => parseMessageContent(item.content))
+        .filter((text) => text.length > 0)
+        .join("\n");
+      const toolCalls = payload.output.filter(isResponsesFunctionCall).map(parseResponsesFunctionCall);
+      if (content.length === 0 && toolCalls.length === 0) return null;
+      return { role: "assistant", content, toolCalls: toolCalls.length > 0 ? toolCalls : undefined };
+    }
+    case "unknown":
+      return null;
+  }
+};
+
+const parseChatMessage = (message: unknown): ParsedMessage => {
+  if (!isRecord(message)) return { role: "user", content: parseMessageContent(message) };
+  return {
+    role: toRole(message.role, "user"),
+    content: parseMessageContent(message.content),
+    toolCalls: parseChatToolCalls(message.tool_calls),
+    toolCallId: typeof message.tool_call_id === "string" ? message.tool_call_id : undefined,
+  };
+};
+
+const parseResponsesInputItem = (item: unknown): ParsedMessage[] => {
+  if (typeof item === "string") return [{ role: "user", content: item }];
+  if (!isRecord(item)) return [];
+  if (item.type === "function_call") {
+    return [{ role: "assistant", content: "", toolCalls: [parseResponsesFunctionCall(item)] }];
+  }
+  if (item.type === "function_call_output") {
+    return [{ role: "tool", content: parseMessageContent(item.output), toolCallId: asString(item.call_id) }];
+  }
+  if (item.type === "reasoning") return [];
+  if ("role" in item || "content" in item) {
+    return [{ role: toRole(item.role, "user"), content: parseMessageContent(item.content) }];
+  }
+  return [];
+};
+
+const isResponsesFunctionCall = (item: unknown): item is UnknownRecord =>
+  isRecord(item) && item.type === "function_call";
+
+const parseResponsesFunctionCall = (item: UnknownRecord): ToolCall => ({
+  id: asString(item.call_id) || asString(item.id),
+  name: asString(item.name) || "unknown",
+  arguments: parseToolArguments(item.arguments),
+});
 
 /**
  * Parse message content - handle strings and content arrays (for vision, etc.)
  */
-const parseMessageContent = (content: any): string => {
-  if (typeof content === "string") {
-    return content;
-  }
-
-  if (Array.isArray(content)) {
-    // Handle content arrays (vision API format)
-    return content
-      .map((item) => {
-        if (typeof item === "string") return item;
-        if (item.type === "text") return item.text;
-        if (item.type === "image_url") return "[Image]";
-        return JSON.stringify(item);
-      })
-      .join("\n");
-  }
-
-  // Fallback to JSON string for complex content
+const parseMessageContent = (content: unknown): string => {
+  if (typeof content === "string") return content;
+  if (content === null || content === undefined) return "";
+  if (Array.isArray(content)) return content.map(parseContentPart).join("\n");
   return JSON.stringify(content);
+};
+
+const parseContentPart = (part: unknown): string => {
+  if (typeof part === "string") return part;
+  if (!isRecord(part)) return JSON.stringify(part);
+  switch (part.type) {
+    case "text":
+    case "input_text":
+    case "output_text":
+      return asString(part.text);
+    case "refusal":
+      return asString(part.refusal);
+    case "image_url":
+    case "input_image":
+      return "[Image]";
+    case "input_file":
+      return "[File]";
+    case "input_audio":
+      return "[Audio]";
+    default:
+      return JSON.stringify(part);
+  }
 };
 
 /**
  * Parse tool calls from response message
  */
-const parseToolCalls = (
-  toolCalls: any[],
-):
-  | Array<{
-      id: string;
-      name: string;
-      arguments: Record<string, any>;
-    }>
-  | undefined => {
-  if (!toolCalls || !Array.isArray(toolCalls)) return undefined;
-
-  return toolCalls.map((tc) => ({
-    id: tc.id || "",
-    name: tc.function?.name || "unknown",
-    arguments: parseToolArguments(tc.function?.arguments),
-  }));
+const parseChatToolCalls = (toolCalls: unknown): ToolCall[] | undefined => {
+  if (!Array.isArray(toolCalls)) return undefined;
+  return toolCalls.map((toolCall) => {
+    const call = isRecord(toolCall) ? toolCall : {};
+    const fn = isRecord(call.function) ? call.function : {};
+    return {
+      id: asString(call.id),
+      name: asString(fn.name) || "unknown",
+      arguments: parseToolArguments(fn.arguments),
+    };
+  });
 };
 
 /**
  * Parse tool arguments - handle both string and object formats
  */
-const parseToolArguments = (args: any): Record<string, any> => {
+const parseToolArguments = (args: unknown): Record<string, unknown> => {
   if (!args) return {};
-
   if (typeof args === "string") {
     try {
-      return JSON.parse(args);
+      const parsed: unknown = JSON.parse(args);
+      return isRecord(parsed) ? parsed : { raw: args };
     } catch {
       return { raw: args };
     }
   }
-
-  return args;
+  return isRecord(args) ? args : {};
 };


### PR DESCRIPTION
## TLDR

Problem this solves:

- Logs drawer shows "No response data available" for /v1/responses calls
- Input card renders empty even though the spend log holds the prompt
- Also hits /v1/chat/completions callers routed over the Responses bridge

How it solves it:

- Parse the Responses `input`/`output` shape, not just `messages`/`choices`
- Branch on a tagged union instead of sniffing keys with `||`
- Map `output_text` parts to content and `function_call` items to tool calls

## Relevant issues

Fixes #23636

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs below are real requests against a live proxy hitting real OpenAI and Anthropic APIs, costing real money. No mocks. The proxy ran on port 4071 against a local Postgres so the spend logs are real rows.

Before: commit `9d5984b358`. After: commit `9c2c79f976`.

The proxy config used:

```yaml
model_list:
  - model_name: gpt-5.6
    litellm_params:
      model: openai/gpt-5.6
      api_key: os.environ/OPENAI_API_KEY
  - model_name: claude-sonnet-5
    litellm_params:
      model: anthropic/claude-sonnet-5
      api_key: os.environ/ANTHROPIC_API_KEY

general_settings:
  master_key: sk-1234
  store_model_in_db: true
  store_prompts_in_spend_logs: true
  proxy_batch_write_at: 1
```

### 1. Send a Responses API request

```bash
curl -s http://localhost:4071/v1/responses \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"model":"gpt-5.6","input":[{"role":"user","content":"Reply with exactly: hello from responses api"}],"max_output_tokens":64}'
```

```json
{"id":"resp_4R_bHMirim6OPsVsXq1uOyEYIIDCEKoviMF...","model":"gpt-5.6","object":"response","output":[{"id":"msg_070989277645d4ae...","content":[{"annotations":[],"text":"hello from responses api","type":"output_text"}],"role":"assistant","status":"completed","type":"message"}],"status":"completed","usage":{"input_tokens":14,"output_tokens":8,"total_tokens":22}}
```

### 2. Read back what the drawer is given

```bash
curl -s -G "http://localhost:4071/spend/logs/ui/resp_4R_bHMirim6OPsVsXq1uOyEYIIDCEKoviMF..." \
  --data-urlencode "start_date=2026-08-02 21:20:18" \
  -H "Authorization: Bearer sk-1234" | jq '{call_type, messages, proxy_server_request, response}'
```

```json
{
  "call_type": "aresponses",
  "messages": {},
  "proxy_server_request": {"input": [{"role": "user", "content": "Reply with exactly: hello from responses api"}], "model": "gpt-5.6", "max_output_tokens": 64},
  "response": {"id": "resp_4R_...", "output": [{"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "hello from responses api"}]}], "status": "completed"}
}
```

The prompt and the completion are both there. `proxy_server_request` uses `input`, and `response` uses `output`; neither key was understood by the drawer.

### 3. Before (`9d5984b358`) — the drawer renders nothing

Feeding that exact row through the drawer's own code path (`LogDetailContent` -> `formatData` -> `parseMessages`):

```
[FAIL] bug-1  POST /v1/responses
        InputCard  -> 0 message(s)  => renders EMPTY
        OutputCard -> "No response data available"
[FAIL] bug-2  POST /v1/responses          (tool call)
        InputCard  -> 0 message(s)  => renders EMPTY
        OutputCard -> "No response data available"
[FAIL] bug-3  POST /v1/chat/completions   (Responses bridge)
        InputCard  -> 1 message(s) roles=["user"] first="What is the weather in San Francisco? Use the tool."
        OutputCard -> "No response data available"
[PASS] adj-1  POST /v1/chat/completions
        InputCard  -> 1 message(s) roles=["user"] first="Reply with exactly: hello from chat completions"
        OutputCard -> content="hello from chat completions" toolCalls=[]
[PASS] adj-2  POST /v1/chat/completions   (multi-turn)
        InputCard  -> 4 message(s) roles=["system","user","assistant","user"] first="You are terse."
        OutputCard -> content="hello from multi turn" toolCalls=[]
[PASS] adj-3  POST /v1/chat/completions   (native tool call)
        InputCard  -> 1 message(s) roles=["user"] first="What is the weather in San Francisco? Use the tool."
        OutputCard -> content="" toolCalls=["get_weather"]

3 FAILING
```

### 4. After (`9c2c79f976`) — same six live calls, all rendering

```
[PASS] bug-1  POST /v1/responses
        InputCard  -> 1 message(s) roles=["user"] first="Reply with exactly: hello from responses api"
        OutputCard -> content="hello from responses api" toolCalls=[]
[PASS] bug-2  POST /v1/responses          (tool call)
        InputCard  -> 1 message(s) roles=["user"] first="What is the weather in San Francisco? Use the tool."
        OutputCard -> content="" toolCalls=["get_weather"]
[PASS] bug-3  POST /v1/chat/completions   (Responses bridge)
        InputCard  -> 1 message(s) roles=["user"] first="What is the weather in San Francisco? Use the tool."
        OutputCard -> content="" toolCalls=["get_weather"]
[PASS] adj-1  POST /v1/chat/completions
        InputCard  -> 1 message(s) roles=["user"] first="Reply with exactly: hello from chat completions"
        OutputCard -> content="hello from chat completions" toolCalls=[]
[PASS] adj-2  POST /v1/chat/completions   (multi-turn)
        InputCard  -> 4 message(s) roles=["system","user","assistant","user"] first="You are terse."
        OutputCard -> content="hello from multi turn" toolCalls=[]
[PASS] adj-3  POST /v1/chat/completions   (native tool call)
        InputCard  -> 1 message(s) roles=["user"] first="What is the weather in San Francisco? Use the tool."
        OutputCard -> content="" toolCalls=["get_weather"]

ALL GREEN
```

### 5. Reproduce the UI side by hand

1. Start a proxy with the config above; run the dashboard dev server with `npm run dev` in `ui/litellm-dashboard`
2. Send the two curls from steps 1 and 2 above, plus one `/v1/chat/completions` call for comparison
3. Open http://localhost:4000/ui/?page=logs
4. Click the `/v1/chat/completions` row, keep the "Pretty" toggle selected in the Request & Response panel; the Input and Output cards are populated on both `main` and this branch
5. Click the `/v1/responses` row. On `main` the Input card is blank and the Output card reads "No response data available"; on this branch both cards render the prompt and the completion
6. Toggle to "JSON" on the same row; the Request tab already showed the payload on both branches, which is what made the Pretty view look like missing data rather than a parsing gap

### /v1/messages

Not applicable. This changes only how the Admin UI parses a stored spend-log row, and `/v1/messages` is not one of the two payload shapes involved. Its rows are unaffected either way.

## Type

🐛 Bug Fix

## Changes

`parseMessages` only ever understood the Chat Completions payload: it read `request.messages` and `response.choices[0].message`. A spend log stores whatever shape the call actually used, so a `/v1/responses` row arrives with `input` and `output` and neither key matched. The Input card got an empty array and the Output card got `null`, which is what prints "No response data available".

The empty `messages` column mentioned in the issue is a red herring. `_get_messages_for_spend_logs_payload` returns `"{}"` for every call type except `_arealtime`, so it is empty for chat completions too; those still render because `LogDetailContent` falls back to `proxy_server_request`, whose body happens to carry a `messages` key. For the Responses API that body carries `input` instead, so the fallback landed on a shape nothing downstream could read.

This is not limited to callers who use `/v1/responses` directly. One of the live cases above is a plain `/v1/chat/completions` request that litellm routed over the Responses bridge; the stored response came back with `output` and no `choices`, so the drawer went blank for a caller who never touched the Responses API. That is the likeliest explanation for the reports in the issue of the panel working one day and not the next.

Rather than adding another `||` chain to an `any`-typed function that had already grown one bespoke branch for realtime, parsing now classifies the payload into a tagged union (`RequestPayload`, `ResponsePayload`) and switches on it once. The Responses branch covers what the live payloads actually contain: `input` as a bare string, `instructions` as a leading system turn, `input_text`/`output_text` content parts, `function_call` and `function_call_output` items, and `reasoning` items which carry no user-facing text. Output items fold into a single assistant message so tool calls render the same way they do for chat completions.

Two smaller things came along with it, both consequences of typing the function rather than separate changes: `role` is now validated against the union instead of `msg.role || "user"`, which maps `developer` onto `system` and the legacy `function` role onto `tool` instead of leaving a role the cards cannot style; and `parseMessageContent` returns `""` rather than `undefined` for absent content, which is what the rest of the drawer already assumed.

The now-unused `no-nested-ternary` suppression for this file is pruned from `eslint-suppressions.json`.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
