### PR TITLE
fix(anthropic): resolve capabilities for mantle-routed bedrock ids

### DIFF
--- a/litellm/llms/anthropic/common_utils.py
+++ b/litellm/llms/anthropic/common_utils.py
@@ -309,7 +309,9 @@ class AnthropicModelInfo(BaseLLMModelInfo):
         prefixes = (
             "bedrock/converse/",
             "bedrock/invoke/",
+            "bedrock/mantle/",
             "bedrock/",
+            "mantle/",
             "vertex_ai/",
         )
         deprefixed = tuple(model[len(p) :] for p in prefixes if model.startswith(p))

--- a/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
+++ b/tests/test_litellm/llms/bedrock/chat/invoke_transformations/test_bedrock_chat_invoke_transformations_anthropic_claude3_transformation.py
@@ -430,6 +430,34 @@ def test_output_config_forwarded_for_bedrock_chat_invoke_request():
     assert result["max_tokens"] == 100
 
 
+def test_output_config_forwarded_for_mantle_routed_model():
+    """A mantle-routed id must resolve the same capabilities as its us.* twin.
+
+    bedrock/mantle/anthropic.claude-opus-5 and bedrock/us.anthropic.claude-opus-5
+    are the same underlying model, but the mantle route segment was not among the
+    prefixes capability lookups strip, so supports_output_config and the effort
+    check both came back False and this path stripped output_config. The request
+    then went out with the legacy thinking.type=enabled shape, which Bedrock
+    rejects.
+    """
+    config = AmazonAnthropicClaudeConfig()
+
+    optional_params = {
+        "max_tokens": 100,
+        "output_config": {"effort": "high"},
+    }
+
+    result = config.transform_request(
+        model="mantle/anthropic.claude-opus-5",
+        messages=[{"role": "user", "content": "test"}],
+        optional_params=optional_params,
+        litellm_params={},
+        headers={},
+    )
+
+    assert result.get("output_config") == {"effort": "high"}
+
+
 def test_output_config_format_converted_for_bedrock_chat_invoke_request():
     """Bedrock Invoke chat path consumes ``output_config.format`` before forwarding."""
     config = AmazonAnthropicClaudeConfig()


### PR DESCRIPTION
## TLDR

Problem this solves:

`bedrock/mantle/anthropic.claude-opus-5` and `bedrock/us.anthropic.claude-opus-5` are the same underlying model, but they did not resolve the same capabilities. The mantle route segment was missing from the prefixes the model-map candidate walk strips, so the lookup never reached the `anthropic.claude-opus-5` entry that carries the flags:

```
model id                                    effort_param
mantle/anthropic.claude-opus-5              False
us.anthropic.claude-opus-5                  True
```

The Bedrock invoke path strips `output_config` when neither `supports_output_config` nor the effort check passes. So a mantle-routed Opus 5 lost the effort it was given and went out with the legacy `thinking.type=enabled` shape, which Bedrock rejects. Only `reasoning_effort="none"` avoided the error, and only because it drops the thinking block rather than fixing its shape

This is not a missing cost-map flag. Every Opus 5 variant already carries `supports_adaptive_thinking: true`, and the adaptive classifier resolved the mantle id fine; the other lookups on the same path did not, so one model disagreed with itself depending on which id you used

How it solves it:

Add `bedrock/mantle/` and bare `mantle/` to the prefix list in `_model_map_lookup_candidates`, which is the candidate walk `_get_model_capability` uses. There is no `mantle/`-prefixed key anywhere in the cost map, so stripping the segment is the resolution that was intended

I deliberately did not touch `strip_bedrock_routing_prefix`, which is the other obvious place to add `mantle/`. That helper also builds the wire model id, and the mantle transformations strip the segment themselves, so adding it there changes request routing rather than just capability resolution. This change is confined to the capability lookup

`bedrock_mantle/...` ids are unaffected: the check is `startswith`, so the provider prefix is never mistaken for the `mantle/` route segment

## Relevant issues

Fixes #35670

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

I have no Bedrock mantle access, so I cannot show you the real request going out; that part needs someone with the route enabled. The capability resolution itself needs no credentials, so I could measure it directly on both trees:

```
$ uv run --frozen python probe.py    # on litellm_internal_staging
mantle/anthropic.claude-opus-5   adaptive=True  effort_param=False
us.anthropic.claude-opus-5       adaptive=True  effort_param=True

$ uv run --frozen python probe.py    # on this branch
mantle/anthropic.claude-opus-5   adaptive=True  effort_param=True
us.anthropic.claude-opus-5       adaptive=True  effort_param=True
```

`mantle/anthropic.claude-opus-4-5` stays False, which is correct; there is no `anthropic.claude-opus-4-5` entry in the cost map at all

## Type

🐛 Bug Fix

## Changes

`_model_map_lookup_candidates` in the Anthropic common utils gained `bedrock/mantle/` and `mantle/`

Added `test_output_config_forwarded_for_mantle_routed_model` next to the existing `output_config` invoke tests. It drives the real `transform_request` for a mantle id with `output_config.effort` set and asserts it survives, which is the behaviour the guard was breaking

Ran the full `tests/test_litellm/llms/anthropic/` and `tests/test_litellm/llms/bedrock/` suites, 2343 passed, to check the widened candidate list does not shift any other model's capabilities

## QA runbook

1. On a deployment with Bedrock mantle access, call `bedrock/mantle/anthropic.claude-opus-5` with a normal `reasoning_effort` such as `high`
2. Before this change Bedrock rejects the request because it carries `thinking.type=enabled`; now it should be accepted with `thinking.type=adaptive` and `output_config.effort`
3. Compare against `bedrock/us.anthropic.claude-opus-5` with the same body and confirm the two now produce the same shape
4. Confirm `reasoning_effort="none"` still suppresses the thinking block as before

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

An AI coding agent was used while preparing this change. I reviewed the diff, confirmed the new test fails on the base branch with `assert None == {'effort': 'high'}` and passes here, and `make pre-commit` is green
