### PR TITLE
fix(anthropic): unwrap single-key envelope in json_tool_call responses

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -2494,6 +2494,20 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 if isinstance(args, dict) and (values := args.get("values")) is not None:
                     _message = litellm.Message(content=json.dumps(values))
                     return _message
+                elif isinstance(args, dict) and len(args) == 1:
+                    # Unwrap single-key envelope dicts. Claude wraps
+                    # json_tool_call responses in a single-key dict whose name
+                    # varies by provider path ("values" for direct Anthropic,
+                    # "parameter" for Vertex AI Anthropic, "properties" for
+                    # Bedrock).  Rather than chasing each key, unwrap any
+                    # single-key dict whose value is itself a dict — the
+                    # wrapped payload is always the inner value.
+                    inner = next(iter(args.values()))
+                    if isinstance(inner, dict):
+                        _message = litellm.Message(content=json.dumps(inner))
+                        return _message
+                    _message = litellm.Message(content=json.dumps(args))
+                    return _message
                 else:
                     # a lot of the times the `values` key is not present in the tool response
                     # relevant issue: https://github.com/BerriAI/litellm/issues/6741

--- a/tests/llm_translation/test_anthropic_completion.py
+++ b/tests/llm_translation/test_anthropic_completion.py
@@ -609,6 +609,62 @@ def test_convert_tool_response_to_message_without_values():
     assert message.content == '{"name": "John", "age": 30}'
 
 
+def test_convert_tool_response_to_message_single_key_envelope():
+    """
+    Test unwrapping single-key envelope dicts in tool responses.
+
+    Vertex AI Anthropic wraps json_tool_call responses in
+    {"parameter": {"facts": [...]}} instead of {"facts": [...]}.
+    The wrapper key varies by provider ("parameter" for Vertex AI,
+    "properties" for Bedrock, "values" for direct Anthropic).
+    Single-key dicts whose value is a dict should be unwrapped.
+    """
+    tool_calls = [
+        ChatCompletionToolCallChunk(
+            id="test_id",
+            type="function",
+            function=ChatCompletionToolCallFunctionChunk(
+                name="json_tool_call",
+                arguments='{"parameter": {"facts": [{"what": "test"}]}}',
+            ),
+            index=0,
+        )
+    ]
+
+    message = AnthropicConfig._convert_tool_response_to_message(
+        tool_calls=tool_calls
+    )
+
+    assert message is not None
+    import json
+
+    parsed = json.loads(message.content)
+    assert "facts" in parsed
+    assert parsed["facts"][0]["what"] == "test"
+
+
+def test_convert_tool_response_to_message_multi_key_no_unwrap():
+    """Multi-key dicts should not be unwrapped even without 'values' key."""
+    tool_calls = [
+        ChatCompletionToolCallChunk(
+            id="test_id",
+            type="function",
+            function=ChatCompletionToolCallFunctionChunk(
+                name="json_tool_call",
+                arguments='{"name": "John", "age": 30}',
+            ),
+            index=0,
+        )
+    ]
+
+    message = AnthropicConfig._convert_tool_response_to_message(
+        tool_calls=tool_calls
+    )
+
+    assert message is not None
+    assert message.content == '{"name": "John", "age": 30}'
+
+
 def test_convert_tool_response_to_message_invalid_json():
     """Test converting a tool response with invalid JSON"""
     tool_calls = [


### PR DESCRIPTION
## Summary

Fixes `_convert_tool_response_to_message()` to unwrap single-key envelope dicts in `json_tool_call` responses. Vertex AI Claude wraps responses in `{"parameter": {...}}`, which is not handled by the existing `"values"` unwrap (line 2494).

## Problem

When `response_format: json_schema` is converted to a `json_tool_call` tool for Anthropic models, Claude's tool response wraps the output in a single-key dict. The wrapper key varies by provider path:
- `"values"` — direct Anthropic (already handled)
- `"properties"` — Bedrock (handled by `_unwrap_bedrock_properties`)  
- `"parameter"` — Vertex AI Anthropic (**not handled** → bug)

## Fix

After the existing `"values"` check, unwrap any single-key dict whose value is itself a dict. This is the same pattern used by `_unwrap_bedrock_properties` but applied generically in the base Anthropic handler.

```python
elif isinstance(args, dict) and len(args) == 1:
    inner = next(iter(args.values()))
    if isinstance(inner, dict):
        _message = litellm.Message(content=json.dumps(inner))
        return _message
```

**Constraints:**
- Only fires when dict has exactly one key (multi-key dicts pass through unchanged)
- Only fires when the inner value is a dict (single-key with string/int/etc. passes through)
- Existing `"values"` check takes priority (no behavior change for direct Anthropic)

## Tests

Added 2 test cases to `test_anthropic_completion.py`:
- `test_convert_tool_response_to_message_single_key_envelope` — verifies `{"parameter": {"facts": [...]}}` is unwrapped
- `test_convert_tool_response_to_message_multi_key_no_unwrap` — verifies multi-key dicts are not affected

All existing `_convert_tool_response_to_message` tests pass unchanged.

Fixes #35790