### PR TITLE
fix(bedrock):  strip unsupported cache_control fields on the invoke chat completions path

### DIFF
--- a/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/anthropic_claude3_transformation.py
@@ -22,6 +22,7 @@ from litellm.llms.bedrock.common_utils import (
     normalize_tool_input_schema_types_for_bedrock_invoke,
     pop_bedrock_invoke_output_config_format,
     remove_custom_field_from_tools,
+    remove_ttl_from_cache_control,
 )
 from litellm.types.llms.anthropic import ANTHROPIC_TOOL_SEARCH_BETA_HEADER
 from litellm.types.llms.openai import AllMessageValues
@@ -246,6 +247,7 @@ class AmazonAnthropicClaudeConfig(AmazonInvokeConfig, AnthropicConfig):
         # Remove `custom` field from tools (Bedrock doesn't support it)
         remove_custom_field_from_tools(anthropic_request)
         normalize_tool_input_schema_types_for_bedrock_invoke(anthropic_request)
+        remove_ttl_from_cache_control(anthropic_request, model=model)
         return anthropic_request
 
     def _compute_bedrock_invoke_beta_headers(

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -704,6 +704,58 @@ def is_claude_4_5_on_bedrock(model: str) -> bool:
     )
 
 
+def remove_ttl_from_cache_control(
+    anthropic_request: dict,  # mutable-ok: sanitizes the built request body in place
+    model: str | None = None,
+) -> None:
+    """
+    Remove cache_control fields Bedrock rejects with ``"Extra inputs are not
+    permitted"``: `scope` always, and `ttl` on models without extended-TTL caching.
+
+    Ref: https://github.com/BerriAI/litellm/issues/34248
+    """
+    is_claude_4_5 = False
+    if model:
+        is_claude_4_5 = is_claude_4_5_on_bedrock(model)
+
+    def _sanitize_cache_control(cache_control: dict) -> None:
+        if not isinstance(cache_control, dict):
+            return
+        # Bedrock doesn't support scope (e.g., "global" for cross-request caching)
+        cache_control.pop("scope", None)
+        # Remove ttl for models that don't support it
+        if "ttl" in cache_control:
+            ttl = cache_control["ttl"]
+            if is_claude_4_5 and ttl in ["5m", "1h"]:
+                return
+            cache_control.pop("ttl", None)
+
+    def _process_content_list(content: list) -> None:
+        for item in content:
+            if isinstance(item, dict) and "cache_control" in item:
+                _sanitize_cache_control(item["cache_control"])
+
+    # Process tools
+    if "tools" in anthropic_request:
+        for tool in anthropic_request["tools"]:
+            if isinstance(tool, dict) and "cache_control" in tool:
+                _sanitize_cache_control(tool["cache_control"])
+
+    # Process system (list of content blocks)
+    if "system" in anthropic_request:
+        system = anthropic_request["system"]
+        if isinstance(system, list):
+            _process_content_list(system)
+
+    # Process messages
+    if "messages" in anthropic_request:
+        for message in anthropic_request["messages"]:
+            if isinstance(message, dict) and "content" in message:
+                content = message["content"]
+                if isinstance(content, list):
+                    _process_content_list(content)
+
+
 _BEDROCK_MODEL_VERSION_SUFFIX_RE = re.compile(r"-v\d+(?::\d+)?$")
 
 

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -40,6 +40,7 @@ from litellm.llms.bedrock.common_utils import (
     normalize_tool_input_schema_types_for_bedrock_invoke,
     pop_bedrock_invoke_output_config_format,
     remove_custom_field_from_tools,
+    remove_ttl_from_cache_control,
 )
 from litellm.types.llms.anthropic import (
     ANTHROPIC_BETA_HEADER_VALUES,
@@ -136,59 +137,8 @@ class AmazonAnthropicClaudeMessagesConfig(
         )
 
     def _remove_ttl_from_cache_control(self, anthropic_messages_request: dict, model: str | None = None) -> None:
-        """
-        Remove unsupported fields from cache_control for Bedrock.
-
-        Bedrock only supports `type` and `ttl` in cache_control. It does NOT support:
-        - `scope` (e.g., "global") - always removed
-        - `ttl` - removed for older models; Claude 4.5+ supports "5m" and "1h"
-
-        Processes `tools`, `system`, and `messages` content blocks.
-
-        Args:
-            anthropic_messages_request: The request dictionary to modify in-place
-            model: The model name to check if it supports ttl
-        """
-        is_claude_4_5 = False
-        if model:
-            is_claude_4_5 = self._is_claude_4_5_on_bedrock(model)
-
-        def _sanitize_cache_control(cache_control: dict) -> None:
-            if not isinstance(cache_control, dict):
-                return
-            # Bedrock doesn't support scope (e.g., "global" for cross-request caching)
-            cache_control.pop("scope", None)
-            # Remove ttl for models that don't support it
-            if "ttl" in cache_control:
-                ttl = cache_control["ttl"]
-                if is_claude_4_5 and ttl in ["5m", "1h"]:
-                    return
-                cache_control.pop("ttl", None)
-
-        def _process_content_list(content: list) -> None:
-            for item in content:
-                if isinstance(item, dict) and "cache_control" in item:
-                    _sanitize_cache_control(item["cache_control"])
-
-        # Process tools
-        if "tools" in anthropic_messages_request:
-            for tool in anthropic_messages_request["tools"]:
-                if isinstance(tool, dict) and "cache_control" in tool:
-                    _sanitize_cache_control(tool["cache_control"])
-
-        # Process system (list of content blocks)
-        if "system" in anthropic_messages_request:
-            system = anthropic_messages_request["system"]
-            if isinstance(system, list):
-                _process_content_list(system)
-
-        # Process messages
-        if "messages" in anthropic_messages_request:
-            for message in anthropic_messages_request["messages"]:
-                if isinstance(message, dict) and "content" in message:
-                    content = message["content"]
-                    if isinstance(content, list):
-                        _process_content_list(content)
+        """Delegates to the shared helper, also used by the chat completions invoke path."""
+        remove_ttl_from_cache_control(anthropic_request=anthropic_messages_request, model=model)
 
     def _supports_extended_thinking_on_bedrock(self, model: str) -> bool:
         """

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
@@ -545,3 +545,68 @@ def test_output_format_removed_from_bedrock_invoke_request():
     assert (
         "output_format" not in result
     ), f"output_format should be removed for Bedrock Invoke, got keys: {result.keys()}"
+
+
+class TestBedrockInvokeCacheControlSanitization:
+    """Regression tests for https://github.com/BerriAI/litellm/issues/34248."""
+
+    def _transform(self, model: str) -> dict:
+        config = AmazonAnthropicClaudeConfig()
+        cache_control = {"type": "ephemeral", "ttl": "1h", "scope": "global"}
+        messages = [
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": "You are helpful.", "cache_control": dict(cache_control)}],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Hello", "cache_control": dict(cache_control)}],
+            },
+        ]
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+                "cache_control": dict(cache_control),
+            }
+        ]
+        return config.transform_request(
+            model=model,
+            messages=messages,
+            optional_params={"max_tokens": 100, "tools": tools},
+            litellm_params={},
+            headers={},
+        )
+
+    def _cache_control_blocks(self, request: dict) -> list:
+        return [
+            request["system"][0]["cache_control"],
+            request["messages"][0]["content"][0]["cache_control"],
+            request["tools"][0]["cache_control"],
+        ]
+
+    def test_ttl_stripped_for_non_extended_ttl_model(self):
+        """Bedrock rejects ttl for models without extended-TTL caching, so it is stripped while type is kept."""
+        request = self._transform("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+        for cache_control in self._cache_control_blocks(request):
+            assert cache_control == {"type": "ephemeral"}
+
+    def test_ttl_preserved_for_extended_ttl_model(self):
+        """Claude 4.5+ on Bedrock supports the extended 1h TTL, so ttl survives the transform."""
+        request = self._transform("anthropic.claude-sonnet-4-5-20250929-v1:0")
+        for cache_control in self._cache_control_blocks(request):
+            assert cache_control == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_scope_stripped_for_both_model_classes(self):
+        """Bedrock never accepts scope in cache_control, regardless of model."""
+        for model in (
+            "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+            "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        ):
+            request = self._transform(model)
+            for cache_control in self._cache_control_blocks(request):
+                assert "scope" not in cache_control

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
@@ -550,9 +550,9 @@ def test_output_format_removed_from_bedrock_invoke_request():
 class TestBedrockInvokeCacheControlSanitization:
     """Regression tests for https://github.com/BerriAI/litellm/issues/34248."""
 
-    def _transform(self, model: str) -> dict:
+    def _transform(self, model: str, ttl: str = "1h") -> dict:
         config = AmazonAnthropicClaudeConfig()
-        cache_control = {"type": "ephemeral", "ttl": "1h", "scope": "global"}
+        cache_control = {"type": "ephemeral", "ttl": ttl, "scope": "global"}
         messages = [
             {
                 "role": "system",
@@ -600,6 +600,12 @@ class TestBedrockInvokeCacheControlSanitization:
         request = self._transform("anthropic.claude-sonnet-4-5-20250929-v1:0")
         for cache_control in self._cache_control_blocks(request):
             assert cache_control == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_invalid_ttl_stripped_even_for_extended_ttl_model(self):
+        """Only 5m and 1h are valid ttl values, so anything else is stripped even on Claude 4.5."""
+        request = self._transform("anthropic.claude-sonnet-4-5-20250929-v1:0", ttl="2h")
+        for cache_control in self._cache_control_blocks(request):
+            assert cache_control == {"type": "ephemeral"}
 
     def test_scope_stripped_for_both_model_classes(self):
         """Bedrock never accepts scope in cache_control, regardless of model."""


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock 400s when cache_control carries a ttl
- Chat completions invoke path forwarded ttl and scope untouched

How it solves it:

- Runs the same sanitizer the /v1/messages path already uses
- Claude 4.5 models keep valid ttl values (5m/1h)

## Relevant issues

Fixes #34248

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

No Bedrock access on my side, so this shows the exact body litellm emits before and after, the transform is the whole surface of this bug and the 400 in the issue is Bedrock validating that body

Input in both runs: `"cache_control": {"type": "ephemeral", "ttl": "1h"}`

Before 8ad5d144:

```
us.anthropic.claude-3-7-sonnet-20250219-v1:0  -> {"type": "ephemeral", "ttl": "1h"}   Bedrock: 400 "Extra inputs are not permitted"
us.anthropic.claude-haiku-4-5-20251001-v1:0   -> {"type": "ephemeral", "ttl": "1h"}
```

After on this branch:

```
us.anthropic.claude-3-7-sonnet-20250219-v1:0  -> {"type": "ephemeral"}
us.anthropic.claude-haiku-4-5-20251001-v1:0   -> {"type": "ephemeral", "ttl": "1h"}
```

Claude 3.7 falls back to the default 5m cache instead of erroring, the 4.5 family keeps 1h, which Bedrock supports there (https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html)

## Type

🐛 Bug Fix

## Changes

Bedrock's invoke API rejects cache_control fields it doesn't know with `messages.0.content.0.text.cache_control.ephemeral.ttl: Extra inputs are not permitted`. The /v1/messages invoke path already strips them (`_remove_ttl_from_cache_control`) and Converse gates them, but the chat completions invoke path inherits the direct Anthropic transform, which forwards cache_control verbatim, so ttl and scope reached Bedrock unchanged

Hoisted that sanitizer to `common_utils.py` and call it from `_build_bedrock_anthropic_request_base`, next to the existing `remove_custom_field_from_tools` cleanup for the same class of error (#22847). scope is always removed, ttl only kept on models with extended-TTL caching. Direct Anthropic is untouched

Tests: `TestBedrockInvokeCacheControlSanitization`, four cases (ttl stripped, ttl kept on 4.5, invalid ttl stripped, scope stripped); all fail without the fix

### Final Attestation

- [X] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR