### PR TITLE
fix(auth): return 403 from the OAuth2 enterprise gate

### DIFF
--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -1189,9 +1189,12 @@ async def _user_api_key_auth_builder(
             from litellm.proxy.proxy_server import premium_user
 
             if premium_user is not True:
-                raise ValueError(
-                    "Oauth2 token validation is only available for premium users"
-                    + CommonProxyErrors.not_premium_user.value
+                raise ProxyException(
+                    message="Oauth2 token validation is only available for premium users. "
+                    + CommonProxyErrors.not_premium_user.value,
+                    type=ProxyErrorTypes.auth_error,
+                    param="premium_user",
+                    code=status.HTTP_403_FORBIDDEN,
                 )
 
             return await Oauth2Handler.check_oauth2_token(token=api_key)

--- a/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
+++ b/tests/test_litellm/proxy/auth/test_user_api_key_auth.py
@@ -2066,10 +2066,47 @@ class TestJWTOAuth2Coexistence:
                 )
 
             assert exc_info.value.type == ProxyErrorTypes.auth_error
+            assert exc_info.value.code == "403"
             assert (
                 "Oauth2 token validation is only available for premium users"
                 in exc_info.value.message
             )
+            mock_oauth2.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_oauth2_disabled_unknown_key_stays_unauthorized(self):
+        """
+        The enterprise gate on the OAuth2 path is the only thing that turns 403
+        here. With `enable_oauth2_auth` off, an unknown opaque key is an
+        ordinary bad credential and must still be 401, so a blanket 403 is as
+        wrong in this direction as the 401 was in the gated one.
+        """
+        opaque_token = "some-opaque-m2m-oauth2-token"
+
+        mock_request = MagicMock()
+        mock_request.url.path = "/v1/chat/completions"
+        mock_request.headers = {"authorization": f"Bearer {opaque_token}"}
+        mock_request.query_params = {}
+
+        with (
+            patch("litellm.proxy.proxy_server.general_settings", {}),
+            patch("litellm.proxy.proxy_server.premium_user", False),
+            patch("litellm.proxy.proxy_server.master_key", "sk-master"),
+            patch("litellm.proxy.proxy_server.prisma_client", MagicMock()),
+            patch("litellm.proxy.proxy_server.user_api_key_cache", DualCache()),
+            patch(
+                "litellm.proxy.auth.user_api_key_auth.Oauth2Handler.check_oauth2_token",
+                new_callable=AsyncMock,
+            ) as mock_oauth2,
+        ):
+            with pytest.raises(ProxyException) as exc_info:
+                await user_api_key_auth(
+                    request=mock_request,
+                    api_key=f"Bearer {opaque_token}",
+                )
+
+            assert exc_info.value.code == "401"
+            assert "premium" not in exc_info.value.message.lower()
             mock_oauth2.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Unlicensed OAuth2 auth answers 401, not 403 like every sibling gate
- A 401 tells the client to retry with a better credential
- No credential can satisfy it while the install is unlicensed

How it solves it:

- Raise a 403 `ProxyException` instead of a bare `ValueError`
- Same shape the SSO enterprise gate already uses
- Give that message the sentence break it was missing

## Relevant issues

## Linear ticket

Resolves LIT-5180

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Postgres-backed proxy on a namespaced port with `LITELLM_LICENSE` exported empty so the install is unlicensed. Before runs captured at `27885076e7`, after runs at `315f6181a9`

Config for the gated case, an opaque bearer token on an LLM route with OAuth2 auth switched on

```
model_list:
  - model_name: gpt-4o-mini
    litellm_params:
      model: openai/gpt-4o-mini
      api_key: os.environ/OPENAI_API_KEY

general_settings:
  master_key: sk-lit5180-master
  enable_oauth2_auth: True
```

```bash
curl -sS -i -X POST http://127.0.0.1:4180/v1/chat/completions \
  -H "Authorization: Bearer some-opaque-m2m-oauth2-token" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
```

Before, at `27885076e7`

```
HTTP/1.1 401 Unauthorized
{"error":{"message":"Authentication Error, Oauth2 token validation is only available for premium usersYou must be a LiteLLM Enterprise user to use this feature. If you have a license please set `LITELLM_LICENSE` in your env. Get a 7 day trial key here: https://www.litellm.ai/enterprise#trial. \nPricing: https://www.litellm.ai/#pricing","type":"auth_error","param":"None","code":"401"}}
```

After, at `315f6181a9`

```
HTTP/1.1 403 Forbidden
{"error":{"message":"Oauth2 token validation is only available for premium users. You must be a LiteLLM Enterprise user to use this feature. If you have a license please set `LITELLM_LICENSE` in your env. Get a 7 day trial key here: https://www.litellm.ai/enterprise#trial. \nPricing: https://www.litellm.ai/#pricing","type":"auth_error","param":"premium_user","code":"403"}}
```

The same config with `enable_oauth2_auth` removed, proving the change is confined to the gate and did not turn into a blanket 403. The same opaque token is now just an unknown credential and stays 401 on both sides

Before, at `27885076e7`

```
HTTP/1.1 401 Unauthorized
{"error":{"message":"LiteLLM Virtual Key expected. Received=some****oken, expected to start with 'sk-'.","type":"auth_error","param":"None","code":"401"}}
```

After, at `315f6181a9`

```
HTTP/1.1 401 Unauthorized
{"error":{"message":"LiteLLM Virtual Key expected. Received=some****oken, expected to start with 'sk-'.","type":"auth_error","param":"None","code":"401"}}
```

Control on the fixed build, showing an ordinary virtual key still authenticates and reaches the real OpenAI API at real cost, at `315f6181a9`

```bash
KEY=$(curl -sS -X POST http://127.0.0.1:4180/key/generate \
  -H "Authorization: Bearer sk-lit5180-master" -H "Content-Type: application/json" \
  -d '{"models":["gpt-4o-mini"]}' | python -c "import sys,json;print(json.load(sys.stdin)['key'])")
curl -sS -i -X POST http://127.0.0.1:4180/v1/chat/completions \
  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"Say OK"}]}'
```

```
HTTP/1.1 200 OK
{"id":"chatcmpl-E9HFiOP8vtZQsdo2HESYVsP6GKvTz","created":1785879978,"model":"gpt-4o-mini","object":"chat.completion","choices":[{"finish_reason":"stop","index":0,"message":{"content":"OK!","role":"assistant"}}], ...}
```

## Type

🐛 Bug Fix

## Changes

The enterprise gate on the OAuth2 auth path raised a bare `ValueError`. Nothing between it and the terminal handler in `auth_exception_handler.py` recognizes that type, so it lands in the catch-all and is answered as a 401. Every sibling enterprise gate answers 403, including `_premium_user_check` in `litellm/proxy/utils.py` and the SSO gate in `ui_sso.py`. A 401 is an instruction to the client to retry with a better credential, and no credential can satisfy it while the install is unlicensed, so a well-behaved client is told to loop on a condition only an operator can clear

It now raises a `ProxyException` carrying `HTTP_403_FORBIDDEN`, shaped like the SSO gate rather than routed through `_premium_user_check`. That helper raises `HTTPException(403, detail={"error": msg})`, and the handler puts `detail` straight into `ProxyException.message`, whose constructor calls `str()` on it, so the client would receive a stringified Python dict. Raising the `ProxyException` directly avoids that and the handler re-raises it unmodified

Two response deltas come with the status code and are worth stating so they do not read as accidents. The 401 body was prefixed "Authentication Error, " because the catch-all builds its message out of `str(e)`; a `ProxyException` bypasses that construction, so the 403 body carries the gate's own message without the prefix. The `param` field also moves from `None` to `premium_user`, which is what the SSO gate sets and which names the condition an operator has to clear

The gate's own text gains a period and a space, which is the third visible change and a deliberate one rather than stray whitespace. It concatenated straight onto `CommonProxyErrors.not_premium_user`, so it rendered as "premium usersYou must be a LiteLLM Enterprise user"; the before capture above shows it. The sibling JWT gate already separates the two sentences the same way

Nothing else on the path moves. Authentication behavior is identical, no request that authenticated before stops authenticating, and with `enable_oauth2_auth` off the gate is never reached at all, which the second proof pair shows directly

The tests assert both directions on purpose. Asserting only that the gated case returns 403 would be satisfied by any change that returns 403 more widely, so there is a companion test pinning the flag-off case at 401. Running a mutant that forces 403 in the exception handler kills the second test while the first still passes, which is the check that the pair is worth having

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
