### PR TITLE
fix(proxy): promote caller metadata trace fields into litellm_metadata

### DIFF
--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -151,6 +151,20 @@ LITELLM_METADATA_ROUTES: Final = (
     "files",
 )
 
+LITELLM_TRACE_CONTROL_METADATA_FIELDS: Final = frozenset(
+    {
+        "mask_input",
+        "mask_output",
+        "session_id",
+        "trace_id",
+        "trace_metadata",
+        "trace_name",
+        "trace_release",
+        "trace_user_id",
+        "trace_version",
+    }
+)
+
 _UNTRUSTED_ROOT_CONTROL_FIELDS: Final = (
     "proxy_server_request",
     "standard_logging_object",
@@ -456,6 +470,18 @@ def _get_metadata_variable_name(request: Request) -> str:
         return "litellm_metadata"
 
     return "metadata"
+
+
+def _promoted_trace_control_fields(
+    requester_metadata: Mapping[str, Any],
+    litellm_metadata: Mapping[str, Any],
+) -> tuple[tuple[str, Any], ...]:
+    """Return the caller's trace-control fields that ``litellm_metadata`` does not already set."""
+    return tuple(
+        (key, value)
+        for key, value in requester_metadata.items()
+        if key in LITELLM_TRACE_CONTROL_METADATA_FIELDS and key not in litellm_metadata
+    )
 
 
 def _extract_generic_session_id_from_headers(
@@ -1670,6 +1696,13 @@ async def add_litellm_data_to_request(
     # paths may read from it.
     if "metadata" in data and isinstance(data["metadata"], dict):
         data[_metadata_variable_name]["requester_metadata"] = copy.deepcopy(data["metadata"])
+        if _metadata_variable_name == "litellm_metadata":
+            data[_metadata_variable_name].update(
+                _promoted_trace_control_fields(
+                    requester_metadata=data[_metadata_variable_name]["requester_metadata"],
+                    litellm_metadata=data[_metadata_variable_name],
+                )
+            )
 
     # Merge litellm_metadata into the metadata variable (preserving existing
     # values). Runs after the user_api_key_* / _pipeline_managed_guardrails

--- a/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
+++ b/tests/test_litellm/proxy/test_litellm_pre_call_utils.py
@@ -20,6 +20,7 @@ from litellm.proxy.litellm_pre_call_utils import (
     _get_dynamic_logging_metadata,
     _get_enforced_params,
     _get_metadata_variable_name,
+    _promoted_trace_control_fields,
     _resolve_credential_from_model_config,
     _resolve_provider_from_deployment,
     _update_model_if_key_alias_exists,
@@ -5870,3 +5871,182 @@ async def test_key_level_callback_vars_survive_the_strip():
 
     assert updated[TRUSTED_CALLBACK_VARS_FIELD] == {"dd_api_key": "key-dd-key", "dd_site": "us5.datadoghq.com"}
     assert updated["dd_site"] == "us5.datadoghq.com"
+
+
+class TestPromotedTraceControlFields:
+    """LIT-5137: caller metadata trace fields must reach litellm_metadata."""
+
+    def _make_request(self, path: str) -> MagicMock:
+        request = MagicMock(spec=Request)
+        request.url = MagicMock()
+        request.url.path = path
+        request.url.__str__.return_value = f"http://localhost{path}"
+        request.method = "POST"
+        request.query_params = {}
+        request.headers = {"Content-Type": "application/json"}
+        request.client = MagicMock()
+        request.client.host = "127.0.0.1"
+        return request
+
+    async def _run(self, path: str, data: dict, headers: dict | None = None) -> dict:
+        request = self._make_request(path)
+        if headers is not None:
+            request.headers = {"Content-Type": "application/json", **headers}
+        return await add_litellm_data_to_request(
+            data=data,
+            request=request,
+            user_api_key_dict=UserAPIKeyAuth(api_key="hashed-key"),
+            proxy_config=MagicMock(),
+            general_settings={},
+            version="test-version",
+        )
+
+    def test_returns_litellm_metadata_for_responses_route(self):
+        assert _get_metadata_variable_name(self._make_request("/v1/responses")) == "litellm_metadata"
+
+    def test_promotes_trace_prefixed_and_allow_listed_fields(self):
+        requester_metadata = {
+            "trace_id": "trace-1",
+            "trace_name": "name-1",
+            "trace_user_id": "user-1",
+            "trace_metadata": {"tenant_id": "tenant-1"},
+            "trace_version": "v1",
+            "trace_release": "r1",
+            "session_id": "session-1",
+            "mask_input": True,
+            "mask_output": True,
+        }
+
+        promoted = _promoted_trace_control_fields(
+            requester_metadata=requester_metadata,
+            litellm_metadata={},
+        )
+
+        assert dict(promoted) == requester_metadata
+
+    def test_does_not_promote_unlisted_trace_prefixed_fields(self):
+        """trace_public flips a trace to publicly readable, so the allow-list is explicit."""
+        promoted = _promoted_trace_control_fields(
+            requester_metadata={"trace_id": "trace-1", "trace_public": True, "trace_tags": ["a"]},
+            litellm_metadata={},
+        )
+
+        assert dict(promoted) == {"trace_id": "trace-1"}
+
+    def test_does_not_promote_non_trace_fields(self):
+        promoted = _promoted_trace_control_fields(
+            requester_metadata={
+                "trace_id": "trace-1",
+                "tags": ["free-tier"],
+                "user_api_key": "forged",
+                "user_api_key_user_id": "forged-user",
+                "spend_logs_metadata": {"forged": True},
+                "guardrails": ["disabled"],
+                "debug_langfuse": True,
+                "session": "not-session-id",
+                "existing_trace_id": "victim-trace",
+                "update_trace_keys": ["input", "output"],
+            },
+            litellm_metadata={},
+        )
+
+        assert dict(promoted) == {"trace_id": "trace-1"}
+
+    def test_does_not_promote_trace_mutation_controls(self):
+        """existing_trace_id + update_trace_keys let a caller overwrite any trace in the project."""
+        promoted = _promoted_trace_control_fields(
+            requester_metadata={
+                "trace_id": "trace-1",
+                "existing_trace_id": "someone-elses-trace",
+                "update_trace_keys": ["input", "output"],
+            },
+            litellm_metadata={},
+        )
+
+        assert dict(promoted) == {"trace_id": "trace-1"}
+
+    def test_existing_litellm_metadata_value_wins(self):
+        promoted = _promoted_trace_control_fields(
+            requester_metadata={"trace_id": "from-body", "session_id": "from-body", "trace_name": "from-body"},
+            litellm_metadata={"trace_id": "from-header", "session_id": "from-header"},
+        )
+
+        assert dict(promoted) == {"trace_name": "from-body"}
+
+    def test_empty_requester_metadata_promotes_nothing(self):
+        assert _promoted_trace_control_fields(requester_metadata={}, litellm_metadata={}) == ()
+
+    @pytest.mark.asyncio
+    async def test_responses_route_end_to_end(self):
+        caller_metadata = {
+            "trace_id": "22662678-30c1-41a1-a24b-216d6e5fb83d",
+            "session_id": "218af06c-28a2-4705-8a0a-5f9970d39326",
+            "trace_user_id": "user-123",
+            "trace_metadata": {"tenant_id": "tenant-1"},
+            "mask_input": True,
+        }
+
+        updated = await self._run(
+            "/v1/responses",
+            {"model": "gpt-4.1-mini", "input": "say resp", "metadata": copy.deepcopy(caller_metadata)},
+        )
+
+        litellm_metadata = updated["litellm_metadata"]
+        for key, value in caller_metadata.items():
+            assert litellm_metadata[key] == value
+        assert updated["metadata"] == caller_metadata
+
+    @pytest.mark.asyncio
+    async def test_messages_route_end_to_end(self):
+        updated = await self._run(
+            "/v1/messages",
+            {
+                "model": "claude-sonnet-4-5",
+                "max_tokens": 32,
+                "messages": [{"role": "user", "content": "hi"}],
+                "metadata": {"trace_id": "msg-trace-1", "session_id": "msg-session-1"},
+            },
+        )
+
+        assert updated["litellm_metadata"]["trace_id"] == "msg-trace-1"
+        assert updated["litellm_metadata"]["session_id"] == "msg-session-1"
+
+    @pytest.mark.asyncio
+    async def test_session_id_header_beats_body_metadata(self):
+        updated = await self._run(
+            "/v1/responses",
+            {"model": "gpt-4.1-mini", "input": "say resp", "metadata": {"session_id": "from-body"}},
+            headers={"x-litellm-session-id": "from-header-12345678"},
+        )
+
+        assert updated["litellm_metadata"]["session_id"] == "from-header-12345678"
+
+    @pytest.mark.asyncio
+    async def test_forged_user_api_key_fields_are_not_promoted(self):
+        updated = await self._run(
+            "/v1/responses",
+            {
+                "model": "gpt-4.1-mini",
+                "input": "say resp",
+                "metadata": {"trace_id": "trace-1", "user_api_key_user_id": "forged", "spend_logs_metadata": {"a": 1}},
+            },
+        )
+
+        litellm_metadata = updated["litellm_metadata"]
+        assert litellm_metadata["trace_id"] == "trace-1"
+        assert litellm_metadata.get("user_api_key_user_id") != "forged"
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_route_is_untouched(self):
+        updated = await self._run(
+            "/v1/chat/completions",
+            {
+                "model": "gpt-4.1-mini",
+                "messages": [{"role": "user", "content": "hello"}],
+                "metadata": {"trace_id": "trace-1", "session_id": "session-1"},
+            },
+        )
+
+        assert "litellm_metadata" not in updated
+        assert updated["metadata"]["trace_id"] == "trace-1"
+        assert updated["metadata"]["session_id"] == "session-1"


### PR DESCRIPTION
## TLDR

Problem this solves:

- On `/v1/responses` the caller's `metadata` never reached the logging callbacks as trace-level fields, so a Langfuse trace came out with `sessionId`, `userId` and `metadata` all null
- The trace was created at the caller's `metadata.session_id` instead of their `metadata.trace_id`, so looking the trace up by the id the client generated returned 404
- Every `/v1/responses` call sharing one `session_id` collapsed into a single trace whose input and output were overwritten by whichever call was ingested last
- The same request shape against `/v1/chat/completions` was already correct, so the two routes disagreed
- The same gap silently dropped `mask_input` / `mask_output`, so a caller asking for redaction on `/v1/responses` had their raw prompt written to Langfuse in full

How it solves it:

- Routes in `LITELLM_METADATA_ROUTES` keep the caller's `metadata` as a provider passthrough field and track proxy state in `litellm_metadata`, which is the dict every logging integration ends up reading, so the proxy now promotes an explicit allow-list of the caller's trace-control fields into it
- This covers providers with a native Responses API config. Providers that reach `/v1/responses` through the chat-completions bridge need the companion change in #36105, which is stacked on this PR, so both are required to close the issue

## Relevant issues

Fixes #34226 together with #36105, which is stacked on this branch and covers the completion-transformation bridge path

## Linear ticket

Resolves LIT-5137

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live proxy on localhost, real Postgres, real provider traffic (Gemini), with Langfuse pointed at a local ingestion endpoint so the raw `trace-create` bodies are visible. The same four requests, all carrying the same caller `metadata`, on `litellm_internal_staging` and then on this branch alone, without the stacked #36105:

```console
### before
# caller metadata: trace_id=22662678-30c1-41a1-a24b-216d6e5fb83d session_id=218af06c-28a2-4705-8a0a-5f9970d39326 trace_user_id=user-123 trace_metadata={tenant_id:tenant-1}

POST /v1/chat/completions              -> 200
POST /v1/responses  (native provider)  -> 200
POST /v1/responses  (completion bridge)-> 200
POST /v1/messages                      -> 200

# trace-create bodies received by the Langfuse ingestion endpoint
{"name": "litellm-acompletion", "id": "22662678-30c1-41a1-a24b-216d6e5fb83d", "sessionId": "218af06c-28a2-4705-8a0a-5f9970d39326", "userId": "user-123", "metadata": {"tenant_id": "tenant-1"}}
{"name": "litellm-aresponses", "id": "218af06c-28a2-4705-8a0a-5f9970d39326", "sessionId": null, "userId": null, "metadata": null}
{"name": "litellm-aresponses", "id": "bb6a5f83-862c-4907-989a-f77011b757fe", "sessionId": null, "userId": null, "metadata": null}
{"name": "litellm-anthropic_messages", "id": "084bc495-2802-4a9c-be02-6ddc2142d113", "sessionId": null, "userId": null, "metadata": null}
```

`/v1/chat/completions` is correct already. On `/v1/responses` with a native provider config the trace is created at the caller's `session_id` instead of their `trace_id`, which is the reported 404-on-lookup. On the bridge and on `/v1/messages` the trace id is a per-request UUID. All three have `sessionId`, `userId` and `metadata` null.

```console
### after, this PR alone
POST /v1/chat/completions              -> 200
POST /v1/responses  (native provider)  -> 200
POST /v1/responses  (completion bridge)-> 200
POST /v1/messages                      -> 200

{"name": "litellm-acompletion", "id": "22662678-30c1-41a1-a24b-216d6e5fb83d", "sessionId": "218af06c-28a2-4705-8a0a-5f9970d39326", "userId": "user-123", "metadata": {"tenant_id": "tenant-1"}}
{"name": "litellm-aresponses", "id": "22662678-30c1-41a1-a24b-216d6e5fb83d", "sessionId": "218af06c-28a2-4705-8a0a-5f9970d39326", "userId": "user-123", "metadata": {"tenant_id": "tenant-1"}}
{"name": "litellm-aresponses", "id": "1d137817-2b37-45e4-a544-a42989330515", "sessionId": null, "userId": null, "metadata": null}
{"name": "litellm-anthropic_messages", "id": "33a3c750-57cd-4690-876c-019f2b14219f", "sessionId": null, "userId": null, "metadata": null}
```

The native Responses path is fixed by this PR on its own. The completion-transformation bridge and `/v1/messages` still show the old behavior on the third and fourth lines, because those paths lose the fields again inside `get_litellm_params`, which is what #36105 fixes. Both PRs together produce the caller's `trace_id` on all four routes, and that combined run is in #36105

Redaction on the native path, `/v1/responses` with `metadata: {"mask_input": true, "mask_output": true}` and the literal string `SECRET-AONLY-abc` as the input:

```console
mask (native) -> 200
raw prompt leaked: False
trace id   : mask-a-only
trace input: 'redacted-by-litellm'
```

Before this PR the same request wrote the prompt to Langfuse in full, since `mask_input` never reached the callback

The two control classes that are deliberately not promoted, captured on the wire while they still were, then re-checked after the allow-list was made explicit:

```console
# trace_public, while the allow-list still matched the trace_ prefix
id     : someone-elses-trace
public : True

# existing_trace_id + update_trace_keys, while they were still promoted
{"id": "<someone-elses-trace>", "input": "<caller content>", "output": ...}

# both, after restricting the allow-list
trace_public probe -> public = False
native trace input still original: True
attacker text absent from it     : True
```

## Type

🐛 Bug Fix

## Changes

`litellm/proxy/litellm_pre_call_utils.py` gains `_promoted_trace_control_fields`, called from `add_litellm_data_to_request` next to the existing `requester_metadata` snapshot and only when the route resolved to `litellm_metadata`. Promotion is an explicit allow-list: `trace_id`, `trace_name`, `trace_user_id`, `trace_metadata`, `session_id`, `mask_input`, `mask_output`. It reads the `requester_metadata` deepcopy rather than `data["metadata"]`, because on these routes that dict is forwarded to the provider and sharing a nested object with it would let a callback write into an outbound request body. It never overwrites a value that is already set, so header-derived `trace_id` / `session_id` keep the precedence they have on `/chat/completions`.

The allow-list is deliberately explicit rather than a `trace_` prefix match. Langfuse maps any `trace_<x>` key onto the trace, and two of those are not correlation fields: `trace_public` flips a trace to publicly readable, and `existing_trace_id` together with `update_trace_keys` rewrites an already-existing trace with no ownership check. A prefix rule would hand a caller both. Earlier revisions of this PR did, and live captures confirmed the proxy then emitted `public: true` and `{"id": "<someone-elses-trace>", "input": "<caller content>"}` on the wire. `tags` is excluded for a different reason: per-tag budget enforcement runs at auth time, before this function, so promoting tags would reach tag-based routing and tag spend attribution without passing `_tag_max_budget_check`. `debug_langfuse` is excluded because it dumps the full proxy metadata blob into the trace.

## Behavior changes

Callbacks on `LITELLM_METADATA_ROUTES` now see the caller's trace-control fields where they previously saw none. That is the fix. Nothing else about those dicts changes here.

The consequences of the companion change, `litellm_params["metadata"]` going from `None` to a populated dict on the bridge and the callbacks that starts waking up, are described in #36105 rather than here.

## QA runbook

Point the proxy at any HTTP server that accepts `POST /api/public/ingestion` and returns 207, so the raw trace bodies are visible, then send the same metadata through both routes and compare:

```bash
TID=22662678-30c1-41a1-a24b-216d6e5fb83d; SID=218af06c-28a2-4705-8a0a-5f9970d39326
META="{\"trace_id\":\"$TID\",\"session_id\":\"$SID\",\"trace_user_id\":\"user-123\",\"trace_metadata\":{\"tenant_id\":\"tenant-1\"}}"

curl -s localhost:4000/v1/chat/completions -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' \
  -d "{\"model\":\"gpt-4.1-mini\",\"messages\":[{\"role\":\"user\",\"content\":\"say chat\"}],\"metadata\":$META}"

curl -s localhost:4000/v1/responses -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' \
  -d "{\"model\":\"gpt-4.1-mini\",\"input\":\"say resp\",\"metadata\":$META}"
```

Both trace-create bodies must carry `id` equal to `$TID`, `sessionId` equal to `$SID`, `userId` of `user-123` and `metadata` of `{"tenant_id": "tenant-1"}`. Then send two `/v1/responses` calls with distinct `trace_id` and a shared `session_id` and confirm they produce two traces rather than one

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proxy pre-call metadata merging on high-traffic routes and affects observability/trace correlation, but scope is a tight allow-list with precedence rules and broad regression tests; companion PR may still be needed for bridge paths.
> 
> **Overview**
> On routes that use **`litellm_metadata`** (e.g. `/v1/responses`, `/v1/messages`), caller **`metadata`** trace controls were not copied into the dict logging integrations read, so Langfuse traces missed **`trace_id`**, **`session_id`**, **`trace_user_id`**, **`trace_metadata`**, and **`mask_input`/`mask_output`**.
> 
> **`add_litellm_data_to_request`** now, right after **`requester_metadata`** is snapshotted, merges an **explicit allow-list** of trace-control keys from that snapshot into **`litellm_metadata`** only when the route’s metadata slot is **`litellm_metadata`**. Values already set on **`litellm_metadata`** (e.g. from **`x-litellm-session-id`**) are left unchanged. Keys outside the allow-list—such as **`trace_public`**, **`existing_trace_id`**, **`update_trace_keys`**, **`tags`**, and forged **`user_api_key_*`** fields—are not promoted.
> 
> **`/v1/chat/completions`** behavior is unchanged (still uses **`metadata`** only). Tests cover unit promotion rules and end-to-end proxy behavior for responses/messages vs chat completions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a8773557015f5f17ea18651d7767cdb9b6ed24c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
