### PR TITLE
fix(router): don't warn about cache pricing the shared backend key strips

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -7546,7 +7546,7 @@ class Router:
             if "responses/" in _model_name:
                 _stripped_model_name = _model_name.replace("responses/", "")
                 _backend_alias_cost[_stripped_model_name] = _shared_model_info
-            litellm.register_model(model_cost=_backend_alias_cost)
+            litellm.register_model(model_cost=_backend_alias_cost, warn_on_missing_cache_cost=False)
 
             ## Check if LLM Deployment is allowed for this deployment
             if self.deployment_is_active_for_environment(deployment=deployment) is not True:
@@ -8271,7 +8271,7 @@ class Router:
         if "responses/" in _model_name:
             _stripped_model_name = _model_name.replace("responses/", "")
             _backend_alias_cost[_stripped_model_name] = _shared_model_info
-        litellm.register_model(model_cost=_backend_alias_cost)
+        litellm.register_model(model_cost=_backend_alias_cost, warn_on_missing_cache_cost=False)
 
         # add to model names
         self._add_model_to_list_and_index_map(model=_deployment, model_id=deployment.model_info.id)

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -2680,7 +2680,7 @@ def _get_builtin_model_info_for_registration(model: str) -> ModelInfo | None:
     return None
 
 
-def register_model(model_cost: str | dict):
+def register_model(model_cost: str | dict, *, warn_on_missing_cache_cost: bool = True):
     """
     Register new / Override existing models (and their pricing) to specific providers.
     Provide EITHER a model cost dictionary or a url to a hosted json blob
@@ -2694,6 +2694,11 @@ def register_model(model_cost: str | dict):
             "mode": "chat"
         },
     }
+
+    Set `warn_on_missing_cache_cost=False` when the caller has already stripped
+    per-deployment cache pricing out of `model_cost` on purpose, as the router does
+    for shared backend keys. The warning tells you to add fields the caller did
+    supply and the caller then discarded, so it cannot be acted on from config.
     """
 
     loaded_model_cost = {}
