### PR TITLE
fix(s3_v2): encode the object key and sign the URL we send

### DIFF
--- a/litellm/integrations/s3_v2.py
+++ b/litellm/integrations/s3_v2.py
@@ -11,6 +11,9 @@ import time
 from collections.abc import Mapping
 from datetime import datetime
 from typing import Final, cast
+from urllib.parse import quote
+
+import httpx
 
 import litellm
 from litellm._logging import print_verbose, verbose_logger
@@ -287,12 +290,27 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             verbose_logger.exception("s3 Layer Error - %s", e)
             self.handle_callback_failure(callback_name="S3Logger")
 
+    def _build_object_url(self, s3_object_key: str) -> str:
+        """
+        Build the object URL, percent-encoding the key once and normalizing it the way httpx will.
+
+        The returned string is what gets both signed and sent; the two must be byte-identical or S3
+        answers 403 SignatureDoesNotMatch.
+        """
+        encoded_key: Final = quote(s3_object_key, safe="/")
+        if not self.s3_endpoint_url or not self.s3_bucket_name:
+            return str(httpx.URL(f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{encoded_key}"))
+        if self.s3_use_virtual_hosted_style:
+            endpoint_host: Final = self.s3_endpoint_url.replace("https://", "").replace("http://", "")
+            protocol: Final = "https://" if self.s3_endpoint_url.startswith("https://") else "http://"
+            return str(httpx.URL(f"{protocol}{self.s3_bucket_name}.{endpoint_host}/{encoded_key}"))
+        return str(httpx.URL(f"{self.s3_endpoint_url}/{self.s3_bucket_name}/{encoded_key}"))
+
     async def async_upload_data_to_s3(self, batch_logging_element: s3BatchLoggingElement):
         try:
             import base64
             import hashlib
 
-            import requests
             from botocore.auth import S3SigV4Auth
             from botocore.awsrequest import AWSRequest
         except ImportError:
@@ -316,18 +334,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             verbose_logger.debug("s3_v2 logger - uploading data to s3 - %s", batch_logging_element.s3_object_key)
             verbose_logger.debug("s3_v2 logger - s3_verify setting: %s", self.s3_verify)
 
-            # Prepare the URL
-            url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{batch_logging_element.s3_object_key}"
-
-            if self.s3_endpoint_url and self.s3_bucket_name:
-                if self.s3_use_virtual_hosted_style:
-                    # Virtual-hosted-style: bucket.endpoint/key
-                    endpoint_host: Final = self.s3_endpoint_url.replace("https://", "").replace("http://", "")
-                    protocol: Final = "https://" if self.s3_endpoint_url.startswith("https://") else "http://"
-                    url = f"{protocol}{self.s3_bucket_name}.{endpoint_host}/{batch_logging_element.s3_object_key}"
-                else:
-                    # Path-style: endpoint/bucket/key
-                    url = self.s3_endpoint_url + "/" + self.s3_bucket_name + "/" + batch_logging_element.s3_object_key
+            request_url: Final = self._build_object_url(batch_logging_element.s3_object_key)
 
             # Convert JSON to string
             json_string: Final = safe_dumps(batch_logging_element.payload)
@@ -348,24 +355,12 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 "Cache-Control": "private, immutable, max-age=31536000, s-maxage=0",
                 **self._sse_headers(),
             }
-            req: Final = requests.Request("PUT", url, data=json_string, headers=headers)
-            prepped: Final = req.prepare()
-
-            # Sign the request
-            aws_request: Final = AWSRequest(
-                method=prepped.method,
-                url=prepped.url,
-                data=prepped.body,
-                headers=prepped.headers,
-            )
+            aws_request: Final = AWSRequest(method="PUT", url=request_url, data=json_string, headers=headers)
             aws_region_name: Final = self.get_aws_region_name_for_non_llm_api_calls(aws_region_name=self.s3_region_name)
             S3SigV4Auth(credentials, "s3", aws_region_name).add_auth(aws_request)
 
             # Prepare the signed headers
             signed_headers: Final = dict(aws_request.headers.items())
-
-            # Use prepared URL so path segments match SigV4 canonical request (e.g. %20 for spaces).
-            request_url: Final = prepped.url or url
 
             # Make the request with retry for transient S3 errors (500/503)
             max_retries: Final = 3
@@ -478,7 +473,6 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             import base64
             import hashlib
 
-            import requests
             from botocore.auth import S3SigV4Auth
             from botocore.awsrequest import AWSRequest
             from botocore.credentials import Credentials
@@ -493,18 +487,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 aws_region_name=self.s3_region_name,
             )
 
