### PR TITLE
test(e2e): retry provider-transient statuses at the transport with bounded backoff

### DIFF
--- a/tests/e2e/e2e_http.py
+++ b/tests/e2e/e2e_http.py
@@ -303,7 +303,7 @@ def _params(params: BaseModel | None) -> dict[str, str]:
     return {key: str(value) for key, value in dumped.items()}
 
 
-TRANSIENT_STATUSES: frozenset[int] = frozenset({500, 502, 503, 504, 529})
+TRANSIENT_STATUSES: frozenset[int] = frozenset({529})
 RETRY_ATTEMPTS: int = 3
 RETRY_BACKOFF_SECONDS: float = 0.5
 
@@ -317,17 +317,21 @@ class RetryableResponse(Protocol):
 def request_with_retry[T: RetryableResponse](
     issue: Callable[[], T], *, sleep: Callable[[float], None] = time.sleep
 ) -> T:
-    """Bounded retry on provider-transient statuses only (500/502/503/504/529),
-    the set production SDKs retry by default (Anthropic's own client retries 529
-    overloaded_error). The intent stays clean because only the dependency call
-    is retried; every assertion still judges a single successful response.
+    """Bounded retry on statuses attributable to the PROVIDER, never the proxy.
 
-    Deliberately NOT retried: 429, because this suite asserts the proxy's own
-    rate-limit and budget 429s and a transport that absorbed them would
-    silently break those tests; network errors and timeouts, because a hang
-    should surface as a hang instead of doubling the wall clock. Every retry
-    prints, so flakiness stays visible in the run log instead of vanishing
-    into green."""
+    The system under test is the proxy, so the transport may only absorb
+    statuses the proxy itself cannot emit; today that is exactly 529, the
+    Anthropic overloaded_error passed through verbatim (their own SDK retries
+    it too). 500/502/503/504 stay first-class failures: at this layer a 5xx
+    from the proxy is indistinguishable from one it relayed, and retrying them
+    could mask an intermittently failing proxy. Widen the set only for a
+    status litellm provably never originates, with an observed flake in hand.
+
+    Also deliberately NOT retried: 429, because this suite asserts the proxy's
+    own rate-limit and budget 429s; network errors and timeouts, because a
+    hang should surface as a hang instead of doubling the wall clock. Every
+    retry prints, so flakiness stays visible in the run log instead of
+    vanishing into green."""
     for attempt in range(1, RETRY_ATTEMPTS):
         resp = issue()
         if resp.status_code not in TRANSIENT_STATUSES:

--- a/tests/e2e/e2e_http.py
+++ b/tests/e2e/e2e_http.py
@@ -10,7 +10,9 @@ requests itself imports.
 
 from __future__ import annotations
 
-from typing import Generic, Iterator, Literal, NewType, TypeVar, cast
+import time
+from collections.abc import Callable
+from typing import Generic, Iterator, Literal, NewType, Protocol, TypeVar, cast
 
 import pytest
 import requests
@@ -301,6 +303,45 @@ def _params(params: BaseModel | None) -> dict[str, str]:
     return {key: str(value) for key, value in dumped.items()}
 
 
