### PR TITLE
fix(azure): respect DEFAULT_MAX_RETRIES in initialize_azure_sdk_client

### DIFF
--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -536,7 +536,11 @@ class BaseAzureLLM(BaseOpenAILLM):
         if scope is None:
             scope = "https://cognitiveservices.azure.com/.default"
 
-        max_retries: Final = litellm_params.get("max_retries")
+        max_retries = litellm_params.get("max_retries")
+        if max_retries is None:
+            from litellm.constants import DEFAULT_MAX_RETRIES
+
+            max_retries = DEFAULT_MAX_RETRIES
         timeout: Final = litellm_params.get("timeout")
         if not api_key and azure_ad_token_provider is None and tenant_id and client_id and client_secret:
             verbose_logger.debug("Using Azure AD Token Provider from Entra ID for Azure Auth")

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -11,6 +11,7 @@ from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
 import litellm
 from litellm._logging import verbose_logger
 from litellm.caching.caching import DualCache
+from litellm.constants import DEFAULT_MAX_RETRIES
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.openai.common_utils import BaseOpenAILLM
 from litellm.secret_managers.get_azure_ad_token_provider import (
@@ -536,11 +537,8 @@ class BaseAzureLLM(BaseOpenAILLM):
         if scope is None:
             scope = "https://cognitiveservices.azure.com/.default"
 
-        max_retries = litellm_params.get("max_retries")
-        if max_retries is None:
-            from litellm.constants import DEFAULT_MAX_RETRIES
-
-            max_retries = DEFAULT_MAX_RETRIES
+        configured_max_retries: Final = litellm_params.get("max_retries")
+        max_retries: Final = DEFAULT_MAX_RETRIES if configured_max_retries is None else configured_max_retries
         timeout: Final = litellm_params.get("timeout")
         if not api_key and azure_ad_token_provider is None and tenant_id and client_id and client_secret:
             verbose_logger.debug("Using Azure AD Token Provider from Entra ID for Azure Auth")
@@ -600,8 +598,7 @@ class BaseAzureLLM(BaseOpenAILLM):
         else:
             azure_client_params["http_client"] = self._get_sync_http_client()
 
-        if max_retries is not None:
-            azure_client_params["max_retries"] = max_retries
+        azure_client_params["max_retries"] = max_retries
         if timeout is not None:
             azure_client_params["timeout"] = timeout
 

--- a/tests/test_litellm/llms/azure/test_azure_common_utils.py
+++ b/tests/test_litellm/llms/azure/test_azure_common_utils.py
@@ -1,6 +1,5 @@
 import json
 import os
-import subprocess
 import sys
 import traceback
 from typing import Callable, Optional
@@ -446,6 +445,9 @@ def test_initialize_honors_explicit_max_retries(setup_mocks, configured, expecte
 
 
 def test_default_max_retries_env_var_reaches_azure_sdk_client():
+    import subprocess
+    import sys
+
     code = (
         "from litellm.llms.azure.common_utils import BaseAzureLLM\n"
         "client = BaseAzureLLM().get_azure_openai_client("

--- a/tests/test_litellm/llms/azure/test_azure_common_utils.py
+++ b/tests/test_litellm/llms/azure/test_azure_common_utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 import sys
 import traceback
 from typing import Callable, Optional
@@ -412,6 +413,55 @@ def test_select_azure_base_url_called(setup_mocks):
 
     # Verify that select_azure_base_url_or_endpoint was called
     setup_mocks["select_url"].assert_called_once()
+
+
+def test_initialize_defaults_max_retries_to_litellm_default(setup_mocks):
+    result = BaseAzureLLM().initialize_azure_sdk_client(
+        litellm_params={},
+        api_key="test-api-key",
+        api_base="https://test.openai.azure.com",
+        model_name="gpt-4",
+        api_version="2023-06-01",
+        is_async=False,
+    )
+
+    assert result["max_retries"] == litellm.constants.DEFAULT_MAX_RETRIES
+
+
+@pytest.mark.parametrize(
+    "configured, expected",
+    [(0, 0), (5, 5), (None, litellm.constants.DEFAULT_MAX_RETRIES)],
+)
+def test_initialize_honors_explicit_max_retries(setup_mocks, configured, expected):
+    result = BaseAzureLLM().initialize_azure_sdk_client(
+        litellm_params={"max_retries": configured},
+        api_key="test-api-key",
+        api_base="https://test.openai.azure.com",
+        model_name="gpt-4",
+        api_version="2023-06-01",
+        is_async=False,
+    )
+
+    assert result["max_retries"] == expected
+
+
+def test_default_max_retries_env_var_reaches_azure_sdk_client():
+    code = (
+        "from litellm.llms.azure.common_utils import BaseAzureLLM\n"
+        "client = BaseAzureLLM().get_azure_openai_client("
+        "api_key='test-api-key', api_base='https://test.openai.azure.com', api_version='2024-02-01',"
+        " client=None, _is_async=True, litellm_params={}, model='gpt-4')\n"
+        "print(client.max_retries)"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        env={**os.environ, "DEFAULT_MAX_RETRIES": "0"},
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert completed.stdout.strip() == "0"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## TLDR

Problem this solves:

- `DEFAULT_MAX_RETRIES` never reached Azure SDK clients built without `max_retries`
- The openai SDK then quietly retried every failed Azure call twice
- Files, batches, fine-tuning, assistants and audio calls off the router were all affected

How it solves it:

- A missing `max_retries` now falls back to `litellm.constants.DEFAULT_MAX_RETRIES`
- An explicit `max_retries`, including `0`, still wins
- Regression tests cover the default, explicit values, and the env var end to end

## User Flow

Before: an operator who set `DEFAULT_MAX_RETRIES=0` to turn SDK retries off still sees every failing Azure file upload tried three times, so the failure comes back seconds late

1. The operator starts the proxy with `DEFAULT_MAX_RETRIES=0` in its environment and `files_settings` pointing at their Azure OpenAI resource
2. A developer sends `POST https://litellm-domain/v1/files` with `custom_llm_provider=azure`, `purpose=batch` and a `.jsonl` file while Azure is slow enough to time out
3. The response is `HTTP 500` with `Request timed out.`, but it only arrives after roughly two seconds, because the gateway retried the upload two more times with backoff in between
4. Uploads that do go through come back `HTTP 200` with a `file-...` id

After: the same upload fails once and comes back right away, as `DEFAULT_MAX_RETRIES=0` promises

1. The operator starts the proxy with `DEFAULT_MAX_RETRIES=0` in its environment and `files_settings` pointing at their Azure OpenAI resource
2. A developer sends `POST https://litellm-domain/v1/files` with `custom_llm_provider=azure`, `purpose=batch` and a `.jsonl` file while Azure is slow enough to time out
3. The response is `HTTP 500` with `Request timed out.` right after the single attempt, in about the configured timeout
4. Uploads that do go through still come back `HTTP 200` with a `file-...` id

## Relevant issues

Related: #5124 fixed the same gap in the other Azure code paths but left this one

## Linear ticket

Resolves LIT-7396

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] The handful of test files covering my change pass locally, e.g. `uv run pytest tests/test_litellm/<your_test_file>.py -v`. Leave the suites (`make test-unit-*`, `make test-unit`) to CI: it finishes in ~15 minutes where a laptop takes an hour or more
- [ ] My PR passes all required CI/CD checks (e.g., lint, schema.d.ts sync check, etc.)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Shared setup for both runs: a real Azure OpenAI resource (`gpt-5.4-nano` deployment), the proxy started with `DEFAULT_MAX_RETRIES=0` and `OPENAI_LOG=debug` in its environment as `python litellm/proxy/proxy_cli.py --config config.yaml --port 21483 --num_workers 2`, and no database. The timed-out case uses this config, where `timeout: 0.1` on `files_settings` makes every upload time out so the retry behavior is visible; the other two cases use the same config without the `timeout` line

```yaml
model_list:
  - model_name: azure-gpt-5.4-nano
    litellm_params:
      model: azure/gpt-5.4-nano
      api_base: os.environ/AZURE_API_BASE
      api_key: os.environ/AZURE_API_KEY
      api_version: "2024-10-21"

files_settings:
  - custom_llm_provider: azure
    api_base: os.environ/AZURE_API_BASE
    api_key: os.environ/AZURE_API_KEY
    api_version: "2024-10-21"
    timeout: 0.1

general_settings:
  master_key: sk-lit7396-qa
```

`batch.jsonl`:

```json
{"custom_id": "req-1", "method": "POST", "url": "/chat/completions", "body": {"model": "gpt-5.4-nano", "messages": [{"role": "user", "content": "Say hi"}], "max_completion_tokens": 16}}
```

### Before (f529d6d6bd)

#### Timed-out upload with DEFAULT_MAX_RETRIES=0

1. Upload the file three times

   ```bash
   for i in 1 2 3; do curl -s -X POST http://127.0.0.1:21483/v1/files -H 'Authorization: Bearer sk-lit7396-qa' -F custom_llm_provider=azure -F purpose=batch -F file=@batch.jsonl -w '\nHTTP %{http_code} in %{time_total}s\n'; done
   ```

   ```
   {"error":{"message":"Request timed out.","type":"internal_server_error","param":null,"code":"500"}}
   HTTP 500 in 2.460555s
   {"error":{"message":"Request timed out.","type":"internal_server_error","param":null,"code":"500"}}
   HTTP 500 in 1.670863s
   {"error":{"message":"Request timed out.","type":"internal_server_error","param":null,"code":"500"}}
   HTTP 500 in 1.721672s
   ```

2. Follow the first upload through the proxy log (`OPENAI_LOG=debug` makes the SDK log its retries)

   ```bash
   grep -n 'Retrying request to /files\|Sending HTTP Request: POST https://.*openai.azure.com/openai/files\|POST /v1/files HTTP' proxy.log
   ```

   ```
   745:[2026-09-09 13:23:56 - Sending HTTP Request: POST https://mateo-resource.openai.azure.com/openai/files?api-version=2024-10-21
   838:[2026-09-09 13:23:56 - openai._base_client:1722 - INFO] Retrying request to /files in 0.455191 seconds
   840:[2026-09-09 13:23:57 - Sending HTTP Request: POST https://mateo-resource.openai.azure.com/openai/files?api-version=2024-10-21
   929:[2026-09-09 13:23:57 - openai._base_client:1722 - INFO] Retrying request to /files in 0.995487 seconds
   1220:[2026-09-09 13:23:58 - Sending HTTP Request: POST https://mateo-resource.openai.azure.com/openai/files?api-version=2024-10-21
   1413:INFO:     127.0.0.1:58581 - "POST /v1/files HTTP/1.1" 500 Internal Server Error
   ```

   The other two uploads look the same: 9 attempts reached Azure and 6 were SDK retries, so each `HTTP 500` took 1.7 to 2.5 seconds to come back even though `DEFAULT_MAX_RETRIES=0` was set

#### Successful upload

1. Upload the file with the config that has no `timeout`

   ```bash
   curl -s -X POST http://127.0.0.1:21483/v1/files -H 'Authorization: Bearer sk-lit7396-qa' -F custom_llm_provider=azure -F purpose=batch -F file=@batch.jsonl -w '\nHTTP %{http_code} in %{time_total}s\n'
   ```

   ```
   {"id":"file-176c22929c1540ef92c70f20767051c9","bytes":186,"created_at":1788985609,"filename":"batch.jsonl","object":"file","purpose":"batch","status":"processed","expires_at":null,"status_details":null}
   HTTP 200 in 2.163818s
   ```

2. List the files on the Azure resource directly to confirm the three timed-out uploads left nothing behind

   ```bash
   curl -s "$AZURE_API_BASE/openai/files?api-version=2024-10-21" -H "api-key: $AZURE_API_KEY" | python3 -c 'import json,sys; d=json.load(sys.stdin)["data"]; print(len(d)); [print(f["id"], f["created_at"], f["filename"]) for f in d]'
   ```

   ```
   1
   file-176c22929c1540ef92c70f20767051c9 1788985609 batch.jsonl
   ```

#### Chat completion through the router

1. Send a chat completion to the Azure deployment

   ```bash
   curl -s -X POST http://127.0.0.1:21483/v1/chat/completions -H 'Authorization: Bearer sk-lit7396-qa' -H 'Content-Type: application/json' -d '{"model":"azure-gpt-5.4-nano","messages":[{"role":"user","content":"Reply with the single word ok"}]}' -w '\nHTTP %{http_code} in %{time_total}s\n'
   ```

   ```
   {"id":"chatcmpl-EMJAZOjouZWhFTDgKTHetx9YBcnAJ","created":1788985611,"model":"azure-gpt-5.4-nano","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok","role":"assistant", ...}}], "usage":{"completion_tokens":5,"prompt_tokens":12,"total_tokens":17, ...}}
   HTTP 200 in 2.035192s
   ```

### After (422e7e68f2, run merged onto f529d6d6bd as c61afdc365)

#### Timed-out upload with DEFAULT_MAX_RETRIES=0

1. Upload the file three times

   ```bash
   for i in 1 2 3; do curl -s -X POST http://127.0.0.1:21483/v1/files -H 'Authorization: Bearer sk-lit7396-qa' -F custom_llm_provider=azure -F purpose=batch -F file=@batch.jsonl -w '\nHTTP %{http_code} in %{time_total}s\n'; done
   ```

   ```
   {"error":{"message":"Request timed out.","type":"internal_server_error","param":null,"code":"500"}}
   HTTP 500 in 0.897149s
   {"error":{"message":"Request timed out.","type":"internal_server_error","param":null,"code":"500"}}
   HTTP 500 in 0.119294s
   {"error":{"message":"Request timed out.","type":"internal_server_error","param":null,"code":"500"}}
   HTTP 500 in 0.125745s
   ```

2. Follow the uploads through the proxy log with the same grep

   ```bash
   grep -n 'Retrying request to /files\|Sending HTTP Request: POST https://.*openai.azure.com/openai/files\|POST /v1/files HTTP' proxy.log
   ```

   ```
   38806:[2026-09-09 14:13:46 - Sending HTTP Request: POST https://mateo-resource.openai.azure.com/openai/files?api-version=2024-10-21
   39007:INFO:     127.0.0.1:61648 - "POST /v1/files HTTP/1.1" 500 Internal Server Error
   39009:[2026-09-09 14:13:46 - Sending HTTP Request: POST https://mateo-resource.openai.azure.com/openai/files?api-version=2024-10-21
   39203:INFO:     127.0.0.1:61656 - "POST /v1/files HTTP/1.1" 500 Internal Server Error
   39205:[2026-09-09 14:13:46 - Sending HTTP Request: POST https://mateo-resource.openai.azure.com/openai/files?api-version=2024-10-21
   39398:INFO:     127.0.0.1:61662 - "POST /v1/files HTTP/1.1" 500 Internal Server Error
   ```

   Each upload reached Azure exactly once, no `Retrying request` line, and the `HTTP 500` came back in about the 0.1s timeout (the first call also pays for the client and TLS setup)

#### Successful upload

1. Upload the file with the config that has no `timeout`

   ```bash
   curl -s -X POST http://127.0.0.1:21483/v1/files -H 'Authorization: Bearer sk-lit7396-qa' -F custom_llm_provider=azure -F purpose=batch -F file=@batch.jsonl -w '\nHTTP %{http_code} in %{time_total}s\n'
   ```

   ```
   {"id":"file-65c62b75083e4c2586aef95434d3edab","bytes":186,"created_at":1788988609,"filename":"batch.jsonl","object":"file","purpose":"batch","status":"processed","expires_at":null,"status_details":null}
   HTTP 200 in 2.529845s
   ```

2. List the files on the Azure resource directly: one file per successful upload, nothing from the timed-out ones

   ```bash
   curl -s "$AZURE_API_BASE/openai/files?api-version=2024-10-21" -H "api-key: $AZURE_API_KEY" | python3 -c 'import json,sys; d=json.load(sys.stdin)["data"]; print(len(d)); [print(f["id"], f["created_at"], f["filename"]) for f in d]'
   ```

   ```
   2
   file-65c62b75083e4c2586aef95434d3edab 1788988609 batch.jsonl
   file-176c22929c1540ef92c70f20767051c9 1788985609 batch.jsonl
   ```

#### Chat completion through the router

1. Send a chat completion to the Azure deployment

   ```bash
   curl -s -X POST http://127.0.0.1:21483/v1/chat/completions -H 'Authorization: Bearer sk-lit7396-qa' -H 'Content-Type: application/json' -d '{"model":"azure-gpt-5.4-nano","messages":[{"role":"user","content":"Reply with the single word ok"}]}' -w '\nHTTP %{http_code} in %{time_total}s\n'
   ```

   ```
   {"id":"chatcmpl-EMJwwz8I1g15Tql5mqcy8aFJ2xSvR","created":1788988610,"model":"azure-gpt-5.4-nano","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"ok","role":"assistant", ...}}], ...}
   HTTP 200 in 2.156249s
   ```

## Type

🐛 Bug Fix

## Caveats (if any)

### Low

- `DEFAULT_MAX_RETRIES` is read once at import, so it has to be set before the proxy starts, same as the OpenAI paths
- Router deployments already default `max_retries` to `0`, so only Azure clients built outside the router (files, batches, fine-tuning, assistants, audio) change behavior
- Operators who set `DEFAULT_MAX_RETRIES` above `2` now get that many SDK retries on those Azure clients too

## Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

---

## Original description from the contributor

## Summary

`initialize_azure_sdk_client()` ignores the `DEFAULT_MAX_RETRIES` env var when creating `AsyncAzureOpenAI` clients for deployments that don't have explicit `max_retries` in their `litellm_params`.

## Problem

In `litellm/llms/azure/common_utils.py:541`:

```python
max_retries = litellm_params.get("max_retries")  # → None for most deployments
...
if max_retries is not None:
    azure_client_params["max_retries"] = max_retries  # SKIPPED when None!
```

When `max_retries` is `None` (the common case — deployments don't typically set it), the parameter is never passed to `AsyncAzureOpenAI()`. The SDK then uses its own hardcoded default: `openai.DEFAULT_MAX_RETRIES = 2`.

This means `DEFAULT_MAX_RETRIES=0` (env var → `litellm.constants.DEFAULT_MAX_RETRIES`) has **no effect** on the actual SDK client's retry behavior.

## Fix

Fall back to `litellm.constants.DEFAULT_MAX_RETRIES` when `litellm_params` has no `max_retries`:

```python
max_retries = litellm_params.get("max_retries")
if max_retries is None:
    from litellm.constants import DEFAULT_MAX_RETRIES
    max_retries = DEFAULT_MAX_RETRIES
```

## Steps to Reproduce

```python
import os
os.environ["DEFAULT_MAX_RETRIES"] = "0"

from litellm.llms.azure.common_utils import BaseAzureLLM
handler = BaseAzureLLM()
client = handler.get_azure_openai_client(
    api_key="fake",
    api_base="https://test.openai.azure.com/",
    api_version="2024-02-01",
    client=None,
    _is_async=True,
    litellm_params={},  # No max_retries — standard deployment
    model="gpt-4",
)
print(f"client.max_retries = {client.max_retries}")
# Before fix: 2 (SDK default, ignores env var)
# After fix:  0 (respects DEFAULT_MAX_RETRIES env var)
```

## Impact

- Users setting `DEFAULT_MAX_RETRIES=0` to disable SDK retries find it has no effect
- SDK silently retries on timeout/connection errors, causing 300-600s invisible request holds
- LiteLLM's own retry tracking (`attempted_retries`, `retry_policy`) is bypassed since the SDK handles retries internally before surfacing errors to the router

## Related

- #5124 — fixed `data.pop("max_retries", 2)` hardcoding but missed this code path in `common_utils.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Azure client construction retry wiring; behavior shifts only when `max_retries` was previously omitted, aligning with existing LiteLLM defaults rather than the SDK’s built-in 2 retries.
> 
> **Overview**
> **Azure SDK clients now honor LiteLLM’s global retry default** when `litellm_params` omits `max_retries`.
> 
> `initialize_azure_sdk_client` falls back to `litellm.constants.DEFAULT_MAX_RETRIES` (including `DEFAULT_MAX_RETRIES` from the environment) instead of leaving `max_retries` unset so the OpenAI SDK defaults to 2. Explicit `max_retries` values—including `0`—are unchanged. **`max_retries` is always passed** into Azure client params.
> 
> New tests cover the default path, explicit overrides, and a subprocess check that `DEFAULT_MAX_RETRIES=0` reaches the live `AsyncAzureOpenAI` client. This mainly affects Azure clients built outside router chat paths (e.g. files, batches, assistants).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 422e7e68f2d33815f079f37fc747ed2e440c0196. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

