### PR TITLE
fix(pricing): map Azure GPT-5.6 Luna snapshot

### DIFF
--- a/ci_cd/generate_model_prices_schema.py
+++ b/ci_cd/generate_model_prices_schema.py
@@ -52,6 +52,12 @@ OBJECT_KEYS: dict[str, JsonSchema] = {
 }
 
 ARRAY_KEYS: dict[str, JsonSchema] = {
+    "aliases": {
+        "type": "array",
+        "description": "Alternate model ids that share this entry's pricing and capabilities.",
+        "items": STRING,
+        "uniqueItems": True,
+    },
     "supported_endpoints": {
         "type": "array",
         "description": "OpenAI-style API routes this model can be called through, e.g. /v1/chat/completions.",

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -6476,6 +6476,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-luna": {
+        "aliases": [
+            "azure/gpt-5.6-luna-2026-07-09"
+        ],
         "cache_read_input_token_cost": 2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4e-08,
         "cache_read_input_token_cost_priority": 4e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -6476,6 +6476,9 @@
         "supports_minimal_reasoning_effort": false
     },
     "azure/gpt-5.6-luna": {
+        "aliases": [
+            "azure/gpt-5.6-luna-2026-07-09"
+        ],
         "cache_read_input_token_cost": 2e-08,
         "cache_read_input_token_cost_above_272k_tokens": 4e-08,
         "cache_read_input_token_cost_priority": 4e-08,

--- a/model_prices_and_context_window.schema.json
+++ b/model_prices_and_context_window.schema.json
@@ -49,6 +49,14 @@
         "litellm_provider"
       ],
       "properties": {
+        "aliases": {
+          "type": "array",
+          "description": "Alternate model ids that share this entry's pricing and capabilities.",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
         "annotation_cost_per_page": {
           "type": "number",
           "minimum": 0

--- a/tests/test_litellm/llms/azure/test_azure_gpt56_cost_calculation.py
+++ b/tests/test_litellm/llms/azure/test_azure_gpt56_cost_calculation.py
@@ -1,0 +1,26 @@
+import pytest
+
+import litellm
+from litellm.types.utils import Choices, Message, ModelResponse, Usage
+
+
+def test_completion_cost_supports_luna_dated_snapshot(monkeypatch):
+    """Azure response model snapshots should resolve to canonical pricing."""
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+
+    response = ModelResponse(
+        model="gpt-5.6-luna-2026-07-09",
+        choices=[
+            Choices(
+                index=0,
+                message=Message(role="assistant", content="hi"),
+                finish_reason="stop",
+            )
+        ],
+        usage=Usage(prompt_tokens=100, completion_tokens=50, total_tokens=150),
+    )
+    response._hidden_params = {"custom_llm_provider": "azure"}
+
+    assert "azure/gpt-5.6-luna-2026-07-09" in litellm.model_cost
+    assert litellm.completion_cost(completion_response=response) == pytest.approx(0.0004)

--- a/tests/test_litellm/llms/azure/test_azure_gpt56_cost_calculation.py
+++ b/tests/test_litellm/llms/azure/test_azure_gpt56_cost_calculation.py
@@ -7,7 +7,7 @@ from litellm.types.utils import Choices, Message, ModelResponse, Usage
 def test_completion_cost_supports_luna_dated_snapshot(monkeypatch):
     """Azure response model snapshots should resolve to canonical pricing."""
     monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
-    litellm.model_cost = litellm.get_model_cost_map(url="")
+    monkeypatch.setattr(litellm, "model_cost", litellm.get_model_cost_map(url=""))
 
     response = ModelResponse(
         model="gpt-5.6-luna-2026-07-09",
@@ -22,5 +22,14 @@ def test_completion_cost_supports_luna_dated_snapshot(monkeypatch):
     )
     response._hidden_params = {"custom_llm_provider": "azure"}
 
-    assert "azure/gpt-5.6-luna-2026-07-09" in litellm.model_cost
-    assert litellm.completion_cost(completion_response=response) == pytest.approx(0.0004)
+    snapshot = "azure/gpt-5.6-luna-2026-07-09"
+    canonical_cost = litellm.model_cost["azure/gpt-5.6-luna"]
+    expected_cost = (
+        100 * canonical_cost["input_cost_per_token"]
+        + 50 * canonical_cost["output_cost_per_token"]
+    )
+
+    assert litellm.model_cost[snapshot] == canonical_cost
+    assert litellm.completion_cost(completion_response=response) == pytest.approx(
+        expected_cost
+    )

--- a/tests/test_litellm/test_model_prices_schema.py
+++ b/tests/test_litellm/test_model_prices_schema.py
@@ -70,6 +70,7 @@ def test_prices_file_validates_against_committed_schema(prices: dict, committed_
         {"litellm_provider": "openai", "supports_vision": "yes"},
         {"litellm_provider": "openai", "max_tokens": 8191.5},
         {"litellm_provider": "openai", "tiered_pricing": [{"unknown_tier_field": 1}]},
+        {"litellm_provider": "openai", "aliases": ["duplicate", "duplicate"]},
     ],
     ids=[
         "cost_as_string",
@@ -86,6 +87,7 @@ def test_prices_file_validates_against_committed_schema(prices: dict, committed_
         "boolean_flag_as_string",
         "fractional_max_tokens",
         "unknown_tiered_pricing_field",
+        "duplicate_alias",
     ],
 )
 def test_schema_rejects_malformed_entries(committed_schema: dict, entry: dict):

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -934,6 +934,11 @@ def test_aaamodel_prices_and_context_window_json_is_valid():
                 "bedrock_converse_supports_strict_tools": {"type": "boolean"},
                 "tpm": {"type": "number"},
                 "provider_specific_entry": {"type": "object"},
+                "aliases": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "uniqueItems": True,
+                },
                 "supported_endpoints": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure returns an unmapped dated GPT-5.6 Luna model
- Successful completions fail during automatic cost calculation

How it solves it:

- Maps the dated snapshot to canonical Luna pricing
- Covers online and bundled offline cost maps
- Declares the existing model alias field in both schema validators
- Adds cost and schema regression coverage

## Relevant issues

Fixes #35762

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

No credentials or mocks are required; this exercises the public `completion_cost()` path from the issue reproduction.

Before (`956d5177d`):

```text
commit=956d5177d
dated_key_present=False
error=Exception: This model isn't mapped yet. model=gpt-5.6-luna-2026-07-09, custom_llm_provider=azure.
```

After (rebased head `5c322d1cde`):

```text
commit=5c322d1cde
dated_key_present=True
cost=0.00008000
```

## Type

Bug Fix
Test

## Changes

- Added `azure/gpt-5.6-luna-2026-07-09` as a canonical pricing alias
- Kept the remote and packaged fallback cost maps in sync
- Declared `aliases` as a unique string array in the generated and compatibility schemas
- Added regressions that derive the expected snapshot cost from canonical pricing and reject duplicate aliases

## Verification

Rebased onto `bbc6e3feea` and verified at head `5c322d1cde`:

```text
20 passed in 5.49s
```

Focused Ruff checks passed for the Azure and schema tests. The 20 focused tests cover the completion-cost regression, committed schema generation and validation, malformed schema cases, and the compatibility price-map validator.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

AI assistance was used for implementation and test drafting; the diff and verification results were reviewed before submission