### PR TITLE
fix(auth): name enable_jwt_auth when a JWT-shaped key is rejected

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -677,6 +677,12 @@ async def check_api_key_for_custom_headers_or_pass_through_endpoints(
 # the lookup and return None (caller proceeds to auth_builder).
 _JWT_PROXY_ADMIN_SENTINEL = "__JWT_PROXY_ADMIN__"
 
+_JWT_AUTH_DISABLED_HINT = (
+    " This key has the structure of a JWT, but JWT auth is not enabled on this proxy, so it was treated as a"
+    " virtual key. Set `enable_jwt_auth: true` under `general_settings` in your proxy config to authenticate"
+    " with JWTs."
+)
+
 
 class _PendingAutoRegister(NamedTuple):
     """
@@ -1206,8 +1212,11 @@ async def _user_api_key_auth_builder(
                 from litellm.proxy.proxy_server import premium_user
 
                 if premium_user is not True:
-                    raise ValueError(
-                        f"JWT Auth is an enterprise only feature. {CommonProxyErrors.not_premium_user.value}"
+                    raise ProxyException(
+                        message=f"JWT Auth is an enterprise only feature. {CommonProxyErrors.not_premium_user.value}",
+                        type=ProxyErrorTypes.auth_error,
+                        param="premium_user",
+                        code=status.HTTP_403_FORBIDDEN,
                     )
                 # Try JWT-to-Virtual-Key mapping first to avoid
                 # unnecessary DB queries in auth_builder
@@ -1672,9 +1681,13 @@ async def _user_api_key_auth_builder(
             if isinstance(api_key, str):  # if generated token, make sure it starts with sk-.
                 _masked_key = f"{api_key[:4]}****{api_key[-4:]}" if len(api_key) > 8 else "****"
                 if not api_key.startswith("sk-"):
+                    _hint = _JWT_AUTH_DISABLED_HINT if not enable_jwt_auth and JWTHandler.is_jwt(token=api_key) else ""
                     raise HTTPException(
                         status_code=status.HTTP_401_UNAUTHORIZED,
-                        detail=(f"LiteLLM Virtual Key expected. Received={_masked_key}, expected to start with 'sk-'."),
+                        detail=(
+                            f"LiteLLM Virtual Key expected. Received={_masked_key}, "
+                            f"expected to start with 'sk-'.{_hint}"
+                        ),
                     )  # prevent token hashes from being used
             else:
                 verbose_logger.warning(

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -5681,3 +5681,101 @@ async def test_temp_budget_increase_applied_for_cached_key():
 
     cached_after = await user_api_key_cache.async_get_cache(key=hashed_token)
     assert cached_after.max_budget == 2.0
+
+
+async def _proxy_exception_for_key(
+    api_key: str,
+    general_settings: dict[str, bool],
+    premium_user: bool,
+) -> ProxyException:
+    mock_request = MagicMock()
+    mock_request.url.path = "/v1/chat/completions"
+    mock_request.method = "POST"
+    mock_request.headers = {"authorization": f"Bearer {api_key}"}
+    mock_request.query_params = {}
+    mock_request.state = SimpleNamespace()
+
+    proxy_logging_obj = MagicMock()
+    proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+
+    user_api_key_cache = DualCache()
+    jwt_handler = JWTHandler()
+    jwt_handler.update_environment(
+        prisma_client=None,
+        user_api_key_cache=user_api_key_cache,
+        litellm_jwtauth=LiteLLM_JWTAuth(),
+    )
+
+    with (
+        patch("litellm.proxy.proxy_server.general_settings", general_settings),
+        patch("litellm.proxy.proxy_server.premium_user", premium_user),
+        patch("litellm.proxy.proxy_server.master_key", "sk-master"),
+        patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+        patch("litellm.proxy.proxy_server.user_api_key_cache", user_api_key_cache),
+        patch("litellm.proxy.proxy_server.proxy_logging_obj", proxy_logging_obj),
+        patch("litellm.proxy.proxy_server.jwt_handler", jwt_handler),
+    ):
+        with pytest.raises(ProxyException) as exc_info:
+            await _user_api_key_auth_builder(
+                request=mock_request,
+                api_key=f"Bearer {api_key}",
+                azure_api_key_header="",
+                anthropic_api_key_header=None,
+                google_ai_studio_api_key_header=None,
+                azure_apim_header=None,
+                request_data={"model": "gpt-4o-mini"},
+            )
+
+    return exc_info.value
+
+
+@pytest.mark.asyncio
+async def test_jwt_shaped_key_error_names_enable_jwt_auth_when_disabled():
+    """
+    A three-segment token presented while `general_settings.enable_jwt_auth`
+    is unset is never treated as JWT-shaped, so it falls through to the
+    virtual-key path and is rejected for not starting with 'sk-'. That reads
+    as a missing database row and sends the operator to inspect virtual keys,
+    when the real cause is the missing config key. The rejection must name
+    `enable_jwt_auth`, and must claim only that the key is JWT-shaped, since
+    segment count cannot tell a JWT from any other dotted credential.
+
+    The existing 'expected to start with sk-' text has to survive: the
+    Prometheus invalid-key filter and the admin UI both substring-match it.
+    Keys that are not JWT-shaped must not pick up the hint.
+    """
+    jwt_error = await _proxy_exception_for_key(
+        "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJzdmMtMSJ9.c2lnbmF0dXJl", {}, True
+    )
+
+    assert jwt_error.code == "401"
+    assert "enable_jwt_auth" in jwt_error.message
+    assert "general_settings" in jwt_error.message
+    assert "expected to start with 'sk-'" in jwt_error.message
+    assert "structure of a JWT" in jwt_error.message
+    assert "is a JWT" not in jwt_error.message
+
+    opaque_error = await _proxy_exception_for_key("not-a-jwt-at-all", {}, True)
+    two_segment_error = await _proxy_exception_for_key(
+        "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJzdmMtMSJ9", {}, True
+    )
+
+    assert "enable_jwt_auth" not in opaque_error.message
+    assert "enable_jwt_auth" not in two_segment_error.message
+
+
+@pytest.mark.asyncio
+async def test_unlicensed_jwt_auth_is_forbidden_not_unauthorized():
+    """
+    JWT auth is enterprise-gated. An unlicensed install must answer 403 like
+    every other enterprise gate; a 401 tells the client its credential was
+    wrong and invites a retry loop that can never succeed.
+    """
+    error = await _proxy_exception_for_key(
+        "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJzdmMtMSJ9.c2lnbmF0dXJl",
+        {"enable_jwt_auth": True},
+        False,
+    )
+
+    assert error.code == "403"
+    assert "enterprise" in error.message.lower()


### PR DESCRIPTION
## TLDR

Problem this solves:

- A JWT sent without `enable_jwt_auth` is reported as a bad virtual key
- The error names no config, so operators go debug virtual keys
- The unlicensed JWT gate answers 401, inviting an endless retry

How it solves it:

- Append a hint naming `general_settings.enable_jwt_auth` to that rejection
- Only for keys that are actually three-segment JWTs
- Raise 403 from the enterprise gate, matching every sibling gate

## Relevant issues

## Linear ticket

Resolves LIT-5166

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Postgres-backed proxy on a namespaced port, `LITELLM_LICENSE` exported empty so the install is unlicensed, and a real RS256 JWT with a `kid` header minted for the run. Before runs captured at `ad79b314c5`, after runs at `ffad9185b7`

Case 1 uses a `general_settings` block that sets `JWT_PUBLIC_KEY_URL` in the environment and omits `enable_jwt_auth`, which is the configuration mistake this fixes

```
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-lit5171-master
```

```bash
curl -sS -i -X POST http://127.0.0.1:4171/v1/chat/completions \
  -H "Authorization: Bearer $JWT" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
```

Before, at `ad79b314c5`

```
HTTP/1.1 401 Unauthorized
{"error":{"message":"LiteLLM Virtual Key expected. Received=eyJh****vuRw, expected to start with 'sk-'.","type":"auth_error","param":"None","code":"401"}}
```

After, at `ffad9185b7`

```
HTTP/1.1 401 Unauthorized
{"error":{"message":"LiteLLM Virtual Key expected. Received=eyJh****vuRw, expected to start with 'sk-'. This key has the structure of a JWT, but JWT auth is not enabled on this proxy, so it was treated as a virtual key. Set `enable_jwt_auth: true` under `general_settings` in your proxy config to authenticate with JWTs.","type":"auth_error","param":"None","code":"401"}}
```

The same config and the same build, with an opaque key instead of a JWT-shaped one, showing the hint is scoped rather than appended to every rejection

```bash
curl -sS -i -X POST http://127.0.0.1:4171/v1/chat/completions \
  -H "Authorization: Bearer not-a-jwt-at-all" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
```

```
HTTP/1.1 401 Unauthorized
{"error":{"message":"LiteLLM Virtual Key expected. Received=not-****-all, expected to start with 'sk-'.","type":"auth_error","param":"None","code":"401"}}
```

Case 2 adds `enable_jwt_auth: True` to the same config, still unlicensed, same curl

Before, at `ad79b314c5`

```
HTTP/1.1 401 Unauthorized
{"error":{"message":"Authentication Error, JWT Auth is an enterprise only feature. You must be a LiteLLM Enterprise user to use this feature. If you have a license please set `LITELLM_LICENSE` in your env. Get a 7 day trial key here: https://www.litellm.ai/enterprise#trial. \nPricing: https://www.litellm.ai/#pricing","type":"auth_error","param":"None","code":"401"}}
```

After, at `ffad9185b7`

```
HTTP/1.1 403 Forbidden
{"error":{"message":"JWT Auth is an enterprise only feature. You must be a LiteLLM Enterprise user to use this feature. If you have a license please set `LITELLM_LICENSE` in your env. Get a 7 day trial key here: https://www.litellm.ai/enterprise#trial. \nPricing: https://www.litellm.ai/#pricing","type":"auth_error","param":"premium_user","code":"403"}}
```

The `Authentication Error, ` prefix drops because it belonged to the terminal catch-all; a `ProxyException` passes through the handler unmodified

Control on the fixed build, showing an ordinary virtual key still authenticates and reaches the real OpenAI API at real cost, at `ffad9185b7`

```bash
KEY=$(curl -sS -X POST http://127.0.0.1:4171/key/generate \
  -H "Authorization: Bearer sk-lit5171-master" -H "Content-Type: application/json" \
  -d '{"models":["gpt-4o-mini"]}' | python -c "import sys,json;print(json.load(sys.stdin)['key'])")
curl -sS -i -X POST http://127.0.0.1:4171/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say OK"}]}'
```

```
HTTP/1.1 200 OK
{"id":"chatcmpl-E9GunUjPPrIYA6ngZG5lA7EQc6Tzm","created":1785878681,"model":"gpt-4o-mini","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"OK!","role":"assistant"}}], ...}
```

## Type

🐛 Bug Fix

## Changes

`general_settings.enable_jwt_auth` gates whether a token is even recognized as a JWT. With the flag unset, `is_jwt` is hardcoded to `False`, so a JWT falls through to the virtual-key path and is rejected by the `sk-` prefix guard for not looking like a virtual key. The docs list `JWT_PUBLIC_KEY_URL` first, so setting the env var and forgetting the config line is an easy mistake, and the resulting message sends the operator to inspect virtual keys for what is a one-line config problem

The rejection now appends a sentence naming `enable_jwt_auth`, and only when the presented key is three-segment. `JWTHandler.is_jwt` is a pure structural check with no side effects, so consulting it in that branch costs nothing and cannot change who authenticates. Note it is called explicitly rather than reusing the local `is_jwt`, which is pinned to `False` whenever the flag is off and would make the branch unreachable. Nothing beyond the already-masked key is added to the message

The hint claims only that the key has the structure of a JWT, never that it is one. Segment count cannot distinguish a JWT from any other dotted credential, so a message asserting the key IS a JWT would trade one confident misdiagnosis for a narrower one, which is the same failure this PR exists to fix. The classifier itself is deliberately left alone; `is_jwt` is litellm's definition of JWT-shaped everywhere else on this path, and applying a stricter rule in one branch would be an inconsistency for the next reader to trip over

The hint is appended rather than substituted because the existing text is matched elsewhere. `PrometheusLogger._is_invalid_api_key_request` substring-matches `expected to start with 'sk-'` to suppress metrics for invalid keys, so replacing that text would quietly distort an invalid-key metric instead of failing loudly. I checked the filter against the lengthened message directly and it still matches, and `tests/test_litellm/integrations/test_prometheus_invalid_key_filtering.py` passes unchanged

The second change is narrower and worth stating precisely, because the message on that path is not the problem. A client that sets the flag on an unlicensed install already receives "JWT Auth is an enterprise only feature. You must be a LiteLLM Enterprise user...", which says what is wrong. What is wrong is only the status code. The gate raised a bare `ValueError`, which the terminal handler in `auth_exception_handler.py` converts to a 401, while every sibling enterprise gate answers 403, including `_premium_user_check` and the SSO gate. A 401 tells a client its credential was wrong and to retry with a better one, and no credential can satisfy that while the install is unlicensed. It now raises a 403 `ProxyException` shaped like the SSO gate

One string delta comes with that status code change and is worth calling out so it does not read as an accident. The 401 body was prefixed "Authentication Error, " because the terminal catch-all builds that message itself out of `str(e)`. A `ProxyException` is re-raised by the handler unmodified, so the 403 body carries the gate's own message without the prefix. The sentence naming the enterprise requirement is unchanged

On how much this is worth: a GitHub issue search turned up no other user reporting this specific symptom. The confusing-auth-error surface is well attested, in #18474 and #24680 among others, but those are virtual-key problems on a different code path. The case for this one rests on the code path itself and a single customer report, not on a pattern of reports

Authentication behavior is unchanged. No new config, no new environment variable, and every request that authenticated before still authenticates

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
