### PR TITLE
feat(ui): reorder Add Auto Router into name + template, with a collapsible detailed config

### DIFF
--- a/ui/litellm-dashboard/src/autorouter_presets.json
+++ b/ui/litellm-dashboard/src/autorouter_presets.json
@@ -1,0 +1,32 @@
+{
+  "anthropic_family": {
+    "label": "Anthropic Family",
+    "description": "Routes across the Claude model family: Haiku for simple queries, Sonnet for medium, Opus for complex and reasoning-heavy requests.",
+    "complexity_router_config": {
+      "tiers": {
+        "SIMPLE": ["claude-haiku-4-5"],
+        "MEDIUM": ["claude-sonnet-4-5"],
+        "COMPLEX": ["claude-opus-5"],
+        "REASONING": ["claude-opus-5"]
+      },
+      "classifier_type": "heuristic",
+      "escalation_keywords": ["LITELLM ESCALATE"],
+      "session_affinity": false
+    }
+  },
+  "openai_family": {
+    "label": "OpenAI Family",
+    "description": "Routes across the GPT model family: gpt-5-nano for simple queries, gpt-5-mini for medium, gpt-5 for complex, o3 for reasoning-heavy requests.",
+    "complexity_router_config": {
+      "tiers": {
+        "SIMPLE": ["gpt-5-nano"],
+        "MEDIUM": ["gpt-5-mini"],
+        "COMPLEX": ["gpt-5"],
+        "REASONING": ["o3"]
+      },
+      "classifier_type": "heuristic",
+      "escalation_keywords": ["LITELLM ESCALATE"],
+      "session_affinity": false
+    }
+  }
+}

