### PR TITLE
fix(db): cover spend window reseed queries

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260804233000_add_spend_log_api_key_window_covering_index/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260804233000_add_spend_log_api_key_window_covering_index/migration.sql
@@ -1,0 +1,6 @@
+-- Keep budget-window reseeds off the wide spend-log heap, including for keys
+-- that own most rows. CONCURRENTLY avoids blocking inserts on production tables.
+-- This migration must remain a single statement because CREATE INDEX
+-- CONCURRENTLY cannot run inside a transaction.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "LiteLLM_SpendLogs_api_key_startTime_idx"
+ON "LiteLLM_SpendLogs" ("api_key", "startTime") INCLUDE ("spend");

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260804233100_add_spend_log_team_window_covering_index/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260804233100_add_spend_log_team_window_covering_index/migration.sql
@@ -1,0 +1,5 @@
+-- Match the team budget-window aggregate with the same index-only access path.
+-- This migration is separate from the api-key index because each concurrent
+-- index build must be applied outside a transaction as a single statement.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "LiteLLM_SpendLogs_team_id_startTime_idx"
+ON "LiteLLM_SpendLogs" ("team_id", "startTime") INCLUDE ("spend");

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -639,6 +639,8 @@ model LiteLLM_SpendLogs {
   proxy_server_request Json?     @default("{}")
   @@index([startTime])
   @@index([startTime, request_id])
+  @@index([api_key, startTime])
+  @@index([team_id, startTime])
   @@index([end_user])
   @@index([session_id])
 }

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -639,6 +639,8 @@ model LiteLLM_SpendLogs {
   proxy_server_request Json?     @default("{}")
   @@index([startTime])
   @@index([startTime, request_id])
+  @@index([api_key, startTime])
+  @@index([team_id, startTime])
   @@index([end_user])
   @@index([session_id])
 }

--- a/schema.prisma
+++ b/schema.prisma
@@ -639,6 +639,8 @@ model LiteLLM_SpendLogs {
   proxy_server_request Json?     @default("{}")
   @@index([startTime])
   @@index([startTime, request_id])
+  @@index([api_key, startTime])
+  @@index([team_id, startTime])
   @@index([end_user])
   @@index([session_id])
 }

--- a/tests/test_litellm/proxy/db/test_spend_log_budget_window_indexes.py
+++ b/tests/test_litellm/proxy/db/test_spend_log_budget_window_indexes.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+EXTRAS_ROOT = REPO_ROOT / "litellm-proxy-extras" / "litellm_proxy_extras"
+
+INDEXES = {
+    "api_key": (
+        EXTRAS_ROOT / "migrations" / "20260804233000_add_spend_log_api_key_window_covering_index" / "migration.sql"
+    ),
+    "team_id": (
+        EXTRAS_ROOT / "migrations" / "20260804233100_add_spend_log_team_window_covering_index" / "migration.sql"
+    ),
+}
+
+
+def test_spend_log_budget_window_indexes_are_declared_in_both_schemas():
+    root_schema = (REPO_ROOT / "schema.prisma").read_text(encoding="utf-8")
+    packaged_schema = (EXTRAS_ROOT / "schema.prisma").read_text(encoding="utf-8")
+
+    for field in INDEXES:
+        declaration = f"@@index([{field}, startTime])"
+        assert declaration in root_schema
+        assert declaration in packaged_schema
+
+
+def test_spend_log_budget_window_migrations_create_covering_indexes_concurrently():
+    for field, migration_path in INDEXES.items():
+        migration = migration_path.read_text(encoding="utf-8")
+
+        assert migration.count("CREATE INDEX CONCURRENTLY IF NOT EXISTS") == 1
+        assert "CREATE INDEX CONCURRENTLY IF NOT EXISTS" in migration
+        assert f'("{field}", "startTime") INCLUDE ("spend")' in migration

--- a/tests/test_litellm/proxy/db/test_spend_log_budget_window_indexes.py
+++ b/tests/test_litellm/proxy/db/test_spend_log_budget_window_indexes.py
@@ -3,6 +3,11 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 EXTRAS_ROOT = REPO_ROOT / "litellm-proxy-extras" / "litellm_proxy_extras"
+SCHEMAS = (
+    REPO_ROOT / "schema.prisma",
+    REPO_ROOT / "litellm" / "proxy" / "schema.prisma",
+    EXTRAS_ROOT / "schema.prisma",
+)
 
 INDEXES = {
     "api_key": (
@@ -14,14 +19,13 @@ INDEXES = {
 }
 
 
-def test_spend_log_budget_window_indexes_are_declared_in_both_schemas():
-    root_schema = (REPO_ROOT / "schema.prisma").read_text(encoding="utf-8")
-    packaged_schema = (EXTRAS_ROOT / "schema.prisma").read_text(encoding="utf-8")
+def test_spend_log_budget_window_indexes_are_declared_in_all_schemas():
+    schemas = [schema.read_text(encoding="utf-8") for schema in SCHEMAS]
 
-    for field in INDEXES:
-        declaration = f"@@index([{field}, startTime])"
-        assert declaration in root_schema
-        assert declaration in packaged_schema
+    assert all(schema == schemas[0] for schema in schemas[1:])
+    for schema in schemas:
+        for field in INDEXES:
+            assert f"@@index([{field}, startTime])" in schema
 
 
 def test_spend_log_budget_window_migrations_create_covering_indexes_concurrently():


### PR DESCRIPTION
## TLDR

Problem this solves:

- Budget reseeds scan the wide spend-log heap
- Hot keys amplify database load during cold starts

How it solves it:

- Add covering indexes for key and team windows
- Build indexes concurrently to avoid blocking writes

## Relevant issues

Fixes #35766

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a database migration rather than an endpoint behavior change. The migrations create the exact index-only access paths requested by the production report:

```sql
(api_key, startTime) INCLUDE (spend)
(team_id, startTime) INCLUDE (spend)
```

The reporter's PostgreSQL measurements in #35766 show the dominant-key aggregate improving from about 170 ms (parallel sequential scan) to 65 ms (parallel index-only scan), while selective keys become sub-millisecond

Prisma cannot represent `INCLUDE` columns. Schema-driven `db push` installations still receive the composite range indexes; PostgreSQL migration installations receive the covering variants

Verified after rebasing onto `d1ca826ff6`, at head `7ed3291502`:

- `pytest tests/test_litellm/proxy/db/test_spend_log_budget_window_indexes.py -q` (2 passed)
- Focused Ruff check and format check
- Prisma validation for all three schema copies
- Strict Ruff and type-discipline delta gates against `upstream/litellm_internal_staging`
- No lint or type budget files changed
- `git diff --check`

## Type

Bug Fix
Infrastructure
Test

## Changes

- Declare API-key and team budget-window indexes in all three Prisma schemas
- Add one-statement concurrent migrations with `spend` as an included column
- Add regression tests for schema parity and migration structure
- Keep concurrent builds separate so each can run outside a transaction

### Final Attestation

- [x] The tests check schema parity, both lookup dimensions, covering columns, and concurrent single-index migrations

AI assistance: OpenAI Codex helped inspect the repository and draft portions of the change. I reviewed the implementation and ran every verification command listed above