### PR TITLE
fix(proxy): serve dashboard routes from flat Next.js exports without restructuring

### DIFF
--- a/litellm/proxy/common_utils/ui_static_files.py
+++ b/litellm/proxy/common_utils/ui_static_files.py
@@ -1,0 +1,27 @@
+"""Static file serving for the Next.js dashboard export."""
+
+import os
+
+from starlette.staticfiles import StaticFiles
+
+
+class UiStaticFiles(StaticFiles):
+    """StaticFiles that falls back to ``<route>.html`` when ``<route>/index.html`` is missing.
+
+    Next.js exports built without ``trailingSlash: true`` emit ``chat.html`` plus an
+    index-less ``chat/`` data directory; Starlette matches the directory first, finds no
+    ``index.html``, and returns 404 (https://github.com/BerriAI/litellm/issues/24037).
+    Resolving the fallback at lookup time serves both export layouts as-is, so the UI
+    works on read-only filesystems without restructuring files on disk at startup.
+    """
+
+    def lookup_path(self, path: str) -> "tuple[str, os.stat_result | None]":
+        full_path, stat_result = super().lookup_path(path)
+        if stat_result is not None:
+            return full_path, stat_result
+        route = path.replace(os.sep, "/").rstrip("/")
+        if route.endswith("/index.html"):
+            return super().lookup_path(f"{route.removesuffix('/index.html')}.html")
+        if route and not route.endswith(".html"):
+            return super().lookup_path(f"{route}.html")
+        return full_path, stat_result

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -325,6 +325,7 @@ from litellm.proxy.common_utils.timezone_utils import (
     get_budget_reset_settings,
     get_budget_reset_time,
 )
+from litellm.proxy.common_utils.ui_static_files import UiStaticFiles
 from litellm.proxy.common_utils.user_api_key_cache import (
     UserApiKeyCache,
     get_management_object_ttl,
@@ -1791,7 +1792,7 @@ try:
     )
     # print(f"mounted _next at {server_root_path}/ui/_next")
 
-    app.mount("/ui", StaticFiles(directory=ui_path, html=True), name="ui")
+    app.mount("/ui", UiStaticFiles(directory=ui_path, html=True), name="ui")
 
     def _restructure_ui_html_files(ui_root: str) -> None:
         """Ensure each exported HTML route is available as <route>/index.html."""

--- a/tests/test_litellm/proxy/common_utils/test_ui_static_files.py
+++ b/tests/test_litellm/proxy/common_utils/test_ui_static_files.py
@@ -1,0 +1,110 @@
+"""
+Unit tests for UiStaticFiles, the /ui static mount with <route>.html fallback.
+
+Regression tests for https://github.com/BerriAI/litellm/issues/24037: a Next.js
+export without ``trailingSlash: true`` ships ``chat.html`` plus an index-less
+``chat/`` data directory, which vanilla StaticFiles(html=True) turns into a 404
+on direct navigation to /ui/chat. The fallback must serve that layout without
+writing anything to disk, so read-only deployments work.
+"""
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from litellm.proxy.common_utils.ui_static_files import UiStaticFiles
+
+
+def make_client(ui_dir) -> TestClient:
+    app = Starlette()
+    app.mount("/ui", UiStaticFiles(directory=str(ui_dir), html=True), name="ui")
+    return TestClient(app)
+
+
+@pytest.fixture
+def flat_export(tmp_path):
+    (tmp_path / "index.html").write_text("<h1>root</h1>")
+    (tmp_path / "chat.html").write_text("<h1>chat page</h1>")
+    chat_dir = tmp_path / "chat"
+    chat_dir.mkdir()
+    (chat_dir / "__next.chat.__PAGE__.txt").write_text("rsc payload")
+    (tmp_path / "model_hub.html").write_text("<h1>model hub page</h1>")
+    return tmp_path
+
+
+def test_route_shadowed_by_indexless_directory_serves_html(flat_export):
+    client = make_client(flat_export)
+
+    response = client.get("/ui/chat")
+
+    assert response.status_code == 200
+    assert "chat page" in response.text
+
+
+def test_route_with_trailing_slash_serves_html(flat_export):
+    client = make_client(flat_export)
+
+    response = client.get("/ui/chat/")
+
+    assert response.status_code == 200
+    assert "chat page" in response.text
+
+
+def test_route_without_directory_serves_html(flat_export):
+    client = make_client(flat_export)
+
+    response = client.get("/ui/model_hub")
+
+    assert response.status_code == 200
+    assert "model hub page" in response.text
+
+
+def test_serving_flat_export_writes_nothing_to_disk(flat_export):
+    client = make_client(flat_export)
+    before = sorted(p.relative_to(flat_export) for p in flat_export.rglob("*"))
+
+    client.get("/ui/chat")
+    client.get("/ui/model_hub")
+
+    after = sorted(p.relative_to(flat_export) for p in flat_export.rglob("*"))
+    assert after == before
+
+
+def test_restructured_export_still_served(tmp_path):
+    (tmp_path / "index.html").write_text("<h1>root</h1>")
+    chat_dir = tmp_path / "chat"
+    chat_dir.mkdir()
+    (chat_dir / "index.html").write_text("<h1>restructured chat</h1>")
+    client = make_client(tmp_path)
+
+    response = client.get("/ui/chat")
+
+    assert response.status_code == 200
+    assert "restructured chat" in response.text
+
+
+def test_root_serves_index(flat_export):
+    client = make_client(flat_export)
+
+    response = client.get("/ui/")
+
+    assert response.status_code == 200
+    assert "root" in response.text
+
+
+def test_unknown_route_returns_404(flat_export):
+    client = make_client(flat_export)
+
+    response = client.get("/ui/does-not-exist")
+
+    assert response.status_code == 404
+
+
+def test_asset_files_still_served_directly(flat_export):
+    (flat_export / "next.svg").write_text("<svg></svg>")
+    client = make_client(flat_export)
+
+    response = client.get("/ui/next.svg")
+
+    assert response.status_code == 200
+    assert response.text == "<svg></svg>"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Direct navigation to /ui/chat and other UI sub-routes returns 404
- Startup restructure needs a writable filesystem, so read-only deployments stay broken

