### PR TITLE
refactor(ui): inject the fetch client's base url instead of reading it at import

### DIFF
--- a/ui/litellm-dashboard/src/lib/http/api.sameOrigin.test.ts
+++ b/ui/litellm-dashboard/src/lib/http/api.sameOrigin.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchClient } from "./api";
+import { registerAuthTokenGetter, registerBaseUrlGetter, registerErrorHandler } from "./runtime";
+
+const jsonResponse = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+
+const capturingFetch = (response: Response) => {
+  const requests: Request[] = [];
+  const fetch = vi.fn(async (request: Request) => {
+    requests.push(request);
+    return response;
+  });
+  return { fetch, requests };
+};
+
+describe("typed api client on a same-origin deployment", () => {
+  beforeEach(() => {
+    registerAuthTokenGetter(() => null);
+    registerErrorHandler(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sends requests to the page origin when no base url is registered", async () => {
+    registerBaseUrlGetter(() => "");
+    const { fetch, requests } = capturingFetch(jsonResponse(200, { data: [] }));
+
+    await fetchClient.GET("/model_group/info", { fetch });
+
+    expect(requests[0].url).toBe(`${window.location.origin}/model_group/info`);
+  });
+
+  it("prefers a registered cross-origin base over the page origin", async () => {
+    registerBaseUrlGetter(() => "https://proxy.example.com");
+    const { fetch, requests } = capturingFetch(jsonResponse(200, { data: [] }));
+
+    await fetchClient.GET("/model_group/info", { fetch });
+
+    expect(requests[0].url).toBe("https://proxy.example.com/model_group/info");
+    expect(new URL(requests[0].url).origin).not.toBe(window.location.origin);
+  });
+});

--- a/ui/litellm-dashboard/src/lib/http/api.test.ts
+++ b/ui/litellm-dashboard/src/lib/http/api.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchClient } from "./api";
 import {
@@ -36,7 +37,7 @@ const spyOnRequestConstruction = () => {
 
 describe("typed api client middleware", () => {
   beforeEach(() => {
-    registerBaseUrlGetter(() => "");
+    registerBaseUrlGetter(() => "http://localhost:4000");
     registerAuthHeaderNameGetter(() => "Authorization");
     registerErrorHandler(() => {});
     registerAuthTokenGetter(() => null);
@@ -66,7 +67,7 @@ describe("typed api client middleware", () => {
     expect(requests[0].headers.get("Authorization")).toBeNull();
   });
 
-  it("rebases the request onto the registered base url, preserving path and query", async () => {
+  it("builds the request url from the registered base url, preserving path and query", async () => {
     registerBaseUrlGetter(() => "https://proxy.example.com/");
     const { fetch, requests } = capturingFetch(jsonResponse(200, { data: [] }));
 
@@ -90,7 +91,7 @@ describe("typed api client middleware", () => {
     expect(await requests[0].text()).toBe(JSON.stringify({ key_alias: "my-key" }));
   });
 
-  it("keeps the POST body as bytes when rebasing onto a runtime base url", async () => {
+  it("keeps the POST body as bytes when a different runtime base url is registered", async () => {
     registerBaseUrlGetter(() => "https://proxy.example.com");
     registerAuthTokenGetter(() => "sk-test");
     const { streamBodiedInits } = spyOnRequestConstruction();
@@ -106,6 +107,43 @@ describe("typed api client middleware", () => {
     expect(sent.headers.get("Content-Type")).toBe("application/json");
     expect(await sent.text()).toBe(JSON.stringify({ key_alias: "my-key" }));
   });
+
+  it("reads the base url on every call, so a base registered after import still takes effect", async () => {
+    const requests: Request[] = [];
+    const fetch = vi.fn(async (request: Request) => {
+      requests.push(request);
+      return jsonResponse(200, { data: [] });
+    });
+
+    registerBaseUrlGetter(() => "https://first.example.com");
+    await fetchClient.GET("/model_group/info", { fetch });
+    registerBaseUrlGetter(() => "https://second.example.com");
+    await fetchClient.GET("/model_group/info", { fetch });
+
+    expect(requests.map((request) => new URL(request.url).origin)).toEqual([
+      "https://first.example.com",
+      "https://second.example.com",
+    ]);
+  });
+
+  it("forwards the caller's abort signal so an in-flight request can be cancelled", async () => {
+    const controller = new AbortController();
+    const seen: Request[] = [];
+    const fetch = vi.fn(
+      (request: Request) =>
+        new Promise<Response>((_resolve, reject) => {
+          seen.push(request);
+          request.signal.addEventListener("abort", () => reject(new DOMException("Aborted", "AbortError")));
+        }),
+    );
+
+    const pending = fetchClient.GET("/model_group/info", { fetch, signal: controller.signal });
+    await vi.waitFor(() => expect(seen).toHaveLength(1));
+    controller.abort();
+
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    expect(seen[0].signal.aborted).toBe(true);
+  }, 5000);
 
   it("maps a non-2xx response to an ApiError carrying status and the derived message", async () => {
     const { fetch } = capturingFetch(jsonResponse(403, { error: { message: "no access" } }));

--- a/ui/litellm-dashboard/src/lib/http/api.ts
+++ b/ui/litellm-dashboard/src/lib/http/api.ts
@@ -4,38 +4,18 @@ import type { paths } from "./schema";
 import { ApiError, deriveErrorMessage } from "./client";
 import { getAuthHeaderName, getAuthToken, getRequestBaseUrl, reportError } from "./runtime";
 
-const rebaseUrl = (requestUrl: string, base: string): string => {
-  const { pathname, search } = new URL(requestUrl);
-  return `${base.replace(/\/+$/, "")}${pathname}${search}`;
-};
+const resolveRequestBase = (): string => (getRequestBaseUrl() || globalThis.location?.origin || "").replace(/\/+$/, "");
 
-const rebaseRequest = async (request: Request, url: string): Promise<Request> => {
-  const init: RequestInit = {
-    method: request.method,
-    headers: request.headers,
-    body: request.body ? await request.arrayBuffer() : undefined,
-    mode: request.mode,
-    credentials: request.credentials,
-    cache: request.cache,
-    redirect: request.redirect,
-    referrer: request.referrer,
-    referrerPolicy: request.referrerPolicy,
-    integrity: request.integrity,
-    keepalive: request.keepalive,
-    signal: request.signal,
-  };
-  return new Request(url, init);
-};
+const BaseAwareRequest = function (url: string, init?: RequestInit): Request {
+  return new globalThis.Request(`${resolveRequestBase()}${url}`, init);
+} as unknown as typeof Request;
 
 const middleware: Middleware = {
-  async onRequest({ request }) {
-    const base = getRequestBaseUrl();
-    const next = base ? await rebaseRequest(request, rebaseUrl(request.url, base)) : request;
+  onRequest({ request }) {
     const token = getAuthToken();
     if (token) {
-      next.headers.set(getAuthHeaderName(), `Bearer ${token}`);
+      request.headers.set(getAuthHeaderName(), `Bearer ${token}`);
     }
-    return next;
   },
   async onResponse({ response }) {
     if (response.ok) return response;
@@ -58,12 +38,13 @@ const middleware: Middleware = {
  * (`fetchClient.GET("/path", { params })`) and for imperative calls; path
  * params, query params, and request bodies are inferred from schema.d.ts.
  *
- * The creation-time base is the current origin so request URLs are absolute; the
- * middleware rebases each call onto the runtime base when one is registered (a
- * split-origin proxy or worker URL), injects the auth header, and maps non-2xx
- * responses to ApiError so query functions can just read `.data`.
+ * The base URL is injected, not fixed at import: every request is built against
+ * whatever registerBaseUrlGetter supplies at call time (a split-origin proxy or
+ * worker URL), falling back to the current origin. The middleware injects the
+ * auth header and maps non-2xx responses to ApiError so query functions can just
+ * read `.data`.
  */
-export const fetchClient = createFetchClient<paths>({ baseUrl: globalThis.location?.origin ?? "" });
+export const fetchClient = createFetchClient<paths>({ Request: BaseAwareRequest });
 fetchClient.use(middleware);
 
 /**

--- a/ui/litellm-dashboard/src/lib/http/api.ts
+++ b/ui/litellm-dashboard/src/lib/http/api.ts
@@ -3,11 +3,14 @@ import createQueryClient from "openapi-react-query";
 import type { paths } from "./schema";
 import { ApiError, deriveErrorMessage } from "./client";
 import { getAuthHeaderName, getAuthToken, getRequestBaseUrl, reportError } from "./runtime";
-
-const resolveRequestBase = (): string => (getRequestBaseUrl() || globalThis.location?.origin || "").replace(/\/+$/, "");
+import { resolveRequestUrl } from "./resolveApiBase";
 
 const BaseAwareRequest = function (url: string, init?: RequestInit): Request {
-  return new globalThis.Request(`${resolveRequestBase()}${url}`, init);
+  const target = resolveRequestUrl(url, {
+    registeredBase: getRequestBaseUrl(),
+    pageOrigin: globalThis.location?.origin,
+  });
+  return new globalThis.Request(target, init);
 } as unknown as typeof Request;
 
 const middleware: Middleware = {

--- a/ui/litellm-dashboard/src/lib/http/resolveApiBase.test.ts
+++ b/ui/litellm-dashboard/src/lib/http/resolveApiBase.test.ts
@@ -1,5 +1,41 @@
 import { describe, expect, it } from "vitest";
-import { resolveApiBase } from "./resolveApiBase";
+import { resolveApiBase, resolveRequestUrl } from "./resolveApiBase";
+
+describe("resolveRequestUrl", () => {
+  it("targets the registered base when one is registered", () => {
+    expect(
+      resolveRequestUrl("/model_group/info", {
+        registeredBase: "https://proxy.example.com",
+        pageOrigin: "http://localhost:3000",
+      }),
+    ).toBe("https://proxy.example.com/model_group/info");
+  });
+
+  it("falls back to the page origin when no base is registered", () => {
+    expect(resolveRequestUrl("/model_group/info", { registeredBase: "", pageOrigin: "http://localhost:3000" })).toBe(
+      "http://localhost:3000/model_group/info",
+    );
+  });
+
+  it("trims a trailing slash so the path is not doubled up", () => {
+    expect(resolveRequestUrl("/model_group/info", { registeredBase: "https://proxy.example.com/" })).toBe(
+      "https://proxy.example.com/model_group/info",
+    );
+  });
+
+  it("keeps the path relative when neither a base nor an origin is available", () => {
+    expect(resolveRequestUrl("/model_group/info", {})).toBe("/model_group/info");
+    expect(resolveRequestUrl("/model_group/info", { registeredBase: null, pageOrigin: null })).toBe(
+      "/model_group/info",
+    );
+  });
+
+  it("preserves an already-serialized query string", () => {
+    expect(
+      resolveRequestUrl("/model_group/info?model_group=gpt-4o", { registeredBase: "https://proxy.example.com" }),
+    ).toBe("https://proxy.example.com/model_group/info?model_group=gpt-4o");
+  });
+});
 
 describe("resolveApiBase", () => {
   describe("same-origin (no explicit base)", () => {

--- a/ui/litellm-dashboard/src/lib/http/resolveApiBase.ts
+++ b/ui/litellm-dashboard/src/lib/http/resolveApiBase.ts
@@ -33,3 +33,15 @@ export const resolveApiBase = ({ explicitBase, serverRootPath }: ApiBaseInputs):
   if (rootPath === "" || base.endsWith(rootPath)) return base;
   return `${base}${rootPath}`;
 };
+
+export interface RequestUrlInputs {
+  /** Base registered at runtime (a split-origin proxy or worker URL); empty means none. */
+  registeredBase?: string | null;
+  /** Origin of the page issuing the request; the same-origin fallback. */
+  pageOrigin?: string | null;
+}
+
+export const resolveRequestUrl = (path: string, { registeredBase, pageOrigin }: RequestUrlInputs): string => {
+  const base = (registeredBase || pageOrigin || "").replace(/\/+$/, "");
+  return `${base}${path}`;
+};

--- a/ui/litellm-dashboard/tests/setupTests.ts
+++ b/ui/litellm-dashboard/tests/setupTests.ts
@@ -183,78 +183,80 @@ vi.spyOn(Date.prototype, "toLocaleString").mockImplementation(function (this: Da
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 });
 
-// Fixed matchMedia not found error in tests: https://github.com/vitest-dev/vitest/issues/821
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: (query: string) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  }),
-});
+if (typeof window !== "undefined") {
+  // Fixed matchMedia not found error in tests: https://github.com/vitest-dev/vitest/issues/821
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
 
-// Silence jsdom "getComputedStyle with pseudo-elements" not implemented warnings
-// by ignoring the second argument and delegating to the native implementation.
-const realGetComputedStyle = window.getComputedStyle.bind(window);
-window.getComputedStyle = ((elt: Element) => realGetComputedStyle(elt)) as any;
+  // Silence jsdom "getComputedStyle with pseudo-elements" not implemented warnings
+  // by ignoring the second argument and delegating to the native implementation.
+  const realGetComputedStyle = window.getComputedStyle.bind(window);
+  window.getComputedStyle = ((elt: Element) => realGetComputedStyle(elt)) as any;
 
-// Avoid "navigation to another Document" warnings when clicking <a> with blob: URLs
-// used by download flows in tests.
-Object.defineProperty(HTMLAnchorElement.prototype, "click", {
-  configurable: true,
-  writable: true,
-  value: vi.fn(),
-});
+  // Avoid "navigation to another Document" warnings when clicking <a> with blob: URLs
+  // used by download flows in tests.
+  Object.defineProperty(HTMLAnchorElement.prototype, "click", {
+    configurable: true,
+    writable: true,
+    value: vi.fn(),
+  });
 
-if (!document.getAnimations) {
-  document.getAnimations = () => [];
-}
-
-// Stub URL.revokeObjectURL so vi.spyOn can intercept it in tests
-if (!URL.revokeObjectURL) {
-  URL.revokeObjectURL = () => {};
-}
-
-// Mock ResizeObserver for components that use it (recharts, Tremor UI components).
-// JSDOM has no layout, so for observers inside a shadcn ChartContainer ([data-slot="chart"])
-// the mock immediately reports a fixed 800x400 box; recharts renders nothing until it
-// observes a size. Scoped to chart subtrees only: firing for every observer re-enters
-// React mid-effect for tremor/headlessui consumers whose tests assume the old no-op
-// (chart text would duplicate getByText targets, popover clicks go stale). Widen or
-// drop the scoping once tremor is gone.
-const MOCK_RESIZE_BOX = { inlineSize: 800, blockSize: 400 };
-const MOCK_RESIZE_RECT: DOMRectReadOnly = {
-  width: 800,
-  height: 400,
-  top: 0,
-  left: 0,
-  bottom: 400,
-  right: 800,
-  x: 0,
-  y: 0,
-  toJSON: () => ({}),
-};
-global.ResizeObserver = class ResizeObserver {
-  private readonly callback: ResizeObserverCallback;
-  constructor(callback: ResizeObserverCallback) {
-    this.callback = callback;
+  if (!document.getAnimations) {
+    document.getAnimations = () => [];
   }
-  observe(target: Element) {
-    if (!target.closest('[data-slot="chart"]')) return;
-    const entry: ResizeObserverEntry = {
-      target,
-      contentRect: MOCK_RESIZE_RECT,
-      borderBoxSize: [MOCK_RESIZE_BOX],
-      contentBoxSize: [MOCK_RESIZE_BOX],
-      devicePixelContentBoxSize: [MOCK_RESIZE_BOX],
-    };
-    this.callback([entry], this);
+
+  // Stub URL.revokeObjectURL so vi.spyOn can intercept it in tests
+  if (!URL.revokeObjectURL) {
+    URL.revokeObjectURL = () => {};
   }
-  unobserve() {}
-  disconnect() {}
-};
+
+  // Mock ResizeObserver for components that use it (recharts, Tremor UI components).
+  // JSDOM has no layout, so for observers inside a shadcn ChartContainer ([data-slot="chart"])
+  // the mock immediately reports a fixed 800x400 box; recharts renders nothing until it
+  // observes a size. Scoped to chart subtrees only: firing for every observer re-enters
+  // React mid-effect for tremor/headlessui consumers whose tests assume the old no-op
+  // (chart text would duplicate getByText targets, popover clicks go stale). Widen or
+  // drop the scoping once tremor is gone.
+  const MOCK_RESIZE_BOX = { inlineSize: 800, blockSize: 400 };
+  const MOCK_RESIZE_RECT: DOMRectReadOnly = {
+    width: 800,
+    height: 400,
+    top: 0,
+    left: 0,
+    bottom: 400,
+    right: 800,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  };
+  global.ResizeObserver = class ResizeObserver {
+    private readonly callback: ResizeObserverCallback;
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback;
+    }
+    observe(target: Element) {
+      if (!target.closest('[data-slot="chart"]')) return;
+      const entry: ResizeObserverEntry = {
+        target,
+        contentRect: MOCK_RESIZE_RECT,
+        borderBoxSize: [MOCK_RESIZE_BOX],
+        contentBoxSize: [MOCK_RESIZE_BOX],
+        devicePixelContentBoxSize: [MOCK_RESIZE_BOX],
+      };
+      this.callback([entry], this);
+    }
+    unobserve() {}
+    disconnect() {}
+  };
+}


### PR DESCRIPTION
## TLDR

Problem this solves:

- `api.ts` read `globalThis.location` at module import
- Creation-time `baseUrl` and the runtime rebase overlapped
- Rebasing hand-copied eleven `RequestInit` fields, including `signal`
- `api.test.ts` was pinned to jsdom for no real reason

How it solves it:

- Inject openapi-fetch's `Request` so the base applies per call
- Delete `rebaseUrl` and `rebaseRequest` entirely
- `registerBaseUrlGetter` becomes the only source of the base
- `api.test.ts` runs under `@vitest-environment node`, no stub

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Captured at a6b9cedd03 against a live proxy on `localhost:4000` with the dashboard dev server on `localhost:3000`, so the page origin and the API origin genuinely differ. That split-origin shape is the one the deleted rebase path existed for

Boot both, then sign in at `http://localhost:4000/ui/` so the session cookie is set for `localhost`:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload 2>&1 | tee litellm.log
```

```bash
cd ui/litellm-dashboard && NEXT_PUBLIC_BASE_URL=http://localhost:4000 npm run dev
```

1. Open `http://localhost:3000/users/` and click the "Default User Settings" tab
2. In devtools Network, confirm the request leaves the `:3000` page for `:4000` and is preflighted, which only happens because it really is cross-origin:

```
OPTIONS http://localhost:4000/get/internal_user_settings -> 200 OK
GET     http://localhost:4000/get/internal_user_settings -> 200 OK
```

3. Confirm the rendered panel matches the API exactly:

```bash
curl -s http://localhost:4000/get/internal_user_settings -H "Authorization: Bearer $LITELLM_MASTER_KEY"
```

```json
{"values":{"user_role":"internal_user_viewer","max_budget":null,"budget_duration":null,"models":null,"teams":null}, ...}
```

The panel showed "Default Role: Internal User (View Only)" and "Max Budget (USD): Not set", matching that payload

4. Open `http://localhost:3000/organizations/`, click "+ Create New Organization", give it a name and submit. This is the body-carrying path that used to re-buffer through `arrayBuffer()`; it now hands openapi-fetch's serialized body straight to the platform `Request`:

```
OPTIONS http://localhost:4000/organization/new -> 200 OK
POST    http://localhost:4000/organization/new -> 200 OK
```

The UI showed "Organization created successfully" and the row appeared in the table. I deleted the probe organization afterwards, so the run left no state behind

Full dashboard vitest suite on the same machine, before and after, both exit 0:

```
before  Test Files  579 passed (579)      Tests  6049 passed (6049)
after   Test Files  580 passed (580)      Tests  6058 passed (6058)
```

The extra file is `api.sameOrigin.test.ts`; the extra tests are the regressions described below

## Type

🧹 Refactoring

## Changes

`fetchClient` no longer takes a `baseUrl`. It takes openapi-fetch's public `Request` option instead, and that constructor prefixes whatever `getRequestBaseUrl()` returns at the moment the request is built. The base URL therefore comes entirely from `registerBaseUrlGetter`, which `networking.tsx` already wires to `getProxyBaseUrl`, and nothing is captured at import

This preserves behaviour rather than approximating it. `getProxyBaseUrl()` falls back to `location.origin`, so in a browser the runtime base was never empty, which means the old middleware rebased every single request and discarded the creation-time `baseUrl` on every call. Removing it changes no URL the dashboard actually produces

The base-vs-origin precedence, the trailing-slash trim and the base+path join live in `resolveApiBase.ts` as `resolveRequestUrl`, next to the rest of base resolution, with their own unit tests. `api.ts` holds no resolution logic; it wires that shared resolver into openapi-fetch's `Request` option

`rebaseUrl` and `rebaseRequest` are gone. The request is constructed once, so the `RequestInit` openapi-fetch assembled reaches the platform `Request` untouched. The abort signal is no longer copied by hand, which is what the doc comment on `$api` promises; forwarding it is now structurally guaranteed rather than merely correct today

One consequence worth flagging for future editors, since this codebase does not carry explanatory comments: openapi-fetch validates a middleware's return value with `instanceof` against the injected constructor, so `onRequest` here mutates the request it is given and returns nothing. Returning the request would throw `onRequest: must return new Request() or Response()`. Every test in `api.test.ts` fails immediately if that changes

`tests/setupTests.ts` gates its DOM-only tail behind `typeof window !== "undefined"`. Setup files run for every environment, and that tail dereferenced `window` at module scope, so no node-environment test file could load at all. Ignoring whitespace the change is two lines; the rest of that diff is the reindent, so review it with `git diff -w`

`api.test.ts` moves to `@vitest-environment node` with every existing assertion intact and no `location` stub, and gains two regressions: one proving the base is read per call rather than captured at import, one proving the caller's abort signal still reaches the request and still cancels it. `api.sameOrigin.test.ts` covers the fallback to the page origin, which only a DOM environment can express

I checked each new assertion actually bites by mutating the source: dropping the signal, freezing the base at import, removing the same-origin fallback, skipping header injection, and hardcoding the header name each fail the suite. I also confirmed the existing `vi.stubGlobal("Request")` spy still observes construction, so the two POST body-shape assertions did not quietly become vacuous

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
