### PR TITLE
feat(proxy): add LiteLLM_BudgetWindowSpend table for per-window budget spend

### DIFF
--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260804162853_add_budget_window_spend_table/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260804162853_add_budget_window_spend_table/migration.sql
@@ -1,4 +1,3 @@
--- CreateTable
 CREATE TABLE IF NOT EXISTS "LiteLLM_BudgetWindowSpend" (
     "entity_type" TEXT NOT NULL,
     "entity_id" TEXT NOT NULL,

--- a/litellm-proxy-extras/litellm_proxy_extras/migrations/20260804162853_add_budget_window_spend_table/migration.sql
+++ b/litellm-proxy-extras/litellm_proxy_extras/migrations/20260804162853_add_budget_window_spend_table/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE IF NOT EXISTS "LiteLLM_BudgetWindowSpend" (
+    "entity_type" TEXT NOT NULL,
+    "entity_id" TEXT NOT NULL,
+    "window_duration" TEXT NOT NULL,
+    "window_start" TIMESTAMP(3) NOT NULL,
+    "spend" DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "LiteLLM_BudgetWindowSpend_pkey" PRIMARY KEY ("entity_type","entity_id","window_duration")
+);
+

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -664,6 +664,18 @@ model LiteLLM_SpendLogs {
   @@index([session_id])
 }
 
+model LiteLLM_BudgetWindowSpend {
+  entity_type     String
+  entity_id       String
+  window_duration String
+  window_start    DateTime
+  spend           Float    @default(0.0)
+  created_at      DateTime @default(now())
+  updated_at      DateTime @updatedAt
+
+  @@id([entity_type, entity_id, window_duration])
+}
+
 // View spend, model, api_key per request
 model LiteLLM_ErrorLogs {
   request_id          String   @id @default(uuid())

--- a/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
+++ b/litellm-proxy-extras/litellm_proxy_extras/schema.prisma
@@ -645,6 +645,18 @@ model LiteLLM_SpendLogs {
   @@index([session_id])
 }
 
+model LiteLLM_BudgetWindowSpend {
+  entity_type     String
+  entity_id       String
+  window_duration String
+  window_start    DateTime
+  spend           Float    @default(0.0)
+  created_at      DateTime @default(now())
+  updated_at      DateTime @updatedAt
+
+  @@id([entity_type, entity_id, window_duration])
+}
+
 // View spend, model, api_key per request
 model LiteLLM_ErrorLogs {
   request_id          String   @id @default(uuid())

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -664,6 +664,18 @@ model LiteLLM_SpendLogs {
   @@index([session_id])
 }
 
+model LiteLLM_BudgetWindowSpend {
+  entity_type     String
+  entity_id       String
+  window_duration String
+  window_start    DateTime
+  spend           Float    @default(0.0)
+  created_at      DateTime @default(now())
+  updated_at      DateTime @updatedAt
+
+  @@id([entity_type, entity_id, window_duration])
+}
+
 // View spend, model, api_key per request
 model LiteLLM_ErrorLogs {
   request_id          String   @id @default(uuid())

--- a/litellm/proxy/schema.prisma
+++ b/litellm/proxy/schema.prisma
@@ -645,6 +645,18 @@ model LiteLLM_SpendLogs {
   @@index([session_id])
 }
 
+model LiteLLM_BudgetWindowSpend {
+  entity_type     String
+  entity_id       String
+  window_duration String
+  window_start    DateTime
+  spend           Float    @default(0.0)
+  created_at      DateTime @default(now())
+  updated_at      DateTime @updatedAt
+
+  @@id([entity_type, entity_id, window_duration])
+}
+
 // View spend, model, api_key per request
 model LiteLLM_ErrorLogs {
   request_id          String   @id @default(uuid())

--- a/schema.prisma
+++ b/schema.prisma
@@ -664,6 +664,18 @@ model LiteLLM_SpendLogs {
   @@index([session_id])
 }
 
+model LiteLLM_BudgetWindowSpend {
+  entity_type     String
+  entity_id       String
+  window_duration String
+  window_start    DateTime
+  spend           Float    @default(0.0)
+  created_at      DateTime @default(now())
+  updated_at      DateTime @updatedAt
+
+  @@id([entity_type, entity_id, window_duration])
+}
+
 // View spend, model, api_key per request
 model LiteLLM_ErrorLogs {
   request_id          String   @id @default(uuid())

--- a/schema.prisma
+++ b/schema.prisma
@@ -645,6 +645,18 @@ model LiteLLM_SpendLogs {
   @@index([session_id])
 }
 
+model LiteLLM_BudgetWindowSpend {
+  entity_type     String
+  entity_id       String
+  window_duration String
+  window_start    DateTime
+  spend           Float    @default(0.0)
+  created_at      DateTime @default(now())
+  updated_at      DateTime @updatedAt
+
+  @@id([entity_type, entity_id, window_duration])
+}
+
 // View spend, model, api_key per request
 model LiteLLM_ErrorLogs {
   request_id          String   @id @default(uuid())

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -26193,7 +26193,7 @@ export interface components {
              * @description Default role assigned to new users created
              * @default internal_user_viewer
              */
-            user_role: ("proxy_admin" | "proxy_admin_viewer" | "internal_user" | "internal_user_viewer") | null;
+            user_role: ("internal_user" | "internal_user_viewer" | "proxy_admin" | "proxy_admin_viewer") | null;
         };
         /**
          * DefaultTeamSSOParams

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -26193,7 +26193,7 @@ export interface components {
              * @description Default role assigned to new users created
              * @default internal_user_viewer
              */
-            user_role: ("internal_user" | "internal_user_viewer" | "proxy_admin" | "proxy_admin_viewer") | null;
+            user_role: ("proxy_admin" | "proxy_admin_viewer" | "internal_user" | "internal_user_viewer") | null;
         };
         /**
          * DefaultTeamSSOParams

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -23744,7 +23744,7 @@ export interface components {
              * @description Default role assigned to new users created
              * @default internal_user_viewer
              */
-            user_role: ("proxy_admin" | "proxy_admin_viewer" | "internal_user" | "internal_user_viewer") | null;
+            user_role: ("internal_user" | "internal_user_viewer" | "proxy_admin" | "proxy_admin_viewer") | null;
         };
         /**
          * DefaultTeamSSOParams


### PR DESCRIPTION
## TLDR

Problem this solves:

- Window budget enforcement recomputes spend by aggregating LiteLLM_SpendLogs
- That query has no usable index and saturates large DBs (P2028)
- Every other budget feature reads a maintained spend value instead

How it solves it:

- Adds LiteLLM_BudgetWindowSpend, one row per configured budget window
- Row is keyed (entity_type, entity_id, window_duration), window_start marks the period
- Follow-up PRs maintain rows from the spend writer and read them at enforcement

## Relevant issues

Refs #35766

## Linear ticket

Refs LIT-5155

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests (schema-only PR; covered by the existing `schema_migration_check` CI gate that replays all migrations and diffs against schema.prisma)
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured at 3b1ab1908c. Deploying all migrations onto a fresh Postgres 14 database, exactly what a customer deployment runs at proxy startup:

```
$ DATABASE_URL="postgresql://postgres@127.0.0.1:55436/proofdb" prisma migrate deploy --schema schema.prisma
  ...
  └─ 20260731000000_add_autorouter_savings_spend/
    └─ migration.sql
  └─ 20260804162853_add_budget_window_spend_table/
    └─ migration.sql

All migrations have been successfully applied.

$ psql -h 127.0.0.1 -p 55436 -U postgres -d proofdb -c '\d "LiteLLM_BudgetWindowSpend"'
                          Table "public.LiteLLM_BudgetWindowSpend"
     Column      |              Type              | Collation | Nullable |      Default
-----------------+--------------------------------+-----------+----------+-------------------
 entity_type     | text                           |           | not null |
 entity_id       | text                           |           | not null |
 window_duration | text                           |           | not null |
 window_start    | timestamp(3) without time zone |           | not null |
 spend           | double precision               |           | not null | 0.0
 created_at      | timestamp(3) without time zone |           | not null | CURRENT_TIMESTAMP
 updated_at      | timestamp(3) without time zone |           | not null |
Indexes:
    "LiteLLM_BudgetWindowSpend_pkey" PRIMARY KEY, btree (entity_type, entity_id, window_duration)
```

`tests/proxy_migration_tests/test_db_schema_migration.py` also passes locally against a throwaway Postgres (replays every migration, then `prisma migrate diff --exit-code` against schema.prisma)

## Type

🆕 New Feature

## Changes

Adds the `LiteLLM_BudgetWindowSpend` model to all three tracked schema.prisma copies plus the corresponding migration. One row per configured budget window on a key or team: `entity_type` ("key" or "team"), `entity_id` (hashed token or team_id), `window_duration` (the `budget_duration` string from `budget_limits`, e.g. "30d"), `window_start` (which period the spend belongs to; rolls forward in place), `spend`

Deliberately no new indexes on LiteLLM_SpendLogs: that table can be tens of GB in production and an index build there is its own incident. The point of this table is that steady-state enforcement stops touching SpendLogs entirely

Stacked PRs on top of this one:

1. writer: #35886
2. reader: #35887

The one line of schema.d.ts churn is the gen:api sync gate regenerating union member order; committed exactly as regenerated per the gate's contract

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR


