### PR TITLE
fix(batches): stop hosted_vllm files/batches from silently falling back to OpenAI

### DIFF
--- a/litellm/batches/main.py
+++ b/litellm/batches/main.py
@@ -28,6 +28,7 @@ from litellm.llms.azure.batches.handler import AzureBatchesAPI
 from litellm.llms.bedrock.batches.handler import BedrockBatchesHandler
 from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler, HTTPHandler
 from litellm.llms.custom_httpx.llm_http_handler import BaseLLMHTTPHandler
+from litellm.llms.openai.common_utils import get_openai_credentials
 from litellm.llms.openai.openai import OpenAIBatchesAPI
 from litellm.llms.vertex_ai.batches.handler import VertexAIBatchPrediction
 from litellm.secret_managers.main import get_secret_str
@@ -240,27 +241,15 @@ def create_batch(
             return response
         api_base: str | None = None
         if custom_llm_provider in OPENAI_COMPATIBLE_BATCH_AND_FILES_PROVIDERS:
-            # for deepinfra/perplexity/anyscale/groq we check in get_llm_provider and pass in the api base from there
-            api_base = (
-                optional_params.api_base
-                or litellm.api_base
-                or os.getenv("OPENAI_BASE_URL")
-                or os.getenv("OPENAI_API_BASE")
-                or "https://api.openai.com/v1"
+            openai_creds: Final = get_openai_credentials(
+                api_base=optional_params.api_base,
+                api_key=optional_params.api_key,
+                organization=optional_params.organization,
+                custom_llm_provider=custom_llm_provider,
             )
-            organization: Final = (
-                optional_params.organization
-                or litellm.organization
-                or os.getenv("OPENAI_ORGANIZATION", None)
-                or None  # default - https://github.com/openai/openai-python/blob/284c1799070c723c6a553337134148a7ab088dd8/openai/util.py#L105
-            )
-            # set API KEY
-            api_key = (
-                optional_params.api_key
-                or litellm.api_key  # for deepinfra/perplexity/anyscale we check in get_llm_provider and pass in the api key from there
-                or litellm.openai_key
-                or os.getenv("OPENAI_API_KEY")
-            )
+            api_base = openai_creds.api_base
+            api_key = openai_creds.api_key
+            organization: Final = openai_creds.organization
 
             response = openai_batches_instance.create_batch(
                 api_base=api_base,
@@ -389,27 +378,15 @@ def _handle_retrieve_batch_providers_without_provider_config(
 ):
     api_base: str | None = None
     if custom_llm_provider in OPENAI_COMPATIBLE_BATCH_AND_FILES_PROVIDERS:
-        # for deepinfra/perplexity/anyscale/groq we check in get_llm_provider and pass in the api base from there
-        api_base = (
-            optional_params.api_base
-            or litellm.api_base
-            or os.getenv("OPENAI_BASE_URL")
-            or os.getenv("OPENAI_API_BASE")
-            or "https://api.openai.com/v1"
+        openai_creds: Final = get_openai_credentials(
+            api_base=optional_params.api_base,
+            api_key=optional_params.api_key,
+            organization=optional_params.organization,
+            custom_llm_provider=custom_llm_provider,
         )
-        organization: Final = (
-            optional_params.organization
-            or litellm.organization
-            or os.getenv("OPENAI_ORGANIZATION", None)
-            or None  # default - https://github.com/openai/openai-python/blob/284c1799070c723c6a553337134148a7ab088dd8/openai/util.py#L105
-        )
-        # set API KEY
-        api_key = (
-            optional_params.api_key
-            or litellm.api_key  # for deepinfra/perplexity/anyscale we check in get_llm_provider and pass in the api key from there
-            or litellm.openai_key
-            or os.getenv("OPENAI_API_KEY")
-        )
+        api_base = openai_creds.api_base
+        api_key = openai_creds.api_key
+        organization: Final = openai_creds.organization
 
         response = openai_batches_instance.retrieve_batch(
             _is_async=_is_async,
@@ -729,20 +706,15 @@ def list_batches(
 
         _is_async: Final = kwargs.pop("alist_batches", False) is True
         if custom_llm_provider in OPENAI_COMPATIBLE_BATCH_AND_FILES_PROVIDERS:
-            # for deepinfra/perplexity/anyscale/groq we check in get_llm_provider and pass in the api base from there
-            api_base = (
-                optional_params.api_base
-                or litellm.api_base
-                or os.getenv("OPENAI_BASE_URL")
-                or os.getenv("OPENAI_API_BASE")
-                or "https://api.openai.com/v1"
+            openai_creds: Final = get_openai_credentials(
+                api_base=optional_params.api_base,
+                api_key=api_key,
+                organization=optional_params.organization,
+                custom_llm_provider=custom_llm_provider,
             )
-            organization: Final = (
-                optional_params.organization
-                or litellm.organization
-                or os.getenv("OPENAI_ORGANIZATION", None)
-                or None  # default - https://github.com/openai/openai-python/blob/284c1799070c723c6a553337134148a7ab088dd8/openai/util.py#L105
-            )
+            api_base = openai_creds.api_base
+            api_key = openai_creds.api_key
+            organization: Final = openai_creds.organization
 
             response = openai_batches_instance.list_batches(
                 _is_async=_is_async,
@@ -922,17 +894,15 @@ def cancel_batch(
         _is_async: Final = kwargs.pop("acancel_batch", False) is True
         api_base: str | None = None
         if custom_llm_provider in OPENAI_COMPATIBLE_BATCH_AND_FILES_PROVIDERS:
-            api_base = (
-                optional_params.api_base
-                or litellm.api_base
-                or os.getenv("OPENAI_BASE_URL")
-                or os.getenv("OPENAI_API_BASE")
-                or "https://api.openai.com/v1"
+            openai_creds: Final = get_openai_credentials(
+                api_base=optional_params.api_base,
+                api_key=optional_params.api_key,
+                organization=optional_params.organization,
+                custom_llm_provider=custom_llm_provider,
             )
-            organization: Final = (
-                optional_params.organization or litellm.organization or os.getenv("OPENAI_ORGANIZATION", None) or None
-            )
-            api_key = optional_params.api_key or litellm.api_key or litellm.openai_key or os.getenv("OPENAI_API_KEY")
+            api_base = openai_creds.api_base
+            api_key = openai_creds.api_key
+            organization: Final = openai_creds.organization
 
             response = openai_batches_instance.cancel_batch(
                 _is_async=_is_async,

--- a/litellm/files/main.py
+++ b/litellm/files/main.py
@@ -218,6 +218,7 @@ def create_file(
                 api_base=optional_params.api_base,
                 api_key=optional_params.api_key,
                 organization=optional_params.organization,
+                custom_llm_provider=custom_llm_provider,
             )
             response = openai_files_instance.create_file(
                 _is_async=_is_async,
@@ -339,6 +340,7 @@ def file_retrieve(
                 api_base=optional_params.api_base,
                 api_key=optional_params.api_key,
                 organization=optional_params.organization,
+                custom_llm_provider=custom_llm_provider,
             )
             response = openai_files_instance.retrieve_file(
                 file_id=file_id,
@@ -520,6 +522,7 @@ def file_delete(
                 api_base=optional_params.api_base,
                 api_key=optional_params.api_key,
                 organization=optional_params.organization,
+                custom_llm_provider=custom_llm_provider,
             )
             response = openai_files_instance.delete_file(
                 file_id=file_id,
@@ -722,6 +725,7 @@ def file_list(
                 api_base=optional_params.api_base,
                 api_key=optional_params.api_key,
                 organization=optional_params.organization,
+                custom_llm_provider=custom_llm_provider,
             )
             response = openai_files_instance.list_files(
                 purpose=purpose,
@@ -922,6 +926,7 @@ def file_content(
                 api_base=optional_params.api_base,
                 api_key=optional_params.api_key,
                 organization=optional_params.organization,
+                custom_llm_provider=custom_llm_provider,
             )
             response = openai_files_instance.file_content(
                 _is_async=_is_async,
@@ -1041,6 +1046,7 @@ def file_content_streaming(
             api_base=optional_params.api_base,
             api_key=optional_params.api_key,
             organization=optional_params.organization,
+            custom_llm_provider=custom_llm_provider,
         )
         response = openai_files_instance.file_content_streaming(
             _is_async=_is_async,

--- a/litellm/llms/openai/common_utils.py
+++ b/litellm/llms/openai/common_utils.py
@@ -17,12 +17,14 @@ if TYPE_CHECKING:
     from aiohttp import ClientSession
 
 import litellm
+from litellm.exceptions import BadRequestError
 from litellm.llms.base_llm.chat.transformation import BaseLLMException
 from litellm.llms.custom_httpx.http_handler import (
     _DEFAULT_TTL_FOR_HTTPX_CLIENTS,
     AsyncHTTPHandler,
     get_ssl_configuration,
 )
+from litellm.types.utils import LlmProviders
 
 
 def _get_client_init_params(cls: type) -> tuple[str, ...]:
@@ -262,8 +264,24 @@ def get_openai_credentials(
     api_base: str | None = None,
     api_key: str | None = None,
     organization: str | None = None,
+    custom_llm_provider: str | None = None,
 ) -> OpenAICredentials:
-    """Resolve OpenAI credentials from params, litellm globals, and env vars."""
+    """Resolve OpenAI credentials from params, litellm globals, and env vars.
+
+    `custom_llm_provider` names the OpenAI-compatible provider the caller is
+    resolving for (see OPENAI_COMPATIBLE_BATCH_AND_FILES_PROVIDERS). Anything other
+    than openai resolves through that provider's own config, so a self-hosted
+    deployment reads its own api_base/api_key env vars (e.g. HOSTED_VLLM_API_BASE)
+    and never silently falls back to api.openai.com with OPENAI_API_KEY, which
+    would send the caller's payload and spend to OpenAI instead of failing.
+    """
+    if custom_llm_provider is not None and custom_llm_provider != LlmProviders.OPENAI.value:
+        return _get_openai_compatible_provider_credentials(
+            api_base=api_base,
+            api_key=api_key,
+            organization=organization,
+            custom_llm_provider=custom_llm_provider,
+        )
     resolved_api_base: Final = (
         api_base
         or litellm.api_base
@@ -277,4 +295,43 @@ def get_openai_credentials(
         api_base=resolved_api_base,
         api_key=resolved_api_key,
         organization=resolved_organization,
+    )
+
+
+def _get_openai_compatible_provider_credentials(
+    api_base: str | None,
+    api_key: str | None,
+    organization: str | None,
+    custom_llm_provider: str,
+) -> OpenAICredentials:
+    """Resolve api_base/api_key for a non-openai OpenAI-compatible provider.
+
+    Delegates to the same `get_llm_provider` path the chat/embedding routes use, so
+    provider env vars stay defined in one place. A provider whose api_base cannot be
+    resolved raises rather than defaulting to OpenAI's base URL.
+    """
+    # Imported lazily: get_llm_provider_logic pulls in the provider configs, which
+    # import this module, so a module-level import would be circular.
+    from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+    _, _, resolved_api_key, resolved_api_base = get_llm_provider(
+        model="",
+        custom_llm_provider=custom_llm_provider,
+        api_base=api_base,
+        api_key=api_key,
+    )
+    if not resolved_api_base:
+        raise BadRequestError(
+            message=(
+                f"api_base is required for custom_llm_provider={custom_llm_provider}. "
+                f"Set it on the call, on the deployment, or via that provider's api_base env var "
+                f"(e.g. HOSTED_VLLM_API_BASE for hosted_vllm)."
+            ),
+            model="",
+            llm_provider=custom_llm_provider,
+        )
+    return OpenAICredentials(
+        api_base=resolved_api_base,
+        api_key=resolved_api_key,
+        organization=organization or litellm.organization or os.getenv("OPENAI_ORGANIZATION", None) or None,
     )

--- a/tests/test_litellm/batches/test_main.py
+++ b/tests/test_litellm/batches/test_main.py
@@ -19,8 +19,11 @@ to exactly one provider handler. These tests lock that dispatch:
 
 Only the provider handler instances are mocked (true network boundaries). The
 real public functions run (including the @client decorator) so dispatch reflects
-production. Provider env vars are not required: missing creds resolve to None and
-flow through harmlessly because the handler is mocked.
+production. Provider env vars are mostly not required: missing creds resolve to None
+and flow through harmlessly because the handler is mocked. The exception is a
+non-openai OpenAI-compatible provider (hosted_vllm), which must resolve its own
+api_base rather than defaulting to api.openai.com, so those cases pass one
+explicitly.
 """
 
 import os
@@ -139,8 +142,13 @@ def test_create__openai_dispatch_and_payload(seams):
 
 def test_create__hosted_vllm_routes_to_openai_instance(seams):
     """hosted_vllm is in OPENAI_COMPATIBLE_BATCH_AND_FILES_PROVIDERS, so it shares
-    the openai handler. Locks that set membership."""
-    result = bm.create_batch(**CREATE_KW, custom_llm_provider="hosted_vllm")
+    the openai handler. Locks that set membership.
+
+    api_base is explicit because a non-openai OpenAI-compatible provider must resolve
+    its own base and refuses to fall back to api.openai.com."""
+    result = bm.create_batch(
+        **CREATE_KW, custom_llm_provider="hosted_vllm", api_base="http://vllm:8000"
+    )
 
     assert result is seams.openai.create_batch.return_value
     _assert_only(seams.openai.create_batch, seams, "create_batch")
@@ -215,7 +223,9 @@ def test_retrieve__openai_dispatch_and_payload(seams):
 
 
 def test_retrieve__hosted_vllm_routes_to_openai_instance(seams):
-    result = bm.retrieve_batch(batch_id="batch-1", custom_llm_provider="hosted_vllm")
+    result = bm.retrieve_batch(
+        batch_id="batch-1", custom_llm_provider="hosted_vllm", api_base="http://vllm:8000"
+    )
 
     assert result is seams.openai.retrieve_batch.return_value
     _assert_only(seams.openai.retrieve_batch, seams, "retrieve_batch")
@@ -307,7 +317,9 @@ def test_list__openai_dispatch_and_payload(seams):
 
 
 def test_list__hosted_vllm_routes_to_openai_instance(seams):
-    result = bm.list_batches(custom_llm_provider="hosted_vllm")
+    result = bm.list_batches(
+        custom_llm_provider="hosted_vllm", api_base="http://vllm:8000"
+    )
 
     assert result is seams.openai.list_batches.return_value
     _assert_only(seams.openai.list_batches, seams, "list_batches")

--- a/tests/test_litellm/llms/openai/test_openai_common_utils.py
+++ b/tests/test_litellm/llms/openai/test_openai_common_utils.py
@@ -247,3 +247,72 @@ def test_a_client_litellm_built_its_own_http_client_for_is_still_closed(monkeypa
     closer.reap()
 
     assert wrapper.is_closed() is True
+
+
+class TestOpenAICompatibleProviderCredentials:
+    """get_openai_credentials must not resolve a non-openai OpenAI-compatible provider
+    to api.openai.com.
+
+    Regression: /v1/files and /v1/batches share the OpenAI branch for every provider in
+    OPENAI_COMPATIBLE_BATCH_AND_FILES_PROVIDERS, and credential resolution only consulted
+    OPENAI_BASE_URL / OPENAI_API_BASE / OPENAI_API_KEY before defaulting to
+    "https://api.openai.com/v1". A hosted_vllm batch call therefore succeeded silently
+    against OpenAI (billing the caller's OpenAI account and uploading their payload)
+    instead of reaching the self-hosted server named by HOSTED_VLLM_API_BASE.
+    """
+
+    def test_hosted_vllm_resolves_its_own_api_base(self, monkeypatch):
+        from litellm.llms.openai.common_utils import get_openai_credentials
+
+        monkeypatch.setenv("HOSTED_VLLM_API_BASE", "http://localhost:8080")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-must-not-be-used")
+        monkeypatch.setattr(litellm, "api_base", None)
+        monkeypatch.setattr(litellm, "api_key", None)
+
+        creds = get_openai_credentials(custom_llm_provider="hosted_vllm")
+
+        assert creds.api_base == "http://localhost:8080"
+        assert creds.api_key != "sk-openai-must-not-be-used", (
+            "hosted_vllm must not authenticate with the caller's OpenAI key"
+        )
+
+    def test_hosted_vllm_without_api_base_raises_instead_of_defaulting_to_openai(self, monkeypatch):
+        """The load-bearing case: no api_base configured anywhere. Silently resolving to
+        OpenAI is the bug, so this must raise."""
+        from litellm.llms.openai.common_utils import get_openai_credentials
+
+        monkeypatch.delenv("HOSTED_VLLM_API_BASE", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-must-not-be-used")
+        monkeypatch.setattr(litellm, "api_base", None)
+        monkeypatch.setattr(litellm, "api_key", None)
+
+        with pytest.raises(litellm.BadRequestError) as excinfo:
+            get_openai_credentials(custom_llm_provider="hosted_vllm")
+
+        assert "api_base" in str(excinfo.value)
+        assert "hosted_vllm" in str(excinfo.value)
+
+    def test_explicit_api_base_wins_for_hosted_vllm(self, monkeypatch):
+        from litellm.llms.openai.common_utils import get_openai_credentials
+
+        monkeypatch.setenv("HOSTED_VLLM_API_BASE", "http://from-env:8080")
+        monkeypatch.setattr(litellm, "api_base", None)
+
+        creds = get_openai_credentials(api_base="http://explicit:9000", custom_llm_provider="hosted_vllm")
+
+        assert creds.api_base == "http://explicit:9000"
+
+    def test_openai_provider_still_defaults_to_openai(self, monkeypatch):
+        """The fix must not disturb the openai path, which legitimately defaults."""
+        from litellm.llms.openai.common_utils import get_openai_credentials
+
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-is-correct-here")
+        monkeypatch.setattr(litellm, "api_base", None)
+        monkeypatch.setattr(litellm, "api_key", None)
+
+        for provider in (None, "openai"):
+            creds = get_openai_credentials(custom_llm_provider=provider)
+            assert creds.api_base == "https://api.openai.com/v1"
+            assert creds.api_key == "sk-openai-is-correct-here"


### PR DESCRIPTION
## TLDR

Problem this solves:

- `hosted_vllm` batch/file calls silently ran against OpenAI
- `HOSTED_VLLM_API_BASE` was ignored; `api.openai.com` was the default
- Caller's payload and spend went to OpenAI, reported as success

How it solves it:

- Credential resolution now takes the provider it resolves for
- Non-openai providers resolve via `get_llm_provider`, same as chat
- Unresolvable `api_base` raises instead of defaulting to OpenAI
- Removes four inlined copies of the fallback in `batches/main.py`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Backend is a local OpenAI-compatible server on `:8080` serving `Qwen/Qwen2.5-0.5B-Instruct-GGUF:Q4_K_M`. It serves `/v1/chat/completions` but not the Batch API, which is what makes the misrouting visible:

```
$ for r in files batches; do printf "POST /v1/$r -> "; curl -s -o /dev/null -w "%{http_code}\n" -X POST http://localhost:8080/v1/$r; done
POST /v1/files -> 404
POST /v1/batches -> 404
```

`repro.py` is the documented SDK flow: `acreate_file` then `acreate_batch`, both with `custom_llm_provider="hosted_vllm"`

### Before (ffcb54b06d, parent of this branch)

```
$ HOSTED_VLLM_API_BASE=http://localhost:8080 python repro.py
File uploaded: file-EBrEE5xkz7XPpjPEfwnyTh
Batch created: batch_6a727aface408190b0179c0750a96e1e
```

Reported success even though the configured backend has no such routes. Asking OpenAI for that id shows where it actually went:

```
$ curl -s https://api.openai.com/v1/files/file-EBrEE5xkz7XPpjPEfwnyTh -H "Authorization: Bearer $OPENAI_API_KEY"
{
  "object": "file",
  "id": "file-EBrEE5xkz7XPpjPEfwnyTh",
  "purpose": "batch",
  "filename": "batch_requests.jsonl",
  "bytes": 188,
  "status": "processed"
}
```

The file was uploaded to OpenAI and the batch queued on the caller's OpenAI account, authenticated with `OPENAI_API_KEY`, with nothing in the response indicating the wrong destination. Both resources were cancelled and deleted after capture

### After (47b488138a)

With `HOSTED_VLLM_API_BASE` set, the call reaches the configured server and surfaces its real answer:

```
$ HOSTED_VLLM_API_BASE=http://localhost:8080 python repro.py
openai.NotFoundError: Error code: 404 - {'error': {'message': 'File Not Found', 'type': 'not_found_error', 'code': 404}}
```

With nothing configured, it refuses rather than falling back:

```
$ python repro.py
litellm.BadRequestError: api_base is required for custom_llm_provider=hosted_vllm. Set it on the call,
on the deployment, or via that provider's api_base env var (e.g. HOSTED_VLLM_API_BASE for hosted_vllm).
```

Note on the 404: upstream vLLM's server registers no `/v1/files` or `/v1/batches` (batch is the offline `vllm run-batch` CLI; the online API is unmerged in vllm-project/vllm#44445), so no self-hosted vLLM can satisfy this flow today. That 404 is the honest upstream answer, and it is the point of the fix: a misconfigured or unsupported `hosted_vllm` batch call now fails visibly instead of quietly succeeding against OpenAI

## Type

🐛 Bug Fix

## Changes

`get_openai_credentials` gains a `custom_llm_provider` parameter. When it names anything other than `openai`, resolution goes through `get_llm_provider`, the same path chat and embeddings already use, so each provider reads its own `api_base`/`api_key` env vars from the one place those are defined. A provider whose `api_base` cannot be resolved raises `BadRequestError` naming the env var. The `openai` path is untouched and still defaults to `https://api.openai.com/v1`

`files/main.py` threads the provider through all six call sites. `batches/main.py` had four inlined copies of the same fallback chain across create/retrieve/list/cancel; those are replaced by the shared helper, so there is now a single resolver and no remaining `api.openai.com` default on the batch path

Four tests in `test_openai_common_utils.py` cover the regression: `hosted_vllm` resolves its own base, refuses to default to OpenAI when nothing is configured, prefers an explicit `api_base`, and `openai` still defaults. Reverting the guard fails two of the four. Three existing dispatch tests in `batches/test_main.py` now pass an explicit `api_base`, since their old reliance on "missing creds resolve to None" was the bug

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
