### PR TITLE
feat: add Cafe24 LLM Router as OpenAI-compatible provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -183,5 +183,10 @@
       "max_completion_tokens": "max_tokens"
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+  },
+  "cafe24": {
+    "base_url": "https://llm-router.cafe24.com/api/v1",
+    "api_key_env": "CAFE24_API_KEY",
+    "api_base_env": "CAFE24_API_BASE"
   }
 }

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3619,6 +3619,7 @@ class LlmProviders(str, Enum):
     CURSOR = "cursor"
     BEDROCK_MANTLE = "bedrock_mantle"
     GDC = "gdc"
+    CAFE24 = "cafe24"
 
 
 # Create a set of all provider values for quick lookup

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2941,6 +2941,23 @@
         "rerank": false,
         "a2a": false
       }
+    },
+    "cafe24": {
+      "display_name": "Cafe24 LLM Router (`cafe24`)",
+      "url": "https://llm-router.cafe24.com/docs",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
     }
   },
   "endpoints": {

--- a/tests/test_litellm/llms/openai_like/test_cafe24.py
+++ b/tests/test_litellm/llms/openai_like/test_cafe24.py
@@ -1,0 +1,105 @@
+"""
+Tests for Cafe24 LLM Router provider configuration and integration.
+"""
+
+import os
+import sys
+
+try:
+    import pytest
+except ImportError:
+    pytest = None
+
+# Add workspace to path
+workspace_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../.."))
+sys.path.insert(0, workspace_path)
+
+import litellm
+
+
+class TestCafe24ProviderConfig:
+    """Test Cafe24 LLM Router provider configuration"""
+
+    def test_cafe24_in_provider_list(self):
+        """Test that cafe24 is in the provider list"""
+        from litellm import LlmProviders
+
+        assert hasattr(LlmProviders, "CAFE24")
+        assert LlmProviders.CAFE24.value == "cafe24"
+        assert "cafe24" in litellm.provider_list
+
+    def test_cafe24_json_config_exists(self):
+        """Test that cafe24 is configured in providers.json"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("cafe24")
+
+        cafe24 = JSONProviderRegistry.get("cafe24")
+        assert cafe24 is not None
+        assert cafe24.base_url == "https://llm-router.cafe24.com/api/v1"
+        assert cafe24.api_key_env == "CAFE24_API_KEY"
+
+    def test_cafe24_provider_resolution(self):
+        """Test that provider resolution finds cafe24.
+
+        Cafe24 LLM Router model IDs contain slashes
+        (e.g. deepseek-ai/DeepSeek-V3.1), so this also verifies that
+        nested slashes in the model name resolve correctly.
+        """
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, api_key, api_base = get_llm_provider(
+            model="cafe24/deepseek-ai/DeepSeek-V3.1",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+
+        assert model == "deepseek-ai/DeepSeek-V3.1"
+        assert provider == "cafe24"
+        assert api_base == "https://llm-router.cafe24.com/api/v1"
+
+    def test_cafe24_router_config(self):
+        """Test that cafe24 can be used in Router configuration"""
+        from litellm import Router
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "qwen3-8b",
+                    "litellm_params": {
+                        "model": "cafe24/Qwen/Qwen3-8B",
+                        "api_key": "test-key",
+                    },
+                }
+            ]
+        )
+
+        assert len(router.model_list) == 1
+        assert router.model_list[0]["model_name"] == "qwen3-8b"
+
+
+if __name__ == "__main__":
+    print("Testing Cafe24 LLM Router Provider...")
+
+    test_config = TestCafe24ProviderConfig()
+
+    print("\n1. Testing provider in list...")
+    test_config.test_cafe24_in_provider_list()
+    print("   ✓ cafe24 in provider list")
+
+    print("\n2. Testing JSON config...")
+    test_config.test_cafe24_json_config_exists()
+    print("   ✓ cafe24 JSON config loaded")
+
+    print("\n3. Testing provider resolution...")
+    test_config.test_cafe24_provider_resolution()
+    print("   ✓ Provider resolution works")
+
+    print("\n4. Testing router configuration...")
+    test_config.test_cafe24_router_config()
+    print("   ✓ Router configuration works")
+
+    print("\n" + "=" * 50)
+    print("✓ All configuration tests passed!")
+    print("=" * 50)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cafe24 LLM Router users cannot call it through LiteLLM today
- Korean developers lack a first-class Korean LLM gateway in LiteLLM

How it solves it:

- Adds `cafe24` as a JSON-based OpenAI-compatible provider
- `model="cafe24/<model-id>"` now routes to https://llm-router.cafe24.com

## Relevant issues

N/A — new provider addition. [Cafe24](https://www.cafe24.com) is a KRX-listed Korean e-commerce & hosting platform company. Cafe24 LLM Router (https://llm-router.cafe24.com) is our OpenAI-compatible LLM gateway with automatic routing (`cafe24/auto`), fallbacks, and semantic caching. We are the Cafe24 LLM Router team and will maintain this integration. Docs: https://llm-router.cafe24.com/docs

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

All proofs captured at the exact file tree in this PR's head commit `a46001c` (proof runs originally committed as `b986930`; later rebased/retargeted with identical file contents) against the **live** Cafe24 LLM Router endpoint (real LLM calls, no mocks).

Non-streaming completion:

```
>>> litellm.completion(model='cafe24/Qwen/Qwen3-8B',
...     messages=[{'role':'user','content':'Say OK'}])
model=cafe24/Qwen/Qwen3-8B finish_reason=stop
content='\n\nOK! How can I help you today? 😊' usage=10+347=357
```

Auto-routing model (the gateway selects the underlying model and reports it):

```
>>> litellm.completion(model='cafe24/cafe24/auto', ...)
model=cafe24/inclusionAI/Ling-flash-2.0 finish_reason=stop
content='OK! 😊 How can I help you today?' usage=20+11=31
```

Streaming:

```
>>> litellm.completion(model='cafe24/Qwen/Qwen3-8B',
...     messages=[{'role':'user','content':'Count 1 to 3'}], stream=True)
stream chunks=372 text='\n\n1  \n2  \n3'
```

Nested-slash model IDs resolve correctly (`cafe24/deepseek-ai/DeepSeek-V3.1` → provider `cafe24`, model `deepseek-ai/DeepSeek-V3.1`) — covered by unit test.

## Type

🆕 New Feature

## Changes

Adds `cafe24` (Cafe24 LLM Router) as a JSON-based OpenAI-compatible provider:

- `litellm/llms/openai_like/providers.json`: provider entry (base_url `https://llm-router.cafe24.com/api/v1`, key env `CAFE24_API_KEY`)
- `litellm/types/utils.py`: `LlmProviders.CAFE24`
- `provider_endpoints_support.json`: endpoint support matrix
- `tests/test_litellm/llms/openai_like/test_cafe24.py`: config/registry/resolution/Router tests (follows the existing charity_engine pattern)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
