### PR TITLE
fix(proxy): only treat a recoverable database outage as grounds to serve without one

### DIFF
--- a/litellm/proxy/db/exception_handler.py
+++ b/litellm/proxy/db/exception_handler.py
@@ -35,21 +35,52 @@ class PrismaDBExceptionHandler:
 
     @staticmethod
     def is_database_connection_error(e: Exception) -> bool:
-        """True iff the exception is (or could be) a DB-connectivity
-        failure, i.e. something that justifies the
-        ``allow_requests_on_db_unavailable`` HA fallback.
+        """True only for a database that is temporarily unreachable and is
+        expected to come back on its own.
+
+        This is the gate for ``allow_requests_on_db_unavailable``, which lets
+        the proxy keep serving, and issue fallback identities, without a
+        verified database. Only a transient outage justifies that. A fault that
+        will never resolve by itself, such as a query engine that is missing or
+        version-skewed, a malformed query the client library built, or a
+        transaction used incorrectly, must surface rather than be absorbed into
+        an indefinite degraded mode.
+
+        Membership is an allowlist, so an unrecognized failure is treated as
+        permanent. A genuine outage reaches the caller as one of
+        ``DB_CONNECTION_ERROR_TYPES``: the engine is a local HTTP server, and an
+        unreachable database surfaces as a transport error against it rather
+        than as a prisma type.
+
+        Reporting decisions want the opposite breadth; use
+        ``is_database_infrastructure_error`` for those.
+        """
+        import prisma.engine.errors
+
+        if isinstance(e, DB_CONNECTION_ERROR_TYPES):
+            return True
+        if isinstance(e, prisma.engine.errors.EngineConnectionError):
+            return True
+        return isinstance(e, ProxyException) and e.type == ProxyErrorTypes.no_db_connection
+
+    @staticmethod
+    def is_database_infrastructure_error(e: Exception) -> bool:
+        """True when the failure came from the database or its query engine
+        rather than from the caller's request.
+
+        This answers a reporting question, not a serving one: should the caller
+        be told the service is at fault, or that their request was. It stays
+        deliberately broad, because a permanently faulted engine is still a
+        service problem, and reporting one as a credential failure sends an
+        operator looking in the wrong place. Widening it can only change which
+        error a caller sees; it never grants access.
 
         Known data-layer PrismaError subclasses (``UniqueViolationError``,
-        ``RecordNotFoundError``, etc.) are explicitly excluded — the DB IS
-        reachable, so a fallback that grants an anonymous token would be
-        an auth bypass. Unknown / bare ``PrismaError`` instances default
-        to True so genuine outages that don't match a specific subclass
-        still trigger the fallback.
+        ``RecordNotFoundError``, etc.) are excluded — the DB IS reachable and
+        the request itself is what failed.
         """
         import prisma
 
-        # Explicit data-layer exclusion: DB IS reachable, fallback must
-        # NOT fire.
         data_layer_errors: Final = (
             prisma.errors.DataError,
             prisma.errors.UniqueViolationError,
@@ -194,7 +225,7 @@ class PrismaDBExceptionHandler:
         """
         import asyncio
 
-        if PrismaDBExceptionHandler.is_database_connection_error(e):
+        if PrismaDBExceptionHandler.is_database_infrastructure_error(e):
             return True
         if PrismaDBExceptionHandler.is_database_transport_error(e):
             return True

--- a/litellm/proxy/management_endpoints/access_group_endpoints.py
+++ b/litellm/proxy/management_endpoints/access_group_endpoints.py
@@ -611,7 +611,7 @@ async def delete_access_group(
             access_group_id,
             e,
         )
