### PR TITLE
fix(proxy): log the model cost map reload failure lazily

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -6546,7 +6546,8 @@ class ProxyConfig:
                 reload_result = await refetch_model_cost_map(url=model_cost_map_url)
                 if isinstance(reload_result, ModelCostMapReloadUnavailable):
                     verbose_proxy_logger.warning(
-                        f"Model cost map reload failed ({reload_result.reason}); keeping current pricing data, will retry on the next config poll"
+                        "Model cost map reload failed (%s); keeping current pricing data, will retry on the next config poll",
+                        reload_result.reason,
                     )
                     return
                 new_model_cost_map = reload_result.model_cost_map


### PR DESCRIPTION
## TLDR

Problem this solves:

- `test_logging_calls_do_not_build_their_message_eagerly` scans every file under `litellm/` and asserts zero offenders, and one call in `proxy_server.py` builds its message with an f-string
- That reds `misc / Run tests` on `litellm_internal_staging` itself, so every branch cut from staging inherits the failure

How it solves it:

- Passes the reason as a `%`-style argument, which defers interpolation to `record.getMessage()` and only runs it once the record passes the level check

## Relevant issues

- The offending line came in with #35739; this is a one-line follow-up, not a revert of anything in it

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

The gate is red on staging before the change and green after, on a worktree cut from `origin/litellm_internal_staging`:

```
$ git rev-parse --short HEAD   # staging, before
abe3289398
$ pytest tests/test_litellm/test_logging.py -q
FAILED tests/test_litellm/test_logging.py::test_logging_calls_do_not_build_their_message_eagerly
E   AssertionError: these logging calls build their message eagerly; pass the values as %-style arguments instead:
E     litellm/proxy/proxy_server.py:6549
1 failed, 10 passed

$ pytest tests/test_litellm/test_logging.py -q   # after
11 passed
```

The existing gate is the regression test; it fails on the previous line and passes on the new one, so no new test is warranted.

## Type

🐛 Bug Fix

## Changes

The reload-failure warning interpolated its message before the call ran, so the string was built and discarded on every failed reload the level filtered out. The value is a scalar with no format spec, so the `%`-style form the gate asks for is an exact equivalent.

## QA runbook

1. `pytest tests/test_litellm/test_logging.py -q` should report 11 passed with no offenders
2. Point a proxy at an unreachable `model_cost_map_url` and confirm the warning still renders the reason in full at WARNING level

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single logging call-site change with equivalent output; no logic, auth, or data-path changes.
> 
> **Overview**
> Fixes a **lazy-logging** violation in the proxy’s model cost map reload path so CI’s `test_logging_calls_do_not_build_their_message_eagerly` passes again.
> 
> The reload-failure `verbose_proxy_logger.warning` no longer uses an f-string; it passes `reload_result.reason` as a `%s` argument so the message is only formatted when the record is actually emitted. **Behavior at WARNING is unchanged**—the same reason text still appears in the log line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45de0135cfaad3dd8340d1105434766199ac4594. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->