### PR TITLE
fix(mcp): honor x-litellm-tags on the MCP gateway's tools/list and tools/call

### DIFF
--- a/.github/resolve_pr35777.py
+++ b/.github/resolve_pr35777.py
@@ -1,0 +1,150 @@
+from pathlib import Path
+
+server_path = Path("litellm/proxy/_experimental/mcp_server/server.py")
+text = server_path.read_text()
+
+helper_anchor = "\n\ndef _jsonrpc_text_has_top_level_method(text: str) -> bool:\n"
+helper = '''
+
+
+def _request_tags_from_raw_headers(
+    raw_headers: Mapping[str, str] | None,
+) -> Sequence[str] | None:
+    """Parse the caller's x-litellm-tags header with the shared proxy tag parser."""
+    if not raw_headers:
+        return None
+    for key, value in raw_headers.items():
+        if isinstance(key, str) and key.lower() == "x-litellm-tags" and value:
+            return LiteLLMProxyRequestSetup.add_request_tag_to_metadata(
+                llm_router=None,
+                headers={"x-litellm-tags": value},
+                data={},
+            )
+    return None
+'''
+if "def _request_tags_from_raw_headers(" not in text:
+    if helper_anchor not in text:
+        raise SystemExit("helper anchor not found")
+    text = text.replace(helper_anchor, helper + helper_anchor, 1)
+
+old = "            effective_litellm_trace_id: Final = litellm_trace_id or get_chain_id_from_headers(raw_headers)\n            spend_logs_metadata: Final[dict[str, object]] = {\n"
+new = "            effective_litellm_trace_id: Final = litellm_trace_id or get_chain_id_from_headers(raw_headers)\n            effective_request_tags: Final = request_tags or _request_tags_from_raw_headers(raw_headers)\n            spend_logs_metadata: Final[dict[str, object]] = {\n"
+if "effective_request_tags: Final" not in text:
+    if old not in text:
+        raise SystemExit("list-tools logging anchor not found")
+    text = text.replace(old, new, 1)
+
+old_tags = '                    **({"tags": request_tags} if request_tags else {}),\n'
+new_tags = '                    **({"tags": effective_request_tags} if effective_request_tags else {}),\n'
+if old_tags in text:
+    text = text.replace(old_tags, new_tags, 1)
+elif new_tags not in text:
+    raise SystemExit("tags metadata anchor not found")
+
+server_path.write_text(text)
+
+test_path = Path("tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py")
+tests = test_path.read_text()
+marker = "test_request_tags_from_raw_headers_reads_x_litellm_tags"
+if marker not in tests:
+    tests += r'''
+
+
+@pytest.mark.parametrize(
+    "raw_headers, expected",
+    [
+        (None, None),
+        ({"mcp-session-id": "abc"}, None),
+        ({"x-litellm-tags": ""}, None),
+        (
+            {"X-LiteLLM-Tags": "application:orders, service:checkout"},
+            ["application:orders", "service:checkout"],
+        ),
+    ],
+)
+def test_request_tags_from_raw_headers_reads_x_litellm_tags(raw_headers, expected):
+    from litellm.proxy._experimental.mcp_server.server import (
+        _request_tags_from_raw_headers,
+    )
+
+    assert _request_tags_from_raw_headers(raw_headers) == expected
+
+
+@pytest.mark.asyncio
+async def test_get_tools_from_mcp_servers_uses_x_litellm_tags_for_spend_logging():
+    from litellm.proxy._experimental.mcp_server.server import (
+        _get_tools_from_mcp_servers,
+    )
+    from mcp.types import Tool as MCPTool
+
+    user_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+
+    server_a = MagicMock(name="server_a_obj")
+    server_a.name = "server_a"
+    server_a.alias = "server_a"
+    server_a.server_name = "server_a"
+    server_a.server_id = "a"
+    server_a.auth_type = None
+    server_a.extra_headers = None
+    server_a.tool_name_to_display_name = None
+    server_a.tool_name_to_description = None
+
+    tool_1 = MCPTool(
+        name="server_a-tool_1",
+        description="test tool",
+        inputSchema={"type": "object"},
+    )
+
+    dummy_logging_obj = MagicMock()
+    dummy_logging_obj.model_call_details = {"metadata": {"spend_logs_metadata": {}}}
+    dummy_logging_obj.async_success_handler = AsyncMock()
+    function_setup_kwargs = {}
+
+    def _capture_function_setup(*_args, **kwargs):
+        function_setup_kwargs.update(kwargs)
+        return dummy_logging_obj, None
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._get_allowed_mcp_servers",
+            new=AsyncMock(return_value=[server_a]),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._prepare_mcp_server_headers",
+            return_value=(None, None),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager",
+        ) as mock_manager,
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.filter_tools_by_allowed_tools",
+            side_effect=lambda tools, _server: tools,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.filter_tools_by_key_team_permissions",
+            new=AsyncMock(side_effect=lambda tools, **_: tools),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.function_setup",
+            side_effect=_capture_function_setup,
+        ),
+    ):
+        mock_manager._get_tools_from_server = AsyncMock(return_value=[tool_1])
+
+        listing = await _get_tools_from_mcp_servers(
+            user_api_key_auth=user_auth,
+            mcp_auth_header=None,
+            mcp_servers=["server_a"],
+            mcp_server_auth_headers=None,
+            raw_headers={"X-LiteLLM-Tags": "application:orders, service:checkout"},
+            log_list_tools_to_spendlogs=True,
+            list_tools_log_source="mcp_protocol",
+        )
+
+    assert listing.tools == [tool_1]
+    assert function_setup_kwargs["metadata"]["tags"] == [
+        "application:orders",
+        "service:checkout",
+    ]
+'''
+    test_path.write_text(tests)

--- a/.github/workflows/resolve-pr-35777.yml
+++ b/.github/workflows/resolve-pr-35777.yml
@@ -2,203 +2,32 @@ name: Resolve PR 35777 conflicts
 
 on:
   push:
-    branches:
-      - litellm_mcp_gateway_request_tags
+    branches: [litellm_mcp_gateway_request_tags]
+    paths:
+      - .github/workflows/resolve-pr-35777.yml
 
 permissions:
   contents: write
 
 jobs:
   resolve:
-    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: litellm_mcp_gateway_request_tags
-
-      - name: Merge latest staging and preserve MCP request tags fix
-        shell: bash
-        run: |
-          set -euo pipefail
+      - run: |
+          set -e
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git remote add upstream https://github.com/BerriAI/litellm.git 2>/dev/null || true
+          git remote add upstream https://github.com/BerriAI/litellm.git || true
           git fetch upstream litellm_internal_staging
-
           git merge --no-commit --no-ff upstream/litellm_internal_staging || true
-
-          # Both files changed substantially upstream. Start from current staging,
-          # then re-apply only the part of #35777 that is still needed.
-          git checkout upstream/litellm_internal_staging -- \
-            litellm/proxy/_experimental/mcp_server/server.py \
-            tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
-
-          python - <<'PY'
-          from pathlib import Path
-
-          server_path = Path("litellm/proxy/_experimental/mcp_server/server.py")
-          text = server_path.read_text()
-
-          helper_anchor = "\n\ndef _jsonrpc_text_has_top_level_method(text: str) -> bool:\n"
-          helper = '''
-
-
-def _request_tags_from_raw_headers(
-    raw_headers: Mapping[str, str] | None,
-) -> Sequence[str] | None:
-    """Parse the caller's x-litellm-tags header with the shared proxy tag parser."""
-    if not raw_headers:
-        return None
-    for key, value in raw_headers.items():
-        if isinstance(key, str) and key.lower() == "x-litellm-tags" and value:
-            return LiteLLMProxyRequestSetup.add_request_tag_to_metadata(
-                llm_router=None,
-                headers={"x-litellm-tags": value},
-                data={},
-            )
-    return None
-'''
-          if "def _request_tags_from_raw_headers(" not in text:
-              if helper_anchor not in text:
-                  raise SystemExit("helper anchor not found")
-              text = text.replace(helper_anchor, helper + helper_anchor, 1)
-
-          old = "            effective_litellm_trace_id: Final = litellm_trace_id or get_chain_id_from_headers(raw_headers)\n            spend_logs_metadata: Final[dict[str, object]] = {\n"
-          new = "            effective_litellm_trace_id: Final = litellm_trace_id or get_chain_id_from_headers(raw_headers)\n            effective_request_tags: Final = request_tags or _request_tags_from_raw_headers(raw_headers)\n            spend_logs_metadata: Final[dict[str, object]] = {\n"
-          if "effective_request_tags: Final" not in text:
-              if old not in text:
-                  raise SystemExit("list-tools logging anchor not found")
-              text = text.replace(old, new, 1)
-
-          old_tags = '                    **({"tags": request_tags} if request_tags else {}),\n'
-          new_tags = '                    **({"tags": effective_request_tags} if effective_request_tags else {}),\n'
-          if old_tags in text:
-              text = text.replace(old_tags, new_tags, 1)
-          elif new_tags not in text:
-              raise SystemExit("tags metadata anchor not found")
-
-          server_path.write_text(text)
-
-          test_path = Path("tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py")
-          tests = test_path.read_text()
-          marker = "test_request_tags_from_raw_headers_reads_x_litellm_tags"
-          if marker not in tests:
-              tests += r'''
-
-
-@pytest.mark.parametrize(
-    "raw_headers, expected",
-    [
-        (None, None),
-        ({"mcp-session-id": "abc"}, None),
-        ({"x-litellm-tags": ""}, None),
-        (
-            {"X-LiteLLM-Tags": "application:orders, service:checkout"},
-            ["application:orders", "service:checkout"],
-        ),
-    ],
-)
-def test_request_tags_from_raw_headers_reads_x_litellm_tags(raw_headers, expected):
-    from litellm.proxy._experimental.mcp_server.server import (
-        _request_tags_from_raw_headers,
-    )
-
-    assert _request_tags_from_raw_headers(raw_headers) == expected
-
-
-@pytest.mark.asyncio
-async def test_get_tools_from_mcp_servers_uses_x_litellm_tags_for_spend_logging():
-    from litellm.proxy._experimental.mcp_server.server import (
-        _get_tools_from_mcp_servers,
-    )
-    from mcp.types import Tool as MCPTool
-
-    user_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
-
-    server_a = MagicMock(name="server_a_obj")
-    server_a.name = "server_a"
-    server_a.alias = "server_a"
-    server_a.server_name = "server_a"
-    server_a.server_id = "a"
-    server_a.auth_type = None
-    server_a.extra_headers = None
-    server_a.tool_name_to_display_name = None
-    server_a.tool_name_to_description = None
-
-    tool_1 = MCPTool(
-        name="server_a-tool_1",
-        description="test tool",
-        inputSchema={"type": "object"},
-    )
-
-    dummy_logging_obj = MagicMock()
-    dummy_logging_obj.model_call_details = {"metadata": {"spend_logs_metadata": {}}}
-    dummy_logging_obj.async_success_handler = AsyncMock()
-    function_setup_kwargs = {}
-
-    def _capture_function_setup(*_args, **kwargs):
-        function_setup_kwargs.update(kwargs)
-        return dummy_logging_obj, None
-
-    with (
-        patch(
-            "litellm.proxy._experimental.mcp_server.server._get_allowed_mcp_servers",
-            new=AsyncMock(return_value=[server_a]),
-        ),
-        patch(
-            "litellm.proxy._experimental.mcp_server.server._prepare_mcp_server_headers",
-            return_value=(None, None),
-        ),
-        patch(
-            "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager",
-        ) as mock_manager,
-        patch(
-            "litellm.proxy._experimental.mcp_server.server.filter_tools_by_allowed_tools",
-            side_effect=lambda tools, _server: tools,
-        ),
-        patch(
-            "litellm.proxy._experimental.mcp_server.server.filter_tools_by_key_team_permissions",
-            new=AsyncMock(side_effect=lambda tools, **_: tools),
-        ),
-        patch(
-            "litellm.proxy._experimental.mcp_server.server.function_setup",
-            side_effect=_capture_function_setup,
-        ),
-    ):
-        mock_manager._get_tools_from_server = AsyncMock(return_value=[tool_1])
-
-        listing = await _get_tools_from_mcp_servers(
-            user_api_key_auth=user_auth,
-            mcp_auth_header=None,
-            mcp_servers=["server_a"],
-            mcp_server_auth_headers=None,
-            raw_headers={"X-LiteLLM-Tags": "application:orders, service:checkout"},
-            log_list_tools_to_spendlogs=True,
-            list_tools_log_source="mcp_protocol",
-        )
-
-    assert listing.tools == [tool_1]
-    assert function_setup_kwargs["metadata"]["tags"] == [
-        "application:orders",
-        "service:checkout",
-    ]
-'''
-              test_path.write_text(tests)
-          PY
-
-          # This workflow is only a one-shot resolver and must not remain in the PR tree.
-          git rm .github/workflows/resolve-pr-35777.yml
-          git add \
-            litellm/proxy/_experimental/mcp_server/server.py \
-            tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
-
-          if git ls-files -u | grep -q .; then
-            echo "Unresolved merge entries remain:" >&2
-            git ls-files -u >&2
-            exit 1
-          fi
-
+          git checkout upstream/litellm_internal_staging -- litellm/proxy/_experimental/mcp_server/server.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+          python .github/resolve_pr35777.py
+          git rm .github/workflows/resolve-pr-35777.yml .github/resolve_pr35777.py
+          git add litellm/proxy/_experimental/mcp_server/server.py tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+          test -z "$(git ls-files -u)"
           git commit -m "Merge litellm_internal_staging and resolve MCP request-tags conflicts"
           git push origin HEAD:litellm_mcp_gateway_request_tags

--- a/.github/workflows/resolve-pr-35777.yml
+++ b/.github/workflows/resolve-pr-35777.yml
@@ -1,0 +1,204 @@
+name: Resolve PR 35777 conflicts
+
+on:
+  push:
+    branches:
+      - litellm_mcp_gateway_request_tags
+
+permissions:
+  contents: write
+
+jobs:
+  resolve:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: litellm_mcp_gateway_request_tags
+
+      - name: Merge latest staging and preserve MCP request tags fix
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote add upstream https://github.com/BerriAI/litellm.git 2>/dev/null || true
+          git fetch upstream litellm_internal_staging
+
+          git merge --no-commit --no-ff upstream/litellm_internal_staging || true
+
+          # Both files changed substantially upstream. Start from current staging,
+          # then re-apply only the part of #35777 that is still needed.
+          git checkout upstream/litellm_internal_staging -- \
+            litellm/proxy/_experimental/mcp_server/server.py \
+            tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+
+          python - <<'PY'
+          from pathlib import Path
+
+          server_path = Path("litellm/proxy/_experimental/mcp_server/server.py")
+          text = server_path.read_text()
+
+          helper_anchor = "\n\ndef _jsonrpc_text_has_top_level_method(text: str) -> bool:\n"
+          helper = '''
+
+
+def _request_tags_from_raw_headers(
+    raw_headers: Mapping[str, str] | None,
+) -> Sequence[str] | None:
+    """Parse the caller's x-litellm-tags header with the shared proxy tag parser."""
+    if not raw_headers:
+        return None
+    for key, value in raw_headers.items():
+        if isinstance(key, str) and key.lower() == "x-litellm-tags" and value:
+            return LiteLLMProxyRequestSetup.add_request_tag_to_metadata(
+                llm_router=None,
+                headers={"x-litellm-tags": value},
+                data={},
+            )
+    return None
+'''
+          if "def _request_tags_from_raw_headers(" not in text:
+              if helper_anchor not in text:
+                  raise SystemExit("helper anchor not found")
+              text = text.replace(helper_anchor, helper + helper_anchor, 1)
+
+          old = "            effective_litellm_trace_id: Final = litellm_trace_id or get_chain_id_from_headers(raw_headers)\n            spend_logs_metadata: Final[dict[str, object]] = {\n"
+          new = "            effective_litellm_trace_id: Final = litellm_trace_id or get_chain_id_from_headers(raw_headers)\n            effective_request_tags: Final = request_tags or _request_tags_from_raw_headers(raw_headers)\n            spend_logs_metadata: Final[dict[str, object]] = {\n"
+          if "effective_request_tags: Final" not in text:
+              if old not in text:
+                  raise SystemExit("list-tools logging anchor not found")
+              text = text.replace(old, new, 1)
+
+          old_tags = '                    **({"tags": request_tags} if request_tags else {}),\n'
+          new_tags = '                    **({"tags": effective_request_tags} if effective_request_tags else {}),\n'
+          if old_tags in text:
+              text = text.replace(old_tags, new_tags, 1)
+          elif new_tags not in text:
+              raise SystemExit("tags metadata anchor not found")
+
+          server_path.write_text(text)
+
+          test_path = Path("tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py")
+          tests = test_path.read_text()
+          marker = "test_request_tags_from_raw_headers_reads_x_litellm_tags"
+          if marker not in tests:
+              tests += r'''
+
+
+@pytest.mark.parametrize(
+    "raw_headers, expected",
+    [
+        (None, None),
+        ({"mcp-session-id": "abc"}, None),
+        ({"x-litellm-tags": ""}, None),
+        (
+            {"X-LiteLLM-Tags": "application:orders, service:checkout"},
+            ["application:orders", "service:checkout"],
+        ),
+    ],
+)
+def test_request_tags_from_raw_headers_reads_x_litellm_tags(raw_headers, expected):
+    from litellm.proxy._experimental.mcp_server.server import (
+        _request_tags_from_raw_headers,
+    )
+
+    assert _request_tags_from_raw_headers(raw_headers) == expected
+
+
+@pytest.mark.asyncio
+async def test_get_tools_from_mcp_servers_uses_x_litellm_tags_for_spend_logging():
+    from litellm.proxy._experimental.mcp_server.server import (
+        _get_tools_from_mcp_servers,
+    )
+    from mcp.types import Tool as MCPTool
+
+    user_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+
+    server_a = MagicMock(name="server_a_obj")
+    server_a.name = "server_a"
+    server_a.alias = "server_a"
+    server_a.server_name = "server_a"
+    server_a.server_id = "a"
+    server_a.auth_type = None
+    server_a.extra_headers = None
+    server_a.tool_name_to_display_name = None
+    server_a.tool_name_to_description = None
+
+    tool_1 = MCPTool(
+        name="server_a-tool_1",
+        description="test tool",
+        inputSchema={"type": "object"},
+    )
+
+    dummy_logging_obj = MagicMock()
+    dummy_logging_obj.model_call_details = {"metadata": {"spend_logs_metadata": {}}}
+    dummy_logging_obj.async_success_handler = AsyncMock()
+    function_setup_kwargs = {}
+
+    def _capture_function_setup(*_args, **kwargs):
+        function_setup_kwargs.update(kwargs)
+        return dummy_logging_obj, None
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._get_allowed_mcp_servers",
+            new=AsyncMock(return_value=[server_a]),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._prepare_mcp_server_headers",
+            return_value=(None, None),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager",
+        ) as mock_manager,
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.filter_tools_by_allowed_tools",
+            side_effect=lambda tools, _server: tools,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.filter_tools_by_key_team_permissions",
+            new=AsyncMock(side_effect=lambda tools, **_: tools),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.function_setup",
+            side_effect=_capture_function_setup,
+        ),
+    ):
+        mock_manager._get_tools_from_server = AsyncMock(return_value=[tool_1])
+
+        listing = await _get_tools_from_mcp_servers(
+            user_api_key_auth=user_auth,
+            mcp_auth_header=None,
+            mcp_servers=["server_a"],
+            mcp_server_auth_headers=None,
+            raw_headers={"X-LiteLLM-Tags": "application:orders, service:checkout"},
+            log_list_tools_to_spendlogs=True,
+            list_tools_log_source="mcp_protocol",
+        )
+
+    assert listing.tools == [tool_1]
+    assert function_setup_kwargs["metadata"]["tags"] == [
+        "application:orders",
+        "service:checkout",
+    ]
+'''
+              test_path.write_text(tests)
+          PY
+
+          # This workflow is only a one-shot resolver and must not remain in the PR tree.
+          git rm .github/workflows/resolve-pr-35777.yml
+          git add \
+            litellm/proxy/_experimental/mcp_server/server.py \
+            tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+
+          if git ls-files -u | grep -q .; then
+            echo "Unresolved merge entries remain:" >&2
+            git ls-files -u >&2
+            exit 1
+          fi
+
+          git commit -m "Merge litellm_internal_staging and resolve MCP request-tags conflicts"
+          git push origin HEAD:litellm_mcp_gateway_request_tags

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -184,15 +184,32 @@ def _mcp_session_id_from_headers(
     return None
 
 
-def _request_tags_from_raw_headers(
-    raw_headers: dict[str, str] | None,
-) -> list[str] | None:
-    """The caller's ``x-litellm-tags``, parsed by the same helper the LLM routes use so an
-    MCP operation and a chat completion attribute an identical header identically."""
+def _request_tags_header(
+    raw_headers: Mapping[str, str] | None,
+) -> str | None:
+    """The caller's ``x-litellm-tags`` value, read case-insensitively like the other header
+    lookups in this module. ``None`` when the caller sent no tags."""
     if not raw_headers:
         return None
-    headers = {key.lower(): value for key, value in raw_headers.items() if isinstance(key, str)}
-    return LiteLLMProxyRequestSetup.add_request_tag_to_metadata(llm_router=None, headers=headers, data={})
+    for key, value in raw_headers.items():
+        if isinstance(key, str) and key.lower() == "x-litellm-tags":
+            return value or None
+    return None
+
+
+def _request_tags_from_raw_headers(
+    raw_headers: Mapping[str, str] | None,
+) -> Sequence[str] | None:
+    """The caller's tags, parsed by the same helper the LLM routes use so an MCP operation and a
+    chat completion attribute an identical header identically."""
+    header_value = _request_tags_header(raw_headers)
+    if header_value is None:
+        return None
+    return LiteLLMProxyRequestSetup.add_request_tag_to_metadata(
+        llm_router=None,
+        headers={"x-litellm-tags": header_value},  # mutable-ok: the shared parser reads a plain dict
+        data={},  # mutable-ok: no request body to read tags from on this path
+    )
 
 
 def _jsonrpc_text_has_top_level_method(text: str) -> bool:
@@ -1045,24 +1062,23 @@ if MCP_AVAILABLE:
 
                 host_progress_callback: Final = _capture_host_progress_callback(server)
                 # Create a body date for logging
-                request_tags: Final = _request_tags_from_raw_headers(raw_headers)
-                body_data: Final = {
-                    "name": name,
-                    "arguments": arguments,
-                    **({"tags": request_tags} if request_tags else {}),
-                }
+                body_data: Final = {"name": name, "arguments": arguments}
                 # Set trace/session id from raw_headers so spend logs and logging_obj stay consistent (same as A2A)
                 chain_id: Final = get_chain_id_from_headers(raw_headers)
                 if chain_id:
                     body_data["litellm_trace_id"] = chain_id
                     body_data["litellm_session_id"] = chain_id
 
+                tags_header: Final = _request_tags_header(raw_headers)
+                tags_scope_header: Final = (
+                    ((b"x-litellm-tags", tags_header.encode("latin-1")),) if tags_header is not None else ()
+                )
                 request: Final = Request(
                     scope={
                         "type": "http",
                         "method": "POST",
                         "path": "/mcp/tools/call",
-                        "headers": [(b"content-type", b"application/json")],
+                        "headers": [(b"content-type", b"application/json"), *tags_scope_header],
                     }
                 )
                 if user_api_key_auth is not None:

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -184,6 +184,17 @@ def _mcp_session_id_from_headers(
     return None
 
 
+def _request_tags_from_raw_headers(
+    raw_headers: dict[str, str] | None,
+) -> list[str] | None:
+    """The caller's ``x-litellm-tags``, parsed by the same helper the LLM routes use so an
+    MCP operation and a chat completion attribute an identical header identically."""
+    if not raw_headers:
+        return None
+    headers = {key.lower(): value for key, value in raw_headers.items() if isinstance(key, str)}
+    return LiteLLMProxyRequestSetup.add_request_tag_to_metadata(llm_router=None, headers=headers, data={})
+
+
 def _jsonrpc_text_has_top_level_method(text: str) -> bool:
     """Whether a (possibly truncated) JSON-RPC envelope has a ``method`` key at
     the root object's top level.
@@ -1034,7 +1045,12 @@ if MCP_AVAILABLE:
 
                 host_progress_callback: Final = _capture_host_progress_callback(server)
                 # Create a body date for logging
-                body_data: Final = {"name": name, "arguments": arguments}
+                request_tags: Final = _request_tags_from_raw_headers(raw_headers)
+                body_data: Final = {
+                    "name": name,
+                    "arguments": arguments,
+                    **({"tags": request_tags} if request_tags else {}),
+                }
                 # Set trace/session id from raw_headers so spend logs and logging_obj stay consistent (same as A2A)
                 chain_id: Final = get_chain_id_from_headers(raw_headers)
                 if chain_id:
@@ -1890,6 +1906,7 @@ if MCP_AVAILABLE:
             list_tools_call_id: Final = str(uuid.uuid4())
             # Derive trace_id from raw_headers when not explicitly passed (same as A2A / MCP call_tool)
             effective_litellm_trace_id: Final = litellm_trace_id or get_chain_id_from_headers(raw_headers)
+            effective_request_tags: Final = request_tags or _request_tags_from_raw_headers(raw_headers)
             spend_logs_metadata: Final[dict[str, object]] = {
                 "mcp_operation": "list_tools",
             }
@@ -1905,7 +1922,7 @@ if MCP_AVAILABLE:
                 "litellm_trace_id": effective_litellm_trace_id,
                 "metadata": {
                     "spend_logs_metadata": spend_logs_metadata,
-                    **({"tags": request_tags} if request_tags else {}),
+                    **({"tags": effective_request_tags} if effective_request_tags else {}),
                 },
                 # Provide a small input payload for standard logging
                 "input": [

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -192,7 +192,7 @@ def _request_tags_header(
     if not raw_headers:
         return None
     for key, value in raw_headers.items():
-        if isinstance(key, str) and key.lower() == "x-litellm-tags":
+        if key.lower() == "x-litellm-tags":
             return value or None
     return None
 

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -13,7 +13,7 @@ import time
 import traceback
 import types
 import uuid
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final, cast
 
@@ -182,15 +182,32 @@ def _mcp_session_id_from_headers(
     return None
 
 
-def _request_tags_from_raw_headers(
-    raw_headers: dict[str, str] | None,
-) -> list[str] | None:
-    """The caller's ``x-litellm-tags``, parsed by the same helper the LLM routes use so an
-    MCP operation and a chat completion attribute an identical header identically."""
+def _request_tags_header(
+    raw_headers: Mapping[str, str] | None,
+) -> str | None:
+    """The caller's ``x-litellm-tags`` value, read case-insensitively like the other header
+    lookups in this module. ``None`` when the caller sent no tags."""
     if not raw_headers:
         return None
-    headers = {key.lower(): value for key, value in raw_headers.items() if isinstance(key, str)}
-    return LiteLLMProxyRequestSetup.add_request_tag_to_metadata(llm_router=None, headers=headers, data={})
+    for key, value in raw_headers.items():
+        if isinstance(key, str) and key.lower() == "x-litellm-tags":
+            return value or None
+    return None
+
+
+def _request_tags_from_raw_headers(
+    raw_headers: Mapping[str, str] | None,
+) -> Sequence[str] | None:
+    """The caller's tags, parsed by the same helper the LLM routes use so an MCP operation and a
+    chat completion attribute an identical header identically."""
+    header_value = _request_tags_header(raw_headers)
+    if header_value is None:
+        return None
+    return LiteLLMProxyRequestSetup.add_request_tag_to_metadata(
+        llm_router=None,
+        headers={"x-litellm-tags": header_value},  # mutable-ok: the shared parser reads a plain dict
+        data={},  # mutable-ok: no request body to read tags from on this path
+    )
 
 
 def _jsonrpc_text_has_top_level_method(text: str) -> bool:
@@ -1034,24 +1051,23 @@ if MCP_AVAILABLE:
 
                 host_progress_callback: Final = _capture_host_progress_callback(server)
                 # Create a body date for logging
-                request_tags: Final = _request_tags_from_raw_headers(raw_headers)
-                body_data: Final = {
-                    "name": name,
-                    "arguments": arguments,
-                    **({"tags": request_tags} if request_tags else {}),
-                }
+                body_data: Final = {"name": name, "arguments": arguments}
                 # Set trace/session id from raw_headers so spend logs and logging_obj stay consistent (same as A2A)
                 chain_id: Final = get_chain_id_from_headers(raw_headers)
                 if chain_id:
                     body_data["litellm_trace_id"] = chain_id
                     body_data["litellm_session_id"] = chain_id
 
+                tags_header: Final = _request_tags_header(raw_headers)
+                tags_scope_header: Final = (
+                    ((b"x-litellm-tags", tags_header.encode("latin-1")),) if tags_header is not None else ()
+                )
                 request: Final = Request(
                     scope={
                         "type": "http",
                         "method": "POST",
                         "path": "/mcp/tools/call",
-                        "headers": [(b"content-type", b"application/json")],
+                        "headers": [(b"content-type", b"application/json"), *tags_scope_header],
                     }
                 )
                 if user_api_key_auth is not None:

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -182,6 +182,17 @@ def _mcp_session_id_from_headers(
     return None
 
 
+def _request_tags_from_raw_headers(
+    raw_headers: dict[str, str] | None,
+) -> list[str] | None:
+    """The caller's ``x-litellm-tags``, parsed by the same helper the LLM routes use so an
+    MCP operation and a chat completion attribute an identical header identically."""
+    if not raw_headers:
+        return None
+    headers = {key.lower(): value for key, value in raw_headers.items() if isinstance(key, str)}
+    return LiteLLMProxyRequestSetup.add_request_tag_to_metadata(llm_router=None, headers=headers, data={})
+
+
 def _jsonrpc_text_has_top_level_method(text: str) -> bool:
     """Whether a (possibly truncated) JSON-RPC envelope has a ``method`` key at
     the root object's top level.
@@ -1023,7 +1034,12 @@ if MCP_AVAILABLE:
 
                 host_progress_callback: Final = _capture_host_progress_callback(server)
                 # Create a body date for logging
-                body_data: Final = {"name": name, "arguments": arguments}
+                request_tags: Final = _request_tags_from_raw_headers(raw_headers)
+                body_data: Final = {
+                    "name": name,
+                    "arguments": arguments,
+                    **({"tags": request_tags} if request_tags else {}),
+                }
                 # Set trace/session id from raw_headers so spend logs and logging_obj stay consistent (same as A2A)
                 chain_id: Final = get_chain_id_from_headers(raw_headers)
                 if chain_id:
@@ -1879,6 +1895,7 @@ if MCP_AVAILABLE:
             list_tools_call_id: Final = str(uuid.uuid4())
             # Derive trace_id from raw_headers when not explicitly passed (same as A2A / MCP call_tool)
             effective_litellm_trace_id: Final = litellm_trace_id or get_chain_id_from_headers(raw_headers)
+            effective_request_tags: Final = request_tags or _request_tags_from_raw_headers(raw_headers)
             spend_logs_metadata: Final[dict[str, Any]] = {
                 "mcp_operation": "list_tools",
             }
@@ -1894,7 +1911,7 @@ if MCP_AVAILABLE:
                 "litellm_trace_id": effective_litellm_trace_id,
                 "metadata": {
                     "spend_logs_metadata": spend_logs_metadata,
-                    **({"tags": request_tags} if request_tags else {}),
+                    **({"tags": effective_request_tags} if effective_request_tags else {}),
                 },
                 # Provide a small input payload for standard logging
                 "input": [

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -4631,6 +4631,28 @@ async def test_get_tools_from_mcp_servers_prefers_explicit_request_tags_over_the
     assert function_setup_kwargs["metadata"]["tags"] == ["explicit"]
 
 
+@pytest.mark.parametrize(
+    "raw_headers, expected",
+    [
+        (None, None),
+        ({"mcp-session-id": "abc"}, None),
+        ({"x-litellm-tags": ""}, None),
+        ({"X-LiteLLM-Tags": "application:orders, service:checkout"}, ["application:orders", "service:checkout"]),
+    ],
+)
+def test_request_tags_from_raw_headers_only_reads_the_tag_header(raw_headers, expected):
+    """Only `x-litellm-tags` carries tags, whatever its casing, and an empty value is not a tag.
+    A request whose headers are unrelated must attribute nothing rather than the first value seen."""
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _request_tags_from_raw_headers,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    assert _request_tags_from_raw_headers(raw_headers) == expected
+
+
 @pytest.mark.asyncio
 async def test_get_tools_from_mcp_servers_returns_tools_when_success_logging_fails():
     """

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -117,6 +117,48 @@ async def test_mcp_server_tool_call_body_contains_request_data():
 
 
 @pytest.mark.asyncio
+async def test_mcp_server_tool_call_carries_x_litellm_tags_header_into_request_data():
+    """The tool-call handler hands `add_litellm_data_to_request` a synthetic request that carries only
+    a content type, so the caller's `x-litellm-tags` never reached the tag merge that runs there and
+    the spend log for a tools/call had no tags. The tags travel in the body instead, which that same
+    helper already reads, so the header attributes MCP traffic exactly as it does an LLM route."""
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            mcp_server_tool_call,
+            set_auth_context,
+        )
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    set_auth_context(
+        UserAPIKeyAuth(api_key="test_key", user_id="test_user"),
+        raw_headers={"X-LiteLLM-Tags": "application:orders, service:checkout"},
+    )
+
+    captured_data = {}
+
+    async def mock_add_litellm_data_to_request(data, request, user_api_key_dict, proxy_config):
+        captured_data.update(data)
+        return data
+
+    async def mock_call_mcp_tool(*args, **kwargs):
+        return [{"type": "text", "text": "mocked response"}]
+
+    with patch(
+        "litellm.proxy.litellm_pre_call_utils.add_litellm_data_to_request",
+        mock_add_litellm_data_to_request,
+    ):
+        with patch(
+            "litellm.proxy._experimental.mcp_server.server.call_mcp_tool",
+            mock_call_mcp_tool,
+        ):
+            with patch("litellm.proxy.proxy_server.proxy_config", MagicMock()):
+                await mcp_server_tool_call("test_tool", {"param1": "value1"})
+
+    assert captured_data["tags"] == ["application:orders", "service:checkout"]
+
+
+@pytest.mark.asyncio
 async def test_mcp_server_tool_call_relays_upstream_auth_error_as_iserror():
     """The MCP session manager serializes handler exceptions as JSON-RPC errors, so a mid-session
     tool call cannot emit a raw 401 the way the REST path does. mcp_server_tool_call must turn an
@@ -4434,6 +4476,156 @@ async def test_get_tools_from_mcp_servers_logs_list_tools_to_spendlogs_when_enab
     assert spend_meta["allowed_server_count"] == 1
     assert spend_meta["per_server_tool_counts"]["server_a"] == 1
     assert spend_meta["per_server_list_outcomes"] == {"server_a": {"status": "ok", "tool_count": 1}}
+
+
+@pytest.mark.asyncio
+async def test_get_tools_from_mcp_servers_takes_list_tools_tags_from_x_litellm_tags_header():
+    """A gateway that stamps `x-litellm-tags` on proxied traffic gets per-application attribution on
+    LLM routes; list_tools must read the same header so MCP usage is not stuck under the shared key.
+    Nothing populated `request_tags`, so the header was the only source and it was being dropped."""
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _get_tools_from_mcp_servers,
+        )
+        from litellm.proxy._types import UserAPIKeyAuth
+        from mcp.types import Tool as MCPTool
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    user_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+
+    server_a = MagicMock(name="server_a_obj")
+    server_a.name = "server_a"
+    server_a.alias = "server_a"
+    server_a.server_name = "server_a"
+    server_a.server_id = "a"
+    server_a.auth_type = None
+    server_a.extra_headers = None
+
+    tool_1 = MCPTool(name="server_a-tool_1", description="test tool", inputSchema={"type": "object"})
+
+    dummy_logging_obj = MagicMock()
+    dummy_logging_obj.model_call_details = {"metadata": {"spend_logs_metadata": {}}}
+    dummy_logging_obj.async_success_handler = AsyncMock()
+    function_setup_kwargs = {}
+
+    def _capture_function_setup(*_args, **kwargs):
+        function_setup_kwargs.update(kwargs)
+        return dummy_logging_obj, None
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._get_allowed_mcp_servers",
+            new=AsyncMock(return_value=[server_a]),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._prepare_mcp_server_headers",
+            return_value=(None, None),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager",
+        ) as mock_manager,
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.filter_tools_by_allowed_tools",
+            side_effect=lambda tools, _server: tools,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.filter_tools_by_key_team_permissions",
+            new=AsyncMock(side_effect=lambda tools, **_: tools),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.function_setup",
+            side_effect=_capture_function_setup,
+        ),
+    ):
+        mock_manager._get_tools_from_server = AsyncMock(return_value=[tool_1])
+
+        listing = await _get_tools_from_mcp_servers(
+            user_api_key_auth=user_auth,
+            mcp_auth_header=None,
+            mcp_servers=["server_a"],
+            mcp_server_auth_headers=None,
+            raw_headers={"X-LiteLLM-Tags": "application:orders, service:checkout"},
+            log_list_tools_to_spendlogs=True,
+            list_tools_log_source="mcp_protocol",
+        )
+
+    assert listing.tools == [tool_1]
+    assert function_setup_kwargs["metadata"]["tags"] == ["application:orders", "service:checkout"]
+
+
+@pytest.mark.asyncio
+async def test_get_tools_from_mcp_servers_prefers_explicit_request_tags_over_the_header():
+    """`request_tags` is the resolved value a caller passes in; a header must not override it."""
+    try:
+        from litellm.proxy._experimental.mcp_server.server import (
+            _get_tools_from_mcp_servers,
+        )
+        from litellm.proxy._types import UserAPIKeyAuth
+        from mcp.types import Tool as MCPTool
+    except ImportError:
+        pytest.skip("MCP server not available")
+
+    user_auth = UserAPIKeyAuth(api_key="test-key", user_id="test-user")
+
+    server_a = MagicMock(name="server_a_obj")
+    server_a.name = "server_a"
+    server_a.alias = "server_a"
+    server_a.server_name = "server_a"
+    server_a.server_id = "a"
+    server_a.auth_type = None
+    server_a.extra_headers = None
+
+    tool_1 = MCPTool(name="server_a-tool_1", description="test tool", inputSchema={"type": "object"})
+
+    dummy_logging_obj = MagicMock()
+    dummy_logging_obj.model_call_details = {"metadata": {"spend_logs_metadata": {}}}
+    dummy_logging_obj.async_success_handler = AsyncMock()
+    function_setup_kwargs = {}
+
+    def _capture_function_setup(*_args, **kwargs):
+        function_setup_kwargs.update(kwargs)
+        return dummy_logging_obj, None
+
+    with (
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._get_allowed_mcp_servers",
+            new=AsyncMock(return_value=[server_a]),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server._prepare_mcp_server_headers",
+            return_value=(None, None),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.global_mcp_server_manager",
+        ) as mock_manager,
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.filter_tools_by_allowed_tools",
+            side_effect=lambda tools, _server: tools,
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.filter_tools_by_key_team_permissions",
+            new=AsyncMock(side_effect=lambda tools, **_: tools),
+        ),
+        patch(
+            "litellm.proxy._experimental.mcp_server.server.function_setup",
+            side_effect=_capture_function_setup,
+        ),
+    ):
+        mock_manager._get_tools_from_server = AsyncMock(return_value=[tool_1])
+
+        await _get_tools_from_mcp_servers(
+            user_api_key_auth=user_auth,
+            mcp_auth_header=None,
+            mcp_servers=["server_a"],
+            mcp_server_auth_headers=None,
+            raw_headers={"x-litellm-tags": "from-header"},
+            log_list_tools_to_spendlogs=True,
+            list_tools_log_source="mcp_protocol",
+            request_tags=["explicit"],
+        )
+
+    assert function_setup_kwargs["metadata"]["tags"] == ["explicit"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
+++ b/tests/test_litellm/proxy/_experimental/mcp_server/test_mcp_server.py
@@ -118,15 +118,16 @@ async def test_mcp_server_tool_call_body_contains_request_data():
 
 @pytest.mark.asyncio
 async def test_mcp_server_tool_call_carries_x_litellm_tags_header_into_request_data():
-    """The tool-call handler hands `add_litellm_data_to_request` a synthetic request that carries only
-    a content type, so the caller's `x-litellm-tags` never reached the tag merge that runs there and
-    the spend log for a tools/call had no tags. The tags travel in the body instead, which that same
-    helper already reads, so the header attributes MCP traffic exactly as it does an LLM route."""
+    """The tool-call handler hands `add_litellm_data_to_request` a synthetic request that carried
+    only a content type, so the caller's `x-litellm-tags` never reached the tag merge running there
+    and a tools/call spend log had no tags. The synthetic request now carries the header, so the
+    shared parser resolves it exactly as it does on an LLM route."""
     try:
         from litellm.proxy._experimental.mcp_server.server import (
             mcp_server_tool_call,
             set_auth_context,
         )
+        from litellm.proxy.litellm_pre_call_utils import LiteLLMProxyRequestSetup
     except ImportError:
         pytest.skip("MCP server not available")
 
@@ -135,10 +136,12 @@ async def test_mcp_server_tool_call_carries_x_litellm_tags_header_into_request_d
         raw_headers={"X-LiteLLM-Tags": "application:orders, service:checkout"},
     )
 
-    captured_data = {}
+    resolved_tags = {}
 
     async def mock_add_litellm_data_to_request(data, request, user_api_key_dict, proxy_config):
-        captured_data.update(data)
+        resolved_tags["tags"] = LiteLLMProxyRequestSetup.add_request_tag_to_metadata(
+            llm_router=None, headers=dict(request.headers), data={}
+        )
         return data
 
     async def mock_call_mcp_tool(*args, **kwargs):
@@ -155,7 +158,7 @@ async def test_mcp_server_tool_call_carries_x_litellm_tags_header_into_request_d
             with patch("litellm.proxy.proxy_server.proxy_config", MagicMock()):
                 await mcp_server_tool_call("test_tool", {"param1": "value1"})
 
-    assert captured_data["tags"] == ["application:orders", "service:checkout"]
+    assert resolved_tags["tags"] == ["application:orders", "service:checkout"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- `x-litellm-tags` is silently ignored on MCP gateway routes
- MCP spend logs carry no tags, so usage cannot be attributed
- The same header already works on every LLM route

How it solves it:

- The synthetic tool-call request now carries that header
- `add_litellm_data_to_request` then merges tags as usual
- tools/list reads the header when no tags were passed in

## Relevant issues

Fixes #35765

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Run against a live proxy on `localhost:4000` backed by Postgres, with one MCP server registered. No LLM provider is involved because `tools/list` and `tools/call` never reach one; the rows this changes are the `MCP: list_tools` and `MCP: <tool>` spend logs

```yaml
mcp_servers:
  proofserver:
    url: "http://127.0.0.1:9099/mcp"
    transport: "http"

general_settings:
  master_key: sk-1234
```

```
$ uvicorn litellm.proxy.proxy_server:app --host 127.0.0.1 --port 4000
```

Open the session, then list and call a tool, sending the gateway header on each request:

```
$ curl -sS -D headers.txt -X POST http://127.0.0.1:4000/mcp/ \
    -H "x-litellm-api-key: Bearer sk-1234" \
    -H "x-litellm-tags: application:orders, service:checkout" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"proof","version":"1"}}}'

$ curl -sS -X POST http://127.0.0.1:4000/mcp/ \
    -H "x-litellm-api-key: Bearer sk-1234" \
    -H "x-litellm-tags: application:orders, service:checkout" \
    -H "mcp-session-id: 4f8f887a64f648169b31b037be6d05fc" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
event: message
data: {"jsonrpc":"2.0","id":2,"result":{"_meta":{"litellm.ai/server_outcomes":{"proofserver":{"status":"ok","tool_count":1}}},"tools":[{"name":"proofserver-echo",...}]}}

$ curl -sS -X POST http://127.0.0.1:4000/mcp/ \
    -H "x-litellm-api-key: Bearer sk-1234" \
    -H "x-litellm-tags: application:orders, service:checkout" \
    -H "mcp-session-id: 4f8f887a64f648169b31b037be6d05fc" \
    -H "Accept: application/json, text/event-stream" \
    -H "Content-Type: application/json" \
    -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"proofserver-echo","arguments":{"text":"hello"}}}'
event: message
data: {"jsonrpc":"2.0","id":3,"result":{"content":[{"type":"text","text":"echo: hello"}],"structuredContent":{"result":"echo: hello"},"isError":false}}
```

### BEFORE, at 956d5177d1

```
$ psql -c 'SELECT model, request_tags FROM "LiteLLM_SpendLogs" ORDER BY "startTime";'
         model         | request_tags
-----------------------+--------------
 MCP: list_tools       | []
 MCP: proofserver-echo | []
(2 rows)
```

### AFTER, at 4037c385b9

```
$ psql -c 'SELECT model, request_tags FROM "LiteLLM_SpendLogs" ORDER BY "startTime";'
         model         |                request_tags
-----------------------+--------------------------------------------
 MCP: list_tools       | ["application:orders", "service:checkout"]
 MCP: proofserver-echo | ["application:orders", "service:checkout"]
(2 rows)
```

The same rows through the API, so the value is what a consumer reads and not only what the table holds:

```
$ curl -sS http://127.0.0.1:4000/spend/logs -H "Authorization: Bearer sk-1234"
[{"call_type":"call_mcp_tool","model":"MCP: proofserver-echo", ...,"request_tags":["application:orders","service:checkout"], ...},
 {"call_type":"list_mcp_tools","model":"MCP: list_tools", ...,"request_tags":["application:orders","service:checkout"], ...}]
```

Same commands, same header, same MCP server on both runs; only the checked-out code differs

## Type

🐛 Bug Fix

## Changes

The tool-call handler already calls `add_litellm_data_to_request`, which is what turns `x-litellm-tags` into `metadata.tags`. It just hands it a request built from a scope whose only header is a content type, so by the time the tag merge runs there is nothing left to read. Putting the caller's tag header back on that synthetic request is the whole fix for tools/call: the parse, the merge and the precedence against body tags all stay in the one place they already live, so a header stamped by a gateway resolves identically for MCP and for chat completions. Nothing else about the request is reconstructed, and no other header is newly forwarded anywhere

`_get_tools_from_mcp_servers` already had a `request_tags` parameter feeding `metadata.tags` on the list_tools spend log, but no caller ever populated it. It now falls back to the same header read, next to the existing `litellm_trace_id or get_chain_id_from_headers(raw_headers)` line that resolves the trace id the same way. An explicitly passed `request_tags` still wins

`_request_tags_header` reads the header case-insensitively, matching `_mcp_session_id_from_headers` right above it. A request without the header behaves exactly as before

The `osv-scan` failure on this PR is the repository-wide `cryptography` 48.0.1 advisory in `uv.lock`, which this diff does not touch; #35759 is the fix for it

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
