### PR TITLE
chore(lint): zero out basedpyright headroom for purely local rules

### DIFF
--- a/basedpyright-code-budget.json
+++ b/basedpyright-code-budget.json
@@ -15,13 +15,13 @@
     "limit": 123
   },
   "reportConstantRedefinition": {
-    "limit": 59
+    "limit": 40
   },
   "reportDeprecated": {
     "limit": 325
   },
   "reportDuplicateImport": {
-    "limit": 38
+    "limit": 24
   },
   "reportExplicitAny": {
     "limit": 9473
@@ -81,13 +81,13 @@
     "limit": 0
   },
   "reportPossiblyUnboundVariable": {
-    "limit": 77
+    "limit": 56
   },
   "reportPrivateUsage": {
     "limit": 2436
   },
   "reportRedeclaration": {
-    "limit": 12
+    "limit": 8
   },
   "reportReturnType": {
     "limit": 219
@@ -114,16 +114,16 @@
     "limit": 31978
   },
   "reportUnnecessaryCast": {
-    "limit": 173
+    "limit": 124
   },
   "reportUnnecessaryComparison": {
-    "limit": 1017
+    "limit": 703
   },
   "reportUnnecessaryContains": {
-    "limit": 7
+    "limit": 5
   },
   "reportUnnecessaryIsInstance": {
-    "limit": 1203
+    "limit": 866
   },
   "reportUntypedBaseClass": {
     "limit": 165
@@ -132,15 +132,15 @@
     "limit": 33
   },
   "reportUnusedClass": {
-    "limit": 33
+    "limit": 23
   },
   "reportUnusedFunction": {
-    "limit": 204
+    "limit": 139
   },
   "reportUnusedImport": {
-    "limit": 1003
+    "limit": 588
   },
   "reportUnusedVariable": {
-    "limit": 1297
+    "limit": 147
   }
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Purely local basedpyright rules carry big stale headroom
- reportUnusedVariable alone allows 1150 net-new dead locals
- That headroom lets trivially avoidable errors merge silently

How it solves it:

- Set twelve local-rule limits to their live counts
- Unused, unnecessary, redeclaration, and possibly-unbound families zeroed
- Any net-new error in them now reddens the gate

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs below were captured at 98d4f9151c. This PR touches only `basedpyright-code-budget.json`, so there is no runtime behavior to exercise; the gate itself is the end-to-end surface

The whole-tree gate green with the tightened limits:

```
$ uv run basedpyright --outputjson | python scripts/type_check_gate.py --base origin/litellm_internal_staging
OK: every rule is within its basedpyright limit or no higher than base (149647 errors total)
```

A two-line demo file reddening the gate through two of the zeroed rules (the file was deleted right after):

```
$ printf 'def _demo() -> None:\n    dead = 1\n' > litellm/_demo_unused.py
$ uv run basedpyright --outputjson | python scripts/type_check_gate.py --base origin/litellm_internal_staging
FAIL: basedpyright errors exceed the per-rule limit:
  reportUnusedFunction: total 140 over limit 139 (this change added 1)
  reportUnusedVariable: total 148 over limit 147 (this change added 1)
Reduce the new errors or remove an equal number elsewhere; the ceiling is the limit in basedpyright-code-budget.json.
BREACHED RULES: reportUnusedFunction 140/139 (+1); reportUnusedVariable 148/147 (+1)
```

## Type

🚄 Infrastructure

## Changes

Some basedpyright rules deserve headroom because their errors are contagious: building on code that is already `Any`-typed forces new `reportAny` or `reportUnknown*` errors that only a disproportionate refactor could avoid, and we do not want unrelated PRs doing drive-by refactors just to please the type checker. The rules tightened here have no such excuse. An unused variable, an unused or duplicate import, an unnecessary isinstance or cast, a redeclaration, or a possibly unbound variable is always introduced by the change itself and is always fixable locally by deleting or restructuring a few lines, or in the rare deliberate case suppressible with a justified `# pyright: ignore[...]`. Carrying hundreds of spare errors for them means that many can merge without ever reddening CI

`basedpyright-code-budget.json` accordingly drops these twelve limits to the live count measured on this branch point:

| Rule | Old | New |
|---|---|---|
| reportUnusedVariable | 1297 | 147 |
| reportUnnecessaryIsInstance | 1203 | 866 |
| reportUnnecessaryComparison | 1017 | 703 |
| reportUnusedImport | 1003 | 588 |
| reportUnusedFunction | 204 | 139 |
| reportUnnecessaryCast | 173 | 124 |
| reportPossiblyUnboundVariable | 77 | 56 |
| reportConstantRedefinition | 59 | 40 |
| reportDuplicateImport | 38 | 24 |
| reportUnusedClass | 33 | 23 |
| reportRedeclaration | 12 | 8 |
| reportUnnecessaryContains | 7 | 5 |

The gate fails a rule only when its count is both over the limit and above the merge-base count, so pre-existing drift keeps merging fine while any net-new error in these categories now fails pre-commit and CI, as the demo above shows. The contagious `reportAny` and `reportUnknown*` families keep their grandfathered headroom untouched

No tests are added because no code changes; the gate logic that enforces these limits is already covered by `tests/test_litellm/test_type_check_gate.py`

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to type-check gate thresholds; no production code paths affected.
> 
> **Overview**
> Tightens **twelve** `basedpyright-code-budget.json` per-rule ceilings to the current error counts for diagnostics that are always fixable in the diff (unused imports/variables/functions/classes, duplicate imports, unnecessary casts/comparisons/isinstance/contains, redeclarations, constant redefinition, possibly unbound variables).
> 
> **Effect:** CI/pre-commit via `scripts/type_check_gate.py` can no longer absorb large net-new violations in those categories while staying green; contagious `reportAny` / `reportUnknown*` limits are unchanged. No runtime or library code is modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98d4f9151c4291d02f2ecc42917498ac57b60065. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->