### PR TITLE
fix(router): resolve provider-prefixed model costs

### DIFF
--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -1,7 +1,9 @@
 #### What this does ####
 #   picks based on response time (for streaming, this is time to first token)
 from datetime import datetime, timedelta
-from typing import Final, TypedDict, cast
+from typing import Final, cast
+
+from typing_extensions import TypedDict
 
 import litellm
 from litellm import ModelResponse, token_counter, verbose_logger
@@ -13,6 +15,7 @@ from litellm.integrations.custom_logger import CustomLogger
 class _ModelCostInfo(TypedDict, total=False):
     input_cost_per_token: float | None
     output_cost_per_token: float | None
+    litellm_provider: str | None
 
 
 def _get_model_cost_info(model_name: str | None) -> _ModelCostInfo:
@@ -26,12 +29,14 @@ def _get_model_cost_info(model_name: str | None) -> _ModelCostInfo:
     if exact_model_cost is not None:
         return exact_model_cost
 
-    try:
-        return cast(  # cast-ok: only the two declared numeric fields are read below
-            _ModelCostInfo, litellm.get_model_info(model_name)
-        )
-    except Exception:
+    provider_name, separator, unprefixed_model_name = model_name.partition("/")
+    if separator == "":
         return {}  # mutable-ok: each unresolved model gets an independent cost map
+
+    unprefixed_model_cost = model_cost.get(unprefixed_model_name)
+    if unprefixed_model_cost is None or unprefixed_model_cost.get("litellm_provider") != provider_name:
+        return {}
+    return unprefixed_model_cost
 
 
 class LowestCostLoggingHandler(CustomLogger):

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -1,13 +1,37 @@
 #### What this does ####
 #   picks based on response time (for streaming, this is time to first token)
 from datetime import datetime, timedelta
-from typing import Final
+from typing import Final, TypedDict, cast
 
 import litellm
 from litellm import ModelResponse, token_counter, verbose_logger
 from litellm._logging import verbose_router_logger
 from litellm.caching.caching import DualCache
 from litellm.integrations.custom_logger import CustomLogger
+
+
+class _ModelCostInfo(TypedDict, total=False):
+    input_cost_per_token: float | None
+    output_cost_per_token: float | None
+
+
+def _get_model_cost_info(model_name: str | None) -> _ModelCostInfo:
+    if model_name is None:
+        return {}  # mutable-ok: each unresolved model gets an independent cost map
+
+    model_cost = cast(  # cast-ok: model_cost values come from the typed model cost JSON
+        dict[str, _ModelCostInfo], litellm.model_cost
+    )
+    exact_model_cost = model_cost.get(model_name)
+    if exact_model_cost is not None:
+        return exact_model_cost
+
+    try:
+        return cast(  # cast-ok: only the two declared numeric fields are read below
+            _ModelCostInfo, litellm.get_model_info(model_name)
+        )
+    except Exception:
+        return {}  # mutable-ok: each unresolved model gets an independent cost map
 
 
 class LowestCostLoggingHandler(CustomLogger):
@@ -245,7 +269,7 @@ class LowestCostLoggingHandler(CustomLogger):
                 or float("inf")
             )
             item_litellm_model_name = _deployment.get("litellm_params", {}).get("model")
-            item_litellm_model_cost_map = litellm.model_cost.get(item_litellm_model_name, {})
+            item_litellm_model_cost_map = _get_model_cost_info(item_litellm_model_name)
 
             # check if user provided input_cost_per_token and output_cost_per_token in litellm_params
             item_input_cost = None
@@ -257,10 +281,12 @@ class LowestCostLoggingHandler(CustomLogger):
                 item_output_cost = _deployment.get("litellm_params", {}).get("output_cost_per_token")
 
             if item_input_cost is None:
-                item_input_cost = item_litellm_model_cost_map.get("input_cost_per_token", 5.0)
+                model_input_cost = item_litellm_model_cost_map.get("input_cost_per_token")
+                item_input_cost = model_input_cost if model_input_cost is not None else 5.0
 
             if item_output_cost is None:
-                item_output_cost = item_litellm_model_cost_map.get("output_cost_per_token", 5.0)
+                model_output_cost = item_litellm_model_cost_map.get("output_cost_per_token")
+                item_output_cost = model_output_cost if model_output_cost is not None else 5.0
 
             # if litellm["model"] is not in model_cost map -> use item_cost = $10
 

--- a/litellm/router_strategy/lowest_cost.py
+++ b/litellm/router_strategy/lowest_cost.py
@@ -1,8 +1,9 @@
 #### What this does ####
 #   picks based on response time (for streaming, this is time to first token)
 from datetime import datetime, timedelta
-from typing import Final, cast
+from typing import Final
 
+from pydantic import TypeAdapter, ValidationError
 from typing_extensions import TypedDict
 
 import litellm
@@ -18,14 +19,25 @@ class _ModelCostInfo(TypedDict, total=False):
     litellm_provider: str | None
 
 
+_MODEL_COST_INFO_ADAPTER: Final = TypeAdapter(_ModelCostInfo)
+
+
+def _get_validated_model_cost_info(model_name: str) -> _ModelCostInfo | None:
+    raw_model_cost_info: Final[object] = litellm.model_cost.get(model_name)
+    if raw_model_cost_info is None:
+        return None
+
+    try:
+        return _MODEL_COST_INFO_ADAPTER.validate_python(raw_model_cost_info)
+    except ValidationError:
+        return None
+
+
 def _get_model_cost_info(model_name: str | None) -> _ModelCostInfo:
     if model_name is None:
         return {}  # mutable-ok: each unresolved model gets an independent cost map
 
-    model_cost = cast(  # cast-ok: model_cost values come from the typed model cost JSON
-        dict[str, _ModelCostInfo], litellm.model_cost
-    )
-    exact_model_cost = model_cost.get(model_name)
+    exact_model_cost: Final = _get_validated_model_cost_info(model_name)
     if exact_model_cost is not None:
         return exact_model_cost
 
@@ -33,7 +45,7 @@ def _get_model_cost_info(model_name: str | None) -> _ModelCostInfo:
     if separator == "":
         return {}  # mutable-ok: each unresolved model gets an independent cost map
 
-    unprefixed_model_cost = model_cost.get(unprefixed_model_name)
+    unprefixed_model_cost: Final = _get_validated_model_cost_info(unprefixed_model_name)
     if unprefixed_model_cost is None or unprefixed_model_cost.get("litellm_provider") != provider_name:
         return {}
     return unprefixed_model_cost

--- a/tests/test_litellm/router_strategy/test_lowest_cost.py
+++ b/tests/test_litellm/router_strategy/test_lowest_cost.py
@@ -1,0 +1,29 @@
+import pytest
+
+from litellm.caching.caching import DualCache
+from litellm.router_strategy.lowest_cost import LowestCostLoggingHandler
+
+
+@pytest.mark.asyncio
+async def test_provider_prefixed_models_use_resolved_costs() -> None:
+    deployments = [
+        {
+            "model_name": "test-group",
+            "litellm_params": {"model": "openai/gpt-5.6-sol"},
+            "model_info": {"id": "sol"},
+        },
+        {
+            "model_name": "test-group",
+            "litellm_params": {"model": "openai/gpt-5.6-luna"},
+            "model_info": {"id": "luna"},
+        },
+    ]
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+
+    selected = await handler.async_get_available_deployments(
+        model_group="test-group",
+        healthy_deployments=deployments,
+    )
+
+    assert selected is not None
+    assert selected["model_info"]["id"] == "luna"

--- a/tests/test_litellm/router_strategy/test_lowest_cost.py
+++ b/tests/test_litellm/router_strategy/test_lowest_cost.py
@@ -57,3 +57,32 @@ async def test_unknown_provider_model_does_not_query_dynamic_metadata() -> None:
     assert selected is not None
     assert selected["model_info"]["id"] == "luna"
     get_model_info.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_invalid_static_cost_entry_is_ignored() -> None:
+    deployments = [
+        {
+            "model_name": "test-group",
+            "litellm_params": {"model": "test-provider/corrupt-cost"},
+            "model_info": {"id": "invalid"},
+        },
+        {
+            "model_name": "test-group",
+            "litellm_params": {"model": "openai/gpt-5.6-luna"},
+            "model_info": {"id": "luna"},
+        },
+    ]
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+
+    with patch.dict(
+        litellm.model_cost,
+        {"test-provider/corrupt-cost": {"input_cost_per_token": "invalid"}},
+    ):
+        selected = await handler.async_get_available_deployments(
+            model_group="test-group",
+            healthy_deployments=deployments,
+        )
+
+    assert selected is not None
+    assert selected["model_info"]["id"] == "luna"

--- a/tests/test_litellm/router_strategy/test_lowest_cost.py
+++ b/tests/test_litellm/router_strategy/test_lowest_cost.py
@@ -1,3 +1,6 @@
+from unittest.mock import patch
+
+import litellm
 import pytest
 
 from litellm.caching.caching import DualCache
@@ -27,3 +30,30 @@ async def test_provider_prefixed_models_use_resolved_costs() -> None:
 
     assert selected is not None
     assert selected["model_info"]["id"] == "luna"
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_model_does_not_query_dynamic_metadata() -> None:
+    deployments = [
+        {
+            "model_name": "test-group",
+            "litellm_params": {"model": "ollama/caller-controlled-model"},
+            "model_info": {"id": "unknown"},
+        },
+        {
+            "model_name": "test-group",
+            "litellm_params": {"model": "openai/gpt-5.6-luna"},
+            "model_info": {"id": "luna"},
+        },
+    ]
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+
+    with patch.object(litellm, "get_model_info") as get_model_info:
+        selected = await handler.async_get_available_deployments(
+            model_group="test-group",
+            healthy_deployments=deployments,
+        )
+
+    assert selected is not None
+    assert selected["model_info"]["id"] == "luna"
+    get_model_info.assert_not_called()

--- a/tests/test_litellm/router_strategy/test_lowest_cost.py
+++ b/tests/test_litellm/router_strategy/test_lowest_cost.py
@@ -32,12 +32,18 @@ async def test_provider_prefixed_models_use_resolved_costs() -> None:
     assert selected["model_info"]["id"] == "luna"
 
 
+@pytest.mark.parametrize(
+    "unknown_model",
+    [None, "caller-controlled-model", "ollama/caller-controlled-model"],
+)
 @pytest.mark.asyncio
-async def test_unknown_provider_model_does_not_query_dynamic_metadata() -> None:
+async def test_unknown_models_do_not_query_dynamic_metadata(
+    unknown_model: str | None,
+) -> None:
     deployments = [
         {
             "model_name": "test-group",
-            "litellm_params": {"model": "ollama/caller-controlled-model"},
+            "litellm_params": {"model": unknown_model},
             "model_info": {"id": "unknown"},
         },
         {
@@ -57,6 +63,40 @@ async def test_unknown_provider_model_does_not_query_dynamic_metadata() -> None:
     assert selected is not None
     assert selected["model_info"]["id"] == "luna"
     get_model_info.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_exact_custom_cost_entry_remains_authoritative() -> None:
+    deployments = [
+        {
+            "model_name": "test-group",
+            "litellm_params": {"model": "custom/provider-entry"},
+            "model_info": {"id": "custom"},
+        },
+        {
+            "model_name": "test-group",
+            "litellm_params": {"model": "openai/gpt-5.6-luna"},
+            "model_info": {"id": "luna"},
+        },
+    ]
+    handler = LowestCostLoggingHandler(router_cache=DualCache())
+
+    with patch.dict(
+        litellm.model_cost,
+        {
+            "custom/provider-entry": {
+                "input_cost_per_token": 1e-9,
+                "output_cost_per_token": 1e-9,
+            }
+        },
+    ):
+        selected = await handler.async_get_available_deployments(
+            model_group="test-group",
+            healthy_deployments=deployments,
+        )
+
+    assert selected is not None
+    assert selected["model_info"]["id"] == "custom"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Provider-prefixed deployments miss existing model pricing
- Lowest-cost routing can therefore choose a costlier model
- Malformed static prices can interrupt route selection

How it solves it:

- Preserve exact custom price entries before resolving provider prefixes
- Reuse bare prices only when their provider matches the prefix
- Validate matched static entries at the untyped price-map boundary
- Never call provider metadata discovery from the async routing path
- Add regressions for selection, unknown names, and invalid prices

## Relevant issues

Fixes #35787

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (5/5 on the previous head; latest-head review requested after rebase)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

Regression scenario:

```text
before: selected=sol
fixed:  selected=luna
luna_input=2e-07
sol_input=5e-06
```

## Type

Bug Fix
Test

## Changes

The lowest-cost router checks an exact price-map key first, preserving custom provider-prefixed pricing. On an exact miss it reuses a bare static entry only when that entry's `litellm_provider` matches the prefix. Matched entries are validated through a module-level Pydantic adapter, malformed entries retain the existing 5+5 fallback cost, and the async routing path never calls dynamic provider metadata discovery.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

## Verification

Rebased onto `e4fd790f1c` and verified at head `51d8fed940`:

- `pytest tests/test_litellm/router_strategy/test_lowest_cost.py -q` (6 passed)
- Focused line coverage: every new static-cost lookup branch exercised
- Focused Ruff check and format check
- Strict Ruff and type-discipline delta gates against `upstream/litellm_internal_staging`
- Full basedpyright delta gate: every rule within its limit or no higher than base (148,627 repository errors)
- Compile and import smoke checks
- No lint or type budget files changed

AI assistance was used for implementation and test drafting; the diff and verification results were reviewed before submission.