### PR TITLE
fix(ci): make the env-key doc gate see get_secret_bool reads

### DIFF
--- a/tests/documentation_tests/test_env_keys.py
+++ b/tests/documentation_tests/test_env_keys.py
@@ -1,20 +1,19 @@
 import os
 import re
+from collections.abc import Iterator
 
 # Define the base directory for the litellm repository and documentation path
 repo_base = "./litellm"  # Change this to your actual path
 
-# Regular expressions to capture the keys used in os.getenv() and litellm.get_secret()
-getenv_pattern = re.compile(r'os\.getenv\(\s*[\'"]([^\'"]+)[\'"]\s*(?:,\s*[^)]*)?\)')
-get_secret_pattern = re.compile(
-    r'litellm\.get_secret\(\s*[\'"]([^\'"]+)[\'"]\s*(?:,\s*[^)]*|,\s*default_value=[^)]*)?\)'
-)
-get_secret_str_pattern = re.compile(
-    r'litellm\.get_secret_str\(\s*[\'"]([^\'"]+)[\'"]\s*(?:,\s*[^)]*|,\s*default_value=[^)]*)?\)'
-)
+_GETENV_ARGS = r"""\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]*)?\)"""
+_GET_SECRET_ARGS = r"""\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]*|,\s*default_value=[^)]*)?\)"""
 
-# Set to store unique keys from the code
-env_keys = set()
+ENV_KEY_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"os\.getenv" + _GETENV_ARGS),
+    re.compile(r"litellm\.get_secret" + _GET_SECRET_ARGS),
+    re.compile(r"litellm\.get_secret_str" + _GET_SECRET_ARGS),
+    re.compile(r"(?<![\w.])(?:litellm\.)?get_secret_bool" + _GET_SECRET_ARGS),
+)
 
 # Terminal/environment detection variables that should not be documented
 # These are internal variables used for terminal detection, not user-configurable settings
@@ -48,6 +47,8 @@ EXCLUDED_TERMINAL_VARS = {
     "ALACRITTY_SOCKET",
 }
 
+EXCLUDED_KEYS = frozenset(EXCLUDED_TERMINAL_VARS | EXCLUDED_GUARD_ONLY_VARS | EXCLUDED_ROLLOUT_FLAGS)
+
 # Directories to skip (dependencies, venvs, caches) - only scan litellm source
 SKIP_DIRS = {
     ".venv",
@@ -61,88 +62,69 @@ SKIP_DIRS = {
     "build",
 }
 
-# Walk through all files in the litellm repo to find references of os.getenv() and litellm.get_secret()
-for root, dirs, files in os.walk(repo_base):
-    # Skip dependency/venv directories - prevents picking up env vars from installed packages
-    dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
-    for file in files:
-        if file.endswith(".py"):  # Only process Python files
-            file_path = os.path.join(root, file)
-            with open(file_path, "r", encoding="utf-8") as f:
-                content = f.read()
 
-                # Find all keys using os.getenv()
-                getenv_matches = getenv_pattern.findall(content)
-                env_keys.update(
-                    match
-                    for match in getenv_matches
-                    if match not in EXCLUDED_TERMINAL_VARS
-                    and match not in EXCLUDED_GUARD_ONLY_VARS
-                    and match not in EXCLUDED_ROLLOUT_FLAGS
-                )  # Extract only the key part, excluding terminal vars
-
-                # Find all keys using litellm.get_secret()
-                get_secret_matches = get_secret_pattern.findall(content)
-                env_keys.update(match for match in get_secret_matches)
-
-                # Find all keys using litellm.get_secret_str()
-                get_secret_str_matches = get_secret_str_pattern.findall(content)
-                env_keys.update(match for match in get_secret_str_matches)
-
-# Print the unique keys found
-print(env_keys)
-
-
-# Parse the documentation to extract documented keys
-repo_base = "./"
-print(os.listdir(repo_base))
-docs_path = (
-    "./docs/my-website/docs/proxy/config_settings.md"  # Path to the documentation
-)
-documented_keys = set()
-try:
-    with open(docs_path, "r", encoding="utf-8") as docs_file:
-        content = docs_file.read()
-
-        print(f"content: {content}")
-
-        # Find the section titled "general_settings - Reference"
-        general_settings_section = re.search(
-            r"### environment variables - Reference(.*?)(?=\n###|\Z)",
-            content,
-            re.DOTALL | re.MULTILINE,
-        )
-        print(f"general_settings_section: {general_settings_section}")
-        if general_settings_section:
-            # Extract the table rows - only first column (key name) from each row
-            table_content = general_settings_section.group(1)
-            for line in table_content.split("\n"):
-                # Match | KEY_NAME | description | - capture first column only
-                match = re.match(r"^\|\s*([A-Z_][A-Z0-9_]*)\s*\|", line)
-                if match:
-                    documented_keys.add(match.group(1).strip())
-except Exception as e:
-    raise Exception(
-        f"Error reading documentation: {e}, \n repo base - {os.listdir(repo_base)}"
+def extract_env_keys(source: str) -> frozenset[str]:
+    """Return every documentable env var name read by the given Python source."""
+    return frozenset(
+        match for pattern in ENV_KEY_PATTERNS for match in pattern.findall(source) if match not in EXCLUDED_KEYS
     )
 
 
-print(f"documented_keys: {documented_keys}")
-# Compare and find undocumented keys
-undocumented_keys = env_keys - documented_keys
+def collect_env_keys(base_dir: str) -> frozenset[str]:
+    """Return every documentable env var name read anywhere under ``base_dir``."""
+    return frozenset(key for file_path in _python_files(base_dir) for key in extract_env_keys(_read_text(file_path)))
 
-# Print results
-print("Keys expected in 'environment settings' (found in code):")
-for key in sorted(env_keys):
-    print(key)
 
-if undocumented_keys:
-    raise Exception(
-        f"\nKeys not documented in 'environment settings - Reference': {undocumented_keys}"
+def _python_files(base_dir: str) -> Iterator[str]:
+    for root, dirs, files in os.walk(base_dir):
+        # Skip dependency/venv directories - prevents picking up env vars from installed packages
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
+        yield from (os.path.join(root, name) for name in files if name.endswith(".py"))
+
+
+def _read_text(file_path: str) -> str:
+    with open(file_path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def extract_documented_keys(docs_content: str) -> frozenset[str]:
+    """Return the key names listed in the 'environment variables - Reference' table."""
+    section = re.search(
+        r"### environment variables - Reference(.*?)(?=\n###|\Z)",
+        docs_content,
+        re.DOTALL | re.MULTILINE,
     )
-else:
-    print(
-        "\nAll keys are documented in 'environment settings - Reference'. - {}".format(
-            env_keys
-        )
+    if section is None:
+        return frozenset()
+    # Match | KEY_NAME | description | - capture first column only
+    return frozenset(
+        match.group(1).strip()
+        for match in (re.match(r"^\|\s*([A-Z_][A-Z0-9_]*)\s*\|", line) for line in section.group(1).split("\n"))
+        if match is not None
     )
+
+
+def main() -> None:
+    env_keys = collect_env_keys(repo_base)
+    print(env_keys)
+
+    docs_path = "./docs/my-website/docs/proxy/config_settings.md"  # Path to the documentation
+    try:
+        documented_keys = extract_documented_keys(_read_text(docs_path))
+    except Exception as e:
+        raise Exception(f"Error reading documentation: {e}, \n repo base - {os.listdir('./')}")
+
+    print(f"documented_keys: {documented_keys}")
+    undocumented_keys = env_keys - documented_keys
+
+    print("Keys expected in 'environment settings' (found in code):")
+    for key in sorted(env_keys):
+        print(key)
+
+    if undocumented_keys:
+        raise Exception(f"\nKeys not documented in 'environment settings - Reference': {sorted(undocumented_keys)}")
+    print(f"\nAll keys are documented in 'environment settings - Reference'. - {env_keys}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_litellm/test_env_key_doc_gate.py
+++ b/tests/test_litellm/test_env_key_doc_gate.py
@@ -1,0 +1,103 @@
+"""Tests for the env-var extraction used by tests/documentation_tests/test_env_keys.py.
+
+That script is the CI gate that fails when a user-facing environment variable read
+under litellm/ has no row in the docs reference table. It only sees a key if one of its
+patterns matches the call, so a call shape the patterns miss silently bypasses the gate.
+Each supported shape is asserted here, along with the shapes that must not be treated as
+env var reads, so narrowing a pattern makes a test fail instead of quietly reopening the
+hole.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MODULE_PATH = _REPO_ROOT / "tests" / "documentation_tests" / "test_env_keys.py"
+_spec = importlib.util.spec_from_file_location("documentation_test_env_keys", _MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+gate = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = gate
+_spec.loader.exec_module(gate)
+
+
+def test_bare_get_secret_bool_is_captured() -> None:
+    assert gate.extract_env_keys('flag = get_secret_bool("QSTASH_FLUSH_ON_BOOT")') == {"QSTASH_FLUSH_ON_BOOT"}
+
+
+def test_get_secret_bool_with_default_is_captured() -> None:
+    assert gate.extract_env_keys('if get_secret_bool("QSTASH_FLUSH_ON_BOOT", False) is not True:') == {
+        "QSTASH_FLUSH_ON_BOOT"
+    }
+
+
+def test_get_secret_bool_with_keyword_default_is_captured() -> None:
+    assert gate.extract_env_keys('get_secret_bool("QSTASH_FLUSH_ON_BOOT", default_value=False)') == {
+        "QSTASH_FLUSH_ON_BOOT"
+    }
+
+
+def test_litellm_prefixed_get_secret_bool_is_captured() -> None:
+    assert gate.extract_env_keys('litellm.get_secret_bool("QSTASH_FLUSH_ON_BOOT")') == {"QSTASH_FLUSH_ON_BOOT"}
+
+
+def test_previously_supported_call_shapes_are_still_captured() -> None:
+    source = "\n".join(
+        (
+            'os.getenv("QSTASH_ALPHA")',
+            'os.getenv("QSTASH_BRAVO", "fallback")',
+            'litellm.get_secret("QSTASH_CHARLIE")',
+            'litellm.get_secret_str("QSTASH_DELTA", default_value=None)',
+        )
+    )
+    assert gate.extract_env_keys(source) == {"QSTASH_ALPHA", "QSTASH_BRAVO", "QSTASH_CHARLIE", "QSTASH_DELTA"}
+
+
+def test_get_secret_calls_on_unrelated_objects_are_not_env_reads() -> None:
+    source = "\n".join(
+        (
+            'vault_client.get_secret("QSTASH_ALPHA")',
+            'self.get_secret_str("QSTASH_BRAVO")',
+            'provider.get_secret_bool("QSTASH_CHARLIE")',
+        )
+    )
+    assert gate.extract_env_keys(source) == frozenset()
+
+
+def test_similarly_named_helpers_are_not_env_reads() -> None:
+    assert gate.extract_env_keys('get_secret_bundle("QSTASH_ALPHA")') == frozenset()
+
+
+def test_non_literal_arguments_are_not_env_reads() -> None:
+    assert gate.extract_env_keys("get_secret_bool(flag_name)") == frozenset()
+
+
+def test_excluded_keys_are_filtered_for_every_call_shape() -> None:
+    source = "\n".join(
+        (
+            'os.getenv("TERM_PROGRAM")',
+            'get_secret_bool("LITELLM_RUST")',
+            'litellm.get_secret_str("MAVVRIK_FOCUS_FREQUENCY")',
+        )
+    )
+    assert gate.extract_env_keys(source) == frozenset()
+
+
+def test_documented_keys_are_read_from_the_reference_table_only() -> None:
+    docs = "\n".join(
+        (
+            "### general_settings - Reference",
+            "| BEFORE_THE_TABLE | not the env var table",
+            "",
+            "### environment variables - Reference",
+            "",
+            "| Name | Description |",
+            "|------|-------------|",
+            "| QSTASH_ALPHA | first key",
+            "| QSTASH_BRAVO | second key",
+            "",
+            "### another section - Reference",
+            "| AFTER_THE_TABLE | also not the env var table",
+        )
+    )
+    assert gate.extract_documented_keys(docs) == {"QSTASH_ALPHA", "QSTASH_BRAVO"}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gate prints "All keys are documented" while eight are not
- A bare `get_secret_bool("X")` matches none of its patterns
- 13 live keys were never checked by CI

How it solves it:

- Add a fourth pattern matching `get_secret_bool` calls
- Lookbehind rejects unrelated receivers' `.get_secret*(` calls
- Unit test the patterns where CI actually collects them

## Relevant issues

## Linear ticket

Resolves LIT-5173

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

**Merge after https://github.com/BerriAI/litellm-docs/pull/767.** The CI checkbox above is deliberately unchecked. Widening the regex makes the gate immediately demand documentation for the keys it was previously blind to, so `code-quality` and `documentation` stay red on this branch until the companion litellm-docs PR adds those rows. That is the expected end state here, not a defect to chase

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

There is no request path to curl here. The change only affects `tests/documentation_tests/test_env_keys.py`, which greps the source tree and compares it against the docs table, so the gate itself is the proof. Each run below symlinks a litellm-docs checkout into `docs/my-website` exactly as `.github/workflows/test-code-quality.yml` and `.github/workflows/test-unit-documentation.yml` do before invoking the script

Step 1, before the fix, at `ad79b314c5`, against litellm-docs `main` at `02b4a5b2`. The gate exits 0 and reports that everything is documented, while eight keys it should be guarding have no row anywhere. That is the bug

```
$ ln -s /path/to/litellm-docs docs/my-website
$ python tests/documentation_tests/test_env_keys.py; echo "exit=$?"
...
All keys are documented in 'environment settings - Reference'. - {...}
exit=0
```

Step 2, after the fix, at `be7962ee9e`, still against litellm-docs `main` at `02b4a5b2`. The gate now sees the keys and fails, naming every one of them

```
$ python tests/documentation_tests/test_env_keys.py; echo "exit=$?"
Traceback (most recent call last):
  ...
Exception:
Keys not documented in 'environment settings - Reference': ['DISABLE_PRISMA_HEALTH_CHECK_ON_STARTUP', 'EXPERIMENTAL_OPENAI_BASE_LLM_HTTP_HANDLER', 'EXPERIMENTAL_UI_LOGIN', 'LITELLM_STORE_AUDIT_LOGS', 'STORE_PROMPTS_IN_SPEND_LOGS', 'USE_DDPROFILER', 'USE_DDTRACE', 'USE_LITELLM_PROXY']
exit=1
```

Step 3, after the fix, at `be7962ee9e`, against the companion docs branch that adds the missing rows

```
$ python tests/documentation_tests/test_env_keys.py; echo "exit=$?"
...
All keys are documented in 'environment settings - Reference'. - {...}
exit=0
```

## Type

🐛 Bug Fix

## Changes

### Why a one-line regex fix rewrites most of the file

Because the regex could not be tested where it lived. Getting it under test required making the gate script importable, which meant moving its procedural body into `main()` behind a `__main__` guard and extracting the extraction and table parsing into functions. That restructuring is most of the diff, which is why the gate script reads +71/-88 on a 149-line file rather than a couple of changed lines. The alternative was to skip the test, which is the worse trade for a gate whose whole failure mode is silently matching less than it should. Two smaller cleanups rode along in the same pass and are called out below

### The defect

`tests/documentation_tests/test_env_keys.py` requires every user-facing environment variable read under `./litellm` to have a row in the docs "environment variables - Reference" table. It matched three call shapes: `os.getenv(`, `litellm.get_secret(` and `litellm.get_secret_str(`. A bare `get_secret_bool("X")` matches none of them, since it is not `get_secret` and the call site carries no `litellm.` prefix, so any key read that way skipped the requirement entirely

There are 19 such call sites covering 14 distinct keys. One of them, `IAM_TOKEN_DB_AUTH`, was already caught because `litellm/proxy/utils.py:3017` also reads it through `os.getenv`. The other 13 were never checked, and 8 of those have no row today

### The pattern

```
(?<![\w.])(?:litellm\.)?get_secret_bool\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]*|,\s*default_value=[^)]*)?\)
```

The negative lookbehind matters. Without it, making the `litellm.` prefix optional also matches attribute calls on unrelated receivers, so a third-party SDK's `client.get_secret("SOME_NAME")` would be reported as an undocumented environment variable. Today that happens to be harmless in this tree because the only such call sites pass variables or keyword arguments and so fail the quoted-literal capture, but that is luck rather than design. The three existing patterns share the same weakness and are deliberately left alone here, since retrofitting the lookbehind onto them would change what they match and widen this PR

I verified the change is a strict superset of the old behavior against the real tree. The old patterns find 669 keys, the new set finds 682, the 13 added are exactly the `get_secret_bool` keys, and the removed set is empty. Nothing that used to be gated stopped being gated

### One behavior change, verified to be a no-op today

The exclusion sets (`EXCLUDED_TERMINAL_VARS`, `EXCLUDED_GUARD_ONLY_VARS`, `EXCLUDED_ROLLOUT_FLAGS`) previously applied only to `os.getenv` matches and were skipped for the `get_secret` patterns. They now apply uniformly to every call shape. This is intentional rather than incidental: the sets exist to name variables that should not be documented, and which helper happens to read one has no bearing on that. I checked that no excluded key is currently reachable through any `get_secret` call, so there is no behavior delta on this tree; the uniformity matters for the next variable added to those sets

The other cleanup is that a `print` which dumped the entire contents of `config_settings.md` into the CI log is gone. CI invokes the script exactly as before

### Why the scope stops at `get_secret_bool`

Bare `get_secret(` and `get_secret_str(` calls bypass the gate the same way, and that hole is much larger: 97 keys across 191 call sites for `get_secret`, and 318 keys across 735 call sites for `get_secret_str`, together newly surfacing 345 keys and requiring roughly 320 new reference rows. Those are overwhelmingly provider credentials and base URLs. That is tracked as LIT-5178 rather than folded in here, because 320 rows each needing an accurate call-site-derived description is a different piece of work and would not get a real review as part of this change

### Where the test lives, and why

`tests/documentation_tests/` is only ever run as a bare script invocation. `grep -rn documentation_tests .circleci/config.yml .github/workflows/` returns `python ./tests/documentation_tests/test_env_keys.py` and nothing that collects the directory with pytest, so a test file added next to the gate would never run. That reads as coverage while providing none

The regression test is therefore at `tests/test_litellm/test_env_key_doc_gate.py`, which the misc unit shard picks up through the `tests/test_litellm/test_*.py` entry in `.github/workflows/test-unit-misc.yml`. It loads the gate by path with `importlib`, following the convention `tests/test_litellm/test_check_type_discipline.py` already uses for `scripts/check_type_discipline.py`, so there is no `sys.path` manipulation and no new package plumbing

The tests were checked against mutation. Dropping the new pattern fails 4 of them, dropping the lookbehind fails the unrelated-receiver test, and dropping the exclusion filter fails 2

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
