### PR TITLE
fix(proxy): revert ssrf settings to the yaml baseline when db overrides are removed

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -17,7 +17,7 @@ import traceback
 import warnings
 from collections.abc import AsyncGenerator, Callable, Mapping
 from datetime import datetime, timedelta, timezone
-from types import UnionType
+from types import MappingProxyType, UnionType
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -3659,6 +3659,38 @@ def _apply_ssrf_general_settings(settings: Mapping[str, object]) -> None:
         )
 
 
+_SSRF_SETTINGS_KEYS = (
+    "user_url_allowed_hosts",
+    "user_url_validation",
+    "provider_url_destination_allowed_hosts",
+)
+
+
+def _snapshot_ssrf_yaml_baseline() -> Mapping[str, object]:
+    return MappingProxyType(
+        {
+            "user_url_allowed_hosts": litellm.user_url_allowed_hosts,
+            "user_url_validation": litellm.user_url_validation,
+            "provider_url_destination_allowed_hosts": litellm.provider_url_destination_allowed_hosts,
+        }
+    )
+
+
+def _reconcile_ssrf_settings_from_db(
+    db_settings: Mapping[str, object],
+    yaml_baseline: Mapping[str, object] | None,
+) -> None:
+    """
+    Apply the SSRF keys present in the DB rows; absent keys revert to the yaml
+    baseline. Callers must only pass a successfully read DB state, so a failed
+    read skips reconciling instead of wiping an operator's restrictions.
+    """
+    if yaml_baseline is None:
+        return
+    overrides = {k: db_settings[k] for k in _SSRF_SETTINGS_KEYS if k in db_settings}  # mutable-ok: one-shot
+    _apply_ssrf_general_settings({**yaml_baseline, **overrides})  # mutable-ok: applied immediately
+
+
 def _set_redis_usage_cache(coordination_redis_cache: RedisCache | None) -> None:
     """Publish the resolved coordination Redis to the consumers that read it directly."""
     global redis_usage_cache
@@ -3832,6 +3864,7 @@ class ProxyConfig:
         self._last_hashicorp_vault_config: dict[str, Any] | None = None
         self.worker_registry: list[WorkerRegistryEntry] = []
         self.config_sync_subscriber: ConfigSyncSubscriber | None = None
+        self._ssrf_yaml_baseline: Mapping[str, object] | None = None
 
     def is_yaml(self, config_file_path: str) -> bool:
         if not os.path.isfile(config_file_path):
@@ -4916,6 +4949,7 @@ class ProxyConfig:
 
             ### SSRF URL VALIDATION SETTINGS ###
             _apply_ssrf_general_settings(general_settings)
+            self._ssrf_yaml_baseline = _snapshot_ssrf_yaml_baseline()
 
             ## check if user has set a premium feature in general_settings
             if general_settings.get("enforced_params") is not None and premium_user is not True:
@@ -5963,14 +5997,9 @@ class ProxyConfig:
             if old_value != new_value:
                 await self._reschedule_spend_log_cleanup_job()
 
-        for key in (
-            "user_url_allowed_hosts",
-            "user_url_validation",
-            "provider_url_destination_allowed_hosts",
-        ):
+        for key in _SSRF_SETTINGS_KEYS:
             if key in _general_settings:
                 general_settings[key] = _general_settings[key]
-        _apply_ssrf_general_settings(_general_settings)
 
     def _update_config_fields(
         self,
@@ -6195,6 +6224,18 @@ class ProxyConfig:
                 await self._update_general_settings(
                     db_general_settings=db_general_settings.param_value,
                 )
+
+            # Reconcile SSRF settings so removed DB keys or rows revert to the
+            # yaml baseline; a failed read raises above and skips this
+            db_litellm_settings = await get_config_param(prisma_client, "litellm_settings")
+            db_ssrf_settings: dict[str, object] = {}  # mutable-ok: merged across two rows then applied once
+            for row in (db_litellm_settings, db_general_settings):  # later wins: general_settings
+                row_value = getattr(row, "param_value", None)
+                if isinstance(row_value, dict):
+                    for key in _SSRF_SETTINGS_KEYS:
+                        if key in row_value:
+                            db_ssrf_settings[key] = row_value[key]
+            _reconcile_ssrf_settings_from_db(db_ssrf_settings, self._ssrf_yaml_baseline)
 
             # initialize vector stores, guardrails, etc. table in db
             await self._init_non_llm_objects_in_db(prisma_client=prisma_client)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -3684,11 +3684,12 @@ def _reconcile_ssrf_settings_from_db(
     Apply the SSRF keys present in the DB rows; absent keys revert to the yaml
     baseline. Callers must only pass a successfully read DB state, so a failed
     read skips reconciling instead of wiping an operator's restrictions.
+
+    Without a baseline (no `load_config` yet) the DB values still apply, they
+    just have nothing to revert to.
     """
-    if yaml_baseline is None:
-        return
     overrides = {k: db_settings[k] for k in _SSRF_SETTINGS_KEYS if k in db_settings}  # mutable-ok: one-shot
-    _apply_ssrf_general_settings({**yaml_baseline, **overrides})  # mutable-ok: applied immediately
+    _apply_ssrf_general_settings({**(yaml_baseline or {}), **overrides})  # mutable-ok: applied immediately
 
 
 def _set_redis_usage_cache(coordination_redis_cache: RedisCache | None) -> None:
@@ -4949,7 +4950,6 @@ class ProxyConfig:
 
             ### SSRF URL VALIDATION SETTINGS ###
             _apply_ssrf_general_settings(general_settings)
-            self._ssrf_yaml_baseline = _snapshot_ssrf_yaml_baseline()
 
             ## check if user has set a premium feature in general_settings
             if general_settings.get("enforced_params") is not None and premium_user is not True:
@@ -4959,6 +4959,10 @@ class ProxyConfig:
             if "litellm_license" in general_settings:
                 _license_check.license_str = general_settings["litellm_license"]
                 premium_user = _license_check.is_premium()
+
+        # Snapshot outside the general_settings block: a config without that
+        # section still needs a baseline for the DB sync to reconcile against
+        self._ssrf_yaml_baseline = _snapshot_ssrf_yaml_baseline()
 
         router_params: dict = {
             "cache_responses": litellm.cache is not None,  # cache if user passed in cache values

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -10765,3 +10765,69 @@ def test_startup_is_silent_when_mock_testing_params_disabled(caplog):
         ProxyStartupEvent._warn_if_mock_testing_params_enabled(general_settings={})
 
     assert MOCK_TESTING_CONFIG_KEY not in caplog.text
+
+
+def _snapshot_yaml_ssrf_state(monkeypatch, proxy_server_module, allowed_hosts):
+    monkeypatch.setattr(litellm, "user_url_validation", True)
+    monkeypatch.setattr(litellm, "user_url_allowed_hosts", allowed_hosts)
+    monkeypatch.setattr(litellm, "provider_url_destination_allowed_hosts", [])
+    return proxy_server_module._snapshot_ssrf_yaml_baseline()
+
+
+def test_reconcile_ssrf_settings_reverts_removed_db_overrides(monkeypatch):
+    """A DB override that disappears reverts to the yaml baseline instead of staying applied."""
+    import litellm.proxy.proxy_server as proxy_server_module
+
+    baseline = _snapshot_yaml_ssrf_state(monkeypatch, proxy_server_module, ["yaml.example"])
+
+    proxy_server_module._reconcile_ssrf_settings_from_db(
+        {"user_url_allowed_hosts": ["db.example"], "user_url_validation": False}, baseline
+    )
+    assert litellm.user_url_allowed_hosts == ["db.example"]
+    assert litellm.user_url_validation is False
+
+    proxy_server_module._reconcile_ssrf_settings_from_db({}, baseline)
+    assert litellm.user_url_allowed_hosts == ["yaml.example"]
+    assert litellm.user_url_validation is True
+
+
+def test_reconcile_ssrf_settings_explicit_empty_overrides_baseline(monkeypatch):
+    """An explicit empty allowlist in the DB wins over a non-empty yaml baseline."""
+    import litellm.proxy.proxy_server as proxy_server_module
+
+    baseline = _snapshot_yaml_ssrf_state(monkeypatch, proxy_server_module, ["yaml.example"])
+
+    proxy_server_module._reconcile_ssrf_settings_from_db({"user_url_allowed_hosts": []}, baseline)
+    assert litellm.user_url_allowed_hosts == []
+
+
+@pytest.mark.asyncio
+async def test_add_deployment_reconciles_ssrf_from_both_db_rows(monkeypatch):
+    """add_deployment applies SSRF keys from both config rows with general_settings winning, and a deleted row reverts them."""
+    import litellm.proxy.proxy_server as proxy_server_module
+
+    baseline = _snapshot_yaml_ssrf_state(monkeypatch, proxy_server_module, ["yaml.example"])
+
+    rows = {
+        "general_settings": types.SimpleNamespace(param_value={"user_url_allowed_hosts": ["general.example"]}),
+        "litellm_settings": types.SimpleNamespace(param_value={"user_url_allowed_hosts": ["litellm.example"]}),
+    }
+
+    async def fake_get_config_param(prisma_client, param_name):
+        return rows.get(param_name)
+
+    monkeypatch.setattr(proxy_server_module, "prefetch_config_params", AsyncMock())
+    monkeypatch.setattr(proxy_server_module, "get_config_param", fake_get_config_param)
+
+    proxy_config = proxy_server_module.ProxyConfig()
+    proxy_config._ssrf_yaml_baseline = baseline
+    monkeypatch.setattr(proxy_config, "_should_load_db_object", lambda object_type: False)
+    monkeypatch.setattr(proxy_config, "_init_non_llm_objects_in_db", AsyncMock())
+    monkeypatch.setattr(proxy_config, "_update_general_settings", AsyncMock())
+
+    await proxy_config.add_deployment(prisma_client=MagicMock(), proxy_logging_obj=MagicMock())
+    assert litellm.user_url_allowed_hosts == ["general.example"]
+
+    rows.clear()
+    await proxy_config.add_deployment(prisma_client=MagicMock(), proxy_logging_obj=MagicMock())
+    assert litellm.user_url_allowed_hosts == ["yaml.example"]

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -10831,3 +10831,40 @@ async def test_add_deployment_reconciles_ssrf_from_both_db_rows(monkeypatch):
     rows.clear()
     await proxy_config.add_deployment(prisma_client=MagicMock(), proxy_logging_obj=MagicMock())
     assert litellm.user_url_allowed_hosts == ["yaml.example"]
+
+
+@pytest.mark.asyncio
+async def test_load_config_snapshots_ssrf_baseline_without_general_settings(tmp_path, monkeypatch):
+    """A config with no general_settings section still gets a baseline, so DB overrides keep applying."""
+    import litellm.proxy.proxy_server as proxy_server_module
+
+    monkeypatch.setattr(litellm, "user_url_validation", True)
+    monkeypatch.setattr(litellm, "user_url_allowed_hosts", [])
+    monkeypatch.setattr(litellm, "provider_url_destination_allowed_hosts", [])
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({"model_list": []}))
+
+    proxy_config = proxy_server_module.ProxyConfig()
+    await proxy_config.load_config(router=MagicMock(), config_file_path=str(config_file))
+
+    assert proxy_config._ssrf_yaml_baseline is not None
+
+    proxy_server_module._reconcile_ssrf_settings_from_db(
+        {"user_url_allowed_hosts": ["db.example"]}, proxy_config._ssrf_yaml_baseline
+    )
+    assert litellm.user_url_allowed_hosts == ["db.example"]
+
+    proxy_server_module._reconcile_ssrf_settings_from_db({}, proxy_config._ssrf_yaml_baseline)
+    assert litellm.user_url_allowed_hosts == []
+
+
+def test_reconcile_ssrf_settings_applies_db_values_without_a_baseline(monkeypatch):
+    """With no baseline captured yet the DB values still apply rather than being dropped."""
+    import litellm.proxy.proxy_server as proxy_server_module
+
+    monkeypatch.setattr(litellm, "user_url_allowed_hosts", [])
+
+    proxy_server_module._reconcile_ssrf_settings_from_db({"user_url_allowed_hosts": ["db.example"]}, None)
+    assert litellm.user_url_allowed_hosts == ["db.example"]
+


### PR DESCRIPTION
## TLDR

Problem this solves:

- Removing SSRF keys from the DB never took effect
- A host deleted from the allowlist stayed allowed until restart

How it solves it:

- Snapshot what the yaml resolved to at startup
- Sync reconciles the DB against that baseline instead of only applying

## Relevant issues

Fixes #35502

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live on a postgres backed proxy with DB sync enabled. yaml sets an unrelated allowlist entry so the host under test is blocked at startup. Same three steps in both runs: discover a blocked host, allowlist it via the general_settings DB row, then delete the row and wait for the next sync poll

Before c6a796a8:

1. yaml baseline only, host NOT allowlisted - HTTP 400 "URL targets a blocked address (127.0.0.1)"
2. add DB override allowlisting the host - HTTP 200 agent card returned
3. DELETE the row, wait for next poll - HTTP 200 agent card still returned

After 21a2a2a7:

1. yaml baseline only, host NOT allowlisted - HTTP 400 "URL targets a blocked address (127.0.0.1)"
2. add DB override allowlisting the host - HTTP 200 agent card returned
3. DELETE the row, wait for next poll - HTTP 400 "URL targets a blocked address  (127.0.0.1)"

Step 3 is the fix. The removed override reverts to the yaml baseline within one poll instead of staying applied until restart

## Type

🐛 Bug Fix

## Changes

The config sync only ever applied SSRF keys it found in the DB but nothing unset them so deleting `user_url_allowed_hosts` or the whole row left the last DB value applied until restart, which is surprising for a security control

`ProxyConfig` now snapshots the values yaml resolved to once `load_config` has applied them, and `add_deployment` reconciles both config rows against that baseline on each poll, so a removed key reverts to yaml instead of lingering. `general_settings` still wins over `litellm_settings` on conflict. Reconciling only runs after a successful read, so a transient DB error skips it rather than wiping an operator's restrictions mid flight

Tests: five cases in test_proxy_server.py covering an override applying then reverting when removed, an explicit empty list still overriding yaml, add_deployment reverting when the rows disappear, a config with no general_settings section still getting a baseline, and DB values still applying when no baseline was captured; all five fail without the fix

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR