### PR TITLE
fix(anthropic): coerce explicit additionalProperties to false in output_format schema

### DIFF
--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -597,7 +597,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
 
         # Anthropic requires additionalProperties=false for object schemas
         # See: https://docs.anthropic.com/en/docs/build-with-claude/structured-outputs
-        if result.get("type") == "object" and "additionalProperties" not in result:
+        if result.get("type") == "object":
             result["additionalProperties"] = False
 
         return result

--- a/tests/litellm/llms/anthropic/test_anthropic_schema_filter.py
+++ b/tests/litellm/llms/anthropic/test_anthropic_schema_filter.py
@@ -281,7 +281,10 @@ class TestFilterAnthropicOutputSchema:
             "unevaluatedProperties",
         ):
             assert field not in result
-        assert 'properties whose names match each pattern must satisfy: {"^x": {"type": "string"}}' in result["description"]
+        assert (
+            'properties whose names match each pattern must satisfy: {"^x": {"type": "string"}}'
+            in result["description"]
+        )
         assert 'property names must satisfy: {"pattern": "^[a-z]+$"}' in result["description"]
         assert 'dependent required properties: {"first": ["last"]}' in result["description"]
         assert 'dependent schemas: {"first": {"required": ["last"]}}' in result["description"]
@@ -347,3 +350,70 @@ class TestFilterAnthropicOutputSchema:
             "all array items must be unique, minimum number of matching items: 2, "
             "maximum number of matching items: 3."
         )
