### PR TITLE
fix(proxy): enforce per-model budgets against resolved cursor model variants

### DIFF
--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -19,6 +19,10 @@ from litellm.proxy.auth.user_api_key_auth import (
     user_api_key_auth_websocket,
 )
 from litellm.proxy.common_request_processing import ProxyBaseLLMRequestProcessing
+from litellm.proxy.common_utils.http_parsing_utils import (
+    _read_request_body,
+    _safe_set_request_parsed_body,
+)
 from litellm.types.llms.openai import REASONING_EFFORT, ResponseAPIUsage, ResponsesAPIResponse
 from litellm.types.responses.main import DeleteResponseResult
 
@@ -146,6 +150,18 @@ def _resolve_cursor_model_variant(
             return resolved
         return {**resolved, "reasoning": {**reasoning, "effort": variant.reasoning_effort}}  # mutable-ok: same
     return {**resolved, "reasoning": {"effort": variant.reasoning_effort}}  # mutable-ok: plain body dict
+
+
+async def _resolve_cursor_model_variant_before_auth(request: Request) -> None:
+    from litellm.proxy.proxy_server import llm_router
+
+    try:
+        raw_body: Final = await _read_request_body(request=request)
+    except (json.JSONDecodeError, ProxyException):
+        return
+    resolved: Final = _resolve_cursor_model_variant(raw_body, llm_router)
+    if resolved is not raw_body:
+        _safe_set_request_parsed_body(request=request, parsed_body=resolved)
 
 
 @router.post(
@@ -440,7 +456,10 @@ async def cursor_model_list(
 
 @router.post(
     "/cursor/chat/completions",
-    dependencies=[Depends(user_api_key_auth)],
+    dependencies=[
+        Depends(_resolve_cursor_model_variant_before_auth),
+        Depends(user_api_key_auth),
+    ],
     tags=["responses"],
 )
 async def cursor_chat_completions(
@@ -479,9 +498,7 @@ async def cursor_chat_completions(
         responses_api_bridge,
     )
     from litellm.litellm_core_utils.streaming_handler import CustomStreamWrapper
-    from litellm.proxy.common_utils.http_parsing_utils import _safe_set_request_parsed_body
     from litellm.proxy.proxy_server import (
-        _read_request_body,
         async_data_generator,
         chat_completion,
         general_settings,
@@ -499,14 +516,13 @@ async def cursor_chat_completions(
     from litellm.types.utils import ModelResponse
 
     raw_body: Final = await _read_request_body(request=request)
-    data = _resolve_cursor_model_variant(raw_body, llm_router)
 
-    if _is_chat_completions_body(data):
+    if _is_chat_completions_body(raw_body):
         # Genuine chat completions body (Cursor sends these for models whose BYOK it
         # already fixed); delegate so behavior matches /chat/completions exactly.
         # Keyed on messages CONTENT, not key presence: Cursor can send a null or
         # empty messages stub alongside a real agent-mode input array
-        normalized: Final = _normalize_tool_dialect(data, to_chat=True)
+        normalized: Final = _normalize_tool_dialect(raw_body, to_chat=True)
         if normalized is not raw_body:
             _safe_set_request_parsed_body(request=request, parsed_body=normalized)
         return await chat_completion(
@@ -521,7 +537,7 @@ async def cursor_chat_completions(
     # Rebuild rather than pop: _read_request_body can return the request-scope
     # cached parsed-body dict itself, and removing keys from it corrupts the
     # cache's key snapshot so later readers get an empty body
-    data = {key: value for key, value in data.items() if key != "stream_options"}  # mutable-ok: plain body dict
+    data = {key: value for key, value in raw_body.items() if key != "stream_options"}  # mutable-ok: plain body dict
 
     data = _normalize_tool_dialect(data, to_chat=False)
 

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -537,9 +537,11 @@ async def cursor_chat_completions(
     # Rebuild rather than pop: _read_request_body can return the request-scope
     # cached parsed-body dict itself, and removing keys from it corrupts the
     # cache's key snapshot so later readers get an empty body
-    data = {key: value for key, value in raw_body.items() if key != "stream_options"}  # mutable-ok: plain body dict
+    body_without_stream_options: Final = {  # mutable-ok: base_process_llm_request mutates the body dict in place
+        key: value for key, value in raw_body.items() if key != "stream_options"
+    }
 
-    data = _normalize_tool_dialect(data, to_chat=False)
+    data: Final = _normalize_tool_dialect(body_without_stream_options, to_chat=False)
 
     processor: Final = ProxyBaseLLMRequestProcessing(data=data)
 

--- a/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py
@@ -851,8 +851,9 @@ def test_cursor_chat_completions_input_body_uses_responses_pipeline_and_strips_s
 
     app.dependency_overrides[user_api_key_auth] = _auth_override
     try:
-        with patch.object(ps, "llm_router", mock_router), patch.object(
-            ps, "_read_request_body", side_effect=capturing_read_request_body
+        with patch.object(ps, "llm_router", mock_router), patch(
+            "litellm.proxy.response_api_endpoints.endpoints._read_request_body",
+            side_effect=capturing_read_request_body,
         ):
             client = TestClient(app)
             response = client.post(
@@ -1568,3 +1569,157 @@ class TestCursorModelSuffixResolutionEndToEnd:
         assert mock_router.aresponses.call_args is not None
         assert mock_router.aresponses.call_args.kwargs["model"] == "claude-opus-5"
         assert mock_router.aresponses.call_args.kwargs["reasoning"] == {"effort": "high"}
+
+
+def _cursor_budget_auth_env(base_model: str, spend: float):
+    from litellm import Router
+    from litellm.caching.dual_cache import DualCache
+    from litellm.proxy._types import UserAPIKeyAuth
+    from litellm.proxy.hooks.model_max_budget_limiter import (
+        VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX,
+        _PROXY_VirtualKeyModelMaxBudgetLimiter,
+    )
+
+    valid_token = UserAPIKeyAuth(
+        api_key="sk-cursor-budget-test",
+        token="hashed-cursor-budget-token",
+        model_max_budget={base_model: {"budget_limit": 0.00001, "time_period": "1d"}},
+    )
+    limiter = _PROXY_VirtualKeyModelMaxBudgetLimiter(dual_cache=DualCache())
+    limiter.dual_cache.in_memory_cache.set_cache(
+        key=f"{VIRTUAL_KEY_SPEND_CACHE_KEY_PREFIX}:{valid_token.token}:{base_model}:1d",
+        value=spend,
+    )
+    router = Router(
+        model_list=[{"model_name": "anthropic/*", "litellm_params": {"model": "anthropic/*", "api_key": "fake"}}]
+    )
+
+    mock_proxy_logging_obj = MagicMock()
+    mock_proxy_logging_obj.post_call_failure_hook = AsyncMock(return_value=None)
+
+    proxy_server_attrs = {
+        "prisma_client": MagicMock(),
+        "user_api_key_cache": DualCache(),
+        "proxy_logging_obj": mock_proxy_logging_obj,
+        "master_key": "sk-master-key",
+        "general_settings": {},
+        "llm_model_list": [],
+        "llm_router": router,
+        "open_telemetry_logger": None,
+        "model_max_budget_limiter": limiter,
+        "user_custom_auth": None,
+        "jwt_handler": None,
+        "litellm_proxy_admin_name": "admin",
+    }
+    return valid_token, proxy_server_attrs
+
+
+def _post_cursor_with_real_auth(valid_token, proxy_server_attrs, request_model: str):
+    with (
+        patch.multiple("litellm.proxy.proxy_server", **proxy_server_attrs),
+        patch(
+            "litellm.proxy.auth.resolvers.store.IdentityStore._resolve_key",
+            new_callable=AsyncMock,
+            return_value=valid_token,
+        ),
+    ):
+        client = TestClient(app)
+        return client.post(
+            "/cursor/chat/completions",
+            json={"model": request_model, "input": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer sk-cursor-budget-test"},
+        )
+
+
+class TestCursorVariantPerModelBudgetEnforcement:
+    """Regression tests for the per-model budget bypass on /cursor/chat/completions.
+
+    user_api_key_auth enforced key model_max_budget against the raw request model,
+    but _resolve_cursor_model_variant only rewrote minted aliases like
+    <base>-thinking-<level> to <base> inside the handler, after auth had already
+    run. A key whose budget for <base> was exhausted could keep calling <base>
+    through any unconfigured alias. The variant must now be resolved in a
+    route-level dependency that runs before user_api_key_auth, so these tests
+    exercise the real dependency chain (real auth, real budget limiter) through
+    TestClient and fail if that ordering ever breaks."""
+
+    def test_minted_alias_rejected_when_base_model_budget_exhausted(self):
+        valid_token, attrs = _cursor_budget_auth_env(base_model="claude-opus-5", spend=1.0)
+
+        response = _post_cursor_with_real_auth(valid_token, attrs, request_model="claude-opus-5-thinking-high")
+
+        assert response.status_code == 429, response.text
+        error = response.json()["error"]
+        assert error["type"] == "budget_exceeded"
+        assert "exceeded budget for model=claude-opus-5" in error["message"]
+
+    def test_alias_rejection_matches_base_model_rejection(self):
+        valid_token, attrs = _cursor_budget_auth_env(base_model="claude-opus-5", spend=1.0)
+
+        base_response = _post_cursor_with_real_auth(valid_token, attrs, request_model="claude-opus-5")
+        alias_response = _post_cursor_with_real_auth(valid_token, attrs, request_model="claude-opus-5-fast")
+
+        assert base_response.status_code == 429, base_response.text
+        assert alias_response.status_code == 429, alias_response.text
+        assert alias_response.json() == base_response.json()
+
+
+class TestCursorVariantResolvedBeforeAuth:
+    """The route-level resolver dependency must rewrite the parsed body before
+    user_api_key_auth reads it, so every auth check (model access, key and
+    end-user model budgets, rate limits) sees the base model, and names the
+    router already serves must reach auth untouched."""
+
+    def _run_with_recording_auth(self, mock_router, request_model: str):
+        from litellm.proxy._types import UserAPIKeyAuth
+        from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
+        from litellm.proxy.common_utils.http_parsing_utils import _read_request_body
+
+        from fastapi import Request
+
+        bodies_seen_by_auth = []
+
+        async def recording_auth(request: Request) -> UserAPIKeyAuth:
+            bodies_seen_by_auth.append(await _read_request_body(request=request))
+            return UserAPIKeyAuth(api_key="sk-test-cursor")
+
+        async def fake_chat_completion(request, fastapi_response, model, user_api_key_dict):
+            return {"id": "chatcmpl-fake", "object": "chat.completion", "choices": []}
+
+        app.dependency_overrides[user_api_key_auth] = recording_auth
+        try:
+            with (
+                patch("litellm.proxy.proxy_server.llm_router", new=mock_router),
+                patch("litellm.proxy.proxy_server.chat_completion", new=fake_chat_completion),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    "/cursor/chat/completions",
+                    json={"model": request_model, "messages": [{"role": "user", "content": "hi"}]},
+                    headers={"Authorization": "Bearer sk-test-cursor"},
+                )
+        finally:
+            app.dependency_overrides.pop(user_api_key_auth, None)
+
+        assert response.status_code == 200, response.text
+        assert len(bodies_seen_by_auth) == 1
+        return bodies_seen_by_auth[0]
+
+    def test_auth_sees_base_model_for_minted_alias(self):
+        auth_body = self._run_with_recording_auth(
+            mock_router=_router_serving_only("claude-opus-5"),
+            request_model="claude-opus-5-thinking-xhigh-fast",
+        )
+        assert auth_body["model"] == "claude-opus-5"
+        assert auth_body["reasoning_effort"] == "xhigh"
+
+    def test_auth_sees_servable_model_name_untouched(self):
+        mock_router = _router_serving_only("claude-opus-5")
+        mock_router.model_names = {"claude-opus-5-thinking-high"}
+
+        auth_body = self._run_with_recording_auth(
+            mock_router=mock_router,
+            request_model="claude-opus-5-thinking-high",
+        )
+        assert auth_body["model"] == "claude-opus-5-thinking-high"
+        assert "reasoning_effort" not in auth_body


### PR DESCRIPTION
## TLDR

Problem this solves:

- Cursor variant aliases bypassed exhausted per-model key budgets
- Auth checked the requested alias while the handler billed the base model

How it solves it:

- Resolves the minted variant to its base model before auth runs
- Budget and model access checks now see the billed model

## Relevant issues

Follow-up to the per-model budget bypass concern raised on #34029: https://github.com/BerriAI/litellm/pull/34029#discussion_r3698483183

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A key whose per-model budget for `gpt-4o-mini` is exhausted could still complete calls through `/cursor/chat/completions` by requesting the minted alias `gpt-4o-mini-thinking-low`, which the endpoint rewrites back to `gpt-4o-mini` after auth already ran. Both runs below hit the real OpenAI API through a live proxy on `litellm/proxy/dev_config.yaml`; the before run was captured at the merge base 27885076e7 and the after run at this PR's commit 1cd481d4f2

```
lsof -nP -iTCP:41273 -sTCP:LISTEN    # no output, port free
python -m litellm.proxy.proxy_cli --config litellm/proxy/dev_config.yaml --port 41273 --detailed_debug --use_v2_migration_resolver 2>&1 | tee litellm.log
```

One repro note: the proxy must be started with `python -m litellm.proxy.proxy_cli` here, not `python litellm/proxy/proxy_cli.py`. Running the file by path puts `litellm/proxy` on `sys.path`, so the `from proxy_server import ...` at proxy_cli.py line 996 creates a second top-level `proxy_server` module; its `_PROXY_VirtualKeyModelMaxBudgetLimiter` wins the callback dedup and tracks spend while auth reads the canonical `litellm.proxy.proxy_server` instance, so per-model key budgets never trip at all under that invocation. Installed entrypoints import the module by its canonical name and are unaffected; it is a pre-existing quirk independent of this PR, just flagging it since it masks this repro

Runbook for both runs: mint a key with a per-model budget small enough that the first call exhausts it, spend it on the base model, confirm the base model is rejected, then request the minted aliases

```
KEY=$(curl -s http://localhost:41273/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"key_alias": "qa-cursor-variant-budget", "model_max_budget": {"gpt-4o-mini": {"budget_limit": 0.0000001, "time_period": "1d"}}}' | jq -r .key)
curl -s -w "\nHTTP %{http_code}\n" http://localhost:41273/cursor/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model": "<MODEL>", "messages": [{"role": "user", "content": "Say ok"}]}'
```

Before, at 27885076e7 (key `sk-8gH79i...`, redacted):

```
=== call 1: model gpt-4o-mini, expect 200 and budget exhaustion ===
{"id":"chatcmpl-E9HApnPX5SJ57vP3Z0KITBFnqH53O","created":1785879675,"model":"gpt-4o-mini","object":"chat.completion","system_fingerprint":"fp_25b7d0bd77","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Ok!","role":"assistant","provider_specific_fields":{"refusal":null},"annotations":[]},"provider_specific_fields":{}}],"usage":{"completion_tokens":2,"prompt_tokens":9,"total_tokens":11,...},"service_tier":"default"}
HTTP 200
=== call 2: model gpt-4o-mini again, budget now enforced ===
{"error":{"message":"LiteLLM Virtual Key: 1ea123dc82d41b321b1b64cc3a00fa42e38b306f7ecfe1b9891933d1899d0d75, key_alias: qa-cursor-variant-budget-before-2788507, exceeded budget for model=gpt-4o-mini","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
=== call 3: model gpt-4o-mini-thinking-low, THE BYPASS: succeeds and bills gpt-4o-mini ===
{"id":"chatcmpl-E9HAtMsr6ibfoJJl0DM7y50nZjcww","created":1785879679,"model":"gpt-4o-mini","object":"chat.completion","system_fingerprint":"fp_25b7d0bd77","choices":[{"finish_reason":"stop","index":0,"message":{"content":"Ok!","role":"assistant","provider_specific_fields":{"refusal":null},"annotations":[]},"provider_specific_fields":{}}],"usage":{"completion_tokens":2,"prompt_tokens":9,"total_tokens":11,...},"service_tier":"default"}
HTTP 200
```

The server log confirms the budget check ran against the alias name and found no budget to enforce

```
$ grep "not found in internal_model_max_budget" litellm.log | tail -1
LiteLLM Proxy:DEBUG: model_max_budget_limiter.py:60 - Model gpt-4o-mini-thinking-low not found in internal_model_max_budget
```

After, at 1cd481d4f2 (fresh key `sk-dY3xdP...`, redacted, same runbook):

```
=== call 1: model gpt-4o-mini, expect 200 and budget exhaustion ===
{"id":"chatcmpl-E9H9DoiE74rRgM3fMfSOPpqkRWQL9","created":1785879575,"model":"gpt-4o-mini","object":"chat.completion",...}
HTTP 200
=== call 2: model gpt-4o-mini again, budget enforced ===
{"error":{"message":"LiteLLM Virtual Key: a2d25557131ddb314f6ec81cd1804893d4f00332d081a4bc416258f045d12cfd, key_alias: qa-cursor-variant-budget-after-1cd481d, exceeded budget for model=gpt-4o-mini","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
=== call 3: model gpt-4o-mini-thinking-low, bypass closed ===
{"error":{"message":"LiteLLM Virtual Key: a2d25557131ddb314f6ec81cd1804893d4f00332d081a4bc416258f045d12cfd, key_alias: qa-cursor-variant-budget-after-1cd481d, exceeded budget for model=gpt-4o-mini","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
=== call 4: model gpt-4o-mini-fast, bypass closed for the other minted variant too ===
{"error":{"message":"LiteLLM Virtual Key: a2d25557131ddb314f6ec81cd1804893d4f00332d081a4bc416258f045d12cfd, key_alias: qa-cursor-variant-budget-after-1cd481d, exceeded budget for model=gpt-4o-mini","type":"budget_exceeded","param":null,"code":"429"}}
HTTP 429
```

Positive control on the after proxy: the master key (no per-model budget) still completes the alias request normally

```
$ curl -s -w "\nHTTP %{http_code}\n" http://localhost:41273/cursor/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model": "gpt-4o-mini-thinking-low", "messages": [{"role": "user", "content": "Say ok"}]}'
{"id":"chatcmpl-E9H9OhbD9G3Ao6HupUxgB4z7fUHY3","created":1785879586,"model":"gpt-4o-mini","object":"chat.completion",...}
HTTP 200
```

## Type

🐛 Bug Fix

## Changes

`/cursor/chat/completions` accepts minted variant aliases (`<base>-thinking-<low|medium|high>` and `<base>-fast`) and resolved them to the servable base model inside the handler, after `user_api_key_auth` had already run. Auth's per-model budget check (`_check_key_model_budget_with_fallback` -> `is_key_within_model_budget`) therefore looked up the budget config under the alias name, found none, and treated the request as unrestricted, while spend was tracked under the base model; any authenticated key with an exhausted per-model budget could keep calling that model forever through a variant alias

The fix moves variant resolution ahead of auth. A new route-level dependency, `_resolve_cursor_model_variant_before_auth`, is declared before `Depends(user_api_key_auth)` in the route's `dependencies` list, so FastAPI runs it first: it reads the body via `_read_request_body`, resolves the variant against the router with the existing `_resolve_cursor_model_variant`, and persists any rewrite with `_safe_set_request_parsed_body`. Auth and the handler both consume the cached parsed body, so every key, team, and end-user check now evaluates the model that is actually billed, and the handler's own resolution step is removed. Bodies that fail JSON parsing are left untouched so the existing auth and handler error paths respond exactly as before

One deliberate behavior change: model access checks also now see the base model, so a key restricted to `gpt-4o-mini` can call `gpt-4o-mini-thinking-low` (previously rejected by the key's model access check, now served, billed, and budgeted as `gpt-4o-mini`), which matches how the endpoint mints those aliases from models the key can already reach

Regression tests extend the mapped `tests/test_litellm/proxy/response_api_endpoints/test_endpoints.py` and run through the real FastAPI dependency chain with the real `user_api_key_auth` (only the key lookup is stubbed, returning a key whose `gpt-4o-mini` budget is already exhausted): `test_minted_alias_rejected_when_base_model_budget_exhausted` and `test_alias_rejection_matches_base_model_rejection` pin the 429 `budget_exceeded` parity between the base model and its aliases, while `test_auth_sees_base_model_for_minted_alias` and `test_auth_sees_servable_model_name_untouched` pin the ordering by asserting what auth observes. All 102 tests in the file pass and `make pre-commit` is clean

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