-        if PrismaDBExceptionHandler.is_database_connection_error(e):
+        if PrismaDBExceptionHandler.is_database_infrastructure_error(e):
             raise HTTPException(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail=CommonProxyErrors.db_not_connected_error.value,

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -4957,7 +4957,7 @@ class PrismaClient:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                if isinstance(e, asyncio.TimeoutError) or PrismaDBExceptionHandler.is_database_connection_error(e):
+                if isinstance(e, asyncio.TimeoutError) or PrismaDBExceptionHandler.is_database_infrastructure_error(e):
                     await self.attempt_db_reconnect(
                         reason="db_health_watchdog_connection_error",
                         timeout_seconds=self._db_watchdog_reconnect_timeout_seconds,

--- a/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
+++ b/tests/test_litellm/proxy/auth/test_auth_exception_handler.py
@@ -4,9 +4,15 @@ import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import HTTPException, Request, status
 from prisma import errors as prisma_errors
+from prisma.engine.errors import (
+    BinaryNotFoundError,
+    EngineConnectionError,
+    MismatchedVersionsError,
+)
 from prisma.errors import (
     ClientNotConnectedError,
     DataError,
@@ -31,19 +37,20 @@ from litellm.proxy.auth.auth_exception_handler import UserAPIKeyAuthExceptionHan
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "prisma_error",
+    "db_error",
     [
-        # Specific connectivity subclasses.
-        HTTPClientClosedError(),
-        ClientNotConnectedError(),
-        # Bare / generic PrismaError defaults to connectivity — we can't
-        # tell what it is, so err on the safe side for genuine outages.
-        PrismaError(),
+        pytest.param(httpx.ConnectError("All connection attempts failed"), id="ConnectError"),
+        pytest.param(httpx.ReadError("read failed"), id="ReadError"),
+        pytest.param(httpx.ReadTimeout("timed out"), id="ReadTimeout"),
+        pytest.param(EngineConnectionError(), id="EngineConnectionError"),
     ],
 )
-async def test_handle_authentication_error_db_unavailable_connectivity(prisma_error):
-    """Transport-level / connectivity failures (and generic PrismaError)
-    trigger the HA fallback."""
+async def test_handle_authentication_error_db_unavailable_connectivity(db_error):
+    """A database that is temporarily unreachable triggers the HA fallback.
+
+    These are the failures a real outage actually produces: the query engine is
+    a local HTTP server, so an unreachable database surfaces as a transport
+    error against it."""
     handler = UserAPIKeyAuthExceptionHandler()
 
     mock_request = MagicMock()
@@ -52,7 +59,7 @@ async def test_handle_authentication_error_db_unavailable_connectivity(prisma_er
         {"allow_requests_on_db_unavailable": True},
     ):
         result = await handler._handle_authentication_error(
-            prisma_error,
+            db_error,
             mock_request,
             {},
             "/test",
@@ -61,6 +68,52 @@ async def test_handle_authentication_error_db_unavailable_connectivity(prisma_er
         )
         assert result.key_name == "failed-to-connect-to-db"
         assert result.token == "failed-to-connect-to-db"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "prisma_error",
+    [
+        pytest.param(BinaryNotFoundError("query engine binary not found"), id="BinaryNotFoundError"),
+        pytest.param(MismatchedVersionsError(expected="1", got="2"), id="MismatchedVersionsError"),
+        pytest.param(HTTPClientClosedError(), id="HTTPClientClosedError"),
+        pytest.param(ClientNotConnectedError(), id="ClientNotConnectedError"),
+        pytest.param(PrismaError(), id="bare_PrismaError"),
+    ],
+)
+async def test_handle_authentication_error_permanent_fault_gets_no_fallback_identity(
+    prisma_error,
+):
+    """A fault that cannot resolve on its own must not mint a fallback identity,
+    even with ``allow_requests_on_db_unavailable`` enabled.
+
+    That setting trades verification for availability on the assumption the
+    database returns. When it never will, the trade buys nothing and the proxy
+    would keep admitting callers it cannot verify for as long as it runs, so the
+    fault has to reach the caller instead.
+
+    It must still reach them as a service failure. Denying the fallback is not
+    licence to report a database fault as a rejected credential, which would
+    send an operator hunting a key problem that does not exist."""
+    handler = UserAPIKeyAuthExceptionHandler()
+
+    mock_request = MagicMock()
+    with patch(
+        "litellm.proxy.proxy_server.general_settings",
+        {"allow_requests_on_db_unavailable": True},
+    ):
+        with pytest.raises(ProxyException) as exc_info:
+            await handler._handle_authentication_error(
+                prisma_error,
+                mock_request,
+                {},
+                "/test",
+                None,
+                "test-key",
+            )
+
+    assert exc_info.value.type == ProxyErrorTypes.no_db_connection
+    assert exc_info.value.code == str(status.HTTP_503_SERVICE_UNAVAILABLE)
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/db/test_exception_handler.py
+++ b/tests/test_litellm/proxy/db/test_exception_handler.py
@@ -4,6 +4,7 @@ import os
 import sys
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from fastapi import HTTPException, Request, status
 from prisma import errors as prisma_errors
@@ -41,11 +42,13 @@ from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
         PrismaError("timed out while connecting"),
     ],
 )
-def test_is_database_connection_error_prisma_connection_errors(prisma_error):
+def test_is_database_infrastructure_error_prisma_connection_errors(prisma_error):
     """
-    Test that only Prisma connection-related errors are considered DB connection errors.
+    Test that Prisma failures originating below the request are reported as
+    infrastructure faults, so a caller is told the service failed rather than
+    that its credentials did.
     """
-    assert PrismaDBExceptionHandler.is_database_connection_error(prisma_error) == True
+    assert PrismaDBExceptionHandler.is_database_infrastructure_error(prisma_error) == True
 
 
 @pytest.mark.parametrize(
@@ -398,7 +401,7 @@ def test_handle_db_exception_with_connection_error():
     """
     Test that DB connection errors are handled gracefully when allow_requests_on_db_unavailable is True
     """
-    db_error = ClientNotConnectedError()
+    db_error = httpx.ConnectError("All connection attempts failed")
     result = PrismaDBExceptionHandler.handle_db_exception(db_error)
     assert result is None
 
@@ -411,8 +414,8 @@ def test_handle_db_exception_raises_error():
     """
     Test that DB connection errors are raised when allow_requests_on_db_unavailable is False
     """
-    db_error = ClientNotConnectedError()
-    with pytest.raises(ClientNotConnectedError):
+    db_error = httpx.ConnectError("All connection attempts failed")
+    with pytest.raises(httpx.ConnectError):
         PrismaDBExceptionHandler.handle_db_exception(db_error)
 
 
@@ -426,3 +429,123 @@ def test_handle_db_exception_with_non_db_error():
     )
     with pytest.raises(litellm.BudgetExceededError):
         PrismaDBExceptionHandler.handle_db_exception(regular_error)
