### PR TITLE
feat(ui): add Microsoft Entra ID directory search to the invite-user flow

### DIFF
--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -75,12 +75,22 @@ class DataDogLogger(
     # Class variables or attributes
     def __init__(
         self,
+        dd_api_key: Optional[str] = None,
+        dd_site: Optional[str] = None,
+        dd_agent_host: Optional[str] = None,
+        dd_agent_port: Optional[str] = None,
         **kwargs,
     ):
         """
         Initializes the datadog logger, checks if the correct env variables are set
 
-        Required environment variables (Direct API):
+        Args:
+            dd_api_key: Datadog API key. Falls back to DD_API_KEY env var.
+            dd_site: Datadog site (e.g. "us5.datadoghq.com"). Falls back to DD_SITE env var.
+            dd_agent_host: Hostname or IP of DataDog agent. Falls back to LITELLM_DD_AGENT_HOST env var.
+            dd_agent_port: Port of DataDog agent (default: 10518). Falls back to LITELLM_DD_AGENT_PORT env var.
+
+        Required environment variables (Direct API) when kwargs not provided:
         `DD_API_KEY` - your datadog api key
         `DD_SITE` - your datadog site, example = `"us5.datadoghq.com"`
 
@@ -113,12 +123,19 @@ class DataDogLogger(
             )
 
             # Configure DataDog endpoint (Agent or Direct API)
-            # Use LITELLM_DD_AGENT_HOST to avoid conflicts with ddtrace's DD_AGENT_HOST
-            dd_agent_host = os.getenv("LITELLM_DD_AGENT_HOST")
-            if dd_agent_host:
-                self._configure_dd_agent(dd_agent_host=dd_agent_host)
+            # Prefer explicit kwargs, then fall back to env vars
+            resolved_agent_host = dd_agent_host or os.getenv("LITELLM_DD_AGENT_HOST")
+            if resolved_agent_host:
+                self._configure_dd_agent(
+                    dd_agent_host=resolved_agent_host,
+                    dd_agent_port=dd_agent_port,
+                    dd_api_key=dd_api_key,
+                )
             else:
-                self._configure_dd_direct_api()
+                self._configure_dd_direct_api(
+                    dd_api_key=dd_api_key,
+                    dd_site=dd_site,
+                )
 
             # Optional override for testing
             dd_base_url = get_datadog_base_url_from_env()
@@ -153,34 +170,54 @@ class DataDogLogger(
                 ).model_dump()
         return dict_datadog_params
 
-    def _configure_dd_agent(self, dd_agent_host: str) -> None:
+    def _configure_dd_agent(
+        self,
+        dd_agent_host: str,
+        dd_agent_port: Optional[str] = None,
+        dd_api_key: Optional[str] = None,
+    ) -> None:
         """
         Configure DataDog Agent for log forwarding
 
         Args:
             dd_agent_host: Hostname or IP of DataDog agent
+            dd_agent_port: Port of DataDog agent. Falls back to LITELLM_DD_AGENT_PORT env var (default: 10518).
+            dd_api_key: Datadog API key. Falls back to DD_API_KEY env var. Optional when using agent.
         """
-        dd_agent_port = os.getenv(
+        resolved_port = dd_agent_port or os.getenv(
             "LITELLM_DD_AGENT_PORT", "10518"
         )  # default port for logs
-        self.intake_url = f"http://{dd_agent_host}:{dd_agent_port}/api/v2/logs"
-        self.DD_API_KEY = os.getenv("DD_API_KEY")  # Optional when using agent
+        self.intake_url = f"http://{dd_agent_host}:{resolved_port}/api/v2/logs"
+        self.DD_API_KEY = dd_api_key or os.getenv(
+            "DD_API_KEY"
+        )  # Optional when using agent
         verbose_logger.debug(f"Datadog: Using DD Agent at {self.intake_url}")
 
-    def _configure_dd_direct_api(self) -> None:
+    def _configure_dd_direct_api(
+        self,
+        dd_api_key: Optional[str] = None,
+        dd_site: Optional[str] = None,
+    ) -> None:
         """
         Configure direct DataDog API connection
 
+        Args:
+            dd_api_key: Datadog API key. Falls back to DD_API_KEY env var.
+            dd_site: Datadog site. Falls back to DD_SITE env var.
+
         Raises:
-            Exception: If required environment variables are not set
+            Exception: If required credentials are not provided via args or env vars
         """
-        if os.getenv("DD_API_KEY", None) is None:
+        resolved_api_key = dd_api_key or os.getenv("DD_API_KEY")
+        resolved_site = dd_site or os.getenv("DD_SITE")
+
+        if resolved_api_key is None:
             raise Exception("DD_API_KEY is not set, set 'DD_API_KEY=<>")
-        if os.getenv("DD_SITE", None) is None:
+        if resolved_site is None:
             raise Exception("DD_SITE is not set in .env, set 'DD_SITE=<>")
 
-        self.DD_API_KEY = os.getenv("DD_API_KEY")
-        self.intake_url = f"https://http-intake.logs.{os.getenv('DD_SITE')}/api/v2/logs"
+        self.DD_API_KEY = resolved_api_key
+        self.intake_url = f"https://http-intake.logs.{resolved_site}/api/v2/logs"
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         """

--- a/litellm/integrations/datadog/datadog_team_handler.py
+++ b/litellm/integrations/datadog/datadog_team_handler.py
@@ -1,0 +1,117 @@
+"""
+DataDog Team Handler
+
+Used to get the DataDogLogger for a given request.
+Handles Key/Team Based Datadog Logging, following the same pattern as LangFuseHandler.
+"""
+
+from typing import TYPE_CHECKING, Any, Dict, Optional, TypedDict
+
+from litellm._logging import verbose_logger
+from litellm.litellm_core_utils.litellm_logging import StandardCallbackDynamicParams
+
+from .datadog import DataDogLogger
+
+if TYPE_CHECKING:
+    from litellm.litellm_core_utils.litellm_logging import DynamicLoggingCache
+else:
+    DynamicLoggingCache = Any
+
+
+class DatadogLoggingConfig(TypedDict):
+    dd_api_key: Optional[str]
+    dd_site: Optional[str]
+    dd_agent_host: Optional[str]
+    dd_agent_port: Optional[str]
+
+
+class DataDogHandler:
+    @staticmethod
+    def get_datadog_logger_for_request(
+        standard_callback_dynamic_params: StandardCallbackDynamicParams,
+        in_memory_dynamic_logger_cache: DynamicLoggingCache,
+    ) -> DataDogLogger:
+        """
+        Get a team-scoped DataDogLogger for a given request.
+
+        Resolves and caches per-team DataDogLogger instances using DynamicLoggingCache,
+        keyed by the team's DD credentials. Each unique set of credentials gets its own
+        logger instance with its own batch/flush loop.
+
+        Note: This handler is only called when team-scoped DD credentials are present.
+        The global (env-var based) DataDogLogger is managed separately by
+        _init_custom_logger_compatible_class via _in_memory_loggers.
+        """
+        _credentials = DataDogHandler.get_dynamic_datadog_logging_config(
+            standard_callback_dynamic_params=standard_callback_dynamic_params,
+        )
+        credentials_dict = dict(_credentials)
+
+        # check if datadog logger is already cached
+        temp_datadog_logger = in_memory_dynamic_logger_cache.get_cache(
+            credentials=credentials_dict, service_name="datadog"
+        )
+
+        # if not cached, create a new datadog logger and cache it
+        if temp_datadog_logger is None:
+            temp_datadog_logger = (
+                DataDogHandler._create_datadog_logger_from_credentials(
+                    credentials=credentials_dict,
+                    in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
+                )
+            )
+
+        return temp_datadog_logger
+
+    @staticmethod
+    def _create_datadog_logger_from_credentials(
+        credentials: Dict,
+        in_memory_dynamic_logger_cache: DynamicLoggingCache,
+    ) -> DataDogLogger:
+        """
+        Create a DataDogLogger from the credentials and cache it.
+        """
+        datadog_logger = DataDogLogger(
+            dd_api_key=credentials.get("dd_api_key"),
+            dd_site=credentials.get("dd_site"),
+            dd_agent_host=credentials.get("dd_agent_host"),
+            dd_agent_port=credentials.get("dd_agent_port"),
+        )
+        in_memory_dynamic_logger_cache.set_cache(
+            credentials=credentials,
+            service_name="datadog",
+            logging_obj=datadog_logger,
+        )
+        verbose_logger.debug(
+            "Datadog: Created and cached new DataDogLogger for team-scoped credentials"
+        )
+        return datadog_logger
+
+    @staticmethod
+    def get_dynamic_datadog_logging_config(
+        standard_callback_dynamic_params: StandardCallbackDynamicParams,
+    ) -> DatadogLoggingConfig:
+        """
+        Get the Datadog logging config for a given request from dynamic params.
+        """
+        return DatadogLoggingConfig(
+            dd_api_key=standard_callback_dynamic_params.get("dd_api_key"),
+            dd_site=standard_callback_dynamic_params.get("dd_site"),
+            dd_agent_host=standard_callback_dynamic_params.get("dd_agent_host"),
+            dd_agent_port=standard_callback_dynamic_params.get("dd_agent_port"),
+        )
+
+    @staticmethod
+    def _dynamic_datadog_credentials_are_passed(
+        standard_callback_dynamic_params: StandardCallbackDynamicParams,
+    ) -> bool:
+        """
+        Check if dynamic Datadog credentials are passed in standard_callback_dynamic_params.
+        """
+        if (
+            standard_callback_dynamic_params.get("dd_api_key") is not None
+            or standard_callback_dynamic_params.get("dd_site") is not None
+            or standard_callback_dynamic_params.get("dd_agent_host") is not None
+        ):
+            return True
+        return False

--- a/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
+++ b/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
@@ -53,11 +53,19 @@ _supported_callback_params = [
     "braintrust_host",
     "slack_webhook_url",
     "lunary_public_key",
+    "dd_api_key",
+    "dd_site",
+    "dd_agent_host",
+    "dd_agent_port",
 ]
 
 _request_blocked_callback_params = {
     "gcs_bucket_name",
     "gcs_path_service_account",
+    "dd_api_key",
+    "dd_site",
+    "dd_agent_host",
+    "dd_agent_port",
 }
 
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -376,13 +376,14 @@ class Logging(LiteLLMLoggingBaseClass):
             List[Union[str, Callable, CustomLogger]]
         ] = dynamic_async_failure_callbacks
 
-        # Process dynamic callbacks
-        self.process_dynamic_callbacks()
-
         ## DYNAMIC LANGFUSE / GCS / logging callback KEYS ##
         self.standard_callback_dynamic_params: StandardCallbackDynamicParams = (
             self.initialize_standard_callback_dynamic_params(kwargs)
         )
+
+        # Process dynamic callbacks (after standard_callback_dynamic_params is initialized,
+        # so team-scoped credentials are available for callback initialization)
+        self.process_dynamic_callbacks()
         self.standard_built_in_tools_params: StandardBuiltInToolsParams = (
             self.initialize_standard_built_in_tools_params(kwargs)
         )
@@ -477,8 +478,21 @@ class Logging(LiteLLMLoggingBaseClass):
                 isinstance(callback, str)
                 and callback in litellm._known_custom_logger_compatible_callbacks
             ):
+                # For callbacks that support team-scoped credentials (e.g. datadog),
+                # pass only the relevant dynamic params as custom_logger_init_args.
+                _custom_logger_init_args: Optional[dict] = None
+                if callback == "datadog":
+                    _custom_logger_init_args = {
+                        k: v
+                        for k, v in self.standard_callback_dynamic_params.items()
+                        if k.startswith("dd_")
+                    }
+
                 callback_class = _init_custom_logger_compatible_class(
-                    callback, internal_usage_cache=None, llm_router=None  # type: ignore
+                    callback,  # type: ignore[arg-type]
+                    internal_usage_cache=None,
+                    llm_router=None,  # type: ignore
+                    custom_logger_init_args=_custom_logger_init_args,
                 )
                 if callback_class is not None:
                     processed_list.append(callback_class)
@@ -3797,6 +3811,24 @@ def _init_custom_logger_compatible_class(  # noqa: PLR0915
             _in_memory_loggers.append(_prometheus_logger)
             return _prometheus_logger  # type: ignore
         elif logging_integration == "datadog":
+            # Check if team-scoped credentials are provided
+            _dd_api_key = custom_logger_init_args.get("dd_api_key")
+            _dd_site = custom_logger_init_args.get("dd_site")
+            _dd_agent_host = custom_logger_init_args.get("dd_agent_host")
+            _dd_agent_port = custom_logger_init_args.get("dd_agent_port")
+
+            if _dd_api_key or _dd_site or _dd_agent_host:
+                # Team-scoped credentials: use DynamicLoggingCache for per-credential isolation
+                from litellm.integrations.datadog.datadog_team_handler import (
+                    DataDogHandler,
+                )
+
+                return DataDogHandler.get_datadog_logger_for_request(
+                    standard_callback_dynamic_params=custom_logger_init_args,  # type: ignore
+                    in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
+                )
+
+            # Global (env-var based): reuse cached instance
             for callback in _in_memory_loggers:
                 if isinstance(callback, DataDogLogger):
                     return callback  # type: ignore

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -380,6 +380,7 @@ class Logging(LiteLLMLoggingBaseClass):
         self.standard_callback_dynamic_params: StandardCallbackDynamicParams = (
             self.initialize_standard_callback_dynamic_params(kwargs)
         )
+        self._init_kwargs = kwargs
 
         # Process dynamic callbacks (after standard_callback_dynamic_params is initialized,
         # so team-scoped credentials are available for callback initialization)
@@ -482,10 +483,12 @@ class Logging(LiteLLMLoggingBaseClass):
                 # pass only the relevant dynamic params as custom_logger_init_args.
                 _custom_logger_init_args: Optional[dict] = None
                 if callback == "datadog":
+                    # dd_* params are blocked from standard_callback_dynamic_params
+                    # (request-level security), but team callback_vars in kwargs
+                    # are admin-configured and trusted.
+                    _source = self._init_kwargs or {}
                     _custom_logger_init_args = {
-                        k: v
-                        for k, v in self.standard_callback_dynamic_params.items()
-                        if k.startswith("dd_")
+                        k: v for k, v in _source.items() if k.startswith("dd_")
                     }
 
                 callback_class = _init_custom_logger_compatible_class(

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -504,10 +504,22 @@ def _get_dynamic_logging_metadata(
     # Key-based callbacks
     #########################################################################################
     if key_dynamic_logging_settings is not None:
+        from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
+            _request_blocked_callback_params,
+        )
+
         for item in key_dynamic_logging_settings:
             callback = _get_validated_callback_metadata(item=item, source="key-level")
             if callback is None:
                 continue
+            # Strip params that could redirect traffic to attacker-controlled
+            # destinations (e.g. dd_site, dd_agent_host). Key metadata is
+            # user-configurable; only team-level callbacks are admin-trusted.
+            callback.callback_vars = {
+                k: v
+                for k, v in callback.callback_vars.items()
+                if k not in _request_blocked_callback_params
+            }
             callback_settings_obj = convert_key_logging_metadata_to_callback(
                 data=callback,
                 team_callback_settings_obj=callback_settings_obj,

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -19,7 +19,8 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Union, cast
 
 import fastapi
-from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+import httpx
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
 
 import litellm
 from litellm._logging import verbose_proxy_logger
@@ -41,6 +42,11 @@ from litellm.proxy.management_endpoints.key_management_endpoints import (
     generate_key_helper_fn,
     prepare_metadata_fields,
 )
+from litellm.proxy.management_endpoints.microsoft_graph_directory_search import (
+    MICROSOFT_DIRECTORY_SEARCH_MIN_QUERY_LENGTH,
+    _search_microsoft_directory_users,
+    is_microsoft_directory_search_configured,
+)
 from litellm.proxy.management_helpers.utils import management_endpoint_wrapper
 from litellm.proxy.utils import handle_exception_on_proxy, hash_password
 from litellm.types.proxy.management_endpoints.common_daily_activity import (
@@ -49,6 +55,7 @@ from litellm.types.proxy.management_endpoints.common_daily_activity import (
 from litellm.types.proxy.management_endpoints.internal_user_endpoints import (
     BulkUpdateUserRequest,
     BulkUpdateUserResponse,
+    MicrosoftDirectoryUser,
     UserListResponse,
     UserUpdateResult,
 )
@@ -57,6 +64,83 @@ if TYPE_CHECKING:
     from litellm.proxy.proxy_server import PrismaClient
 
 router = APIRouter()
+
+
+@router.get(
+    "/user/directory_search",
+    tags=["Internal User management"],
+    dependencies=[Depends(user_api_key_auth)],
+    response_model=List[MicrosoftDirectoryUser],
+)
+@management_endpoint_wrapper
+async def directory_user_search(
+    query: str = Query(...),
+    user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
+) -> List[MicrosoftDirectoryUser]:
+    """
+    Search Microsoft Entra ID users for the Admin UI invite user flow.
+
+    Requires `MICROSOFT_DIRECTORY_SEARCH_ENABLED=true` and Microsoft Graph
+    app-only credentials, via either `MICROSOFT_DIRECTORY_TENANT` /
+    `MICROSOFT_DIRECTORY_CLIENT_ID` / `MICROSOFT_DIRECTORY_CLIENT_SECRET`
+    (a dedicated app registration) or the `MICROSOFT_TENANT` /
+    `MICROSOFT_CLIENT_ID` / `MICROSOFT_CLIENT_SECRET` already used for
+    Microsoft SSO login. The app registration must have a directory read
+    permission such as `User.Read.All` or `Directory.Read.All`.
+
+    Restricted to callers with admin view access (`PROXY_ADMIN` or
+    `PROXY_ADMIN_VIEW_ONLY`). Queries shorter than
+    `MICROSOFT_DIRECTORY_SEARCH_MIN_QUERY_LENGTH` return `[]` without
+    contacting Graph, and a 404 is returned if the feature isn't configured.
+    """
+    try:
+        if not _user_has_admin_view(user_api_key_dict):
+            raise HTTPException(
+                status_code=403,
+                detail="Only proxy admins (including admin viewers) can search directory users.",
+            )
+
+        cleaned_query = query.strip()
+        if len(cleaned_query) < MICROSOFT_DIRECTORY_SEARCH_MIN_QUERY_LENGTH:
+            return []
+
+        if not is_microsoft_directory_search_configured():
+            raise HTTPException(
+                status_code=404,
+                detail="Microsoft directory search is not configured.",
+            )
+
+        return await _search_microsoft_directory_users(cleaned_query)
+    except HTTPException as e:
+        # Deliberate errors (403/404 above, or 500 from missing Graph
+        # credentials) - preserves their status code/detail via
+        # handle_exception_on_proxy instead of falling into the 500 below.
+        raise handle_exception_on_proxy(e)
+    except httpx.HTTPStatusError as e:
+        verbose_proxy_logger.exception(
+            "Microsoft Graph directory search failed - {}".format(str(e))
+        )
+        raise handle_exception_on_proxy(
+            HTTPException(
+                status_code=502,
+                detail="Microsoft Graph directory search failed.",
+            )
+        )
+    except httpx.HTTPError as e:
+        verbose_proxy_logger.exception(
+            "Microsoft Graph directory search request failed - {}".format(str(e))
+        )
+        raise handle_exception_on_proxy(
+            HTTPException(
+                status_code=502,
+                detail="Microsoft Graph directory search request failed.",
+            )
+        )
+    except Exception as e:
+        verbose_proxy_logger.exception(
+            "directory_user_search(): Exception occurred - {}".format(str(e))
+        )
+        raise handle_exception_on_proxy(e)
 
 
 def _hash_password_in_dict(data: dict) -> None:

--- a/litellm/proxy/management_endpoints/microsoft_graph_directory_search.py
+++ b/litellm/proxy/management_endpoints/microsoft_graph_directory_search.py
@@ -1,0 +1,252 @@
+"""
+Microsoft Graph directory search helpers.
+
+Shared by `internal_user_endpoints.py` (GET /user/directory_search) and
+`ui_sso.py` (MICROSOFT_DIRECTORY_SEARCH_ENABLED in /sso/get_ui_settings) so
+neither has to import the other.
+
+Uses app-only (client credentials) Graph auth - distinct from the delegated
+user-login flow in `MicrosoftSSOHandler`.
+"""
+
+import asyncio
+import time
+from typing import Dict, List, Optional, Union
+
+import httpx
+from fastapi import HTTPException
+
+from litellm._logging import verbose_proxy_logger
+from litellm.llms.custom_httpx.http_handler import get_async_httpx_client
+from litellm.secret_managers.main import get_secret_bool, get_secret_str
+from litellm.types.llms.custom_http import httpxSpecialProvider
+from litellm.types.proxy.management_endpoints.internal_user_endpoints import (
+    MicrosoftDirectoryUser,
+)
+
+MICROSOFT_GRAPH_DEFAULT_ENDPOINT = "https://graph.microsoft.com/v1.0"
+MICROSOFT_GRAPH_DEFAULT_SCOPE = "https://graph.microsoft.com/.default"
+MICROSOFT_DIRECTORY_SEARCH_MIN_QUERY_LENGTH = 2
+MICROSOFT_DIRECTORY_SEARCH_MAX_RESULTS = 10
+# 60s safety margin so a cached token doesn't expire mid-request.
+MICROSOFT_GRAPH_TOKEN_EXPIRY_SKEW_SECONDS = 60
+
+_microsoft_graph_token_cache: Dict[str, Union[str, float]] = {}
+# Serializes token (re)fetches so concurrent searches on a cold/expired
+# cache converge on a single Graph token request instead of a stampede.
+_microsoft_graph_token_lock = asyncio.Lock()
+
+
+def _is_microsoft_directory_search_enabled() -> bool:
+    return get_secret_bool("MICROSOFT_DIRECTORY_SEARCH_ENABLED") is True
+
+
+def is_microsoft_directory_search_configured() -> bool:
+    if not _is_microsoft_directory_search_enabled():
+        return False
+    return all(
+        get()
+        for get in (
+            _get_microsoft_directory_tenant,
+            _get_microsoft_directory_client_id,
+            _get_microsoft_directory_client_secret,
+        )
+    )
+
+
+def _first_configured_secret(*secret_names: str) -> Optional[str]:
+    """Returns the first secret_name whose value is set (even if empty),
+    falling back to the next only when a name is entirely unset. This keeps
+    an explicitly-set-but-empty directory-specific override from silently
+    falling through to the shared SSO credentials."""
+    for secret_name in secret_names:
+        value = get_secret_str(secret_name)
+        if value is not None:
+            return value or None
+    return None
+
+
+def _get_microsoft_directory_tenant() -> Optional[str]:
+    return _first_configured_secret("MICROSOFT_DIRECTORY_TENANT", "MICROSOFT_TENANT")
+
+
+def _get_microsoft_directory_client_id() -> Optional[str]:
+    return _first_configured_secret(
+        "MICROSOFT_DIRECTORY_CLIENT_ID", "MICROSOFT_CLIENT_ID"
+    )
+
+
+def _get_microsoft_directory_client_secret() -> Optional[str]:
+    return _first_configured_secret(
+        "MICROSOFT_DIRECTORY_CLIENT_SECRET", "MICROSOFT_CLIENT_SECRET"
+    )
+
+
+def _get_microsoft_graph_endpoint() -> str:
+    return (
+        get_secret_str("MICROSOFT_GRAPH_ENDPOINT") or MICROSOFT_GRAPH_DEFAULT_ENDPOINT
+    ).rstrip("/")
+
+
+def _escape_microsoft_graph_filter_value(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def _clear_microsoft_graph_token_cache() -> None:
+    _microsoft_graph_token_cache.pop("access_token", None)
+    _microsoft_graph_token_cache.pop("expires_at", None)
+
+
+def _get_cached_token_if_fresh() -> Optional[str]:
+    cached_token = _microsoft_graph_token_cache.get("access_token")
+    expires_at = _microsoft_graph_token_cache.get("expires_at")
+    if (
+        isinstance(cached_token, str)
+        and isinstance(expires_at, (float, int))
+        and expires_at > time.time() + MICROSOFT_GRAPH_TOKEN_EXPIRY_SKEW_SECONDS
+    ):
+        return cached_token
+    return None
+
+
+async def _get_microsoft_graph_access_token(force_refresh: bool = False) -> str:
+    if not force_refresh:
+        cached_token = _get_cached_token_if_fresh()
+        if cached_token is not None:
+            return cached_token
+
+    # Serialize refreshes so concurrent callers on a cold/expired cache
+    # converge on a single Graph token request instead of a stampede.
+    async with _microsoft_graph_token_lock:
+        if not force_refresh:
+            cached_token = _get_cached_token_if_fresh()
+            if cached_token is not None:
+                return cached_token
+
+        tenant = _get_microsoft_directory_tenant()
+        client_id = _get_microsoft_directory_client_id()
+        client_secret = _get_microsoft_directory_client_secret()
+        if not tenant or not client_id or not client_secret:
+            raise HTTPException(
+                status_code=500,
+                detail="Microsoft directory search is missing tenant, client id, or client secret.",
+            )
+
+        token_url = f"https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token"
+        client = get_async_httpx_client(llm_provider=httpxSpecialProvider.SSO_HANDLER)
+        try:
+            response = await client.post(
+                token_url,
+                data={
+                    "client_id": client_id,
+                    "client_secret": client_secret,
+                    "scope": MICROSOFT_GRAPH_DEFAULT_SCOPE,
+                    "grant_type": "client_credentials",
+                },
+            )
+        except httpx.HTTPStatusError as e:
+            # Azure's error body (e.g. invalid_client, AADSTS7000215) is the
+            # actionable part - log it before the generic 502 handling upstream.
+            verbose_proxy_logger.error(
+                "Microsoft Graph token request failed (%s): %s",
+                e.response.status_code,
+                e.response.text,
+            )
+            raise
+        token_response = response.json()
+
+        access_token = token_response.get("access_token")
+        if not isinstance(access_token, str):
+            raise HTTPException(
+                status_code=500,
+                detail="Microsoft Graph token response did not include an access token.",
+            )
+
+        expires_in = token_response.get("expires_in", 3600)
+        try:
+            expires_in_seconds = int(expires_in)
+        except (TypeError, ValueError):
+            expires_in_seconds = 3600
+        _microsoft_graph_token_cache["access_token"] = access_token
+        _microsoft_graph_token_cache["expires_at"] = time.time() + expires_in_seconds
+        return access_token
+
+
+def _parse_microsoft_directory_users(
+    directory_response: dict,
+) -> List[MicrosoftDirectoryUser]:
+    users: List[MicrosoftDirectoryUser] = []
+    for raw_user in directory_response.get("value", []):
+        if not isinstance(raw_user, dict):
+            continue
+        # `mail` is often empty for guest/unlicensed accounts; userPrincipalName
+        # is the more reliable fallback (still guarded below in case both are missing).
+        email = raw_user.get("mail") or raw_user.get("userPrincipalName")
+        user_id = raw_user.get("id")
+        if not isinstance(email, str) or not isinstance(user_id, str):
+            verbose_proxy_logger.warning(
+                "directory_user_search: skipping AD record - missing id or email "
+                "(id=%s, displayName=%s, mail=%s, userPrincipalName=%s)",
+                raw_user.get("id"),
+                raw_user.get("displayName"),
+                raw_user.get("mail"),
+                raw_user.get("userPrincipalName"),
+            )
+            continue
+        users.append(
+            MicrosoftDirectoryUser(
+                id=user_id,
+                display_name=raw_user.get("displayName"),
+                email=email,
+            )
+        )
+    return users
+
+
+async def _fetch_microsoft_directory_users(
+    query: str, access_token: str
+) -> httpx.Response:
+    escaped_query = _escape_microsoft_graph_filter_value(query)
+    graph_url = f"{_get_microsoft_graph_endpoint()}/users"
+    client = get_async_httpx_client(llm_provider=httpxSpecialProvider.SSO_HANDLER)
+    response = await client.get(
+        graph_url,
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            # Required by Graph for advanced queries like an OR of multiple
+            # startswith() clauses - see Microsoft's "advanced query
+            # capabilities on Microsoft Entra ID objects" docs.
+            "ConsistencyLevel": "eventual",
+        },
+        params={
+            "$filter": (
+                f"startswith(displayName,'{escaped_query}') or "
+                f"startswith(mail,'{escaped_query}') or "
+                f"startswith(userPrincipalName,'{escaped_query}')"
+            ),
+            "$select": "id,displayName,mail,userPrincipalName",
+            "$top": str(MICROSOFT_DIRECTORY_SEARCH_MAX_RESULTS),
+            "$count": "true",
+        },
+    )
+    response.raise_for_status()
+    return response
+
+
+async def _search_microsoft_directory_users(
+    query: str,
+) -> List[MicrosoftDirectoryUser]:
+    access_token = await _get_microsoft_graph_access_token()
+    try:
+        response = await _fetch_microsoft_directory_users(query, access_token)
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 401:
+            # Cached token was rejected (e.g. secret rotated) - refresh once
+            # and retry rather than failing the whole search.
+            _clear_microsoft_graph_token_cache()
+            access_token = await _get_microsoft_graph_access_token(force_refresh=True)
+            response = await _fetch_microsoft_directory_users(query, access_token)
+        else:
+            raise
+
+    return _parse_microsoft_directory_users(response.json())

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -4593,10 +4593,32 @@ async def team_model_add(
             detail={"error": "Only proxy admin or team admin can modify team models"},
         )
 
-    updated_models = add_new_models_to_team(team_obj=team_obj, new_models=data.models)
-    # Update team
+    # Atomic array append with dedup at the database level so concurrent
+    # BYOK model creates don't overwrite each other's team.models entries.
+    # When the team currently has models=[] (unrestricted access), the
+    # CASE expression inserts the 'all-proxy-models' sentinel first.
+    models_to_add = list(data.models)
+    await prisma_client.db.execute_raw(
+        'UPDATE "LiteLLM_TeamTable" '
+        "SET models = ("
+        "  SELECT ARRAY(SELECT DISTINCT unnest("
+        "    CASE WHEN cardinality(COALESCE(models, ARRAY[]::text[])) = 0 "
+        "         THEN ARRAY['all-proxy-models']::text[] "
+        "         ELSE models "
+        "    END || $1::text[]"
+        "  ))"
+        ") "
+        "WHERE team_id = $2",
+        models_to_add,
+        data.team_id,
+    )
+    # Re-fetch via update (write-routed) instead of find_unique (read-routed)
+    # to avoid returning stale data from a read replica. The models column
+    # was already set by execute_raw above; this just retrieves the row from
+    # the writer and lets Prisma bump updated_at.
     updated_team = await prisma_client.db.litellm_teamtable.update(
-        where={"team_id": data.team_id}, data={"models": updated_models}
+        where={"team_id": data.team_id},
+        data={"updated_at": datetime.now(timezone.utc)},
     )
 
     return updated_team

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -93,6 +93,9 @@ from litellm.proxy.common_utils.html_forms.jwt_display_template import (
 )
 from litellm.proxy.common_utils.html_forms.ui_login import html_form
 from litellm.proxy.management_endpoints.internal_user_endpoints import new_user
+from litellm.proxy.management_endpoints.microsoft_graph_directory_search import (
+    is_microsoft_directory_search_configured,
+)
 from litellm.proxy.management_endpoints.sso import CustomMicrosoftSSO
 from litellm.proxy.management_endpoints.sso_helper_utils import (
     check_is_admin_only_access,
@@ -2366,6 +2369,21 @@ async def insert_sso_user(
     return response
 
 
+def _is_microsoft_directory_search_configured_safe() -> bool:
+    """
+    Wraps `is_microsoft_directory_search_configured()` so a secret manager
+    backend failure (e.g. Vault/Secrets Manager unreachable) can't take down
+    the whole `/sso/get_ui_settings` response for every user.
+    """
+    try:
+        return is_microsoft_directory_search_configured()
+    except Exception:
+        verbose_proxy_logger.exception(
+            "Failed to resolve Microsoft directory search configuration"
+        )
+        return False
+
+
 @router.get(
     "/sso/get/ui_settings",
     tags=["experimental"],
@@ -2394,6 +2412,7 @@ async def get_ui_settings(request: Request):
         "LITELLM_UI_API_DOC_BASE_URL": _api_doc_base_url,
         "DEFAULT_TEAM_DISABLED": default_team_disabled,
         "SSO_ENABLED": _is_sso_enabled,
+        "MICROSOFT_DIRECTORY_SEARCH_ENABLED": _is_microsoft_directory_search_configured_safe(),
         "NUM_SPEND_LOGS_ROWS": proxy_state.get_proxy_state_variable(
             "spend_logs_row_count"
         ),

--- a/litellm/types/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/types/proxy/management_endpoints/internal_user_endpoints.py
@@ -10,6 +10,14 @@ from litellm.proxy._types import (
 )
 
 
+class MicrosoftDirectoryUser(BaseModel):
+    """A single result row from the Microsoft Graph directory search endpoint."""
+
+    id: str
+    display_name: Optional[str] = None
+    email: str
+
+
 class UserListResponse(BaseModel):
     """
     Response model for the user list endpoint

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3010,6 +3010,12 @@ class StandardCallbackDynamicParams(TypedDict, total=False):
     wandb_api_key: Optional[str]
     weave_project_id: Optional[str]
 
+    # Datadog dynamic params
+    dd_api_key: Optional[str]
+    dd_site: Optional[str]
+    dd_agent_host: Optional[str]
+    dd_agent_port: Optional[str]
+
     # Logging settings
     turn_off_message_logging: Optional[bool]  # when true will not log messages
     litellm_disabled_callbacks: Optional[List[str]]

--- a/tests/test_litellm/integrations/datadog/test_datadog_team_handler.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_team_handler.py
@@ -1,0 +1,194 @@
+"""
+Tests for team-scoped Datadog callback support.
+
+Verifies that DataDogLogger can be instantiated with per-team credentials
+(dd_api_key, dd_site) instead of relying solely on environment variables,
+and that the DataDogHandler correctly resolves and caches per-team loggers.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from litellm.integrations.datadog.datadog import DataDogLogger
+from litellm.integrations.datadog.datadog_team_handler import (
+    DataDogHandler,
+    DatadogLoggingConfig,
+)
+from litellm.litellm_core_utils.specialty_caches.dynamic_logging_cache import (
+    DynamicLoggingCache,
+)
+from litellm.types.utils import StandardCallbackDynamicParams
+
+
+@pytest.fixture
+def datadog_env(monkeypatch):
+    """Set global DD env vars for the default/global logger."""
+    monkeypatch.setenv("DD_API_KEY", "global_api_key")
+    monkeypatch.setenv("DD_SITE", "us1.datadoghq.com")
+
+
+class TestDataDogLoggerCredentialKwargs:
+    """Test that DataDogLogger accepts credentials as kwargs."""
+
+    def test_init_with_explicit_credentials(self):
+        """Logger should use explicit kwargs instead of env vars."""
+        with patch("asyncio.create_task"):
+            logger = DataDogLogger(
+                dd_api_key="team_api_key",
+                dd_site="eu1.datadoghq.com",
+            )
+
+        assert logger.DD_API_KEY == "team_api_key"
+        assert "eu1.datadoghq.com" in logger.intake_url
+
+    def test_init_falls_back_to_env_vars(self, datadog_env):
+        """Logger should fall back to env vars when no kwargs provided."""
+        with patch("asyncio.create_task"):
+            logger = DataDogLogger()
+
+        assert logger.DD_API_KEY == "global_api_key"
+        assert "us1.datadoghq.com" in logger.intake_url
+
+    def test_init_kwargs_override_env_vars(self, datadog_env):
+        """Explicit kwargs should take precedence over env vars."""
+        with patch("asyncio.create_task"):
+            logger = DataDogLogger(
+                dd_api_key="override_key",
+                dd_site="ap1.datadoghq.com",
+            )
+
+        assert logger.DD_API_KEY == "override_key"
+        assert "ap1.datadoghq.com" in logger.intake_url
+
+    def test_init_with_agent_credentials(self):
+        """Logger should use agent mode when dd_agent_host is provided."""
+        with patch("asyncio.create_task"):
+            logger = DataDogLogger(
+                dd_agent_host="dd-agent.local",
+                dd_agent_port="8125",
+                dd_api_key="agent_api_key",
+            )
+
+        assert "dd-agent.local:8125" in logger.intake_url
+        assert logger.DD_API_KEY == "agent_api_key"
+
+    def test_init_raises_without_credentials(self, monkeypatch):
+        """Logger should raise if no credentials are available."""
+        monkeypatch.delenv("DD_API_KEY", raising=False)
+        monkeypatch.delenv("DD_SITE", raising=False)
+        monkeypatch.delenv("LITELLM_DD_AGENT_HOST", raising=False)
+
+        with pytest.raises(Exception, match="DD_API_KEY"):
+            with patch("asyncio.create_task"):
+                DataDogLogger()
+
+
+class TestDataDogHandler:
+    """Test that DataDogHandler resolves the correct logger per team."""
+
+    def test_creates_team_logger_with_dynamic_credentials(self, datadog_env):
+        """Should create a new logger when team credentials are provided."""
+        cache = DynamicLoggingCache()
+        params = StandardCallbackDynamicParams(
+            dd_api_key="team_a_key",
+            dd_site="eu1.datadoghq.com",
+        )
+
+        with patch("asyncio.create_task"):
+            result = DataDogHandler.get_datadog_logger_for_request(
+                standard_callback_dynamic_params=params,
+                in_memory_dynamic_logger_cache=cache,
+            )
+
+        assert result.DD_API_KEY == "team_a_key"
+        assert "eu1.datadoghq.com" in result.intake_url
+
+    def test_caches_team_logger(self, datadog_env):
+        """Same team credentials should return the same cached logger instance."""
+        cache = DynamicLoggingCache()
+        params = StandardCallbackDynamicParams(
+            dd_api_key="team_b_key",
+            dd_site="us5.datadoghq.com",
+        )
+
+        with patch("asyncio.create_task"):
+            result1 = DataDogHandler.get_datadog_logger_for_request(
+                standard_callback_dynamic_params=params,
+                in_memory_dynamic_logger_cache=cache,
+            )
+            result2 = DataDogHandler.get_datadog_logger_for_request(
+                standard_callback_dynamic_params=params,
+                in_memory_dynamic_logger_cache=cache,
+            )
+
+        assert result1 is result2
+
+    def test_different_teams_get_different_loggers(self, datadog_env):
+        """Different team credentials should create separate logger instances."""
+        cache = DynamicLoggingCache()
+
+        params_a = StandardCallbackDynamicParams(
+            dd_api_key="team_a_key",
+            dd_site="us1.datadoghq.com",
+        )
+        params_b = StandardCallbackDynamicParams(
+            dd_api_key="team_b_key",
+            dd_site="eu1.datadoghq.com",
+        )
+
+        with patch("asyncio.create_task"):
+            result_a = DataDogHandler.get_datadog_logger_for_request(
+                standard_callback_dynamic_params=params_a,
+                in_memory_dynamic_logger_cache=cache,
+            )
+            result_b = DataDogHandler.get_datadog_logger_for_request(
+                standard_callback_dynamic_params=params_b,
+                in_memory_dynamic_logger_cache=cache,
+            )
+
+        assert result_a is not result_b
+        assert result_a.DD_API_KEY == "team_a_key"
+        assert result_b.DD_API_KEY == "team_b_key"
+
+    def test_request_blocked_callback_params_includes_dd(self):
+        """DD params should be blocked from request-level metadata (security)."""
+        from litellm.litellm_core_utils.initialize_dynamic_callback_params import (
+            _request_blocked_callback_params,
+        )
+
+        assert "dd_api_key" in _request_blocked_callback_params
+        assert "dd_site" in _request_blocked_callback_params
+        assert "dd_agent_host" in _request_blocked_callback_params
+        assert "dd_agent_port" in _request_blocked_callback_params
+
+
+class TestDynamicCredentialDetection:
+    """Test that _dynamic_datadog_credentials_are_passed works correctly."""
+
+    def test_no_credentials(self):
+        params = StandardCallbackDynamicParams()
+        assert DataDogHandler._dynamic_datadog_credentials_are_passed(params) is False
+
+    def test_dd_api_key_only(self):
+        params = StandardCallbackDynamicParams(dd_api_key="key")
+        assert DataDogHandler._dynamic_datadog_credentials_are_passed(params) is True
+
+    def test_dd_site_only(self):
+        params = StandardCallbackDynamicParams(dd_site="site")
+        assert DataDogHandler._dynamic_datadog_credentials_are_passed(params) is True
+
+    def test_dd_agent_host_only(self):
+        params = StandardCallbackDynamicParams(dd_agent_host="host")
+        assert DataDogHandler._dynamic_datadog_credentials_are_passed(params) is True
+
+
+class TestStandardCallbackDynamicParamsIncludesDatadog:
+    """Verify that Datadog params are in the allow-list."""
+
+    def test_dd_params_in_annotations(self):
+        annotations = StandardCallbackDynamicParams.__annotations__
+        assert "dd_api_key" in annotations
+        assert "dd_site" in annotations
+        assert "dd_agent_host" in annotations
+        assert "dd_agent_port" in annotations

--- a/tests/test_litellm/integrations/datadog/test_datadog_team_handler.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_team_handler.py
@@ -192,3 +192,55 @@ class TestStandardCallbackDynamicParamsIncludesDatadog:
         assert "dd_site" in annotations
         assert "dd_agent_host" in annotations
         assert "dd_agent_port" in annotations
+
+
+class TestTeamCallbackFlowPassesDDCredentials:
+    """
+    Integration test for the full team callback flow.
+
+    Verifies that DD credentials configured via team callback_vars
+    actually reach DataDogHandler when a request is processed.
+    The dd_* params are in _request_blocked_callback_params (to prevent
+    request-level injection), but team callback_vars are admin-configured
+    and must pass through.
+    """
+
+    def test_process_dynamic_callbacks_passes_dd_params_from_kwargs(self):
+        """
+        Simulates the Logging.__init__ flow where team callback_vars
+        (dd_api_key, dd_site) are unpacked into kwargs. Verifies that
+        _process_dynamic_callback_list picks them up and passes them
+        to DataDogHandler despite _request_blocked_callback_params.
+        """
+        from litellm.litellm_core_utils.litellm_logging import Logging
+
+        kwargs = {
+            "dd_api_key": "team-dd-key-123",
+            "dd_site": "us5.datadoghq.com",
+            "model": "gpt-4",
+            "litellm_params": {"metadata": {}},
+        }
+
+        with patch("asyncio.create_task"):
+            logging_obj = Logging(
+                model="gpt-4",
+                messages=[{"role": "user", "content": "hi"}],
+                stream=False,
+                call_type="completion",
+                start_time="2026-01-01",
+                litellm_call_id="test-call-id",
+                function_id="test-func",
+                dynamic_success_callbacks=["datadog"],
+                kwargs=kwargs,
+            )
+
+        dd_loggers = [
+            cb
+            for cb in (logging_obj.dynamic_success_callbacks or [])
+            if isinstance(cb, DataDogLogger)
+        ]
+        assert (
+            len(dd_loggers) == 1
+        ), "DataDogLogger should be initialized from team callback_vars"
+        assert dd_loggers[0].DD_API_KEY == "team-dd-key-123"
+        assert "us5.datadoghq.com" in dd_loggers[0].intake_url

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -20,7 +20,9 @@ from litellm.proxy._types import (
 )
 from litellm.proxy.management_endpoints.internal_user_endpoints import (
     LiteLLM_UserTableWithKeyCount,
+    MicrosoftDirectoryUser,
     _update_internal_user_params,
+    directory_user_search,
     get_user_key_counts,
     get_users,
     new_user,
@@ -29,6 +31,224 @@ from litellm.proxy.management_endpoints.internal_user_endpoints import (
 from litellm.proxy.proxy_server import app
 
 client = TestClient(app)
+
+
+@pytest.mark.asyncio
+async def test_directory_user_search_returns_microsoft_directory_users(mocker):
+    async def mock_search(query: str):
+        assert query == "alice"
+        return [
+            MicrosoftDirectoryUser(
+                id="aad-user-id",
+                display_name="Alice Example",
+                email="alice@example.com",
+            )
+        ]
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.is_microsoft_directory_search_configured",
+        return_value=True,
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._search_microsoft_directory_users",
+        mock_search,
+    )
+
+    response = await directory_user_search(
+        query=" alice ",
+        user_api_key_dict=UserAPIKeyAuth(
+            user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
+        ),
+    )
+
+    assert response == [
+        MicrosoftDirectoryUser(
+            id="aad-user-id",
+            display_name="Alice Example",
+            email="alice@example.com",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_directory_user_search_requires_admin_view(mocker):
+    mock_search = mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._search_microsoft_directory_users"
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await directory_user_search(
+            query="alice",
+            user_api_key_dict=UserAPIKeyAuth(
+                user_id="user", user_role=LitellmUserRoles.INTERNAL_USER
+            ),
+        )
+
+    assert exc_info.value.code == 403 or exc_info.value.code == "403"
+    mock_search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_directory_user_search_ignores_short_queries(mocker):
+    mock_search = mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._search_microsoft_directory_users"
+    )
+
+    response = await directory_user_search(
+        query="a",
+        user_api_key_dict=UserAPIKeyAuth(
+            user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
+        ),
+    )
+
+    assert response == []
+    mock_search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_directory_user_search_allows_admin_view_only(mocker):
+    """PROXY_ADMIN_VIEW_ONLY should be allowed - _user_has_admin_view grants
+    both PROXY_ADMIN and PROXY_ADMIN_VIEW_ONLY read access."""
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.is_microsoft_directory_search_configured",
+        return_value=True,
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._search_microsoft_directory_users",
+        return_value=[],
+    )
+
+    response = await directory_user_search(
+        query="alice",
+        user_api_key_dict=UserAPIKeyAuth(
+            user_id="viewer", user_role=LitellmUserRoles.PROXY_ADMIN_VIEW_ONLY
+        ),
+    )
+
+    assert response == []
+
+
+@pytest.mark.asyncio
+async def test_directory_user_search_exact_min_length_proceeds(mocker):
+    """A query of exactly MICROSOFT_DIRECTORY_SEARCH_MIN_QUERY_LENGTH should
+    proceed to search, not short-circuit."""
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.is_microsoft_directory_search_configured",
+        return_value=True,
+    )
+    mock_search = mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._search_microsoft_directory_users",
+        return_value=[],
+    )
+
+    await directory_user_search(
+        query="al",
+        user_api_key_dict=UserAPIKeyAuth(
+            user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
+        ),
+    )
+
+    mock_search.assert_called_once_with("al")
+
+
+@pytest.mark.asyncio
+async def test_directory_user_search_whitespace_padded_short_query_is_ignored(mocker):
+    """A query that trims below the length threshold should short-circuit,
+    even if its raw (untrimmed) length would have passed."""
+    mock_search = mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._search_microsoft_directory_users"
+    )
+
+    response = await directory_user_search(
+        query="  a  ",
+        user_api_key_dict=UserAPIKeyAuth(
+            user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
+        ),
+    )
+
+    assert response == []
+    mock_search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_directory_user_search_returns_404_when_not_configured(mocker):
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.is_microsoft_directory_search_configured",
+        return_value=False,
+    )
+    mock_search = mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._search_microsoft_directory_users"
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await directory_user_search(
+            query="alice",
+            user_api_key_dict=UserAPIKeyAuth(
+                user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
+            ),
+        )
+
+    assert exc_info.value.code == 404 or exc_info.value.code == "404"
+    mock_search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_directory_user_search_http_status_error_maps_to_502(mocker):
+    import httpx
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.is_microsoft_directory_search_configured",
+        return_value=True,
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._search_microsoft_directory_users",
+        side_effect=httpx.HTTPStatusError(
+            "boom", request=mocker.MagicMock(), response=mocker.MagicMock()
+        ),
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await directory_user_search(
+            query="alice",
+            user_api_key_dict=UserAPIKeyAuth(
+                user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
+            ),
+        )
+
+    assert exc_info.value.code == 502 or exc_info.value.code == "502"
+
+
+@pytest.mark.asyncio
+async def test_directory_user_search_does_not_relabel_deliberate_http_exceptions(
+    mocker,
+):
+    """A deliberate HTTPException raised inside _search_microsoft_directory_users
+    (e.g. missing Graph credentials -> 500) must propagate with its original
+    status code, not get relabeled by the generic except-Exception branch."""
+    from fastapi import HTTPException
+
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.is_microsoft_directory_search_configured",
+        return_value=True,
+    )
+    mocker.patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints._search_microsoft_directory_users",
+        side_effect=HTTPException(
+            status_code=500,
+            detail="Microsoft directory search is missing tenant, client id, or client secret.",
+        ),
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await directory_user_search(
+            query="alice",
+            user_api_key_dict=UserAPIKeyAuth(
+                user_id="admin", user_role=LitellmUserRoles.PROXY_ADMIN
+            ),
+        )
+
+    assert exc_info.value.code == 500 or exc_info.value.code == "500"
+    assert "tenant, client id, or client secret" in str(exc_info.value.message)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/test_microsoft_graph_directory_search.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_microsoft_graph_directory_search.py
@@ -1,0 +1,479 @@
+import asyncio
+import os
+import sys
+import time
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.proxy.management_endpoints import microsoft_graph_directory_search as mgds
+
+
+@pytest.fixture(autouse=True)
+def _reset_token_cache():
+    """Every test starts with a clean in-memory token cache."""
+    mgds._microsoft_graph_token_cache.clear()
+    yield
+    mgds._microsoft_graph_token_cache.clear()
+
+
+def _set_directory_env(
+    monkeypatch,
+    enabled="true",
+    tenant="tenant-1",
+    client_id="client-1",
+    client_secret="secret-1",
+):
+    monkeypatch.setenv("MICROSOFT_DIRECTORY_SEARCH_ENABLED", enabled)
+    if tenant is not None:
+        monkeypatch.setenv("MICROSOFT_DIRECTORY_TENANT", tenant)
+    if client_id is not None:
+        monkeypatch.setenv("MICROSOFT_DIRECTORY_CLIENT_ID", client_id)
+    if client_secret is not None:
+        monkeypatch.setenv("MICROSOFT_DIRECTORY_CLIENT_SECRET", client_secret)
+
+
+class TestEscapeFilterValue:
+    def test_escapes_single_quote(self):
+        assert mgds._escape_microsoft_graph_filter_value("O'Brien") == "O''Brien"
+
+    def test_no_quotes_unchanged(self):
+        assert mgds._escape_microsoft_graph_filter_value("alice") == "alice"
+
+    def test_multiple_quotes(self):
+        assert mgds._escape_microsoft_graph_filter_value("'''") == "''''''"
+
+
+class TestIsMicrosoftDirectorySearchConfigured:
+    def test_fully_configured(self, monkeypatch):
+        _set_directory_env(monkeypatch)
+        assert mgds.is_microsoft_directory_search_configured() is True
+
+    def test_flag_disabled(self, monkeypatch):
+        _set_directory_env(monkeypatch, enabled="false")
+        assert mgds.is_microsoft_directory_search_configured() is False
+
+    def test_flag_enabled_missing_client_id(self, monkeypatch):
+        monkeypatch.setenv("MICROSOFT_DIRECTORY_SEARCH_ENABLED", "true")
+        monkeypatch.setenv("MICROSOFT_DIRECTORY_TENANT", "tenant-1")
+        monkeypatch.delenv("MICROSOFT_DIRECTORY_CLIENT_ID", raising=False)
+        monkeypatch.delenv("MICROSOFT_CLIENT_ID", raising=False)
+        monkeypatch.setenv("MICROSOFT_DIRECTORY_CLIENT_SECRET", "secret-1")
+        assert mgds.is_microsoft_directory_search_configured() is False
+
+    def test_falls_back_to_generic_microsoft_env_vars(self, monkeypatch):
+        monkeypatch.setenv("MICROSOFT_DIRECTORY_SEARCH_ENABLED", "true")
+        monkeypatch.delenv("MICROSOFT_DIRECTORY_TENANT", raising=False)
+        monkeypatch.delenv("MICROSOFT_DIRECTORY_CLIENT_ID", raising=False)
+        monkeypatch.delenv("MICROSOFT_DIRECTORY_CLIENT_SECRET", raising=False)
+        monkeypatch.setenv("MICROSOFT_TENANT", "generic-tenant")
+        monkeypatch.setenv("MICROSOFT_CLIENT_ID", "generic-client")
+        monkeypatch.setenv("MICROSOFT_CLIENT_SECRET", "generic-secret")
+        assert mgds.is_microsoft_directory_search_configured() is True
+
+    def test_directory_specific_env_vars_take_precedence(self, monkeypatch):
+        monkeypatch.setenv("MICROSOFT_DIRECTORY_TENANT", "directory-tenant")
+        monkeypatch.setenv("MICROSOFT_TENANT", "generic-tenant")
+        assert mgds._get_microsoft_directory_tenant() == "directory-tenant"
+
+    def test_explicitly_empty_directory_var_does_not_fall_back_to_generic(
+        self, monkeypatch
+    ):
+        """An explicitly-set-but-empty MICROSOFT_DIRECTORY_TENANT (e.g. an
+        unresolved template variable) must not silently resolve to the
+        generic MICROSOFT_TENANT used for SSO login."""
+        monkeypatch.setenv("MICROSOFT_DIRECTORY_TENANT", "")
+        monkeypatch.setenv("MICROSOFT_TENANT", "generic-tenant")
+        assert mgds._get_microsoft_directory_tenant() is None
+
+
+class TestGetMicrosoftGraphAccessToken:
+    @pytest.mark.asyncio
+    async def test_missing_credentials_raises_500(self, monkeypatch):
+        monkeypatch.delenv("MICROSOFT_DIRECTORY_TENANT", raising=False)
+        monkeypatch.delenv("MICROSOFT_TENANT", raising=False)
+        monkeypatch.delenv("MICROSOFT_DIRECTORY_CLIENT_ID", raising=False)
+        monkeypatch.delenv("MICROSOFT_CLIENT_ID", raising=False)
+        monkeypatch.delenv("MICROSOFT_DIRECTORY_CLIENT_SECRET", raising=False)
+        monkeypatch.delenv("MICROSOFT_CLIENT_SECRET", raising=False)
+
+        with pytest.raises(Exception) as exc_info:
+            await mgds._get_microsoft_graph_access_token()
+        assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_cold_cache_fetches_and_caches_token(self, monkeypatch, mocker):
+        _set_directory_env(monkeypatch)
+        mock_response = mocker.MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "brand-new-token",
+            "expires_in": 3600,
+        }
+        mock_client = mocker.MagicMock()
+
+        async def mock_post(*args, **kwargs):
+            return mock_response
+
+        mock_client.post = mock_post
+        mocker.patch.object(mgds, "get_async_httpx_client", return_value=mock_client)
+
+        token = await mgds._get_microsoft_graph_access_token()
+
+        assert token == "brand-new-token"
+        assert mgds._microsoft_graph_token_cache["access_token"] == "brand-new-token"
+
+    @pytest.mark.asyncio
+    async def test_warm_cache_skips_http_call(self, monkeypatch, mocker):
+        _set_directory_env(monkeypatch)
+        mgds._microsoft_graph_token_cache["access_token"] = "cached-token"
+        mgds._microsoft_graph_token_cache["expires_at"] = time.time() + 3600
+
+        mock_get_client = mocker.patch.object(mgds, "get_async_httpx_client")
+
+        token = await mgds._get_microsoft_graph_access_token()
+
+        assert token == "cached-token"
+        mock_get_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_expired_cache_refetches(self, monkeypatch, mocker):
+        _set_directory_env(monkeypatch)
+        mgds._microsoft_graph_token_cache["access_token"] = "stale-token"
+        # Already within the 60s expiry skew, so treated as expired.
+        mgds._microsoft_graph_token_cache["expires_at"] = time.time() + 1
+
+        mock_response = mocker.MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "refreshed-token",
+            "expires_in": 3600,
+        }
+        mock_client = mocker.MagicMock()
+
+        async def mock_post(*args, **kwargs):
+            return mock_response
+
+        mock_client.post = mock_post
+        mocker.patch.object(mgds, "get_async_httpx_client", return_value=mock_client)
+
+        token = await mgds._get_microsoft_graph_access_token()
+
+        assert token == "refreshed-token"
+
+    @pytest.mark.asyncio
+    async def test_force_refresh_ignores_warm_cache(self, monkeypatch, mocker):
+        _set_directory_env(monkeypatch)
+        mgds._microsoft_graph_token_cache["access_token"] = "cached-token"
+        mgds._microsoft_graph_token_cache["expires_at"] = time.time() + 3600
+
+        mock_response = mocker.MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "forced-refresh-token",
+            "expires_in": 3600,
+        }
+        mock_client = mocker.MagicMock()
+
+        async def mock_post(*args, **kwargs):
+            return mock_response
+
+        mock_client.post = mock_post
+        mocker.patch.object(mgds, "get_async_httpx_client", return_value=mock_client)
+
+        token = await mgds._get_microsoft_graph_access_token(force_refresh=True)
+
+        assert token == "forced-refresh-token"
+
+    @pytest.mark.asyncio
+    async def test_missing_access_token_in_response_raises_500(
+        self, monkeypatch, mocker
+    ):
+        _set_directory_env(monkeypatch)
+        mock_response = mocker.MagicMock()
+        mock_response.json.return_value = {"expires_in": 3600}
+        mock_client = mocker.MagicMock()
+
+        async def mock_post(*args, **kwargs):
+            return mock_response
+
+        mock_client.post = mock_post
+        mocker.patch.object(mgds, "get_async_httpx_client", return_value=mock_client)
+
+        with pytest.raises(Exception) as exc_info:
+            await mgds._get_microsoft_graph_access_token()
+        assert exc_info.value.status_code == 500
+
+    @pytest.mark.asyncio
+    async def test_non_int_expires_in_falls_back_to_default(self, monkeypatch, mocker):
+        _set_directory_env(monkeypatch)
+        mock_response = mocker.MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "token-with-bad-expiry",
+            "expires_in": "not-a-number",
+        }
+        mock_client = mocker.MagicMock()
+
+        async def mock_post(*args, **kwargs):
+            return mock_response
+
+        mock_client.post = mock_post
+        mocker.patch.object(mgds, "get_async_httpx_client", return_value=mock_client)
+
+        before = time.time()
+        token = await mgds._get_microsoft_graph_access_token()
+        assert token == "token-with-bad-expiry"
+        # Falls back to the 3600s default rather than raising.
+        assert mgds._microsoft_graph_token_cache["expires_at"] >= before + 3600
+
+    @pytest.mark.asyncio
+    async def test_concurrent_cold_cache_fetches_only_once(self, monkeypatch, mocker):
+        """Concurrent callers on a cold cache must converge on a single
+        Graph token request instead of each independently fetching."""
+        _set_directory_env(monkeypatch)
+        mock_response = mocker.MagicMock()
+        mock_response.json.return_value = {
+            "access_token": "shared-token",
+            "expires_in": 3600,
+        }
+        mock_client = mocker.MagicMock()
+        post_call_count = 0
+
+        async def mock_post(*args, **kwargs):
+            nonlocal post_call_count
+            post_call_count += 1
+            await asyncio.sleep(0.01)
+            return mock_response
+
+        mock_client.post = mock_post
+        mocker.patch.object(mgds, "get_async_httpx_client", return_value=mock_client)
+
+        tokens = await asyncio.gather(
+            *[mgds._get_microsoft_graph_access_token() for _ in range(5)]
+        )
+
+        assert tokens == ["shared-token"] * 5
+        assert post_call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_logs_azure_error_body_on_token_request_failure(
+        self, monkeypatch, mocker
+    ):
+        """A bad/rotated client secret must not fail silently - the Azure
+        error body (invalid_client, AADSTS...) should be logged."""
+        _set_directory_env(monkeypatch)
+        mock_400_response = mocker.MagicMock(
+            status_code=400,
+            text='{"error": "invalid_client", "error_description": "AADSTS7000215: Invalid client secret."}',
+        )
+        invalid_client_error = httpx.HTTPStatusError(
+            "400", request=mocker.MagicMock(), response=mock_400_response
+        )
+        mock_client = mocker.MagicMock()
+
+        async def mock_post(*args, **kwargs):
+            raise invalid_client_error
+
+        mock_client.post = mock_post
+        mocker.patch.object(mgds, "get_async_httpx_client", return_value=mock_client)
+        log_spy = mocker.patch.object(mgds.verbose_proxy_logger, "error")
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await mgds._get_microsoft_graph_access_token()
+
+        log_spy.assert_called_once()
+        assert "AADSTS7000215" in log_spy.call_args.args[2]
+
+
+class TestParseMicrosoftDirectoryUsers:
+    def test_prefers_mail_over_upn(self):
+        result = mgds._parse_microsoft_directory_users(
+            {
+                "value": [
+                    {
+                        "id": "1",
+                        "displayName": "Alice",
+                        "mail": "alice@example.com",
+                        "userPrincipalName": "alice_upn@example.com",
+                    }
+                ]
+            }
+        )
+        assert result[0].email == "alice@example.com"
+
+    def test_falls_back_to_user_principal_name_when_mail_missing(self):
+        """Guest/unlicensed AD accounts often have a null `mail` attribute."""
+        result = mgds._parse_microsoft_directory_users(
+            {
+                "value": [
+                    {
+                        "id": "2",
+                        "displayName": "Bob",
+                        "mail": None,
+                        "userPrincipalName": "bob@example.com",
+                    }
+                ]
+            }
+        )
+        assert len(result) == 1
+        assert result[0].email == "bob@example.com"
+
+    def test_skips_record_missing_email_and_upn(self):
+        result = mgds._parse_microsoft_directory_users(
+            {"value": [{"id": "3", "displayName": "No Email", "mail": None}]}
+        )
+        assert result == []
+
+    def test_skips_record_missing_id(self):
+        result = mgds._parse_microsoft_directory_users(
+            {"value": [{"displayName": "No Id", "mail": "noid@example.com"}]}
+        )
+        assert result == []
+
+    def test_skips_non_dict_entries(self):
+        result = mgds._parse_microsoft_directory_users({"value": ["not-a-dict", None]})
+        assert result == []
+
+    def test_empty_value_list(self):
+        assert mgds._parse_microsoft_directory_users({}) == []
+
+
+class TestGetMicrosoftGraphEndpoint:
+    def test_default_endpoint(self, monkeypatch):
+        monkeypatch.delenv("MICROSOFT_GRAPH_ENDPOINT", raising=False)
+        assert (
+            mgds._get_microsoft_graph_endpoint() == "https://graph.microsoft.com/v1.0"
+        )
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv(
+            "MICROSOFT_GRAPH_ENDPOINT", "https://graph.microsoft.us/v1.0"
+        )
+        assert mgds._get_microsoft_graph_endpoint() == "https://graph.microsoft.us/v1.0"
+
+    def test_strips_trailing_slash(self, monkeypatch):
+        monkeypatch.setenv(
+            "MICROSOFT_GRAPH_ENDPOINT", "https://graph.microsoft.us/v1.0/"
+        )
+        assert mgds._get_microsoft_graph_endpoint() == "https://graph.microsoft.us/v1.0"
+
+
+class TestFetchMicrosoftDirectoryUsers:
+    @pytest.mark.asyncio
+    async def test_builds_request_with_escaped_filter_and_auth_header(
+        self, monkeypatch, mocker
+    ):
+        monkeypatch.delenv("MICROSOFT_GRAPH_ENDPOINT", raising=False)
+        mock_response = mocker.MagicMock()
+        mock_client = mocker.MagicMock()
+
+        async def mock_get(*args, **kwargs):
+            return mock_response
+
+        get_spy = mocker.patch.object(mock_client, "get", wraps=mock_get)
+        mocker.patch.object(mgds, "get_async_httpx_client", return_value=mock_client)
+
+        await mgds._fetch_microsoft_directory_users("O'Brien", "token-abc")
+
+        get_spy.assert_called_once()
+        _, kwargs = get_spy.call_args
+        assert kwargs["headers"] == {
+            "Authorization": "Bearer token-abc",
+            "ConsistencyLevel": "eventual",
+        }
+        params = kwargs["params"]
+        assert "startswith(displayName,'O''Brien')" in params["$filter"]
+        assert "startswith(mail,'O''Brien')" in params["$filter"]
+        assert "startswith(userPrincipalName,'O''Brien')" in params["$filter"]
+        assert params["$select"] == "id,displayName,mail,userPrincipalName"
+        assert params["$top"] == str(mgds.MICROSOFT_DIRECTORY_SEARCH_MAX_RESULTS)
+        assert params["$count"] == "true"
+        mock_response.raise_for_status.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_request_url_uses_configured_graph_endpoint(
+        self, monkeypatch, mocker
+    ):
+        monkeypatch.setenv(
+            "MICROSOFT_GRAPH_ENDPOINT", "https://graph.microsoft.us/v1.0"
+        )
+        mock_response = mocker.MagicMock()
+        mock_client = mocker.MagicMock()
+
+        async def mock_get(*args, **kwargs):
+            return mock_response
+
+        get_spy = mocker.patch.object(mock_client, "get", wraps=mock_get)
+        mocker.patch.object(mgds, "get_async_httpx_client", return_value=mock_client)
+
+        await mgds._fetch_microsoft_directory_users("alice", "token-abc")
+
+        args, _ = get_spy.call_args
+        assert args[0] == "https://graph.microsoft.us/v1.0/users"
+
+
+class TestSearchMicrosoftDirectoryUsers:
+    @pytest.mark.asyncio
+    async def test_happy_path(self, monkeypatch, mocker):
+        mocker.patch.object(
+            mgds, "_get_microsoft_graph_access_token", return_value="token-123"
+        )
+        mock_response = mocker.MagicMock()
+        mock_response.json.return_value = {
+            "value": [
+                {
+                    "id": "1",
+                    "displayName": "Alice",
+                    "mail": "alice@example.com",
+                }
+            ]
+        }
+        mocker.patch.object(
+            mgds, "_fetch_microsoft_directory_users", return_value=mock_response
+        )
+
+        users = await mgds._search_microsoft_directory_users("alice")
+
+        assert len(users) == 1
+        assert users[0].email == "alice@example.com"
+
+    @pytest.mark.asyncio
+    async def test_retries_once_on_401_with_fresh_token(self, mocker):
+        get_token = mocker.patch.object(
+            mgds,
+            "_get_microsoft_graph_access_token",
+            side_effect=["stale-token", "fresh-token"],
+        )
+        mock_401_response = mocker.MagicMock(status_code=401)
+        unauthorized_error = httpx.HTTPStatusError(
+            "401", request=mocker.MagicMock(), response=mock_401_response
+        )
+        mock_success_response = mocker.MagicMock()
+        mock_success_response.json.return_value = {"value": []}
+
+        mocker.patch.object(
+            mgds,
+            "_fetch_microsoft_directory_users",
+            side_effect=[unauthorized_error, mock_success_response],
+        )
+
+        users = await mgds._search_microsoft_directory_users("alice")
+
+        assert users == []
+        assert get_token.call_count == 2
+        get_token.assert_called_with(force_refresh=True)
+
+    @pytest.mark.asyncio
+    async def test_non_401_http_status_error_propagates(self, mocker):
+        mocker.patch.object(
+            mgds, "_get_microsoft_graph_access_token", return_value="token-123"
+        )
+        mock_500_response = mocker.MagicMock(status_code=500)
+        server_error = httpx.HTTPStatusError(
+            "500", request=mocker.MagicMock(), response=mock_500_response
+        )
+        mocker.patch.object(
+            mgds, "_fetch_microsoft_directory_users", side_effect=server_error
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await mgds._search_microsoft_directory_users("alice")

--- a/tests/test_litellm/proxy/management_endpoints/test_team_model_alias_merge.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_team_model_alias_merge.py
@@ -1,0 +1,71 @@
+"""
+Tests for atomic team model operations during BYOK model creation.
+
+Regression tests for https://github.com/BerriAI/litellm/issues/22594
+Concurrent BYOK model creates must not overwrite each other's entries
+in team.models.
+"""
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../.."))
+
+from litellm.proxy._types import (
+    LitellmUserRoles,
+    TeamModelAddRequest,
+    UserAPIKeyAuth,
+)
+
+
+class TestTeamModelAddAtomicAppend:
+    """Verify team_model_add uses atomic SQL for the models array append."""
+
+    @pytest.mark.asyncio
+    async def test_uses_atomic_array_append_with_dedup(self):
+        """team_model_add must call execute_raw with DISTINCT unnest SQL."""
+        from unittest.mock import patch
+
+        from litellm.proxy.management_endpoints.team_endpoints import team_model_add
+
+        mock_request = MagicMock()
+        mock_user = UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN, user_id="test_user"
+        )
+
+        existing_team = MagicMock()
+        existing_team.model_dump.return_value = {
+            "team_id": "team-1",
+            "models": ["existing-model"],
+        }
+
+        updated_team = MagicMock()
+        updated_team.team_id = "team-1"
+
+        with patch("litellm.proxy.proxy_server.prisma_client") as mock_prisma:
+            mock_prisma.db.litellm_teamtable.find_unique = AsyncMock(
+                return_value=existing_team
+            )
+            mock_prisma.db.execute_raw = AsyncMock(return_value=None)
+            mock_prisma.db.litellm_teamtable.update = AsyncMock(
+                return_value=updated_team
+            )
+
+            await team_model_add(
+                data=TeamModelAddRequest(team_id="team-1", models=["new-model"]),
+                http_request=mock_request,
+                user_api_key_dict=mock_user,
+            )
+
+            mock_prisma.db.execute_raw.assert_called_once()
+            sql = mock_prisma.db.execute_raw.call_args[0][0]
+            assert "DISTINCT unnest" in sql
+            assert "all-proxy-models" in sql
+            assert mock_prisma.db.execute_raw.call_args[0][1] == ["new-model"]
+            assert mock_prisma.db.execute_raw.call_args[0][2] == "team-1"
+
+            # Should use write-routed update to re-fetch, not find_unique
+            mock_prisma.db.litellm_teamtable.update.assert_called_once()

