### PR TITLE
fix(proxy): stop writing UI session token info-route auth failures to SpendLogs

### DIFF
--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -3,6 +3,7 @@ import re
 from fastapi import HTTPException, Request, status
 
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
 from litellm.proxy._types import (
     CommonProxyErrors,
     KeyManagementRoutes,
@@ -437,6 +438,29 @@ class RouteChecks:
         Check if route is an info route
         """
         return route in LiteLLMRoutes.info_routes.value
+
+    @staticmethod
+    def should_log_proxy_failure_for_route(route: str, team_id: str | None = None) -> bool:
+        """
+        Whether a proxy-gate failure (auth error, rate limit, guardrail block)
+        on this route should reach the failure-logging paths — the SpendLogs
+        DB row and the failure callbacks.
+
+        - LLM API routes: always log.
+        - Info routes: log, EXCEPT for UI session tokens
+          (``team_id == UI_SESSION_TOKEN_TEAM_ID``). The dashboard polls info
+          routes (``/key/list``, ``/user/info``, ``/models``, ...) with its
+          session token; once that token expires, every open browser tab keeps
+          replaying it, and each 401 used to be written to SpendLogs as an LLM
+          request carrying a session id — noise that reads as key abuse.
+        - Anything else (management endpoints): never log, so temporary
+          keys/auth info can't leak into logs.
+        """
+        if RouteChecks.is_llm_api_route(route=route):
+            return True
+        if RouteChecks.is_info_route(route=route):
+            return team_id != UI_SESSION_TOKEN_TEAM_ID
+        return False
 
     @staticmethod
     def _is_azure_openai_route(route: str) -> bool:

--- a/litellm/proxy/auth/route_checks.py
+++ b/litellm/proxy/auth/route_checks.py
@@ -10,6 +10,8 @@ from litellm.proxy._types import (
     LiteLLM_UserTable,
     LiteLLMRoutes,
     LitellmUserRoles,
+    ProxyErrorTypes,
+    ProxyException,
     UserAPIKeyAuth,
 )
 
@@ -440,27 +442,44 @@ class RouteChecks:
         return route in LiteLLMRoutes.info_routes.value
 
     @staticmethod
-    def should_log_proxy_failure_for_route(route: str, team_id: str | None = None) -> bool:
+    def should_log_proxy_failure_for_route(
+        route: str,
+        team_id: str | None = None,
+        original_exception: Exception | None = None,
+    ) -> bool:
         """
         Whether a proxy-gate failure (auth error, rate limit, guardrail block)
         on this route should reach the failure-logging paths — the SpendLogs
         DB row and the failure callbacks.
 
-        - LLM API routes: always log.
-        - Info routes: log, EXCEPT for UI session tokens
+        - Info routes (checked first — ``/models``/``/v1/models`` are also LLM
+          API routes, and the exclusion below must apply to them too): log,
+          EXCEPT expired-key failures from UI session tokens
           (``team_id == UI_SESSION_TOKEN_TEAM_ID``). The dashboard polls info
           routes (``/key/list``, ``/user/info``, ``/models``, ...) with its
           session token; once that token expires, every open browser tab keeps
           replaying it, and each 401 used to be written to SpendLogs as an LLM
-          request carrying a session id — noise that reads as key abuse.
+          request carrying a session id — noise that reads as key abuse. Other
+          failure types (authorization denials, rate limits, guardrail blocks)
+          from UI sessions stay logged, so a live low-privilege session probing
+          info routes still leaves an audit trail.
+        - LLM API routes: always log.
         - Anything else (management endpoints): never log, so temporary
           keys/auth info can't leak into logs.
         """
+        if RouteChecks.is_info_route(route=route):
+            if team_id == UI_SESSION_TOKEN_TEAM_ID and RouteChecks._is_expired_key_error(original_exception):
+                return False
+            return True
         if RouteChecks.is_llm_api_route(route=route):
             return True
-        if RouteChecks.is_info_route(route=route):
-            return team_id != UI_SESSION_TOKEN_TEAM_ID
         return False
+
+    @staticmethod
+    def _is_expired_key_error(e: Exception | None) -> bool:
+        """True if ``e`` is the typed expired-key auth failure raised by
+        ``user_api_key_auth`` (``ProxyErrorTypes.expired_key``)."""
+        return isinstance(e, ProxyException) and e.type == ProxyErrorTypes.expired_key
 
     @staticmethod
     def _is_azure_openai_route(route: str) -> bool:

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -72,7 +72,9 @@ class _ProxyDBLogger(CustomLogger):
             _ProxyDBLogger._should_track_errors_in_db() is False
             or request_route is not None
             and not RouteChecks.should_log_proxy_failure_for_route(
-                route=request_route, team_id=user_api_key_dict.team_id
+                route=request_route,
+                team_id=user_api_key_dict.team_id,
+                original_exception=original_exception,
             )
         ):
             return

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -71,8 +71,8 @@ class _ProxyDBLogger(CustomLogger):
         if (
             _ProxyDBLogger._should_track_errors_in_db() is False
             or request_route is not None
-            and not (
-                RouteChecks.is_llm_api_route(route=request_route) or RouteChecks.is_info_route(route=request_route)
+            and not RouteChecks.should_log_proxy_failure_for_route(
+                route=request_route, team_id=user_api_key_dict.team_id
             )
         ):
             return

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2212,7 +2212,9 @@ class ProxyLogging:
         #########################################################
         if route is None:
             return False
-        if not RouteChecks.should_log_proxy_failure_for_route(route=route, team_id=team_id):
+        if not RouteChecks.should_log_proxy_failure_for_route(
+            route=route, team_id=team_id, original_exception=original_exception
+        ):
             return False
 
         return isinstance(original_exception, (HTTPException, ProxyException)) or (

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -2113,6 +2113,7 @@ class ProxyLogging:
             original_exception=original_exception,
             error_type=error_type,
             route=user_api_key_dict.request_route,
+            team_id=user_api_key_dict.team_id,
         ):
             await self._handle_logging_proxy_only_error(
                 request_data=request_data,
@@ -2186,6 +2187,7 @@ class ProxyLogging:
         original_exception: Exception,
         error_type: ProxyErrorTypes | None = None,
         route: str | None = None,
+        team_id: str | None = None,
     ) -> bool:
         """
         Return True if the error is a Proxy Only LLM API Error
@@ -2204,10 +2206,13 @@ class ProxyLogging:
         # Note: This fixes a security issue where we
         #       would log temporary keys/auth info
         #       from management endpoints
+        # Info-route failures from UI session tokens are excluded:
+        # they are the dashboard polling itself with an expired
+        # session token, not API traffic worth a SpendLogs row.
         #########################################################
         if route is None:
             return False
-        if not (RouteChecks.is_llm_api_route(route) or RouteChecks.is_info_route(route)):
+        if not RouteChecks.should_log_proxy_failure_for_route(route=route, team_id=team_id):
             return False
 
         return isinstance(original_exception, (HTTPException, ProxyException)) or (

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -3192,3 +3192,46 @@ def test_internal_user_blocked_from_search_tool_writes(route):
     assert "Only proxy admin" in str(exc_info.value)
     assert f"Route={route}" in str(exc_info.value)
     assert "Your role=internal_user" in str(exc_info.value)
+
+
+def test_should_log_proxy_failure_for_route_ui_session_token():
+    """Info-route failures from UI session tokens are the dashboard polling
+    itself with an expired session token — they must not reach the
+    failure-logging paths. The same routes stay logged for regular keys, and
+    LLM API routes stay logged for everyone, including the UI session token
+    (playground test calls)."""
+    from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+
+    # info route + UI session token -> suppressed
+    assert (
+        RouteChecks.should_log_proxy_failure_for_route(
+            route="/key/list", team_id=UI_SESSION_TOKEN_TEAM_ID
+        )
+        is False
+    )
+    # info route + regular team -> logged
+    assert (
+        RouteChecks.should_log_proxy_failure_for_route(
+            route="/key/list", team_id="my-team"
+        )
+        is True
+    )
+    # info route + unresolved team (e.g. garbage key) -> logged
+    assert (
+        RouteChecks.should_log_proxy_failure_for_route(route="/key/list", team_id=None)
+        is True
+    )
+    # LLM API route + UI session token (playground) -> logged
+    assert (
+        RouteChecks.should_log_proxy_failure_for_route(
+            route="/chat/completions", team_id=UI_SESSION_TOKEN_TEAM_ID
+        )
+        is True
+    )
+    # management route -> never logged, regardless of team
+    assert (
+        RouteChecks.should_log_proxy_failure_for_route(
+            route="/key/generate", team_id="my-team"
+        )
+        is False
+    )

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -3194,37 +3194,54 @@ def test_internal_user_blocked_from_search_tool_writes(route):
     assert "Your role=internal_user" in str(exc_info.value)
 
 
+def _expired_key_exc() -> Exception:
+    from litellm.proxy._types import ProxyErrorTypes, ProxyException
+
+    return ProxyException(
+        message="Authentication Error - Expired Key.",
+        type=ProxyErrorTypes.expired_key,
+        param="sk-...abcd",
+        code=401,
+    )
+
+
 def test_should_log_proxy_failure_for_route_ui_session_token():
-    """Info-route failures from UI session tokens are the dashboard polling
-    itself with an expired session token — they must not reach the
-    failure-logging paths. The same routes stay logged for regular keys, and
-    LLM API routes stay logged for everyone, including the UI session token
-    (playground test calls)."""
+    """Expired-key failures from the UI session token on info routes are the
+    dashboard polling itself with a dead session token — they must not reach
+    the failure-logging paths. The same routes stay logged for regular keys,
+    and LLM API routes stay logged for everyone, including the UI session
+    token (playground test calls)."""
     from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
 
-    # info route + UI session token -> suppressed
+    # info route + UI session token + expired key -> suppressed
     assert (
         RouteChecks.should_log_proxy_failure_for_route(
-            route="/key/list", team_id=UI_SESSION_TOKEN_TEAM_ID
+            route="/key/list",
+            team_id=UI_SESSION_TOKEN_TEAM_ID,
+            original_exception=_expired_key_exc(),
         )
         is False
     )
     # info route + regular team -> logged
     assert (
         RouteChecks.should_log_proxy_failure_for_route(
-            route="/key/list", team_id="my-team"
+            route="/key/list", team_id="my-team", original_exception=_expired_key_exc()
         )
         is True
     )
     # info route + unresolved team (e.g. garbage key) -> logged
     assert (
-        RouteChecks.should_log_proxy_failure_for_route(route="/key/list", team_id=None)
+        RouteChecks.should_log_proxy_failure_for_route(
+            route="/key/list", team_id=None, original_exception=_expired_key_exc()
+        )
         is True
     )
     # LLM API route + UI session token (playground) -> logged
     assert (
         RouteChecks.should_log_proxy_failure_for_route(
-            route="/chat/completions", team_id=UI_SESSION_TOKEN_TEAM_ID
+            route="/chat/completions",
+            team_id=UI_SESSION_TOKEN_TEAM_ID,
+            original_exception=_expired_key_exc(),
         )
         is True
     )
@@ -3235,3 +3252,57 @@ def test_should_log_proxy_failure_for_route_ui_session_token():
         )
         is False
     )
+
+
+@pytest.mark.parametrize("route", ["/models", "/v1/models"])
+def test_should_log_proxy_failure_overlapping_model_routes(route):
+    """``/models`` and ``/v1/models`` are in BOTH info_routes and the LLM API
+    route set, and the dashboard polls them. The info-route branch must be
+    evaluated first, or the UI-session exclusion never applies to them."""
+    from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+
+    assert (
+        RouteChecks.should_log_proxy_failure_for_route(
+            route=route,
+            team_id=UI_SESSION_TOKEN_TEAM_ID,
+            original_exception=_expired_key_exc(),
+        )
+        is False
+    )
+    # still logged for a regular key on the same route
+    assert (
+        RouteChecks.should_log_proxy_failure_for_route(
+            route=route, team_id="my-team", original_exception=_expired_key_exc()
+        )
+        is True
+    )
+
+
+def test_should_log_proxy_failure_ui_session_non_expiry_failures_still_logged():
+    """Only the expired-key failure is suppressed. A live UI session hitting
+    an authorization denial / rate limit / guardrail block on an info route
+    must still leave an audit trail."""
+    from fastapi import HTTPException
+
+    from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+    from litellm.proxy._types import ProxyErrorTypes, ProxyException
+
+    for exc in (
+        HTTPException(status_code=401, detail="Authentication Error"),
+        ProxyException(
+            message="Rate limit",
+            type=ProxyErrorTypes.budget_exceeded,
+            param=None,
+            code=429,
+        ),
+        Exception("Key is blocked. Update via `/key/unblock` if you're an admin."),
+        None,
+    ):
+        assert (
+            RouteChecks.should_log_proxy_failure_for_route(
+                route="/key/list",
+                team_id=UI_SESSION_TOKEN_TEAM_ID,
+                original_exception=exc,
+            )
+            is True
+        )

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -129,11 +129,25 @@ async def test_async_post_call_failure_hook_non_llm_route():
         mock_update_database.assert_not_called()
 
 
+def _expired_key_exception():
+    from litellm.proxy._types import ProxyErrorTypes, ProxyException
+
+    return ProxyException(
+        message="Authentication Error - Expired Key.",
+        type=ProxyErrorTypes.expired_key,
+        param="sk-...abcd",
+        code=401,
+    )
+
+
+@pytest.mark.parametrize("route", ["/key/list", "/models", "/v1/models"])
 @pytest.mark.asyncio
-async def test_async_post_call_failure_hook_ui_session_token_info_route():
+async def test_async_post_call_failure_hook_ui_session_token_info_route(route):
     """An expired UI session token replayed by a stale dashboard tab against
     an info route must NOT produce a SpendLogs failure row — it used to be
-    written as an LLM request carrying a session id."""
+    written as an LLM request carrying a session id. ``/models`` and
+    ``/v1/models`` are covered because they are in both info_routes and the
+    LLM API route set."""
     from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
 
     logger = _ProxyDBLogger()
@@ -142,7 +156,7 @@ async def test_async_post_call_failure_hook_ui_session_token_info_route():
         api_key="test_api_key",
         user_id="test_user_id",
         team_id=UI_SESSION_TOKEN_TEAM_ID,
-        request_route="/key/list",  # dashboard polling an info route
+        request_route=route,  # dashboard polling an info route
     )
 
     with patch(
@@ -151,11 +165,42 @@ async def test_async_post_call_failure_hook_ui_session_token_info_route():
     ) as mock_update_database:
         await logger.async_post_call_failure_hook(
             request_data={},
-            original_exception=Exception("Authentication Error - Expired Key"),
+            original_exception=_expired_key_exception(),
             user_api_key_dict=user_api_key_dict,
         )
 
         mock_update_database.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_hook_ui_session_non_expiry_still_logged():
+    """A live UI session denied on an info route (authorization denial, rate
+    limit, guardrail block) must still produce a SpendLogs row — only the
+    expired-key replay is suppressed."""
+    from fastapi import HTTPException
+
+    from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+
+    logger = _ProxyDBLogger()
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test_api_key",
+        user_id="test_user_id",
+        team_id=UI_SESSION_TOKEN_TEAM_ID,
+        request_route="/key/list",
+    )
+
+    with patch(
+        "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter.update_database",
+        new_callable=AsyncMock,
+    ) as mock_update_database:
+        await logger.async_post_call_failure_hook(
+            request_data={"metadata": {}},
+            original_exception=HTTPException(status_code=401, detail="denied"),
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        mock_update_database.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
+++ b/tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py
@@ -130,6 +130,67 @@ async def test_async_post_call_failure_hook_non_llm_route():
 
 
 @pytest.mark.asyncio
+async def test_async_post_call_failure_hook_ui_session_token_info_route():
+    """An expired UI session token replayed by a stale dashboard tab against
+    an info route must NOT produce a SpendLogs failure row — it used to be
+    written as an LLM request carrying a session id."""
+    from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+
+    logger = _ProxyDBLogger()
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test_api_key",
+        user_id="test_user_id",
+        team_id=UI_SESSION_TOKEN_TEAM_ID,
+        request_route="/key/list",  # dashboard polling an info route
+    )
+
+    with patch(
+        "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter.update_database",
+        new_callable=AsyncMock,
+    ) as mock_update_database:
+        await logger.async_post_call_failure_hook(
+            request_data={},
+            original_exception=Exception("Authentication Error - Expired Key"),
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        mock_update_database.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_post_call_failure_hook_info_route_regular_key_still_logged():
+    """Info-route failures from regular (non UI session) keys must keep
+    producing SpendLogs failure rows — only the dashboard's own session
+    token is excluded."""
+    logger = _ProxyDBLogger()
+
+    user_api_key_dict = UserAPIKeyAuth(
+        api_key="test_api_key",
+        user_id="test_user_id",
+        team_id="test_team_id",
+        request_route="/key/list",
+    )
+
+    request_data = {
+        "metadata": {},
+        "proxy_server_request": {"request_id": "test_request_id"},
+    }
+
+    with patch(
+        "litellm.proxy.db.db_spend_update_writer.DBSpendUpdateWriter.update_database",
+        new_callable=AsyncMock,
+    ) as mock_update_database:
+        await logger.async_post_call_failure_hook(
+            request_data=request_data,
+            original_exception=Exception("Authentication Error - Expired Key"),
+            user_api_key_dict=user_api_key_dict,
+        )
+
+        mock_update_database.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_async_post_call_failure_hook_releases_budget_reservation_before_route_skip():
     logger = _ProxyDBLogger()
     budget_reservation = {"reserved_cost": 0.5, "entries": []}

--- a/tests/test_litellm/proxy/utils/proxy_logging/test_post_call_failure_hook.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/test_post_call_failure_hook.py
@@ -65,37 +65,62 @@ def test_is_proxy_only_llm_api_missing_exception_raises(proxy_logging):
 
 
 def test_is_proxy_only_llm_api_ui_session_token(proxy_logging):
-    """Info-route auth failures from UI session tokens are the dashboard
-    polling itself with an expired session token — they must not be handed
-    to the failure-logging paths (they used to land in SpendLogs typed as
-    LLM requests). Regular keys on info routes and the UI session token on
-    LLM routes (playground) both keep logging."""
+    """Expired-key failures from UI session tokens on info routes are the
+    dashboard polling itself with a dead session token — they must not be
+    handed to the failure-logging paths (they used to land in SpendLogs typed
+    as LLM requests). Regular keys on info routes, the UI session token on LLM
+    routes (playground), the overlapping ``/models`` route, and non-expiry
+    failure types all keep logging."""
     from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+    from litellm.proxy._types import ProxyException
+
+    expired = ProxyException(
+        message="Authentication Error - Expired Key.",
+        type=ProxyErrorTypes.expired_key,
+        param="sk-...abcd",
+        code=401,
+    )
 
     snapshot = {
         "ui_session_info_route": proxy_logging._is_proxy_only_llm_api_error(
-            original_exception=Exception("expired"),
+            original_exception=expired,
             error_type=ProxyErrorTypes.auth_error,
             route="/key/list",
             team_id=UI_SESSION_TOKEN_TEAM_ID,
         ),
+        # /models is in BOTH info_routes and the LLM route set
+        "ui_session_models_route": proxy_logging._is_proxy_only_llm_api_error(
+            original_exception=expired,
+            error_type=ProxyErrorTypes.auth_error,
+            route="/models",
+            team_id=UI_SESSION_TOKEN_TEAM_ID,
+        ),
         "regular_key_info_route": proxy_logging._is_proxy_only_llm_api_error(
-            original_exception=Exception("expired"),
+            original_exception=expired,
             error_type=ProxyErrorTypes.auth_error,
             route="/key/list",
             team_id="my-team",
         ),
         "ui_session_llm_route": proxy_logging._is_proxy_only_llm_api_error(
-            original_exception=Exception("expired"),
+            original_exception=expired,
             error_type=ProxyErrorTypes.auth_error,
             route="/chat/completions",
+            team_id=UI_SESSION_TOKEN_TEAM_ID,
+        ),
+        # a live UI session denied on an info route still gets logged
+        "ui_session_non_expiry_failure": proxy_logging._is_proxy_only_llm_api_error(
+            original_exception=HTTPException(status_code=401, detail="denied"),
+            error_type=ProxyErrorTypes.auth_error,
+            route="/key/list",
             team_id=UI_SESSION_TOKEN_TEAM_ID,
         ),
     }
     assert snapshot == {
         "ui_session_info_route": False,
+        "ui_session_models_route": False,
         "regular_key_info_route": True,
         "ui_session_llm_route": True,
+        "ui_session_non_expiry_failure": True,
     }
 
 

--- a/tests/test_litellm/proxy/utils/proxy_logging/test_post_call_failure_hook.py
+++ b/tests/test_litellm/proxy/utils/proxy_logging/test_post_call_failure_hook.py
@@ -64,6 +64,41 @@ def test_is_proxy_only_llm_api_missing_exception_raises(proxy_logging):
         proxy_logging._is_proxy_only_llm_api_error()  # type: ignore[call-arg]
 
 
+def test_is_proxy_only_llm_api_ui_session_token(proxy_logging):
+    """Info-route auth failures from UI session tokens are the dashboard
+    polling itself with an expired session token — they must not be handed
+    to the failure-logging paths (they used to land in SpendLogs typed as
+    LLM requests). Regular keys on info routes and the UI session token on
+    LLM routes (playground) both keep logging."""
+    from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+
+    snapshot = {
+        "ui_session_info_route": proxy_logging._is_proxy_only_llm_api_error(
+            original_exception=Exception("expired"),
+            error_type=ProxyErrorTypes.auth_error,
+            route="/key/list",
+            team_id=UI_SESSION_TOKEN_TEAM_ID,
+        ),
+        "regular_key_info_route": proxy_logging._is_proxy_only_llm_api_error(
+            original_exception=Exception("expired"),
+            error_type=ProxyErrorTypes.auth_error,
+            route="/key/list",
+            team_id="my-team",
+        ),
+        "ui_session_llm_route": proxy_logging._is_proxy_only_llm_api_error(
+            original_exception=Exception("expired"),
+            error_type=ProxyErrorTypes.auth_error,
+            route="/chat/completions",
+            team_id=UI_SESSION_TOKEN_TEAM_ID,
+        ),
+    }
+    assert snapshot == {
+        "ui_session_info_route": False,
+        "regular_key_info_route": True,
+        "ui_session_llm_route": True,
+    }
+
+
 # ---------------------------------------------------------------------------
 # post_call_failure_hook
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## TLDR

Problem this solves:

- Expired UI session tokens replayed by stale dashboard tabs
- Their info-route 401s were written to SpendLogs as LLM requests
- Reads as key abuse in Usage/Logs (see #35789, #19894, #12806)

How it solves it:

- New `RouteChecks.should_log_proxy_failure_for_route(route, team_id)`
- Info-route failures skipped only when `team_id == UI_SESSION_TOKEN_TEAM_ID`
- Real keys on info routes + playground LLM calls keep logging

## Relevant issues

Fixes #35789

Prior reports of the same defect, all closed by the stale bot: #19894, #12806, #16118.

## Linear ticket



## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests) — 78 passed / 1 skipped / 1 failed; the sole failure is `osv-scan`, which flags `cryptography 48.0.1` in `uv.lock` and fails identically on the base branch (this PR touches no lockfile). Details in [this comment](https://github.com/BerriAI/litellm/pull/35791#issuecomment-5183269268).
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes) — scored **4/5**; its one P1 (`/models` overlapping info + LLM route sets) and veria-ai's finding are both fixed in `7cebd3c`.

## Screenshots / Proof of Fix

**The bug, observed on a production deployment (v1.93.1):** a `/ui` tab left open over a weekend kept replaying its expired session key against the dashboard's polling endpoints —

```
Authentication Error - Expired Key. Key Expiry time 2026-08-01 10:37:52 and current time 2026-08-03 19:05:27
INFO: "GET /key/list?... HTTP/1.1" 401 Unauthorized
```

— and every one of those 401s produced a `LiteLLM_SpendLogs` row rendered in the UI as `Type: LLM` with a session id and `Unknown item` model, which triggered a key-compromise investigation on our side before we traced it here.

**Behavior change, pinned by tests** (`.venv/bin/python -m pytest tests/test_litellm/proxy/auth/test_route_checks.py tests/test_litellm/proxy/hooks/test_proxy_track_cost_callback.py tests/test_litellm/proxy/utils/proxy_logging/test_post_call_failure_hook.py` → **403 passed**):

| caller | route | failure spend-logged? |
|---|---|---|
| UI session token (`litellm-dashboard`) | `/key/list` (info) | before: yes → **after: no** |
| regular virtual key | `/key/list` (info) | yes (unchanged) |
| UI session token | `/chat/completions` (playground) | yes (unchanged) |
| any | management routes | no (unchanged) |

Both gates are covered: `ProxyLogging._is_proxy_only_llm_api_error` (failure callbacks — DB/s3/langfuse fan-out) and `_ProxyDBLogger.async_post_call_failure_hook` (the SpendLogs write itself, asserted via `DBSpendUpdateWriter.update_database` called / not called).

The e2e proof of this fix is the *absence* of new failure rows while an expired-session tab polls the dashboard — happy to provide a before/after capture from our deployment once a build containing this change is available, or a local repro with `LITELLM_UI_SESSION_DURATION=2m` if a maintainer wants it.

Note: complementary to `ExpiredUISessionKeyCleanupManager` — that deletes the expired key *rows*; this stops the failure *spend-log writes* those keys generate while a tab is still replaying them.