+
+
+def _permanent_prisma_faults():
+    """Every prisma error class that is not a transient outage and not a
+    data-layer error, built by enumeration so the list cannot drift out of sync
+    with the installed prisma version."""
+    import inspect
+
+    from prisma import engine as prisma_engine
+
+    payload = {"user_facing_error": {"meta": {"target": ["x"]}}, "error_message": "boom"}
+
+    class _Response:
+        status = 422
+
+    def build(cls):
+        attempts = (
+            ((), {}),
+            ((payload,), {}),
+            (("x",), {}),
+            (("x", "y"), {}),
+            ((_Response(),), {}),
+            ((_Response(), "body"), {}),
+            ((), {"expected": "1", "got": "2"}),
+        )
+        for args, kwargs in attempts:
+            try:
+                return cls(*args, **kwargs)
+            except Exception:
+                continue
+        return None
+
+    discovered = {}
+    for module in (prisma_errors, prisma_engine.errors):
+        for name, obj in vars(module).items():
+            if inspect.isclass(obj) and issubclass(obj, BaseException) and obj.__module__.startswith("prisma"):
+                discovered[name] = obj
+
+    faults = []
+    for name, cls in sorted(discovered.items()):
+        if issubclass(cls, prisma_engine.errors.EngineConnectionError):
+            continue
+        instance = build(cls)
+        if instance is None or not PrismaDBExceptionHandler.is_database_infrastructure_error(instance):
+            continue
+        faults.append(pytest.param(instance, id=name))
+    return faults
+
+
+PERMANENT_PRISMA_FAULTS = _permanent_prisma_faults()
+
+
+def test_permanent_fault_enumeration_is_not_empty():
+    """Guards the parametrized tests below: if the enumeration silently found
+    nothing, those tests would pass without asserting anything."""
+    assert len(PERMANENT_PRISMA_FAULTS) >= 15
+
+
+@pytest.mark.parametrize("prisma_error", PERMANENT_PRISMA_FAULTS)
+def test_permanent_prisma_faults_are_not_transient(prisma_error):
+    """A fault that cannot resolve on its own must not qualify a request to be
+    served without a verified database.
+
+    ``allow_requests_on_db_unavailable`` trades verification for availability on
+    the assumption the database returns. A missing or version-skewed query
+    engine, a malformed generated query, or a misused transaction never returns,
+    so absorbing one turns a bounded degraded window into a permanent one."""
+    assert PrismaDBExceptionHandler.is_database_connection_error(prisma_error) is False
+
+
+@pytest.mark.parametrize("prisma_error", PERMANENT_PRISMA_FAULTS)
+def test_permanent_prisma_faults_are_still_reported_as_service_problems(prisma_error):
+    """Narrowing what may be served without a database must not change what the
+    caller is told.
+
+    A permanently faulted engine is still the service's fault, so it has to keep
+    reaching the reporting predicate that renders it as unavailable rather than
+    as a rejected credential."""
+    assert PrismaDBExceptionHandler.is_database_infrastructure_error(prisma_error) is True
+    assert PrismaDBExceptionHandler.is_database_service_unavailable_error(prisma_error) is True
+
+
+@pytest.mark.parametrize(
+    "transient_error",
+    [
+        pytest.param(httpx.ConnectError("All connection attempts failed"), id="ConnectError"),
+        pytest.param(httpx.ReadError("read failed"), id="ReadError"),
+        pytest.param(httpx.ReadTimeout("timed out"), id="ReadTimeout"),
+        pytest.param(prisma_errors.HTTPClientClosedError(), id="HTTPClientClosedError_is_not_transient"),
+    ],
+)
+def test_genuine_outage_still_qualifies_for_the_fallback(transient_error):
+    """The httpx transport errors are how a real outage actually reaches the
+    caller: the query engine is a local HTTP server, so an unreachable database
+    surfaces as a transport failure against it rather than as a prisma type.
+    Narrowing the classifier must leave that path intact."""
+    expected = not isinstance(transient_error, prisma_errors.HTTPClientClosedError)
+    assert PrismaDBExceptionHandler.is_database_connection_error(transient_error) is expected
+
+
+def test_engine_connection_error_is_the_transient_prisma_type():
+    """``EngineConnectionError`` is the one prisma class that means the engine
+    could not reach the database and may succeed later."""
+    from prisma.engine.errors import EngineConnectionError
+
+    assert PrismaDBExceptionHandler.is_database_connection_error(EngineConnectionError()) is True
+
+
+@patch(
+    "litellm.proxy.proxy_server.general_settings",
+    {"allow_requests_on_db_unavailable": True},
+)
+def test_handle_db_exception_surfaces_a_permanent_fault_even_when_degraded_mode_is_enabled():
+    """The startup gate must not boot a proxy whose engine is permanently
+    faulted. Absorbing it produces a process that reports healthy and persists
+    nothing, indefinitely, with no error for an operator to find."""
+    from prisma.engine.errors import BinaryNotFoundError
+
+    with pytest.raises(BinaryNotFoundError):
+        PrismaDBExceptionHandler.handle_db_exception(BinaryNotFoundError("query engine binary not found"))