How it solves it:

- /ui mount serves the sibling `<route>.html` when `<route>/index.html` is missing
- Both export layouts now work as-is, with zero disk writes at startup

## Relevant issues

Fixes #24037

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests) — all green except `osv-scan`, which is the pre-existing cryptography CVE failure that has been red on every branch since 2026-08-03 and is fixed by #35759; it is unrelated to this PR
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The failing deployment shape from the issue is a UI bundle in the pre-trailingSlash layout (`chat.html` next to an index-less `chat/` RSC data directory) served from a location where the startup restructure cannot run, which is what a read-only pod filesystem looks like in practice. To reproduce it locally I copied `litellm/proxy/_experimental/out`, moved each route's `index.html` back to a sibling `<route>.html`, and dropped a `.litellm_ui_ready` marker so startup skips the restructure, exactly like a read-only filesystem would

Both runs start the proxy the same way and hit it with plain curl:

```bash
LITELLM_UI_PATH=/path/to/flat_ui litellm --config config.yaml --port 4000
for route in chat logs models-and-endpoints api-keys usage; do
  printf "GET /ui/%s -> " "$route"
  curl -sS -o /dev/null -w "%{http_code} (final: %{url_effective})\n" -L "http://localhost:4000/ui/$route"
done
```

Before, at a625d1e1ca:

```
GET /ui/chat -> 404 (final: http://localhost:4000/ui/chat)
GET /ui/logs -> 404 (final: http://localhost:4000/ui/logs)
```

`curl -i http://localhost:4000/ui/chat` returns `HTTP/1.1 404 Not Found` with the Next.js `<title>404: This page could not be found.</title>` page, which is exactly what users report in #24037

After, at 6257a6c6b5:

```
GET /ui/chat -> 200 (final: http://localhost:4000/ui/chat/)
GET /ui/logs -> 200 (final: http://localhost:4000/ui/logs/)
GET /ui/models-and-endpoints -> 200 (final: http://localhost:4000/ui/models-and-endpoints/)
GET /ui/api-keys -> 200 (final: http://localhost:4000/ui/api-keys/)
GET /ui/usage -> 200 (final: http://localhost:4000/ui/usage/)

$ curl -sS -L http://localhost:4000/ui/chat | grep -o "<title>[^<]*</title>"
<title>LiteLLM Dashboard</title>
```

After serving, `flat_ui/chat/` still has no `index.html` and `chat.html` is still at the top level, confirming the proxy wrote nothing to the bundle

## Type

🐛 Bug Fix

## Changes

`StaticFiles(html=True)` resolves `/ui/chat` by matching the `chat/` directory first and looking for `chat/index.html`; the sibling `chat.html` is never tried, so the request 404s. The existing compensation moves files around at startup (`_restructure_ui_html_files`), but it only runs when the UI directory is writable, so read-only deployments serving a flat bundle keep failing, as reported on the issue as recently as v1.90.0

This PR adds `UiStaticFiles` in `litellm/proxy/common_utils/ui_static_files.py`, a `StaticFiles` subclass that falls back at lookup time: when a lookup misses, it retries `<route>/index.html` as `<route>.html`, and a plain extensionless miss as `<route>.html`. The `/ui` mount in `proxy_server.py` now uses it. Restructured bundles resolve on the first lookup and never reach the fallback, flat bundles resolve on the retry, and nothing is written to disk either way

Tests in `tests/test_litellm/proxy/common_utils/test_ui_static_files.py` cover the flat layout with and without the shadowing directory, the restructured layout, the guarantee that serving writes nothing to disk, plain asset files, and unknown routes still returning 404. The flat-layout cases fail against vanilla `StaticFiles`, so a regression of #24037 fails the suite

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