--- a/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_ui_sso.py
@@ -3065,6 +3065,76 @@ async def test_get_ui_settings_includes_api_doc_base_url():
         assert response["LITELLM_UI_API_DOC_BASE_URL"] == "https://custom.docs"
 
 
+class TestMicrosoftDirectorySearchConfiguredSafe:
+    """_is_microsoft_directory_search_configured_safe() must never let a
+    secret manager failure break /sso/get_ui_settings for every user."""
+
+    def test_returns_true_when_configured(self, mocker):
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _is_microsoft_directory_search_configured_safe,
+        )
+
+        mocker.patch(
+            "litellm.proxy.management_endpoints.ui_sso.is_microsoft_directory_search_configured",
+            return_value=True,
+        )
+        assert _is_microsoft_directory_search_configured_safe() is True
+
+    def test_returns_false_when_not_configured(self, mocker):
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _is_microsoft_directory_search_configured_safe,
+        )
+
+        mocker.patch(
+            "litellm.proxy.management_endpoints.ui_sso.is_microsoft_directory_search_configured",
+            return_value=False,
+        )
+        assert _is_microsoft_directory_search_configured_safe() is False
+
+    def test_swallows_exception_and_returns_false(self, mocker):
+        from litellm.proxy.management_endpoints.ui_sso import (
+            _is_microsoft_directory_search_configured_safe,
+        )
+
+        mocker.patch(
+            "litellm.proxy.management_endpoints.ui_sso.is_microsoft_directory_search_configured",
+            side_effect=Exception("secret manager unreachable"),
+        )
+        assert _is_microsoft_directory_search_configured_safe() is False
+
+    @pytest.mark.asyncio
+    async def test_get_ui_settings_survives_directory_search_config_failure(
+        self, mocker
+    ):
+        """A secret manager blip resolving the directory-search flag must not
+        break the rest of /sso/get_ui_settings."""
+        from fastapi import Request
+
+        from litellm.proxy.management_endpoints.ui_sso import get_ui_settings
+
+        mocker.patch(
+            "litellm.proxy.management_endpoints.ui_sso.is_microsoft_directory_search_configured",
+            side_effect=Exception("secret manager unreachable"),
+        )
+
+        mock_request = Request(
+            scope={
+                "type": "http",
+                "headers": [],
+                "method": "GET",
+                "scheme": "http",
+                "server": ("testserver", 80),
+                "path": "/sso/get/ui_settings",
+                "query_string": b"",
+            }
+        )
+
+        response = await get_ui_settings(mock_request)
+
+        assert response["MICROSOFT_DIRECTORY_SEARCH_ENABLED"] is False
+        assert "PROXY_BASE_URL" in response
+
+
 class TestGenericResponseConvertorNestedAttributes:
     """Test generic_response_convertor with nested attribute paths"""
 