--- a/tests/test_litellm/proxy/db/test_prisma_self_heal.py
+++ b/tests/test_litellm/proxy/db/test_prisma_self_heal.py
@@ -290,7 +290,7 @@ async def test_db_health_watchdog_should_trigger_reconnect_on_db_error(
             AsyncMock(side_effect=[None, asyncio.CancelledError()]),
         ),
         patch(
-            "litellm.proxy.db.exception_handler.PrismaDBExceptionHandler.is_database_connection_error",
+            "litellm.proxy.db.exception_handler.PrismaDBExceptionHandler.is_database_infrastructure_error",
             return_value=True,
         ),
     ):
@@ -321,7 +321,7 @@ async def test_db_health_watchdog_should_trigger_reconnect_on_probe_timeout(
             AsyncMock(side_effect=[None, asyncio.CancelledError()]),
         ),
         patch(
-            "litellm.proxy.db.exception_handler.PrismaDBExceptionHandler.is_database_connection_error",
+            "litellm.proxy.db.exception_handler.PrismaDBExceptionHandler.is_database_infrastructure_error",
             return_value=False,
         ),
     ):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Any unrecognized prisma error counted as "database temporarily down"
- Permanent engine faults were absorbed, so degraded mode never ended
- A faulted proxy booted clean, served traffic and persisted nothing

How it solves it:

- Allowlist what is genuinely transient; treat the unrecognized as permanent
- Keep a separate broad predicate for reporting, so 503 stays 503
- Surface a permanent fault at startup instead of running on indefinitely

## Behavior change, read this first

If you run `general_settings.allow_requests_on_db_unavailable: true`, this changes what happens on some startups, deliberately.

That flag exists to keep you serving through database trouble, and it still does exactly that for a real outage. What changes is that it no longer keeps you serving through a fault that cannot heal. A query engine that is missing or version-skewed, a malformed query the client library generated, or a misused transaction used to satisfy the same check as a database that was briefly unreachable, so the proxy absorbed it and carried on. After this change those surface, and a deployment with a genuinely broken engine will fail to start rather than run in a degraded mode that has no end

The argument for accepting that is the before capture below. On the current code a proxy with a permanently faulted engine reports `"status":"healthy"`, answers a real paid completion with HTTP 200, and writes zero spend rows. It costs money, records none of it, and looks fine on a dashboard. A crash at startup is worse in exactly one respect, which is that it is visible, and that is the respect we want

## Relevant issues

## Linear ticket

Resolves LIT-5182

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

A permanently faulted query engine, induced with `PRISMA_QUERY_ENGINE_BINARY` pointing at a path that does not exist, which is what a wrongly built image looks like at runtime. Postgres itself is healthy and reachable throughout, so the only fault is the engine. `allow_requests_on_db_unavailable: true` in both runs

### Before, at `d64e79bf05f73497f1c67013b93d1bf0f55a9665`

```
Application startup complete

$ curl -s http://127.0.0.1:45182/health/readiness
{"status":"healthy","db":"Not connected"}

$ curl -s -w 'http_status=%{http_code}\n' -X POST http://127.0.0.1:45182/v1/chat/completions \
    -H 'Authorization: Bearer sk-...' -H 'Content-Type: application/json' \
    -d '{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"Reply with exactly: lit5182"}]}'
http_status=200
content: lit5182

$ docker exec lit5182-postgres psql -U lit5182 -d lit5182 -tAc 'SELECT COUNT(*) FROM "LiteLLM_SpendLogs"'
0
```

The 200 and the 0 are the same run. A real paid provider call was served and nothing about it was recorded, and the proxy will stay in that state for as long as the process lives, because the fault it absorbed cannot resolve

### After, at `38acfbdff641a1afc4cfa6de3bcb1b35b267b96a`

Same rig, torn down and rebuilt:

```
ERROR:    Application startup failed. Exiting.
prisma.engine.errors.NotConnectedError: Not connected to the query engine

process EXITED, nothing listening on 45182
```

