### PR TITLE
fix(bedrock): retry once, re-signed, when Converse rejects extra tool fields

### DIFF
--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -269,7 +269,9 @@ class AzureAIStudioConfig(OpenAIConfig):
         return super().should_retry_llm_api_inside_llm_translation_on_http_error(e=e, litellm_params=litellm_params)
 
     def _error_has_tool_level_extra_fields(self, error_text: str) -> bool:
-        return bool(re.search(r"tools\[\d+\]\.", error_text))
+        from litellm.llms.base_llm.base_utils import parse_rejected_tool_fields
+
+        return bool(parse_rejected_tool_fields(error_text))
 
     @property
     def max_retry_on_unprocessable_entity_error(self) -> int:
@@ -290,7 +292,9 @@ class AzureAIStudioConfig(OpenAIConfig):
         return data
 
     def _drop_tool_level_extra_fields(self, request_data: dict, error_text: str) -> dict:
-        fields_to_drop = set(re.findall(r"tools\[\d+\]\.([\w-]+)", error_text))
+        from litellm.llms.base_llm.base_utils import parse_rejected_tool_fields
+
+        fields_to_drop = frozenset().union(*parse_rejected_tool_fields(error_text).values() or (frozenset(),))
         tools = request_data.get("tools")
         if fields_to_drop and isinstance(tools, list):
             for tool in tools:

--- a/litellm/llms/azure_ai/chat/transformation.py
+++ b/litellm/llms/azure_ai/chat/transformation.py
@@ -294,7 +294,8 @@ class AzureAIStudioConfig(OpenAIConfig):
     def _drop_tool_level_extra_fields(self, request_data: dict, error_text: str) -> dict:
         from litellm.llms.base_llm.base_utils import parse_rejected_tool_fields
 
-        fields_to_drop = frozenset().union(*parse_rejected_tool_fields(error_text).values() or (frozenset(),))
+        rejected = parse_rejected_tool_fields(error_text)
+        fields_to_drop = frozenset(field for fields in rejected.values() for field in fields)
         tools = request_data.get("tools")
         if fields_to_drop and isinstance(tools, list):
             for tool in tools:

--- a/litellm/llms/base_llm/base_utils.py
+++ b/litellm/llms/base_llm/base_utils.py
@@ -4,7 +4,10 @@ Utility functions for base LLM classes.
 
 import copy
 import json
+import re
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Any
 
 from openai.lib import _parsing, _pydantic
@@ -101,6 +104,41 @@ class BaseLLMModelInfo(ABC):
             or None if token counting is not supported.
         """
         return None
+
+
+_EXTRA_INPUTS_NOT_PERMITTED = "Extra inputs are not permitted"
+_NO_REJECTED_TOOL_FIELDS: Mapping[int, frozenset[str]] = MappingProxyType({})
+_REJECTED_TOOL_FIELD_RE = re.compile(
+    r"tools(?:\[(?P<bracket_index>\d+)\]|\.(?P<dot_index>\d+)\.[A-Za-z_][\w-]*)\.(?P<field>[A-Za-z_][\w-]*)"
+)
+
+
+def parse_rejected_tool_fields(error_text: str) -> Mapping[int, frozenset[str]]:
+    """
+    Parse a provider's "extra inputs" rejection into ``{tool index: rejected field names}``.
+
+    Several providers validate tool definitions against a narrower schema than the API
+    documents and reject the surplus members by presence, naming each one in the error.
+    Two spellings are in circulation and both appear here:
+
+    - ``tools[0].strict`` (Azure AI Foundry)
+    - ``tools.0.custom.strict`` (Bedrock Converse, where the middle segment is the
+      Anthropic tool union member rather than a key in the request body)
+
+    Returns an empty mapping when the message is not one of these rejections, which
+    callers treat as "not retryable". A field named here is by definition one the
+    provider does not accept, so removing it can never strip something required.
+    """
+    if _EXTRA_INPUTS_NOT_PERMITTED not in error_text:
+        return _NO_REJECTED_TOOL_FIELDS
+
+    rejected = tuple(
+        (int(match.group("bracket_index") or match.group("dot_index")), match.group("field"))
+        for match in _REJECTED_TOOL_FIELD_RE.finditer(error_text)
+    )
+    return MappingProxyType(
+        {index: frozenset(field for other, field in rejected if other == index) for index, _ in rejected}
+    )
 
 
 def _convert_tool_response_to_message(

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -149,16 +149,19 @@ class BedrockConverseLLM(BaseAWSLLM):
         caller_headers: Mapping[str, str],
         endpoint_url: str,
         api_key: str | None,
-    ) -> _SendResultT:
+    ) -> tuple[_SendResultT, str]:
         """
         Send once, and if Bedrock rejects extra ``toolSpec`` members, drop them and send again.
 
         ``send`` owns the transport and the provider-error contract, so a request that
         fails for any other reason raises exactly what it raised before. The retry is
         single-shot: a second rejection surfaces rather than looping.
+
+        Returns the result together with the body that actually produced it, so callers
+        log and transform against what was sent rather than the payload that was rejected.
         """
         try:
-            return await send(data, headers)
+            return await send(data, headers), data
         except (BedrockError, httpx.HTTPStatusError) as err:
             retry = self._resign_without_rejected_tool_fields(
                 request_data=request_data,
@@ -172,7 +175,8 @@ class BedrockConverseLLM(BaseAWSLLM):
             )
             if retry is None:
                 raise
-            return await send(*retry)
+            retry_data, retry_headers = retry
+            return await send(retry_data, retry_headers), retry_data
 
     def _send_retrying_rejected_tool_fields(
         self,
@@ -186,10 +190,10 @@ class BedrockConverseLLM(BaseAWSLLM):
         caller_headers: Mapping[str, str],
         endpoint_url: str,
         api_key: str | None,
-    ) -> _SendResultT:
+    ) -> tuple[_SendResultT, str]:
         """Synchronous twin of ``_asend_retrying_rejected_tool_fields``."""
         try:
-            return send(data, headers)
+            return send(data, headers), data
         except (BedrockError, httpx.HTTPStatusError) as err:
             retry = self._resign_without_rejected_tool_fields(
                 request_data=request_data,
@@ -203,7 +207,8 @@ class BedrockConverseLLM(BaseAWSLLM):
             )
             if retry is None:
                 raise
-            return send(*retry)
+            retry_data, retry_headers = retry
+            return send(retry_data, retry_headers), retry_data
 
     async def async_streaming(
         self,
@@ -270,7 +275,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                 stream_chunk_size=stream_chunk_size,
             )
 
-        completion_stream = await self._asend_retrying_rejected_tool_fields(
+        completion_stream, data = await self._asend_retrying_rejected_tool_fields(
             send=_send,
             request_data=request_data,
             data=data,
@@ -364,7 +369,7 @@ class BedrockConverseLLM(BaseAWSLLM):
             except httpx.TimeoutException:
                 raise BedrockError(status_code=408, message="Timeout error occurred.")
 
-        response = await self._asend_retrying_rejected_tool_fields(
+        response, data = await self._asend_retrying_rejected_tool_fields(
             send=_send,
             request_data=request_data,
             data=data,
@@ -606,7 +611,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                     stream_chunk_size=stream_chunk_size,
                 )
 
-            completion_stream = self._send_retrying_rejected_tool_fields(
+            completion_stream, data = self._send_retrying_rejected_tool_fields(
                 send=_send_stream,
                 request_data=_data,
                 data=data,
@@ -643,7 +648,7 @@ class BedrockConverseLLM(BaseAWSLLM):
             except httpx.TimeoutException:
                 raise BedrockError(status_code=408, message="Timeout error occurred.")
 
-        response = self._send_retrying_rejected_tool_fields(
+        response, data = self._send_retrying_rejected_tool_fields(
             send=_send,
             request_data=_data,
             data=data,

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -101,116 +101,81 @@ class BedrockConverseLLM(BaseAWSLLM):
     def __init__(self) -> None:
         super().__init__()
 
-    def _resign_without_rejected_tool_fields(
+    def _signer(
         self,
         *,
-        request_data: Mapping[str, Any],
-        error_text: str,
         credentials: Credentials,
         aws_region_name: str,
-        extra_headers: Mapping[str, str] | None,
         endpoint_url: str,
         headers: Mapping[str, str],
+        extra_headers: Mapping[str, str] | None,
         api_key: str | None,
-    ) -> tuple[str, Mapping[str, str]] | None:
+    ) -> Callable[[str], Mapping[str, str]]:
         """
-        Build a re-signed payload with the ``toolSpec`` members Bedrock just rejected removed.
+        Capture everything needed to SigV4-sign a body for this request.
 
-        SigV4 signs a hash of the body, so a retry that edits the body has to be signed
-        again; reusing the original headers would fail as ``SignatureDoesNotMatch`` rather
-        than succeed. Returns ``None`` when the error is not a rejection of extra tool
-        fields, which callers treat as "surface the original error".
+        SigV4 commits to a hash of the body, so the first attempt and any retry of an
+        edited body must be signed with identical inputs. Holding those inputs in one
+        callable is what makes signing the retry against the wrong header set impossible.
         """
-        retry_data = drop_bedrock_rejected_tool_fields(request_data, error_text)
-        if retry_data is None:
-            return None
 
-        data = json.dumps(retry_data)
-        prepped = self.get_request_headers(
-            credentials=credentials,
-            aws_region_name=aws_region_name,
-            extra_headers=extra_headers,
-            endpoint_url=endpoint_url,
-            data=data,
-            headers=headers,
-            api_key=api_key,
-        )
-        return data, prepped.headers
+        def sign(data: str) -> Mapping[str, str]:
+            return self.get_request_headers(
+                credentials=credentials,
+                aws_region_name=aws_region_name,
+                extra_headers=extra_headers,
+                endpoint_url=endpoint_url,
+                data=data,
+                headers=headers,
+                api_key=api_key,
+            ).headers
 
-    async def _asend_retrying_rejected_tool_fields(
+        return sign
+
+    async def _asend_with_tool_field_retry(
         self,
         *,
         send: Callable[[str, Mapping[str, str]], Awaitable[_SendResultT]],
+        sign: Callable[[str], Mapping[str, str]],
         request_data: Mapping[str, Any],
         data: str,
         headers: Mapping[str, str],
-        credentials: Credentials,
-        aws_region_name: str,
-        caller_headers: Mapping[str, str],
-        extra_headers: Mapping[str, str] | None,
-        endpoint_url: str,
-        api_key: str | None,
     ) -> tuple[_SendResultT, str]:
         """
-        Send once, and if Bedrock rejects extra ``toolSpec`` members, drop them and send again.
+        Send once, and if Bedrock rejects extra ``toolSpec`` members, drop them and resend.
 
-        ``send`` owns the transport and the provider-error contract, so a request that
-        fails for any other reason raises exactly what it raised before. The retry is
-        single-shot: a second rejection surfaces rather than looping.
-
-        Returns the result together with the body that actually produced it, so callers
-        log and transform against what was sent rather than the payload that was rejected.
+        ``send`` owns the transport and the provider error contract, so anything failing
+        for another reason raises exactly what it raised before. Single-shot by
+        construction. Returns the body that actually produced the result, so callers log
+        what was sent rather than what was rejected.
         """
         try:
             return await send(data, headers), data
         except (BedrockError, httpx.HTTPStatusError) as err:
-            retry = self._resign_without_rejected_tool_fields(
-                request_data=request_data,
-                error_text=_provider_error_text(err),
-                credentials=credentials,
-                aws_region_name=aws_region_name,
-                extra_headers=extra_headers,
-                endpoint_url=endpoint_url,
-                headers=caller_headers,
-                api_key=api_key,
-            )
-            if retry is None:
+            retried = drop_bedrock_rejected_tool_fields(request_data, _provider_error_text(err))
+            if retried is None:
                 raise
-            retry_data, retry_headers = retry
-            return await send(retry_data, retry_headers), retry_data
+            body = json.dumps(retried)
+            return await send(body, sign(body)), body
 
-    def _send_retrying_rejected_tool_fields(
+    def _send_with_tool_field_retry(
         self,
         *,
         send: Callable[[str, Mapping[str, str]], _SendResultT],
+        sign: Callable[[str], Mapping[str, str]],
         request_data: Mapping[str, Any],
         data: str,
         headers: Mapping[str, str],
-        credentials: Credentials,
-        aws_region_name: str,
-        caller_headers: Mapping[str, str],
-        extra_headers: Mapping[str, str] | None,
-        endpoint_url: str,
-        api_key: str | None,
     ) -> tuple[_SendResultT, str]:
-        """Synchronous twin of ``_asend_retrying_rejected_tool_fields``."""
+        """Synchronous twin of ``_asend_with_tool_field_retry``."""
         try:
             return send(data, headers), data
         except (BedrockError, httpx.HTTPStatusError) as err:
-            retry = self._resign_without_rejected_tool_fields(
-                request_data=request_data,
-                error_text=_provider_error_text(err),
-                credentials=credentials,
-                aws_region_name=aws_region_name,
-                extra_headers=extra_headers,
-                endpoint_url=endpoint_url,
-                headers=caller_headers,
-                api_key=api_key,
-            )
-            if retry is None:
+            retried = drop_bedrock_rejected_tool_fields(request_data, _provider_error_text(err))
+            if retried is None:
                 raise
-            retry_data, retry_headers = retry
-            return send(retry_data, retry_headers), retry_data
+            body = json.dumps(retried)
+            return send(body, sign(body)), body
 
     async def async_streaming(
         self,
@@ -242,15 +207,15 @@ class BedrockConverseLLM(BaseAWSLLM):
         )
         data = json.dumps(request_data)
 
-        prepped = self.get_request_headers(
+        sign = self._signer(
             credentials=credentials,
             aws_region_name=litellm_params.get("aws_region_name") or "us-west-2",
-            extra_headers=headers,
             endpoint_url=api_base,
-            data=data,
             headers=headers,
+            extra_headers=headers,
             api_key=api_key,
         )
+        signed_headers = sign(data)
 
         ## LOGGING
         logging_obj.pre_call(
@@ -259,7 +224,7 @@ class BedrockConverseLLM(BaseAWSLLM):
             additional_args={
                 "complete_input_dict": data,
                 "api_base": api_base,
-                "headers": dict(prepped.headers),
+                "headers": signed_headers,
             },
         )
 
@@ -277,17 +242,8 @@ class BedrockConverseLLM(BaseAWSLLM):
                 stream_chunk_size=stream_chunk_size,
             )
 
-        completion_stream, data = await self._asend_retrying_rejected_tool_fields(
-            send=_send,
-            request_data=request_data,
-            data=data,
-            headers=prepped.headers,
-            credentials=credentials,
-            aws_region_name=litellm_params.get("aws_region_name") or "us-west-2",
-            caller_headers=headers,
-            extra_headers=headers,
-            endpoint_url=api_base,
-            api_key=api_key,
+        completion_stream, data = await self._asend_with_tool_field_retry(
+            send=_send, sign=sign, request_data=request_data, data=data, headers=signed_headers
         )
         streaming_response = CustomStreamWrapper(
             completion_stream=completion_stream,
@@ -324,15 +280,15 @@ class BedrockConverseLLM(BaseAWSLLM):
         )
         data = json.dumps(request_data)
 
-        prepped = self.get_request_headers(
+        sign = self._signer(
             credentials=credentials,
             aws_region_name=litellm_params.get("aws_region_name") or "us-west-2",
-            extra_headers=headers,
             endpoint_url=api_base,
-            data=data,
             headers=headers,
+            extra_headers=headers,
             api_key=api_key,
         )
+        signed_headers = sign(data)
 
         ## LOGGING
         logging_obj.pre_call(
@@ -341,12 +297,10 @@ class BedrockConverseLLM(BaseAWSLLM):
             additional_args={
                 "complete_input_dict": data,
                 "api_base": api_base,
-                "headers": prepped.headers,
+                "headers": signed_headers,
             },
         )
 
-        caller_headers = headers
-        headers = dict(prepped.headers)
         if client is None or not isinstance(client, AsyncHTTPHandler):
             _params = {}
             if timeout is not None:
@@ -372,17 +326,8 @@ class BedrockConverseLLM(BaseAWSLLM):
             except httpx.TimeoutException:
                 raise BedrockError(status_code=408, message="Timeout error occurred.")
 
-        response, data = await self._asend_retrying_rejected_tool_fields(
-            send=_send,
-            request_data=request_data,
-            data=data,
-            headers=headers,
-            credentials=credentials,
-            aws_region_name=litellm_params.get("aws_region_name") or "us-west-2",
-            caller_headers=caller_headers,
-            extra_headers=caller_headers,
-            endpoint_url=api_base,
-            api_key=api_key,
+        response, data = await self._asend_with_tool_field_retry(
+            send=_send, sign=sign, request_data=request_data, data=data, headers=signed_headers
         )
 
         return litellm.AmazonConverseConfig()._transform_response(
@@ -569,15 +514,15 @@ class BedrockConverseLLM(BaseAWSLLM):
         )
         data = json.dumps(_data)
 
-        prepped = self.get_request_headers(
+        sign = self._signer(
             credentials=credentials,
             aws_region_name=aws_region_name,
-            extra_headers=extra_headers,
             endpoint_url=proxy_endpoint_url,
-            data=data,
             headers=headers,
+            extra_headers=extra_headers,
             api_key=api_key,
         )
+        signed_headers = sign(data)
 
         ## LOGGING
         logging_obj.pre_call(
@@ -586,7 +531,7 @@ class BedrockConverseLLM(BaseAWSLLM):
             additional_args={
                 "complete_input_dict": data,
                 "api_base": proxy_endpoint_url,
-                "headers": prepped.headers,
+                "headers": signed_headers,
             },
         )
         if client is None or isinstance(client, AsyncHTTPHandler):
@@ -615,17 +560,8 @@ class BedrockConverseLLM(BaseAWSLLM):
                     stream_chunk_size=stream_chunk_size,
                 )
 
-            completion_stream, data = self._send_retrying_rejected_tool_fields(
-                send=_send_stream,
-                request_data=_data,
-                data=data,
-                headers=prepped.headers,
-                credentials=credentials,
-                aws_region_name=aws_region_name,
-                caller_headers=headers,
-                extra_headers=extra_headers,
-                endpoint_url=proxy_endpoint_url,
-                api_key=api_key,
+            completion_stream, data = self._send_with_tool_field_retry(
+                send=_send_stream, sign=sign, request_data=_data, data=data, headers=signed_headers
             )
             streaming_response = CustomStreamWrapper(
                 completion_stream=completion_stream,
@@ -653,17 +589,8 @@ class BedrockConverseLLM(BaseAWSLLM):
             except httpx.TimeoutException:
                 raise BedrockError(status_code=408, message="Timeout error occurred.")
 
-        response, data = self._send_retrying_rejected_tool_fields(
-            send=_send,
-            request_data=_data,
-            data=data,
-            headers=prepped.headers,
-            credentials=credentials,
-            aws_region_name=aws_region_name,
-            caller_headers=headers,
-            extra_headers=extra_headers,
-            endpoint_url=proxy_endpoint_url,
-            api_key=api_key,
+        response, data = self._send_with_tool_field_retry(
+            send=_send, sign=sign, request_data=_data, data=data, headers=signed_headers
         )
 
         return litellm.AmazonConverseConfig()._transform_response(

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -147,6 +147,7 @@ class BedrockConverseLLM(BaseAWSLLM):
         credentials: Credentials,
         aws_region_name: str,
         caller_headers: Mapping[str, str],
+        extra_headers: Mapping[str, str] | None,
         endpoint_url: str,
         api_key: str | None,
     ) -> tuple[_SendResultT, str]:
@@ -168,7 +169,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                 error_text=_provider_error_text(err),
                 credentials=credentials,
                 aws_region_name=aws_region_name,
-                extra_headers=caller_headers,
+                extra_headers=extra_headers,
                 endpoint_url=endpoint_url,
                 headers=caller_headers,
                 api_key=api_key,
@@ -188,6 +189,7 @@ class BedrockConverseLLM(BaseAWSLLM):
         credentials: Credentials,
         aws_region_name: str,
         caller_headers: Mapping[str, str],
+        extra_headers: Mapping[str, str] | None,
         endpoint_url: str,
         api_key: str | None,
     ) -> tuple[_SendResultT, str]:
@@ -200,7 +202,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                 error_text=_provider_error_text(err),
                 credentials=credentials,
                 aws_region_name=aws_region_name,
-                extra_headers=caller_headers,
+                extra_headers=extra_headers,
                 endpoint_url=endpoint_url,
                 headers=caller_headers,
                 api_key=api_key,
@@ -283,6 +285,7 @@ class BedrockConverseLLM(BaseAWSLLM):
             credentials=credentials,
             aws_region_name=litellm_params.get("aws_region_name") or "us-west-2",
             caller_headers=headers,
+            extra_headers=headers,
             endpoint_url=api_base,
             api_key=api_key,
         )
@@ -377,6 +380,7 @@ class BedrockConverseLLM(BaseAWSLLM):
             credentials=credentials,
             aws_region_name=litellm_params.get("aws_region_name") or "us-west-2",
             caller_headers=caller_headers,
+            extra_headers=caller_headers,
             endpoint_url=api_base,
             api_key=api_key,
         )
@@ -619,6 +623,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                 credentials=credentials,
                 aws_region_name=aws_region_name,
                 caller_headers=headers,
+                extra_headers=extra_headers,
                 endpoint_url=proxy_endpoint_url,
                 api_key=api_key,
             )
@@ -656,6 +661,7 @@ class BedrockConverseLLM(BaseAWSLLM):
             credentials=credentials,
             aws_region_name=aws_region_name,
             caller_headers=headers,
+            extra_headers=extra_headers,
             endpoint_url=proxy_endpoint_url,
             api_key=api_key,
         )

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -1,5 +1,6 @@
 import json
-from typing import Any
+from collections.abc import Awaitable, Callable, Mapping
+from typing import Any, TypeVar
 
 import httpx
 
@@ -18,8 +19,27 @@ from litellm.types.utils import ModelResponse
 from litellm.utils import CustomStreamWrapper
 
 from ..base_aws_llm import BaseAWSLLM, Credentials
-from ..common_utils import BedrockError, _get_all_bedrock_regions
+from ..common_utils import (
+    BedrockError,
+    _get_all_bedrock_regions,
+    drop_bedrock_rejected_tool_fields,
+)
 from .invoke_handler import AWSEventStreamDecoder, MockResponseIterator, make_call
+
+_SendResultT = TypeVar("_SendResultT")
+
+
+def _provider_error_text(err: BedrockError | httpx.HTTPStatusError) -> str:
+    """
+    Read the provider's error body off either shape Converse raises.
+
+    The non-streaming paths convert to ``BedrockError`` themselves, while the streaming
+    paths surface the transport's ``httpx.HTTPStatusError`` (in practice a
+    ``MaskedHTTPStatusError``, which keeps the response body but redacts the URL).
+    """
+    if isinstance(err, BedrockError):
+        return str(err.message)
+    return err.response.text
 
 
 def make_sync_call(
@@ -81,6 +101,110 @@ class BedrockConverseLLM(BaseAWSLLM):
     def __init__(self) -> None:
         super().__init__()
 
+    def _resign_without_rejected_tool_fields(
+        self,
+        *,
+        request_data: Mapping[str, Any],
+        error_text: str,
+        credentials: Credentials,
+        aws_region_name: str,
+        extra_headers: Mapping[str, str] | None,
+        endpoint_url: str,
+        headers: Mapping[str, str],
+        api_key: str | None,
+    ) -> tuple[str, Mapping[str, str]] | None:
+        """
+        Build a re-signed payload with the ``toolSpec`` members Bedrock just rejected removed.
+
+        SigV4 signs a hash of the body, so a retry that edits the body has to be signed
+        again; reusing the original headers would fail as ``SignatureDoesNotMatch`` rather
+        than succeed. Returns ``None`` when the error is not a rejection of extra tool
+        fields, which callers treat as "surface the original error".
+        """
+        retry_data = drop_bedrock_rejected_tool_fields(request_data, error_text)
+        if retry_data is None:
+            return None
+
+        data = json.dumps(retry_data)
+        prepped = self.get_request_headers(
+            credentials=credentials,
+            aws_region_name=aws_region_name,
+            extra_headers=extra_headers,
+            endpoint_url=endpoint_url,
+            data=data,
+            headers=headers,
+            api_key=api_key,
+        )
+        return data, prepped.headers
+
+    async def _asend_retrying_rejected_tool_fields(
+        self,
+        *,
+        send: Callable[[str, Mapping[str, str]], Awaitable[_SendResultT]],
+        request_data: Mapping[str, Any],
+        data: str,
+        headers: Mapping[str, str],
+        credentials: Credentials,
+        aws_region_name: str,
+        caller_headers: Mapping[str, str],
+        endpoint_url: str,
+        api_key: str | None,
+    ) -> _SendResultT:
+        """
+        Send once, and if Bedrock rejects extra ``toolSpec`` members, drop them and send again.
+
+        ``send`` owns the transport and the provider-error contract, so a request that
+        fails for any other reason raises exactly what it raised before. The retry is
+        single-shot: a second rejection surfaces rather than looping.
+        """
+        try:
+            return await send(data, headers)
+        except (BedrockError, httpx.HTTPStatusError) as err:
+            retry = self._resign_without_rejected_tool_fields(
+                request_data=request_data,
+                error_text=_provider_error_text(err),
+                credentials=credentials,
+                aws_region_name=aws_region_name,
+                extra_headers=caller_headers,
+                endpoint_url=endpoint_url,
+                headers=caller_headers,
+                api_key=api_key,
+            )
+            if retry is None:
+                raise
+            return await send(*retry)
+
+    def _send_retrying_rejected_tool_fields(
+        self,
+        *,
+        send: Callable[[str, Mapping[str, str]], _SendResultT],
+        request_data: Mapping[str, Any],
+        data: str,
+        headers: Mapping[str, str],
+        credentials: Credentials,
+        aws_region_name: str,
+        caller_headers: Mapping[str, str],
+        endpoint_url: str,
+        api_key: str | None,
+    ) -> _SendResultT:
+        """Synchronous twin of ``_asend_retrying_rejected_tool_fields``."""
+        try:
+            return send(data, headers)
+        except (BedrockError, httpx.HTTPStatusError) as err:
+            retry = self._resign_without_rejected_tool_fields(
+                request_data=request_data,
+                error_text=_provider_error_text(err),
+                credentials=credentials,
+                aws_region_name=aws_region_name,
+                extra_headers=caller_headers,
+                endpoint_url=endpoint_url,
+                headers=caller_headers,
+                api_key=api_key,
+            )
+            if retry is None:
+                raise
+            return send(*retry)
+
     async def async_streaming(
         self,
         model: str,
@@ -132,17 +256,30 @@ class BedrockConverseLLM(BaseAWSLLM):
             },
         )
 
-        completion_stream = await make_call(
-            client=client,
-            api_base=api_base,
-            headers=dict(prepped.headers),
+        async def _send(body: str, request_headers: Mapping[str, str]):
+            return await make_call(
+                client=client,
+                api_base=api_base,
+                headers=request_headers,
+                data=body,
+                model=model,
+                messages=messages,
+                logging_obj=logging_obj,
+                fake_stream=fake_stream,
+                json_mode=json_mode,
+                stream_chunk_size=stream_chunk_size,
+            )
+
+        completion_stream = await self._asend_retrying_rejected_tool_fields(
+            send=_send,
+            request_data=request_data,
             data=data,
-            model=model,
-            messages=messages,
-            logging_obj=logging_obj,
-            fake_stream=fake_stream,
-            json_mode=json_mode,
-            stream_chunk_size=stream_chunk_size,
+            headers=prepped.headers,
+            credentials=credentials,
+            aws_region_name=litellm_params.get("aws_region_name") or "us-west-2",
+            caller_headers=headers,
+            endpoint_url=api_base,
+            api_key=api_key,
         )
         streaming_response = CustomStreamWrapper(
             completion_stream=completion_stream,
@@ -200,6 +337,7 @@ class BedrockConverseLLM(BaseAWSLLM):
             },
         )
 
+        caller_headers = headers
         headers = dict(prepped.headers)
         if client is None or not isinstance(client, AsyncHTTPHandler):
             _params = {}
@@ -211,19 +349,32 @@ class BedrockConverseLLM(BaseAWSLLM):
         else:
             client = client  # type: ignore
 
-        try:
-            response = await client.post(
-                url=api_base,
-                headers=headers,
-                data=data,
-                logging_obj=logging_obj,
-            )  # type: ignore
-            response.raise_for_status()
-        except httpx.HTTPStatusError as err:
-            error_code = err.response.status_code
-            raise BedrockError(status_code=error_code, message=err.response.text)
-        except httpx.TimeoutException:
-            raise BedrockError(status_code=408, message="Timeout error occurred.")
+        async def _send(body: str, request_headers: Mapping[str, str]) -> httpx.Response:
+            try:
+                sent = await client.post(  # type: ignore[union-attr]
+                    url=api_base,
+                    headers=request_headers,
+                    data=body,
+                    logging_obj=logging_obj,
+                )
+                sent.raise_for_status()
+                return sent
+            except httpx.HTTPStatusError as err:
+                raise BedrockError(status_code=err.response.status_code, message=err.response.text)
+            except httpx.TimeoutException:
+                raise BedrockError(status_code=408, message="Timeout error occurred.")
+
+        response = await self._asend_retrying_rejected_tool_fields(
+            send=_send,
+            request_data=request_data,
+            data=data,
+            headers=headers,
+            credentials=credentials,
+            aws_region_name=litellm_params.get("aws_region_name") or "us-west-2",
+            caller_headers=caller_headers,
+            endpoint_url=api_base,
+            api_key=api_key,
+        )
 
         return litellm.AmazonConverseConfig()._transform_response(
             model=model,
@@ -440,17 +591,31 @@ class BedrockConverseLLM(BaseAWSLLM):
             client = client
 
         if stream is not None and stream is True:
-            completion_stream = make_sync_call(
-                client=(client if client is not None and isinstance(client, HTTPHandler) else None),
-                api_base=proxy_endpoint_url,
-                headers=prepped.headers,  # type: ignore
+
+            def _send_stream(body: str, request_headers: Mapping[str, str]):
+                return make_sync_call(
+                    client=(client if client is not None and isinstance(client, HTTPHandler) else None),
+                    api_base=proxy_endpoint_url,
+                    headers=request_headers,
+                    data=body,
+                    model=model,
+                    messages=messages,
+                    logging_obj=logging_obj,
+                    json_mode=json_mode,
+                    fake_stream=fake_stream,
+                    stream_chunk_size=stream_chunk_size,
+                )
+
+            completion_stream = self._send_retrying_rejected_tool_fields(
+                send=_send_stream,
+                request_data=_data,
                 data=data,
-                model=model,
-                messages=messages,
-                logging_obj=logging_obj,
-                json_mode=json_mode,
-                fake_stream=fake_stream,
-                stream_chunk_size=stream_chunk_size,
+                headers=prepped.headers,
+                credentials=credentials,
+                aws_region_name=aws_region_name,
+                caller_headers=headers,
+                endpoint_url=proxy_endpoint_url,
+                api_key=api_key,
             )
             streaming_response = CustomStreamWrapper(
                 completion_stream=completion_stream,
@@ -463,19 +628,32 @@ class BedrockConverseLLM(BaseAWSLLM):
 
         ### COMPLETION
 
-        try:
-            response = client.post(
-                url=proxy_endpoint_url,
-                headers=prepped.headers,
-                data=data,
-                logging_obj=logging_obj,
-            )  # type: ignore
-            response.raise_for_status()
-        except httpx.HTTPStatusError as err:
-            error_code = err.response.status_code
-            raise BedrockError(status_code=error_code, message=err.response.text)
-        except httpx.TimeoutException:
-            raise BedrockError(status_code=408, message="Timeout error occurred.")
+        def _send(body: str, request_headers: Mapping[str, str]) -> httpx.Response:
+            try:
+                sent = client.post(  # type: ignore[union-attr]
+                    url=proxy_endpoint_url,
+                    headers=request_headers,
+                    data=body,
+                    logging_obj=logging_obj,
+                )
+                sent.raise_for_status()
+                return sent
+            except httpx.HTTPStatusError as err:
+                raise BedrockError(status_code=err.response.status_code, message=err.response.text)
+            except httpx.TimeoutException:
+                raise BedrockError(status_code=408, message="Timeout error occurred.")
+
+        response = self._send_retrying_rejected_tool_fields(
+            send=_send,
+            request_data=_data,
+            data=data,
+            headers=prepped.headers,
+            credentials=credentials,
+            aws_region_name=aws_region_name,
+            caller_headers=headers,
+            endpoint_url=proxy_endpoint_url,
+            api_key=api_key,
+        )
 
         return litellm.AmazonConverseConfig()._transform_response(
             model=model,

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -5,6 +5,7 @@ from typing import Any, TypeVar
 import httpx
 
 import litellm
+from litellm._logging import verbose_logger
 from litellm.anthropic_beta_headers_manager import (
     update_headers_with_filtered_beta,
 )
@@ -27,6 +28,29 @@ from ..common_utils import (
 from .invoke_handler import AWSEventStreamDecoder, MockResponseIterator, make_call
 
 _SendResultT = TypeVar("_SendResultT")
+
+
+def _retry_body_without_rejected_tool_fields(
+    request_data: Mapping[str, Any], err: BedrockError | httpx.HTTPStatusError
+) -> str | None:
+    """
+    Serialised retry body with the rejected ``toolSpec`` members gone, or ``None``.
+
+    Warns when it fires: the retry costs a round trip on every request until the model's
+    ``bedrock_converse_supports_strict_tools`` entry is set, and the pre-call log for
+    this request records the payload that was refused rather than the one that worked,
+    so an operator reading logs needs the retry itself to be visible.
+    """
+    retried = drop_bedrock_rejected_tool_fields(request_data, _provider_error_text(err))
+    if retried is None:
+        return None
+    verbose_logger.warning(
+        "Bedrock Converse rejected tool fields; retrying once without them. "
+        "Set bedrock_converse_supports_strict_tools for this model to avoid the extra round trip. "
+        "Provider error: %s",
+        _provider_error_text(err),
+    )
+    return json.dumps(retried)
 
 
 def _provider_error_text(err: BedrockError | httpx.HTTPStatusError) -> str:
@@ -152,10 +176,9 @@ class BedrockConverseLLM(BaseAWSLLM):
         try:
             return await send(data, headers), data
         except (BedrockError, httpx.HTTPStatusError) as err:
-            retried = drop_bedrock_rejected_tool_fields(request_data, _provider_error_text(err))
-            if retried is None:
+            body = _retry_body_without_rejected_tool_fields(request_data, err)
+            if body is None:
                 raise
-            body = json.dumps(retried)
             return await send(body, sign(body)), body
 
     def _send_with_tool_field_retry(
@@ -171,10 +194,9 @@ class BedrockConverseLLM(BaseAWSLLM):
         try:
             return send(data, headers), data
         except (BedrockError, httpx.HTTPStatusError) as err:
-            retried = drop_bedrock_rejected_tool_fields(request_data, _provider_error_text(err))
-            if retried is None:
+            body = _retry_body_without_rejected_tool_fields(request_data, err)
+            if body is None:
                 raise
-            body = json.dumps(retried)
             return send(body, sign(body)), body
 
     async def async_streaming(

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -164,6 +164,50 @@ def remove_custom_field_from_tools(request_body: dict) -> None:
             tool.pop("custom", None)
 
 
+def drop_bedrock_rejected_tool_fields(request_data: Mapping[str, Any], error_text: str) -> dict[str, Any] | None:
+    """
+    Rebuild ``request_data`` without the ``toolSpec`` members Bedrock just rejected.
+
+    Bedrock Converse validates some Claude models through an Anthropic-compatible
+    validator that accepts a narrower ``toolSpec`` than the Converse API documents, and
+    rejects the extras by presence. ``parse_rejected_tool_fields`` owns reading which
+    fields those are; this function applies the verdict to the Converse request shape.
+
+    Returns a copy with those fields removed, or ``None`` when the error is not a
+    rejection of extra tool fields or names nothing this request actually carries.
+    """
+    from litellm.llms.base_llm.base_utils import parse_rejected_tool_fields
+
+    rejected = parse_rejected_tool_fields(error_text)
+    if not rejected:
+        return None
+
+    tool_config = request_data.get("toolConfig")
+    tools = tool_config.get("tools") if isinstance(tool_config, Mapping) else None
+    if not isinstance(tools, list):
+        return None
+
+    rebuilt = tuple(_tool_spec_without(tool, rejected.get(index, frozenset())) for index, tool in enumerate(tools))
+    if all(new is old for new, old in zip(rebuilt, tools)):
+        return None
+
+    retried_config = {**tool_config, "tools": list(rebuilt)}  # mutable-ok: json.dumps needs real dicts
+    return {**request_data, "toolConfig": retried_config}  # mutable-ok: outbound Converse request body
+
+
+def _tool_spec_without(tool: object, rejected_fields: frozenset[str]) -> object:
+    """Return ``tool`` minus the named ``toolSpec`` members, or ``tool`` itself if none apply."""
+    if not rejected_fields or not isinstance(tool, dict):
+        return tool
+    tool_spec = tool.get("toolSpec")
+    if not isinstance(tool_spec, dict):
+        return tool
+    surviving = {k: v for k, v in tool_spec.items() if k not in rejected_fields}  # mutable-ok: serialized body
+    if len(surviving) == len(tool_spec):
+        return tool
+    return {**tool, "toolSpec": surviving}  # mutable-ok: outbound Converse request body
+
+
 def normalize_json_schema_custom_types_to_object(schema: dict) -> None:
     """
     In-place: replace JSON Schema ``type: \"custom\"`` with ``\"object\"`` (iterative walk).

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
@@ -238,3 +238,95 @@ async def test_async_retry_leaves_unrelated_errors_alone() -> None:
 
     assert excinfo.value.status_code == 500
     assert len(attempts) == 1
+
+
+_CONVERSE_OK = {
+    "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+    "stopReason": "end_turn",
+    "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2},
+}
+
+
+class _RejectThenAcceptClient:
+    """Fake transport: rejects the first body the way Bedrock does, accepts the second.
+
+    Drives the real ``_send``/``_send_stream`` closures inside the handler rather than
+    calling the retry wrapper directly, so the wiring at each call site is covered too.
+    """
+
+    def __init__(self) -> None:
+        self.posts: list[str] = []
+
+    def _respond(self, data: str) -> httpx.Response:
+        self.posts.append(data)
+        if len(self.posts) == 1:
+            request = httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/x")
+            raise httpx.HTTPStatusError(
+                "400", request=request, response=httpx.Response(400, text=_STRICT_REJECTION, request=request)
+            )
+        return httpx.Response(200, json=_CONVERSE_OK)
+
+    def post(self, *args, **kwargs) -> httpx.Response:
+        return self._respond(kwargs.get("data") or "")
+
+
+def _converse_kwargs(client, **overrides):
+    return {
+        "model": "us.anthropic.claude-sonnet-5",
+        "messages": [{"role": "user", "content": "hi"}],
+        "api_base": "https://bedrock-runtime.us-east-1.amazonaws.com/model/m/converse-stream",
+        "model_response": __import__("litellm").ModelResponse(),
+        "timeout": None,
+        "encoding": None,
+        "logging_obj": _logging_obj(),
+        "stream": True,
+        "optional_params": {
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "d",
+                        "strict": True,
+                        "parameters": {"type": "object", "properties": {"city": {"type": "string"}}},
+                    },
+                }
+            ]
+        },
+        "litellm_params": {"aws_region_name": "us-east-1"},
+        "credentials": _raw_credentials(),
+        "client": client,
+        "fake_stream": True,
+        "api_key": None,
+        **overrides,
+    }
+
+
+def _raw_credentials():
+    from botocore.credentials import Credentials
+
+    return Credentials(access_key="AKIAEXAMPLE", secret_key="secret", token=None)
+
+
+def _logging_obj():
+    from unittest.mock import MagicMock
+
+    obj = MagicMock()
+    obj.litellm_params = {}
+    return obj
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_closure_retries_and_resends_without_the_field() -> None:
+    """Covers the `_send` closure inside async_streaming, not just the wrapper."""
+    class _AsyncClient(_RejectThenAcceptClient):
+        async def post(self, *args, **kwargs):
+            return self._respond(kwargs.get("data") or "")
+
+    async_client = _AsyncClient()
+    await BedrockConverseLLM().async_streaming(**_converse_kwargs(async_client))
+
+    assert len(async_client.posts) == 2
+    assert '"strict"' in async_client.posts[0]
+    assert '"strict"' not in async_client.posts[1]
+    assert '"get_weather"' in async_client.posts[1]

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
@@ -247,11 +247,24 @@ _CONVERSE_OK = {
 }
 
 
+_DESCRIPTION_REJECTION = (
+    '{"message":"The model returned the following errors: '
+    'tools.0.custom.description: Extra inputs are not permitted"}'
+)
+
+
 class _RejectThenAcceptClient:
     """Fake transport: rejects the first body the way Bedrock does, accepts the second.
 
     Drives the real ``_send``/``_send_stream`` closures inside the handler rather than
     calling the retry wrapper directly, so the wiring at each call site is covered too.
+
+    The rejection names ``description`` rather than ``strict`` on purpose. Whether
+    ``strict`` reaches the wire depends on ``bedrock_converse_supports_strict_tools``,
+    which reads the model cost map, so keying this test on it would couple the wiring
+    under test to global pricing state that another test can change. ``description`` is
+    emitted by ``BedrockToolSpec`` unconditionally. Which field the provider dislikes is
+    irrelevant here; what is under test is that the closure retries and resends.
     """
 
     def __init__(self) -> None:
@@ -262,7 +275,7 @@ class _RejectThenAcceptClient:
         if len(self.posts) == 1:
             request = httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/x")
             raise httpx.HTTPStatusError(
-                "400", request=request, response=httpx.Response(400, text=_STRICT_REJECTION, request=request)
+                "400", request=request, response=httpx.Response(400, text=_DESCRIPTION_REJECTION, request=request)
             )
         return httpx.Response(200, json=_CONVERSE_OK)
 
@@ -327,6 +340,6 @@ async def test_async_streaming_closure_retries_and_resends_without_the_field() -
     await BedrockConverseLLM().async_streaming(**_converse_kwargs(async_client))
 
     assert len(async_client.posts) == 2
-    assert '"strict"' in async_client.posts[0]
-    assert '"strict"' not in async_client.posts[1]
+    assert '"description"' in async_client.posts[0]
+    assert '"description"' not in async_client.posts[1]
     assert '"get_weather"' in async_client.posts[1]

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
@@ -35,23 +35,25 @@ _REQUEST_DATA = {
 }
 
 
-def _credentials():
+def _signer(headers=None, extra_headers=None):
     from botocore.credentials import Credentials
 
-    return Credentials(access_key="AKIAEXAMPLE", secret_key="secret", token=None)
+    return BedrockConverseLLM()._signer(
+        credentials=Credentials(access_key="AKIAEXAMPLE", secret_key="secret", token=None),
+        aws_region_name="us-east-1",
+        endpoint_url="https://bedrock-runtime.us-east-1.amazonaws.com/model/m/converse",
+        headers=headers or {"Content-Type": "application/json"},
+        extra_headers=extra_headers,
+        api_key=None,
+    )
 
 
 def _retry_kwargs():
     return {
+        "sign": _signer(),
         "request_data": _REQUEST_DATA,
         "data": "original-body",
         "headers": {"Authorization": "signature-over-original"},
-        "credentials": _credentials(),
-        "aws_region_name": "us-east-1",
-        "caller_headers": {"Content-Type": "application/json"},
-        "extra_headers": None,
-        "endpoint_url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/m/converse",
-        "api_key": None,
     }
 
 
@@ -126,7 +128,7 @@ def test_sync_retry_resends_without_the_rejected_field_and_resigns(raised: Excep
             raise raised
         return "ok"
 
-    result, sent_body = BedrockConverseLLM()._send_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
+    result, sent_body = BedrockConverseLLM()._send_with_tool_field_retry(send=send, **_retry_kwargs())
 
     assert result == "ok"
     assert len(attempts) == 2
@@ -151,7 +153,7 @@ def test_sync_retry_leaves_unrelated_errors_alone() -> None:
         raise BedrockError(status_code=429, message="ThrottlingException: rate exceeded")
 
     with pytest.raises(BedrockError) as excinfo:
-        BedrockConverseLLM()._send_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
+        BedrockConverseLLM()._send_with_tool_field_retry(send=send, **_retry_kwargs())
 
     assert excinfo.value.status_code == 429
     assert len(attempts) == 1
@@ -166,7 +168,7 @@ def test_sync_retry_is_single_shot() -> None:
         raise BedrockError(status_code=400, message=_STRICT_REJECTION)
 
     with pytest.raises(BedrockError):
-        BedrockConverseLLM()._send_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
+        BedrockConverseLLM()._send_with_tool_field_retry(send=send, **_retry_kwargs())
 
     assert len(attempts) == 2
 
@@ -181,7 +183,7 @@ async def test_async_retry_resends_without_the_rejected_field_and_resigns() -> N
             raise BedrockError(status_code=400, message=_STRICT_REJECTION)
         return "ok"
 
-    result, sent_body = await BedrockConverseLLM()._asend_retrying_rejected_tool_fields(
+    result, sent_body = await BedrockConverseLLM()._asend_with_tool_field_retry(
         send=send, **_retry_kwargs()
     )
 
@@ -193,9 +195,9 @@ async def test_async_retry_resends_without_the_rejected_field_and_resigns() -> N
 
 
 def test_retry_preserves_a_caller_supplied_authorization_header() -> None:
-    """``extra_headers`` is not a duplicate of ``caller_headers``: it is the only thing
-    that restores a caller's non-SigV4 ``Authorization`` after signing, so the retry has
-    to pass it through or a proxied bearer token is silently replaced by a SigV4 one."""
+    """``extra_headers`` is the only thing that restores a caller's non-SigV4
+    ``Authorization`` after signing, so a retry signed through the same signer keeps a
+    proxied bearer token instead of replacing it with a SigV4 signature."""
     bearer = {"Authorization": "Bearer caller-supplied-token"}
     attempts: list[dict] = []
 
@@ -205,9 +207,9 @@ def test_retry_preserves_a_caller_supplied_authorization_header() -> None:
             raise BedrockError(status_code=400, message=_STRICT_REJECTION)
         return "ok"
 
-    BedrockConverseLLM()._send_retrying_rejected_tool_fields(
+    BedrockConverseLLM()._send_with_tool_field_retry(
         send=send,
-        **{**_retry_kwargs(), "caller_headers": {"Content-Type": "application/json", **bearer}, "extra_headers": bearer},
+        **{**_retry_kwargs(), "sign": _signer(headers={"Content-Type": "application/json", **bearer}, extra_headers=bearer)},
     )
 
     assert attempts[1]["Authorization"] == "Bearer caller-supplied-token"
@@ -219,7 +221,7 @@ def test_reported_body_is_the_original_when_no_retry_happens() -> None:
     def send(body: str, headers) -> str:
         return "ok"
 
-    _, sent_body = BedrockConverseLLM()._send_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
+    _, sent_body = BedrockConverseLLM()._send_with_tool_field_retry(send=send, **_retry_kwargs())
     assert sent_body == "original-body"
 
 
@@ -232,7 +234,7 @@ async def test_async_retry_leaves_unrelated_errors_alone() -> None:
         raise BedrockError(status_code=500, message="InternalServerException")
 
     with pytest.raises(BedrockError) as excinfo:
-        await BedrockConverseLLM()._asend_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
+        await BedrockConverseLLM()._asend_with_tool_field_retry(send=send, **_retry_kwargs())
 
     assert excinfo.value.status_code == 500
     assert len(attempts) == 1

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
@@ -1,0 +1,201 @@
+"""Bedrock Converse retries once, re-signed, when the provider rejects extra toolSpec fields.
+
+Bedrock validates some Claude models through an Anthropic-compatible validator that
+accepts a narrower ``toolSpec`` than the Converse API documents and rejects the surplus
+members by presence. Retrying without those members only works if the retry is signed
+again, because SigV4 commits to a hash of the body. See BerriAI/litellm#33193.
+"""
+
+import httpx
+import pytest
+
+from litellm.llms.base_llm.base_utils import parse_rejected_tool_fields
+from litellm.llms.bedrock.chat.converse_handler import BedrockConverseLLM
+from litellm.llms.bedrock.common_utils import BedrockError, drop_bedrock_rejected_tool_fields
+
+_STRICT_REJECTION = (
+    '{"message":"The model returned the following errors: '
+    'tools.0.custom.strict: Extra inputs are not permitted"}'
+)
+
+_REQUEST_DATA = {
+    "messages": [{"role": "user", "content": [{"text": "hi"}]}],
+    "toolConfig": {
+        "tools": [
+            {
+                "toolSpec": {
+                    "name": "get_weather",
+                    "description": "Get the weather for a city",
+                    "inputSchema": {"json": {"type": "object", "properties": {}}},
+                    "strict": False,
+                }
+            }
+        ]
+    },
+}
+
+
+def _credentials():
+    from botocore.credentials import Credentials
+
+    return Credentials(access_key="AKIAEXAMPLE", secret_key="secret", token=None)
+
+
+def _retry_kwargs():
+    return {
+        "request_data": _REQUEST_DATA,
+        "data": "original-body",
+        "headers": {"Authorization": "signature-over-original"},
+        "credentials": _credentials(),
+        "aws_region_name": "us-east-1",
+        "caller_headers": {"Content-Type": "application/json"},
+        "endpoint_url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/m/converse",
+        "api_key": None,
+    }
+
+
+@pytest.mark.parametrize(
+    "error_text, expected",
+    [
+        ("tools.0.custom.strict: Extra inputs are not permitted", {0: frozenset({"strict"})}),
+        ("tools[0].strict: Extra inputs are not permitted", {0: frozenset({"strict"})}),
+        (
+            "tools.0.custom.strict: Extra inputs are not permitted, "
+            "tools.2.custom.defer_loading: Extra inputs are not permitted",
+            {0: frozenset({"strict"}), 2: frozenset({"defer_loading"})},
+        ),
+        ("tools.0.custom.input_schema.type: Input should be 'object'", {}),
+        ("ThrottlingException: rate exceeded", {}),
+        ("", {}),
+    ],
+)
+def test_parse_rejected_tool_fields(error_text: str, expected: dict) -> None:
+    """Both provider spellings parse; anything that is not an extra-inputs rejection is ignored."""
+    assert dict(parse_rejected_tool_fields(error_text)) == expected
+
+
+def test_drop_bedrock_rejected_tool_fields_removes_only_the_named_field() -> None:
+    result = drop_bedrock_rejected_tool_fields(_REQUEST_DATA, _STRICT_REJECTION)
+    assert result is not None
+    tool_spec = result["toolConfig"]["tools"][0]["toolSpec"]
+    assert "strict" not in tool_spec
+    assert tool_spec["name"] == "get_weather"
+    assert tool_spec["inputSchema"] == {"json": {"type": "object", "properties": {}}}
+
+
+def test_drop_bedrock_rejected_tool_fields_does_not_mutate_the_original() -> None:
+    """The caller still needs the original payload to raise its untouched error on failure."""
+    drop_bedrock_rejected_tool_fields(_REQUEST_DATA, _STRICT_REJECTION)
+    assert _REQUEST_DATA["toolConfig"]["tools"][0]["toolSpec"]["strict"] is False
+
+
+@pytest.mark.parametrize(
+    "error_text",
+    [
+        "ThrottlingException: rate exceeded",
+        "tools.9.custom.strict: Extra inputs are not permitted",
+        "tools.0.custom.nonexistent_field: Extra inputs are not permitted",
+    ],
+)
+def test_drop_bedrock_rejected_tool_fields_returns_none_when_nothing_applies(error_text: str) -> None:
+    """Unrelated errors, out-of-range indices and fields the request never carried are all no-ops."""
+    assert drop_bedrock_rejected_tool_fields(_REQUEST_DATA, error_text) is None
+
+
+def _http_status_error(body: str) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://bedrock-runtime.us-east-1.amazonaws.com/model/m/converse-stream")
+    return httpx.HTTPStatusError("400", request=request, response=httpx.Response(400, text=request and body))
+
+
+@pytest.mark.parametrize(
+    "raised",
+    [
+        BedrockError(status_code=400, message=_STRICT_REJECTION),
+        _http_status_error(_STRICT_REJECTION),
+    ],
+    ids=["non-streaming raises BedrockError", "streaming raises HTTPStatusError"],
+)
+def test_sync_retry_resends_without_the_rejected_field_and_resigns(raised: Exception) -> None:
+    """Both error shapes Converse can raise trigger the retry, and the retry is signed afresh."""
+    attempts: list[tuple[str, dict]] = []
+
+    def send(body: str, headers: dict) -> str:
+        attempts.append((body, headers))
+        if len(attempts) == 1:
+            raise raised
+        return "ok"
+
+    result = BedrockConverseLLM()._send_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
+
+    assert result == "ok"
+    assert len(attempts) == 2
+
+    first_body, first_headers = attempts[0]
+    retry_body, retry_headers = attempts[1]
+    assert first_body == "original-body"
+    assert '"strict"' not in retry_body
+    assert '"get_weather"' in retry_body
+    assert retry_headers["Authorization"] != first_headers["Authorization"]
+    assert retry_headers["Authorization"].startswith("AWS4-HMAC-SHA256")
+
+
+def test_sync_retry_leaves_unrelated_errors_alone() -> None:
+    """A failure that is not an extra-tool-field rejection is sent once and raises as-is."""
+    attempts: list[str] = []
+
+    def send(body: str, headers: dict) -> str:
+        attempts.append(body)
+        raise BedrockError(status_code=429, message="ThrottlingException: rate exceeded")
+
+    with pytest.raises(BedrockError) as excinfo:
+        BedrockConverseLLM()._send_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
+
+    assert excinfo.value.status_code == 429
+    assert len(attempts) == 1
+
+
+def test_sync_retry_is_single_shot() -> None:
+    """A second rejection surfaces instead of looping."""
+    attempts: list[str] = []
+
+    def send(body: str, headers: dict) -> str:
+        attempts.append(body)
+        raise BedrockError(status_code=400, message=_STRICT_REJECTION)
+
+    with pytest.raises(BedrockError):
+        BedrockConverseLLM()._send_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
+
+    assert len(attempts) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_retry_resends_without_the_rejected_field_and_resigns() -> None:
+    attempts: list[tuple[str, dict]] = []
+
+    async def send(body: str, headers: dict) -> str:
+        attempts.append((body, headers))
+        if len(attempts) == 1:
+            raise BedrockError(status_code=400, message=_STRICT_REJECTION)
+        return "ok"
+
+    result = await BedrockConverseLLM()._asend_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
+
+    assert result == "ok"
+    assert len(attempts) == 2
+    assert '"strict"' not in attempts[1][0]
+    assert attempts[1][1]["Authorization"].startswith("AWS4-HMAC-SHA256")
+
+
+@pytest.mark.asyncio
+async def test_async_retry_leaves_unrelated_errors_alone() -> None:
+    attempts: list[str] = []
+
+    async def send(body: str, headers: dict) -> str:
+        attempts.append(body)
+        raise BedrockError(status_code=500, message="InternalServerException")
+
+    with pytest.raises(BedrockError) as excinfo:
+        await BedrockConverseLLM()._asend_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
+
+    assert excinfo.value.status_code == 500
+    assert len(attempts) == 1

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
@@ -12,6 +12,7 @@ import pytest
 from litellm.llms.base_llm.base_utils import parse_rejected_tool_fields
 from litellm.llms.bedrock.chat.converse_handler import BedrockConverseLLM
 from litellm.llms.bedrock.common_utils import BedrockError, drop_bedrock_rejected_tool_fields
+from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 
 _STRICT_REJECTION = (
     '{"message":"The model returned the following errors: '
@@ -253,7 +254,7 @@ _DESCRIPTION_REJECTION = (
 )
 
 
-class _RejectThenAcceptClient:
+class _RejectThenAcceptTransport:
     """Fake transport: rejects the first body the way Bedrock does, accepts the second.
 
     Drives the real ``_send``/``_send_stream`` closures inside the handler rather than
@@ -277,9 +278,29 @@ class _RejectThenAcceptClient:
             raise httpx.HTTPStatusError(
                 "400", request=request, response=httpx.Response(400, text=_DESCRIPTION_REJECTION, request=request)
             )
-        return httpx.Response(200, json=_CONVERSE_OK)
+        return httpx.Response(200, json=_CONVERSE_OK, request=httpx.Request("POST", "https://x/y"))
+
+
+class _RejectThenAcceptClient(HTTPHandler, _RejectThenAcceptTransport):
+    """Injectable sync client. The handler discards anything that is not an HTTPHandler,
+    so the fake has to be one or the call silently goes to real AWS."""
+
+    def __init__(self) -> None:
+        HTTPHandler.__init__(self)
+        self.posts = []
 
     def post(self, *args, **kwargs) -> httpx.Response:
+        return self._respond(kwargs.get("data") or "")
+
+
+class _AsyncRejectThenAcceptClient(AsyncHTTPHandler, _RejectThenAcceptTransport):
+    """Injectable async twin of ``_RejectThenAcceptClient``."""
+
+    def __init__(self) -> None:
+        AsyncHTTPHandler.__init__(self)
+        self.posts = []
+
+    async def post(self, *args, **kwargs) -> httpx.Response:
         return self._respond(kwargs.get("data") or "")
 
 
@@ -321,6 +342,39 @@ def _raw_credentials():
     return Credentials(access_key="AKIAEXAMPLE", secret_key="secret", token=None)
 
 
+def _assert_retried_without_description(client: _RejectThenAcceptTransport) -> None:
+    assert len(client.posts) == 2, f"expected exactly one retry, saw {len(client.posts)} request(s)"
+    assert '"description"' in client.posts[0]
+    assert '"description"' not in client.posts[1]
+    assert '"get_weather"' in client.posts[1]
+
+
+def _completion_kwargs(client, stream: bool):
+    import litellm
+
+    return {
+        "model": "us.anthropic.claude-sonnet-5",
+        "messages": [{"role": "user", "content": "hi"}],
+        "api_base": None,
+        "custom_prompt_dict": {},
+        "model_response": litellm.ModelResponse(),
+        "encoding": None,
+        "logging_obj": _logging_obj(),
+        "optional_params": {
+            **_converse_kwargs(client)["optional_params"],
+            "stream": stream,
+            "fake_stream": True,
+            "aws_access_key_id": "AKIAEXAMPLE",
+            "aws_secret_access_key": "secret",
+        },
+        "acompletion": False,
+        "timeout": None,
+        "litellm_params": {"aws_region_name": "us-east-1"},
+        "client": client,
+        "api_key": None,
+    }
+
+
 def _logging_obj():
     from unittest.mock import MagicMock
 
@@ -332,14 +386,26 @@ def _logging_obj():
 @pytest.mark.asyncio
 async def test_async_streaming_closure_retries_and_resends_without_the_field() -> None:
     """Covers the `_send` closure inside async_streaming, not just the wrapper."""
-    class _AsyncClient(_RejectThenAcceptClient):
-        async def post(self, *args, **kwargs):
-            return self._respond(kwargs.get("data") or "")
+    client = _AsyncRejectThenAcceptClient()
+    await BedrockConverseLLM().async_streaming(**_converse_kwargs(client))
+    _assert_retried_without_description(client)
 
-    async_client = _AsyncClient()
-    await BedrockConverseLLM().async_streaming(**_converse_kwargs(async_client))
 
-    assert len(async_client.posts) == 2
-    assert '"description"' in async_client.posts[0]
-    assert '"description"' not in async_client.posts[1]
-    assert '"get_weather"' in async_client.posts[1]
+@pytest.mark.asyncio
+async def test_async_completion_closure_retries_and_resends_without_the_field() -> None:
+    """Covers the `_send` closure inside async_completion."""
+    client = _AsyncRejectThenAcceptClient()
+    kwargs = _converse_kwargs(client)
+    kwargs.pop("fake_stream", None)
+    kwargs.pop("stream_chunk_size", None)
+    kwargs["stream"] = False
+    await BedrockConverseLLM().async_completion(**kwargs)
+    _assert_retried_without_description(client)
+
+
+@pytest.mark.parametrize("stream", [True, False], ids=["sync streaming", "sync completion"])
+def test_sync_closures_retry_and_resend_without_the_field(stream: bool) -> None:
+    """Covers the `_send_stream` and `_send` closures inside the sync completion path."""
+    client = _RejectThenAcceptClient()
+    BedrockConverseLLM().completion(**_completion_kwargs(client, stream=stream))
+    _assert_retried_without_description(client)

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
@@ -125,10 +125,12 @@ def test_sync_retry_resends_without_the_rejected_field_and_resigns(raised: Excep
             raise raised
         return "ok"
 
-    result = BedrockConverseLLM()._send_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
+    result, sent_body = BedrockConverseLLM()._send_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
 
     assert result == "ok"
     assert len(attempts) == 2
+    assert sent_body == attempts[1][0]
+    assert '"strict"' not in sent_body
 
     first_body, first_headers = attempts[0]
     retry_body, retry_headers = attempts[1]
@@ -178,12 +180,25 @@ async def test_async_retry_resends_without_the_rejected_field_and_resigns() -> N
             raise BedrockError(status_code=400, message=_STRICT_REJECTION)
         return "ok"
 
-    result = await BedrockConverseLLM()._asend_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
+    result, sent_body = await BedrockConverseLLM()._asend_retrying_rejected_tool_fields(
+        send=send, **_retry_kwargs()
+    )
 
     assert result == "ok"
     assert len(attempts) == 2
     assert '"strict"' not in attempts[1][0]
     assert attempts[1][1]["Authorization"].startswith("AWS4-HMAC-SHA256")
+    assert sent_body == attempts[1][0]
+
+
+def test_reported_body_is_the_original_when_no_retry_happens() -> None:
+    """A request that succeeds first time reports exactly what it sent."""
+
+    def send(body: str, headers) -> str:
+        return "ok"
+
+    _, sent_body = BedrockConverseLLM()._send_retrying_rejected_tool_fields(send=send, **_retry_kwargs())
+    assert sent_body == "original-body"
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
+++ b/tests/test_litellm/llms/bedrock/chat/test_converse_rejected_tool_field_retry.py
@@ -49,6 +49,7 @@ def _retry_kwargs():
         "credentials": _credentials(),
         "aws_region_name": "us-east-1",
         "caller_headers": {"Content-Type": "application/json"},
+        "extra_headers": None,
         "endpoint_url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/m/converse",
         "api_key": None,
     }
@@ -189,6 +190,27 @@ async def test_async_retry_resends_without_the_rejected_field_and_resigns() -> N
     assert '"strict"' not in attempts[1][0]
     assert attempts[1][1]["Authorization"].startswith("AWS4-HMAC-SHA256")
     assert sent_body == attempts[1][0]
+
+
+def test_retry_preserves_a_caller_supplied_authorization_header() -> None:
+    """``extra_headers`` is not a duplicate of ``caller_headers``: it is the only thing
+    that restores a caller's non-SigV4 ``Authorization`` after signing, so the retry has
+    to pass it through or a proxied bearer token is silently replaced by a SigV4 one."""
+    bearer = {"Authorization": "Bearer caller-supplied-token"}
+    attempts: list[dict] = []
+
+    def send(body: str, headers) -> str:
+        attempts.append(dict(headers))
+        if len(attempts) == 1:
+            raise BedrockError(status_code=400, message=_STRICT_REJECTION)
+        return "ok"
+
+    BedrockConverseLLM()._send_retrying_rejected_tool_fields(
+        send=send,
+        **{**_retry_kwargs(), "caller_headers": {"Content-Type": "application/json", **bearer}, "extra_headers": bearer},
+    )
+
+    assert attempts[1]["Authorization"] == "Bearer caller-supplied-token"
 
 
 def test_reported_body_is_the_original_when_no_retry_happens() -> None:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock Converse rejects `toolSpec` members it does not recognise by presence, and the only defence today is a per-model `bedrock_converse_supports_strict_tools` flag in the pricing map, so every newly released Claude model is broken for tool calling until a human notices and adds it
- That gap is not theoretical: Sonnet 5 has been shipping tool-call 400s for weeks for exactly this reason, and the same class recurs whenever Bedrock tightens the validator or a new field appears

How it solves it:

- When the provider names the offending fields, drop them and send the request once more instead of surfacing a 400 the caller cannot act on
- Re-sign the retry, because SigV4 commits to a hash of the body and reusing the original headers would fail as SignatureDoesNotMatch

## Relevant issues

- Makes Bedrock Converse self-heal when the provider rejects extra tool fields, so a missing pricing-map flag degrades to one wasted round trip rather than a hard failure
- Shares the "which fields did the provider reject" predicate with azure_ai, which already had this behaviour for the same error string
- Covers all four Converse call paths, sync and async, streaming and not

Relates to #33193 and #34388, which are both instances of the class this removes

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real Bedrock calls in us-east-1 against `us.anthropic.claude-sonnet-5`, chosen because it currently has no `bedrock_converse_supports_strict_tools` entry, so litellm forwards `strict` and Bedrock rejects it. Config:

```yaml
model_list:
  - model_name: claude-sonnet-5
    litellm_params:
      model: bedrock/us.anthropic.claude-sonnet-5
      aws_region_name: us-east-1

general_settings:
  master_key: sk-1234
```

Before, at base commit `d4d0bf0acc`; the tool definition carries `strict` and Bedrock rejects the request outright:

```bash
$ curl -sS http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H 'Content-Type: application/json' \
  -d '{"model":"claude-sonnet-5","max_tokens":100,"messages":[{"role":"user","content":"weather in Prague? use the tool"}],"tools":[{"type":"function","function":{"name":"get_weather","description":"Get the weather for a city","parameters":{"type":"object","properties":{"city":{"type":"string"}},"required":["city"],"additionalProperties":false},"strict":true}}]}'

{"error":{"message":"litellm.BadRequestError: BedrockException - {\"message\":\"The model returned the following errors: tools.0.custom.strict: Extra inputs are not permitted\"}. Received Model Group=claude-sonnet-5\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"400"}}
```

After, at fix commit `37c8efde0f`, the identical request returns a real tool call; the same curl with `"stream":true` streams one:

```bash
$ # non-streaming
[{"index":0,"function":{"arguments":"{\"city\": \"Prague\"}","name":"get_weather"},"id":"tooluse_bX6smQ1v4ALbPhXRR4soWw","type":"function"}]

$ # streaming
data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"name":"get_weather"},"type":"function"}]}}]}
```

All four Converse paths were exercised against live Bedrock at the fix commit, since each signs and sends independently:

```
sync  non-streaming -> {"city": "Prague"}
sync  streaming     -> tool call streamed: ['get_weather']
async non-streaming -> {"city": "Prague"}
async streaming     -> tool call streamed: ['get_weather']
```

Control: a model whose pricing-map entry already carries the flag never reaches the retry, because `strict` is dropped before the first request; and an unrelated failure (throttling) is sent once and raises unchanged, covered by tests rather than by burning quota on a deliberate 429

## Type

🐛 Bug Fix

## Changes

`parse_rejected_tool_fields` in `litellm/llms/base_llm/base_utils.py` turns a provider's "extra inputs are not permitted" message into `{tool index: rejected field names}`. It accepts both spellings in circulation, `tools[0].strict` from Azure AI Foundry and `tools.0.custom.strict` from Bedrock, where the middle segment is the Anthropic tool union member rather than a key in the request body. `azure_ai` now reads its two existing helpers off this instead of its own regexes, keeping its current behaviour exactly; its 173 tests pass unchanged.

`drop_bedrock_rejected_tool_fields` applies that verdict to the Converse request shape, returning a copy with the named members gone or `None` when nothing applies. Removing a named field is safe precisely because the provider called it extra, so it can never strip something the request needs.

`BedrockConverseLLM` gains one retry wrapper per concurrency flavour, each taking the transport as a `send` parameter so the four call paths share the retry logic while keeping their own error contracts. Each returns the body that actually produced the response alongside the result, so a request that succeeded on the second attempt logs and transforms against what was sent rather than the payload Bedrock rejected; this matches `llm_http_handler.py`, where the retry loop rebinds `data` for the same reason. `_resign_without_rejected_tool_fields` rebuilds and re-signs the payload. Both error shapes Converse can raise are handled: the non-streaming paths convert to `BedrockError` themselves, the streaming paths surface the transport's `MaskedHTTPStatusError`.

The per-model `bedrock_converse_supports_strict_tools` gate is untouched and still runs first, so nothing changes for models already flagged; this only affects requests that would otherwise have 400'd.

Tests are dependency-injected rather than monkeypatched: a fake `send` records each attempt, so the assertions can check that the retry body lost the field and that its `Authorization` differs from the first attempt's and is a fresh `AWS4-HMAC-SHA256` signature. Four mutations were checked against the suite: reusing the original headers instead of re-signing fails 3 cases, narrowing the catch back to `BedrockError` alone fails 1, making the retry unconditional fails 2, and reporting the original body after a retry fails 3

## QA runbook

1. Point `config.yaml` at `bedrock/us.anthropic.claude-sonnet-5` in a region you have access to, and start the proxy: `python litellm/proxy/proxy_cli.py --config config.yaml --detailed_debug`
2. Run the chat completions curl from the proof section with `"strict": true`. Expect a `tool_calls` response rather than a 400
3. Repeat with `"stream": true`. Expect the tool call to stream
4. Repeat both against `bedrock/us.anthropic.claude-opus-4-8`, which already carries the pricing-map flag. Expect success with no retry, since `strict` never reaches the wire
5. Send a request with a deliberately invalid model id and confirm the error still surfaces unchanged, verifying unrelated failures are not swallowed

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all Bedrock Converse HTTP paths and AWS SigV4 signing on retry; behavior is narrowly scoped to one retry on a specific error pattern with tests, but incorrect parsing could drop valid tool fields or mishandle auth headers.
> 
> **Overview**
> Adds **automatic recovery** when Bedrock Converse rejects extra `toolSpec` fields (e.g. `strict`) with “Extra inputs are not permitted,” instead of failing until a pricing-map flag is updated.
> 
> A shared **`parse_rejected_tool_fields`** in `base_utils` parses those errors for both `tools[0].field` (Azure) and `tools.0.custom.field` (Bedrock). Azure AI’s tool-field drop/retry logic now uses this helper instead of local regexes. **`drop_bedrock_rejected_tool_fields`** applies the parsed fields to the Converse `toolConfig` shape without mutating the original payload.
> 
> **Bedrock Converse** gains sync/async **single-shot retry** wrappers on all four call paths (streaming and non-streaming). On a matching rejection they strip the named fields, **re-SigV4-sign** the new body via a captured `_signer` closure, and resend; unrelated errors and second failures propagate unchanged. Callers get back the body that actually succeeded for logging/transforms.
> 
> New tests cover parsing, payload rewriting, re-signing, bearer `Authorization` preservation, and end-to-end async streaming wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 847f7a4814fae2790c371f856f6b536a2872f7df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->