### PR TITLE
fix(proxy): assemble the read-replica URL in the CLI startup path

### DIFF
--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -18,6 +18,11 @@ from pydantic import BaseModel, ConfigDict
 
 import litellm
 from litellm.constants import DEFAULT_NUM_WORKERS_LITELLM_PROXY
+from litellm.proxy.db.db_url_settings import (
+    DatabaseURLSettings,
+    unsupported_db_scheme,
+    unsupported_db_scheme_message,
+)
 from litellm.proxy.db.query_engine_reaper import start_query_engine_reaper
 from litellm.secret_managers.main import get_secret_bool
 
@@ -94,6 +99,24 @@ def _build_db_connection_url_params(
     return params
 
 
+def _exit_on_unsupported_db_scheme(env_var: str, url: str) -> None:
+    """Exit with an actionable message when a connection URL is not PostgreSQL.
+
+    Prisma's failure against the postgresql-only datasource is opaque and version
+    dependent (a confusing migration error, or a startup that never binds), so the
+    CLI rejects the URL before touching prisma.
+    """
+    bad_scheme = unsupported_db_scheme(url)
+    if bad_scheme is None:
+        return
+    print(
+        f"\033[1;31mLiteLLM Proxy: {unsupported_db_scheme_message(env_var, bad_scheme)}\033[0m",
+        file=sys.stderr,
+        flush=True,
+    )
+    sys.exit(1)
+
+
 def _read_replica_url_from_env() -> str | None:
     """Return the read-replica URL Prisma should use, or None when read routing is off.
 
@@ -109,9 +132,6 @@ def _read_replica_url_from_env() -> str | None:
         return pinned_url
     if not os.getenv("DATABASE_HOST_READ_REPLICA"):
         return None
-
-    from litellm.proxy.db.db_url_settings import DatabaseURLSettings
-
     return DatabaseURLSettings.from_env().build_reader_url()
 
 
@@ -1241,23 +1261,11 @@ def run_server(
             db_connection_timeout = LiteLLMDatabaseConnectionPool.database_connection_pool_timeout.value
 
         if os.getenv("DATABASE_URL", None) is not None or os.getenv("DIRECT_URL", None) is not None:
-            from litellm.proxy.db.db_url_settings import (
-                unsupported_db_scheme,
-                unsupported_db_scheme_message,
-            )
-
-            for _db_env in ("DATABASE_URL", "DIRECT_URL", "DATABASE_URL_READ_REPLICA"):
+            for _db_env in ("DATABASE_URL", "DIRECT_URL"):
                 _candidate_url = os.getenv(_db_env)
                 if _candidate_url is None:
                     continue
-                _bad_scheme = unsupported_db_scheme(_candidate_url)
-                if _bad_scheme is not None:
-                    print(
-                        f"\033[1;31mLiteLLM Proxy: {unsupported_db_scheme_message(_db_env, _bad_scheme)}\033[0m",
-                        file=sys.stderr,
-                        flush=True,
-                    )
-                    sys.exit(1)
+                _exit_on_unsupported_db_scheme(_db_env, _candidate_url)
             try:
                 from litellm.secret_managers.main import get_secret
 
@@ -1293,6 +1301,7 @@ def run_server(
                     os.environ["DIRECT_URL"] = modified_url
                 reader_url = _read_replica_url_from_env()
                 if reader_url:
+                    _exit_on_unsupported_db_scheme("DATABASE_URL_READ_REPLICA", reader_url)
                     os.environ["DATABASE_URL_READ_REPLICA"] = append_query_params(reader_url, connection_url_params)
                 subprocess.run(["prisma"], capture_output=True)
                 is_prisma_runnable = True

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -94,6 +94,27 @@ def _build_db_connection_url_params(
     return params
 
 
+def _read_replica_url_from_env() -> str | None:
+    """Return the read-replica URL Prisma should use, or None when read routing is off.
+
+    An operator-pinned ``DATABASE_URL_READ_REPLICA`` wins; otherwise the reader is
+    assembled from the discrete ``DATABASE_*_READ_REPLICA`` vars (each falling back
+    to its writer equivalent), the same way the componentized entrypoints do via
+    ``DatabaseURLSettings.apply_to_env``. The discrete vars are only loaded once
+    ``DATABASE_HOST_READ_REPLICA`` opts in, so single-database deployments never
+    depend on the rest of the ``DATABASE_*`` environment parsing cleanly.
+    """
+    pinned_url = os.getenv("DATABASE_URL_READ_REPLICA")
+    if pinned_url:
+        return pinned_url
+    if not os.getenv("DATABASE_HOST_READ_REPLICA"):
+        return None
+
+    from litellm.proxy.db.db_url_settings import DatabaseURLSettings
+
+    return DatabaseURLSettings.from_env().build_reader_url()
+
+
 class DatabaseTimeoutSettings(BaseModel):
     """The `general_settings` keys that bound how long a statement may hold locks.
 
@@ -1225,7 +1246,7 @@ def run_server(
                 unsupported_db_scheme_message,
             )
 
-            for _db_env in ("DATABASE_URL", "DIRECT_URL"):
+            for _db_env in ("DATABASE_URL", "DIRECT_URL", "DATABASE_URL_READ_REPLICA"):
                 _candidate_url = os.getenv(_db_env)
                 if _candidate_url is None:
                     continue
@@ -1270,6 +1291,9 @@ def run_server(
                     database_url = os.getenv("DIRECT_URL")
                     modified_url = append_query_params(database_url, connection_url_params)
                     os.environ["DIRECT_URL"] = modified_url
+                reader_url = _read_replica_url_from_env()
+                if reader_url:
+                    os.environ["DATABASE_URL_READ_REPLICA"] = append_query_params(reader_url, connection_url_params)
                 subprocess.run(["prisma"], capture_output=True)
                 is_prisma_runnable = True
             except FileNotFoundError:

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -2416,6 +2416,17 @@ class TestReadReplicaUrlWiring:
 
         assert exc_info.value.code == 1
 
+    def test_empty_reader_url_is_ignored_rather_than_rejected(self):
+        """An optional env var rendered empty by a chart or compose file is not a
+        misconfigured URL; treating it as one would fail startup for deployments that
+        never asked for a reader."""
+        captured = self._run_server_and_capture_urls(
+            extra_env={**self._WRITER_ENV, "DATABASE_URL_READ_REPLICA": ""}
+        )
+
+        assert captured.get("DATABASE_URL_READ_REPLICA", "") == ""
+        assert urlparse.urlparse(captured["DATABASE_URL"]).hostname == "writer.internal"
+
     def test_discrete_vars_are_not_read_without_the_opt_in_host(self):
         """DatabaseURLSettings validates the whole DATABASE_* environment, so loading
         it unconditionally would fail startup for single-database deployments that

--- a/tests/test_litellm/proxy/test_proxy_cli.py
+++ b/tests/test_litellm/proxy/test_proxy_cli.py
@@ -2277,3 +2277,192 @@ class TestPostgresStatementTimeoutOptions:
                 standalone_mode=False,
             )
             return {k: os.environ[k] for k in ("DATABASE_URL", "DIRECT_URL") if k in os.environ}
+
+
+_READER_ENV_KEYS = (
+    "DATABASE_URL",
+    "DIRECT_URL",
+    "DATABASE_URL_READ_REPLICA",
+    "DATABASE_HOST",
+    "DATABASE_PORT",
+    "DATABASE_USER",
+    "DATABASE_USERNAME",
+    "DATABASE_NAME",
+    "DATABASE_SCHEMA",
+    "DATABASE_PASSWORD",
+    "DATABASE_HOST_READ_REPLICA",
+    "DATABASE_PORT_READ_REPLICA",
+    "DATABASE_USER_READ_REPLICA",
+    "DATABASE_USERNAME_READ_REPLICA",
+    "DATABASE_NAME_READ_REPLICA",
+    "DATABASE_SCHEMA_READ_REPLICA",
+    "DATABASE_PASSWORD_READ_REPLICA",
+    "IAM_TOKEN_DB_AUTH",
+)
+
+
+@pytest.mark.xdist_group("proxy_cli")
+class TestReadReplicaUrlWiring:
+    """Read routing is driven by DATABASE_URL_READ_REPLICA, which PrismaClient reads
+    straight from the environment. The CLI is the entrypoint the docker image uses, so
+    it has to leave that var assembled from the discrete DATABASE_*_READ_REPLICA vars
+    and carrying the same pool params as the writer, or the reader silently never
+    comes up (or comes up on Prisma's default pool size).
+    """
+
+    _WRITER_ENV = {
+        "DATABASE_HOST": "writer.internal",
+        "DATABASE_USERNAME": "litellm_admin",
+        "DATABASE_PASSWORD": "p@ss+w0rd/x",
+        "DATABASE_NAME": "ai_gateway",
+    }
+
+    def test_discrete_reader_vars_assemble_the_reader_url(self):
+        """The reported bug: with only the discrete vars set, the CLI never assembled
+        a reader URL, so read routing stayed off on the docker/CLI path."""
+        captured = self._run_server_and_capture_urls(
+            extra_env={
+                **self._WRITER_ENV,
+                "DATABASE_HOST_READ_REPLICA": "reader.internal",
+            }
+        )
+
+        reader = urlparse.urlparse(captured["DATABASE_URL_READ_REPLICA"])
+        assert reader.hostname == "reader.internal"
+        assert reader.port == 5432
+        assert reader.username == "litellm_admin"
+        assert urlparse.unquote_plus(reader.password or "") == "p@ss+w0rd/x"
+        assert reader.path == "/ai_gateway"
+
+    def test_reader_only_overrides_win_over_writer_fallbacks(self):
+        """A reader identity distinct from the writer's is the point of the split, so
+        the *_READ_REPLICA overrides must not be dropped in favor of the writer's."""
+        captured = self._run_server_and_capture_urls(
+            extra_env={
+                **self._WRITER_ENV,
+                "DATABASE_HOST_READ_REPLICA": "reader.internal",
+                "DATABASE_PORT_READ_REPLICA": "6543",
+                "DATABASE_USER_READ_REPLICA": "litellm_reader",
+                "DATABASE_PASSWORD_READ_REPLICA": "r3@d+er/x",
+            }
+        )
+
+        reader = urlparse.urlparse(captured["DATABASE_URL_READ_REPLICA"])
+        assert reader.port == 6543
+        assert reader.username == "litellm_reader"
+        assert urlparse.unquote_plus(reader.password or "") == "r3@d+er/x"
+        assert reader.path == "/ai_gateway"
+
+    def test_pool_params_reach_the_reader(self):
+        """Without these the reader engine sizes its pool off Prisma's default
+        (num_cpus * 2 + 1) and ignores the operator's configured limit entirely."""
+        captured = self._run_server_and_capture_urls(
+            general_settings={
+                "database_connection_pool_limit": 1,
+                "database_connection_timeout": 5,
+                "database_socket_timeout": 10,
+            },
+            extra_env={
+                **self._WRITER_ENV,
+                "DATABASE_HOST_READ_REPLICA": "reader.internal",
+            },
+        )
+
+        params = urlparse.parse_qs(urlparse.urlparse(captured["DATABASE_URL_READ_REPLICA"]).query)
+        assert params["connection_limit"] == ["1"]
+        assert params["pool_timeout"] == ["5"]
+        assert params["socket_timeout"] == ["10"]
+
+    def test_pinned_reader_url_keeps_its_identity_and_gains_pool_params(self):
+        """Appending query params is the only mutation allowed on an operator-supplied
+        reader URL; its host, credentials and database must survive untouched."""
+        captured = self._run_server_and_capture_urls(
+            general_settings={"database_connection_pool_limit": 3},
+            extra_env={
+                **self._WRITER_ENV,
+                "DATABASE_HOST_READ_REPLICA": "ignored.internal",
+                "DATABASE_URL_READ_REPLICA": "postgresql://pinned_reader:pinned_pw@pinned.internal:6543/pinned_db?schema=public",
+            },
+        )
+
+        reader = urlparse.urlparse(captured["DATABASE_URL_READ_REPLICA"])
+        assert reader.hostname == "pinned.internal"
+        assert reader.port == 6543
+        assert reader.username == "pinned_reader"
+        assert reader.password == "pinned_pw"
+        assert reader.path == "/pinned_db"
+        params = urlparse.parse_qs(reader.query)
+        assert params["schema"] == ["public"]
+        assert params["connection_limit"] == ["3"]
+
+    def test_no_reader_vars_leaves_read_routing_off(self):
+        """Reader stays strictly opt-in: a single-database deployment must not end up
+        with DATABASE_URL_READ_REPLICA set, which would turn on routing."""
+        captured = self._run_server_and_capture_urls(extra_env=self._WRITER_ENV)
+
+        assert "DATABASE_URL_READ_REPLICA" not in captured
+        assert urlparse.urlparse(captured["DATABASE_URL"]).hostname == "writer.internal"
+
+    def test_non_postgres_reader_url_exits_before_prisma_setup(self):
+        """The postgresql-only datasource cannot connect to it, and the resulting
+        Prisma failure is opaque, so it has to be rejected up front like the writer."""
+        with pytest.raises(SystemExit) as exc_info:
+            self._run_server_and_capture_urls(
+                extra_env={
+                    **self._WRITER_ENV,
+                    "DATABASE_URL_READ_REPLICA": "sqlite:///data/reader.db",
+                }
+            )
+
+        assert exc_info.value.code == 1
+
+    def test_discrete_vars_are_not_read_without_the_opt_in_host(self):
+        """DatabaseURLSettings validates the whole DATABASE_* environment, so loading
+        it unconditionally would fail startup for single-database deployments that
+        carry an unparseable value (an empty IAM_TOKEN_DB_AUTH, say)."""
+        from litellm.proxy.proxy_cli import _read_replica_url_from_env
+
+        with patch.dict(os.environ, {"IAM_TOKEN_DB_AUTH": ""}, clear=False):
+            os.environ.pop("DATABASE_URL_READ_REPLICA", None)
+            os.environ.pop("DATABASE_HOST_READ_REPLICA", None)
+            assert _read_replica_url_from_env() is None
+
+    @staticmethod
+    def _run_server_and_capture_urls(
+        general_settings: dict | None = None,
+        extra_env: dict | None = None,
+    ) -> dict:
+        from litellm.proxy.proxy_cli import run_server
+
+        mock_proxy_config = MagicMock()
+        mock_proxy_config.return_value.get_config = AsyncMock(
+            return_value={"model_list": [], "general_settings": general_settings or {}}
+        )
+        mock_proxy_module = MagicMock(
+            app=MagicMock(),
+            ProxyConfig=mock_proxy_config,
+            KeyManagementSettings=MagicMock(),
+            save_worker_config=MagicMock(),
+        )
+        clean_env = {k: v for k, v in os.environ.items() if k not in _READER_ENV_KEYS}
+        clean_env.update(extra_env or {})
+
+        with (
+            patch.dict(os.environ, clean_env, clear=True),
+            patch.dict(
+                "sys.modules",
+                {
+                    "proxy_server": mock_proxy_module,
+                    "litellm.proxy.proxy_server": mock_proxy_module,
+                },
+            ),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)),
+            patch("atexit.register"),
+            patch("litellm.proxy.db.prisma_client.should_update_prisma_schema", return_value=False),
+            patch("litellm.proxy.db.check_migration.check_prisma_schema_diff"),
+        ):
+            run_server.main(
+                ["--config", "test-config.yaml", "--local", "--skip_server_startup"],
+                standalone_mode=False,
+            )
+            return {k: os.environ[k] for k in ("DATABASE_URL", "DIRECT_URL", "DATABASE_URL_READ_REPLICA") if k in os.environ}


### PR DESCRIPTION
## TLDR

Problem this solves:

- `DATABASE_*_READ_REPLICA` vars do nothing on the docker/CLI path
- read routing silently stays off, no warning logged
- reader pool ignores `general_settings`, runs Prisma defaults

How it solves it:

- CLI now assembles the reader URL like the componentized entrypoints
- appends the same pool params it gives the writer
- rejects a pinned non-postgres reader URL up front

## Relevant issues

Fixes #35742

Partial overlap with #33021 (and its open PR #33022) on the pool-param half: that one moves pool-param application into a shared helper for the componentized entrypoints, and its reader coverage kicks in only when something already set `DATABASE_URL_READ_REPLICA`. This one is what sets it on the CLI path. If #33022 lands first the two compose; the merge conflict is the three lines added next to the `DIRECT_URL` append

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

Two red checks are inherited from base, not from this change. `misc / Run tests` fails on `tests/test_litellm/test_logging.py::test_logging_calls_do_not_build_their_message_eagerly`, pointing at the f-string log call added to `proxy_server.py` by #35739; that test passes on this branch's merge-base. `osv-scan` fails on three `cryptography` 48.0.1 advisories in `uv.lock`, which this PR does not touch. Both are red on the other PRs open at the same time (#35746, #35748)

## Screenshots / Proof of Fix

Before is base `c9887a1f94`, after is `4f31c79f98`. There is no LLM call in the proof: the change decides which Postgres role serves reads and how large the reader pool is, so the operator-visible evidence is the startup log, the per-role statement log, and `pg_stat_activity`. Postgres runs with `log_statement=all` and `log_connections=on`, and the reader connects as a second login role (`litellm_reader`) so its queries can be told apart from the writer's

Rig, all three files in one directory:

```yaml
# compose.yml
name: rr-proof
services:
  pg:
    image: postgres:17-alpine
    environment:
      POSTGRES_USER: litellm_admin
      POSTGRES_PASSWORD: 'p@ss+w0rd/x'
      POSTGRES_DB: ai_gateway
    command: [postgres, -c, log_statement=all, -c, log_connections=on, -c, "log_line_prefix=%m [%p] user=%u db=%d app=%a"]
    volumes: ['./initdb.sql:/docker-entrypoint-initdb.d/initdb.sql:ro']
    ports: ['5432:5432']
```

```sql
-- initdb.sql
CREATE ROLE litellm_reader WITH LOGIN SUPERUSER PASSWORD 'r3@d+er/x';
```

```yaml
# config.yaml
model_list:
  - model_name: fake-model
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: sk-fake
      api_base: http://127.0.0.1:9/v1
general_settings:
  master_key: os.environ/LITELLM_MASTER_KEY
  store_model_in_db: true
  database_connection_pool_limit: 1
  database_connection_timeout: 5
  database_socket_timeout: 10
```

```bash
docker compose up -d --wait

# the deployment shape from the issue: discrete writer vars, discrete reader vars, no URLs
LITELLM_MASTER_KEY=sk-proof-1234 LITELLM_SALT_KEY=sk-salt LITELLM_LOG=INFO PYTHONUNBUFFERED=1 \
DATABASE_HOST=127.0.0.1 DATABASE_USERNAME=litellm_admin DATABASE_PASSWORD='p@ss+w0rd/x' DATABASE_NAME=ai_gateway \
DATABASE_HOST_READ_REPLICA=127.0.0.1 DATABASE_USER_READ_REPLICA=litellm_reader DATABASE_PASSWORD_READ_REPLICA='r3@d+er/x' \
python litellm/proxy/proxy_cli.py --config config.yaml --port 4000 --num_workers 1 2>&1 | tee litellm.log
```

Before, on `c9887a1f94`, the reader is nowhere in the startup log:

```
$ grep -ciE 'read.replica|reader' litellm.log
0
```

After, on `4f31c79f98`, the same env brings the reader up:

```
$ grep -oiE 'read-replica routing enabled.*|\[reader\] DB connected|\[writer\] DB connected' litellm.log | sort -u
[reader] DB connected
[writer] DB connected
read-replica routing enabled via DATABASE_URL_READ_REPLICA
```

Reads then land on the reader role and writes stay on the writer. One `POST /key/generate` plus 40 `GET /user/list` at concurrency 20, counted from a marker in the Postgres log so the window is only these requests:

```bash
docker exec rr-proof-pg-1 psql -h 127.0.0.1 -U litellm_admin -d ai_gateway -tAc "select 'PROOF_WINDOW_START';"
curl -s -o /dev/null -X POST http://127.0.0.1:4000/key/generate \
  -H 'Authorization: Bearer sk-proof-1234' -H 'Content-Type: application/json' -d '{"key_alias":"rr-window"}'
seq 1 40 | xargs -P 20 -I{} curl -s -o /dev/null \
  -H 'Authorization: Bearer sk-proof-1234' 'http://127.0.0.1:4000/user/list?page=1&page_size=5'
docker logs rr-proof-pg-1 2>&1 | sed -n '/PROOF_WINDOW_START/,$p' \
  | grep -oE 'user=litellm_[a-z]+.*LOG: *[a-z ]*[a-zA-Z0-9]*: *(SELECT|INSERT|BEGIN|COMMIT)' \
  | sed -E 's/.*(user=litellm_[a-z]+).*(SELECT|INSERT|BEGIN|COMMIT)/\1 \2/' | sort | uniq -c | sort -rn
```

```
  83 user=litellm_reader SELECT
   3 user=litellm_admin SELECT
   1 user=litellm_admin INSERT
   1 user=litellm_admin COMMIT
   1 user=litellm_admin BEGIN
```

An empty `DATABASE_URL_READ_REPLICA=` alongside those discrete vars starts the same way rather than being read as a malformed URL, and a pinned `sqlite:///data/reader.db` still exits before prisma runs:

```
$ LiteLLM Proxy: DATABASE_URL_READ_REPLICA uses unsupported scheme 'sqlite'. LiteLLM's database features
(virtual keys, store_model_in_db, spend tracking) require PostgreSQL; use a 'postgresql://' connection string
```

The pool-param half needs a reader that comes up on both sides of the change, so swap the three discrete reader vars for the equivalent pinned URL carrying no query params, and drive the same 40 reads:

```bash
DATABASE_URL_READ_REPLICA='postgresql://litellm_reader:r3%40d%2Ber%2Fx@127.0.0.1:5432/ai_gateway'
...
docker exec rr-proof-pg-1 psql -h 127.0.0.1 -U litellm_admin -d ai_gateway -tAc \
  "select usename, count(*) from pg_stat_activity where datname='ai_gateway' and usename is not null group by usename order by 1;"
```

Before, with `database_connection_pool_limit: 1` configured (14 CPUs on this host, so Prisma's own ceiling was `14 * 2 + 1`):

```
litellm_admin|2
litellm_reader|7
```

After:

```
litellm_admin|2
litellm_reader|1
```

## Type

🐛 Bug Fix

## Changes

`DatabaseURLSettings.build_reader_url()` already assembles a reader URL from the discrete `DATABASE_*_READ_REPLICA` vars, with every field falling back to its writer equivalent, and it is already unit tested. Its only caller was `apply_to_env()`, which runs in `gateway/main.py`, `backend/main.py` and `migrations/run.py`. The docker image runs `docker/prod_entrypoint.sh` -> `litellm` -> `proxy_cli.py`, which assembles the writer URL through `construct_database_url_from_env_vars()` and nothing else, so on that path the reader vars did nothing at all: `PrismaClient` reads `DATABASE_URL_READ_REPLICA` out of the environment, found it unset, and routing stayed off with no diagnostic

`proxy_cli.py` now resolves the reader through a small `_read_replica_url_from_env()` helper, right where it already appends pool params to `DATABASE_URL` and `DIRECT_URL`. An operator-pinned `DATABASE_URL_READ_REPLICA` wins over assembly; either way the reader gets the same `connection_limit` / `pool_timeout` / `connect_timeout` / `socket_timeout` / `pgbouncer` params as the writer, which is the only mutation applied to a pinned URL. The resolved URL is also scheme-checked, matching `_raise_for_unsupported_scheme()` on the `apply_to_env` path, so a `sqlite://` reader exits with the same actionable message as a `sqlite://` writer instead of failing opaquely inside Prisma. That check sits where the reader is resolved rather than in the existing `DATABASE_URL` / `DIRECT_URL` loop, because the loop skips only `None`: an optional var that a chart or compose file renders empty would otherwise be read as a missing scheme and kill startup for deployments that never asked for a reader. Writer and direct URLs keep their current semantics

Two deliberate constraints. The discrete vars are read only once `DATABASE_HOST_READ_REPLICA` opts in, because `DatabaseURLSettings` validates the whole `DATABASE_*` environment and an unparseable value elsewhere (an empty `IAM_TOKEN_DB_AUTH`, for instance) would otherwise start failing startup for single-database deployments that work today. And the whole block still sits behind the existing writer check, so nothing runs for a deployment with no database at all

Two further known limits of the routing feature itself, neither of them this PR's to change. Under `IAM_TOKEN_DB_AUTH`, `parse_iam_endpoint_from_url` keeps only `schema`, so the params written here are dropped from writer and reader alike at the first token refresh; that is `IAMEndpoint`'s to fix and #33022 already proposes it. And `RoutingPrismaWrapper` routes the virtual-key lookup to the reader, so a lagging replica lets a revoked key keep working and rejects a freshly created one; reproduced against `a625d1e1ca` with no part of this branch involved, and filed as #35757

Tests extend `tests/test_litellm/proxy/test_proxy_cli.py` with a `TestReadReplicaUrlWiring` class covering assembly from the discrete vars with writer fallbacks, reader-only overrides winning over those fallbacks, pool params landing on the reader, a pinned reader URL keeping its host, credentials and database while gaining the params, no reader vars leaving `DATABASE_URL_READ_REPLICA` unset, an empty pinned value being ignored rather than rejected, a pinned non-postgres reader URL exiting 1, and the opt-in guard keeping the discrete vars unread. Seven of the eight fail on base

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