--- a/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.test.tsx
@@ -8,6 +8,7 @@ import NotificationsManager from "./molecules/notifications_manager";
 
 vi.mock("./networking", () => ({
   userCreateCall: vi.fn(),
+  directoryUsersSearchCall: vi.fn(),
   modelAvailableCall: vi.fn().mockResolvedValue({ data: [] }),
   invitationCreateCall: vi.fn(),
   organizationMemberAddCall: vi.fn(),
@@ -18,6 +19,7 @@ vi.mock("./networking", () => ({
     SSO_ENABLED: false,
   }),
   getProxyBaseUrl: vi.fn().mockReturnValue("http://localhost"),
+  getGlobalLitellmHeaderName: vi.fn().mockReturnValue("Authorization"),
 }));
 
 vi.mock("./bulk_create_users_button", () => ({
@@ -29,6 +31,7 @@ vi.mock("@/app/(dashboard)/hooks/organizations/useOrganizations", () => ({
 }));
 
 const mockUserCreateCall = vi.mocked(networking.userCreateCall);
+const mockDirectoryUsersSearchCall = vi.mocked(networking.directoryUsersSearchCall);
 const mockInvitationCreateCall = vi.mocked(networking.invitationCreateCall);
 const mockGetProxyUISettings = vi.mocked(networking.getProxyUISettings);
 const mockOrganizationMemberAddCall = vi.mocked(networking.organizationMemberAddCall);
@@ -60,6 +63,7 @@ describe("CreateUserButton", () => {
       DEFAULT_TEAM_DISABLED: false,
       SSO_ENABLED: false,
     });
+    mockDirectoryUsersSearchCall.mockResolvedValue([]);
   });
 
   describe("rendering and visibility", () => {
@@ -212,6 +216,112 @@ describe("CreateUserButton", () => {
   });
 
   describe("standalone mode submission", () => {
+    it("should search directory users and populate user email when a result is selected", async () => {
+      const user = userEvent.setup();
+      mockGetProxyUISettings.mockResolvedValue({
+        PROXY_BASE_URL: null,
+        PROXY_LOGOUT_URL: null,
+        DEFAULT_TEAM_DISABLED: false,
+        SSO_ENABLED: true,
+        MICROSOFT_DIRECTORY_SEARCH_ENABLED: true,
+      });
+      mockDirectoryUsersSearchCall.mockResolvedValue([
+        {
+          id: "aad-user-id",
+          display_name: "Alice Example",
+          email: "alice@example.com",
+        },
+      ]);
+      mockUserCreateCall.mockResolvedValue({ data: { user_id: "directory-user" } });
+
+      renderWithProviders(
+        <CreateUserButton {...defaultProps} possibleUIRoles={{ proxy_user: { ui_label: "User", description: "" } }} />,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /\+ invite user/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /\+ invite user/i }));
+
+      const dialog = screen.getByRole("dialog", { name: /invite user/i });
+      await user.type(within(dialog).getByRole("combobox", { name: /user email/i }), "ali");
+
+      await waitFor(() => {
+        expect(mockDirectoryUsersSearchCall).toHaveBeenCalledWith("token", "ali");
+      });
+      await user.click(await screen.findByText("Alice Example"));
+
+      expect(within(dialog).getByLabelText(/user email/i)).toHaveValue("alice@example.com");
+
+      await user.click(within(dialog).getByRole("combobox", { name: /global proxy role/i }));
+      await user.click(screen.getByText("User"));
+      await user.click(within(dialog).getByRole("button", { name: /invite user/i }));
+
+      await waitFor(() => {
+        expect(mockUserCreateCall).toHaveBeenCalledWith("token", null, expect.objectContaining({
+          user_email: "alice@example.com",
+          user_role: "proxy_user",
+        }));
+      });
+    });
+
+    it("should not show a stale selected directory user after the modal is reopened", async () => {
+      const user = userEvent.setup();
+      mockGetProxyUISettings.mockResolvedValue({
+        PROXY_BASE_URL: null,
+        PROXY_LOGOUT_URL: null,
+        DEFAULT_TEAM_DISABLED: false,
+        SSO_ENABLED: false,
+        MICROSOFT_DIRECTORY_SEARCH_ENABLED: true,
+      });
+      mockDirectoryUsersSearchCall.mockResolvedValue([
+        { id: "aad-user-id", display_name: "Alice Example", email: "alice@example.com" },
+      ]);
+
+      renderWithProviders(<CreateUserButton {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /\+ invite user/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /\+ invite user/i }));
+
+      let dialog = screen.getByRole("dialog", { name: /invite user/i });
+      await user.type(within(dialog).getByRole("combobox", { name: /user email/i }), "ali");
+      await user.click(await screen.findByText("Alice Example"));
+      expect(within(dialog).getByLabelText(/user email/i)).toHaveValue("alice@example.com");
+
+      await user.click(within(dialog).getByRole("button", { name: /close/i }));
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /\+ invite user/i }));
+      dialog = screen.getByRole("dialog", { name: /invite user/i });
+
+      expect(screen.queryByText("Alice Example")).not.toBeInTheDocument();
+      expect(within(dialog).getByLabelText(/user email/i)).toHaveValue("");
+    });
+
+    it("should not render the directory-backed email input when the feature is disabled", async () => {
+      const user = userEvent.setup();
+      mockGetProxyUISettings.mockResolvedValue({
+        PROXY_BASE_URL: null,
+        PROXY_LOGOUT_URL: null,
+        DEFAULT_TEAM_DISABLED: false,
+        SSO_ENABLED: false,
+        MICROSOFT_DIRECTORY_SEARCH_ENABLED: false,
+      });
+
+      renderWithProviders(<CreateUserButton {...defaultProps} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /\+ invite user/i })).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole("button", { name: /\+ invite user/i }));
+
+      const dialog = screen.getByRole("dialog", { name: /invite user/i });
+      expect(within(dialog).queryByRole("combobox", { name: /user email/i })).not.toBeInTheDocument();
+      expect(mockDirectoryUsersSearchCall).not.toHaveBeenCalled();
+    });
+
     it("should show success notification when user is created successfully in standalone mode", async () => {
       const user = userEvent.setup();
       mockUserCreateCall.mockResolvedValue({ data: { user_id: "new-user-789" } });

--- a/ui/litellm-dashboard/src/components/CreateUserButton.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.tsx
@@ -5,16 +5,11 @@ import { Accordion, AccordionBody, AccordionHeader, SelectItem, TextInput } from
 import { Alert, Button, Checkbox, Form, Input, Modal, Select, Select as Select2, Space, Tooltip, Typography } from "antd";
 import React, { useEffect, useMemo, useState } from "react";
 import BulkCreateUsers from "./bulk_create_users_button";
+import { AdDirectoryUserSearch } from "./common_components/AdDirectoryUserSearch";
 import TeamDropdown from "./common_components/team_dropdown";
 import { getModelDisplayName } from "./key_team_helpers/fetch_available_models_team_key";
 import NotificationsManager from "./molecules/notifications_manager";
-import {
-  getProxyBaseUrl,
-  getProxyUISettings,
-  invitationCreateCall,
-  modelAvailableCall,
-  userCreateCall,
-} from "./networking";
+import { getProxyBaseUrl, getProxyUISettings, invitationCreateCall, modelAvailableCall, userCreateCall } from "./networking";
 import OnboardingModal, { InvitationLink } from "./onboarding_link";
 const { Option } = Select;
 const { Text, Link, Title } = Typography;
@@ -46,6 +41,7 @@ interface UISettings {
   PROXY_LOGOUT_URL: string | null;
   DEFAULT_TEAM_DISABLED: boolean;
   SSO_ENABLED: boolean;
+  MICROSOFT_DIRECTORY_SEARCH_ENABLED?: boolean;
 }
 
 export const CreateUserButton: React.FC<CreateuserProps> = ({
@@ -65,6 +61,8 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
   const [isInvitationLinkModalVisible, setIsInvitationLinkModalVisible] = useState(false);
   const [invitationLinkData, setInvitationLinkData] = useState<InvitationLink | null>(null);
   const [baseUrl, setBaseUrl] = useState<string | null>(null);
+  // Bumped on modal close to clear the AD search box's state.
+  const [directorySearchResetSignal, setDirectorySearchResetSignal] = useState(0);
   const { data: organizations = [] } = useOrganizations();
 
   // Derive teams from the user's organizations, falling back to the teams prop
@@ -98,14 +96,28 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
 
   const handleOk = () => {
     setIsModalVisible(false);
+    setDirectorySearchResetSignal((signal) => signal + 1);
     form.resetFields();
   };
 
   const handleCancel = () => {
     setIsModalVisible(false);
     setApiuser(false);
+    setDirectorySearchResetSignal((signal) => signal + 1);
     form.resetFields();
   };
+
+  const userEmailFormItem = uiSettings?.MICROSOFT_DIRECTORY_SEARCH_ENABLED ? (
+    <AdDirectoryUserSearch
+      accessToken={accessToken}
+      resetSignal={directorySearchResetSignal}
+      onSelectUser={(user) => form.setFieldsValue({ user_email: user.email })}
+    />
+  ) : (
+    <Form.Item label="User Email" name="user_email">
+      {isEmbedded ? <TextInput placeholder="" /> : <Input />}
+    </Form.Item>
+  );
 
   const handleCreate = async (formValues: {
     user_id: string;
@@ -199,9 +211,7 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
           showIcon
           className="mb-4"
         />
-        <Form.Item label="User Email" name="user_email">
-          <TextInput placeholder="" />
-        </Form.Item>
+        {userEmailFormItem}
         <Form.Item label="User Role" name="user_role">
           <Select2>
             {possibleUIRoles &&
@@ -281,9 +291,7 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
           labelAlign="left"
           initialValues={{ user_role: "internal_user_viewer", send_invite_email: true }}
         >
-          <Form.Item label="User Email" name="user_email">
-            <Input />
-          </Form.Item>
+          {userEmailFormItem}
           <Form.Item
             label={
               <span>

--- a/ui/litellm-dashboard/src/components/common_components/AdDirectoryUserSearch.test.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/AdDirectoryUserSearch.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AdDirectoryUserSearch } from "./AdDirectoryUserSearch";
+import * as networking from "../networking";
+
+vi.mock("../networking", async (importOriginal) => {
+  const actual = await importOriginal<typeof networking>();
+  return {
+    ...actual,
+    directoryUsersSearchCall: vi.fn(),
+  };
+});
+
+const mockDirectoryUsersSearchCall = vi.mocked(networking.directoryUsersSearchCall);
+
+describe("AdDirectoryUserSearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDirectoryUsersSearchCall.mockResolvedValue([]);
+  });
+
+  it("should render the search combobox", () => {
+    render(<AdDirectoryUserSearch accessToken="token" resetSignal={0} onSelectUser={vi.fn()} />);
+    expect(screen.getByRole("combobox", { name: /user email/i })).toBeInTheDocument();
+  });
+
+  it("should not call directoryUsersSearchCall for a single-character query", async () => {
+    const user = userEvent.setup();
+    render(<AdDirectoryUserSearch accessToken="token" resetSignal={0} onSelectUser={vi.fn()} />);
+
+    await user.type(screen.getByRole("combobox", { name: /user email/i }), "a");
+
+    await waitFor(() => {
+      expect(screen.getByText(/no users found/i)).toBeInTheDocument();
+    });
+    expect(mockDirectoryUsersSearchCall).not.toHaveBeenCalled();
+  });
+
+  it("should collapse rapid keystrokes into a single debounced search call", async () => {
+    const user = userEvent.setup({ delay: 1 });
+    render(<AdDirectoryUserSearch accessToken="token" resetSignal={0} onSelectUser={vi.fn()} />);
+
+    await user.type(screen.getByRole("combobox", { name: /user email/i }), "ali");
+
+    await waitFor(() => {
+      expect(mockDirectoryUsersSearchCall).toHaveBeenCalledTimes(1);
+    });
+    expect(mockDirectoryUsersSearchCall).toHaveBeenCalledWith("token", "ali");
+  });
+
+  it("should call onSelectUser with the chosen directory user", async () => {
+    const user = userEvent.setup();
+    const onSelectUser = vi.fn();
+    mockDirectoryUsersSearchCall.mockResolvedValue([
+      { id: "aad-user-id", display_name: "Alice Example", email: "alice@example.com" },
+    ]);
+
+    render(<AdDirectoryUserSearch accessToken="token" resetSignal={0} onSelectUser={onSelectUser} />);
+
+    await user.type(screen.getByRole("combobox", { name: /user email/i }), "ali");
+    await user.click(await screen.findByText("Alice Example"));
+
+    expect(onSelectUser).toHaveBeenCalledWith({
+      id: "aad-user-id",
+      display_name: "Alice Example",
+      email: "alice@example.com",
+    });
+  });
+
+  it("should show an error message instead of 'No users found' when the search call fails", async () => {
+    const user = userEvent.setup();
+    mockDirectoryUsersSearchCall.mockRejectedValue(new Error("Microsoft directory search is not configured."));
+
+    render(<AdDirectoryUserSearch accessToken="token" resetSignal={0} onSelectUser={vi.fn()} />);
+
+    await user.type(screen.getByRole("combobox", { name: /user email/i }), "ali");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/directory search failed: microsoft directory search is not configured/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should discard a stale search response that resolves after a newer one", async () => {
+    const user = userEvent.setup();
+    let resolveFirstSearch: (users: any[]) => void = () => {};
+    const firstSearch = new Promise<any[]>((resolve) => {
+      resolveFirstSearch = resolve;
+    });
+    mockDirectoryUsersSearchCall.mockImplementationOnce(() => firstSearch).mockResolvedValueOnce([
+      { id: "bob-id", display_name: "Bob Example", email: "bob@example.com" },
+    ]);
+
+    render(<AdDirectoryUserSearch accessToken="token" resetSignal={0} onSelectUser={vi.fn()} />);
+
+    const searchBox = screen.getByRole("combobox", { name: /user email/i });
+    await user.type(searchBox, "ali");
+    await waitFor(() => {
+      expect(mockDirectoryUsersSearchCall).toHaveBeenCalledWith("token", "ali");
+    });
+
+    await user.clear(searchBox);
+    await user.type(searchBox, "bob");
+    await waitFor(() => {
+      expect(mockDirectoryUsersSearchCall).toHaveBeenCalledWith("token", "bob");
+    });
+    await screen.findByText("Bob Example");
+
+    // The stale "ali" response resolves after the newer "bob" one - it must not overwrite the results.
+    resolveFirstSearch([{ id: "alice-id", display_name: "Alice Example", email: "alice@example.com" }]);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.getByText("Bob Example")).toBeInTheDocument();
+    expect(screen.queryByText("Alice Example")).not.toBeInTheDocument();
+  });
+
+  it("should clear the selected value and options when resetSignal changes", async () => {
+    const user = userEvent.setup();
+    mockDirectoryUsersSearchCall.mockResolvedValue([
+      { id: "aad-user-id", display_name: "Alice Example", email: "alice@example.com" },
+    ]);
+
+    const { rerender } = render(
+      <AdDirectoryUserSearch accessToken="token" resetSignal={0} onSelectUser={vi.fn()} />,
+    );
+
+    await user.type(screen.getByRole("combobox", { name: /user email/i }), "ali");
+    await user.click(await screen.findByText("Alice Example"));
+
+    rerender(<AdDirectoryUserSearch accessToken="token" resetSignal={1} onSelectUser={vi.fn()} />);
+
+    expect(screen.queryByText("Alice Example")).not.toBeInTheDocument();
+  });
+});

--- a/ui/litellm-dashboard/src/components/common_components/AdDirectoryUserSearch.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/AdDirectoryUserSearch.tsx
@@ -1,0 +1,138 @@
+import React, { useEffect, useRef, useState } from "react";
+import { AutoComplete, Form, Typography } from "antd";
+import { deriveErrorMessage, directoryUsersSearchCall } from "../networking";
+import type { DirectoryUser } from "../networking";
+
+const { Text } = Typography;
+
+const MIN_QUERY_LENGTH = 2;
+const SEARCH_DEBOUNCE_MS = 300;
+
+interface DirectoryUserOption {
+  label: React.ReactNode;
+  value: string;
+  user: DirectoryUser;
+}
+
+interface AdDirectoryUserSearchProps {
+  accessToken: string;
+  onSelectUser: (user: DirectoryUser) => void;
+  label?: string;
+  name?: string;
+  /** Bump this (e.g. on modal close) to clear search state and the
+   * selected value - antd Select otherwise keeps the previously selected
+   * option's rendered label cached internally. */
+  resetSignal: number;
+}
+
+export const AdDirectoryUserSearch: React.FC<AdDirectoryUserSearchProps> = ({
+  accessToken,
+  onSelectUser,
+  label = "User Email",
+  name = "user_email",
+  resetSignal,
+}) => {
+  const [options, setOptions] = useState<DirectoryUserOption[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedValue, setSelectedValue] = useState<string | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Discards out-of-order search responses.
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    requestIdRef.current++;
+    setOptions([]);
+    setError(null);
+    setLoading(false);
+    setSelectedValue(null);
+  }, [resetSignal]);
+
+  const handleSearch = (query: string) => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+    }
+    const requestId = ++requestIdRef.current;
+
+    if (query.trim().length < MIN_QUERY_LENGTH) {
+      setOptions([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    timeoutRef.current = setTimeout(async () => {
+      try {
+        const users = await directoryUsersSearchCall(accessToken, query.trim());
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+        setOptions(
+          users.map((user) => ({
+            value: user.email,
+            user,
+            label: (
+              <div className="flex flex-col">
+                <Text>{user.display_name || user.email}</Text>
+                {user.display_name && <Text type="secondary">{user.email}</Text>}
+              </div>
+            ),
+          })),
+        );
+      } catch (err) {
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+        console.error("Error searching directory users:", err);
+        setOptions([]);
+        setError(deriveErrorMessage(err));
+      } finally {
+        if (requestId === requestIdRef.current) {
+          setLoading(false);
+        }
+      }
+    }, SEARCH_DEBOUNCE_MS);
+  };
+
+  const handleSelect = (value: string, option: DirectoryUserOption) => {
+    setSelectedValue(value);
+    onSelectUser(option.user);
+  };
+
+  const notFoundContent = loading ? (
+    "Searching..."
+  ) : error ? (
+    <Text type="danger">Directory search failed: {error}</Text>
+  ) : (
+    "No users found"
+  );
+
+  return (
+    <Form.Item label={label} name={name}>
+      <AutoComplete
+        key={resetSignal}
+        placeholder="Search by name or email"
+        onSearch={handleSearch}
+        onSelect={(value, option) => handleSelect(value, option as DirectoryUserOption)}
+        onChange={(value) => setSelectedValue(value || null)}
+        value={selectedValue}
+        options={options}
+        allowClear
+        notFoundContent={notFoundContent}
+      />
+    </Form.Item>
+  );
+};

--- a/ui/litellm-dashboard/src/components/networking.test.ts
+++ b/ui/litellm-dashboard/src/components/networking.test.ts
@@ -453,3 +453,29 @@ describe("teamInfoCall", () => {
     expect(parsed.searchParams.has("team_id")).toBe(false);
   });
 });