Worth one note on how that fault arrives. I expected `BinaryNotFoundError`, since that is the obvious class for a missing engine. What actually happens is that the engine never starts and the failure surfaces at the first query as `NotConnectedError`. The fix covers it because the classification is computed from the installed prisma package rather than from a list of class names written by hand, so a class nobody enumerated is still handled correctly. I know this because I checked the type the live run produced instead of assuming it was the one the ticket named

## Type

🐛 Bug Fix

## Changes

`is_database_connection_error` ended in a catch-all that answered True for any `PrismaError` it did not recognize. The reasoning was that an unclassified failure might be an outage, so the safer default was to keep serving. That default is right for a database that will come back and wrong for a fault that will not, and the predicate could not tell the two apart

It is now an allowlist: the httpx transport errors already checked first, prisma's `EngineConnectionError`, and a `no_db_connection` ProxyException. Anything unrecognized is treated as permanent

Narrowing it does not weaken the high-availability path, which was worth checking rather than assuming. Pointing a client at a dead database and running a query produces `httpx.ConnectError`, because the query engine is a local HTTP server and an unreachable database surfaces as a transport failure against it. That was already the first branch of the predicate, so the catch-all was not what kept real outages working

### Why the reporting paths keep the broad behavior

Deciding whether to serve without a database and deciding what to tell the caller are different questions, and answering both from one predicate is what made the original catch-all look necessary

Inverting the shared predicate would have made a permanently faulted engine report to the caller as an authentication failure, because the auth handler renders anything that fails this check as a rejected credential rather than as a service problem. That would trade one defect for another, and the new one would only appear during an outage, which is the worst time to be debugging a misleading error

So the broad behavior is preserved under `is_database_infrastructure_error`, which now backs the three sites that answer the reporting and recovery question: service-unavailable classification, the access-group endpoint's status mapping, and the health watchdog's reconnect trigger. Their behavior is unchanged. Only the two sites that decide whether to serve without a verified database are narrowed, which are the startup gate and the auth fallback

Five further consumers sit behind `is_database_service_unavailable_error`, in the MCP bridge and MCP auth paths, and they inherit the broad predicate by construction

One site is provably unaffected rather than merely believed to be. The spend-log write at `utils.py` consults this only after `is_prisma_data_error` has already returned True, and no class is both a data error and a connection error, so the two predicates cannot overlap there

### Tests

The parametrized fixture enumerates prisma's error classes from the installed package at collection time instead of hardcoding names, so it cannot drift when prisma is upgraded, and it is what made the `NotConnectedError` case above work without special handling. It yields 22 cases, and a guard test asserts the enumeration found at least fifteen, because a parametrization that silently collected nothing would pass while asserting nothing

Two existing tests encoded the old contract and were re-homed rather than weakened. The parametrized case asserting that transport-level prisma errors are database failures now asserts it against the broad predicate, where its intent still holds exactly. The auth fallback test split in two: a transient failure still receives a fallback identity, and a permanent fault does not, and instead surfaces as a 503 with `no_db_connection`. That second assertion pins both halves of the split at once, since it shows the fallback was denied and the caller was still told the service failed rather than that its credentials did

Two `patch` targets in the watchdog tests pointed at the strict predicate. The watchdog now uses the broad one, so they were repointed. Worth knowing if you hit something similar: a stale patch target there does not fail as a clean assertion error. The real function runs against that module's mocked `prisma`, and the data-layer tuple becomes mock objects, so it surfaces as `TypeError: isinstance() arg 2 must be a type`

### Verification

Mutation tested against two mutants, each checked to be a real edit before running. Reverting the predicate to the old catch-all fails 29 tests. A one-line special case for `BinaryNotFoundError`, keeping both functions present and otherwise restoring the old behavior, still fails 26. That second one is the answer to why this is not just a carve-out for the single class the ticket named

`tests/test_litellm/proxy/db/` and `tests/test_litellm/proxy/auth/` pass together at 1849. The MCP consumers pass at 644

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
