### PR TITLE
fix(proxy): reconcile budget reservation to recovered stream cost on failure

### DIFF
--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -54,10 +54,28 @@ class _ProxyDBLogger(CustomLogger):
         user_api_key_dict: UserAPIKeyAuth,
         traceback_str: str | None = None,
     ):
+        # A stream that broke mid-flight still billed the provider for the chunks
+        # already delivered. ``post_call_failure_hook`` lifts that recovered cost
+        # onto request_data (the usage rides along in ``combined_usage_object``
+        # for the token columns), so reconcile the reservation to it instead of
+        # refunding to zero; refunding drops spend LiteLLM already calculated out
+        # of the live enforcement counters until the async DB writes flush.
+        recovered_response_cost = 0.0
+        if isinstance(request_data.get("combined_usage_object"), litellm.Usage):
+            recovered_response_cost = max(float(request_data.get("response_cost") or 0.0), 0.0)
+
         try:
-            await _release_budget_reservation(budget_reservation=user_api_key_dict.budget_reservation)
+            if user_api_key_dict.budget_reservation is not None:
+                from litellm.proxy.spend_tracking.budget_reservation import (
+                    reconcile_budget_reservation,
+                )
+
+                await reconcile_budget_reservation(
+                    budget_reservation=user_api_key_dict.budget_reservation,
+                    actual_cost=recovered_response_cost,
+                )
         except Exception:
-            verbose_proxy_logger.exception("Failed to release budget reservation during failure handling")
+            verbose_proxy_logger.exception("Failed to reconcile budget reservation during failure handling")
             try:
                 await _invalidate_budget_reservation_counters(budget_reservation=user_api_key_dict.budget_reservation)
                 if user_api_key_dict.budget_reservation is not None:
@@ -155,15 +173,6 @@ class _ProxyDBLogger(CustomLogger):
             obj_start = getattr(_litellm_logging_obj, "start_time", None)
             if obj_start is not None:
                 actual_start_time = obj_start
-
-        # A stream that broke mid-flight still billed the provider for the
-        # chunks already delivered. ``post_call_failure_hook`` lifts that
-        # recovered cost onto request_data (the usage rides along in
-        # ``combined_usage_object`` for the token columns), so attribute the
-        # real partial spend to this failure row instead of zero.
-        recovered_response_cost = 0.0
-        if isinstance(request_data.get("combined_usage_object"), litellm.Usage):
-            recovered_response_cost = max(float(request_data.get("response_cost") or 0.0), 0.0)
 
         await proxy_logging_obj.db_spend_update_writer.update_database(
             token=user_api_key_dict.api_key,

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -141,9 +141,9 @@ async def test_async_post_call_failure_hook_releases_budget_reservation_before_r
 
     with (
         patch(
-            "litellm.proxy.spend_tracking.budget_reservation.release_budget_reservation",
+            "litellm.proxy.spend_tracking.budget_reservation.reconcile_budget_reservation",
             new_callable=AsyncMock,
-        ) as mock_release_budget_reservation,
+        ) as mock_reconcile_budget_reservation,
         patch(
             "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter.update_database",
             new_callable=AsyncMock,
@@ -155,11 +155,12 @@ async def test_async_post_call_failure_hook_releases_budget_reservation_before_r
             user_api_key_dict=user_api_key_dict,
         )
 
-        assert mock_release_budget_reservation.await_count == 1
+        assert mock_reconcile_budget_reservation.await_count == 1
         assert (
-            mock_release_budget_reservation.await_args.kwargs["budget_reservation"]
+            mock_reconcile_budget_reservation.await_args.kwargs["budget_reservation"]
             is user_api_key_dict.budget_reservation
         )
+        assert mock_reconcile_budget_reservation.await_args.kwargs["actual_cost"] == 0.0
         mock_update_database.assert_not_called()
 
 
@@ -177,10 +178,10 @@ async def test_should_continue_failure_tracking_when_budget_release_fails():
 
     with (
         patch(
-            "litellm.proxy.spend_tracking.budget_reservation.release_budget_reservation",
+            "litellm.proxy.spend_tracking.budget_reservation.reconcile_budget_reservation",
             new_callable=AsyncMock,
             side_effect=RuntimeError("redis unavailable"),
-        ) as mock_release_budget_reservation,
+        ) as mock_reconcile_budget_reservation,
         patch(
             "litellm.proxy.hooks.proxy_track_cost_callback._invalidate_budget_reservation_counters",
             new_callable=AsyncMock,
@@ -202,9 +203,9 @@ async def test_should_continue_failure_tracking_when_budget_release_fails():
             user_api_key_dict=user_api_key_dict,
         )
 
-        assert mock_release_budget_reservation.await_count == 1
+        assert mock_reconcile_budget_reservation.await_count == 1
         assert (
-            mock_release_budget_reservation.await_args.kwargs["budget_reservation"]
+            mock_reconcile_budget_reservation.await_args.kwargs["budget_reservation"]
             is user_api_key_dict.budget_reservation
         )
         assert mock_invalidate_budget_reservation_counters.await_count == 1
@@ -1105,6 +1106,57 @@ async def test_async_post_call_failure_hook_records_recovered_partial_spend():
 
         mock_update_database.assert_called_once()
         assert mock_update_database.call_args[1]["response_cost"] == 3.5e-05
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_hook_reconciles_reservation_to_recovered_cost():
+    """Recovered partial cost must land on the live budget counters, not be refunded.
+
+    The pre-call reservation holds a worst-case amount on the shared spend
+    counters. Refunding it to zero on failure drops cost LiteLLM already
+    calculated out of live enforcement until the async DB writes flush, so a key
+    can keep serving past its max_budget. Reconcile to the recovered cost.
+    """
+    from litellm.types.utils import Usage
+
+    logger = _ProxyDBLogger()
+    budget_reservation = {"reserved_cost": 0.5, "entries": []}
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test_api_key",
+        user_id="u",
+        team_id="t",
+        request_route="/chat/completions",
+        budget_reservation=budget_reservation,
+    )
+
+    request_data = {
+        "model": "anthropic/claude-haiku-4-5",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "response_cost": 3.5e-05,
+        "combined_usage_object": Usage(prompt_tokens=30, completion_tokens=1, total_tokens=31),
+    }
+
+    with (
+        patch(
+            "litellm.proxy.spend_tracking.budget_reservation.reconcile_budget_reservation",
+            new_callable=AsyncMock,
+        ) as mock_reconcile_budget_reservation,
+        patch(
+            "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter.update_database",
+            new_callable=AsyncMock,
+        ) as mock_update_database,
+    ):
+        await logger.async_post_call_failure_hook(
+            request_data=request_data,
+            original_exception=Exception("MidStreamFallbackError: read timeout"),
+            user_api_key_dict=user_api_key_dict,
+        )
+
+    mock_reconcile_budget_reservation.assert_awaited_once()
+    reconcile_kwargs = mock_reconcile_budget_reservation.await_args.kwargs
+    assert reconcile_kwargs["budget_reservation"] is user_api_key_dict.budget_reservation
+    assert reconcile_kwargs["actual_cost"] == 3.5e-05
+    assert mock_update_database.call_args[1]["response_cost"] == 3.5e-05
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

