### PR TITLE
feat(vertex-ai): add Grok 4.3 pricing metadata

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -38558,6 +38558,29 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "vertex_ai/xai/grok-4.3": {
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "litellm_provider": "vertex_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 200000,
+        "max_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "output_cost_per_token_above_200k_tokens": 5e-06,
+        "source": "https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing#grok-models",
+        "supported_regions": [
+            "global"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "vertex_ai/qwen/qwen3-235b-a22b-instruct-2507-maas": {
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "vertex_ai-qwen_models",

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -38649,6 +38649,29 @@
         "supports_vision": true,
         "supports_web_search": true
     },
+    "vertex_ai/xai/grok-4.3": {
+        "cache_read_input_token_cost": 2e-07,
+        "cache_read_input_token_cost_above_200k_tokens": 4e-07,
+        "input_cost_per_token": 1.25e-06,
+        "input_cost_per_token_above_200k_tokens": 2.5e-06,
+        "litellm_provider": "vertex_ai",
+        "max_input_tokens": 200000,
+        "max_output_tokens": 200000,
+        "max_tokens": 200000,
+        "mode": "chat",
+        "output_cost_per_token": 2.5e-06,
+        "output_cost_per_token_above_200k_tokens": 5e-06,
+        "source": "https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing#grok-models",
+        "supported_regions": [
+            "global"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
     "vertex_ai/qwen/qwen3-235b-a22b-instruct-2507-maas": {
         "input_cost_per_token": 2.5e-07,
         "litellm_provider": "vertex_ai-qwen_models",

--- a/tests/test_litellm/test_xai_grok_4_3_model_metadata.py
+++ b/tests/test_litellm/test_xai_grok_4_3_model_metadata.py
@@ -2,10 +2,11 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import litellm
 import pytest
 
+from litellm.cost_calculator import cost_per_token
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
-from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
 from litellm.types.utils import Usage
 
 
@@ -121,14 +122,16 @@ def test_vertex_ai_grok_4_3_tiered_pricing(prompt_tokens, input_rate, output_rat
         completion_tokens=completion_tokens,
         total_tokens=prompt_tokens + completion_tokens,
     )
-    with patch(
-        "litellm.litellm_core_utils.llm_cost_calc.utils.get_model_info",
-        return_value=model_info,
+    with patch.dict(
+        litellm.model_cost,
+        {"vertex_ai/xai/grok-4.3": model_info},
     ):
-        prompt_cost, completion_cost = generic_cost_per_token(
-            model="xai/grok-4.3",
-            usage=usage,
+        prompt_cost, completion_cost = cost_per_token(
+            model="vertex_ai/xai/grok-4.3",
             custom_llm_provider="vertex_ai",
+            prompt_characters=prompt_tokens * 4,
+            completion_characters=completion_tokens * 4,
+            usage_object=usage,
         )
 
     assert prompt_cost == pytest.approx(prompt_tokens * input_rate)

--- a/tests/test_litellm/test_xai_grok_4_3_model_metadata.py
+++ b/tests/test_litellm/test_xai_grok_4_3_model_metadata.py
@@ -1,9 +1,12 @@
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
 from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+from litellm.types.utils import Usage
 
 
 @pytest.mark.parametrize("model", ["xai/grok-4.3", "xai/grok-4.3-latest"])
@@ -60,3 +63,73 @@ def test_xai_grok_4_3_backup_matches_main():
         assert backup_cost.get(model) == main_cost.get(
             model
         ), f"{model} differs between main and backup model cost maps"
+
+
+@pytest.mark.parametrize(
+    "model_cost_map_path",
+    [
+        Path(__file__).parents[2] / "model_prices_and_context_window.json",
+        Path(__file__).parents[2] / "litellm" / "model_prices_and_context_window_backup.json",
+    ],
+)
+def test_vertex_ai_grok_4_3_model_info(model_cost_map_path):
+    with open(model_cost_map_path) as f:
+        model_cost = json.load(f)
+
+    model = "vertex_ai/xai/grok-4.3"
+    info = model_cost[model]
+
+    assert info["litellm_provider"] == "vertex_ai"
+    assert info["mode"] == "chat"
+    assert info["input_cost_per_token"] == 1.25e-06
+    assert info["output_cost_per_token"] == 2.5e-06
+    assert info["cache_read_input_token_cost"] == 2e-07
+    assert info["input_cost_per_token_above_200k_tokens"] == 2.5e-06
+    assert info["output_cost_per_token_above_200k_tokens"] == 5e-06
+    assert info["cache_read_input_token_cost_above_200k_tokens"] == 4e-07
+    assert info["max_input_tokens"] == 200000
+    assert info["max_output_tokens"] == 200000
+    assert info["max_tokens"] == 200000
+    assert info["supported_regions"] == ["global"]
+    assert info["supports_function_calling"] is True
+    assert info["supports_prompt_caching"] is True
+    assert info["supports_reasoning"] is True
+    assert info["supports_response_schema"] is True
+    assert info["supports_tool_choice"] is True
+    assert info["supports_vision"] is True
+
+    routed_model, provider, _, _ = get_llm_provider(model=model)
+    assert routed_model == "xai/grok-4.3"
+    assert provider == "vertex_ai"
+
+
+@pytest.mark.parametrize(
+    ("prompt_tokens", "input_rate", "output_rate"),
+    [
+        (200000, 1.25e-06, 2.5e-06),
+        (200001, 2.5e-06, 5e-06),
+    ],
+)
+def test_vertex_ai_grok_4_3_tiered_pricing(prompt_tokens, input_rate, output_rate):
+    model_cost_map_path = Path(__file__).parents[2] / "model_prices_and_context_window.json"
+    with open(model_cost_map_path) as f:
+        model_info = json.load(f)["vertex_ai/xai/grok-4.3"]
+
+    completion_tokens = 10
+    usage = Usage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+    with patch(
+        "litellm.litellm_core_utils.llm_cost_calc.utils.get_model_info",
+        return_value=model_info,
+    ):
+        prompt_cost, completion_cost = generic_cost_per_token(
+            model="xai/grok-4.3",
+            usage=usage,
+            custom_llm_provider="vertex_ai",
+        )
+
+    assert prompt_cost == pytest.approx(prompt_tokens * input_rate)
+    assert completion_cost == pytest.approx(completion_tokens * output_rate)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex AI does not recognize Grok 4.3 metadata
- Built-in cost tracking misses its context pricing tiers

How it solves it:

- Adds Google Cloud model metadata and pricing
- Tests the 200K boundary and bundled map parity

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Google Cloud publishes the following Grok 4.3 rates:

| Input context | Input / 1M | Output / 1M | Cache hit / 1M |
| --- | ---: | ---: | ---: |
| `<= 200K` | $1.25 | $2.50 | $0.20 |
| `> 200K` | $2.50 | $5.00 | $0.40 |

Sources:

- [Grok 4.3 model reference](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/partner-models/grok/grok-4-3)
- [Google Cloud Grok pricing](https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing#grok-models)

The model reference lists a 200,000-token context limit while the pricing page also publishes rates above 200K. This entry preserves the documented model limit and both published pricing tiers

Checks run on `3928ca69a4`:

```text
7 passed in 0.40s  tests/test_litellm/test_xai_grok_4_3_model_metadata.py
model_prices_and_context_window.schema.json validates
make pre-commit passes
```

## Type

New Feature
Test

## Changes

Adds `vertex_ai/xai/grok-4.3` to the primary and bundled model maps with Google Cloud pricing, global availability, context limits, and documented capabilities

Extends the existing Grok 4.3 metadata tests to cover both Vertex AI model maps and short- versus long-context cost calculation at the 200K boundary

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