+
+describe("directoryUsersSearchCall", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("should throw with the readable message from litellm's ProxyException error envelope", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      json: vi.fn().mockResolvedValue({
+        error: {
+          message: "Microsoft directory search is not configured.",
+          type: "internal_server_error",
+          param: "None",
+          code: "404",
+        },
+      }),
+    } as any);
+
+    await expect(Networking.directoryUsersSearchCall("token", "alice")).rejects.toThrow(
+      "Microsoft directory search is not configured.",
+    );
+  });
+});

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1068,6 +1068,43 @@ export const userCreateCall = async (
   }
 };
 
+export interface DirectoryUser {
+  id: string;
+  display_name?: string | null;
+  email: string;
+}
+
+export const directoryUsersSearchCall = async (
+  accessToken: string,
+  query: string,
+): Promise<DirectoryUser[]> => {
+  try {
+    const params = new URLSearchParams({ query });
+    const url = proxyBaseUrl
+      ? `${proxyBaseUrl}/user/directory_search?${params.toString()}`
+      : `/user/directory_search?${params.toString()}`;
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        [globalLitellmHeaderName]: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json();
+      const errorMessage = deriveErrorMessage(errorData);
+      handleError(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    return response.json();
+  } catch (error) {
+    console.error("Failed to search directory users:", error);
+    throw error;
+  }
+};
+
 export const keyDeleteCall = async (accessToken: string, user_key: string) => {
   try {
     const url = proxyBaseUrl ? `${proxyBaseUrl}/key/delete` : `/key/delete`;


### PR DESCRIPTION
## Summary
- Adds `GET /user/directory_search` so proxy admins can search Microsoft Entra ID (Azure AD) users by name/email when inviting a new user, instead of typing the address manually.
- Auth is app-only (client credentials); credentials can be a dedicated `MICROSOFT_DIRECTORY_TENANT`/`CLIENT_ID`/`CLIENT_SECRET` app registration, or the existing `MICROSOFT_TENANT`/`CLIENT_ID`/`CLIENT_SECRET` already used for Microsoft SSO login.
- Gated behind `MICROSOFT_DIRECTORY_SEARCH_ENABLED=true`; UI only shows the search field when the backend reports it configured via `/sso/get/ui_settings`.
- Restricted to `PROXY_ADMIN`/`PROXY_ADMIN_VIEW_ONLY`.

## Test plan
- [x] `pytest tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py tests/test_litellm/proxy/management_endpoints/test_microsoft_graph_directory_search.py tests/test_litellm/proxy/management_endpoints/test_ui_sso.py` — 302 passed
- [x] `vitest run` on `CreateUserButton.test.tsx`, `AdDirectoryUserSearch.test.tsx`, `networking.test.ts`, `errorUtils.test.ts` — 55 passed
- [x] `black --check` / `ruff check` clean on all touched Python files