### PR TITLE
fix(ollama_chat): set finish_reason to tool_calls when tool calls arrive before the final chunk

### DIFF
--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -423,6 +423,7 @@ class OllamaChatConfig(BaseConfig):
 class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
     started_reasoning_content: bool = False
     finished_reasoning_content: bool = False
+    emitted_tool_calls: bool = False
 
     def _is_function_call_complete(self, function_args: str | dict) -> bool:
         if isinstance(function_args, dict):
@@ -468,6 +469,7 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
             # process tool calls - if complete function arg - add id to tool call
             tool_calls: Final = chunk["message"].get("tool_calls")
             if tool_calls is not None:
+                self.emitted_tool_calls = True
                 for tool_call in tool_calls:
                     function_args = tool_call.get("function").get("arguments")
                     if function_args is not None and len(function_args) > 0:
@@ -508,9 +510,10 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
 
             if chunk["done"] is True:
                 finish_reason = chunk.get("done_reason") or "stop"
-                # Override finish_reason when tool_calls are present
+                # Override finish_reason when tool_calls were emitted in any chunk of the stream
                 # Fixes: https://github.com/BerriAI/litellm/issues/18922
-                if tool_calls is not None:
+                #        https://github.com/BerriAI/litellm/issues/35663
+                if self.emitted_tool_calls:
                     finish_reason = "tool_calls"
                 choices = [
                     StreamingChoices(

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -510,10 +510,12 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
 
             if chunk["done"] is True:
                 finish_reason = chunk.get("done_reason") or "stop"
-                # Override finish_reason when tool_calls were emitted in any chunk of the stream
+                # Override finish_reason when tool_calls were emitted in any chunk of the
+                # stream. Only upgrade a "stop" ending - other terminal reasons such as
+                # "length" mean the tool call may be truncated, so don't report it as complete.
                 # Fixes: https://github.com/BerriAI/litellm/issues/18922
                 #        https://github.com/BerriAI/litellm/issues/35663
-                if self.emitted_tool_calls:
+                if self.emitted_tool_calls and finish_reason == "stop":
                     finish_reason = "tool_calls"
                 choices = [
                     StreamingChoices(

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -425,6 +425,7 @@ class OllamaChatConfig(BaseConfig):
 class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
     started_reasoning_content: bool = False
     finished_reasoning_content: bool = False
+    emitted_tool_calls: bool = False
 
     def _is_function_call_complete(self, function_args: str | dict) -> bool:
         if isinstance(function_args, dict):
@@ -470,6 +471,7 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
             # process tool calls - if complete function arg - add id to tool call
             tool_calls = chunk["message"].get("tool_calls")
             if tool_calls is not None:
+                self.emitted_tool_calls = True
                 for tool_call in tool_calls:
                     function_args = tool_call.get("function").get("arguments")
                     if function_args is not None and len(function_args) > 0:
@@ -510,9 +512,10 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
 
             if chunk["done"] is True:
                 finish_reason = chunk.get("done_reason") or "stop"
-                # Override finish_reason when tool_calls are present
+                # Override finish_reason when tool_calls were emitted in any chunk of the stream
                 # Fixes: https://github.com/BerriAI/litellm/issues/18922
-                if tool_calls is not None:
+                #        https://github.com/BerriAI/litellm/issues/35663
+                if self.emitted_tool_calls:
                     finish_reason = "tool_calls"
                 choices = [
                     StreamingChoices(

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -512,10 +512,12 @@ class OllamaChatCompletionResponseIterator(BaseModelResponseIterator):
 
             if chunk["done"] is True:
                 finish_reason = chunk.get("done_reason") or "stop"
-                # Override finish_reason when tool_calls were emitted in any chunk of the stream
+                # Override finish_reason when tool_calls were emitted in any chunk of the
+                # stream. Only upgrade a "stop" ending - other terminal reasons such as
+                # "length" mean the tool call may be truncated, so don't report it as complete.
                 # Fixes: https://github.com/BerriAI/litellm/issues/18922
                 #        https://github.com/BerriAI/litellm/issues/35663
-                if self.emitted_tool_calls:
+                if self.emitted_tool_calls and finish_reason == "stop":
                     finish_reason = "tool_calls"
                 choices = [
                     StreamingChoices(

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -527,6 +527,53 @@ class TestOllamaToolCalling:
             result.choices[0].finish_reason == "tool_calls"
         ), f"Expected 'tool_calls' when tool calls were streamed in an earlier chunk, got '{result.choices[0].finish_reason}'"
 
+    def test_finish_reason_length_survives_earlier_tool_call_chunk(self):
+        """Streaming: a truncated stream keeps finish_reason='length' after a tool call.
+
+        Ollama emits tool_calls in an earlier chunk and can then terminate with
+        done_reason='length' once num_predict is reached. The tool call arguments may be
+        cut off, so the terminal reason must survive rather than be upgraded to
+        'tool_calls'. Mirrors the guard in litellm's own streaming finalizer, which only
+        upgrades a 'stop' ending.
+        """
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        tool_call_chunk = {
+            "model": "qwen3:14b",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"location": "San Francisco"},
+                        }
+                    }
+                ],
+            },
+            "done": False,
+        }
+
+        done_chunk = {
+            "model": "qwen3:14b",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": "length",
+            "prompt_eval_count": 100,
+            "eval_count": 51,
+        }
+
+        iterator.chunk_parser(tool_call_chunk)
+        result = iterator.chunk_parser(done_chunk)
+
+        assert (
+            result.choices[0].finish_reason == "length"
+        ), f"Expected 'length' to survive truncation after a tool call chunk, got '{result.choices[0].finish_reason}'"
+
 
 class TestOllamaFinishReasonLength:
     """Tests for done_reason 'length' → finish_reason 'length' mapping.

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -478,6 +478,55 @@ class TestOllamaToolCalling:
         assert result.choices[0].finish_reason == "stop"
         assert result.choices[0].message.tool_calls is None
 
+    def test_finish_reason_tool_calls_streaming_tool_calls_in_earlier_chunk(self):
+        """Streaming: tool_calls streamed before the final done chunk must produce finish_reason='tool_calls'.
+
+        Ollama emits tool_calls in a chunk with done=False, then a separate final
+        chunk with done=True, an empty message, and done_reason='stop'. The final
+        chunk must still report finish_reason='tool_calls' per the OpenAI spec.
+        Regression test for https://github.com/BerriAI/litellm/issues/35663
+        """
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        tool_call_chunk = {
+            "model": "qwen3:14b",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"location": "San Francisco"},
+                        }
+                    }
+                ],
+            },
+            "done": False,
+        }
+
+        done_chunk = {
+            "model": "qwen3:14b",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 100,
+            "eval_count": 50,
+        }
+
+        tool_call_result = iterator.chunk_parser(tool_call_chunk)
+        assert tool_call_result.choices[0].delta.tool_calls is not None
+        assert tool_call_result.choices[0].finish_reason is None
+
+        result = iterator.chunk_parser(done_chunk)
+
+        assert (
+            result.choices[0].finish_reason == "tool_calls"
+        ), f"Expected 'tool_calls' when tool calls were streamed in an earlier chunk, got '{result.choices[0].finish_reason}'"
+
 
 class TestOllamaFinishReasonLength:
     """Tests for done_reason 'length' → finish_reason 'length' mapping.

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -529,6 +529,53 @@ class TestOllamaToolCalling:
             result.choices[0].finish_reason == "tool_calls"
         ), f"Expected 'tool_calls' when tool calls were streamed in an earlier chunk, got '{result.choices[0].finish_reason}'"
 
+    def test_finish_reason_length_survives_earlier_tool_call_chunk(self):
+        """Streaming: a truncated stream keeps finish_reason='length' after a tool call.
+
+        Ollama emits tool_calls in an earlier chunk and can then terminate with
+        done_reason='length' once num_predict is reached. The tool call arguments may be
+        cut off, so the terminal reason must survive rather than be upgraded to
+        'tool_calls'. Mirrors the guard in litellm's own streaming finalizer, which only
+        upgrades a 'stop' ending.
+        """
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        tool_call_chunk = {
+            "model": "qwen3:14b",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"location": "San Francisco"},
+                        }
+                    }
+                ],
+            },
+            "done": False,
+        }
+
+        done_chunk = {
+            "model": "qwen3:14b",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": "length",
+            "prompt_eval_count": 100,
+            "eval_count": 51,
+        }
+
+        iterator.chunk_parser(tool_call_chunk)
+        result = iterator.chunk_parser(done_chunk)
+
+        assert (
+            result.choices[0].finish_reason == "length"
+        ), f"Expected 'length' to survive truncation after a tool call chunk, got '{result.choices[0].finish_reason}'"
+
 
 class TestOllamaFinishReasonLength:
     """Tests for done_reason 'length' → finish_reason 'length' mapping.

--- a/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
+++ b/tests/test_litellm/llms/ollama/test_ollama_chat_transformation.py
@@ -480,6 +480,55 @@ class TestOllamaToolCalling:
         assert result.choices[0].finish_reason == "stop"
         assert result.choices[0].message.tool_calls is None
 
+    def test_finish_reason_tool_calls_streaming_tool_calls_in_earlier_chunk(self):
+        """Streaming: tool_calls streamed before the final done chunk must produce finish_reason='tool_calls'.
+
+        Ollama emits tool_calls in a chunk with done=False, then a separate final
+        chunk with done=True, an empty message, and done_reason='stop'. The final
+        chunk must still report finish_reason='tool_calls' per the OpenAI spec.
+        Regression test for https://github.com/BerriAI/litellm/issues/35663
+        """
+        iterator = OllamaChatCompletionResponseIterator(
+            streaming_response=iter([]),
+            sync_stream=True,
+        )
+
+        tool_call_chunk = {
+            "model": "qwen3:14b",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"location": "San Francisco"},
+                        }
+                    }
+                ],
+            },
+            "done": False,
+        }
+
+        done_chunk = {
+            "model": "qwen3:14b",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 100,
+            "eval_count": 50,
+        }
+
+        tool_call_result = iterator.chunk_parser(tool_call_chunk)
+        assert tool_call_result.choices[0].delta.tool_calls is not None
+        assert tool_call_result.choices[0].finish_reason is None
+
+        result = iterator.chunk_parser(done_chunk)
+
+        assert (
+            result.choices[0].finish_reason == "tool_calls"
+        ), f"Expected 'tool_calls' when tool calls were streamed in an earlier chunk, got '{result.choices[0].finish_reason}'"
+
 
 class TestOllamaFinishReasonLength:
     """Tests for done_reason 'length' → finish_reason 'length' mapping.


