### PR TITLE
fix(gemini-realtime): prevent ValueError crash when generationComplete arrives without prior modelTurn on native-audio models

### DIFF
--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -167,10 +167,10 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
     def map_generation_complete_event(self, delta_type: ALL_DELTA_TYPES | None) -> OpenAIRealtimeEventTypes:
         if delta_type == "text":
             return OpenAIRealtimeEventTypes.RESPONSE_TEXT_DONE
-        elif delta_type == "audio":
-            return OpenAIRealtimeEventTypes.RESPONSE_AUDIO_DONE
-        else:
-            raise ValueError(f"Unexpected delta type: {delta_type}")
+        # None occurs on native-audio sessions where generationComplete arrives in a
+        # serverContent frame that has outputTranscription but no modelTurn; those
+        # models produce audio by definition, so default to RESPONSE_AUDIO_DONE.
+        return OpenAIRealtimeEventTypes.RESPONSE_AUDIO_DONE
 
     def get_audio_mime_type(self, input_audio_format: str = "pcm16"):
         mime_types = {
@@ -1208,6 +1208,11 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
                             delta_type="audio",
                         )
                     )
+                # outputTranscription always belongs to audio output; track the type so
+                # that a generationComplete arriving in a later frame (without a preceding
+                # modelTurn) can resolve to RESPONSE_AUDIO_DONE instead of relying solely
+                # on the None-fallback in map_generation_complete_event.
+                current_delta_type = "audio"
                 returned_message.append(
                     cast(
                         OpenAIRealtimeEvents,

--- a/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
+++ b/tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py
@@ -1868,3 +1868,117 @@ def test_is_setup_message_and_is_content_message():
     assert config.is_content_message({"clientContent": {}}) is True
     assert config.is_content_message({"toolResponse": {}}) is True
     assert config.is_content_message({"setup": {}}) is False
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for native-audio generationComplete crash (Bug 1 + Bug 2)
+# ---------------------------------------------------------------------------
+
+
+def _base_transform_input(**overrides):
+    base = {
+        "session_configuration_request": json.dumps(
+            {
+                "setup": {
+                    "model": "models/gemini-live-2.5-flash-preview-native-audio-09-2025",
+                    "generationConfig": {"responseModalities": ["AUDIO"]},
+                }
+            }
+        ),
+        "current_output_item_id": None,
+        "current_response_id": None,
+        "current_conversation_id": None,
+        "current_delta_chunks": [],
+        "current_item_chunks": [],
+        "current_delta_type": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_generation_complete_with_null_delta_type_does_not_raise():
+    """generationComplete with delta_type=None must not raise; native-audio sessions
+    can emit generationComplete before any modelTurn has been seen."""
+    from litellm.types.llms.openai import OpenAIRealtimeEventTypes
+
+    config = GeminiRealtimeConfig()
+    frame = {"serverContent": {"generationComplete": True}}
+
+    result = config.transform_realtime_response(
+        json.dumps(frame),
+        "gemini-live-2.5-flash-preview-native-audio-09-2025",
+        MagicMock(),
+        realtime_response_transform_input=_base_transform_input(
+            current_output_item_id="item_existing",
+            current_response_id="resp_existing",
+            current_delta_type=None,
+        ),
+    )
+
+    event_types = [e["type"] for e in result["response"]]
+    assert OpenAIRealtimeEventTypes.RESPONSE_OUTPUT_AUDIO_DONE.value in event_types
+
+
+def test_generation_complete_in_output_transcription_frame_does_not_raise():
+    """A single serverContent frame combining outputTranscription + generationComplete
+    (no modelTurn) must not raise and must emit both a transcript delta and an audio
+    done event. This is the exact frame shape native-audio models (e.g.
+    gemini-live-2.5-flash-preview-native-audio-09-2025) can produce."""
+    from litellm.types.llms.openai import OpenAIRealtimeEventTypes
+
+    config = GeminiRealtimeConfig()
+    frame = {
+        "serverContent": {
+            "outputTranscription": {"text": "Hello from native audio."},
+            "generationComplete": True,
+        }
+    }
+
+    result = config.transform_realtime_response(
+        json.dumps(frame),
+        "gemini-live-2.5-flash-preview-native-audio-09-2025",
+        MagicMock(),
+        realtime_response_transform_input=_base_transform_input(current_delta_type=None),
+    )
+
+    event_types = [e["type"] for e in result["response"]]
+    assert "response.output_audio_transcript.delta" in event_types
+    assert OpenAIRealtimeEventTypes.RESPONSE_OUTPUT_AUDIO_DONE.value in event_types
+
+
+def test_output_transcription_sets_delta_type_for_subsequent_generation_complete():
+    """outputTranscription frame must update current_delta_type to 'audio' so a
+    generationComplete arriving in the very next frame resolves correctly without
+    relying solely on the None fallback."""
+    config = GeminiRealtimeConfig()
+    logging_obj = MagicMock()
+
+    transcription_frame = {
+        "serverContent": {
+            "outputTranscription": {"text": "Hello."},
+        }
+    }
+    state_after_transcription = config.transform_realtime_response(
+        json.dumps(transcription_frame),
+        "gemini-live-2.5-flash-preview-native-audio-09-2025",
+        logging_obj,
+        realtime_response_transform_input=_base_transform_input(current_delta_type=None),
+    )
+
+    assert state_after_transcription["current_delta_type"] == "audio"
+
+    generation_complete_frame = {"serverContent": {"generationComplete": True}}
+    result = config.transform_realtime_response(
+        json.dumps(generation_complete_frame),
+        "gemini-live-2.5-flash-preview-native-audio-09-2025",
+        logging_obj,
+        realtime_response_transform_input={
+            **state_after_transcription,
+            "response": None,
+        },
+    )
+
+    from litellm.types.llms.openai import OpenAIRealtimeEventTypes
+
+    event_types = [e["type"] for e in result["response"]]
+    assert OpenAIRealtimeEventTypes.RESPONSE_OUTPUT_AUDIO_DONE.value in event_types


### PR DESCRIPTION
## TLDR

Problem this solves:

Gemini Live native-audio models (e.g. `gemini-live-2.5-flash-preview-native-audio-09-2025`, `gemini-2.5-flash-native-audio-*`) can emit `serverContent` frames that contain `outputTranscription` and `generationComplete` together but no `modelTurn`. Because `current_delta_type` is only updated when a `modelTurn` is processed, it is still `None` when `map_generation_complete_event` is called for such frames. The method raised `ValueError("Unexpected delta type: None")`, which tore the WebSocket session down with a 1011 error. For users running the proxy against native-audio models, this surfaced as silent failures or disconnections at the start of the first turn.

How it solves it:

Two changes in `litellm/llms/gemini/realtime/transformation.py`:

1. `map_generation_complete_event` no longer raises for `None`; it falls through to `RESPONSE_AUDIO_DONE`, which is always correct when there has been no prior text `modelTurn`.

2. In `transform_realtime_response`, after processing `outputTranscription` the local `current_delta_type` variable is set to `"audio"`. This propagates back to the caller via the return dict so that a `generationComplete` arriving in a subsequent frame can resolve the done-event type from tracked state instead of relying on the `None` fallback.

Three regression tests cover the two failure modes: `generationComplete` with `delta_type=None` alone, the combined `outputTranscription + generationComplete` single-frame case, and the multi-frame case where transcription and completion arrive in separate frames.

## Relevant issues

None open at time of writing; reproduced locally against `gemini-live-2.5-flash-preview-native-audio-09-2025` via the proxy.

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

The three new regression tests exercise the exact frame shapes that triggered the crash:

```
tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py::test_generation_complete_with_null_delta_type_does_not_raise PASSED
tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py::test_generation_complete_in_output_transcription_frame_does_not_raise PASSED
tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py::test_output_transcription_sets_delta_type_for_subsequent_generation_complete PASSED
```

Full suite: 59 passed, 0 failed.

## Type

Bug Fix

## Changes

- `litellm/llms/gemini/realtime/transformation.py`: `map_generation_complete_event` defaults to `RESPONSE_AUDIO_DONE` for `None` delta type; `transform_realtime_response` sets `current_delta_type = "audio"` after processing `outputTranscription`
- `tests/test_litellm/llms/gemini/realtime/test_gemini_realtime_transformation.py`: three regression tests

## QA runbook

Start a proxy with a native-audio Gemini Live model, connect via a WebSocket client (e.g. the `browser-test` page), speak a sentence, and verify the response completes without a 1011 disconnect.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