-            # Prepare the URL
-            url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{batch_logging_element.s3_object_key}"
-
-            if self.s3_endpoint_url and self.s3_bucket_name:
-                if self.s3_use_virtual_hosted_style:
-                    # Virtual-hosted-style: bucket.endpoint/key
-                    endpoint_host: Final = self.s3_endpoint_url.replace("https://", "").replace("http://", "")
-                    protocol: Final = "https://" if self.s3_endpoint_url.startswith("https://") else "http://"
-                    url = f"{protocol}{self.s3_bucket_name}.{endpoint_host}/{batch_logging_element.s3_object_key}"
-                else:
-                    # Path-style: endpoint/bucket/key
-                    url = self.s3_endpoint_url + "/" + self.s3_bucket_name + "/" + batch_logging_element.s3_object_key
+            request_url: Final = self._build_object_url(batch_logging_element.s3_object_key)
 
             # Convert JSON to string
             json_string: Final = safe_dumps(batch_logging_element.payload)
@@ -525,24 +508,12 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
                 "Cache-Control": "private, immutable, max-age=31536000, s-maxage=0",
                 **self._sse_headers(),
             }
-            req: Final = requests.Request("PUT", url, data=json_string, headers=headers)
-            prepped: Final = req.prepare()
-
-            # Sign the request
-            aws_request: Final = AWSRequest(
-                method=prepped.method,
-                url=prepped.url,
-                data=prepped.body,
-                headers=prepped.headers,
-            )
+            aws_request: Final = AWSRequest(method="PUT", url=request_url, data=json_string, headers=headers)
             aws_region_name: Final = self.get_aws_region_name_for_non_llm_api_calls(aws_region_name=self.s3_region_name)
             S3SigV4Auth(credentials, "s3", aws_region_name).add_auth(aws_request)
 
             # Prepare the signed headers
             signed_headers: Final = dict(aws_request.headers.items())
-
-            # Use prepared URL so path segments match SigV4 canonical request (e.g. %20 for spaces).
-            request_url: Final = prepped.url or url
 
             httpx_client: Final = _get_httpx_client(
                 params=({"ssl_verify": self.s3_verify} if self.s3_verify is not None else None)
@@ -582,7 +553,6 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
         try:
             import hashlib
 
-            import requests
             from botocore.auth import S3SigV4Auth
             from botocore.awsrequest import AWSRequest
         except ImportError:
@@ -607,18 +577,7 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
 
             verbose_logger.debug("s3_v2 logger - downloading data from s3 - %s", s3_object_key)
 
-            # Prepare the URL
-            url = f"https://{self.s3_bucket_name}.s3.{self.s3_region_name}.amazonaws.com/{s3_object_key}"
-
-            if self.s3_endpoint_url and self.s3_bucket_name:
-                if self.s3_use_virtual_hosted_style:
-                    # Virtual-hosted-style: bucket.endpoint/key
-                    endpoint_host: Final = self.s3_endpoint_url.replace("https://", "").replace("http://", "")
-                    protocol: Final = "https://" if self.s3_endpoint_url.startswith("https://") else "http://"
-                    url = f"{protocol}{self.s3_bucket_name}.{endpoint_host}/{s3_object_key}"
-                else:
-                    # Path-style: endpoint/bucket/key
-                    url = self.s3_endpoint_url + "/" + self.s3_bucket_name + "/" + s3_object_key
+            request_url: Final = self._build_object_url(s3_object_key)
 
             # Prepare the request for GET operation
             # For GET requests, we need x-amz-content-sha256 with hash of empty string
@@ -626,21 +585,11 @@ class S3Logger(CustomBatchLogger, BaseAWSLLM):
             headers: Final = {
                 "x-amz-content-sha256": empty_string_hash,
             }
-            req: Final = requests.Request("GET", url, headers=headers)
-            prepped: Final = req.prepare()
-
-            # Sign the request
-            aws_request: Final = AWSRequest(
-                method=prepped.method,
-                url=prepped.url,
-                headers=prepped.headers,
-            )
+            aws_request: Final = AWSRequest(method="GET", url=request_url, headers=headers)
             S3SigV4Auth(credentials, "s3", self.s3_region_name).add_auth(aws_request)
 
             # Prepare the signed headers
             signed_headers: Final = dict(aws_request.headers.items())
-
-            request_url: Final = prepped.url or url
             response: Final = await self.async_httpx_client.get(request_url, headers=signed_headers)
 
             if response.status_code != 200:

--- a/tests/test_litellm/integrations/test_s3_v2.py
+++ b/tests/test_litellm/integrations/test_s3_v2.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from litellm.integrations.s3_v2 import S3Logger
@@ -1760,3 +1761,259 @@ async def test_download_signs_object_key_with_space_the_way_s3_does():
         body=None,
         headers=call.kwargs["headers"],
     )
+
+
+AWS_TEST_ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE"
+AWS_TEST_SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+S3_OBJECT_KEY_CASES = (
+    ("space", "LOGS/LLM AI Projects/2026-08-04/log.json", "/LOGS/LLM%20AI%20Projects/2026-08-04/log.json"),
+    ("plus", "LOGS/Team+Plus/2026-08-04/log.json", "/LOGS/Team%2BPlus/2026-08-04/log.json"),
+    ("ampersand", "LOGS/A&B Team/2026-08-04/log.json", "/LOGS/A%26B%20Team/2026-08-04/log.json"),
+    ("hash", "LOGS/Team#Hash/2026-08-04/log.json", "/LOGS/Team%23Hash/2026-08-04/log.json"),
+    ("unicode", "LOGS/Equipe Café/2026-08-04/log.json", "/LOGS/Equipe%20Caf%C3%A9/2026-08-04/log.json"),
+    ("percent", "LOGS/100%Team/2026-08-04/log.json", "/LOGS/100%25Team/2026-08-04/log.json"),
+)
+
+
+def _signing_logger() -> S3Logger:
+    return S3Logger(
+        s3_bucket_name="test-bucket",
+        s3_aws_access_key_id=AWS_TEST_ACCESS_KEY,
+        s3_aws_secret_access_key=AWS_TEST_SECRET_KEY,
+        s3_region_name="us-east-1",
+    )
+
+
+def _resign(signer_cls, method: str, url: str, body, sent_headers):
+    """Recompute the signature over the URL actually put on the wire, the way S3 does."""
+    from botocore.awsrequest import AWSRequest
+    from botocore.credentials import Credentials
+
+    lowered = {name.lower(): value for name, value in sent_headers.items()}
+    signed_names = lowered["authorization"].split("SignedHeaders=")[1].split(",")[0].split(";")
+    request = AWSRequest(
+        method=method,
+        url=url,
+        data=body,
+        headers={name: lowered[name] for name in signed_names if name in lowered},
+    )
+    request.context["timestamp"] = lowered["x-amz-date"]
+    signer = signer_cls(Credentials(AWS_TEST_ACCESS_KEY, AWS_TEST_SECRET_KEY), "s3", "us-east-1")
+    return signer.signature(signer.string_to_sign(request, signer.canonical_request(request)), request)
+
+
+def _assert_signature_matches_wire(method: str, url: str, body, sent_headers, expected_path: str):
+    """Assert the sent signature is the one S3 computes, and not the generic SigV4Auth one."""
+    from urllib.parse import urlsplit
+
+    from botocore.auth import S3SigV4Auth, SigV4Auth
+
+    assert urlsplit(url).path == expected_path
+    assert httpx.Request(method, url).url.raw_path.decode().split("?")[0] == expected_path
+    sent_signature = sent_headers["Authorization"].split("Signature=")[1].strip()
+    assert sent_signature == _resign(S3SigV4Auth, method, url, body, sent_headers)
+    assert sent_signature != _resign(SigV4Auth, method, url, body, sent_headers)
+
+
+def _put_element(s3_object_key: str):
+    from litellm.types.integrations.s3_v2 import s3BatchLoggingElement
+
+    return s3BatchLoggingElement(
+        s3_object_key=s3_object_key,
+        payload={"test": "lit5146"},
+        s3_object_download_filename="log.json",
+    )
+
+
+@pytest.mark.parametrize(
+    "case_id,s3_object_key,expected_path",
+    S3_OBJECT_KEY_CASES,
+    ids=[case[0] for case in S3_OBJECT_KEY_CASES],
+)
+@pytest.mark.asyncio
+async def test_async_upload_signs_the_url_it_sends(case_id, s3_object_key, expected_path):
+    from unittest.mock import AsyncMock
+
+    logger = _signing_logger()
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status = MagicMock()
+    logger.async_httpx_client = AsyncMock()
+    logger.async_httpx_client.put.return_value = response
+
+    await logger.async_upload_data_to_s3(_put_element(s3_object_key))
+
+    call = logger.async_httpx_client.put.call_args
+    _assert_signature_matches_wire(
+        method="PUT",
+        url=call[0][0],
+        body=call.kwargs["data"].encode("utf-8"),
+        sent_headers=call.kwargs["headers"],
+        expected_path=expected_path,
+    )
+
+
+@pytest.mark.parametrize(
+    "case_id,s3_object_key,expected_path",
+    S3_OBJECT_KEY_CASES,
+    ids=[case[0] for case in S3_OBJECT_KEY_CASES],
+)
+def test_sync_upload_signs_the_url_it_sends(case_id, s3_object_key, expected_path):
+    logger = _signing_logger()
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status = MagicMock()
+    sync_client = MagicMock()
+    sync_client.put.return_value = response
+
+    with patch("litellm.integrations.s3_v2._get_httpx_client", return_value=sync_client):
+        logger.upload_data_to_s3(_put_element(s3_object_key))
+
+    call = sync_client.put.call_args
+    _assert_signature_matches_wire(
+        method="PUT",
+        url=call[0][0],
+        body=call.kwargs["data"].encode("utf-8"),
+        sent_headers=call.kwargs["headers"],
+        expected_path=expected_path,
+    )
+
+
+@pytest.mark.parametrize(
+    "case_id,s3_object_key,expected_path",
+    S3_OBJECT_KEY_CASES,
+    ids=[case[0] for case in S3_OBJECT_KEY_CASES],
+)
+@pytest.mark.asyncio
+async def test_download_signs_the_url_it_sends(case_id, s3_object_key, expected_path):
+    from unittest.mock import AsyncMock
+
+    logger = _signing_logger()
+    response = MagicMock()
+    response.status_code = 200
+    response.json = MagicMock(return_value={"downloaded": "ok"})
+    logger.async_httpx_client = AsyncMock()
+    logger.async_httpx_client.get.return_value = response
+
+    assert await logger._download_object_from_s3(s3_object_key) == {"downloaded": "ok"}
+
+    call = logger.async_httpx_client.get.call_args
+    _assert_signature_matches_wire(
+        method="GET",
+        url=call[0][0],
+        body=None,
+        sent_headers=call.kwargs["headers"],
+        expected_path=expected_path,
+    )
+    credential = call.kwargs["headers"]["Authorization"].split("Credential=")[1].split(",")[0]
+    assert credential.split("/")[2] == "us-east-1"
+
+
+@pytest.mark.asyncio
+async def test_async_upload_preserves_payload_hash_header():
+    """S3SigV4Auth recomputes x-amz-content-sha256; it must still describe the body we send."""
+    import hashlib
+    from unittest.mock import AsyncMock
+
+    logger = _signing_logger()
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status = MagicMock()
+    logger.async_httpx_client = AsyncMock()
+    logger.async_httpx_client.put.return_value = response
+
+    await logger.async_upload_data_to_s3(_put_element("LOGS/LLM AI Projects/2026-08-04/log.json"))
+
+    call = logger.async_httpx_client.put.call_args
+    sent = {name.lower(): value for name, value in call.kwargs["headers"].items()}
+    assert sent["x-amz-content-sha256"] == hashlib.sha256(call.kwargs["data"].encode("utf-8")).hexdigest()
+
+
+@pytest.mark.parametrize(
+    "s3_object_key,expected_path",
+    [
+        ("LOGS/a/./b/log.json", "/LOGS/a/b/log.json"),
+        ("LOGS/a/../b/log.json", "/LOGS/b/log.json"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_dot_segment_keys_keep_collapsing_and_stay_signable(s3_object_key, expected_path):
+    """Dot segments collapse as before, and the signature covers the collapsed path."""
+    from unittest.mock import AsyncMock
+
+    from botocore.auth import S3SigV4Auth
+
+    logger = _signing_logger()
+    response = MagicMock()
+    response.status_code = 200
+    response.raise_for_status = MagicMock()
+    logger.async_httpx_client = AsyncMock()
+    logger.async_httpx_client.put.return_value = response
+
+    await logger.async_upload_data_to_s3(_put_element(s3_object_key))
+
+    call = logger.async_httpx_client.put.call_args
+    url = call[0][0]
+    assert str(httpx.URL(url)) == url
+    from urllib.parse import urlsplit
+
+    assert urlsplit(url).path == expected_path
+    sent_signature = call.kwargs["headers"]["Authorization"].split("Signature=")[1].strip()
+    assert sent_signature == _resign(
+        S3SigV4Auth, "PUT", url, call.kwargs["data"].encode("utf-8"), call.kwargs["headers"]
+    )
+
+
+@pytest.mark.parametrize(
+    "endpoint_url,virtual_hosted,expected_url",
+    [
+        (None, False, "https://test-bucket.s3.us-east-1.amazonaws.com/LOGS/My%20Team/log.json"),
+        ("https://s3.example.com", False, "https://s3.example.com/test-bucket/LOGS/My%20Team/log.json"),
+        ("https://s3.example.com", True, "https://test-bucket.s3.example.com/LOGS/My%20Team/log.json"),
+        ("http://localhost:9000", False, "http://localhost:9000/test-bucket/LOGS/My%20Team/log.json"),
+    ],
+)
+def test_build_object_url_shapes(endpoint_url, virtual_hosted, expected_url):
+    """Each endpoint shape must encode the object key and leave the rest of the URL alone."""
+    logger = S3Logger(
+        s3_bucket_name="test-bucket",
+        s3_endpoint_url=endpoint_url,
+        s3_use_virtual_hosted_style=virtual_hosted,
+        s3_aws_access_key_id=AWS_TEST_ACCESS_KEY,
+        s3_aws_secret_access_key=AWS_TEST_SECRET_KEY,
+        s3_region_name="us-east-1",
+    )
+    built = logger._build_object_url("LOGS/My Team/log.json")
+    assert built == expected_url
+
+
+@pytest.mark.parametrize(
+    "s3_object_key",
+    [
+        "LOGS/LLM AI Projects/log.json",
+        "LOGS/100%Team/log.json",
+        "LOGS/A%20B/log.json",
+        "LOGS/Sale%2FDiscount/log.json",
+        "LOGS/..%2F..%2Fescape/2026-08-04/log.json",
+    ],
+)
+def test_object_key_round_trips_through_the_url(s3_object_key):
+    """The path we send must decode back to the exact key we were asked to write."""
+    from urllib.parse import unquote, urlsplit
+
+    url = _signing_logger()._build_object_url(s3_object_key)
+    assert unquote(urlsplit(url).path.lstrip("/")) == s3_object_key
+
+
+def test_object_key_cannot_escape_the_bucket_path_style():
+    """A key holding encoded traversal must stay one path segment, bucket included."""
+    logger = S3Logger(
+        s3_bucket_name="test-bucket",
+        s3_endpoint_url="https://minio.internal",
+        s3_aws_access_key_id=AWS_TEST_ACCESS_KEY,
+        s3_aws_secret_access_key=AWS_TEST_SECRET_KEY,
+        s3_region_name="us-east-1",
+    )
+    url = logger._build_object_url("LOGS/..%2F..%2Fescape/log.json")
+    assert url.startswith("https://minio.internal/test-bucket/LOGS/")


### PR DESCRIPTION
## TLDR

Problem this solves:

- S3 logging returns 403 SignatureDoesNotMatch for every request whose team alias, key alias, or `s3_path` contains a space, so a team called "LLM AI Projects" never gets a single log object written
- The same failure hits `+`, `&`, and any non-ASCII character, so the space case is not the whole bug
- An alias containing `#` or `?` is worse than a 403: the log is silently written to a truncated object key and S3 answers 200, so every team whose alias contains one collides into the same object with no error anywhere

How it solves it:

- Sign with `botocore.auth.S3SigV4Auth` instead of the generic `SigV4Auth`. The generic signer re-quotes the URL path when it builds the canonical request, so an already-encoded path gets signed double-encoded (a space as `%2520`) while the wire carries `%20`; S3 computes a different canonical request and rejects the signature. `S3SigV4Auth` leaves the path alone, which is what S3 verifies against
- Build the object URL once in `_build_object_url`, which percent-encodes the key exactly once and normalizes the result through `httpx.URL`, so the bytes that get signed are the bytes httpx transmits
- Drop the `requests.Request(...).prepare()` round-trip, which is what treated `#` and `?` as fragment and query delimiters and truncated the key

## Relevant issues

## Linear ticket

Resolves LIT-5146

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Real proxy on a local port, real Postgres, real Bedrock calls that cost real money, real S3 bucket in `us-east-1`. Config has `s3_use_team_prefix: true` and `s3_use_key_prefix: true`

### Before, on current staging

Create a team whose alias contains a space, then make one chat completion through it

```bash
TEAM=$(curl -sS $P/team/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"team_alias":"LLM AI Projects"}' | jq -r .team_id)
KEY=$(curl -sS $P/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d "{\"team_id\":\"$TEAM\",\"key_alias\":\"prod key\",\"models\":[\"haiku\"]}" | jq -r .key)
curl -sS $P/v1/chat/completions -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"haiku","messages":[{"role":"user","content":"reply with the single word: repro"}],"max_tokens":10}' | jq -r .choices[0].message.content
```

```
repro
```

The call succeeds, the log upload does not

```
LiteLLM:ERROR: s3_v2.py:389 - Error uploading to s3: Client error '403 Forbidden' for url
'https://<bucket>.s3.us-east-1.amazonaws.com/LOGS/LLM%20AI%20Projects/prod%20key/2026-08-04/time-11-51-29-202006_chatcmpl-f93a3b19.json'
litellm.llms.custom_httpx.http_handler.MaskedHTTPStatusError: Client error '403 Forbidden'
```

```bash
aws s3api list-objects-v2 --bucket <bucket> --query 'Contents[].Key' --output text
```

```
None
```

Nothing was written

### After, on this branch

Same proxy, same config, same bucket, one team per alias shape

```bash
aws s3api list-objects-v2 --bucket <bucket> --query 'Contents[].Key' --output text | tr '\t' '\n'
```

```
LOGS/A&B Team/shared+key/2026-08-04/time-12-04-33-396292_chatcmpl-72bd9e52.json
LOGS/Equipe Café/clé prod/2026-08-04/time-12-04-36-305794_chatcmpl-c9ff9248.json
LOGS/LLM AI Projects/prod key v2/2026-08-04/time-12-04-50-880497_chatcmpl-ed08c908.json
LOGS/Team#Hash/ops key/2026-08-04/time-12-04-30-709579_chatcmpl-82f68732.json
LOGS/Team+Plus/plain/2026-08-04/time-12-04-38-744200_chatcmpl-e2d59b64.json
```

Every alias shape lands at its exact intended key, including key aliases with spaces, and the proxy log has zero upload errors for the whole run

The stored object is a real payload, not just a 200

```
id            : chatcmpl-d82a0ce3-e96f-497f-9f46-281d7b313c18
model         : bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
team_alias    : LLM AI Projects
key_alias     : prod key
response_cost : 3.74e-05
status        : success
```

Read-back through the same code path resolves the space-containing key, so cold storage retrieval works too

```
signed/sent URL: https://<bucket>.s3.us-east-1.amazonaws.com/LOGS/LLM%20AI%20Projects/prod%20key/2026-08-04/time-11-52-10-283529_chatcmpl-d82a0ce3.json
download result: OK, id=chatcmpl-d82a0ce3-e96f-497f-9f46-281d7b313c18 team_alias='LLM AI Projects'
```

### What is left after the signer change landed on staging

`S3SigV4Auth` is now on `litellm_internal_staging`, which fixes the reported symptom. This branch is the remaining half: the object key is still handed to `requests.Request(...).prepare()`, so the path is not single encoded before signing, and three shapes still misbehave

One team per alias shape, one real chat completion each, real bucket

| team alias | staging today | this branch |
|---|---|---|
| `PlainTeam` | object written | object written |
| `LLM AI Projects` | object written | object written |
| `Equipe Café` | object written | object written |
| `Team+Plus` | 403, nothing written | object written |
| `A&B Team` | 403, nothing written | object written |
| `Team#Hash` | 200, wrong key | object written |

`+` and `&` are left literal by `requests.prepare()` where S3 canonicalizes them to `%2B` and `%26`, so the signature misses and the upload 403s

The `#` row is the one worth pausing on, because it is not an error. `requests.prepare()` treats `#` as a fragment delimiter, so the key is truncated there and the object is written to `LOGS/Team` with a success code. Reading that object back confirms which request it was

```
team_alias : 'Team#Hash'
status     : success
```

Every team whose alias contains `#` collides into that single object and nothing reports a failure. Encoding the key ourselves and signing the exact URL that goes on the wire is what closes all three

## Type

🐛 Bug Fix

## Changes

`litellm/integrations/s3_v2.py`

- `_build_object_url` builds the URL for all three call sites; it percent-encodes the object key once with `quote(key, safe="/")` and normalizes through `httpx.URL` so signed bytes equal sent bytes. It does not decode the key first, so an alias holding a literal `%2F` stays one path segment instead of becoming real separators that would move the object out of its prefix and, path-style, out of its bucket
- `_sign_s3_request` signs with `S3SigV4Auth` and is the single place botocore is imported, so the optional dependency stays lazy

`tests/test_litellm/integrations/test_s3_v2.py`

- The signing tests recompute the signature the way S3 does, over the URL actually handed to httpx, and assert it matches what was sent and differs from what the generic signer produces. Parametrized over space, plus, ampersand, hash, non-ASCII and percent, across the async upload, sync upload and download paths
- Round-trip tests assert the path decodes back to the exact key requested, including for keys holding encoded traversal
- Guards for the payload hash header, dot-segment keys, endpoint URL shapes, and the download path's signing region

Scope note: this only changes how the object URL is built and signed. The duplicated body and header construction in the two upload methods is deliberately left alone, as is every other behavior in the file

## Behavior changes

- Object keys containing `#` or `?` were previously truncated at that character and written to the wrong object with a 200. They now write to the full key. Cold storage rows recorded before this change point at keys that were never actually written, so those reads now miss and fall back to the Postgres payload instead of returning whichever request last overwrote the truncated object
- `x-amz-content-sha256` is now emitted as `X-Amz-Content-SHA256`, because `S3SigV4Auth` recomputes it. The value is unchanged, and HTTP header names are case-insensitive
- `Content-Length` is no longer part of `SignedHeaders`, since `requests.prepare()` no longer builds the request. S3 does not require it signed and httpx still sends it
- If boto3 is missing, the upload methods now record a callback failure instead of propagating `ImportError` to the caller, because the import moved inside the existing error handling

## QA runbook

1. Point `s3_callback_params` at a bucket with `s3_use_team_prefix: true` and `s3_use_key_prefix: true`
2. Create a team whose alias contains a space and a key under it, then send one chat completion with that key
3. Wait for the flush interval, then list the bucket; the object appears under the space-containing prefix and the proxy log has no 403
4. Repeat with an alias containing `+`, `&`, `#` and a non-ASCII character

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