### PR DESCRIPTION
## TLDR

Problem this solves:

- ollama_chat streamed tool calls ended with finish_reason "stop"
- spec strict OpenAI clients never executed the streamed tool call

How it solves it:

- iterator remembers tool_calls seen in any earlier chunk
- final done chunk then reports finish_reason "tool_calls"

## Relevant issues

Fixes #35663

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Environment for both runs: local proxy started with `python -m litellm.proxy.proxy_cli --model ollama_chat/llama3.2 --host 127.0.0.1 --port 4000`, ollama 0.15.6 serving llama3.2 locally, real streaming LLM calls, no mocks

```bash
curl -sN http://127.0.0.1:4000/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model": "ollama_chat/llama3.2", "stream": true, "temperature": 0,
  "messages": [{"role": "user", "content": "What is the weather in San Francisco right now? Use the get_weather tool."}],
  "tools": [{"type": "function", "function": {"name": "get_weather", "description": "Get current weather for a location", "parameters": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}}}]}'
```

Before, at cb8c734 (litellm_internal_staging without this fix): the stream carries the tool call delta but the final chunk reports finish_reason "stop" (SSE trimmed to the two relevant chunks)

```
data: {"id":"fdd457f5-68f4-421f-aca9-d09ac47c36c8","created":1785814307,"model":"ollama_chat/llama3.2","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"id":"64712615-3171-4639-ad60-515c161a8480","function":{"arguments":"{\"location\": \"San Francisco\"}","name":"get_weather"},"type":"function","index":0}]}}]}
data: {"id":"ca3be654-bdea-463e-ab0c-6fa74abf5917","object":"chat.completion.chunk","created":1785814307,"model":"ollama_chat/llama3.2","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
```

After, at d216383 (this PR): same request, the tool call delta is unchanged and the final chunk now reports finish_reason "tool_calls"

```
data: {"id":"6e73d45b-ba59-4a62-a7c3-aaf072f2850b","created":1785814351,"model":"ollama_chat/llama3.2","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"id":"b0a71062-7b37-4fd6-9670-f080976bdb77","function":{"arguments":"{\"location\": \"San Francisco\"}","name":"get_weather"},"type":"function","index":0}]}}]}
data: {"id":"b4f96644-1e33-4b15-9318-c1fe82e01e7c","object":"chat.completion.chunk","created":1785814351,"model":"ollama_chat/llama3.2","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}
```

Same fix observed through /v1/messages, where the finish reason surfaces as stop_reason. Request:

```bash
curl -sN http://127.0.0.1:4000/v1/messages -H 'Content-Type: application/json' -H 'anthropic-version: 2023-06-01' -d '{
  "model": "ollama_chat/llama3.2", "max_tokens": 256, "stream": true, "temperature": 0,
  "messages": [{"role": "user", "content": "What is the weather in San Francisco right now? Use the get_weather tool."}],
  "tools": [{"name": "get_weather", "description": "Get current weather for a location", "input_schema": {"type": "object", "properties": {"location": {"type": "string"}}, "required": ["location"]}}]}'
```

Before, at cb8c734, the tool_use block streams but the message ends as end_turn

```
data: {"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"input_tokens": 158, "output_tokens": 18}}
```

After, at d216383, the same request ends with stop_reason "tool_use"

```
data: {"type": "message_delta", "delta": {"stop_reason": "tool_use"}, "usage": {"input_tokens": 158, "output_tokens": 18}}
```

/v1/responses was also checked with the equivalent streamed request at both commits; the full event sequences are identical before and after, because the Responses emulation derives its function_call output items from the tool call deltas rather than from finish_reason, so that endpoint's output is unchanged by this PR

## Type

🐛 Bug Fix

## Changes

`OllamaChatCompletionResponseIterator.chunk_parser` only overrode finish_reason to "tool_calls" when the tool calls appeared on the same chunk as `done: true`. Ollama emits tool calls in a chunk with `done: false`, then a separate final chunk with an empty message and `done_reason: "stop"`, so streamed tool calls ended with finish_reason "stop" and clients that gate tool execution on the finish reason discarded them. The non-streaming path already sets finish_reason correctly for this case

The iterator now sets an `emitted_tool_calls` flag when any chunk carries tool calls, and the done branch checks that flag instead of only the current chunk. The flag is per-stream state on the iterator instance, following the existing `started_reasoning_content` pattern in the same class. Behavior for tool calls arriving on the done chunk itself is unchanged since the flag is set earlier in that same call, and `done_reason: "length"` handling is untouched when no tool calls were streamed

Added a regression test that feeds the iterator a tool call chunk followed by a bare done chunk and asserts the final chunk reports finish_reason "tool_calls"; it fails at cb8c734 and passes with this change. Related but distinct: #35711 tracks tool call streaming for the `ollama/` generate endpoint, which this PR does not touch

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
