### PR TITLE
fix(proxy): keep the connected DB client when a startup health check fails

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -8676,48 +8676,56 @@ class ProxyStartupEvent:
         - Sets up prisma client
         - Adds necessary views to proxy
         """
+        connected_client: PrismaClient | None = None
         try:
-            prisma_client: PrismaClient | None = None
-            if database_url is not None:
-                try:
-                    prisma_client = PrismaClient(database_url=database_url, proxy_logging_obj=proxy_logging_obj)
-                except Exception as e:
-                    raise e
+            if database_url is None:
+                return None
 
-                try:
-                    await prisma_client.connect()
-                except Exception as e:
-                    if "P3018" in str(e) or "P3009" in str(e):
-                        verbose_proxy_logger.debug("CRITICAL: DATABASE MIGRATION FAILED")
-                        verbose_proxy_logger.debug("Your database is in a 'dirty' state.")
-                        verbose_proxy_logger.debug("FIX: Run 'prisma migrate resolve --applied <migration_name>'")
-                    raise e
+            prisma_client = PrismaClient(database_url=database_url, proxy_logging_obj=proxy_logging_obj)
 
-                ## Start RDS IAM token refresh background task if enabled ##
-                # This proactively refreshes IAM tokens before they expire,
-                # preventing the 15-minute connection failure bug (#16220)
-                if hasattr(prisma_client, "db") and hasattr(prisma_client.db, "start_token_refresh_task"):
-                    await prisma_client.db.start_token_refresh_task()
+            try:
+                await prisma_client.connect()
+            except Exception as e:
+                if "P3018" in str(e) or "P3009" in str(e):
+                    verbose_proxy_logger.debug("CRITICAL: DATABASE MIGRATION FAILED")
+                    verbose_proxy_logger.debug("Your database is in a 'dirty' state.")
+                    verbose_proxy_logger.debug("FIX: Run 'prisma migrate resolve --applied <migration_name>'")
+                raise e
 
-                ## Add necessary views to proxy ##
-                asyncio.create_task(
-                    prisma_client.check_view_exists()
-                )  # check if all necessary views exist. Don't block execution
+            connected_client = prisma_client
 
-                asyncio.create_task(
-                    prisma_client._set_spend_logs_row_count_in_proxy_state()
-                )  # set the spend logs row count in proxy state. Don't block execution
+            ## Start RDS IAM token refresh background task if enabled ##
+            # This proactively refreshes IAM tokens before they expire,
+            # preventing the 15-minute connection failure bug (#16220)
+            if hasattr(prisma_client, "db") and hasattr(prisma_client.db, "start_token_refresh_task"):
+                await prisma_client.db.start_token_refresh_task()
 
-                # run a health check to ensure the DB is ready
-                if get_secret_bool("DISABLE_PRISMA_HEALTH_CHECK_ON_STARTUP", False) is not True:
-                    await prisma_client.health_check()
+            ## Add necessary views to proxy ##
+            asyncio.create_task(
+                prisma_client.check_view_exists()
+            )  # check if all necessary views exist. Don't block execution
 
-                if hasattr(prisma_client, "start_db_health_watchdog_task"):
-                    await prisma_client.start_db_health_watchdog_task()
+            asyncio.create_task(
+                prisma_client._set_spend_logs_row_count_in_proxy_state()
+            )  # set the spend logs row count in proxy state. Don't block execution
+
+            if hasattr(prisma_client, "start_db_health_watchdog_task"):
+                await prisma_client.start_db_health_watchdog_task()
+
+            # run a health check to ensure the DB is ready
+            if get_secret_bool("DISABLE_PRISMA_HEALTH_CHECK_ON_STARTUP", False) is not True:
+                await prisma_client.health_check()
+
             return prisma_client
         except Exception as e:
             PrismaDBExceptionHandler.handle_db_exception(e)
-            return None
+            if connected_client is not None:
+                verbose_proxy_logger.warning(
+                    "Retaining the connected Prisma client after a post-connect startup step failed: %s. "
+                    "The DB health watchdog keeps probing and reconnects once the database recovers.",
+                    e,
+                )
+            return connected_client
 
     @classmethod
     def _init_dd_tracer(cls):

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4297,7 +4297,7 @@ class PrismaClient:
             import traceback
 
             error_msg: Final = f"LiteLLM Prisma Client Exception connect(): {e}"
-            print_verbose(error_msg)
+            verbose_proxy_logger.warning(error_msg)
             error_traceback: Final = error_msg + "\n" + traceback.format_exc()
             end_time: Final = time.time()
             _duration: Final = end_time - start_time
@@ -5015,8 +5015,8 @@ class PrismaClient:
         except Exception as e:
             import traceback
 
-            error_msg: Final = f"LiteLLM Prisma Client Exception disconnect(): {e}"
-            print_verbose(error_msg)
+            error_msg: Final = f"LiteLLM Prisma Client Exception health_check(): {e}"
+            verbose_proxy_logger.warning(error_msg)
             error_traceback: Final = error_msg + "\n" + traceback.format_exc()
             end_time: Final = time.time()
             _duration: Final = end_time - start_time

--- a/tests/test_litellm/proxy/test_proxy_server.py
+++ b/tests/test_litellm/proxy/test_proxy_server.py
@@ -10825,3 +10825,123 @@ def test_startup_is_silent_when_mock_testing_params_disabled(caplog):
         ProxyStartupEvent._warn_if_mock_testing_params_enabled(general_settings={})
 
     assert MOCK_TESTING_CONFIG_KEY not in caplog.text
+
+
+def _mock_startup_prisma_client(health_check_error=None, connect_error=None):
+    client = MagicMock()
+    client.connect = AsyncMock(side_effect=connect_error)
+    client.db.start_token_refresh_task = AsyncMock()
+    client.check_view_exists = AsyncMock()
+    client._set_spend_logs_row_count_in_proxy_state = AsyncMock()
+    client.start_db_health_watchdog_task = AsyncMock()
+    client.health_check = AsyncMock(side_effect=health_check_error)
+    return client
+
+
+async def _run_setup_prisma_client(mock_client):
+    from litellm.proxy.proxy_server import ProxyStartupEvent
+
+    with patch.object(proxy_server_module, "PrismaClient", return_value=mock_client):
+        result = await ProxyStartupEvent._setup_prisma_client(
+            database_url="postgresql://litellm:litellm@localhost:5432/litellm",
+            proxy_logging_obj=MagicMock(),
+            user_api_key_cache=DualCache(),
+        )
+    await asyncio.sleep(0.05)
+    return result
+
+
+@pytest.mark.asyncio
+async def test_setup_prisma_client_retains_connected_client_when_startup_health_check_fails(
+    monkeypatch,
+):
+    """A transient failure of the startup ``SELECT 1`` must not discard a client
+    whose ``connect()`` already succeeded.
+
+    Discarding it assigns ``None`` to the module-level ``prisma_client`` for the
+    life of the process, so a database that came back a second later is never
+    used again until the proxy is restarted."""
+    monkeypatch.setenv("DISABLE_PRISMA_HEALTH_CHECK_ON_STARTUP", "False")
+    monkeypatch.setattr(
+        proxy_server_module,
+        "general_settings",
+        {"allow_requests_on_db_unavailable": True},
+    )
+
+    mock_client = _mock_startup_prisma_client(
+        health_check_error=httpx.ReadTimeout("startup health check timed out")
+    )
+    result = await _run_setup_prisma_client(mock_client)
+
+    assert mock_client.connect.await_count == 1
+    assert mock_client.health_check.await_count == 1
+    assert result is mock_client
+
+
+@pytest.mark.asyncio
+async def test_setup_prisma_client_arms_health_watchdog_before_startup_health_check(
+    monkeypatch,
+):
+    """The health watchdog is the only thing that reconnects a dropped DB, so it
+    has to be armed before the startup health check can fail.
+
+    Armed after, the single failure it exists to recover from is exactly the one
+    that skips it, and recovery never happens."""
+    monkeypatch.setenv("DISABLE_PRISMA_HEALTH_CHECK_ON_STARTUP", "False")
+    monkeypatch.setattr(
+        proxy_server_module,
+        "general_settings",
+        {"allow_requests_on_db_unavailable": True},
+    )
+
+    mock_client = _mock_startup_prisma_client(
+        health_check_error=httpx.ReadTimeout("startup health check timed out")
+    )
+    call_order = MagicMock()
+    call_order.attach_mock(mock_client.start_db_health_watchdog_task, "watchdog")
+    call_order.attach_mock(mock_client.health_check, "health_check")
+
+    await _run_setup_prisma_client(mock_client)
+
+    assert mock_client.start_db_health_watchdog_task.await_count == 1
+    assert [call[0] for call in call_order.mock_calls] == ["watchdog", "health_check"]
+
+
+@pytest.mark.asyncio
+async def test_setup_prisma_client_raises_when_db_unavailable_is_not_allowed(monkeypatch):
+    """Without ``allow_requests_on_db_unavailable`` a failed startup health check
+    must still hard-fail startup. Retaining the client is a fallback for
+    operators who opted into serving traffic without a database, never a way to
+    boot a proxy whose DB never answered."""
+    monkeypatch.setenv("DISABLE_PRISMA_HEALTH_CHECK_ON_STARTUP", "False")
+    monkeypatch.setattr(
+        proxy_server_module,
+        "general_settings",
+        {"allow_requests_on_db_unavailable": False},
+    )
+
+    mock_client = _mock_startup_prisma_client(
+        health_check_error=httpx.ReadTimeout("startup health check timed out")
+    )
+    with pytest.raises(httpx.ReadTimeout):
+        await _run_setup_prisma_client(mock_client)
+
+
+@pytest.mark.asyncio
+async def test_setup_prisma_client_returns_none_when_connect_itself_fails(monkeypatch):
+    """Retaining only ever applies to a client that connected. If ``connect()``
+    failed there is no usable client and no watchdog to recover it, so the caller
+    must still get ``None``."""
+    monkeypatch.setenv("DISABLE_PRISMA_HEALTH_CHECK_ON_STARTUP", "False")
+    monkeypatch.setattr(
+        proxy_server_module,
+        "general_settings",
+        {"allow_requests_on_db_unavailable": True},
+    )
+
+    mock_client = _mock_startup_prisma_client(connect_error=httpx.ConnectError("connection refused"))
+    result = await _run_setup_prisma_client(mock_client)
+
+    assert result is None
+    assert mock_client.start_db_health_watchdog_task.await_count == 0
+    assert mock_client.health_check.await_count == 0

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -1085,3 +1085,79 @@ async def test_post_mcp_call_hook_propagates_guardrail_block(restore_callbacks):
             request_data={"mcp_tool_name": "echo"},
             user_api_key_dict=None,
         )
+
+
+@pytest.mark.asyncio
+async def test_prisma_health_check_failure_names_itself_at_operator_visible_level(caplog):
+    """A failing DB health check has to name the check that failed, at a level
+    operators actually run at.
+
+    Reporting it as ``disconnect()`` sends anyone grepping the logs to the wrong
+    function and reads as "the check never ran", and reporting it only at debug
+    level hides a database fault behind a flag nobody enables in production."""
+    import logging
+    from unittest.mock import AsyncMock
+
+    from litellm.proxy.utils import PrismaClient
+
+    client = MagicMock()
+    client.db.query_raw = AsyncMock(side_effect=Exception("connection refused"))
+    client.proxy_logging_obj.failure_handler = AsyncMock()
+
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
+        with pytest.raises(Exception, match="connection refused"):
+            await PrismaClient.health_check(client)
+
+    assert "health_check()" in caplog.text
+    assert "disconnect()" not in caplog.text
+    assert "connection refused" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_prisma_connect_failure_is_reported_at_operator_visible_level(caplog):
+    """The sibling connect failure is labelled correctly but was equally
+    invisible. A database the proxy could not connect to at startup must not be
+    a debug-only record."""
+    import logging
+    from unittest.mock import AsyncMock
+
+    from litellm.proxy.utils import PrismaClient
+
+    client = MagicMock()
+    client.db.is_connected = MagicMock(return_value=False)
+    client.db.connect = AsyncMock(side_effect=Exception("could not reach database"))
+    client.proxy_logging_obj.failure_handler = AsyncMock()
+
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
+        with pytest.raises(Exception, match="could not reach database"):
+            await PrismaClient.connect(client)
+
+    assert "connect()" in caplog.text
+    assert "could not reach database" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_prisma_health_check_failure_redacts_database_credentials(caplog):
+    """Raising the level must not widen what reaches the logs. The exception
+    text can carry a full connection string, so the credential has to be gone
+    from the emitted record."""
+    import logging
+    from unittest.mock import AsyncMock
+
+    from litellm.proxy.utils import PrismaClient
+
+    client = MagicMock()
+    client.db.query_raw = AsyncMock(
+        side_effect=Exception("could not connect to postgresql://admin:hunter2@db.internal:5432/litellm")
+    )
+    client.proxy_logging_obj.failure_handler = AsyncMock()
+
+    with caplog.at_level(logging.WARNING, logger="LiteLLM Proxy"):
+        with pytest.raises(Exception):
+            await PrismaClient.health_check(client)
+
+    emitted = [record.getMessage() for record in caplog.records if record.name == "LiteLLM Proxy"]
+
+    assert emitted
+    assert all("hunter2" not in message for message in emitted)
+    assert any("postgresql://REDACTED@db.internal" in message for message in emitted)


### PR DESCRIPTION
## TLDR

Problem this solves:

- A transient startup DB blip permanently disables the DB client
- The swallow path returns None even though `connect()` had succeeded
- It also skips the watchdog that exists to reconnect
- The health check reported its failure under the wrong method name
- That report was debug-only, so operators saw nothing

How it solves it:

- Arm the health watchdog before running the startup health check
- Return the connected client instead of None when the error is swallowed
- A client whose `connect()` failed is still discarded
- Label the health check failure `health_check()`, not `disconnect()`
- Log both it and the sibling `connect()` failure at warning

## Relevant issues

## Linear ticket

Resolves LIT-5174

Resolves LIT-5179

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs use one namespaced rig: Postgres 16 in a container on 55174, a small TCP relay on 55175 in front of it, and the proxy on 45174 with `general_settings.allow_requests_on_db_unavailable: true`. The relay forwards normally until it sees the query engine's connection go idle, then severs every socket and refuses new ones for 25 seconds, which is wider than the 10 second backoff window on the startup health check, and then restores the database. That reproduces a transient blip landing exactly in the startup window. `PRISMA_HEALTH_WATCHDOG_INTERVAL_SECONDS` is 5, the floor the code allows, so recovery is expected roughly one interval after the database returns rather than at some arbitrary later time

One thing to state plainly about the repro: severing the socket also kills the prisma query engine, so the error the proxy observes is `httpx.ConnectError` from the client to the engine rather than a `ReadTimeout` from the engine to Postgres. Both classify identically through `is_database_connection_error` and both take the same swallow path, so the code under test is the same, but the injected fault is the harsher of the two

### Before, at `d1ca826ff640c0dcdbaa5315399eefd851f46454`

Relay timeline:

```
[12.711] connection #1 established
[13.305] BLOCK: severing all DB connections and refusing new ones for 25.0s
[38.306] UNBLOCK: database reachable again
```

The proxy never recovers, for the full 95 second observation window:

```
15:24:55  /health/readiness -> {"status":"healthy","db":"Not connected"}
15:25:05  /health/readiness -> {"status":"healthy","db":"Not connected"}
...
15:25:30  /health/readiness -> {"status":"healthy","db":"Not connected"}
```

A management endpoint keeps failing 90 seconds after the database came back:

```
$ curl -s -X POST http://127.0.0.1:45174/key/generate \
    -H 'Authorization: Bearer sk-...' -H 'Content-Type: application/json' \
    -d '{"models":["gpt-4.1-mini"]}'
{"error":{"message":"{'error': 'DB not connected. This endpoint needs a database; set DATABASE_URL to a PostgreSQL connection string (postgresql://...) to enable it.'}","type":"internal_server_error","code":"500"}}
```

Postgres itself is fine, and the watchdog never ran once:

```
$ docker exec lit5174-postgres psql -U lit5174 -d lit5174 -tAc "SELECT 'postgres_alive', now()"
postgres_alive|2026-08-04 22:25:41.793382+00

$ grep -c 'Attempting Prisma DB reconnect' proxy-before.log
0

$ grep -c 'Exception health_check()' proxy-before.log
0
```

There is also no health check line at any level an operator runs at, which is the second half of this PR; on `d1ca826ff6` the only report was `print_verbose`, and it named the wrong method

### After, at `f925c98897969a831a2f2b6582696517202d7c21`

Relay timeline from the same rig, rebuilt from scratch:

```
[11.357] BLOCK: severing all DB connections and refusing new ones for 25.0s
[36.358] UNBLOCK: database reachable again
[42.973] connection #2 established
```

The failure now announces itself at default verbosity, under its own name, and the client is kept:

```
15:26:17 WARNING utils.py:4300 - LiteLLM Prisma Client Exception connect(): Could not connect to the query engine
15:26:17 WARNING utils.py:5019 - LiteLLM Prisma Client Exception health_check(): All connection attempts failed
15:26:18 WARNING proxy_server.py:8723 - Retaining the connected Prisma client after a post-connect startup step failed: All connection attempts failed. The DB health watchdog keeps probing and reconnects once the database recovers.
```

Readiness recovers about one watchdog interval after the database returns:

```
15:26:38  /health/readiness -> {"status":"healthy","db":"connected"}
```

A real key is created and lands in Postgres:

```
$ curl -s -X POST http://127.0.0.1:45174/key/generate \
    -H 'Authorization: Bearer sk-...' -H 'Content-Type: application/json' \
    -d '{"models":["gpt-4.1-mini"],"key_alias":"lit5174-r2"}'
{"key_alias":"lit5174-r2","models":["gpt-4.1-mini"],...}

$ docker exec lit5174-postgres psql -U lit5174 -d lit5174 -tAc \
    "SELECT key_alias, models FROM \"LiteLLM_VerificationToken\" WHERE key_alias='lit5174-r2'"
lit5174-r2|{gpt-4.1-mini}
```

And a real, paid OpenAI call authenticated by that database-backed virtual key, which is the client the previous behaviour threw away:

```
$ curl -s -X POST http://127.0.0.1:45174/v1/chat/completions \
    -H "Authorization: Bearer $KEY" -H 'Content-Type: application/json' \
    -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"Reply with exactly: lit5174 recovered"}]}'
lit5174 recovered | model= gpt-4.1-mini
```

## Type

🐛 Bug Fix

## Changes

`ProxyStartupEvent._setup_prisma_client` ran `connect()`, then a `SELECT 1` health check, then armed the DB health watchdog, with a single handler underneath all three. With `allow_requests_on_db_unavailable` set, that handler swallows connection errors and returns None, and the caller assigns the result to the module-level `prisma_client`. So one transient failure of the startup health check discarded a client that had already connected successfully, for the life of the process, and skipped the watchdog whose entire job is to reconnect it. The health check is wrapped in a 3-try, 10 second backoff, so it takes a blip of that length rather than a single unlucky query

The client is now bound to `connected_client` only once `connect()` has returned, the watchdog is armed before the health check can fail, and the handler returns `connected_client`. A post-connect failure that gets swallowed keeps a working client and a running watchdog; a failure in `connect()` itself still yields None, because there is nothing usable to keep. When `allow_requests_on_db_unavailable` is not set the handler re-raises exactly as before and startup still hard-fails, which is pinned by a test in that direction as well as the retain direction

The same check also misreported itself. `health_check()` labelled its error `disconnect()`, copy-pasted from the real `disconnect()` further down the file, so searching the logs for the health check found nothing and read as though the check had never run. Both it and the sibling `connect()` failure reported through `print_verbose`, which routes to `verbose_proxy_logger.debug` and otherwise prints only under the deprecated `litellm.set_verbose`, leaving a startup-blocking database fault invisible at the verbosity operators actually run at. Both now log under their own names

On the level: these log at warning rather than error on purpose. `health_check()` is not startup-only, it is also called from the readiness probe path in `litellm/proxy/health_endpoints/_health_endpoints.py`, and it carries a 3-try backoff. At error level a sustained outage behind a 10 second Kubernetes probe would emit roughly eighteen error lines a minute from a probe loop, which trains operators to filter out the exact line this PR adds. Warning is visible at default verbosity, which is the actual complaint, without that cost

On redaction: raising the level does not widen what reaches the logs. `SecretRedactionFilter` is attached to the proxy logger's handler rather than to `print_verbose`'s print branch, so a connection string carried in the exception text is scrubbed on the new path exactly as it was on the old one. There is a test that pins this with a real connection string rather than leaving it to inspection

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
