### PR TITLE
test: repair three failing suites on litellm_internal_staging

### DIFF
--- a/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
+++ b/tests/enterprise/litellm_enterprise/enterprise_callbacks/test_prometheus_logging_callbacks.py
@@ -1741,26 +1741,16 @@ async def test_initialize_remaining_budget_metrics_exception_handling(
 
             # Verify all five errors were logged (teams, keys, users, orgs, and user/team count)
             assert mock_logger.call_count == 5
-            assert (
-                "Error initializing teams budget metrics"
-                in mock_logger.call_args_list[0][0][0]
-            )
-            assert (
-                "Error initializing keys budget metrics"
-                in mock_logger.call_args_list[1][0][0]
-            )
-            assert (
-                "Error initializing users budget metrics"
-                in mock_logger.call_args_list[2][0][0]
-            )
-            assert (
-                "Error initializing orgs budget metrics"
-                in mock_logger.call_args_list[3][0][0]
-            )
-            assert (
-                "Error initializing user/team count metrics"
-                in mock_logger.call_args_list[4][0][0]
-            )
+            logged = [
+                call.args[0] % call.args[1:] for call in mock_logger.call_args_list
+            ]
+            assert logged == [
+                "Error initializing teams budget metrics: Database error",
+                "Error initializing keys budget metrics: Key listing error",
+                "Error initializing users budget metrics: User database error",
+                "Error initializing orgs budget metrics: Org database error",
+                "Error initializing user/team count metrics: User count error",
+            ]
 
         # Verify the metrics were never called
         prometheus_logger.litellm_remaining_team_budget_metric.assert_not_called()

--- a/tests/local_testing/test_completion.py
+++ b/tests/local_testing/test_completion.py
@@ -213,36 +213,6 @@ def test_completion_empower():
         pytest.fail(f"Error occurred: {e}")
 
 
-def test_completion_github_api():
-    litellm.set_verbose = True
-    messages = [
-        {
-            "role": "user",
-            "content": "\nWhat is the query for `console.log` => `console.error`\n",
-        },
-        {
-            "role": "assistant",
-            "content": "\nThis is the GritQL query for the given before/after examples:\n<gritql>\n`console.log` => `console.error`\n</gritql>\n",
-        },
-        {
-            "role": "user",
-            "content": "\nWhat is the query for `console.info` => `consdole.heaven`\n",
-        },
-    ]
-    try:
-        # test without max tokens
-        response = completion(
-            model="github/gpt-4o",
-            messages=messages,
-        )
-        # Add any assertions, here to check response args
-        print(response)
-    except litellm.AuthenticationError:
-        pass
-    except Exception as e:
-        pytest.fail(f"Error occurred: {e}")
-
-
 def test_completion_claude_3_empty_response():
     litellm.set_verbose = True
 

--- a/tests/proxy_behavior/management/test_team_metadata_schema.py
+++ b/tests/proxy_behavior/management/test_team_metadata_schema.py
@@ -1,0 +1,25 @@
+"""GET /team/metadata_schema — the behavior world declares no
+``general_settings.team_metadata_schema``, so the route is an info route that
+returns an empty field list to every authenticated actor and 401s without a key.
+"""
+
+import pytest
+
+from .actors import Actor
+
+pytestmark = pytest.mark.asyncio(loop_scope="session")
+
+
+@pytest.mark.parametrize("actor", list(Actor), ids=[a.value for a in Actor])
+async def test_team_metadata_schema_default_is_empty(actor: Actor, proxy_client, world):
+    resp = await proxy_client.get(
+        "/team/metadata_schema",
+        headers={"Authorization": f"Bearer {world.keys[actor].cleartext}"},
+    )
+    assert resp.status_code == 200, f"{actor.value}: {resp.status_code} {resp.text}"
+    assert resp.json() == {"fields": []}
+
+
+async def test_team_metadata_schema_requires_auth(proxy_client, world):
+    resp = await proxy_client.get("/team/metadata_schema")
+    assert resp.status_code == 401, resp.text


### PR DESCRIPTION
## TLDR

Problem this solves:

- Three tests are red on `litellm_internal_staging`
- `/team/metadata_schema` shipped with no behavior-suite scenario
- Prometheus assertions read an unrendered `%s` format string
- GitHub Models was retired upstream on 2026-07-30

How it solves it:

- Adds the missing `/team/metadata_schema` behavior scenario
- Renders the prometheus log message from its call args
- Deletes the live test for the retired GitHub Models API

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

### 1. `/team/metadata_schema` behaves the way the new behavior scenario pins it

Live proxy at `a28f7be27e`, booted against a scratch Postgres with `litellm/proxy/proxy_cli.py --config <config> --port 4077`. First boot declares no `general_settings.team_metadata_schema`, which is the state the behavior world reproduces

```
$ curl -sS -w '\nHTTP %{http_code}\n' http://localhost:4077/team/metadata_schema -H 'Authorization: Bearer sk-1234'
{"fields":[]}
HTTP 200

$ curl -sS -w '\nHTTP %{http_code}\n' http://localhost:4077/team/metadata_schema
{"error":{"message":"Authentication Error, No api key passed in.","type":"auth_error","param":"None","code":"401"}}
HTTP 401
```

Second boot declares two fields, which shows the empty list above is the real unconfigured default and not a dead route

```
$ curl -sS -w '\nHTTP %{http_code}\n' http://localhost:4077/team/metadata_schema -H 'Authorization: Bearer sk-1234'
{"fields":[{"key":"cost_center","label":"Cost Center"},{"key":"app_name","label":"App Name"}]}
HTTP 200
```

### 2. GitHub Models is gone upstream

GitHub announced full retirement of GitHub Models on 2026-07-30, covering the playground, catalog, and inference API (https://github.blog/changelog/2026-07-30-github-models-is-now-retired/). Both hosts confirm it, so `github/gpt-4o` can never return a completion again and the live test can only ever fail. This is independent of any commit in this repo

```
$ curl -sS -o /dev/null -w '%{http_code}\n' -X POST https://models.inference.ai.azure.com/chat/completions \
    -H 'Content-Type: application/json' -H 'Authorization: Bearer <token>' \
    -d '{"model":"gpt-4o","messages":[{"role":"user","content":"hi"}]}'
404

$ curl -sS -X POST https://models.github.ai/inference/chat/completions \
    -H 'Content-Type: application/json' \
    -d '{"model":"openai/gpt-4o","messages":[{"role":"user","content":"hi"}]}'
{"error":{"code":"github_models_retirement_brownout","message":"GitHub Models is temporarily unavailable as part of a scheduled retirement brownout."}}
```

`https://models.inference.ai.azure.com` is the default base url `get_llm_provider` hands the `github/` provider, so the 404 is what the failing test sees

### 3. Prometheus budget-metric logging

This one has no runtime surface to curl: #35703 changed only how the log record is built, from an f-string to lazy `%s` args, and the test was asserting against the pre-format string. The rendered message is byte-identical before and after, so there is nothing a live proxy would show differently

Instead the assertion is verified by mutation. Swapping the two log args in `litellm/integrations/prometheus.py` at `a28f7be27e`, so the message renders as `Error initializing Database error budget metrics: teams`, makes `test_initialize_remaining_budget_metrics_exception_handling` fail. The old substring check survived that mutation because it never looked past the format string

## Type

✅ Test

## Changes

`/team/metadata_schema` landed in #33353 without a scenario in `tests/proxy_behavior/management/`, which is exactly what `test_route_coverage.py` exists to catch. The new `test_team_metadata_schema.py` covers all nine seeded actors against the unconfigured default plus the unauthenticated 401, matching how `test_team_available.py` pins the other team info route

The prometheus assertions were reading `mock_logger.call_args_list[i][0][0]`, which #35703 turned into `"Error initializing %s budget metrics: %s"` when it moved logging to lazy args across 419 files. They now render the message from the full call args, so they pin the arg order and the exception text as well, neither of which the old substring check reached. Rendering also keeps the test correct if a call ever moves back to a pre-formatted string, since `msg % ()` returns the message unchanged

`test_completion_github_api` is deleted rather than skipped, because GitHub Models is retired rather than degraded and a permanent skip is just a no-op that reads as coverage. The offline `github/` capability lookups in `tests/test_litellm/test_utils.py` are untouched

Worth flagging separately: the `github/` provider itself still points at the retired endpoint, so it is dead for users too. Deciding whether to deprecate it, and what to tell people migrating, is a bigger call than this PR and belongs in its own change

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
