### PR TITLE
docs: fix duplicate word in test_litellm README (the the → the)

### DIFF
--- a/tests/test_litellm/readme.md
+++ b/tests/test_litellm/readme.md
@@ -1,6 +1,6 @@
 # Testing for `litellm/` 
 
-This directory 1:1 maps the the `litellm/` directory, and can only contain mocked tests. 
+This directory 1:1 maps the `litellm/` directory, and can only contain mocked tests. 
 
 The point of this is to:
 1. Increase test coverage of `litellm/`


### PR DESCRIPTION
## TLDR

Problem this solves:

- Duplicate word "the the" in `tests/test_litellm/readme.md` line 3

How it solves it:

- Remove the extra "the": `maps the the \`litellm/\`` → `maps the \`litellm/\``

## Relevant issues

N/A — minor documentation typo

## Linear ticket

N/A

## Pre-Submission checklist

- [ ] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem

## Screenshots / Proof of Fix

No code change — docs-only fix.

## Type

- [x] Documentation update