### PR TITLE
fix(proxy): restore management_v1 query-param validation under fastapi>=0.140.7

### DIFF
--- a/litellm/proxy/management_endpoints/management_v1/common.py
+++ b/litellm/proxy/management_endpoints/management_v1/common.py
@@ -4,7 +4,8 @@ from typing import Final
 from urllib.parse import urlencode
 
 from fastapi import Request
-from fastapi.dependencies.utils import get_flat_dependant
+from fastapi.dependencies.utils import get_flat_params
+from fastapi.params import ParamTypes
 from fastapi.responses import JSONResponse
 
 from litellm.types.proxy.management_endpoints.management_v1 import (
@@ -42,7 +43,13 @@ def _declared_query_params(request: Request) -> frozenset[str]:
     dependant: Final = getattr(route, "dependant", None)
     if dependant is None:
         return frozenset()
-    return frozenset(field.alias for field in get_flat_dependant(dependant, skip_repeats=True).query_params)
+    # fastapi>=0.140.7 removed get_flat_dependant(); get_flat_params() returns the
+    # flattened (deduped) param list. Filter to query params to match the old behavior.
+    return frozenset(
+        field.alias
+        for field in get_flat_params(dependant)
+        if getattr(field.field_info, "in_", None) == ParamTypes.query
+    )
 
 
 def escape_like(value: str) -> str:

--- a/tests/test_litellm/proxy/management_endpoints/management_v1/test_common.py
+++ b/tests/test_litellm/proxy/management_endpoints/management_v1/test_common.py
@@ -1,0 +1,95 @@
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, Header, Query, Request
+from fastapi.testclient import TestClient
+
+from litellm.proxy.management_endpoints.management_v1.common import (
+    ManagementProblem,
+    PROBLEM_CONTENT_TYPE,
+    _declared_query_params,
+    problem_response,
+    reject_unknown_query_params,
+)
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+
+    @app.exception_handler(ManagementProblem)
+    async def _handle(_request: Request, exc: ManagementProblem):
+        return problem_response(exc.problem)
+
+    @app.get("/things/{thing_id}", dependencies=[Depends(reject_unknown_query_params)])
+    def _handler(
+        thing_id: str,
+        request: Request,
+        status: Annotated[str | None, Query(alias="filter[status]")] = None,
+        page: Annotated[int, Query(ge=1)] = 1,
+        x_trace: Annotated[str | None, Header()] = None,
+    ) -> dict[str, bool]:
+        return {"ok": True}
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_a_declared_query_param_is_accepted_by_its_alias():
+    response = _client().get("/things/abc", params={"filter[status]": "active", "page": "2"})
+    assert response.status_code == 200, response.text
+
+
+def test_an_unknown_query_param_is_rejected_as_a_problem():
+    response = _client().get("/things/abc", params={"bogus": "x"})
+    assert response.status_code == 400
+    assert response.headers["content-type"].startswith(PROBLEM_CONTENT_TYPE)
+    assert "bogus" in response.json()["detail"]
+
+
+def test_a_path_param_name_is_not_a_declared_query_param():
+    """The flatten step returns path+query+header together; only query names count as declared.
+
+    If the ParamTypes.query filter were dropped, `thing_id` (a path param) would leak
+    into the declared set and this request would be wrongly accepted.
+    """
+    response = _client().get("/things/abc", params={"thing_id": "x"})
+    assert response.status_code == 400
+    assert "thing_id" in response.json()["detail"]
+
+
+def test_a_header_param_name_is_not_a_declared_query_param():
+    response = _client().get("/things/abc", params={"x-trace": "x"})
+    assert response.status_code == 400
+    assert "x-trace" in response.json()["detail"]
+
+
+def test_declared_query_params_isolates_query_aliases_from_other_param_types():
+    captured: dict[str, frozenset[str]] = {}
+    app = FastAPI()
+
+    @app.get("/things/{thing_id}")
+    def _handler(
+        thing_id: str,
+        request: Request,
+        status: Annotated[str | None, Query(alias="filter[status]")] = None,
+        page: Annotated[int, Query(ge=1)] = 1,
+        x_trace: Annotated[str | None, Header()] = None,
+    ) -> dict[str, bool]:
+        captured["declared"] = _declared_query_params(request)
+        return {"ok": True}
+
+    TestClient(app).get("/things/abc")
+    assert captured["declared"] == frozenset({"filter[status]", "page"})
+
+
+def test_declared_query_params_is_empty_when_the_route_has_no_dependant():
+    request = Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "scheme": "http",
+            "root_path": "",
+            "path": "/things/abc",
+            "query_string": b"",
+            "headers": [(b"host", b"testserver")],
+        }
+    )
+    assert _declared_query_params(request) == frozenset()