+TRANSIENT_STATUSES: frozenset[int] = frozenset({500, 502, 503, 504, 529})
+RETRY_ATTEMPTS: int = 3
+RETRY_BACKOFF_SECONDS: float = 0.5
+
+
+class RetryableResponse(Protocol):
+    status_code: int
+
+    def close(self) -> None: ...
+
+
+def request_with_retry[T: RetryableResponse](
+    issue: Callable[[], T], *, sleep: Callable[[float], None] = time.sleep
+) -> T:
+    """Bounded retry on provider-transient statuses only (500/502/503/504/529),
+    the set production SDKs retry by default (Anthropic's own client retries 529
+    overloaded_error). The intent stays clean because only the dependency call
+    is retried; every assertion still judges a single successful response.
+
+    Deliberately NOT retried: 429, because this suite asserts the proxy's own
+    rate-limit and budget 429s and a transport that absorbed them would
+    silently break those tests; network errors and timeouts, because a hang
+    should surface as a hang instead of doubling the wall clock. Every retry
+    prints, so flakiness stays visible in the run log instead of vanishing
+    into green."""
+    for attempt in range(1, RETRY_ATTEMPTS):
+        resp = issue()
+        if resp.status_code not in TRANSIENT_STATUSES:
+            return resp
+        delay = RETRY_BACKOFF_SECONDS * (1 << (attempt - 1))
+        print(
+            f"e2e-http: transient {resp.status_code}; retry {attempt}/{RETRY_ATTEMPTS - 1} in {delay}s",
+            flush=True,
+        )
+        resp.close()
+        sleep(delay)
+    return issue()
+
+
 def _classify[R: BaseModel](
     resp: requests.Response, response_type: type[R]
 ) -> Result[R]:
@@ -325,11 +366,13 @@ def post[R: BaseModel](
     timeout: float = 30.0,
 ) -> Result[R]:
     try:
-        resp = requests.post(
-            str(url),
-            headers=_headers(headers),
-            json=json.model_dump(by_alias=True, exclude_none=True),
-            timeout=timeout,
+        resp = request_with_retry(
+            lambda: requests.post(
+                str(url),
+                headers=_headers(headers),
+                json=json.model_dump(by_alias=True, exclude_none=True),
+                timeout=timeout,
+            )
         )
     except requests.RequestException as exc:
         return NetworkError(message=str(exc))
@@ -345,11 +388,13 @@ def get[R: BaseModel](
     timeout: float = 30.0,
 ) -> Result[R]:
     try:
-        resp = requests.get(
-            str(url),
-            headers=_headers(headers),
-            params=params.model_dump(by_alias=True, exclude_none=True),
-            timeout=timeout,
+        resp = request_with_retry(
+            lambda: requests.get(
+                str(url),
+                headers=_headers(headers),
+                params=params.model_dump(by_alias=True, exclude_none=True),
+                timeout=timeout,
+            )
         )
     except requests.RequestException as exc:
         return NetworkError(message=str(exc))
@@ -386,12 +431,14 @@ def delete[R: BaseModel](
     timeout: float = 30.0,
 ) -> Result[R]:
     try:
-        resp = requests.delete(
-            str(url),
-            headers=_headers(headers),
-            json=json.model_dump(by_alias=True, exclude_none=True),
-            params=_params(params),
-            timeout=timeout,
+        resp = request_with_retry(
+            lambda: requests.delete(
+                str(url),
+                headers=_headers(headers),
+                json=json.model_dump(by_alias=True, exclude_none=True),
+                params=_params(params),
+                timeout=timeout,
+            )
         )
     except requests.RequestException as exc:
         return NetworkError(message=str(exc))
@@ -407,11 +454,13 @@ def patch[R: BaseModel](
     timeout: float = 30.0,
 ) -> Result[R]:
     try:
-        resp = requests.patch(
-            str(url),
-            headers=_headers(headers),
-            json=json.model_dump(by_alias=True, exclude_none=True),
-            timeout=timeout,
+        resp = request_with_retry(
+            lambda: requests.patch(
+                str(url),
+                headers=_headers(headers),
+                json=json.model_dump(by_alias=True, exclude_none=True),
+                timeout=timeout,
+            )
         )
     except requests.RequestException as exc:
         return NetworkError(message=str(exc))
@@ -427,11 +476,13 @@ def put[R: BaseModel](
     timeout: float = 30.0,
 ) -> Result[R]:
     try:
-        resp = requests.put(
-            str(url),
-            headers=_headers(headers),
-            json=json.model_dump(by_alias=True, exclude_none=True),
-            timeout=timeout,
+        resp = request_with_retry(
+            lambda: requests.put(
+                str(url),
+                headers=_headers(headers),
+                json=json.model_dump(by_alias=True, exclude_none=True),
+                timeout=timeout,
+            )
         )
     except requests.RequestException as exc:
         return NetworkError(message=str(exc))
@@ -442,11 +493,13 @@ def probe(
     url: URL, *, headers: BaseModel, params: BaseModel, timeout: float = 30.0
 ) -> ProbeResult:
     try:
-        resp = requests.get(
-            str(url),
-            headers=_headers(headers),
-            params=params.model_dump(by_alias=True, exclude_none=True),
-            timeout=timeout,
+        resp = request_with_retry(
+            lambda: requests.get(
+                str(url),
+                headers=_headers(headers),
+                params=params.model_dump(by_alias=True, exclude_none=True),
+                timeout=timeout,
+            )
         )
     except requests.RequestException as exc:
         return ProbeResult(status_code=-1, body=str(exc))
@@ -544,13 +597,15 @@ def send(
     status rather than a typed JSON model (e.g. a budget block is a non-2xx). With
     ``stream=True`` the SSE body is consumed and its events counted instead."""
     try:
-        resp = requests.post(
-            str(url),
-            headers=_headers(headers),
-            params=_params(params),
-            json=json.model_dump(by_alias=True, exclude_none=True),
-            stream=stream,
-            timeout=timeout,
+        resp = request_with_retry(
+            lambda: requests.post(
+                str(url),
+                headers=_headers(headers),
+                params=_params(params),
+                json=json.model_dump(by_alias=True, exclude_none=True),
+                stream=stream,
+                timeout=timeout,
+            )
         )
     except requests.RequestException as exc:
         return StreamingResponse(status_code=-1, body=str(exc))
@@ -585,13 +640,15 @@ def upload[R: BaseModel](
     dumped: dict[str, object] = form.model_dump(by_alias=True, exclude_none=True)
     data = {key: str(value) for key, value in dumped.items()}
     try:
-        resp = requests.post(
-            str(url),
-            headers=_headers(headers),
-            params=_params(params),
-            data=data,
-            files={file_field: (filename, content, file_content_type)},
-            timeout=timeout,
+        resp = request_with_retry(
+            lambda: requests.post(
+                str(url),
+                headers=_headers(headers),
+                params=_params(params),
+                data=data,
+                files={file_field: (filename, content, file_content_type)},
+                timeout=timeout,
+            )
         )
     except requests.RequestException as exc:
         return NetworkError(message=str(exc))

--- a/tests/e2e/test_e2e_http.py
+++ b/tests/e2e/test_e2e_http.py
@@ -1,11 +1,13 @@
 """Harness coverage for the transport's transient-retry policy.
 
 No proxy needed and no ``e2e`` marker: this pins the retry CONTRACT, which is
-load-bearing for the whole suite. 429 especially must never be retried, because
-the quota suites assert the proxy's own rate-limit and budget 429s; a transport
-that absorbed them would make those tests pass or fail for the wrong reason.
-The fakes satisfy the RetryableResponse protocol directly, so nothing here
-imports requests or monkeypatches anything.
+load-bearing for the whole suite. Only statuses the proxy itself cannot emit
+may ever be retried (today exactly 529, Anthropic's overload signal): 429 must
+stay unretried because the quota suites assert the proxy's own rate-limit and
+budget 429s, and proxy-capable 5xx must stay unretried or an intermittently
+failing proxy would slip through green. The fakes satisfy the
+RetryableResponse protocol directly, so nothing here imports requests or
+monkeypatches anything.
 """
 
 from __future__ import annotations
@@ -41,11 +43,11 @@ def _issue_from(responses: Sequence[FakeResponse]) -> Callable[[], FakeResponse]
 
 
 class TestTransientRetryPolicy:
-    def test_transient_set_is_the_provider_transient_statuses_and_excludes_429(self) -> None:
-        assert TRANSIENT_STATUSES == frozenset({500, 502, 503, 504, 529})
+    def test_transient_set_is_only_statuses_the_proxy_cannot_emit(self) -> None:
+        assert TRANSIENT_STATUSES == frozenset({529})
         assert 429 not in TRANSIENT_STATUSES
 
-    @pytest.mark.parametrize("status", [200, 201, 400, 401, 404, 422])
+    @pytest.mark.parametrize("status", [200, 201, 400, 401, 404, 422, 500, 502, 503, 504])
     def test_non_transient_status_returns_immediately(self, status: int) -> None:
         responses = (FakeResponse(status), FakeResponse(200))
         sleep = SleepRecorder()
@@ -72,7 +74,7 @@ class TestTransientRetryPolicy:
         assert responses[1].close_calls == 0
 
     def test_persistent_transient_is_bounded_and_returns_the_last_response(self) -> None:
-        responses = tuple(FakeResponse(500) for _ in range(RETRY_ATTEMPTS + 1))
+        responses = tuple(FakeResponse(529) for _ in range(RETRY_ATTEMPTS + 1))
         sleep = SleepRecorder()
         result = request_with_retry(_issue_from(responses), sleep=sleep)
         assert result is responses[RETRY_ATTEMPTS - 1]

--- a/tests/e2e/test_e2e_http.py
+++ b/tests/e2e/test_e2e_http.py
@@ -1,0 +1,80 @@
+"""Harness coverage for the transport's transient-retry policy.
+
+No proxy needed and no ``e2e`` marker: this pins the retry CONTRACT, which is
+load-bearing for the whole suite. 429 especially must never be retried, because
+the quota suites assert the proxy's own rate-limit and budget 429s; a transport
+that absorbed them would make those tests pass or fail for the wrong reason.
+The fakes satisfy the RetryableResponse protocol directly, so nothing here
+imports requests or monkeypatches anything.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+import pytest
+
+from e2e_http import RETRY_ATTEMPTS, TRANSIENT_STATUSES, request_with_retry
+
+
+@dataclass
+class FakeResponse:
+    status_code: int
+    close_calls: int = 0
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+@dataclass
+class SleepRecorder:
+    delays: list[float] = field(default_factory=list)
+
+    def __call__(self, seconds: float) -> None:
+        self.delays.append(seconds)
+
+
+def _issue_from(responses: Sequence[FakeResponse]) -> Callable[[], FakeResponse]:
+    it = iter(responses)
+    return lambda: next(it)
+
+
+class TestTransientRetryPolicy:
+    def test_transient_set_is_the_provider_transient_statuses_and_excludes_429(self) -> None:
+        assert TRANSIENT_STATUSES == frozenset({500, 502, 503, 504, 529})
+        assert 429 not in TRANSIENT_STATUSES
+
+    @pytest.mark.parametrize("status", [200, 201, 400, 401, 404, 422])
+    def test_non_transient_status_returns_immediately(self, status: int) -> None:
+        responses = (FakeResponse(status), FakeResponse(200))
+        sleep = SleepRecorder()
+        result = request_with_retry(_issue_from(responses), sleep=sleep)
+        assert result is responses[0]
+        assert sleep.delays == []
+        assert responses[0].close_calls == 0
+
+    def test_429_is_never_retried(self) -> None:
+        responses = (FakeResponse(429), FakeResponse(200))
+        sleep = SleepRecorder()
+        result = request_with_retry(_issue_from(responses), sleep=sleep)
+        assert result is responses[0]
+        assert sleep.delays == []
+        assert responses[0].close_calls == 0
+
+    def test_overloaded_529_retries_with_backoff_then_returns_the_success(self) -> None:
+        responses = (FakeResponse(529), FakeResponse(200))
+        sleep = SleepRecorder()
+        result = request_with_retry(_issue_from(responses), sleep=sleep)
+        assert result is responses[1]
+        assert sleep.delays == [0.5]
+        assert responses[0].close_calls == 1
+        assert responses[1].close_calls == 0
+
+    def test_persistent_transient_is_bounded_and_returns_the_last_response(self) -> None:
+        responses = tuple(FakeResponse(500) for _ in range(RETRY_ATTEMPTS + 1))
+        sleep = SleepRecorder()
+        result = request_with_retry(_issue_from(responses), sleep=sleep)
+        assert result is responses[RETRY_ATTEMPTS - 1]
+        assert sleep.delays == [0.5, 1.0]
+        assert [r.close_calls for r in responses] == [1, 1, 0, 0]


### PR DESCRIPTION
## TLDR

Problem this solves:

- a real Anthropic 529 overloaded_error failed a full e2e run
- passthrough routes bypass the router's retries, so provider blips reach the harness
- blanket test reruns would hide real flakiness and erode suite trust

How it solves it:

- transport-level retry scoped to statuses the proxy cannot emit: exactly 529
- bounded exponential backoff, every retry printed so flakiness stays visible
- 429 and all proxy-capable 5xx deliberately excluded and canary-tested

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proof through the real transport at 4146b0dc47, against a local HTTP server: route /a answers 529 then 200, route /b answers a persistent 500. The transport retries the 529 once with the visible log line and returns the success; the 500 comes back untouched on the first attempt, exactly the behavior the review asked to preserve

```
e2e-http: transient 529; retry 1/2 in 0.5s
529-then-200: kind='success' status_code=200 data=Ok(ok=True) | server saw 2 requests (expect 2)
persistent 500: UnknownApiError 500 | server saw 1 request (expect 1, no retry)
```

Motivating failure this absorbs, from the full-suite run on the per-SHA stack (Buildkite litellm-poc build 27, commit f0c3046d7b):

```
FAILED llm_translation/test_passthrough_e2e.py::test_anthropic_passthrough_tool_call_logs_cost
Failed: upstream call failed (status 529); body={"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_011CdiK2AuWo6Lx5Fq3LfWgQ"}
```

Harness contract tests (protocol fakes, no requests import, no monkeypatching):

```
cd tests/e2e && python -m pytest test_e2e_http.py -q
14 passed in 0.01s
```

## Type

✅ Test

## Changes

Adds request_with_retry to tests/e2e/e2e_http.py: bounded retry (3 attempts, 0.5s/1s backoff) on statuses attributable to the provider and never the proxy. Today that set is exactly 529, Anthropic's overloaded_error forwarded verbatim on passthrough, which litellm never originates and whose own SDK retries it; it is also the only transient observed across the full-suite runs. The proxy-path verbs (post, get, delete, patch, put, send, upload, probe) issue through it; get_external, stream_binary, and download are unchanged. Streamed responses retry only before body consumption and the abandoned response is closed

Design constraints honored, tightened per Greptile's review: 500/502/503/504 stay first-class failures because at the transport a proxy-originated 5xx is indistinguishable from a relayed one and the proxy is the system under test; 429 is excluded because the quota suites assert the proxy's own rate-limit and budget 429s; network errors and timeouts are not retried so hangs surface as hangs; each retry prints to the run log so flakiness stays measurable. The retry loop takes injected sleep and issue callables, and tests/e2e/test_e2e_http.py pins the whole contract, including 500/502/503/504 and 429 never being retried, with dataclass fakes satisfying the RetryableResponse protocol

## QA runbook

- tests/e2e/test_e2e_http.py::TestTransientRetryPolicy - the transport retries exactly 529, bounded, with backoff, and never touches 429 or proxy-capable 5xx
  - [ ] cd tests/e2e && python -m pytest test_e2e_http.py -q and expect 14 passed
  - [ ] Reproduce the live proof: run a local HTTP server where /a answers 529 then 200 and /b answers persistent 500; call e2e_http.get against both and expect one retry line plus Success for /a, and an immediate unretried UnknownApiError 500 for /b
  - [ ] Grep the diff for TRANSIENT_STATUSES and confirm it is exactly {529}, then run any quota_management ratelimit test against a live proxy and confirm 429 assertions still pass unretried
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