@@ -2733,7 +2738,8 @@ def register_model(model_cost: str | dict):
                         if value.get(field) is None and builtin_entry.get(field) is not None:
                             existing_model[field] = builtin_entry[field]
                 elif (
-                    value.get("cache_creation_input_token_cost") is None
+                    warn_on_missing_cache_cost
+                    and value.get("cache_creation_input_token_cost") is None
                     and value.get("cache_read_input_token_cost") is None
                 ):
                     verbose_logger.warning(

--- a/tests/test_litellm/test_router_model_cost_isolation.py
+++ b/tests/test_litellm/test_router_model_cost_isolation.py
@@ -944,3 +944,60 @@ def test_wildcard_zero_cost_request_does_not_poison_named_deployment_pricing():
         assert named_cost == pytest.approx(10 * builtin_input_cost)
     finally:
         _restore_model_cost_entries(model_keys)
+
+
+def test_shared_backend_registration_does_not_warn_about_stripped_cache_pricing():
+    """The shared backend key strips cache pricing on purpose, so it must not warn.
+
+    register_model warns when an unknown backend model carries neither cache cost
+    field, telling the operator to add them to model_info. The router registers
+    every deployment a second time under the shared backend key, filtered through
+    shared_backend_model_info(), which removes exactly those two fields. The
+    warning therefore fired on a path where the operator had already supplied
+    them, asking for something no config change could satisfy.
+    """
+    with patch("litellm.utils.verbose_logger.warning") as mock_warning:
+        Router(
+            model_list=[
+                {
+                    "model_name": "local-chat",
+                    "litellm_params": {
+                        "model": "openai/my-local-model-x9y8z7",
+                        "api_base": "http://localhost:9999/v1",
+                        "api_key": "x",
+                    },
+                    "model_info": {
+                        "cache_creation_input_token_cost": 0.000001,
+                        "cache_read_input_token_cost": 0.0000001,
+                    },
+                }
+            ]
+        )
+
+    cache_warnings = [
+        call for call in mock_warning.call_args_list if "cache cost fields will default to 0" in str(call)
+    ]
+    assert cache_warnings == []
+
+
+def test_register_model_still_warns_when_cache_pricing_is_genuinely_absent():
+    """The warning is only suppressed for the stripped shared-backend path.
+
+    A direct register_model call for an unknown backend model with no cache
+    pricing is actionable, so it must keep warning.
+    """
+    with patch("litellm.utils.verbose_logger.warning") as mock_warning:
+        litellm.register_model(
+            model_cost={
+                "openai/another-unknown-model-x9y8z7": {
+                    "litellm_provider": "openai",
+                    "mode": "chat",
+                    "input_cost_per_token": 0.000003,
+                }
+            }
+        )
+
+    cache_warnings = [
+        call for call in mock_warning.call_args_list if "cache cost fields will default to 0" in str(call)
+    ]
+    assert len(cache_warnings) == 1


### PR DESCRIPTION
## TLDR

Problem this solves:

The cache-cost warning added in v1.95.0 cannot be silenced by doing what it asks. It tells you to add `cache_creation_input_token_cost` and `cache_read_input_token_cost` to `model_info`, but the router registers every deployment twice: once under the unique `model_info.id` with the full info, and once under the shared backend key filtered through `shared_backend_model_info()`, which drops exactly those two fields. The warning fires on that second registration, so it asks for fields the operator already supplied and the router deliberately discarded

Stripping per-deployment pricing off a shared key is correct in itself; the bug is that the warning rides along on the stripped path. It is cosmetic but permanent, and on a proxy with dozens of deployments it is dozens of WARNING lines on every boot. Anyone self-hosting models that are legitimately absent from the built-in cost map hits it for every deployment with no config that resolves it

How it solves it:

`register_model` takes a keyword-only `warn_on_missing_cache_cost`, defaulting to True so nothing else changes, and the two shared-backend call sites pass False. The warning is for a caller who genuinely has no cache pricing, not for one whose pricing was removed in transit

A direct `register_model` call for an unknown backend model with no cache pricing still warns, because that one is actionable. The per-deployment registration under `model_info.id` is untouched

## Relevant issues

Fixes #35693

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This one needs no provider key or database, so I could actually run the reporter's reproduction from #35693 against both trees. It is a plain `Router(...)` construction with the two cache fields set in `model_info`, counting the warnings that come out:

```
$ uv run --frozen python repro.py    # on litellm_internal_staging
WARNING:LiteLLM:register_model: model=openai/my-local-model not in built-in cost map and no
prefix/region variant matched; cache cost fields will default to 0. To track cache cost, add
cache_creation_input_token_cost and cache_read_input_token_cost to model_info
cache-cost warnings: 1

$ uv run --frozen python repro.py    # on this branch
cache-cost warnings: 0
```

I have not run it against a real 83-deployment config, so the boot-log runbook is below if you want to confirm the count drops there too

## Type

🐛 Bug Fix

## Changes

`register_model` gained a keyword-only `warn_on_missing_cache_cost` flag, guarding the existing warning, plus a docstring note saying when to pass False so the reason does not get lost

Both shared-backend registrations in the router, the `model_list` path and the `add_deployment` path, pass `warn_on_missing_cache_cost=False`

Added two tests to `test_router_model_cost_isolation.py`: one asserting a `Router` with both cache fields set emits no cache-cost warning, and one asserting a direct `register_model` with no cache pricing still emits exactly one. The second is the guard against muting the warning everywhere

## QA runbook

1. Start the proxy with a config holding several deployments of self-hosted models absent from the built-in cost map, each with `cache_creation_input_token_cost` and `cache_read_input_token_cost` set in `model_info`
2. `grep "cache cost fields will default to 0" litellm.log | wc -l`. Before this change there is one line per distinct backend model string; now there are none
3. Remove the two cache fields from one deployment and restart, then confirm you still get a warning for it, so the signal is not gone

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

An AI coding agent was used while preparing this change. I reviewed the diff, ran the reporter's reproduction against both trees, and confirmed the new suppression test fails on the base branch while the over-suppression guard passes on both. `make pre-commit` is green