### PR DESCRIPTION
## TLDR

Problem this solves:

- fastapi>=0.140.7 removed `get_flat_dependant()`
- importing it broke `management_v1/common.py`
- every `/management/v1` route went down on that fastapi

How it solves it:

- switch to the still-present `get_flat_params()`
- filter to `ParamTypes.query` to keep the old behavior
- unknown-query-param rejection works across fastapi versions

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`get_flat_dependant()` exists through fastapi 0.140.6 and is gone from 0.140.7 onward, while `get_flat_params()` has been present since well before that, so the runs below use a fastapi 0.141.1 interpreter to reproduce the breakage and confirm the fix. This fix touches only route wiring and never calls an LLM, so there is no real-dollar inference request to show; the proof instead drives the actual `spend_logs` route with a real HTTP request (no mock of the guard under test) and only overrides auth so the request can reach the query-param guard

Before, at `4b7adab548` (base, pre-fix) under fastapi 0.141.1: the module fails to import, so every route depending on it fails to register

```
$ python -c "import fastapi; print(fastapi.__version__)"
0.141.1
$ python -c "from fastapi.dependencies.utils import get_flat_dependant"
Traceback (most recent call last):
  File "<string>", line 6, in <module>
    from fastapi.dependencies.utils import get_flat_dependant
ImportError: cannot import name 'get_flat_dependant' from 'fastapi.dependencies.utils' (C:\Python313\Lib\site-packages\fastapi\dependencies\utils.py)
```

After, at `da443d1266` (this branch) under fastapi 0.141.1: the module loads and the real `/management/v1/spend_logs/end_users` route rejects an unknown query param with an RFC 9457 problem before touching the database

```
$ python -c "from litellm.proxy.management_endpoints.management_v1 import common; print('loaded under', __import__('fastapi').__version__)"
loaded under 0.141.1

$ curl -sS --globoff 'http://0.0.0.0:4000/management/v1/spend_logs/end_users?filter[startTime][gte]=2026-07-23T00:00:00Z&filter[startTime][lte]=2026-07-24T00:00:00Z&bogus=1' \
    -H 'Authorization: Bearer sk-1234'
HTTP 400  content-type: application/problem+json
{
  "type": "urn:litellm:error:unknown-query-parameter",
  "title": "Unknown query parameter",
  "status": 400,
  "detail": "Unrecognized query parameter(s): bogus.",
  "allowed": [
    "filter[startTime][gte]",
    "filter[startTime][lte]",
    "page",
    "page_size",
    "q"
  ]
}
```

The `allowed` set is exactly the route's declared query params, so the `ParamTypes.query` filter kept path and header params out of it

## Type

🐛 Bug Fix

## Changes

`_declared_query_params` in `management_v1/common.py` used `get_flat_dependant(...).query_params` to learn which query params a route declared, so `reject_unknown_query_params` could 400 anything else. fastapi 0.140.7 removed `get_flat_dependant`, so the module failed to import and took every `/management/v1` route with it. This swaps in `get_flat_params(dependant)`, which returns the flat, deduped list of all param kinds, and filters to `ParamTypes.query` to recover exactly the old query-only set. Dedup that the old `skip_repeats=True` gave is now handled inside `get_flat_params`

`tests/.../management_v1/test_common.py` adds regression coverage: it stands up a route with query, path and header params behind `reject_unknown_query_params` and asserts a declared query alias is accepted, an unknown one is a 400 problem, and path or header names are not mistaken for declared query params. Dropping the `ParamTypes.query` filter fails the last group

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR