### PR TITLE
fix(azure_storage): honor AZURE_STORAGE_ENDPOINT_SUFFIX for sovereign clouds

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -1305,6 +1305,7 @@ RESPONSE_FORMAT_TOOL_NAME = "json_tool_call"  # default tool name used when conv
 
 ########################### Logging Callback Constants ###########################
 AZURE_STORAGE_MSFT_VERSION: Final = "2019-07-07"
+AZURE_STORAGE_DEFAULT_ENDPOINT_SUFFIX: Final = "core.windows.net"
 PROMETHEUS_BUDGET_METRICS_REFRESH_INTERVAL_MINUTES: Final = int(
     os.getenv("PROMETHEUS_BUDGET_METRICS_REFRESH_INTERVAL_MINUTES", 5)
 )

--- a/litellm/integrations/azure_storage/azure_storage.py
+++ b/litellm/integrations/azure_storage/azure_storage.py
@@ -6,7 +6,11 @@ from typing import Final
 
 from litellm._logging import verbose_logger
 from litellm._uuid import uuid
-from litellm.constants import _DEFAULT_TTL_FOR_HTTPX_CLIENTS, AZURE_STORAGE_MSFT_VERSION
+from litellm.constants import (
+    _DEFAULT_TTL_FOR_HTTPX_CLIENTS,
+    AZURE_STORAGE_DEFAULT_ENDPOINT_SUFFIX,
+    AZURE_STORAGE_MSFT_VERSION,
+)
 from litellm.integrations.custom_batch_logger import CustomBatchLogger
 from litellm.litellm_core_utils.safe_json_dumps import safe_dumps
 from litellm.llms.azure.common_utils import get_azure_ad_token_from_entra_id
@@ -41,6 +45,9 @@ class AzureBlobStorageLogger(CustomBatchLogger):
             if not _azure_storage_file_system:
                 raise ValueError("Missing required environment variable: AZURE_STORAGE_FILE_SYSTEM")
             self.azure_storage_file_system: str = _azure_storage_file_system
+            self.azure_storage_endpoint_suffix: str = (
+                os.getenv("AZURE_STORAGE_ENDPOINT_SUFFIX") or AZURE_STORAGE_DEFAULT_ENDPOINT_SUFFIX
+            )
             self._service_client = None
             # Time that the azure service client expires, in order to reset the connection pool and keep it fresh
             self._service_client_timeout: float | None = None
@@ -58,6 +65,14 @@ class AzureBlobStorageLogger(CustomBatchLogger):
                 "AzureBlobStorageLogger: Got exception on init AzureBlobStorageLogger client %s", e
             )
             raise e
+
+    @property
+    def azure_storage_dfs_endpoint(self) -> str:
+        return f"https://{self.azure_storage_account_name}.dfs.{self.azure_storage_endpoint_suffix}"
+
+    @property
+    def azure_storage_blob_endpoint(self) -> str:
+        return f"https://{self.azure_storage_account_name}.blob.{self.azure_storage_endpoint_suffix}"
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         """
@@ -144,7 +159,7 @@ class AzureBlobStorageLogger(CustomBatchLogger):
                 json_payload: Final = safe_dumps(payload) + "\n"  # Add newline for each log entry
                 payload_bytes: Final = json_payload.encode("utf-8")
                 filename: Final = f"{payload.get('id') or str(uuid.uuid4())}.json"
-                base_url = f"https://{self.azure_storage_account_name}.dfs.core.windows.net/{self.azure_storage_file_system}/{filename}"
+                base_url = f"{self.azure_storage_dfs_endpoint}/{self.azure_storage_file_system}/{filename}"
 
                 # Execute the 3-step upload process
                 await self._create_file(async_client, base_url)
@@ -296,7 +311,7 @@ class AzureBlobStorageLogger(CustomBatchLogger):
             self._service_client = None
         if not self._service_client:
             self._service_client = DataLakeServiceClient(
-                account_url=f"https://{self.azure_storage_account_name}.dfs.core.windows.net",
+                account_url=self.azure_storage_dfs_endpoint,
                 credential=self.azure_storage_account_key,
             )
             self._service_client_timeout = time.time() + _DEFAULT_TTL_FOR_HTTPX_CLIENTS

--- a/litellm/llms/base_llm/files/azure_blob_storage_backend.py
+++ b/litellm/llms/base_llm/files/azure_blob_storage_backend.py
@@ -8,7 +8,7 @@ to reuse all authentication and Azure Storage operations.
 
 import time
 from typing import Final
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 from litellm._logging import verbose_logger
 from litellm._uuid import uuid
@@ -47,6 +47,8 @@ class AzureBlobStorageBackend(BaseFileStorageBackend, AzureBlobStorageLogger):
         - AZURE_STORAGE_TENANT_ID (optional, if using Azure AD)
         - AZURE_STORAGE_CLIENT_ID (optional, if using Azure AD)
         - AZURE_STORAGE_CLIENT_SECRET (optional, if using Azure AD)
+        - AZURE_STORAGE_ENDPOINT_SUFFIX (optional, defaults to core.windows.net; set to
+          core.usgovcloudapi.net or another sovereign-cloud suffix as needed)
 
         Note: We skip periodic_flush since we're not using this as a logger.
         """
@@ -103,7 +105,7 @@ class AzureBlobStorageBackend(BaseFileStorageBackend, AzureBlobStorageLogger):
         """
         Upload a file to Azure Blob Storage.
 
-        Returns the blob URL in format: https://{account}.blob.core.windows.net/{container}/{path}
+        Returns the blob URL in format: https://{account}.blob.{endpoint_suffix}/{container}/{path}
         """
         try:
             # Generate file name
@@ -172,7 +174,7 @@ class AzureBlobStorageBackend(BaseFileStorageBackend, AzureBlobStorageLogger):
         await file_client.flush_data(position=len(file_content), offset=0)
 
         # Return blob URL (not DFS URL)
-        blob_url = f"https://{self.azure_storage_account_name}.blob.core.windows.net/{self.azure_storage_file_system}/{full_path}"
+        blob_url = f"{self.azure_storage_blob_endpoint}/{self.azure_storage_file_system}/{full_path}"
         return blob_url
 
     async def _upload_file_with_azure_ad(self, file_content: bytes, full_path: str) -> str:
@@ -188,7 +190,7 @@ class AzureBlobStorageBackend(BaseFileStorageBackend, AzureBlobStorageLogger):
         async_client: Final = get_async_httpx_client(llm_provider=httpxSpecialProvider.LoggingCallback)
 
         # Use DFS endpoint for upload
-        base_url = f"https://{self.azure_storage_account_name}.dfs.core.windows.net/{self.azure_storage_file_system}/{full_path}"
+        base_url = f"{self.azure_storage_dfs_endpoint}/{self.azure_storage_file_system}/{full_path}"
 
         # Execute 3-step upload process: create, append, flush
         # Reuse the logger's helper methods
@@ -198,7 +200,7 @@ class AzureBlobStorageBackend(BaseFileStorageBackend, AzureBlobStorageLogger):
         await self._flush_data(async_client, base_url, len(file_content))
 
         # Return blob URL (not DFS URL)
-        blob_url = f"https://{self.azure_storage_account_name}.blob.core.windows.net/{self.azure_storage_file_system}/{full_path}"
+        blob_url = f"{self.azure_storage_blob_endpoint}/{self.azure_storage_file_system}/{full_path}"
         return blob_url
 
     async def _append_data_bytes(self, client, base_url: str, file_content: bytes):
@@ -222,23 +224,22 @@ class AzureBlobStorageBackend(BaseFileStorageBackend, AzureBlobStorageLogger):
         Download a file from Azure Blob Storage.
 
         Args:
-            storage_url: Blob URL in format: https://{account}.blob.core.windows.net/{container}/{path}
+            storage_url: Blob URL in format: https://{account}.blob.{endpoint_suffix}/{container}/{path}
 
         Returns:
             bytes: File content
         """
         try:
             # Parse blob URL to extract path
-            # URL format: https://{account}.blob.core.windows.net/{container}/{path}
-            if ".blob.core.windows.net/" not in storage_url:
+            # URL format: https://{account}.blob.{endpoint_suffix}/{container}/{path}
+            parsed_url: Final = urlparse(storage_url)
+            if ".blob." not in (parsed_url.hostname or ""):
                 raise ValueError(f"Invalid Azure Blob Storage URL: {storage_url}")
 
             # Extract path after container name
-            container_and_path: Final = storage_url.split(".blob.core.windows.net/", 1)[1]
-            path_parts: Final = container_and_path.split("/", 1)
-            if len(path_parts) < 2:
+            _, _, file_path = parsed_url.path.lstrip("/").partition("/")
+            if not file_path:
                 raise ValueError(f"Invalid Azure Blob Storage URL format: {storage_url}")
-            file_path: Final = path_parts[1]  # Path after container name
 
             if self.azure_storage_account_key:
                 # Use Azure SDK (reuse logger's service client)
@@ -279,7 +280,7 @@ class AzureBlobStorageBackend(BaseFileStorageBackend, AzureBlobStorageLogger):
         async_client: Final = get_async_httpx_client(llm_provider=httpxSpecialProvider.LoggingCallback)
 
         # Use blob endpoint for download (simpler than DFS)
-        blob_url = f"https://{self.azure_storage_account_name}.blob.core.windows.net/{self.azure_storage_file_system}/{file_path}"
+        blob_url = f"{self.azure_storage_blob_endpoint}/{self.azure_storage_file_system}/{file_path}"
 
         headers: Final = {
             "x-ms-version": AZURE_STORAGE_MSFT_VERSION,

--- a/tests/test_litellm/integrations/azure_storage/test_azure_storage.py
+++ b/tests/test_litellm/integrations/azure_storage/test_azure_storage.py
@@ -20,6 +20,13 @@ def mock_env_vars(monkeypatch):
     monkeypatch.setenv("AZURE_STORAGE_TENANT_ID", "test-tenant-id")
     monkeypatch.setenv("AZURE_STORAGE_CLIENT_ID", "test-client-id")
     monkeypatch.setenv("AZURE_STORAGE_CLIENT_SECRET", "test-client-secret")
+    monkeypatch.delenv("AZURE_STORAGE_ENDPOINT_SUFFIX", raising=False)
+
+
+@pytest.fixture
+def mock_gov_env_vars(mock_env_vars, monkeypatch):
+    """Point the logger at an Azure Government storage account"""
+    monkeypatch.setenv("AZURE_STORAGE_ENDPOINT_SUFFIX", "core.usgovcloudapi.net")
 
 
 @pytest.mark.asyncio
@@ -99,3 +106,76 @@ async def test_async_upload_payload_to_azure_blob_storage(mock_env_vars):
 
         # Verify raise_for_status was called on all responses
         assert mock_response.raise_for_status.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_async_upload_payload_uses_configured_endpoint_suffix(mock_gov_env_vars):
+    """
+    AZURE_STORAGE_ENDPOINT_SUFFIX must reach the Entra-ID REST upload path so a
+    sovereign-cloud account is addressed instead of the commercial dfs host.
+    """
+    with patch(
+        "litellm.integrations.azure_storage.azure_storage.get_async_httpx_client"
+    ) as mock_get_client:
+        mock_http_client = AsyncMock()
+        mock_response = MagicMock()
+        mock_http_client.put.return_value = mock_response
+        mock_http_client.patch.return_value = mock_response
+        mock_get_client.return_value = mock_http_client
+
+        logger = AzureBlobStorageLogger()
+        logger.azure_auth_token = "mock-azure-ad-token"
+        logger.token_expiry = None
+
+        test_payload: StandardLoggingPayload = {"id": "gov-log-id"}
+
+        await logger.async_upload_payload_to_azure_blob_storage(test_payload)
+
+        expected_base_url = (
+            "https://test-account.dfs.core.usgovcloudapi.net/test-container/gov-log-id.json"
+        )
+        assert mock_http_client.put.call_args[0][0] == f"{expected_base_url}?resource=file"
+        assert (
+            mock_http_client.patch.call_args_list[0][0][0]
+            == f"{expected_base_url}?action=append&position=0"
+        )
+        assert mock_http_client.patch.call_args_list[1][0][0].startswith(
+            f"{expected_base_url}?action=flush"
+        )
+
+
+@pytest.mark.asyncio
+async def test_service_client_uses_configured_endpoint_suffix(mock_gov_env_vars):
+    """
+    The account key path builds its own account_url; the Azure SDK derives the blob
+    host from it, so the suffix has to be applied here too.
+    """
+    fake_aio_module = MagicMock()
+
+    with patch.dict(
+        sys.modules, {"azure.storage.filedatalake.aio": fake_aio_module}
+    ):
+        logger = AzureBlobStorageLogger()
+        await logger.get_service_client()
+
+    assert (
+        fake_aio_module.DataLakeServiceClient.call_args.kwargs["account_url"]
+        == "https://test-account.dfs.core.usgovcloudapi.net"
+    )
+
+
+@pytest.mark.asyncio
+async def test_service_client_defaults_to_commercial_endpoint(mock_env_vars):
+    """Unset AZURE_STORAGE_ENDPOINT_SUFFIX keeps the pre-existing commercial host"""
+    fake_aio_module = MagicMock()
+
+    with patch.dict(
+        sys.modules, {"azure.storage.filedatalake.aio": fake_aio_module}
+    ):
+        logger = AzureBlobStorageLogger()
+        await logger.get_service_client()
+
+    assert (
+        fake_aio_module.DataLakeServiceClient.call_args.kwargs["account_url"]
+        == "https://test-account.dfs.core.windows.net"
+    )

--- a/tests/test_litellm/llms/base_llm/files/test_azure_blob_storage_backend.py
+++ b/tests/test_litellm/llms/base_llm/files/test_azure_blob_storage_backend.py
@@ -1,0 +1,226 @@
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from litellm.llms.base_llm.files.azure_blob_storage_backend import (
+    AzureBlobStorageBackend,
+)
+
+GOV_SUFFIX = "core.usgovcloudapi.net"
+
+
+@pytest.fixture
+def mock_env_vars(monkeypatch):
+    """Azure AD (no account key) configuration for the files backend"""
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_NAME", "test-account")
+    monkeypatch.setenv("AZURE_STORAGE_FILE_SYSTEM", "test-container")
+    monkeypatch.setenv("AZURE_STORAGE_TENANT_ID", "test-tenant-id")
+    monkeypatch.setenv("AZURE_STORAGE_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("AZURE_STORAGE_CLIENT_SECRET", "test-client-secret")
+    monkeypatch.delenv("AZURE_STORAGE_ACCOUNT_KEY", raising=False)
+    monkeypatch.delenv("AZURE_STORAGE_ENDPOINT_SUFFIX", raising=False)
+
+
+@pytest.fixture
+def mock_gov_env_vars(mock_env_vars, monkeypatch):
+    monkeypatch.setenv("AZURE_STORAGE_ENDPOINT_SUFFIX", GOV_SUFFIX)
+
+
+def _make_backend() -> AzureBlobStorageBackend:
+    backend = AzureBlobStorageBackend()
+    backend.azure_auth_token = "mock-azure-ad-token"
+    backend.token_expiry = None
+    return backend
+
+
+def _mock_upload_client() -> AsyncMock:
+    client = AsyncMock()
+    response = MagicMock()
+    client.put = AsyncMock(return_value=response)
+    client.patch = AsyncMock(return_value=response)
+    return client
+
+
+@pytest.mark.parametrize(
+    "env_fixture, expected_suffix",
+    [("mock_env_vars", "core.windows.net"), ("mock_gov_env_vars", GOV_SUFFIX)],
+)
+@pytest.mark.asyncio
+async def test_upload_file_with_azure_ad_honors_endpoint_suffix(request, env_fixture, expected_suffix):
+    """
+    The REST upload targets the dfs host and the returned handle is a blob URL, so both
+    have to follow AZURE_STORAGE_ENDPOINT_SUFFIX or a sovereign-cloud account is unreachable.
+    """
+    request.getfixturevalue(env_fixture)
+    client = _mock_upload_client()
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.get_async_httpx_client",
+        return_value=client,
+    ):
+        backend = _make_backend()
+        storage_url = await backend.upload_file(
+            file_content=b"hello",
+            filename="report.json",
+            content_type="application/json",
+            path_prefix="logs",
+            file_naming_strategy="original_filename",
+        )
+
+    expected_dfs = f"https://test-account.dfs.{expected_suffix}/test-container/logs/report.json"
+    assert client.put.call_args[0][0] == f"{expected_dfs}?resource=file"
+    assert client.patch.call_args_list[0][0][0] == f"{expected_dfs}?action=append&position=0"
+    assert storage_url == f"https://test-account.blob.{expected_suffix}/test-container/logs/report.json"
+
+
+@pytest.mark.parametrize(
+    "env_fixture, expected_suffix",
+    [("mock_env_vars", "core.windows.net"), ("mock_gov_env_vars", GOV_SUFFIX)],
+)
+@pytest.mark.asyncio
+async def test_download_file_honors_endpoint_suffix(request, env_fixture, expected_suffix):
+    """
+    download_file both validates and splits the stored blob URL on the host, so a
+    sovereign-cloud URL must parse and round-trip back to the same host.
+    """
+    request.getfixturevalue(env_fixture)
+    response = MagicMock()
+    response.content = b"file-bytes"
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response)
+
+    storage_url = f"https://test-account.blob.{expected_suffix}/test-container/logs/report.json"
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.get_async_httpx_client",
+        return_value=client,
+    ):
+        backend = _make_backend()
+        content = await backend.download_file(storage_url)
+
+    assert content == b"file-bytes"
+    assert client.get.call_args[0][0] == storage_url
+
+
+@pytest.mark.asyncio
+async def test_download_file_accepts_url_persisted_before_the_suffix_was_set(mock_gov_env_vars):
+    """
+    storage_url is persisted in the managed files table while the suffix is process config,
+    so rows written before the suffix was configured must still resolve. Only the path after
+    the container is taken from the stored URL; the host comes from the current config.
+    """
+    response = MagicMock()
+    response.content = b"file-bytes"
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response)
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.get_async_httpx_client",
+        return_value=client,
+    ):
+        backend = _make_backend()
+        content = await backend.download_file(
+            "https://old-account.blob.core.windows.net/old-container/logs/report.json"
+        )
+
+    assert content == b"file-bytes"
+    assert (
+        client.get.call_args[0][0]
+        == f"https://test-account.blob.{GOV_SUFFIX}/test-container/logs/report.json"
+    )
+
+
+@pytest.mark.parametrize(
+    "storage_url",
+    [
+        "https://example-bucket.s3.amazonaws.com/container/report.json",
+        "https://example.com/download?u=.blob.core.windows.net/container/report.json",
+        "mygovacct.blob.core.windows.net/container/report.json",
+    ],
+    ids=["other-provider", "blob-host-only-in-query", "no-scheme"],
+)
+@pytest.mark.asyncio
+async def test_download_file_rejects_url_whose_host_is_not_an_azure_blob_host(mock_env_vars, storage_url):
+    """
+    The host is checked on the parsed hostname, so a blob host appearing anywhere else in the
+    string no longer passes. No first-party producer emits these, and rejecting beats issuing a
+    request built from a mis-split path.
+    """
+    client = AsyncMock()
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.get_async_httpx_client",
+        return_value=client,
+    ):
+        backend = _make_backend()
+
+        with pytest.raises(ValueError, match="Invalid Azure Blob Storage URL"):
+            await backend.download_file(storage_url)
+
+    client.get.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_download_file_drops_query_string_from_the_stored_url(mock_env_vars):
+    """A query string on the stored URL is not part of the blob path and must not reach the request"""
+    response = MagicMock()
+    response.content = b"file-bytes"
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=response)
+
+    with patch(
+        "litellm.llms.custom_httpx.http_handler.get_async_httpx_client",
+        return_value=client,
+    ):
+        backend = _make_backend()
+        await backend.download_file(
+            "https://test-account.blob.core.windows.net/test-container/logs/report.json?sig=redacted&se=2026"
+        )
+
+    assert (
+        client.get.call_args[0][0]
+        == "https://test-account.blob.core.windows.net/test-container/logs/report.json"
+    )
+
+
+@pytest.mark.parametrize(
+    "env_fixture, expected_suffix",
+    [("mock_env_vars", "core.windows.net"), ("mock_gov_env_vars", GOV_SUFFIX)],
+)
+@pytest.mark.asyncio
+async def test_upload_file_with_account_key_honors_endpoint_suffix(request, env_fixture, expected_suffix, monkeypatch):
+    """The account key path returns its own blob URL, built independently of the REST path"""
+    request.getfixturevalue(env_fixture)
+    monkeypatch.setenv("AZURE_STORAGE_ACCOUNT_KEY", "dGVzdC1rZXk=")
+
+    file_client = MagicMock()
+    file_client.create_file = AsyncMock()
+    file_client.append_data = AsyncMock()
+    file_client.flush_data = AsyncMock()
+
+    directory_client = MagicMock()
+    directory_client.exists = AsyncMock(return_value=True)
+    directory_client.get_file_client = MagicMock(return_value=file_client)
+
+    file_system_client = MagicMock()
+    file_system_client.exists = AsyncMock(return_value=True)
+    file_system_client.get_directory_client = MagicMock(return_value=directory_client)
+
+    service_client = MagicMock()
+    service_client.get_file_system_client = MagicMock(return_value=file_system_client)
+
+    fake_aio_module = MagicMock()
+    fake_aio_module.DataLakeServiceClient = MagicMock(return_value=service_client)
+
+    with patch.dict(sys.modules, {"azure.storage.filedatalake.aio": fake_aio_module}):
+        backend = AzureBlobStorageBackend()
+        storage_url = await backend.upload_file(
+            file_content=b"hello",
+            filename="report.json",
+            content_type="application/json",
+            path_prefix="logs",
+            file_naming_strategy="original_filename",
+        )
+
+    assert storage_url == f"https://test-account.blob.{expected_suffix}/test-container/logs/report.json"


### PR DESCRIPTION
## TLDR

Problem this solves:

- Azure Government storage accounts are unreachable by `azure_storage`
- The commercial host is hardcoded in seven places
- No env var or config can override it

How it solves it:

- New `AZURE_STORAGE_ENDPOINT_SUFFIX`, defaulting to `core.windows.net`
- Both upload paths and the files backend build hosts from it
- URL parsing no longer pins the commercial host either

## Docs

Documented in BerriAI/litellm-docs#764, already merged. That had to land first: `tests/documentation_tests/test_env_keys.py` checks out the docs repo's default branch into `docs/my-website` and fails any env var read in `litellm/` that has no row in `config_settings.md`, so the `documentation` and `code-quality` checks here stayed red until it did

## Relevant issues

## Linear ticket

Resolves LIT-5154

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Everything below runs against a live proxy backed by real Postgres, driven by real Bedrock completions that cost real money. Evidence comes in two parts, because no single account can show both halves: a real commercial storage account proves the new code path genuinely writes and reads blobs, and a base-vs-head differential proves the endpoint now follows the configured cloud

The real-storage section was captured at `e86edcc254`, the current head. The sovereign section's before runs were captured at `cbeaf86c8d` and its after runs at `c4accb2021`, an earlier commit on this branch whose only later delta is a squash plus the removal of some `Final` annotations, neither of which touches behavior

### Real Azure Storage account

A real Data Lake Gen2 account, with `AZURE_STORAGE_ENDPOINT_SUFFIX` set EXPLICITLY to the commercial suffix. Same host as today, but the URL is built by the new env-var-driven property rather than by the old hardcoded string, so this exercises the changed code end to end against real storage

```bash
az storage account create -n <account> -g <rg> -l eastus --sku Standard_LRS --kind StorageV2 --hns true
```

One real Bedrock completion per leg, then list the container:

| tree | `AZURE_STORAGE_ENDPOINT_SUFFIX` | object actually written |
| --- | --- | --- |
| this PR | `core.windows.net` (explicit) | `2026-08-04/chatcmpl-3b9e8d74-...json`, 9794 bytes |
| this PR | unset | `2026-08-04/chatcmpl-e0641b28-...json`, 9789 bytes |
| base | unset | `2026-08-04/chatcmpl-2c62ec73-...json`, 9792 bytes |

Downloading the first object back shows it is the real log for that request:

```
id        : chatcmpl-3b9e8d74-eaf1-4b39-80fe-376e368a5704
call_type : acompletion
model     : bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0
status    : success
spend     : 0.00011220000000000002
response  : "sovereign"
```

The files backend round trips too, which exercises `upload_file` and the rewritten `download_file` against real storage:

```bash
curl -sS $PROXY/v1/files -H "Authorization: Bearer sk-1234" \
  -F "file=@lit5154_upload.txt;type=text/plain" -F "purpose=user_data" \
  -F "target_storage=azure_storage" -F "target_model_names=claude-sonnet"
# -> {"id":"bGl0ZWxsbV9wcm94eTp0ZXh0L3BsYWluO3VuaWZpZWRfaWQs...","bytes":34,"status":"uploaded"}

# storage_url persisted in Postgres
azure_storage|https://<account>.blob.core.windows.net/litellm-logs/6603e144-66d8-4e93-b151-d1588d1ba26a.txt

curl -sS $PROXY/v1/files/$FILE_ID/content -H "Authorization: Bearer sk-1234"
# -> hello from lit5154 real azure e2e
# -> HTTP 200
```

The account and resource group were deleted after the run

### What is not covered

No Azure Government subscription was available, so nothing here writes or reads a blob in a Government account. Sovereign support is evidenced by which host the code contacts, in the section below, plus the unit tests; it is not evidenced by a Gov round trip

That leaves a real but narrow gap. Everything downstream of the URL is Microsoft's own SDK, and on the account key path the SDK derives the blob host from the `account_url` litellm hands it, which the real-storage section above exercises. So what remains unproven is whether a given sovereign suffix value is correct for that cloud, not whether the mechanism works. Anyone with a Gov account can confirm by setting `AZURE_STORAGE_ENDPOINT_SUFFIX=core.usgovcloudapi.net` plus `AZURE_AUTHORITY_HOST=https://login.microsoftonline.us` and repeating the upload above

### Sovereign cloud targeting

Setup, identical for every run:

```bash
export AZURE_STORAGE_ACCOUNT_NAME=mygovacct
export AZURE_STORAGE_FILE_SYSTEM=litellm-logs
export AZURE_STORAGE_ENDPOINT_SUFFIX=core.usgovcloudapi.net   # ignored entirely before this PR
export AZURE_STORAGE_ACCOUNT_KEY=$(python3 -c "import base64;print(base64.b64encode(b'0'*32).decode())")
```

```yaml
model_list:
  - model_name: claude-sonnet
    litellm_params:
      model: bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0

litellm_settings:
  callbacks: ["azure_storage"]

general_settings:
  master_key: sk-1234
```

Drive a real completion through the proxy, then read back which host the callback tried to upload to:

```bash
curl -sS http://127.0.0.1:20154/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"claude-sonnet","messages":[{"role":"user","content":"Reply with the single word: government"}],"max_tokens":16}'

grep -oE "Cannot connect to host [A-Za-z0-9.-]+" litellm.log | sort -u
```

### Account key path, which is the reported failure

Before, at `cbeaf86c8d`:

```
{"choices":[{"message":{"content":"government",...}}],"usage":{"total_tokens":18},...}

LiteLLM:ERROR: azure_storage.py:348 - Error occurred: Cannot connect to host
mygovacct.blob.core.windows.net:443 ssl:default [nodename nor servname provided, or not known]
```

After, at `c4accb2021`:

```
{"choices":[{"message":{"content":"government",...}}],"usage":{"total_tokens":18},...}

LiteLLM:ERROR: azure_storage.py:365 - Error occurred: Cannot connect to host
mygovacct.blob.core.usgovcloudapi.net:443 ssl:default [nodename nor servname provided, or not known]
```

### Microsoft Entra ID path

Same rig with `AZURE_STORAGE_ACCOUNT_KEY` unset and `AZURE_STORAGE_TENANT_ID` / `AZURE_STORAGE_CLIENT_ID` / `AZURE_STORAGE_CLIENT_SECRET` set to a real service principal, so a genuine `https://storage.azure.com/.default` token is minted and the upload reaches DNS rather than failing at token acquisition

Before, at `cbeaf86c8d`:

```
httpx.ConnectError: Cannot connect to host mygovacct.dfs.core.windows.net:443
```

After, at `c4accb2021`:

```
httpx.ConnectError: Cannot connect to host mygovacct.dfs.core.usgovcloudapi.net:443
```

### Full matrix

Every leg is a separate live proxy run driven by a real Bedrock completion

| auth path | `AZURE_STORAGE_ENDPOINT_SUFFIX` | code | host the callback contacted |
| --- | --- | --- | --- |
| account key | `core.usgovcloudapi.net` | `cbeaf86c8d` | `mygovacct.blob.core.windows.net` |
| account key | `core.usgovcloudapi.net` | this PR | `mygovacct.blob.core.usgovcloudapi.net` |
| Entra ID | `core.usgovcloudapi.net` | `cbeaf86c8d` | `mygovacct.dfs.core.windows.net` |
| Entra ID | `core.usgovcloudapi.net` | this PR | `mygovacct.dfs.core.usgovcloudapi.net` |
| account key | unset | this PR | `mygovacct.blob.core.windows.net` |
| Entra ID | unset | this PR | `mygovacct.dfs.core.windows.net` |

The last two rows are the compatibility check; with the new variable unset, the host is byte-identical to today's behavior

### All three LLM endpoints

The callback consumes a `StandardLoggingPayload` and the host it builds cannot vary by endpoint, but here is one proxy run on this PR serving all three and producing three uploads, every one of them addressed to the sovereign host

```
$ curl /v1/chat/completions   -> 'government' | 18 tokens
$ curl /v1/messages           -> 'sovereign'  | input_tokens 14, output_tokens 4
$ curl /v1/responses          -> completed

distinct hosts contacted by the azure_storage callback:
   9 Cannot connect to host mygovacct.blob.core.usgovcloudapi.net
completed upload failures: 3
```

Nine connection attempts for three uploads is the Azure SDK's own retry policy

## Type

🐛 Bug Fix

## Changes

`AZURE_STORAGE_ENDPOINT_SUFFIX` is read once in `AzureBlobStorageLogger.__init__` alongside the other `AZURE_STORAGE_*` variables and defaults to `AZURE_STORAGE_DEFAULT_ENDPOINT_SUFFIX` in `litellm/constants.py`. Two properties, `azure_storage_dfs_endpoint` and `azure_storage_blob_endpoint`, derive the Data Lake and Blob hosts from it, and all seven previously hardcoded sites now go through them. `AzureBlobStorageBackend` subclasses the logger, so the files backend picks this up without its own configuration. The name matches Azure's own `EndpointSuffix=` connection string key

Authentication needed no change. `ClientSecretCredential` resolves its authority through `get_default_authority()`, which honors `AZURE_AUTHORITY_HOST`, and `https://storage.azure.com/.default` is the storage resource identifier in every cloud; Microsoft's own storage SDK hardcodes that single scope with no per-cloud variant

`download_file` used to require the literal `.blob.core.windows.net/` substring anywhere in the stored URL, then split on it. It now parses with `urlparse` and requires `.blob.` in the hostname. This is deliberately suffix-agnostic rather than pinned to the configured suffix: `storage_url` is persisted in `LiteLLM_ManagedFileTable`, while the suffix is process configuration, so keying the parse on the current suffix would break reads of rows written before the variable was set. The host in the stored URL was never used to route the download anyway; only the path after the container is taken from it, and the request is rebuilt from the configured account. Two incidental improvements fall out: a URL carrying the marker only in its query string is now rejected instead of mis-split, and a query string can no longer be glued onto the extracted file path

### Behavior changes

URL construction is unchanged when `AZURE_STORAGE_ENDPOINT_SUFFIX` is unset; the last two matrix rows and four of the unit tests pin that down

`download_file` is a different story, and an earlier revision of this description was wrong to call it strictly more permissive. Its accepted-input set moves in both directions. A base-vs-head A/B on two live proxies driving `GET /v1/files/{file_id}/content`, with rows seeded into `LiteLLM_ManagedFileTable`, gives this on the DEFAULT configuration with the new variable unset:

| stored `storage_url` | base | this PR |
| --- | --- | --- |
| `https://acct.blob.core.windows.net/c/f.json` | requests it | identical |
| `https://acct.blob.core.usgovcloudapi.net/c/f.json` | rejected | requests it from the configured account |
| `https://example.com/dl?u=.blob.core.windows.net/c/f.json` | accepted, path mis-split | rejected |
| `acct.blob.core.windows.net/c/f.json` (no scheme) | accepted | rejected |
| `https://acct.blob.core.windows.net/c/f.json?sig=...` | query carried into the request path | query dropped |

No first-party producer emits any of the newly rejected shapes. `upload_file` is the only writer of that column, it always emits `https://{account}.blob.{suffix}/{container}/{path}` with no query string, and no other code path writes `storage_url` or lets a caller supply one. Every row above is pinned by a test

## Tests

`tests/test_litellm/integrations/azure_storage/test_azure_storage.py` gains sovereign-cloud coverage for the Entra ID REST path and for the `DataLakeServiceClient` account URL, plus a default-suffix guard. `tests/test_litellm/llms/base_llm/files/test_azure_blob_storage_backend.py` is new, since the files backend had no mapped test; it covers both upload paths, the download round trip, a URL persisted before the suffix was configured, and rejection of a non-Azure URL

Reverting the fix while keeping the tests fails six of them and leaves the six default-path guards green, so every one of the seven construction sites and the parse has a test that dies with it. The optional `azure-storage-file-datalake` dependency is stubbed through `sys.modules` rather than skipped, because it ships in the `proxy-runtime` extra and is absent from the `ci` group; the tests therefore run for real on the unit shards instead of silently skipping

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Azure storage hosts are built and how persisted blob URLs are parsed for downloads; behavior is unchanged when the env var is unset, but download validation is stricter for some malformed URLs.
> 
> **Overview**
> Adds **`AZURE_STORAGE_ENDPOINT_SUFFIX`** (default **`core.windows.net`**) so Azure Government and other sovereign clouds can be targeted without changing code. **`AzureBlobStorageLogger`** reads the suffix at init and exposes **`azure_storage_dfs_endpoint`** / **`azure_storage_blob_endpoint`**; the Entra ID REST upload path and **`DataLakeServiceClient`** account URL now use those instead of a hardcoded commercial host. **`AzureBlobStorageBackend`** inherits the same behavior for managed file upload/download.
> 
> **`download_file`** no longer requires the literal `.blob.core.windows.net/` substring. It uses **`urlparse`**, requires **`.blob.`** on the hostname, takes only the path after the container from the stored URL, and rebuilds the GET URL from the configured account/suffix—so older commercial URLs still work after switching to Gov, query strings are dropped, and malformed/non-Azure URLs are rejected more safely.
> 
> Tests cover Gov vs default suffix for the logger and files backend (REST, SDK, and download edge cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e86edcc2543979b8cc5a661248a522c8ed3f907d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->