### PR TITLE
fix(e2e): make spend-counter redis connection env-driven for non-cluster deployments

### DIFF
--- a/tests/e2e/CONTRIBUTING.md
+++ b/tests/e2e/CONTRIBUTING.md
@@ -25,7 +25,7 @@ The suites run against a live proxy, so bring one up first by running the litell
    GEMINI_API_KEY="..."
    ```
 
-2. Bring up a Postgres and a Redis for the proxy to use. The repo-root `docker-compose.yml` already defines a Postgres on `5432`; a `docker run -p 6379:6379 redis:7` covers Redis. Point `DATABASE_URL` / `REDIS_HOST` / `REDIS_PORT` at whatever you run
+2. Bring up a Postgres and a Redis for the proxy to use. The repo-root `docker-compose.yml` already defines a Postgres on `5432`; a `docker run -p 6379:6379 redis:7` covers Redis. Point `DATABASE_URL` / `REDIS_HOST` / `REDIS_PORT` at whatever you run. Tests that read Redis directly default to the deployed shape (TLS + cluster mode) whenever `REDIS_HOST` is set, so for a local standalone Redis also set `REDIS_CLUSTER=false` and `REDIS_SSL=false` (plus `REDIS_PASSWORD` when your Redis requires auth)
 
 3. Start the litellm proxy locally against your config and confirm it is live:
 

--- a/tests/e2e/quota_management/budgets/test_spend_counter_reseed_e2e.py
+++ b/tests/e2e/quota_management/budgets/test_spend_counter_reseed_e2e.py
@@ -46,22 +46,43 @@ COLD_WAIT_SECONDS = 80
 _JSON_FLOAT: TypeAdapter[float] = TypeAdapter(float)
 
 
+def _redis_flag(name: str, default: str) -> bool:
+    return os.environ.get(name, default).strip().lower() in ("1", "true", "yes")
+
+
 def _redis() -> "redis.Redis[str] | RedisCluster[str]":
-    """The proxy's Redis. The deployed runner sets REDIS_HOST to the serverless
-    ElastiCache, which is always TLS + cluster-mode; without it, fall back to a
-    local standalone redis for docker-compose runs."""
+    """The proxy's Redis. With REDIS_HOST set, TLS and cluster mode default to
+    on (the stage runner's serverless ElastiCache) and are overridable with
+    REDIS_SSL / REDIS_CLUSTER, plus REDIS_PASSWORD when auth is enabled, so the
+    same test runs against a standalone redis like the ephemeral per-SHA
+    stack's bundled one. Without REDIS_HOST, fall back to a local standalone
+    redis for docker-compose runs."""
     import redis
 
     host = os.getenv("REDIS_HOST")
     if not host:
         return redis.Redis(host="localhost", port=6380, decode_responses=True, socket_connect_timeout=2)
 
+    port = int(os.getenv("REDIS_PORT", "6379"))
+    use_ssl = _redis_flag("REDIS_SSL", "true")
+    password = os.getenv("REDIS_PASSWORD") or None
+    if not _redis_flag("REDIS_CLUSTER", "true"):
+        return redis.Redis(
+            host=host,
+            port=port,
+            ssl=use_ssl,
+            password=password,
+            decode_responses=True,
+            socket_connect_timeout=2,
+        )
+
     from redis.cluster import RedisCluster
 
     return RedisCluster(
         host=host,
-        port=int(os.getenv("REDIS_PORT", "6379")),
-        ssl=True,
+        port=port,
+        ssl=use_ssl,
+        password=password,
         decode_responses=True,
         socket_connect_timeout=2,
     )


### PR DESCRIPTION
## TLDR

Problem this solves:

- test_spend_counter_reseed_e2e hard-codes RedisCluster(ssl=True) whenever REDIS_HOST is set
- against a standalone plaintext Redis the client hangs, so the test can never run there
- local docker-compose runs and the ephemeral per-SHA e2e stack both use standalone Redis

How it solves it:

- TLS, cluster mode, and password become env-driven: REDIS_SSL, REDIS_CLUSTER, REDIS_PASSWORD
- defaults stay TLS + cluster, so the deployed stage runner needs no change

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Probe used for every run below (a real password-protected standalone Redis, no mocks):

```bash
docker run -d --rm --name e2e-redis-fixcheck -p 16390:6379 redis:7-alpine redis-server --requirepass testpw123
export REDIS_HOST=localhost REDIS_PORT=16390
python -c "import test_spend_counter_reseed_e2e as m; r = m._redis(); r.ping(); print('CONNECTED', type(r).__name__)"
```

Before, at d4d0bf0acc, with REDIS_CLUSTER=false REDIS_SSL=false REDIS_PASSWORD=testpw123 exported: the probe hangs past a 30s timeout because the old code ignores the env and always dials a TLS cluster; the TLS handshake against the plaintext port never completes

After, at f0c3046d7b, same exports:

```
GREEN cluster=false ssl=false password=ok: exit=0 last=CONNECTED type=Redis
```

After, at f0c3046d7b, with the overrides unset (deployed stage shape preserved): still attempts TLS + cluster and cannot connect to the plaintext standalone, which proves the default behavior is unchanged

```
RED  defaults(cluster+ssl) vs plaintext standalone: TIMEOUT after 30s (hangs; cannot work against this redis)
```

Password is really enforced, not silently dropped:

```
AUTH wrong password: exit=1 last=redis.exceptions.AuthenticationError: invalid username-password pair or user is disabled.
```

## Type

🐛 Bug Fix

## Changes

`_redis()` in tests/e2e/quota_management/budgets/test_spend_counter_reseed_e2e.py reads REDIS_SSL and REDIS_CLUSTER (both default true, matching the deployed serverless ElastiCache) and REDIS_PASSWORD (default none) instead of hard-coding RedisCluster(ssl=True). The no-REDIS_HOST localhost fallback is untouched. tests/e2e/CONTRIBUTING.md documents the new knobs for local standalone runs

## QA runbook

- tests/e2e/quota_management/budgets/test_spend_counter_reseed_e2e.py::test_cold_counter_reseed_keeps_counter_equal_to_db_spend - the Redis client the test reads counters from now follows REDIS_SSL/REDIS_CLUSTER/REDIS_PASSWORD, so the same test runs against both the deployed TLS cluster and a standalone Redis
  - [ ] Start a password-protected standalone Redis: docker run -d --rm -p 16390:6379 redis:7-alpine redis-server --requirepass testpw123
  - [ ] export REDIS_HOST=localhost REDIS_PORT=16390 REDIS_CLUSTER=false REDIS_SSL=false REDIS_PASSWORD=testpw123
  - [ ] With tests/e2e and tests/e2e/quota_management/budgets on PYTHONPATH run: python -c "import test_spend_counter_reseed_e2e as m; print(m._redis().ping())" and expect True
  - [ ] Unset REDIS_CLUSTER and REDIS_SSL, rerun the probe, and expect it to fail or hang: the defaults still dial a TLS cluster endpoint, which is what the deployed stage runner needs
  - [ ] Run the full test against a live proxy whose cache uses that same Redis (config needs default_redis_ttl around 20 and a proxy_batch_write_at flush around 60s) and expect it to reach its assertions instead of skipping on an unreachable Redis
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
