### PR TITLE
fix(ollama): end streamed tool calls with finish_reason tool_calls

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -425,6 +425,7 @@ class OllamaChatConfig(BaseConfig):
 class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
     started_reasoning_content: bool = False
     finished_reasoning_content: bool = False
+    saw_tool_calls: bool = False
 
     def _is_function_call_complete(self, function_args: str | dict) -> bool:
         if isinstance(function_args, dict):
@@ -470,6 +471,7 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
             # process tool calls - if complete function arg - add id to tool call
             tool_calls = chunk["message"].get("tool_calls")
             if tool_calls is not None:
+                self.saw_tool_calls = True
                 for tool_call in tool_calls:
                     function_args = tool_call.get("function").get("arguments")
                     if function_args is not None and len(function_args) > 0:
@@ -510,9 +512,13 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
 
             if chunk["done"] is True:
                 finish_reason = chunk.get("done_reason") or "stop"
-                # Override finish_reason when tool_calls are present
+                # Override finish_reason when tool_calls are present anywhere in
+                # the stream. Ollama often sends them in a chunk with done false
+                # and then a separate done chunk with an empty message, so keying
+                # off this chunk's tool_calls alone leaves the stream ending in
+                # "stop".
                 # Fixes: https://github.com/BerriAI/litellm/issues/18922
-                if tool_calls is not None:
+                if self.saw_tool_calls:
                     finish_reason = "tool_calls"
                 choices = [
                     StreamingChoices(

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -597,6 +597,52 @@ class TestOllamaFinishReasonLength:
             result.choices[0].finish_reason == "length"
         ), f"Expected 'length' when done_reason='length', got '{result.choices[0].finish_reason}'"
 
+    def test_finish_reason_tool_calls_when_split_across_chunks(self):
+        """Tool calls in an earlier chunk must still end the stream with 'tool_calls'.
+
+        Ollama commonly emits tool_calls in a chunk with done false and then a
+        separate done chunk whose message is empty and whose done_reason is
+        'stop'. Keying the override off the done chunk's own tool_calls left the
+        stream finishing as 'stop', so spec-strict OpenAI clients dropped the
+        accumulated tool_calls delta and never ran the tool.
+        """
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        tool_call_chunk = {
+            "model": "glm-4.7-flash",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "list_files",
+                            "arguments": {"path": "."},
+                        }
+                    }
+                ],
+            },
+            "done": False,
+        }
+        done_chunk = {
+            "model": "glm-4.7-flash",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": "stop",
+        }
+
+        tool_call_result = iterator.chunk_parser(tool_call_chunk)
+        assert tool_call_result.choices[0].delta.tool_calls is not None
+        assert tool_call_result.choices[0].finish_reason is None
+
+        done_result = iterator.chunk_parser(done_chunk)
+        assert (
+            done_result.choices[0].finish_reason == "tool_calls"
+        ), f"Expected 'tool_calls' after a tool call earlier in the stream, got '{done_result.choices[0].finish_reason}'"
+
     def test_finish_reason_stop_streaming(self):
         """Streaming: done_reason='stop' in final chunk must produce finish_reason='stop'."""
         iterator = OllamaChatCompletionResponseIterator(


### PR DESCRIPTION
## TLDR

Problem this solves:

Streaming a tool call through `ollama_chat` ends the stream with `finish_reason` of `stop` instead of `tool_calls`. Any client that only fires a tool-use action when it sees `finish_reason == "tool_calls"` throws away the `tool_calls` delta it just accumulated and treats the turn as ordinary text, so the tool never runs. Text-only streams are fine, and the non-streaming path is fine because it reads `message.tool_calls` off the full response

The override that sets `tool_calls` lived on the `done` branch of `chunk_parser` and only looked at that chunk's own `tool_calls`. Ollama sends the tool call in a chunk with `done` false and then a separate `done` chunk whose `message` is empty and whose `done_reason` is `stop`, so by the time the override runs `tool_calls` is None and the finish reason stays `stop`

How it solves it:

Track on the iterator whether any chunk in the stream carried tool calls, and key the override off that instead of the done chunk alone. The iterator already keeps per-stream state this way for reasoning content, so this follows the same shape

Streams that never produce a tool call are untouched and keep whatever `done_reason` Ollama sent, so `stop` and `length` still come through as before

## Relevant issues

Fixes #35663

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

I do not have an Ollama host with a tool-capable model to curl against, so I cannot give you the live-proxy output this repo prefers. Flagging that rather than passing something else off as proof

The runbook below is the reporter's reproduction and is what I would run against a real Ollama. The regression test drives `chunk_parser` with the exact two-chunk sequence Ollama emits, which is the part that was wrong

## Type

🐛 Bug Fix

## Changes

`OllamaChatCompletionResponseIterator` gains a `saw_tool_calls` flag, set when a chunk carries `tool_calls`, and the done branch consults it instead of the current chunk's `tool_calls`

Added `test_finish_reason_tool_calls_when_split_across_chunks`, which feeds a tool-call chunk with `done` false followed by an empty `done` chunk with `done_reason` of `stop` and asserts the stream finishes as `tool_calls`

## QA runbook

1. Point the proxy at a tool-capable Ollama model, for example `ollama_chat/qwen3` or `ollama_chat/glm-4.7-flash`
2. Put a streaming request in `req.json` with `stream` true, a user message that forces a tool call, and a `tools` array holding a `list_files` function that takes a `path` string
3. `curl -N http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $LITELLM_KEY" -H "Content-Type: application/json" --data @req.json`
4. Look at the trailing SSE chunk. Before this change its `delta` is empty and `finish_reason` is `stop`; now `finish_reason` is `tool_calls`
5. Send a plain text streaming request and confirm it still ends in `stop`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

An AI coding agent was used while preparing this change. I reviewed the diff, confirmed the new test fails on the base branch with `got 'stop'` and passes here, and `make pre-commit` is green
