### PR TITLE
test(e2e): self-seed the ui suite's password-login users in global setup

### DIFF
--- a/tests/e2e/ui/fixtures/users.ts
+++ b/tests/e2e/ui/fixtures/users.ts
@@ -14,7 +14,9 @@ export enum Role {
   TeamAdmin = "team_admin",
 }
 
-export const users: Record<Role, { email: string; password: string }> = {
+export type SeedApiRole = "proxy_admin_viewer" | "internal_user" | "internal_user_viewer";
+
+export const users: Record<Role, { email: string; password: string; seedApiRole?: SeedApiRole }> = {
   [Role.ProxyAdmin]: {
     email: "admin",
     password: process.env.LITELLM_MASTER_KEY || "sk-1234",
@@ -22,18 +24,22 @@ export const users: Record<Role, { email: string; password: string }> = {
   [Role.ProxyAdminViewer]: {
     email: "adminviewer@test.local",
     password: "test",
+    seedApiRole: "proxy_admin_viewer",
   },
   [Role.InternalUser]: {
     email: "internal@test.local",
     password: "test",
+    seedApiRole: "internal_user",
   },
   [Role.InternalUserViewer]: {
     email: "viewer@test.local",
     password: "test",
+    seedApiRole: "internal_user_viewer",
   },
   [Role.TeamAdmin]: {
     email: "teamadmin@test.local",
     password: "test",
+    seedApiRole: "internal_user",
   },
 };
 

--- a/tests/e2e/ui/globalSetup.ts
+++ b/tests/e2e/ui/globalSetup.ts
@@ -29,6 +29,26 @@ async function globalSetup() {
   if (!settingsRes.ok()) {
     throw new Error(`Enabling enable_projects_ui failed (${settingsRes.status()}): ${await settingsRes.text()}`);
   }
+
+  for (const { email, password, seedApiRole } of Object.values(users)) {
+    if (!seedApiRole) {
+      continue;
+    }
+    const createRes = await api.post(`${UI_BASE_URL}${rootPath}/user/new`, {
+      headers: { Authorization: `Bearer ${masterKey}` },
+      data: { user_email: email, user_role: seedApiRole, auto_create_key: false },
+    });
+    if (!createRes.ok() && createRes.status() !== 409) {
+      throw new Error(`Seeding user ${email} failed (${createRes.status()}): ${await createRes.text()}`);
+    }
+    const passwordRes = await api.post(`${UI_BASE_URL}${rootPath}/user/update`, {
+      headers: { Authorization: `Bearer ${masterKey}` },
+      data: { user_email: email, password },
+    });
+    if (!passwordRes.ok()) {
+      throw new Error(`Setting password for ${email} failed (${passwordRes.status()}): ${await passwordRes.text()}`);
+    }
+  }
   await api.dispose();
 
   for (const role of Object.values(Role)) {


### PR DESCRIPTION
## TLDR

Problem this solves:

- The UI e2e suite cannot log in on a fresh database
- Its login users only exist where seed.sql or an old DB provides them
- On a fresh deployment global setup times out at /ui/login

How it solves it:

- Global setup now seeds its own password-login users before logging in
- Each fixture user is created via /user/new, a 409 means already seeded
- The password is then set via /user/update, which is the call that supports it
- Already-seeded databases keep their user_ids, roles, and team memberships

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before, captured at bcce83a17e (global setup identical to this PR's base): on a fresh postgres, creating the suite's login user through the management API and then logging in the way the login page does fails, because /user/new does not accept a password and stores the user with password NULL

```
$ curl -s -X POST http://127.0.0.1:4000/user/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"user_email": "adminviewer@test.local", "password": "test", "user_role": "proxy_admin_viewer", "auto_create_key": false}'
{"user_id":"6cbd718e-0ba9-4422-9ac7-86e84e44de2d", ...}   (HTTP 200)

$ psql ... -c 'SELECT user_email, password IS NULL AS password_is_null FROM "LiteLLM_UserTable"'
       user_email       | password_is_null
------------------------+------------------
 adminviewer@test.local | t

$ curl -s -w "\nHTTP %{http_code}\n" -X POST http://127.0.0.1:4000/v2/login -H "Content-Type: application/json" \
    -d '{"username": "adminviewer@test.local", "password": "test"}'
{"error":{"message":"User has no password set. Please set a password for the user via `/user/update`.","type":"auth_error","param":"password","code":"401"}}
HTTP 401
```

That 401 keeps the login page at /ui/login, so global setup dies with `TimeoutError: page.waitForURL: Timeout 30000ms exceeded` at globalSetup.ts:43 for role proxy_admin_viewer, which is exactly how the suite failed against an ephemeral deployment with a fresh database. The master-key admin login passes because it never reads the user table, so the failure only shows on the first DB-backed role

After, captured at fb353423d8: fresh postgres 16 container, schema pushed via prisma db push, live proxy on localhost:4000, real Chromium run. First run seeds the users on the empty database and every role logs in; the second run proves idempotency (creates 409, passwords re-set) against the now-populated database

```
$ npx playwright test tests/auth/unauthenticatedRedirect.spec.ts --reporter=list
Running 1 test using 1 worker
  ✓  1 [chromium] › tests/auth/unauthenticatedRedirect.spec.ts:4:7 › Authentication Checks › should redirect unauthenticated user from a protected page (269ms)
  1 passed (4.5s)

$ psql ... -c 'SELECT user_email, user_role, left(password, 7) AS pw_prefix FROM "LiteLLM_UserTable" ORDER BY user_email'
       user_email       |      user_role       | pw_prefix
------------------------+----------------------+-----------
 adminviewer@test.local | proxy_admin_viewer   | scrypt:
 internal@test.local    | internal_user        | scrypt:
 teamadmin@test.local   | internal_user        | scrypt:
 viewer@test.local      | internal_user_viewer | scrypt:
                        | proxy_admin          |

$ npx playwright test tests/auth/unauthenticatedRedirect.spec.ts --reporter=list
  1 passed (3.4s)
```

Global setup logs in all five roles before any spec runs, so both green runs above prove the full login matrix, including proxy_admin_viewer which previously timed out

## Type

✅ Test

## Changes

`fixtures/users.ts` gives each fixture user the management-API role it should be created with (`seedApiRole`). The proxy admin has none because that login is the master key and needs no user row. The team admin fixture is created as an `internal_user`, matching seed.sql: team-admin-ness is a team membership the team specs create themselves, not a user role

`globalSetup.ts` seeds those users right after the ui_settings step, reusing the same API request context. Create goes through /user/new with `auto_create_key: false`; a 409 means the user already exists (seed.sql locally, or a long-lived database) and is fine. The password is then set through /user/update, the same call the invite-link onboarding flow uses, because /user/new does not accept a password. Setting it unconditionally keeps the fixture password authoritative without touching user_ids, roles, or team memberships on already-seeded databases. Any other non-2xx fails loudly with the response body, matching the error style of the ui_settings step above it

## QA runbook

- tests/e2e/ui/globalSetup.ts (runs before every spec) - on a fresh database the suite seeds its own login users and all five roles can sign in
  - [ ] Start a throwaway postgres: `docker run -d --rm --name e2e-pg -e POSTGRES_USER=diag -e POSTGRES_PASSWORD=diagpw -e POSTGRES_DB=litellm_diag -p 127.0.0.1:55444:5432 postgres:16`
  - [ ] Push the schema: `DATABASE_URL="postgresql://diag:diagpw@127.0.0.1:55444/litellm_diag" uv run python -m prisma db push --schema litellm/proxy/schema.prisma --accept-data-loss`
  - [ ] Boot the proxy against that DB with `LITELLM_MASTER_KEY=sk-1234` and any config, port 4000
  - [ ] `cd tests/e2e/ui && npm install && npx playwright install chromium`
  - [ ] `E2E_UI_BASE_URL=http://localhost:4000 LITELLM_MASTER_KEY=sk-1234 npx playwright test tests/auth/unauthenticatedRedirect.spec.ts --reporter=list`
  - [ ] Expect global setup to complete (it logs in proxy_admin, proxy_admin_viewer, internal_user, internal_user_viewer, team_admin) and the spec to pass
  - [ ] Re-run the same playwright command and expect green again, proving the create 409 path and password re-set are idempotent
  - [ ] Sanity check: this seeding matches what the suite's storageState logins actually need and cannot mask a login regression, because any login failure still throws in global setup

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
