### PR TITLE
fix(migrations): recover from an interrupted Prisma toolchain install

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/prisma_toolchain.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/prisma_toolchain.py
@@ -1,0 +1,177 @@
+"""Prepare the Node toolchain the Prisma CLI needs, separately from migrations.
+
+The Prisma CLI is a Node program. The first invocation inside a fresh
+container installs a private Node runtime and npm-installs the CLI itself,
+which can take minutes on a cold or slow machine. Sharing one timeout between
+that one-time bootstrap and the migration commands makes a slow bootstrap
+indistinguishable from a slow migration, so the bootstrap gets killed long
+before it can finish.
+
+A killed bootstrap does not correct itself. The installer leaves its cache
+directory behind, and Prisma decides whether to install by testing that
+directory for existence alone, so every later attempt skips the install and
+then fails on a Node binary that was never written. Deleting a cache directory
+that exists without a Node binary is what turns a killed bootstrap back into a
+recoverable one.
+
+Both budgets are overridable so an operator can widen them without a release:
+``LITELLM_PRISMA_BOOTSTRAP_TIMEOUT`` for the toolchain install and
+``LITELLM_PRISMA_COMMAND_TIMEOUT`` for every individual Prisma command.
+"""
+
+import math
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from litellm_proxy_extras._logging import logger
+
+try:
+    from prisma import config as prisma_config
+except ImportError:
+    prisma_config = None
+
+PRISMA_COMMAND_TIMEOUT_ENV_VAR = "LITELLM_PRISMA_COMMAND_TIMEOUT"
+PRISMA_BOOTSTRAP_TIMEOUT_ENV_VAR = "LITELLM_PRISMA_BOOTSTRAP_TIMEOUT"
+NODEENV_CACHE_DIR_ENV_VAR = "PRISMA_NODEENV_CACHE_DIR"
+
+DEFAULT_PRISMA_COMMAND_TIMEOUT = 60.0
+DEFAULT_PRISMA_BOOTSTRAP_TIMEOUT = 600.0
+
+BOOTSTRAP_ARG = "--version"
+
+
+@dataclass(frozen=True)
+class ToolchainBootstrap:
+    """Outcome of preparing the Prisma toolchain."""
+
+    healed_incomplete_cache: bool
+    ready: bool
+
+
+def _timeout_from_env(env_var: str, default: float) -> float:
+    raw = os.getenv(env_var)
+    if raw is None:
+        return default
+    try:
+        seconds = float(raw)
+    except ValueError:
+        logger.warning(
+            "%s=%r is not a number, falling back to %ss", env_var, raw, default
+        )
+        return default
+    if not math.isfinite(seconds) or seconds <= 0:
+        logger.warning(
+            "%s=%r is not a finite positive number, falling back to %ss",
+            env_var,
+            raw,
+            default,
+        )
+        return default
+    return seconds
+
+
+def prisma_command_timeout() -> float:
+    """Seconds any single Prisma command may run for."""
+    return _timeout_from_env(
+        PRISMA_COMMAND_TIMEOUT_ENV_VAR, DEFAULT_PRISMA_COMMAND_TIMEOUT
+    )
+
+
+def prisma_bootstrap_timeout() -> float:
+    """Seconds the one-time Node toolchain install may run for."""
+    return _timeout_from_env(
+        PRISMA_BOOTSTRAP_TIMEOUT_ENV_VAR, DEFAULT_PRISMA_BOOTSTRAP_TIMEOUT
+    )
+
+
+def nodeenv_cache_dir() -> Optional[Path]:
+    """Where Prisma installs its private Node runtime, or None if unknowable."""
+    override = os.getenv(NODEENV_CACHE_DIR_ENV_VAR)
+    if override:
+        return Path(override).absolute()
+    if prisma_config is not None:
+        try:
+            return Path(prisma_config.nodeenv_cache_dir).absolute()
+        except (OSError, ValueError) as e:
+            logger.warning("Could not read the Prisma nodeenv cache dir: %s", e)
+    try:
+        return Path.home() / ".cache" / "prisma-python" / "nodeenv"
+    except RuntimeError:
+        logger.warning(
+            "No resolvable home directory, cannot locate the Prisma nodeenv cache"
+        )
+        return None
+
+
+def node_binary_path(cache_dir: Path) -> Path:
+    """Path the Node binary occupies once the toolchain is fully installed."""
+    if os.name == "nt":
+        return cache_dir / "Scripts" / "node.exe"
+    return cache_dir / "bin" / "node"
+
+
+def heal_incomplete_nodeenv_cache() -> bool:
+    """Delete a nodeenv cache directory left without a Node binary.
+
+    Returns True when a half-installed toolchain was removed, so the next
+    Prisma invocation reinstalls it instead of failing on a missing binary.
+    """
+    cache_dir = nodeenv_cache_dir()
+    if cache_dir is None or not cache_dir.is_dir():
+        return False
+    if node_binary_path(cache_dir).exists():
+        return False
+    logger.warning(
+        "Node toolchain at %s has no %s, so a previous install was interrupted. "
+        "Removing it so it can be reinstalled.",
+        cache_dir,
+        node_binary_path(cache_dir).name,
+    )
+    try:
+        shutil.rmtree(cache_dir)
+    except OSError as e:
+        logger.warning("Could not remove %s: %s", cache_dir, e)
+        return False
+    return True
+
+
+def ensure_prisma_toolchain(
+    prisma_command: str, prisma_env: dict[str, str]
+) -> ToolchainBootstrap:
+    """Install whatever the Prisma CLI needs to run, under its own timeout.
+
+    Never raises. A toolchain that cannot be prepared is reported so the
+    caller can go on and let the real Prisma command produce the real error.
+    """
+    healed = heal_incomplete_nodeenv_cache()
+    timeout = prisma_bootstrap_timeout()
+    logger.info("Preparing the Prisma CLI toolchain (timeout %ss)", timeout)
+    try:
+        subprocess.run(
+            [prisma_command, BOOTSTRAP_ARG],
+            timeout=timeout,
+            check=True,
+            capture_output=True,
+            text=True,
+            env=prisma_env,
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "Preparing the Prisma CLI toolchain timed out after %ss. Raise %s "
+            "if this machine needs longer to install it.",
+            timeout,
+            PRISMA_BOOTSTRAP_TIMEOUT_ENV_VAR,
+        )
+        return ToolchainBootstrap(healed_incomplete_cache=healed, ready=False)
+    except subprocess.CalledProcessError as e:
+        logger.warning("Preparing the Prisma CLI toolchain failed: %s", e.stderr)
+        return ToolchainBootstrap(healed_incomplete_cache=healed, ready=False)
+    except OSError as e:
+        logger.warning("Could not run the Prisma CLI: %s", e)
+        return ToolchainBootstrap(healed_incomplete_cache=healed, ready=False)
+    logger.info("Prisma CLI toolchain ready")
+    return ToolchainBootstrap(healed_incomplete_cache=healed, ready=True)

--- a/litellm-proxy-extras/litellm_proxy_extras/replica_identity.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/replica_identity.py
@@ -16,6 +16,7 @@ import tempfile
 from pathlib import Path
 
 from litellm_proxy_extras._logging import logger
+from litellm_proxy_extras.prisma_toolchain import prisma_command_timeout
 
 REPLICA_IDENTITY_FULL_ENV_VAR = "LITELLM_SET_REPLICA_IDENTITY_FULL"
 
@@ -75,7 +76,7 @@ def apply_replica_identity_full(
                     "--schema",
                     schema_path,
                 ],
-                timeout=60,
+                timeout=prisma_command_timeout(),
                 check=True,
                 capture_output=True,
                 text=True,

--- a/litellm-proxy-extras/litellm_proxy_extras/utils.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/utils.py
@@ -14,6 +14,10 @@ from litellm_proxy_extras.replica_identity import (
     REPLICA_IDENTITY_FULL_ENV_VAR,
     apply_replica_identity_full,
 )
+from litellm_proxy_extras.prisma_toolchain import (
+    ensure_prisma_toolchain,
+    prisma_command_timeout,
+)
 
 
 def str_to_bool(value: Optional[str]) -> bool:
@@ -142,7 +146,7 @@ class ProxyExtrasDBManager:
                 ],
                 stdout=open(migration_file, "w"),
                 check=True,
-                timeout=30,
+                timeout=prisma_command_timeout(),
                 env=prisma_env,
             )
 
@@ -157,7 +161,7 @@ class ProxyExtrasDBManager:
                     "0_init",
                 ],
                 check=True,
-                timeout=30,
+                timeout=prisma_command_timeout(),
                 env=prisma_env,
             )
 
@@ -193,7 +197,7 @@ class ProxyExtrasDBManager:
                 "--rolled-back",
                 migration_name,
             ],
-            timeout=60,
+            timeout=prisma_command_timeout(),
             check=True,
             capture_output=True,
             env=prisma_env,
@@ -205,7 +209,7 @@ class ProxyExtrasDBManager:
         prisma_env = _get_prisma_env()
         subprocess.run(
             [_get_prisma_command(), "migrate", "resolve", "--applied", migration_name],
-            timeout=60,
+            timeout=prisma_command_timeout(),
             check=True,
             capture_output=True,
             env=prisma_env,
@@ -303,7 +307,7 @@ class ProxyExtrasDBManager:
                         "--script",
                     ],
                     check=True,
-                    timeout=60,
+                    timeout=prisma_command_timeout(),
                     stdout=f,
                     env=_get_prisma_env(),
                 )
@@ -335,7 +339,7 @@ class ProxyExtrasDBManager:
                             "--schema",
                             schema_path,
                         ],
-                        timeout=60,
+                        timeout=prisma_command_timeout(),
                         check=True,
                         capture_output=True,
                         text=True,
@@ -364,7 +368,7 @@ class ProxyExtrasDBManager:
                     "--schema",
                     schema_path,
                 ],
-                timeout=60,
+                timeout=prisma_command_timeout(),
                 check=True,
                 capture_output=True,
                 text=True,
@@ -393,7 +397,7 @@ class ProxyExtrasDBManager:
                         "--applied",
                         migration_name,
                     ],
-                    timeout=60,
+                    timeout=prisma_command_timeout(),
                     check=True,
                     capture_output=True,
                     text=True,
@@ -530,7 +534,7 @@ class ProxyExtrasDBManager:
             try:
                 subprocess.run(
                     [_get_prisma_command(), "db", "push", "--accept-data-loss"],
-                    timeout=60,
+                    timeout=prisma_command_timeout(),
                     check=True,
                     env=_get_prisma_env(),
                 )
@@ -555,7 +559,7 @@ class ProxyExtrasDBManager:
                 try:
                     result = subprocess.run(
                         [_get_prisma_command(), "migrate", "deploy"],
-                        timeout=60,
+                        timeout=prisma_command_timeout(),
                         check=True,
                         capture_output=True,
                         text=True,
@@ -731,6 +735,9 @@ class ProxyExtrasDBManager:
         Returns:
             bool: True if setup was successful, False otherwise
         """
+        ensure_prisma_toolchain(
+            prisma_command=_get_prisma_command(), prisma_env=_get_prisma_env()
+        )
         migrated = ProxyExtrasDBManager._run_migrations(
             use_migrate=use_migrate, use_v2_resolver=use_v2_resolver
         )
@@ -757,7 +764,7 @@ class ProxyExtrasDBManager:
                         # Set migrations directory for Prisma
                         result = subprocess.run(
                             [_get_prisma_command(), "migrate", "deploy"],
-                            timeout=60,
+                            timeout=prisma_command_timeout(),
                             check=True,
                             capture_output=True,
                             text=True,
@@ -840,7 +847,7 @@ class ProxyExtrasDBManager:
                                             "--rolled-back",
                                             failed_migration,
                                         ],
-                                        timeout=60,
+                                        timeout=prisma_command_timeout(),
                                         check=True,
                                         capture_output=True,
                                         text=True,
@@ -968,7 +975,7 @@ class ProxyExtrasDBManager:
                     # Use prisma db push with increased timeout
                     subprocess.run(
                         [_get_prisma_command(), "db", "push", "--accept-data-loss"],
-                        timeout=60,
+                        timeout=prisma_command_timeout(),
                         check=True,
                     )
                     return True

--- a/tests/proxy_migration_tests/test_prisma_toolchain.py
+++ b/tests/proxy_migration_tests/test_prisma_toolchain.py
@@ -1,0 +1,221 @@
+"""Migrations must survive a Node toolchain install that was killed mid-flight.
+
+The Prisma CLI installs a private Node runtime on its first invocation. If that
+install is interrupted, the cache directory is left behind without a Node
+binary and Prisma skips reinstalling it forever, so every later migration
+attempt fails identically. These tests pin the two behaviours that keep a
+container recoverable: an incomplete cache is deleted before Prisma is
+invoked, and the install gets a budget of its own rather than sharing the one
+that bounds each migration command.
+"""
+
+import ast
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from litellm_proxy_extras.prisma_toolchain import (
+    DEFAULT_PRISMA_COMMAND_TIMEOUT,
+    PRISMA_BOOTSTRAP_TIMEOUT_ENV_VAR,
+    PRISMA_COMMAND_TIMEOUT_ENV_VAR,
+    ensure_prisma_toolchain,
+    heal_incomplete_nodeenv_cache,
+    node_binary_path,
+    prisma_bootstrap_timeout,
+    prisma_command_timeout,
+)
+from litellm_proxy_extras.utils import ProxyExtrasDBManager
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PROXY_EXTRAS = REPO_ROOT / "litellm-proxy-extras" / "litellm_proxy_extras"
+
+FAKE_PRISMA = """#!{python}
+import json
+import os
+import pathlib
+import sys
+import time
+
+args = sys.argv[1:]
+cache_dir = os.environ["PRISMA_NODEENV_CACHE_DIR"]
+with pathlib.Path(os.environ["FAKE_PRISMA_LOG"]).open("a") as log:
+    log.write(
+        json.dumps({{"args": args, "cache_dir_present": os.path.isdir(cache_dir)}})
+        + "\\n"
+    )
+time.sleep(float(os.environ.get("FAKE_PRISMA_SLEEP", "0")))
+if args[:2] == ["migrate", "deploy"]:
+    print("No pending migrations to apply")
+sys.exit(0)
+"""
+
+
+def _write_fake_prisma(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "fakebin"
+    bin_dir.mkdir()
+    script = bin_dir / "prisma"
+    script.write_text(FAKE_PRISMA.format(python=sys.executable))
+    script.chmod(0o755)
+    return bin_dir
+
+
+def _fake_prisma_calls(log_path: Path) -> list[dict[str, object]]:
+    if not log_path.exists():
+        return []
+    return [json.loads(line) for line in log_path.read_text().splitlines()]
+
+
+@pytest.fixture
+def toolchain_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Point the toolchain at a scratch cache dir driven by a fake Prisma CLI."""
+    cache_dir = tmp_path / "nodeenv"
+    log_path = tmp_path / "prisma-calls.jsonl"
+    bin_dir = _write_fake_prisma(tmp_path)
+    monkeypatch.setenv("PRISMA_NODEENV_CACHE_DIR", str(cache_dir))
+    monkeypatch.setenv("FAKE_PRISMA_LOG", str(log_path))
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ['PATH']}")
+    monkeypatch.delenv(PRISMA_COMMAND_TIMEOUT_ENV_VAR, raising=False)
+    monkeypatch.delenv(PRISMA_BOOTSTRAP_TIMEOUT_ENV_VAR, raising=False)
+    return cache_dir, log_path
+
+
+def _make_incomplete_cache(cache_dir: Path) -> None:
+    (cache_dir / "lib").mkdir(parents=True)
+    (cache_dir / "bin").mkdir()
+
+
+def _make_complete_cache(cache_dir: Path) -> None:
+    node = node_binary_path(cache_dir)
+    node.parent.mkdir(parents=True)
+    node.write_text("")
+
+
+def test_interrupted_toolchain_install_is_removed(
+    toolchain_env: tuple[Path, Path],
+) -> None:
+    cache_dir, _ = toolchain_env
+    _make_incomplete_cache(cache_dir)
+
+    assert heal_incomplete_nodeenv_cache() is True
+    assert not cache_dir.exists()
+
+
+def test_installed_toolchain_is_left_alone(toolchain_env: tuple[Path, Path]) -> None:
+    cache_dir, _ = toolchain_env
+    _make_complete_cache(cache_dir)
+
+    assert heal_incomplete_nodeenv_cache() is False
+    assert node_binary_path(cache_dir).exists()
+
+
+def test_absent_toolchain_is_not_an_error(toolchain_env: tuple[Path, Path]) -> None:
+    cache_dir, _ = toolchain_env
+
+    assert heal_incomplete_nodeenv_cache() is False
+    assert not cache_dir.exists()
+
+
+def test_bootstrap_clears_the_cache_before_invoking_prisma(
+    toolchain_env: tuple[Path, Path],
+) -> None:
+    cache_dir, log_path = toolchain_env
+    _make_incomplete_cache(cache_dir)
+
+    result = ensure_prisma_toolchain(
+        prisma_command="prisma", prisma_env=dict(os.environ)
+    )
+
+    assert result.healed_incomplete_cache is True
+    assert result.ready is True
+    calls = _fake_prisma_calls(log_path)
+    assert len(calls) == 1
+    assert calls[0]["cache_dir_present"] is False
+
+
+def test_bootstrap_is_not_bounded_by_the_per_command_timeout(
+    toolchain_env: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, log_path = toolchain_env
+    monkeypatch.setenv(PRISMA_COMMAND_TIMEOUT_ENV_VAR, "1")
+    monkeypatch.setenv("FAKE_PRISMA_SLEEP", "3")
+
+    result = ensure_prisma_toolchain(
+        prisma_command="prisma", prisma_env=dict(os.environ)
+    )
+
+    assert result.ready is True
+    assert len(_fake_prisma_calls(log_path)) == 1
+
+
+def test_bootstrap_stops_at_its_own_timeout(
+    toolchain_env: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(PRISMA_BOOTSTRAP_TIMEOUT_ENV_VAR, "1")
+    monkeypatch.setenv("FAKE_PRISMA_SLEEP", "30")
+
+    started = time.monotonic()
+    result = ensure_prisma_toolchain(
+        prisma_command="prisma", prisma_env=dict(os.environ)
+    )
+    elapsed = time.monotonic() - started
+
+    assert result.ready is False
+    assert elapsed < 15
+
+
+def test_setup_database_prepares_the_toolchain_before_migrating(
+    toolchain_env: tuple[Path, Path],
+) -> None:
+    cache_dir, log_path = toolchain_env
+    _make_incomplete_cache(cache_dir)
+
+    assert ProxyExtrasDBManager.setup_database(use_migrate=True) is True
+
+    calls = _fake_prisma_calls(log_path)
+    assert [call["args"] for call in calls][:2] == [
+        ["--version"],
+        ["migrate", "deploy"],
+    ]
+    assert calls[0]["cache_dir_present"] is False
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "0", "-5", "not-a-number", "nan", "inf", "-inf", "1e400"],
+)
+def test_unusable_timeout_override_falls_back_to_the_default(
+    raw: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-finite override would silently disable the timeout it configures."""
+    monkeypatch.setenv(PRISMA_COMMAND_TIMEOUT_ENV_VAR, raw)
+
+    assert prisma_command_timeout() == DEFAULT_PRISMA_COMMAND_TIMEOUT
+
+
+def test_timeout_overrides_are_independent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(PRISMA_COMMAND_TIMEOUT_ENV_VAR, "12")
+    monkeypatch.setenv(PRISMA_BOOTSTRAP_TIMEOUT_ENV_VAR, "900")
+
+    assert prisma_command_timeout() == 12
+    assert prisma_bootstrap_timeout() == 900
+
+
+@pytest.mark.parametrize("module", ["utils.py", "replica_identity.py"])
+def test_every_prisma_command_timeout_is_overridable(module: str) -> None:
+    tree = ast.parse((PROXY_EXTRAS / module).read_text())
+    literals = [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.keyword)
+        and node.arg == "timeout"
+        and isinstance(node.value, ast.Constant)
+    ]
+
+    assert literals == [], (
+        f"{module} still hardcodes a Prisma timeout at lines {literals}; "
+        "route it through prisma_command_timeout() so it can be raised without a release"
+    )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Killed Node toolchain install breaks migrations permanently
- Prisma skips reinstalling a half-installed Node cache
- The 60s migration timeout was not overridable

How it solves it:

- Bootstrap the toolchain under its own generous timeout
- Delete a cache directory left without a node binary
- Route all 14 hardcoded timeouts through one configurable helper

## Relevant issues

## Linear ticket

Resolves LIT-5165

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both captures ran on the same rig against the same Postgres 16 container. Before runs are at `ad79b314c5` (the base this branch forked from); after runs are at `02a22b41de`, the first commit on this branch. The current commit amends only the finite-value guard on the timeout overrides onto that tree, which does not touch any path these captures exercise. Each run prints the package directory it actually loaded so the two sides cannot be confused, and the base tree was checked to contain zero occurrences of the new symbol before the before-run

### A cold machine where installing the Node toolchain takes 75s

This is the reported failure. `prisma migrate deploy` carries the whole toolchain install inside its 60s budget, gets killed, and the four-attempt retry loop cannot help because every attempt starts the same install from scratch

Before, on `ad79b314c5`:

```
$ PYTHONPATH=$BASE/litellm-proxy-extras python run_migrations.py
package under test: $BASE/litellm-proxy-extras/litellm_proxy_extras
nodeenv cache dir: $SCRATCH/ne-slow exists= False has bin/node= False
INFO litellm_proxy_extras: Attempt 1 timed out
INFO litellm_proxy_extras: Attempt 2 timed out
INFO litellm_proxy_extras: Attempt 3 timed out
INFO litellm_proxy_extras: Attempt 4 timed out
setup_database returned: False in 281.0s

$ psql -tAc "select count(*) from information_schema.tables
             where table_schema='public' and table_name like 'LiteLLM%'"
0
```

After, on this branch, same 75s install, same empty database:

```
$ PYTHONPATH=$BRANCH/litellm-proxy-extras python run_migrations.py
package under test: $BRANCH/litellm-proxy-extras/litellm_proxy_extras
nodeenv cache dir: $SCRATCH/ne-slow exists= False has bin/node= False
INFO litellm_proxy_extras: Preparing the Prisma CLI toolchain (timeout 600.0s)
INFO litellm_proxy_extras: Prisma CLI toolchain ready
INFO litellm_proxy_extras: prisma migrate deploy stdout: Prisma schema loaded from schema.prisma
setup_database returned: True in 93.2s

$ psql -tAc "select count(*) from information_schema.tables
             where table_schema='public' and table_name like 'LiteLLM%'"
68
```

The 84 seconds of toolchain install land inside the bootstrap budget, and `migrate deploy` then runs against a warm toolchain and finishes well inside its own 60s

### A cache directory left behind by an install that was already killed

This is the state a pod is stuck in after the first failure: the cache directory exists, but the node binary was never written. Prisma tests that directory for existence alone, so it skips reinstalling and fails on the missing binary forever

```
$ mkdir -p $SCRATCH/ne-run/bin $SCRATCH/ne-run/lib   # what a killed install leaves
```

Before, on `ad79b314c5`:

```
$ PYTHONPATH=$BASE/litellm-proxy-extras python run_migrations.py
package under test: $BASE/litellm-proxy-extras/litellm_proxy_extras
nodeenv cache dir: $SCRATCH/ne-run exists= True has bin/node= False
FileNotFoundError: [Errno 2] No such file or directory: '$SCRATCH/ne-run/bin/node'
FileNotFoundError: [Errno 2] No such file or directory: '$SCRATCH/ne-run/bin/node'
FileNotFoundError: [Errno 2] No such file or directory: '$SCRATCH/ne-run/bin/node'
FileNotFoundError: [Errno 2] No such file or directory: '$SCRATCH/ne-run/bin/node'
setup_database returned: False in 10.0s

$ psql -tAc "select count(*) ... like 'LiteLLM%'"
0
```

After, on this branch, from the identical starting state:

```
$ PYTHONPATH=$BRANCH/litellm-proxy-extras python run_migrations.py
package under test: $BRANCH/litellm-proxy-extras/litellm_proxy_extras
nodeenv cache dir: $SCRATCH/ne-run exists= True has bin/node= False
WARNING litellm_proxy_extras: Node toolchain at $SCRATCH/ne-run has no node, so a previous
        install was interrupted. Removing it so it can be reinstalled.
INFO litellm_proxy_extras: Preparing the Prisma CLI toolchain (timeout 600.0s)
INFO litellm_proxy_extras: Prisma CLI toolchain ready
INFO litellm_proxy_extras: prisma migrate deploy stdout: Prisma schema loaded from schema.prisma
setup_database returned: True in 17.9s

$ psql -tAc "select count(*) ... like 'LiteLLM%'"
68
```

### A real proxy starting against a real database

Fresh database, migrations applied by the proxy itself at startup, then a real request billed to a real provider

```
$ python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --port 4000
INFO litellm_proxy_extras: Preparing the Prisma CLI toolchain (timeout 600.0s)
INFO litellm_proxy_extras: Prisma CLI toolchain ready
Applying migration `20250326162113_baseline`
Applying migration `20250326171002_add_daily_user_table`
... (every committed migration applied)

$ curl -s http://localhost:4000/health/readiness
{"status": "healthy", "db": "connected"}

$ curl -s -X POST http://localhost:4000/key/generate \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"models":["gpt-5.5"],"key_alias":"toolchain-proof"}'
sk-WJadJDv...

$ curl -s -X POST http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-WJadJDv..." -H "Content-Type: application/json" \
    -d '{"model":"gpt-5.5","messages":[{"role":"user","content":"Reply with the single word: migrated"}]}'
model: gpt-5.5
content: migrated

$ psql -tAc "select model, total_tokens, round(spend::numeric,6)
             from \"LiteLLM_SpendLogs\" order by \"startTime\" desc limit 1"
openai/gpt-5.5|32|0.000635
```

## Type

🐛 Bug Fix

## Changes

The Prisma CLI is a Node program, and its first invocation in a fresh container installs a private Node runtime and npm-installs the CLI itself. That one-time install used to share the 60s budget that bounds each individual migration command, so on a cold or slow machine it was killed before it could finish

A killed install does not correct itself. The installer leaves its cache directory behind, and Prisma decides whether to install by testing that directory for existence alone, so every later attempt skips the install and then fails on a node binary that was never written. The existing four-attempt retry loop is powerless against this: each attempt re-enters the same resolution, sees the same directory, and fails the same way. One slow start turns into a pod that never migrates again

A new `litellm_proxy_extras/prisma_toolchain.py` separates the two concerns. `heal_incomplete_nodeenv_cache()` deletes a cache directory that exists without a node binary (`Scripts/node.exe` on Windows) so an interrupted install becomes recoverable, and `ensure_prisma_toolchain()` runs the install as its own step under its own budget before any migration command. It never raises; a toolchain that cannot be prepared is reported and stepped over so the real Prisma command produces the real error

Both budgets are now overridable, so an operator can widen them without waiting for a release. `LITELLM_PRISMA_BOOTSTRAP_TIMEOUT` bounds the toolchain install and defaults to 600s. `LITELLM_PRISMA_COMMAND_TIMEOUT` bounds each individual Prisma command and defaults to 60s, unchanged from today. A value that is not a positive number is ignored with a warning rather than silently disabling the timeout

Every previously hardcoded timeout now goes through one helper instead of fourteen literals. Two of those sites (generating and resolving the baseline migration) were at 30s and are now at 60s. That is deliberate: it is a loosening, the only cost is up to 30 extra seconds before a rare failure is reported, and 30s for a baseline `migrate diff` against a large database was thin to begin with. One knob is a simpler contract than two

An override is honoured only when it parses as a finite positive number. This one is worth spelling out, because it is the same failure this PR exists to fix arriving through the door this PR installs: `inf` and `NaN` parse as perfectly good floats and survive a plain positivity check, since every NaN comparison is False and infinity is not less than or equal to zero, and `subprocess` treats either as no deadline at all

```
$ python -c 'import subprocess, time
t = time.monotonic()
subprocess.run(["python", "-c", "import time; time.sleep(3)"], timeout=float("inf"))
print("timeout=inf -> returned after %.1fs (timeout NEVER fired)" % (time.monotonic() - t))'
timeout=inf -> returned after 3.0s (timeout NEVER fired)
```

So `LITELLM_PRISMA_COMMAND_TIMEOUT=inf`, or a fat-fingered `1e400` that overflows to infinity, would have silently removed the timeout from every Prisma subprocess. The guard is `math.isfinite` rather than a string check precisely because of that overflow case, which a check on the raw text would miss

The cache directory is resolved the supported way, from `PRISMA_NODEENV_CACHE_DIR` first since that is what Prisma itself reads, then from Prisma's own `config.nodeenv_cache_dir` behind a guarded import because `litellm-proxy-extras` declares no runtime dependencies, and finally from the documented default. There is no hardcoded path

`ensure_prisma_toolchain()` runs unconditionally rather than behind a "does the toolchain look complete" predicate. Measured cost is 2.4s with the toolchain already warm, and it is paid only on starts that actually run migrations, since `ProxyExtrasDBManager.setup_database` is the only caller. A predicate would have to couple to two separate Prisma internals to be correct, and because `use_global_node` defaults to true the nodeenv cache directory does not exist at all on a machine that already has node, so the predicate would fire on every start in exactly the environments that never needed it

`nodeenv_cache_dir()` returns `Optional[Path]` rather than `Path | None` deliberately. This package declares `requires-python = ">=3.9"` in its own `pyproject.toml` and is publishable standalone, and a return annotation is evaluated at definition time, so `Path | None` is a `TypeError` on 3.9. The neighbouring `utils.py` already uses `Optional[str]`. The root `pyproject.toml` requiring 3.10 does not govern where this package can be installed

The regression tests live in `tests/proxy_migration_tests/`, alongside the other migration tests, rather than in the conventionally-named `tests/litellm-proxy-extras/`, which is referenced by no CI job. Worth stating plainly rather than overclaiming: `.circleci/config.yml` runs that directory in its `schema_migration_check` job against a live Postgres, but CircleCI posts no per-job checks on pull requests in this repository, so I cannot confirm from outside that the job executed. What is demonstrable is that the whole directory passes locally against a live Postgres, 23 passed and 2 skipped. Anyone with Buildkite access can settle the rest in seconds. They drive real subprocesses through a fake `prisma` on `PATH` rather than patching anything, so `setup_database` is exercised end to end. Every mutation of the fix is caught: reverting the heal to Prisma's own existence-only rule kills 3 tests, running the bootstrap on the per-command budget kills 2, reintroducing a single hardcoded literal kills 1, dropping the bootstrap call kills 1, and healing unconditionally kills 1

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
