### PR TITLE
ci(lint): run secret-scan pytest without syncing the project env

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Run secret scan test
         run: |
-          uv run --frozen --with 'pytest==9.0.2' pytest tests/litellm/test_no_hardcoded_secrets.py -v
+          uv run --no-project --with 'pytest==9.0.2' pytest tests/litellm/test_no_hardcoded_secrets.py -v
 
       - name: Run ggshield secret scan
         env:


### PR DESCRIPTION
## TLDR

Problem this solves:

- secret-scan flakes by hitting its five minute job timeout
- `uv run --frozen` first syncs 146 packages and builds the litellm wheel
- the test itself needs only pytest and the stdlib

How it solves it:

- run pytest with `--no-project` so nothing but pytest installs
- environment setup drops from minutes to seconds

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before, at 258d154f18 on PR #35807: the secret-scan job spent its whole budget installing an environment the test never uses, then died at the five minute cap before the single collected test ran ([cancelled run](https://github.com/BerriAI/litellm/actions/runs/30949816087/job/92128807659))

```
20:55:04 Creating virtual environment at: .venv
20:55:04    Building litellm @ file:///home/runner/work/litellm/litellm
20:57:24       Built litellm @ file:///home/runner/work/litellm/litellm
20:57:24 Installed 146 packages in 224ms
20:57:27 collecting ... collected 1 item
20:57:28 ##[error]The operation was canceled.
```

After, at d7ef033418, the same invocation CI now runs, from a shell with no project environment:

```
$ time uv run --no-project --with 'pytest==9.0.2' pytest tests/litellm/test_no_hardcoded_secrets.py -v
Installed 5 packages in 14ms
collecting ... collected 1 item
tests/litellm/test_no_hardcoded_secrets.py::test_no_hardcoded_basic_auth_secrets PASSED [100%]
============================== 1 passed in 1.35s ===============================
uv run --no-project --with 'pytest==9.0.2' pytest  -v  1.02s user 0.70s system 46% cpu 3.648 total
```

And the live end-to-end proof, since pull_request runs use the workflow file from the PR branch: this PR's own secret-scan check at d7ef033418 [passed in 1m8s](https://github.com/BerriAI/litellm/actions/runs/30951708406/job/92135101657), well clear of the five minute cap

## Type

🚄 Infrastructure

## Changes

`tests/litellm/test_no_hardcoded_secrets.py` walks the source tree with `os.walk` and regexes; it imports nothing from litellm, and no conftest exists anywhere on its path (repo root, `tests/`, or `tests/litellm/`). The job's `uv run --frozen` nevertheless synced the full project environment, and on a cold-cache runner building the litellm wheel alone took over two minutes, which is how a job capped at `timeout-minutes: 5` got cancelled before its one test executed. Swapping `--frozen` for `--no-project` makes uv skip the project entirely and spin up an ephemeral environment containing just pytest, so the job no longer races its own timeout. The ggshield step after it already runs isolated through `uv tool run` and is untouched

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
