### PR TITLE
fix: allow owners to manage key budgets

### DIFF
--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -2362,6 +2362,43 @@ async def _validate_mcp_servers_for_key_update(
     return normalized_object_permission
 
 
+async def _can_creator_update_personal_key_budget(
+    data: UpdateKeyRequest,
+    caller_is_creator: bool,
+    key_is_team_key: bool,
+    is_max_budget_change: bool,
+    is_budget_limits_change: bool,
+    user_id: str | None,
+    prisma_client: PrismaClient | None,
+) -> bool:
+    if (
+        not caller_is_creator
+        or key_is_team_key
+        or data.spend is not None
+        or not (is_max_budget_change or is_budget_limits_change)
+        or user_id is None
+        or prisma_client is None
+    ):
+        return False
+    user = await UserRepository(prisma_client).find_by_id(user_id)
+    if user is None:
+        raise HTTPException(status_code=403, detail={"error": "Key owner not found."})
+    requested_budgets = tuple(
+        budget
+        for budget in (
+            data.max_budget if is_max_budget_change else None,
+            *(entry.max_budget for entry in data.budget_limits or ()),
+        )
+        if budget is not None
+    )
+    if user.max_budget is not None and any(budget > user.max_budget for budget in requested_budgets):
+        raise HTTPException(
+            status_code=400,
+            detail={"error": f"Key budget cannot exceed the owner's max_budget ({user.max_budget})."},
+        )
+    return True
+
+
 async def _validate_update_key_data(
     data: UpdateKeyRequest,
     existing_key_row: LiteLLM_VerificationToken,
@@ -2434,21 +2471,16 @@ async def _validate_update_key_data(
     # - Anyone else (non-PROXY_ADMIN, not the owner, not a team member
     #   on a team key): must pass _check_key_admin_access (PROXY_ADMIN
     #   / key-owner / team-admin / org-admin of the key).
-    # - max_budget / spend / budget_limits: always require the admin
-    #   check, even for the key owner or a team member (matches the
-    #   existing admin-only budget semantics).  budget_limits uses
-    #   model_fields_set because an explicit null/[] clears the field
-    #   and must gate the same as setting or changing it.
+    # - Key creators may manage budgets on their own personal keys up to
+    #   their user budget. Team-key budget changes require an admin.
     # - spend gates on presence alone (not a value diff): the DB spend
     #   lags the live cross-pod counter, so letting an "unchanged" spend
     #   through the non-admin path would let a key owner / team member
     #   overwrite the live counter below real usage and silently weaken
     #   enforcement.
-    _is_budget_change = (
-        (data.max_budget is not None and data.max_budget != existing_key_row.max_budget)
-        or data.spend is not None
-        or "budget_limits" in data.model_fields_set
-    )
+    _is_max_budget_change = "max_budget" in data.model_fields_set and data.max_budget != existing_key_row.max_budget
+    _is_budget_limits_change = "budget_limits" in data.model_fields_set
+    _is_budget_change = _is_max_budget_change or data.spend is not None or _is_budget_limits_change
 
     _existing_metadata = getattr(existing_key_row, "metadata", None)
     _existing_throttle = (
@@ -2475,7 +2507,18 @@ async def _validate_update_key_data(
     # non-budget change means the caller was authorized — skip the redundant
     # _check_key_admin_access that would otherwise require team/org admin status.
     _key_is_team_key = getattr(existing_key_row, "team_id", None) is not None
-    can_skip_admin_check = (caller_is_creator or _key_is_team_key) and not _is_budget_change
+    creator_budget_change_allowed = await _can_creator_update_personal_key_budget(
+        data=data,
+        caller_is_creator=caller_is_creator,
+        key_is_team_key=_key_is_team_key,
+        is_max_budget_change=_is_max_budget_change,
+        is_budget_limits_change=_is_budget_limits_change,
+        user_id=user_api_key_dict.user_id,
+        prisma_client=prisma_client,
+    )
+    can_skip_admin_check = (
+        (caller_is_creator or _key_is_team_key) and not _is_budget_change
+    ) or creator_budget_change_allowed
     if (not _is_proxy_admin) and prisma_client is not None and not can_skip_admin_check:
         hashed_key = existing_key_row.token
         await _check_key_admin_access(

--- a/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_key_management_endpoints.py
@@ -10801,7 +10801,8 @@ class TestKeyOwnerPrivilegeEscalation:
     Policy:
     - created_by == caller → can edit any non-budget field without admin
     - created_by != caller (assigned user) → must pass admin check for any edit
-    - budget changes (max_budget/spend) → always require admin
+    - own personal-key budgets → allowed up to the owner's user budget
+    - spend changes → always require admin
     - PROXY_ADMIN → unrestricted
     """
 
@@ -10942,48 +10943,75 @@ class TestKeyOwnerPrivilegeEscalation:
         mock_check.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_creator_cannot_change_own_budget(self):
-        """Budget changes require admin even for the key creator."""
-        data = UpdateKeyRequest(key="sk-test", max_budget=9999.0)
+    @pytest.mark.parametrize("key_budget", [50.0, None])
+    async def test_creator_can_change_own_budget_within_user_budget(self, key_budget: float | None):
+        data = UpdateKeyRequest(key="sk-test", max_budget=key_budget)
         existing = self._make_existing_key(created_by="creator-123")
         existing.max_budget = 10.0
         auth = self._make_auth(user_id="creator-123")
 
-        mock_check = AsyncMock(
-            side_effect=HTTPException(status_code=403, detail="Not authorized")
-        )
+        mock_check = AsyncMock()
         with patch(
             "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
             mock_check,
+        ), patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.UserRepository.find_by_id",
+            AsyncMock(return_value=LiteLLM_UserTable(user_id="creator-123", max_budget=100.0)),
         ):
-            with pytest.raises(HTTPException):
-                await _validate_update_key_data(
-                    data=data,
-                    existing_key_row=existing,
-                    user_api_key_dict=auth,
-                    llm_router=None,
-                    premium_user=False,
-                    prisma_client=AsyncMock(),
-                    user_api_key_cache=MagicMock(),
-                )
-        mock_check.assert_called_once()
+            await _validate_update_key_data(
+                data=data,
+                existing_key_row=existing,
+                user_api_key_dict=auth,
+                llm_router=None,
+                premium_user=False,
+                prisma_client=AsyncMock(),
+                user_api_key_cache=MagicMock(),
+            )
+        mock_check.assert_not_called()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("cleared_value", [[], None])
-    async def test_creator_cannot_clear_own_budget_limits(self, cleared_value):
-        """Clearing budget_limits is a budget change and requires admin."""
+    async def test_creator_can_clear_own_budget_limits(self, cleared_value):
         data = UpdateKeyRequest(key="sk-test", budget_limits=cleared_value)
         existing = self._make_existing_key(created_by="creator-123")
         auth = self._make_auth(user_id="creator-123")
 
-        mock_check = AsyncMock(
-            side_effect=HTTPException(status_code=403, detail="Not authorized")
-        )
+        mock_check = AsyncMock()
         with patch(
             "litellm.proxy.management_endpoints.key_management_endpoints._check_key_admin_access",
             mock_check,
+        ), patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.UserRepository.find_by_id",
+            AsyncMock(return_value=LiteLLM_UserTable(user_id="creator-123", max_budget=100.0)),
         ):
-            with pytest.raises(HTTPException):
+            await _validate_update_key_data(
+                data=data,
+                existing_key_row=existing,
+                user_api_key_dict=auth,
+                llm_router=None,
+                premium_user=False,
+                prisma_client=AsyncMock(),
+                user_api_key_cache=MagicMock(),
+            )
+        mock_check.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "data",
+        [
+            UpdateKeyRequest(key="sk-test", max_budget=101.0),
+            UpdateKeyRequest(key="sk-test", budget_limits=[{"budget_duration": "7d", "max_budget": 101.0}]),
+        ],
+    )
+    async def test_creator_cannot_exceed_user_budget(self, data: UpdateKeyRequest):
+        existing = self._make_existing_key(created_by="creator-123")
+        auth = self._make_auth(user_id="creator-123")
+
+        with patch(
+            "litellm.proxy.management_endpoints.key_management_endpoints.UserRepository.find_by_id",
+            AsyncMock(return_value=LiteLLM_UserTable(user_id="creator-123", max_budget=100.0)),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
                 await _validate_update_key_data(
                     data=data,
                     existing_key_row=existing,
@@ -10993,7 +11021,8 @@ class TestKeyOwnerPrivilegeEscalation:
                     prisma_client=AsyncMock(),
                     user_api_key_cache=MagicMock(),
                 )
-        mock_check.assert_called_once()
+        assert exc_info.value.status_code == 400
+        assert "cannot exceed" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
     async def test_admin_can_clear_budget_limits(self):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Key owners cannot update their personal key budgets
- UI session tokens do not carry the user budget ceiling

How it solves it:

- Reads the owner's budget from the user table
- Allows personal key budgets within that ceiling
- Keeps spend and team key budgets admin-only

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Pending a live proxy run. The PR is draft until this is captured

## Type

🐛 Bug Fix

## Changes

Personal key creators can update `max_budget` and `budget_limits` when every requested limit is within the owner's authoritative user budget. The user budget is loaded from the database because UI session tokens intentionally have no budget. Explicit spend updates, assigned keys, and team key budget changes retain the existing admin checks

Regression tests cover setting and clearing a personal key budget, clearing budget windows, rejecting scalar and window limits above the user ceiling, and preserving spend protection

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