The failure hook already recovers partial usage and cost from a stream that died after delivering chunks, and it writes that cost to the spend log. The live budget counters never see it. `async_post_call_failure_hook` releases the pre-call reservation at hook entry, which reconciles every reserved counter to zero, and `recovered_response_cost` is only computed much further down, right before `update_database`

So the shared counters give the whole reservation back and pick up nothing in its place. The recovered cost lands only once the asynchronous DB writes flush and a later counter repair notices, and in that window a key can keep serving past its `max_budget`

How it solves it:

Compute the recovered cost first and reconcile the reservation to it instead of releasing it. Nothing recovered still means a full refund, so plain failures and streams that died before any chunk behave exactly as they did

The computation moved up but did not change; it is the same `combined_usage_object` check that already guarded the value passed to `update_database`, so the failure spend log still records the same number it did before

## Relevant issues

Fixes #35568

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

I could not give you the live-proxy curl proof this repo prefers. Reproducing it needs a priced streaming model, a key with a low `max_budget`, and a forced mid-stream provider read error so the recovered cost is non-zero, and I have no provider key or database to point a real proxy at. Saying that straight rather than dressing a test run up as proof

The QA runbook below is what I would run if I had a keyed proxy, and the regression test covers the counter path in the meantime

## Type

🐛 Bug Fix

## Changes

`async_post_call_failure_hook` computes `recovered_response_cost` before touching the reservation and reconciles to that value rather than calling the release helper. The exception message now says reconcile instead of release. The invalidate-on-failure fallback is untouched

Two existing tests asserted the old unconditional release at hook entry; they now assert a reconcile with `actual_cost` 0.0, which is the same refund. Added `test_async_post_call_failure_hook_reconciles_reservation_to_recovered_cost`, which is the one that fails if the reservation goes back to being refunded

## QA runbook

1. Configure a priced streaming model and a key with a low `max_budget`
2. Start a stream and let several billed chunks arrive
3. Force a mid-stream provider read error so `combined_usage_object` and `response_cost` are both available
4. Check the failure row in the spend logs records the recovered positive cost, as it did before
5. Inspect the matching live `spend:key:*` counter. Before this change the pre-call reservation was refunded and the counter lost that cost; now it holds the recovered amount

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

An AI coding agent was used while preparing this change. I reviewed the diff, mutation-checked the new test by reverting the reconcile back to 0.0 and confirming it fails, and `make pre-commit` is green