+
+    def test_coerces_explicit_additional_properties_true(self):
+        """An explicit ``additionalProperties: true`` must be coerced to false.
+
+        Anthropic rejects anything other than false with:
+        "output_format.schema: For 'object' type, 'additionalProperties: true' is
+        not supported".
+        """
+        schema = {
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {"a": {"type": "string"}},
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert result["additionalProperties"] is False
+
+    def test_coerces_additional_properties_true_when_nested(self):
+        """Nested object schemas are coerced too, at every recursion site."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "obj": {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "properties": {"a": {"type": "string"}},
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": True,
+                        "properties": {"b": {"type": "string"}},
+                    },
+                },
+            },
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert result["properties"]["obj"]["additionalProperties"] is False
+        assert result["properties"]["rows"]["items"]["additionalProperties"] is False
+
+    def test_coerces_additional_properties_sub_schema(self):
+        """A sub-schema value (free-form map) is also rejected by Anthropic."""
+        schema = {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+            "properties": {"a": {"type": "string"}},
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert result["additionalProperties"] is False
+
+    def test_explicit_additional_properties_false_is_preserved(self):
+        """The already-correct value must survive untouched."""
+        schema = {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {"a": {"type": "string"}},
+        }
+
+        result = AnthropicConfig.filter_anthropic_output_schema(schema)
+
+        assert result["additionalProperties"] is False


### PR DESCRIPTION
## Relevant issues

Fixes #35808

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (lint, format, unit tests) — `ruff format` clean, target suite green
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5**

## Screenshots / Proof of Fix

### Root cause

Anthropic's structured outputs reject any `additionalProperties` value other than `false`. Their [docs](https://platform.claude.com/docs/en/build-with-claude/structured-outputs) list under *Supported features*: "`required` and `additionalProperties` (must be set to `false` for objects)", and under *Not supported*: "`additionalProperties` set to anything other than `false`"

`filter_anthropic_output_schema` only **added** the key when it was **absent**:

```python
if result.get("type") == "object" and "additionalProperties" not in result:
    result["additionalProperties"] = False
```

`additionalProperties` isn't in the unsupported/strip set, so an explicit value is copied verbatim by the catch-all `else: result[key] = value`, and the `not in result` guard never fires. The explicit value reaches `output_format.schema` and 400s

This PR coerces the value for object schemas instead. That is what the official SDKs do — [anthropic-sdk-python `_parse/_transform.py`](https://github.com/anthropics/anthropic-sdk-python/blob/main/src/anthropic/lib/_parse/_transform.py) (`pop(...)` then `strict_schema["additionalProperties"] = False`) and [anthropic-sdk-typescript `transform-json-schema.ts`](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/lib/transform-json-schema.ts)

The permissive tool-use path (`map_response_format_to_anthropic_tool`, which sets `_input_schema["additionalProperties"] = True` and is deliberately forced for `vertex_ai` per #18625 / #19201) is **not** touched

### Before (on `litellm_internal_staging`, v1.96.0)

```python
from litellm.llms.anthropic.chat.transformation import AnthropicConfig
AnthropicConfig.filter_anthropic_output_schema(
    {"type": "object", "additionalProperties": True, "properties": {"a": {"type": "string"}}}
)
# -> {'type': 'object', 'additionalProperties': True, 'properties': {...}}   <-- 400s at Anthropic
```

Every explicit form leaked through — top level, nested under `properties`, inside array `items`, and the dict sub-schema form:

```
top-level explicit true    -> leaked non-false additionalProperties: [True]
nested under properties    -> leaked non-false additionalProperties: [True]
inside array items         -> leaked non-false additionalProperties: [True]
dict sub-schema form       -> leaked non-false additionalProperties: [{'type': 'string'}]
control: key absent        -> leaked non-false additionalProperties: NONE (ok)
```

End-to-end against a real `azure_ai/claude-sonnet-4-6` deployment (un-mocked, real API call), sending a schema with `"additionalProperties": true`:

```
HTTP 400
litellm.BadRequestError: Azure_aiException - {"type":"error","error":{"type":"invalid_request_error",
"message":"output_format.schema: For 'object' type, 'additionalProperties: true' is not supported.
Please set 'additionalProperties' to false"},"request_id":"req_011CdiGH686teY8qpkxwe2mP"}
```

### After (commit `46751ad`)

All five cases clean:

```
top-level true   -> NONE (ok)
nested           -> NONE (ok)
array items      -> NONE (ok)
sub-schema       -> NONE (ok)
control absent   -> NONE (ok)
```

```
$ uv run pytest tests/litellm/llms/anthropic/test_anthropic_schema_filter.py -q
21 passed
```

Regression check on the surrounding suites (`tests/litellm/llms/anthropic/` + `tests/test_litellm/llms/anthropic/`): **41 failed / 1218 passed with this change vs 41 failed / 1214 passed on the unmodified branch** — identical pre-existing failure set, +4 new passing tests. (The pre-existing failures are unrelated `experimental_pass_through/context_management` tests; a `tests/test_litellm/llms/vertex_ai/realtime` collection error is a missing local `websockets` dep and also reproduces unmodified)

> Note on the live "after": reproducing the 400 requires addressing the Azure deployment directly — if the model group has a fallback to a `vertex_ai` deployment, LiteLLM transparently retries there and returns 200, masking the rejection

## Type

🐛 Bug Fix

## Changes

- `litellm/llms/anthropic/chat/transformation.py` — in `filter_anthropic_output_schema`, drop the `and "additionalProperties" not in result` guard so object schemas always get `additionalProperties: False` (applies at every recursion depth and to the dict sub-schema form)
- `tests/litellm/llms/anthropic/test_anthropic_schema_filter.py` — 4 tests: explicit `true` at top level, nested (under `properties` and inside array `items`), the dict sub-schema form, and an explicit `false` preserved

### Semantic caveat (disclosed)

Coercing narrows what the schema permits. For a **bare free-form map** (`{"type": "object", "additionalProperties": true}` with no `properties`) this means "object with no allowed keys", so the model can only emit `{}` — genuine semantic loss. Anthropic has no native encoding for that shape and the official SDKs degrade it identically; the alternative on this path is a guaranteed 400. A more conservative future option would be detecting that shape and routing it to the permissive tool-use path (the one already forced for `vertex_ai`), but that is a larger change and out of scope here

### Prior art

- #22447 and #22500 (both closed, unmerged) contained this same coercion — #22447 even had a test named *"additionalProperties: true should be overridden to false for objects"* — but were bundled with unrelated changes. This PR is deliberately minimal: one condition + its tests
- #21045 (open) introduced the current add-only guard; its test only covers the missing-key path
- #33981 / #34313 / #34319 (merged, shipped v1.95.0) extended the same function for `uniqueItems`/`contains`/`prefixItems`/etc. but contain zero `additionalProperties` changes
