### PR TITLE
feat(infersia): add Infersia via providers.json

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -183,5 +183,9 @@
       "max_completion_tokens": "max_tokens"
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+  },
+  "infersia": {
+    "base_url": "https://api.infersia.com/v1",
+    "api_key_env": "INFERSIA_API_KEY"
   }
 }

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -509,6 +509,23 @@
         "a2a": false
       }
     },
+    "infersia": {
+      "display_name": "Infersia (`infersia`)",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": false,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false,
+        "interactions": false
+      }
+    },
     "clarifai": {
       "display_name": "Clarifai (`clarifai`)",
       "url": "https://docs.litellm.ai/docs/providers/clarifai",


### PR DESCRIPTION
## Summary

Adds [Infersia](https://infersia.com) as an OpenAI-compatible provider, following the Venice precedent in #17962.

Infersia serves open-weight models (DeepSeek, Qwen, StepFun) over an OpenAI-compatible API, so the existing `openai_like` path reaches it as-is — no new handler, no client code, no dependencies.

```python
import litellm

response = litellm.completion(
    model="infersia/deepseek/deepseek-v4-flash-0731",
    messages=[{"role": "user", "content": "hello"}],
)
```

**This replaces #35644**, which was identical but opened from a personal account before we had an organisation account. Same two files, same 21 lines — I re-raised it under the company account so the contribution and the CLA sit with the organisation rather than an individual. Closing the other one now; apologies for the churn in your queue.

## Changes

| File | Change |
|---|---|
| `litellm/llms/openai_like/providers.json` | +4 — base URL and `INFERSIA_API_KEY` |
| `provider_endpoints_support.json` | +17 — declares chat-completions support |

The second file isn't mentioned in CONTRIBUTING, but CI requires it — worth noting for the next person, since the guide describes an OpenAI-compatible provider as "a single JSON file".

Both files were edited surgically rather than round-tripped through a JSON serialiser, so the diff is +21/−0 with no reformatting noise.

## Testing

- Both JSON files parse, and the diff is +21/−0 with no reformatting.
- The endpoint contract the `openai_like` path relies on — OpenAI-format request to `base_url` with bearer auth — was exercised directly against production: non-streaming (`finish_reason: stop`), streaming (SSE `data:` chunks), and tool calling (`tool_calls` returned with correct arguments).
- Model ids are listable at `https://api.infersia.com/v1/models` if you want to check them.

To be precise about what I did *not* do: I didn't run LiteLLM itself against this branch, since the registration is data-only and identical in shape to the merged Venice entry. Say the word if you'd like an integration test added and I'll do it.

## Related Issues

Supersedes #35644.

---

**Disclosure:** I work on Infersia, so this is a vendor-submitted listing.