--- a/ui/litellm-dashboard/src/autorouter_presets.json
+++ b/ui/litellm-dashboard/src/autorouter_presets.json
@@ -5,7 +5,7 @@
     "complexity_router_config": {
       "tiers": {
         "SIMPLE": ["claude-haiku-4-5"],
-        "MEDIUM": ["claude-sonnet-4-5"],
+        "MEDIUM": ["claude-sonnet-5"],
         "COMPLEX": ["claude-opus-5"],
         "REASONING": ["claude-opus-5"]
       },
@@ -19,9 +19,9 @@
     "description": "Routes across the GPT model family: gpt-5-nano for simple queries, gpt-5-mini for medium, gpt-5 for complex, o3 for reasoning-heavy requests.",
     "complexity_router_config": {
       "tiers": {
-        "SIMPLE": ["gpt-5-nano"],
-        "MEDIUM": ["gpt-5-mini"],
-        "COMPLEX": ["gpt-5"],
+        "SIMPLE": ["gpt-5.4-nano"],
+        "MEDIUM": ["gpt-5.4-mini"],
+        "COMPLEX": ["gpt-5.4"],
         "REASONING": ["o3"]
       },
       "classifier_type": "heuristic",

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -1,17 +1,45 @@
-import { renderWithProviders, screen, waitFor, within } from "../../../tests/test-utils";
+import { renderWithProviders, screen, waitFor, within, fireEvent, testQueryClient } from "../../../tests/test-utils";
 import userEvent from "@testing-library/user-event";
 import { vi } from "vitest";
 import AddAutoRouterTab from "./add_auto_router_tab";
 import NotificationManager from "../molecules/notifications_manager";
 import { handleAddAutoRouterSubmit } from "./handle_add_auto_router_submit";
 import { getMissingTiersError } from "./build_complexity_router_config";
+import { ModelGroup } from "@/components/llm_calls/fetch_models";
+
+// Every model referenced by both bundled family presets. A caller holding all of these can select
+// either preset; dropping any one greys out the preset that names it.
+const ALL_FAMILY_MODELS: ModelGroup[] = [
+  { model_group: "claude-haiku-4-5", mode: "chat" },
+  { model_group: "claude-sonnet-4-5", mode: "chat" },
+  { model_group: "claude-opus-5", mode: "chat" },
+  { model_group: "gpt-5-nano", mode: "chat" },
+  { model_group: "gpt-5-mini", mode: "chat" },
+  { model_group: "gpt-5", mode: "chat" },
+  { model_group: "o3", mode: "chat" },
+];
+
+const openTemplateDropdown = (): void => {
+  fireEvent.mouseDown(screen.getByTestId("template-selector").querySelector(".ant-select-selector")!);
+};
+
+// The rendered antd option whose text starts with a preset label. Matching on text (not role +
+// accessible name) sidesteps antd's list re-rendering options in place on every state change.
+const optionByLabel = (label: string): HTMLElement | undefined =>
+  Array.from(document.querySelectorAll<HTMLElement>(".ant-select-item-option")).find((el) =>
+    el.textContent?.startsWith(label),
+  );
+
+const isOptionDisabled = (option: HTMLElement): boolean => option.classList.contains("ant-select-item-option-disabled");
+
+const { mockFetchAvailableModels } = vi.hoisted(() => ({ mockFetchAvailableModels: vi.fn() }));
 
 vi.mock("../networking", () => ({
   modelAvailableCall: vi.fn().mockResolvedValue({ data: [] }),
 }));
 
 vi.mock("@/components/llm_calls/fetch_models", () => ({
-  fetchAvailableModels: vi.fn().mockResolvedValue([]),
+  fetchAvailableModels: mockFetchAvailableModels,
 }));
 
 vi.mock("./handle_add_auto_router_submit", () => ({
@@ -50,6 +78,11 @@ const Harness = () => <AddAutoRouterTab handleOk={vi.fn()} accessToken="token" u
 describe("AddAutoRouterTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // testQueryClient is a shared singleton with staleTime: Infinity, so cached model lists would
+    // otherwise bleed across tests (a later test reusing accessToken="token" would read an earlier
+    // test's data instead of its own mock).
+    testQueryClient.clear();
+    mockFetchAvailableModels.mockResolvedValue([]);
   });
 
   // Nothing is filled in, so there is nothing to submit. The button reports that itself instead of
@@ -230,6 +263,140 @@ describe("AddAutoRouterTab", () => {
     await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
     expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0].complexity_router_config).toMatchObject({
       session_affinity: true,
+    });
+  });
+
+  describe("template presets", () => {
+    // Opens the dropdown once, then waits out the useQuery load: an open antd Select re-renders its
+    // already-mounted options in place as state changes, so polling only re-reads the DOM here.
+    // Re-firing the open/close mousedown on every poll (calling openTemplateDropdown inside the
+    // waitFor callback) fights the dropdown's own open/close animation and hangs the test.
+    const waitForPresetEnabled = async (label: string) => {
+      openTemplateDropdown();
+      await waitFor(() => {
+        expect(isOptionDisabled(optionByLabel(label)!)).toBe(false);
+      });
+    };
+
+    it("disables every preset while the model list is loading", async () => {
+      let resolveModels: (models: ModelGroup[]) => void = () => {};
+      mockFetchAvailableModels.mockImplementation(
+        () =>
+          new Promise<ModelGroup[]>((resolve) => {
+            resolveModels = resolve;
+          }),
+      );
+
+      renderWithProviders(<Harness />);
+      openTemplateDropdown();
+
+      const anthropicOption = optionByLabel("Anthropic Family")!;
+      expect(isOptionDisabled(anthropicOption)).toBe(true);
+      expect(anthropicOption.textContent).toContain("Checking model availability");
+
+      // The dropdown is already open from above; polling re-reads its options in place rather than
+      // reopening (openTemplateDropdown toggles, so a second call here would close it instead).
+      resolveModels(ALL_FAMILY_MODELS);
+      await waitFor(() => {
+        expect(isOptionDisabled(optionByLabel("Anthropic Family")!)).toBe(false);
+      });
+    });
+
+    it("disables every preset and offers a retry when the model list fails to load", async () => {
+      mockFetchAvailableModels.mockRejectedValue(new Error("network error"));
+
+      renderWithProviders(<Harness />);
+
+      expect(await screen.findByText("Could not load available models.")).toBeInTheDocument();
+      openTemplateDropdown();
+      const anthropicOption = optionByLabel("Anthropic Family")!;
+      expect(isOptionDisabled(anthropicOption)).toBe(true);
+      expect(anthropicOption.textContent).toContain("Cannot verify these models are available");
+    });
+
+    it("disables a preset missing one of its models, naming the missing model", async () => {
+      mockFetchAvailableModels.mockResolvedValue(ALL_FAMILY_MODELS.filter((m) => m.model_group !== "claude-opus-5"));
+
+      renderWithProviders(<Harness />);
+      openTemplateDropdown();
+
+      await waitFor(() => {
+        expect(optionByLabel("Anthropic Family")!.textContent).toContain("Missing: claude-opus-5");
+      });
+      expect(isOptionDisabled(optionByLabel("Anthropic Family")!)).toBe(true);
+    });
+
+    it("enables a preset once every model it needs is available", async () => {
+      mockFetchAvailableModels.mockResolvedValue(ALL_FAMILY_MODELS);
+
+      renderWithProviders(<Harness />);
+
+      await waitForPresetEnabled("Anthropic Family");
+      await waitForPresetEnabled("OpenAI Family");
+    });
+
+    it("collapses detailed configuration and shows a tier summary once a preset is applied", async () => {
+      mockFetchAvailableModels.mockResolvedValue(ALL_FAMILY_MODELS);
+      renderWithProviders(<Harness />);
+      await waitForPresetEnabled("Anthropic Family");
+
+      fireEvent.click(optionByLabel("Anthropic Family")!);
+
+      expect(screen.queryByText("Advanced: Keyword/Semantic Matching")).not.toBeInTheDocument();
+      expect(
+        screen.getByText(
+          "Simple: claude-haiku-4-5 · Medium: claude-sonnet-4-5 · Complex: claude-opus-5 · Reasoning: claude-opus-5",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("expands detailed configuration when Custom Configuration is chosen", () => {
+      renderWithProviders(<Harness />);
+      openTemplateDropdown();
+
+      fireEvent.click(optionByLabel("Custom Configuration")!);
+
+      expect(screen.getByText("Advanced: Keyword/Semantic Matching")).toBeInTheDocument();
+    });
+
+    it("lets a caller manually re-expand a detailed configuration a preset just collapsed", async () => {
+      mockFetchAvailableModels.mockResolvedValue(ALL_FAMILY_MODELS);
+      renderWithProviders(<Harness />);
+      await waitForPresetEnabled("Anthropic Family");
+      fireEvent.click(optionByLabel("Anthropic Family")!);
+      expect(screen.queryByText("Advanced: Keyword/Semantic Matching")).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId("detailed-configuration-toggle"));
+
+      expect(screen.getByText("Advanced: Keyword/Semantic Matching")).toBeInTheDocument();
+    });
+
+    // This is the regression test for the whole feature: if handlePresetChange stopped prefilling
+    // complexityRouterConfig, the real (unmocked here) getMissingTiersError would block the submit
+    // and handleAddAutoRouterSubmit would never be called.
+    it("carries a selected preset's tiers through to the create payload", async () => {
+      const user = userEvent.setup();
+      mockFetchAvailableModels.mockResolvedValue(ALL_FAMILY_MODELS);
+
+      renderWithProviders(<Harness />);
+      await waitForPresetEnabled("Anthropic Family");
+      fireEvent.click(optionByLabel("Anthropic Family")!);
+
+      await user.type(screen.getByPlaceholderText(/smart_router/i), "anthropic-router");
+      await user.click(screen.getByRole("button", { name: /add auto router/i }));
+
+      await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
+      expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0]).toMatchObject({
+        auto_router_default_model: "claude-sonnet-4-5",
+        complexity_router_config: {
+          tiers: {
+            SIMPLE: ["claude-haiku-4-5"],
+            MEDIUM: ["claude-sonnet-4-5"],
+            COMPLEX: ["claude-opus-5"],
+            REASONING: ["claude-opus-5"],
+          },
+        },
+      });
     });
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -23,6 +23,12 @@ const openTemplateDropdown = (): void => {
   fireEvent.mouseDown(screen.getByTestId("template-selector").querySelector(".ant-select-selector")!);
 };
 
+// Detailed Configuration is collapsed by default, so any test reaching into it (a tier select, an
+// "Advanced: ..." sub-section) has to open it first.
+const expandDetailedConfiguration = (): void => {
+  fireEvent.click(screen.getByTestId("detailed-configuration-toggle"));
+};
+
 // The rendered antd option whose text starts with a preset label. Matching on text (not role +
 // accessible name) sidesteps antd's list re-rendering options in place on every state change.
 const optionByLabel = (label: string): HTMLElement | undefined =>
@@ -83,6 +89,18 @@ describe("AddAutoRouterTab", () => {
     // test's data instead of its own mock).
     testQueryClient.clear();
     mockFetchAvailableModels.mockResolvedValue([]);
+  });
+
+  // Detailed Configuration starts collapsed so the modal opens onto just Name + Template; a caller
+  // opts into the full tier/classifier form rather than always seeing it up front.
+  it("keeps Detailed Configuration collapsed until a caller opens it", () => {
+    renderWithProviders(<Harness />);
+
+    expect(screen.queryByText("Complexity Tier Configuration")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("detailed-configuration-toggle"));
+
+    expect(screen.getByText("Complexity Tier Configuration")).toBeInTheDocument();
   });
 
   // Nothing is filled in, so there is nothing to submit. The button reports that itself instead of
@@ -148,6 +166,7 @@ describe("AddAutoRouterTab", () => {
     renderWithProviders(<Harness />);
 
     await user.type(screen.getByPlaceholderText(/smart_router/i), "keyword-router");
+    expandDetailedConfiguration();
     await user.click(screen.getByText("Advanced: Keyword/Semantic Matching"));
     await user.click(screen.getByRole("button", { name: /add keyword rule/i }));
 
@@ -164,6 +183,7 @@ describe("AddAutoRouterTab", () => {
     renderWithProviders(<Harness />);
 
     await user.type(screen.getByPlaceholderText(/smart_router/i), "keyword-router");
+    expandDetailedConfiguration();
     await user.click(screen.getByText("Advanced: Keyword/Semantic Matching"));
     await user.click(screen.getByRole("button", { name: /add keyword rule/i }));
     expect(screen.getByRole("button", { name: /add auto router/i })).toBeDisabled();
@@ -184,6 +204,7 @@ describe("AddAutoRouterTab", () => {
     renderWithProviders(<Harness />);
 
     await user.type(screen.getByPlaceholderText(/smart_router/i), "keyword-router");
+    expandDetailedConfiguration();
     await user.click(screen.getByText("Advanced: Keyword/Semantic Matching"));
     await user.click(screen.getByRole("button", { name: /add keyword rule/i }));
     await user.type(
@@ -203,6 +224,7 @@ describe("AddAutoRouterTab", () => {
     renderWithProviders(<Harness />);
 
     await user.type(screen.getByPlaceholderText(/smart_router/i), "keyword-router");
+    expandDetailedConfiguration();
     await user.click(screen.getByText("Advanced: Keyword/Semantic Matching"));
     await user.click(screen.getByRole("button", { name: /add keyword rule/i }));
     const keywordsField = screen.getByText("Keywords 1").closest("div") as HTMLElement;
@@ -237,6 +259,7 @@ describe("AddAutoRouterTab", () => {
     renderWithProviders(<Harness />);
 
     await user.type(screen.getByPlaceholderText(/smart_router/i), "affinity-router");
+    expandDetailedConfiguration();
     await user.click(screen.getByText("Advanced: Session Affinity"));
     expect(await screen.findByRole("switch", { name: "Pin a session to its first model" })).not.toBeChecked();
 
@@ -255,6 +278,7 @@ describe("AddAutoRouterTab", () => {
     renderWithProviders(<Harness />);
 
     await user.type(screen.getByPlaceholderText(/smart_router/i), "affinity-router");
+    expandDetailedConfiguration();
     await user.click(screen.getByText("Advanced: Session Affinity"));
     await user.click(await screen.findByRole("switch", { name: "Pin a session to its first model" }));
 

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -435,5 +435,35 @@ describe("AddAutoRouterTab", () => {
         },
       });
     });
+
+    // Bugbot-found bug: submitBlockedReason disables the button for this, but Form's onFinish
+    // (wired to the same handler as the button) fires whenever the form itself is submitted,
+    // independent of the button's own disabled state. Without submitRecommendedRouter re-checking
+    // it, a real form submission (e.g. Enter, in browsers where that's implicit for this form)
+    // could still create a router referencing a model no longer in availableModelSet.
+    it("blocks a form submit when a referenced model disappears after the tiers are filled in", async () => {
+      mockFetchAvailableModels.mockResolvedValue(ALL_FAMILY_MODELS);
+
+      const { container } = renderWithProviders(<Harness />);
+      await waitForPresetEnabled("Anthropic Family");
+      fireEvent.click(optionByLabel("Anthropic Family")!);
+      fireEvent.change(screen.getByPlaceholderText(/smart_router/i), { target: { value: "stale-model-router" } });
+      expect(screen.getByRole("button", { name: /add auto router/i })).toBeEnabled();
+
+      // The model list changed after the tiers were filled in (e.g. a deployment removed
+      // elsewhere) - update the query cache directly rather than a real refetch, since that's the
+      // one thing under test, not how the data arrived. Waiting for the button to actually reflect
+      // the disabled state confirms the re-render (and availableModelSet) has settled before the
+      // form submits, the same way a real user's next interaction would only happen after that.
+      testQueryClient.setQueryData(["availableModels", "autoRouter", "token"], []);
+      await waitFor(() => expect(screen.getByRole("button", { name: /add auto router/i })).toBeDisabled());
+
+      fireEvent.submit(container.querySelector("form")!);
+
+      await waitFor(() =>
+        expect(NotificationManager.fromBackend).toHaveBeenCalledWith(expect.stringContaining("no longer available")),
+      );
+      expect(handleAddAutoRouterSubmit).not.toHaveBeenCalled();
+    });
   });
 });

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -290,6 +290,19 @@ describe("AddAutoRouterTab", () => {
     });
   });
 
+  // Custom is the escape hatch, not the headline choice, so it's listed after every bundled preset
+  // rather than first.
+  it("lists Custom Configuration after the bundled presets", () => {
+    renderWithProviders(<Harness />);
+    openTemplateDropdown();
+
+    const labels = Array.from(document.querySelectorAll<HTMLElement>(".ant-select-item-option")).map(
+      (option) => option.querySelector(".font-medium")?.textContent,
+    );
+
+    expect(labels).toEqual(["Anthropic Family", "OpenAI Family", "Custom Configuration"]);
+  });
+
   describe("template presets", () => {
     // Opens the dropdown once, then waits out the useQuery load: an open antd Select re-renders its
     // already-mounted options in place as state changes, so polling only re-reads the DOM here.

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -76,6 +76,10 @@ const presetDisabledHint = (availability: PresetAvailability): string | null => 
 // caller-specific missing-model reason gets the alarming red treatment.
 const isPresetHintAlarming = (availability: PresetAvailability): boolean => availability.kind === "missing_models";
 
+// getAllPresets() already returns a stable, module-level array (see autorouter_presets.ts), so
+// this is resolved once at import time rather than re-called from inside the component every render.
+const presets = getAllPresets();
+
 // A one-line summary of what's configured, shown when the detailed section is collapsed so a
 // caller can see the shape of the config without opening it.
 const tierConfigSummary = (tiers: ComplexityTiers): string => {
@@ -159,7 +163,6 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   }));
 
   const availableModelSet = React.useMemo(() => new Set(modelInfo.map((m) => m.model_group)), [modelInfo]);
-  const presets = getAllPresets();
 
   // A preset's models can only be trusted against a successfully loaded list. Selection and the
   // greyed-out state derive from this one function, so a preset that cannot be selected can never

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -203,7 +203,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     if (!preset || presetAvailability(preset).kind !== "available") return;
 
     setSelectedPreset(presetKey);
-    applyPrefill(buildPresetPrefill(preset.complexity_router_config));
+    applyPrefill(buildPresetPrefill(preset.complexity_router_config, availableModelSet));
     setDetailsExpanded(false);
   };
 

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -1,14 +1,17 @@
 import React, { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { Card, Form, Button, Tooltip, Typography, Select as AntdSelect, Modal } from "antd";
+import { DownOutlined, RightOutlined } from "@ant-design/icons";
 import { TextInput } from "@tremor/react";
 import { modelAvailableCall } from "../networking";
 import { all_admin_roles } from "@/utils/roles";
 import { type ModelWriteScope } from "@/utils/modelPermissions";
 import TeamDropdown from "../common_components/team_dropdown";
 import { handleAddAutoRouterSubmit } from "./handle_add_auto_router_submit";
-import { fetchAvailableModels, ModelGroup } from "@/components/llm_calls/fetch_models";
+import { fetchAvailableModels } from "@/components/llm_calls/fetch_models";
 import ComplexityRouterConfig, {
   ComplexityRouterConfigValue,
+  ComplexityTiers,
   DEFAULT_ADAPTIVE_WEIGHTS,
   DEFAULT_SESSION_AFFINITY,
   DEFAULT_TIER_DISTANCE_PENALTY,
@@ -25,6 +28,16 @@ import {
 import { buildAutoRouterTestTargets, AutoRouterTestTarget } from "./build_auto_router_test_targets";
 import AutoRouterConnectionTest from "./auto_router_connection_test";
 import NotificationManager from "../molecules/notifications_manager";
+import {
+  getAllPresets,
+  getPresetByKey,
+  getMissingModelsInPreset,
+  getReferencedModelsError,
+  buildEmptyPrefill,
+  buildPresetPrefill,
+  PresetPrefill,
+  AutoRouterPreset,
+} from "@/lib/autorouter_presets";
 
 interface AddAutoRouterTabProps {
   handleOk: () => void;
@@ -38,7 +51,46 @@ interface AddAutoRouterTabProps {
   createScope?: ModelWriteScope;
 }
 
-const { Title } = Typography;
+type PresetAvailability =
+  | { kind: "available" }
+  | { kind: "loading" }
+  | { kind: "unverifiable" }
+  | { kind: "missing_models"; models: readonly string[] };
+
+// Every non-"available" state disables the option. Selection derives from this same function
+// (see presetAvailability below), so an option a caller can click is always one that can be applied.
+const presetDisabledHint = (availability: PresetAvailability): string | null => {
+  switch (availability.kind) {
+    case "available":
+      return null;
+    case "loading":
+      return "Checking model availability...";
+    case "unverifiable":
+      return "Cannot verify these models are available";
+    case "missing_models":
+      return `Missing: ${availability.models.join(", ")}`;
+  }
+};
+
+// "loading"/"unverifiable" are transient system states, not a gap specific to this preset; only a
+// caller-specific missing-model reason gets the alarming red treatment.
+const isPresetHintAlarming = (availability: PresetAvailability): boolean => availability.kind === "missing_models";
+
+// A one-line summary of what's configured, shown when the detailed section is collapsed so a
+// caller can see the shape of the config without opening it.
+const tierConfigSummary = (tiers: ComplexityTiers): string => {
+  const parts = (
+    [
+      ["Simple", tiers.SIMPLE],
+      ["Medium", tiers.MEDIUM],
+      ["Complex", tiers.COMPLEX],
+      ["Reasoning", tiers.REASONING],
+    ] as const
+  )
+    .filter(([, models]) => models.length > 0)
+    .map(([label, models]) => `${label}: ${models.join(", ")}`);
+  return parts.length > 0 ? parts.join(" · ") : "No tiers configured yet";
+};
 
 const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   handleOk,
@@ -49,7 +101,6 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   const requiresTeamScope = createScope === "team-required";
   const [form] = Form.useForm();
   const [modelAccessGroups, setModelAccessGroups] = useState<string[]>([]);
-  const [modelInfo, setModelInfo] = useState<ModelGroup[]>([]);
 
   const [complexityRouterConfig, setComplexityRouterConfig] = useState<ComplexityRouterConfigValue>({
     tiers: { SIMPLE: [], MEDIUM: [], COMPLEX: [], REASONING: [] },
@@ -64,6 +115,13 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   const [escalationKeywords, setEscalationKeywords] = useState<string[]>(DEFAULT_ESCALATION_KEYWORDS);
   const [showValidationErrors, setShowValidationErrors] = useState<boolean>(false);
 
+  const [selectedPreset, setSelectedPreset] = useState<string | undefined>(undefined);
+  // Collapsed after a preset prefills the config (nothing to fill in yet), expanded for Custom or
+  // before any template is chosen (there's nothing prefilled to hide). A caller can always toggle
+  // it manually; selecting a preset re-collapses it, offering the same "here's what got filled in"
+  // affordance for whichever preset was just applied.
+  const [detailsExpanded, setDetailsExpanded] = useState<boolean>(true);
+
   const [isTestModalVisible, setIsTestModalVisible] = useState<boolean>(false);
   const [isTestingConnection, setIsTestingConnection] = useState<boolean>(false);
   const [connectionTestId, setConnectionTestId] = useState<number>(0);
@@ -77,17 +135,21 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     fetchModelAccessGroups();
   }, [accessToken]);
 
-  useEffect(() => {
-    const loadModels = async () => {
-      try {
-        const uniqueModels = await fetchAvailableModels(accessToken);
-        setModelInfo(uniqueModels);
-      } catch (error) {
-        console.error("Error fetching model info for auto router:", error);
-      }
-    };
-    loadModels();
-  }, [accessToken]);
+  const {
+    data,
+    isLoading: modelsLoading,
+    isError: modelsError,
+    refetch: refetchModels,
+  } = useQuery({
+    queryKey: ["availableModels", "autoRouter", accessToken],
+    queryFn: () => fetchAvailableModels(accessToken),
+    enabled: Boolean(accessToken),
+  });
+  const modelInfo = React.useMemo(() => data ?? [], [data]);
+  // react-query keeps the last successful list around when a later refetch fails, so isError alone
+  // can't tell "never loaded" apart from "loaded, then a background refetch errored" - only the
+  // former leaves us with nothing trustworthy to verify a preset's models against.
+  const modelsUnverifiable = modelsError && data === undefined;
 
   const isAdmin = all_admin_roles.includes(userRole);
 
@@ -96,10 +158,65 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
     label: model_group,
   }));
 
+  const availableModelSet = React.useMemo(() => new Set(modelInfo.map((m) => m.model_group)), [modelInfo]);
+  const presets = React.useMemo(() => getAllPresets(), []);
+
+  // A preset's models can only be trusted against a successfully loaded list. Selection and the
+  // greyed-out state derive from this one function, so a preset that cannot be selected can never
+  // have been applied: while loading we withhold selection rather than let a caller pick a preset
+  // whose models we cannot yet verify, and a failed fetch leaves every preset unverifiable. This
+  // makes the load-race (pick during loading, then discover a missing model) unrepresentable.
+  const presetAvailability = (preset: AutoRouterPreset): PresetAvailability => {
+    if (modelsLoading) return { kind: "loading" };
+    if (modelsUnverifiable) return { kind: "unverifiable" };
+    const missing = getMissingModelsInPreset(preset, availableModelSet);
+    return missing.length > 0 ? { kind: "missing_models", models: missing } : { kind: "available" };
+  };
+
+  const applyPrefill = (prefill: PresetPrefill) => {
+    setComplexityRouterConfig(prefill.complexityRouterConfig);
+    setCustomTechnicalKeywords(prefill.customTechnicalKeywords);
+    setKeywordTierRules(prefill.keywordTierRules);
+    setSemanticMatchingEnabled(prefill.semanticMatchingEnabled);
+    setEmbeddingModel(prefill.embeddingModel);
+    setMatchThreshold(prefill.matchThreshold);
+    setEscalationKeywords(prefill.escalationKeywords);
+  };
+
+  const handlePresetChange = (presetKey: string | undefined) => {
+    if (!presetKey || presetKey === "custom") {
+      setSelectedPreset(presetKey);
+      applyPrefill(buildEmptyPrefill());
+      setDetailsExpanded(true);
+      return;
+    }
+
+    const preset = getPresetByKey(presetKey);
+    // Refuse to apply a preset whose models are not verified available. The dropdown disables
+    // these options, so this is a guard against a stale click resolving after the list changed.
+    if (!preset || presetAvailability(preset).kind !== "available") return;
+
+    setSelectedPreset(presetKey);
+    applyPrefill(buildPresetPrefill(preset.complexity_router_config));
+    setDetailsExpanded(false);
+  };
+
+  const referencedModelsParams = {
+    tiers: complexityRouterConfig.tiers,
+    classifierType: complexityRouterConfig.classifier_type,
+    classifierLlmConfig: complexityRouterConfig.classifier_llm_config,
+    semanticMatchingEnabled,
+    embeddingModel,
+  };
+
   // Why the submit is unavailable, or null when it is available. The button reads this to disable
-  // itself and to say what is missing, so the two can never give different answers.
+  // itself and to say what is missing, so the two can never give different answers. Checks the
+  // config actually being built, not which preset (if any) it came from: a preset only ever
+  // prefills once (handlePresetChange), and everything after that is edited exactly like Custom.
   const submitBlockedReason =
-    getMissingTiersError(complexityRouterConfig.tiers) ?? getKeywordTierRulesError(keywordTierRules);
+    getMissingTiersError(complexityRouterConfig.tiers) ??
+    getKeywordTierRulesError(keywordTierRules) ??
+    getReferencedModelsError(referencedModelsParams, availableModelSet);
 
   const submitRecommendedRouter = (name: string) => {
     const {
@@ -245,6 +362,55 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
             <TextInput placeholder="e.g., smart_router, auto_router_1" />
           </Form.Item>
 
+          <div className="mb-6">
+            <label className="block text-sm font-medium text-gray-900 mb-2">Template</label>
+            <AntdSelect
+              value={selectedPreset}
+              onChange={handlePresetChange}
+              placeholder="Choose a template or select Custom to define your own"
+              className="w-full"
+              optionLabelProp="label"
+              data-testid="template-selector"
+            >
+              <AntdSelect.Option value="custom" label="Custom Configuration">
+                <div>
+                  <div className="font-medium">Custom Configuration</div>
+                  <div className="text-xs text-gray-500">Define your auto router from scratch</div>
+                </div>
+              </AntdSelect.Option>
+              {presets.map((preset) => {
+                const availability = presetAvailability(preset);
+                const disabledHint = presetDisabledHint(availability);
+                const isDisabled = disabledHint !== null;
+                const hintClass = isPresetHintAlarming(availability) ? "text-red-500" : "text-gray-400";
+
+                return (
+                  <AntdSelect.Option
+                    key={preset.key}
+                    value={preset.key}
+                    label={preset.label}
+                    disabled={isDisabled}
+                    title={disabledHint ?? preset.description}
+                  >
+                    <div>
+                      <div className="font-medium">{preset.label}</div>
+                      <div className="text-xs text-gray-500">{preset.description}</div>
+                      {disabledHint && <div className={`text-xs mt-1 ${hintClass}`}>{disabledHint}</div>}
+                    </div>
+                  </AntdSelect.Option>
+                );
+              })}
+            </AntdSelect>
+            {modelsUnverifiable && (
+              <div className="text-xs mt-1 text-red-500">
+                Could not load available models.{" "}
+                <button type="button" className="underline" onClick={() => refetchModels()}>
+                  Retry
+                </button>
+              </div>
+            )}
+          </div>
+
           {requiresTeamScope && (
             <Form.Item
               label="Select Team"
@@ -258,31 +424,49 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
             </Form.Item>
           )}
 
-          <div className="w-full mb-4">
-            <ComplexityRouterConfig
-              modelInfo={modelInfo}
-              value={complexityRouterConfig}
-              onChange={setComplexityRouterConfig}
-              customTechnicalKeywords={customTechnicalKeywords}
-              onCustomTechnicalKeywordsChange={setCustomTechnicalKeywords}
-              keywordTierRules={keywordTierRules}
-              onKeywordTierRulesChange={setKeywordTierRules}
-              semanticMatchingEnabled={semanticMatchingEnabled}
-              onSemanticMatchingEnabledChange={setSemanticMatchingEnabled}
-              embeddingModel={embeddingModel}
-              onEmbeddingModelChange={setEmbeddingModel}
-              matchThreshold={matchThreshold}
-              onMatchThresholdChange={setMatchThreshold}
-              escalationKeywords={escalationKeywords}
-              onEscalationKeywordsChange={setEscalationKeywords}
-              showValidationErrors={showValidationErrors}
-            />
-          </div>
-
-          <div className="flex items-center my-4">
-            <div className="grow border-t border-gray-200"></div>
-            <span className="px-4 text-gray-500 text-sm">Additional Settings</span>
-            <div className="grow border-t border-gray-200"></div>
+          <div className="border border-gray-200 rounded-lg mb-4">
+            <button
+              type="button"
+              onClick={() => setDetailsExpanded((expanded) => !expanded)}
+              className="w-full flex items-center justify-between gap-2 px-4 py-3 text-left hover:bg-gray-50"
+              data-testid="detailed-configuration-toggle"
+            >
+              <span className="flex items-center gap-2 font-medium text-gray-900">
+                {detailsExpanded ? (
+                  <DownOutlined className="text-xs text-gray-500" />
+                ) : (
+                  <RightOutlined className="text-xs text-gray-500" />
+                )}
+                Detailed Configuration
+              </span>
+              {!detailsExpanded && (
+                <span className="text-xs text-gray-500 truncate">
+                  {tierConfigSummary(complexityRouterConfig.tiers)}
+                </span>
+              )}
+            </button>
+            {detailsExpanded && (
+              <div className="px-4 pb-4">
+                <ComplexityRouterConfig
+                  modelInfo={modelInfo}
+                  value={complexityRouterConfig}
+                  onChange={setComplexityRouterConfig}
+                  customTechnicalKeywords={customTechnicalKeywords}
+                  onCustomTechnicalKeywordsChange={setCustomTechnicalKeywords}
+                  keywordTierRules={keywordTierRules}
+                  onKeywordTierRulesChange={setKeywordTierRules}
+                  semanticMatchingEnabled={semanticMatchingEnabled}
+                  onSemanticMatchingEnabledChange={setSemanticMatchingEnabled}
+                  embeddingModel={embeddingModel}
+                  onEmbeddingModelChange={setEmbeddingModel}
+                  matchThreshold={matchThreshold}
+                  onMatchThresholdChange={setMatchThreshold}
+                  escalationKeywords={escalationKeywords}
+                  onEscalationKeywordsChange={setEscalationKeywords}
+                  showValidationErrors={showValidationErrors}
+                />
+              </div>
+            )}
           </div>
 
           {/* Model Access Groups - Admin only */}

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -120,11 +120,11 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   const [showValidationErrors, setShowValidationErrors] = useState<boolean>(false);
 
   const [selectedPreset, setSelectedPreset] = useState<string | undefined>(undefined);
-  // Collapsed after a preset prefills the config (nothing to fill in yet), expanded for Custom or
-  // before any template is chosen (there's nothing prefilled to hide). A caller can always toggle
-  // it manually; selecting a preset re-collapses it, offering the same "here's what got filled in"
-  // affordance for whichever preset was just applied.
-  const [detailsExpanded, setDetailsExpanded] = useState<boolean>(true);
+  // Closed by default: a caller opens it deliberately, either by clicking it or by choosing Custom
+  // (which expands it automatically, since there's nothing else to show them their config from). A
+  // preset re-collapses it after prefilling, offering the same "here's what got filled in, expand to
+  // change it" affordance. A caller can always toggle it manually at any point.
+  const [detailsExpanded, setDetailsExpanded] = useState<boolean>(false);
 
   const [isTestModalVisible, setIsTestModalVisible] = useState<boolean>(false);
   const [isTestingConnection, setIsTestingConnection] = useState<boolean>(false);

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -159,7 +159,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   }));
 
   const availableModelSet = React.useMemo(() => new Set(modelInfo.map((m) => m.model_group)), [modelInfo]);
-  const presets = React.useMemo(() => getAllPresets(), []);
+  const presets = getAllPresets();
 
   // A preset's models can only be trusted against a successfully loaded list. Selection and the
   // greyed-out state derive from this one function, so a preset that cannot be selected can never

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -166,12 +166,15 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
   // have been applied: while loading we withhold selection rather than let a caller pick a preset
   // whose models we cannot yet verify, and a failed fetch leaves every preset unverifiable. This
   // makes the load-race (pick during loading, then discover a missing model) unrepresentable.
-  const presetAvailability = (preset: AutoRouterPreset): PresetAvailability => {
-    if (modelsLoading) return { kind: "loading" };
-    if (modelsUnverifiable) return { kind: "unverifiable" };
-    const missing = getMissingModelsInPreset(preset, availableModelSet);
-    return missing.length > 0 ? { kind: "missing_models", models: missing } : { kind: "available" };
-  };
+  const presetAvailability = React.useCallback(
+    (preset: AutoRouterPreset): PresetAvailability => {
+      if (modelsLoading) return { kind: "loading" };
+      if (modelsUnverifiable) return { kind: "unverifiable" };
+      const missing = getMissingModelsInPreset(preset, availableModelSet);
+      return missing.length > 0 ? { kind: "missing_models", models: missing } : { kind: "available" };
+    },
+    [modelsLoading, modelsUnverifiable, availableModelSet],
+  );
 
   const applyPrefill = (prefill: PresetPrefill) => {
     setComplexityRouterConfig(prefill.complexityRouterConfig);

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -378,12 +378,6 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
               optionLabelProp="label"
               data-testid="template-selector"
             >
-              <AntdSelect.Option value="custom" label="Custom Configuration">
-                <div>
-                  <div className="font-medium">Custom Configuration</div>
-                  <div className="text-xs text-gray-500">Define your auto router from scratch</div>
-                </div>
-              </AntdSelect.Option>
               {presets.map((preset) => {
                 const availability = presetAvailability(preset);
                 const disabledHint = presetDisabledHint(availability);
@@ -406,6 +400,12 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                   </AntdSelect.Option>
                 );
               })}
+              <AntdSelect.Option value="custom" label="Custom Configuration">
+                <div>
+                  <div className="font-medium">Custom Configuration</div>
+                  <div className="text-xs text-gray-500">Define your auto router from scratch</div>
+                </div>
+              </AntdSelect.Option>
             </AntdSelect>
             {modelsUnverifiable && (
               <div className="text-xs mt-1 text-red-500">
@@ -434,7 +434,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
             <button
               type="button"
               onClick={() => setDetailsExpanded((expanded) => !expanded)}
-              className="w-full flex items-center justify-between gap-2 px-4 py-3 text-left hover:bg-gray-50"
+              className="w-full flex flex-col gap-1 px-4 py-3 text-left hover:bg-gray-50"
               data-testid="detailed-configuration-toggle"
             >
               <span className="flex items-center gap-2 font-medium text-gray-900">
@@ -446,7 +446,7 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
                 Detailed Configuration
               </span>
               {!detailsExpanded && (
-                <span className="text-xs text-gray-500 truncate">
+                <span className="text-xs text-gray-500 line-clamp-2">
                   {tierConfigSummary(complexityRouterConfig.tiers)}
                 </span>
               )}

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.tsx
@@ -267,6 +267,17 @@ const AddAutoRouterTab: React.FC<AddAutoRouterTabProps> = ({
       return;
     }
 
+    // submitBlockedReason already disables the button for this, but Form's onFinish (wired to this
+    // same handler) fires on Enter regardless of the button's disabled state - without this check,
+    // Enter in the name field could still create a router referencing a model that disappeared from
+    // availableModelSet after the tiers were filled in.
+    const referencedModelsError = getReferencedModelsError(referencedModelsParams, availableModelSet);
+    if (referencedModelsError) {
+      setShowValidationErrors(true);
+      NotificationManager.fromBackend(referencedModelsError);
+      return;
+    }
+
     const defaultModel = tiers.MEDIUM[0] || tiers.SIMPLE[0] || tiers.COMPLEX[0] || tiers.REASONING[0];
 
     form.setFieldsValue({

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import {
+  getAllPresets,
+  getPresetByKey,
+  getRequiredModelsInPreset,
+  getMissingModelsInPreset,
+  getRequiredModels,
+  getReferencedModelsError,
+  buildEmptyPrefill,
+  buildPresetPrefill,
+} from "./autorouter_presets";
+import { DEFAULT_MATCH_THRESHOLD } from "@/components/add_model/SemanticKeywordMatching";
+import { DEFAULT_ESCALATION_KEYWORDS } from "@/components/add_model/EscalationKeywords";
+
+describe("autorouter_presets", () => {
+  it("loads exactly the two model-family presets", () => {
+    const presets = getAllPresets();
+    expect(presets.map((p) => p.label).sort()).toEqual(["Anthropic Family", "OpenAI Family"]);
+    // Every preset carries all four fields the UI relies on; a JSON typo dropping one fails here.
+    for (const p of presets) {
+      expect(p).toMatchObject({ key: expect.any(String), label: expect.any(String), description: expect.any(String) });
+      expect(p.complexity_router_config.tiers).toBeTruthy();
+    }
+  });
+
+  it("resolves a preset by its stable JSON key, not its display label", () => {
+    expect(getPresetByKey("anthropic_family")?.label).toBe("Anthropic Family");
+    expect(getPresetByKey("does_not_exist")).toBeUndefined();
+  });
+
+  it("keeps every preset a plain heuristic complexity router (no adaptive/quality settings)", () => {
+    for (const { complexity_router_config: config } of getAllPresets()) {
+      expect(config.classifier_type).toBe("heuristic");
+      expect(config.adaptive).toBeUndefined();
+      expect(config.adaptive_weights).toBeUndefined();
+      expect(config.adaptive_eligible).toBeUndefined();
+      expect(config.tier_distance_penalty).toBeUndefined();
+    }
+  });
+
+  it("collects every tier model as a required model", () => {
+    const preset = getPresetByKey("anthropic_family")!;
+    const required = getRequiredModelsInPreset(preset);
+    const tierModels = Object.values(preset.complexity_router_config.tiers).flat();
+    expect(tierModels.length).toBeGreaterThan(0);
+    for (const model of tierModels) expect(required.has(model)).toBe(true);
+  });
+
+  it("reports only the models the caller is missing, and none when the family is fully available", () => {
+    const preset = getPresetByKey("openai_family")!;
+    const required = [...getRequiredModelsInPreset(preset)];
+
+    expect(getMissingModelsInPreset(preset, new Set(["gpt-5-nano"]))).toEqual(
+      required.filter((m) => m !== "gpt-5-nano").sort(),
+    );
+    expect(getMissingModelsInPreset(preset, new Set(required))).toEqual([]);
+  });
+
+  // A classifier_llm_config placeholder is seeded with model: "" before a caller picks one; an
+  // empty string is not a real model reference and must not be reported as an unavailable model.
+  it("does not treat an empty-string classifier or embedding model as a required model", () => {
+    const required = getRequiredModels({
+      tiers: { SIMPLE: ["gpt-5-nano"], MEDIUM: [], COMPLEX: [], REASONING: [] },
+      classifier_llm_config: { model: "", timeout_ms: 5000 },
+      embedding_model: "",
+    });
+    expect(required).toEqual(new Set(["gpt-5-nano"]));
+  });
+
+  describe("getReferencedModelsError", () => {
+    const tiers = { SIMPLE: ["gpt-5-nano"], MEDIUM: [], COMPLEX: [], REASONING: [] };
+    const available = new Set(["gpt-5-nano"]);
+    // Both fields are always populated with a model missing from `available`; only the
+    // enabled/disabled toggles below decide whether that missing model gets reported.
+    const params = {
+      classifierLlmConfig: { model: "missing-classifier", timeout_ms: 5000 },
+      embeddingModel: "missing-embed",
+    };
+
+    // Bugbot-found bug class from #35199's history: a classifier/embedding model left selected
+    // from a prior toggle must not block submit once that toggle is off again, since
+    // buildComplexityRouterConfig never emits the field in that state - only a model whose toggle
+    // is on should ever be reported.
+    it.each([
+      ["both toggles off", "heuristic", false, null],
+      ["classifier type llm, semantic matching off", "llm", false, "missing-classifier"],
+      ["classifier type heuristic, semantic matching on", "heuristic", true, "missing-embed"],
+      ["both toggles on", "llm", true, "missing-classifier, missing-embed"],
+    ] as const)("%s", (_label, classifierType, semanticMatchingEnabled, missingModels) => {
+      const config = { tiers, classifierType, semanticMatchingEnabled, ...params };
+      const error = getReferencedModelsError(config, available);
+      expect(error).toBe(missingModels ? `Model(s) no longer available: ${missingModels}` : null);
+    });
+  });
+
+  describe("buildEmptyPrefill", () => {
+    it("resets every field to its default, empty state", () => {
+      const expected = {
+        complexityRouterConfig: {
+          tiers: { SIMPLE: [], MEDIUM: [], COMPLEX: [], REASONING: [] },
+          classifier_type: "heuristic",
+        },
+        customTechnicalKeywords: [],
+        keywordTierRules: [],
+        semanticMatchingEnabled: false,
+        embeddingModel: undefined,
+        matchThreshold: DEFAULT_MATCH_THRESHOLD,
+        escalationKeywords: DEFAULT_ESCALATION_KEYWORDS,
+      };
+      expect(buildEmptyPrefill()).toEqual(expected);
+    });
+  });
+
+  describe("buildPresetPrefill", () => {
+    it("prefills a real bundled preset's tiers into the config", () => {
+      const preset = getPresetByKey("anthropic_family")!;
+      const prefill = buildPresetPrefill(preset.complexity_router_config);
+      expect(prefill.complexityRouterConfig.tiers).toEqual(preset.complexity_router_config.tiers);
+    });
+
+    // `??`, not `||`: match_threshold: 0 and an empty escalation_keywords array are deliberate,
+    // falsy preset values. A prefill that used `||` would silently replace both with the default,
+    // which is exactly the kind of bug this test would have caught before either bundled preset
+    // happened to avoid the case.
+    it("keeps a preset's falsy match_threshold and escalation_keywords instead of defaulting them", () => {
+      const config = {
+        tiers: { SIMPLE: ["gpt-5-nano"], MEDIUM: [], COMPLEX: [], REASONING: [] },
+        classifier_type: "heuristic" as const,
+        session_affinity: false,
+        match_threshold: 0,
+        escalation_keywords: [],
+      };
+      const prefill = buildPresetPrefill(config);
+      expect(prefill.matchThreshold).toBe(0);
+      expect(prefill.escalationKeywords).toEqual([]);
+    });
+
+    it("falls back to the defaults when a preset omits match_threshold and escalation_keywords", () => {
+      const prefill = buildPresetPrefill({
+        tiers: { SIMPLE: ["gpt-5-nano"], MEDIUM: [], COMPLEX: [], REASONING: [] },
+        classifier_type: "heuristic",
+        session_affinity: false,
+      });
+      expect(prefill.matchThreshold).toBe(DEFAULT_MATCH_THRESHOLD);
+      expect(prefill.escalationKeywords).toEqual(DEFAULT_ESCALATION_KEYWORDS);
+    });
+  });
+});

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -5,6 +5,7 @@ import {
   getRequiredModelsInPreset,
   getMissingModelsInPreset,
   getRequiredModels,
+  getMissingModels,
   getReferencedModelsError,
   buildEmptyPrefill,
   buildPresetPrefill,
@@ -54,6 +55,24 @@ describe("autorouter_presets", () => {
       required.filter((m) => m !== "gpt-5-nano").sort(),
     );
     expect(getMissingModelsInPreset(preset, new Set(required))).toEqual([]);
+  });
+
+  // Admins spell version numbers with either "-" or "." (claude-sonnet-4-5 vs claude-sonnet-4.5);
+  // a caller who only registered one form still satisfies a preset that names the other.
+  it("treats a preset's model as available under either version-separator spelling", () => {
+    const preset = getPresetByKey("anthropic_family")!;
+    expect(
+      getMissingModelsInPreset(preset, new Set(["claude-haiku-4.5", "claude-sonnet-4.5", "claude-opus-5"])),
+    ).toEqual([]);
+  });
+
+  // The two-arm mirror: a differently-punctuated preset model must not be reported missing.
+  it("does not flag a differently-punctuated model as missing via getMissingModels directly", () => {
+    const missing = getMissingModels(
+      { tiers: { SIMPLE: ["claude-sonnet-4-5"], MEDIUM: [], COMPLEX: [], REASONING: [] } },
+      new Set(["claude-sonnet-4.5"]),
+    );
+    expect(missing).toEqual([]);
   });
 
   // A classifier_llm_config placeholder is seeded with model: "" before a caller picks one; an
@@ -114,7 +133,7 @@ describe("autorouter_presets", () => {
   describe("buildPresetPrefill", () => {
     it("prefills a real bundled preset's tiers into the config", () => {
       const preset = getPresetByKey("anthropic_family")!;
-      const prefill = buildPresetPrefill(preset.complexity_router_config);
+      const prefill = buildPresetPrefill(preset.complexity_router_config, getRequiredModelsInPreset(preset));
       expect(prefill.complexityRouterConfig.tiers).toEqual(preset.complexity_router_config.tiers);
     });
 
@@ -130,19 +149,35 @@ describe("autorouter_presets", () => {
         match_threshold: 0,
         escalation_keywords: [],
       };
-      const prefill = buildPresetPrefill(config);
+      const prefill = buildPresetPrefill(config, new Set(["gpt-5-nano"]));
       expect(prefill.matchThreshold).toBe(0);
       expect(prefill.escalationKeywords).toEqual([]);
     });
 
     it("falls back to the defaults when a preset omits match_threshold and escalation_keywords", () => {
-      const prefill = buildPresetPrefill({
-        tiers: { SIMPLE: ["gpt-5-nano"], MEDIUM: [], COMPLEX: [], REASONING: [] },
-        classifier_type: "heuristic",
-        session_affinity: false,
-      });
+      const prefill = buildPresetPrefill(
+        {
+          tiers: { SIMPLE: ["gpt-5-nano"], MEDIUM: [], COMPLEX: [], REASONING: [] },
+          classifier_type: "heuristic",
+          session_affinity: false,
+        },
+        new Set(["gpt-5-nano"]),
+      );
       expect(prefill.matchThreshold).toBe(DEFAULT_MATCH_THRESHOLD);
       expect(prefill.escalationKeywords).toEqual(DEFAULT_ESCALATION_KEYWORDS);
+    });
+
+    // The whole point of the separator normalization: a caller whose proxy only registered the
+    // dotted form of a version number still gets that model written into the tier, not the
+    // preset's own hyphenated spelling (which the caller never actually registered).
+    it("rewrites a preset's model name to the caller's differently-punctuated registered spelling", () => {
+      const config = {
+        tiers: { SIMPLE: ["claude-sonnet-4-5"], MEDIUM: [], COMPLEX: [], REASONING: [] },
+        classifier_type: "heuristic" as const,
+        session_affinity: false,
+      };
+      const prefill = buildPresetPrefill(config, new Set(["claude-sonnet-4.5"]));
+      expect(prefill.complexityRouterConfig.tiers.SIMPLE).toEqual(["claude-sonnet-4.5"]);
     });
   });
 });

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.ts
@@ -45,10 +45,28 @@ export const getRequiredModels = (
   return new Set(models.filter((model): model is string => Boolean(model)));
 };
 
+// Admins spell version numbers inconsistently ("claude-sonnet-4-5" vs "claude-sonnet-4.5"), so a
+// preset's hardcoded name and a caller's registered one can refer to the same model while
+// differing only in that separator. Canonicalizing on "-" (the presets' own convention) lets both
+// spellings match without doing anything looser - two DIFFERENT model names never collide here,
+// only the punctuation within one version number does.
+const normalizeModelName = (model: string): string => model.replace(/(\d)\.(\d)/g, "$1-$2");
+
+// The caller's actual registered spelling for a required model, under either separator
+// convention, or undefined if truly absent. Preset prefill must write THIS spelling, not the
+// preset's literal string - otherwise a caller whose proxy only has the dotted form ends up with
+// a tier pointing at a model name that was never registered.
+const resolveAvailableModel = (requiredModel: string, availableModels: Set<string>): string | undefined => {
+  if (availableModels.has(requiredModel)) return requiredModel;
+  const normalized = normalizeModelName(requiredModel);
+  return Array.from(availableModels).find((available) => normalizeModelName(available) === normalized);
+};
+
 export const getMissingModels = (
   config: Pick<ComplexityRouterConfigPayload, "tiers" | "classifier_llm_config" | "embedding_model">,
   availableModels: Set<string>,
-): string[] => [...getRequiredModels(config)].filter((model) => !availableModels.has(model)).sort();
+): string[] =>
+  [...getRequiredModels(config)].filter((model) => resolveAvailableModel(model, availableModels) === undefined).sort();
 
 export const getRequiredModelsInPreset = (preset: AutoRouterPreset): Set<string> =>
   getRequiredModels(preset.complexity_router_config);
@@ -111,25 +129,47 @@ export const buildEmptyPrefill = (): PresetPrefill => ({
 
 // `??`, never `||`: a preset's match_threshold: 0 or escalation_keywords: [] is a deliberate,
 // falsy value that must survive the prefill, not get silently replaced by the default.
-export const buildPresetPrefill = (config: ComplexityRouterConfigPayload): PresetPrefill => ({
-  complexityRouterConfig: {
-    tiers: config.tiers,
-    classifier_type: config.classifier_type,
-    classifier_llm_config: config.classifier_llm_config,
-    classifier_context_window_size: config.classifier_context_window_size,
-    classifier_context_per_turn_chars: config.classifier_context_per_turn_chars,
-    classifier_context_include_assistant_turns: config.classifier_context_include_assistant_turns,
-    session_affinity: config.session_affinity ?? DEFAULT_SESSION_AFFINITY,
-    adaptive: config.adaptive,
-    adaptive_weights: config.adaptive_weights,
-    tier_distance_penalty: config.tier_distance_penalty,
-    adaptive_eligible: config.adaptive_eligible,
-    return_raw_model_name: config.return_raw_model_name,
-  },
-  customTechnicalKeywords: config.custom_technical_keywords ?? [],
-  keywordTierRules: hydrateKeywordTierRules(config.keyword_tier_rules ?? []),
-  semanticMatchingEnabled: config.semantic_keyword_matching ?? false,
-  embeddingModel: config.embedding_model,
-  matchThreshold: config.match_threshold ?? DEFAULT_MATCH_THRESHOLD,
-  escalationKeywords: config.escalation_keywords ?? DEFAULT_ESCALATION_KEYWORDS,
-});
+//
+// `availableModels` is required, not optional: every model reference gets rewritten to the
+// caller's actual registered spelling (resolveAvailableModel), which may differ from the preset's
+// literal string by version-separator punctuation alone. Called only after presetAvailability has
+// already confirmed every required model resolves, so falling back to the preset's own string
+// when a model somehow doesn't resolve is unreachable in practice, not a silent-failure path.
+export const buildPresetPrefill = (
+  config: ComplexityRouterConfigPayload,
+  availableModels: Set<string>,
+): PresetPrefill => {
+  const resolve = (model: string): string => resolveAvailableModel(model, availableModels) ?? model;
+  const resolveTier = (models: string[]): string[] => models.map(resolve);
+
+  return {
+    complexityRouterConfig: {
+      tiers: {
+        SIMPLE: resolveTier(config.tiers.SIMPLE),
+        MEDIUM: resolveTier(config.tiers.MEDIUM),
+        COMPLEX: resolveTier(config.tiers.COMPLEX),
+        REASONING: resolveTier(config.tiers.REASONING),
+      },
+      classifier_type: config.classifier_type,
+      classifier_llm_config: config.classifier_llm_config && {
+        ...config.classifier_llm_config,
+        model: resolve(config.classifier_llm_config.model),
+      },
+      classifier_context_window_size: config.classifier_context_window_size,
+      classifier_context_per_turn_chars: config.classifier_context_per_turn_chars,
+      classifier_context_include_assistant_turns: config.classifier_context_include_assistant_turns,
+      session_affinity: config.session_affinity ?? DEFAULT_SESSION_AFFINITY,
+      adaptive: config.adaptive,
+      adaptive_weights: config.adaptive_weights,
+      tier_distance_penalty: config.tier_distance_penalty,
+      adaptive_eligible: config.adaptive_eligible,
+      return_raw_model_name: config.return_raw_model_name,
+    },
+    customTechnicalKeywords: config.custom_technical_keywords ?? [],
+    keywordTierRules: hydrateKeywordTierRules(config.keyword_tier_rules ?? []),
+    semanticMatchingEnabled: config.semantic_keyword_matching ?? false,
+    embeddingModel: config.embedding_model && resolve(config.embedding_model),
+    matchThreshold: config.match_threshold ?? DEFAULT_MATCH_THRESHOLD,
+    escalationKeywords: config.escalation_keywords ?? DEFAULT_ESCALATION_KEYWORDS,
+  };
+};

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.ts
@@ -1,0 +1,135 @@
+import { ComplexityRouterConfigPayload } from "@/components/add_model/build_complexity_router_config";
+import {
+  ComplexityRouterConfigValue,
+  ComplexityTiers,
+  ClassifierType,
+  ClassifierLLMConfig,
+  DEFAULT_SESSION_AFFINITY,
+} from "@/components/add_model/ComplexityRouterConfig";
+import { KeywordTierRule } from "@/components/add_model/KeywordTierRules";
+import { hydrateKeywordTierRules } from "@/components/add_model/complexity_router_keywords";
+import { DEFAULT_ESCALATION_KEYWORDS } from "@/components/add_model/EscalationKeywords";
+import { DEFAULT_MATCH_THRESHOLD } from "@/components/add_model/SemanticKeywordMatching";
+import presetsRaw from "@/autorouter_presets.json";
+
+// `key` is the stable JSON object key (e.g. "anthropic_family"); `label` is display text and
+// never an identity.
+export interface AutoRouterPreset {
+  key: string;
+  label: string;
+  description: string;
+  complexity_router_config: ComplexityRouterConfigPayload;
+}
+
+// The bundled JSON is a developer-authored, build-time asset, so it is trusted at the import
+// boundary rather than re-validated at runtime (resolveJsonModule widens its string literals,
+// hence this one cast). autorouter_presets.test.ts pins the parsed shape, so a JSON typo fails CI.
+const RAW = presetsRaw as Record<string, Omit<AutoRouterPreset, "key">>;
+
+const PRESETS: AutoRouterPreset[] = Object.entries(RAW).map(([key, preset]) => ({ key, ...preset }));
+
+export const getAllPresets = (): AutoRouterPreset[] => PRESETS;
+
+export const getPresetByKey = (key: string): AutoRouterPreset | undefined => PRESETS.find((p) => p.key === key);
+
+// Generalized over ComplexityRouterConfigPayload so the same accessors check either a preset's own
+// bundled config or a caller's actually-built config - the two need to agree, since a preset only
+// prefills once and the config is edited freely after (see AddAutoRouterTab.submitBlockedReason).
+export const getRequiredModels = (
+  config: Pick<ComplexityRouterConfigPayload, "tiers" | "classifier_llm_config" | "embedding_model">,
+): Set<string> => {
+  const { tiers, classifier_llm_config: classifier, embedding_model: embedding } = config;
+  const models = [...tiers.SIMPLE, ...tiers.MEDIUM, ...tiers.COMPLEX, ...tiers.REASONING, classifier?.model, embedding];
+  // Boolean(), not != null: an empty-string placeholder (e.g. classifier_llm_config seeded before a
+  // model is chosen) is never a real model reference either.
+  return new Set(models.filter((model): model is string => Boolean(model)));
+};
+
+export const getMissingModels = (
+  config: Pick<ComplexityRouterConfigPayload, "tiers" | "classifier_llm_config" | "embedding_model">,
+  availableModels: Set<string>,
+): string[] => [...getRequiredModels(config)].filter((model) => !availableModels.has(model)).sort();
+
+export const getRequiredModelsInPreset = (preset: AutoRouterPreset): Set<string> =>
+  getRequiredModels(preset.complexity_router_config);
+
+export const getMissingModelsInPreset = (preset: AutoRouterPreset, availableModels: Set<string>): string[] =>
+  getMissingModels(preset.complexity_router_config, availableModels);
+
+// Checks the config actually being built (whether it arrived via a preset prefill or was typed by
+// hand - the two are indistinguishable once the caller has started editing), not a preset's
+// original bundled model list. Only counts classifier_llm_config/embedding_model as referenced
+// when buildComplexityRouterConfig would actually emit them (classifierType === "llm",
+// semanticMatchingEnabled) - otherwise a dormant selection left over from a toggle no longer in
+// effect would block submit for a model that was never going to be submitted.
+export const getReferencedModelsError = (
+  params: {
+    tiers: ComplexityTiers;
+    classifierType: ClassifierType;
+    classifierLlmConfig: ClassifierLLMConfig | undefined;
+    semanticMatchingEnabled: boolean;
+    embeddingModel: string | undefined;
+  },
+  availableModels: Set<string>,
+): string | null => {
+  const missing = getMissingModels(
+    {
+      tiers: params.tiers,
+      classifier_llm_config: params.classifierType === "llm" ? params.classifierLlmConfig : undefined,
+      embedding_model: params.semanticMatchingEnabled ? params.embeddingModel : undefined,
+    },
+    availableModels,
+  );
+  return missing.length > 0 ? `Model(s) no longer available: ${missing.join(", ")}` : null;
+};
+
+// Every piece of AddAutoRouterTab's config state that a preset (or a reset to Custom) prefills in
+// one shot, so handlePresetChange has exactly one thing to apply rather than seven setters to keep
+// in sync by hand.
+export interface PresetPrefill {
+  complexityRouterConfig: ComplexityRouterConfigValue;
+  customTechnicalKeywords: string[];
+  keywordTierRules: KeywordTierRule[];
+  semanticMatchingEnabled: boolean;
+  embeddingModel: string | undefined;
+  matchThreshold: number;
+  escalationKeywords: string[];
+}
+
+export const buildEmptyPrefill = (): PresetPrefill => ({
+  complexityRouterConfig: {
+    tiers: { SIMPLE: [], MEDIUM: [], COMPLEX: [], REASONING: [] },
+    classifier_type: "heuristic",
+  },
+  customTechnicalKeywords: [],
+  keywordTierRules: [],
+  semanticMatchingEnabled: false,
+  embeddingModel: undefined,
+  matchThreshold: DEFAULT_MATCH_THRESHOLD,
+  escalationKeywords: DEFAULT_ESCALATION_KEYWORDS,
+});
+
+// `??`, never `||`: a preset's match_threshold: 0 or escalation_keywords: [] is a deliberate,
+// falsy value that must survive the prefill, not get silently replaced by the default.
+export const buildPresetPrefill = (config: ComplexityRouterConfigPayload): PresetPrefill => ({
+  complexityRouterConfig: {
+    tiers: config.tiers,
+    classifier_type: config.classifier_type,
+    classifier_llm_config: config.classifier_llm_config,
+    classifier_context_window_size: config.classifier_context_window_size,
+    classifier_context_per_turn_chars: config.classifier_context_per_turn_chars,
+    classifier_context_include_assistant_turns: config.classifier_context_include_assistant_turns,
+    session_affinity: config.session_affinity ?? DEFAULT_SESSION_AFFINITY,
+    adaptive: config.adaptive,
+    adaptive_weights: config.adaptive_weights,
+    tier_distance_penalty: config.tier_distance_penalty,
+    adaptive_eligible: config.adaptive_eligible,
+    return_raw_model_name: config.return_raw_model_name,
+  },
+  customTechnicalKeywords: config.custom_technical_keywords ?? [],
+  keywordTierRules: hydrateKeywordTierRules(config.keyword_tier_rules ?? []),
+  semanticMatchingEnabled: config.semantic_keyword_matching ?? false,
+  embeddingModel: config.embedding_model,
+  matchThreshold: config.match_threshold ?? DEFAULT_MATCH_THRESHOLD,
+  escalationKeywords: config.escalation_keywords ?? DEFAULT_ESCALATION_KEYWORDS,
+});


### PR DESCRIPTION
## TLDR

Problem this solves:

- Add Auto Router required filling in every tier's model by hand before a caller could see what a working complexity-router config even looks like, with the full detailed configuration always expanded up front
- #35199 bolted a template dropdown onto that same flat, always-expanded form instead of changing the flow itself

How it solves it:

- Add Auto Router now opens straight into an Auto Router Name field and an optional Template dropdown (Anthropic family, OpenAI family, or Custom)
- Choosing a family preset prefills the full complexity-router config and collapses the detailed configuration behind a one-line tier summary; choosing Custom, or nothing yet, leaves it expanded, and it can always be toggled open manually afterward
- A preset option greys out and names the specific missing model(s) when the caller's proxy is missing one it needs, or while the model list is loading or failed to load, so a caller never applies a preset referencing a model they don't have

## Relevant issues

- Supersedes #35199 (closed), which added the template dropdown but not the reordered flow

## Linear ticket

Resolves LIT-5003

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix
<img width="726" height="424" alt="image" src="https://github.com/user-attachments/assets/b5e09543-f23d-4def-8a89-c985bdff3a16" />
<img width="714" height="408" alt="Screenshot 2026-08-04 at 4 14 31 PM" src="https://github.com/user-attachments/assets/2d4cbd84-0685-4181-85fd-9220da63f0e8" />
<img width="721" height="940" alt="Screenshot 2026-08-04 at 4 14 46 PM" src="https://github.com/user-attachments/assets/d1c33ffa-e740-450e-b985-972c99f5ff5a" />


This is a UI-only change with no backend surface, so see the QA runbook below to click through and capture screenshots.

## Type

🆕 New Feature

## Changes

- `add_auto_router_tab.tsx`: reordered the flow to Auto Router Name, then an optional Template dropdown, then a collapsible Detailed Configuration section wrapping the existing tier/classifier/keyword/semantic config; the detailed section collapses to a one-line tier summary when a preset is applied and expands for Custom or before any template is chosen, with a manual toggle always available. Model loading moved from a hand-rolled fetch to `useQuery`, matching `EditFallbacks.tsx`'s existing pattern.
- `lib/autorouter_presets.ts` (new): preset lookup (`getAllPresets`, `getPresetByKey`), required/missing-model accessors generalized over any complexity-router config shape, `getReferencedModelsError` (the single source for the submit-blocking reason, gated on the same `classifierType`/`semanticMatchingEnabled` conditions `buildComplexityRouterConfig` uses so a dormant classifier or embedding selection never blocks a submit that would never reference it), and `buildEmptyPrefill`/`buildPresetPrefill` (the single place a preset's, or Custom's, values get applied to the seven pieces of form state, using `??` so a preset's falsy `match_threshold: 0` or empty `escalation_keywords` survive instead of getting silently defaulted).
- `autorouter_presets.json` (new): two bundled presets, an Anthropic-family and an OpenAI-family complexity router, each a plain heuristic classifier with no adaptive/quality settings.
- Tests: `autorouter_presets.test.ts` unit-tests the pure lib functions directly, including the classifier/embedding gating and the falsy-preservation case, both mutation-checked. `add_auto_router_tab.test.tsx` extends the existing suite with the preset dropdown's loading/error/missing-model gating, the collapse/expand behavior, and the end-to-end preset-to-submit-payload path (run against the real, unmocked `getMissingTiersError`, so it fails if `handlePresetChange` ever stops actually prefilling the tiers).

## QA runbook

1. `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
2. `cd ui/litellm-dashboard && npm run dev`, then open http://localhost:3000/ui/?page=models&model_tab=add-model, and pick the "Add Auto Router" tab
3. Confirm the form opens with just "Auto Router Name" and "Template" visible; no tier/classifier fields yet
4. Open the Template dropdown. If your proxy has no `claude-*` or `gpt-5*`/`o3` deployments registered, both family presets should show greyed out, each naming the specific model(s) it's missing; register those models (or use whatever models you already have and skip to step 6 for Custom) to unblock them
5. Select "Anthropic Family" (or "OpenAI Family"). Confirm the Template dropdown collapses the "Detailed Configuration" section below it into one line summarizing the four tiers, and that clicking the "Detailed Configuration" row re-expands it to show the actual filled-in tier selects
6. Select "Custom Configuration" instead. Confirm "Detailed Configuration" is expanded by default with every tier empty
7. Fill in a router name, leave Custom's tiers empty, and confirm "Add Auto Router" is disabled with a tooltip naming the missing tiers; fill in all four tiers and confirm it becomes enabled
8. Submit either a preset-backed or Custom-backed router and confirm it's created and appears in the Auto Routers list

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only UI and client validation; no backend or auth changes. Main risk is incorrect model-name matching or allowing creates with unavailable models, which the new checks and tests target.
> 
> **Overview**
> **Add Auto Router** is reordered so callers start with **name + Template** instead of a fully expanded tier form. A new **Template** dropdown offers **Anthropic Family**, **OpenAI Family** (from bundled `autorouter_presets.json`), or **Custom**; family presets prefill complexity-router tiers and **collapse** Detailed Configuration behind a one-line tier summary, while Custom keeps or expands that section.
> 
> Preset options are **gated on live model availability** via `useQuery` (replacing a manual fetch): disabled while loading, on fetch failure, or when specific models are missing (with inline hints). `lib/autorouter_presets.ts` centralizes preset lookup, missing-model checks (including `-` vs `.` version spelling), prefill builders, and **`getReferencedModelsError`** so submit stays blocked—and form submit re-validates—if referenced models disappear after prefill.
> 
> Tests cover preset gating, collapse/expand behavior, preset-to-payload flow, and stale-model submit blocking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f1d2300210d7915ec2f5638d07e515f86f671fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->