### PR TITLE
fix(lint): pick the merge-aware base so in-progress merges are not blamed for base drift

### DIFF
--- a/scripts/ruff_strict_gate.py
+++ b/scripts/ruff_strict_gate.py
@@ -18,7 +18,7 @@ import sys
 import tempfile
 from collections import Counter
 from pathlib import Path
-from typing import NamedTuple
+from typing import Final, NamedTuple
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 STRICT_CONFIG = REPO_ROOT / "ruff-strict.toml"
@@ -48,6 +48,25 @@ def _run(cmd: list, cwd: Path = REPO_ROOT) -> str:
         sys.stderr.write(proc.stderr)
         raise SystemExit(f"{cmd[0]} exited {proc.returncode}")
     return proc.stdout
+
+
+def resolve_base_point(base_ref: str, cwd: Path = REPO_ROOT) -> str:
+    """The snapshot commit base counts are measured at: merge-base(base_ref, HEAD),
+    made aware of an in-progress merge. Mid-merge, HEAD is still the pre-merge tip,
+    so its merge-base is the old branch point and every violation the base gained
+    since then would be blamed on this change. While MERGE_HEAD exists, prefer
+    merge-base(base_ref, MERGE_HEAD) whenever it is the newer of the two."""
+    head_point: Final = _run(["git", "merge-base", base_ref, "HEAD"], cwd=cwd).strip()
+    if not head_point:
+        return base_ref
+    merge_head: Final = _run(["git", "rev-parse", "--verify", "--quiet", "MERGE_HEAD"], cwd=cwd).strip()
+    if not merge_head:
+        return head_point
+    merge_point: Final = _run(["git", "merge-base", base_ref, merge_head], cwd=cwd).strip()
+    if not merge_point:
+        return head_point
+    older: Final = _run(["git", "merge-base", head_point, merge_point], cwd=cwd).strip()
+    return merge_point if older == head_point else head_point
 
 
 def _ruff_json(cwd: Path, config: Path) -> list:
@@ -135,7 +154,7 @@ def cmd_check(base: str) -> None:
     if not over_ceiling(head_counts, budget):
         print(f"OK: every strict rule is within its codebase ceiling (base {base})")
         return
-    base_point = _run(["git", "merge-base", base, "HEAD"]).strip() or base
+    base_point = resolve_base_point(base)
     breaches = evaluate(head_counts, base_counts(base_point), budget)
     if not breaches:
         print(f"OK: every strict rule is within its codebase ceiling (base {base})")
@@ -182,7 +201,7 @@ def cmd_update(base_ref: str = DEFAULT_BASE) -> None:
     fixes tighten its own ceilings by exactly what they cleared since it diverged.
     """
     budget = json.loads(BUDGET_PATH.read_text())
-    base_point = _run(["git", "merge-base", base_ref, "HEAD"]).strip() or base_ref
+    base_point = resolve_base_point(base_ref)
     updated = ratcheted_budget(
         budget, count_by_rule(head_violations()), base_counts(base_point)
     )

--- a/scripts/type_check_gate.py
+++ b/scripts/type_check_gate.py
@@ -42,7 +42,7 @@ import tempfile
 from collections import Counter
 from collections.abc import Callable, Iterator, Mapping
 from pathlib import Path
-from typing import NamedTuple
+from typing import Final, NamedTuple
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BUDGET_PATH = REPO_ROOT / "basedpyright-code-budget.json"
@@ -105,6 +105,25 @@ def _run(cmd: list[str], cwd: Path = REPO_ROOT) -> str:
         sys.stderr.write(proc.stderr)
         raise SystemExit(f"{cmd[0]} exited {proc.returncode}")
     return proc.stdout
+
+
+def resolve_base_point(base_ref: str, cwd: Path = REPO_ROOT) -> str:
+    """The snapshot commit base counts are measured at: merge-base(base_ref, HEAD),
+    made aware of an in-progress merge. Mid-merge, HEAD is still the pre-merge tip,
+    so its merge-base is the old branch point and every violation the base gained
+    since then would be blamed on this change. While MERGE_HEAD exists, prefer
+    merge-base(base_ref, MERGE_HEAD) whenever it is the newer of the two."""
+    head_point: Final = _run(["git", "merge-base", base_ref, "HEAD"], cwd=cwd).strip()
+    if not head_point:
+        return base_ref
+    merge_head: Final = _run(["git", "rev-parse", "--verify", "--quiet", "MERGE_HEAD"], cwd=cwd).strip()
+    if not merge_head:
+        return head_point
+    merge_point: Final = _run(["git", "merge-base", base_ref, merge_head], cwd=cwd).strip()
+    if not merge_point:
+        return head_point
+    older: Final = _run(["git", "merge-base", head_point, merge_point], cwd=cwd).strip()
+    return merge_point if older == head_point else head_point
 
 
 @contextlib.contextmanager
@@ -295,7 +314,7 @@ def cmd_update(current: Mapping[str, int], base_ref: str = DEFAULT_BASE) -> None
     by exactly what they cleared since it diverged, and limits never rise.
     """
     budget = json.loads(BUDGET_PATH.read_text()) if BUDGET_PATH.exists() else {}
-    base_point = _run(["git", "merge-base", base_ref, "HEAD"]).strip() or base_ref
+    base_point = resolve_base_point(base_ref)
     updated = ratcheted_budget(budget, current, base_counts_cached(base_point))
     BUDGET_PATH.write_text(json.dumps(updated, indent=2, sort_keys=True) + "\n")
     cleared = sum(budget[code]["limit"] - updated[code]["limit"] for code in updated)
@@ -321,7 +340,7 @@ def cmd_check(base_ref: str) -> None:
             f"OK: every rule is within its basedpyright limit ({sum(head.values())} errors total)"
         )
         return
-    base_point = _run(["git", "merge-base", base_ref, "HEAD"]).strip() or base_ref
+    base_point = resolve_base_point(base_ref)
     base = base_counts_cached(base_point)
     if is_vacuous_run(base, budget):
         print(

--- a/scripts/type_discipline_gate.py
+++ b/scripts/type_discipline_gate.py
@@ -36,7 +36,7 @@ import sys
 import tempfile
 from collections import Counter
 from pathlib import Path
-from typing import NamedTuple
+from typing import Final, NamedTuple
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 CHECKER = REPO_ROOT / "scripts" / "check_type_discipline.py"
@@ -67,6 +67,25 @@ def _run(cmd: list, cwd: Path = REPO_ROOT) -> str:
         sys.stderr.write(proc.stderr)
         raise SystemExit(f"{cmd[0]} exited {proc.returncode}")
     return proc.stdout
+
+
+def resolve_base_point(base_ref: str, cwd: Path = REPO_ROOT) -> str:
+    """The snapshot commit base counts are measured at: merge-base(base_ref, HEAD),
+    made aware of an in-progress merge. Mid-merge, HEAD is still the pre-merge tip,
+    so its merge-base is the old branch point and every violation the base gained
+    since then would be blamed on this change. While MERGE_HEAD exists, prefer
+    merge-base(base_ref, MERGE_HEAD) whenever it is the newer of the two."""
+    head_point: Final = _run(["git", "merge-base", base_ref, "HEAD"], cwd=cwd).strip()
+    if not head_point:
+        return base_ref
+    merge_head: Final = _run(["git", "rev-parse", "--verify", "--quiet", "MERGE_HEAD"], cwd=cwd).strip()
+    if not merge_head:
+        return head_point
+    merge_point: Final = _run(["git", "merge-base", base_ref, merge_head], cwd=cwd).strip()
+    if not merge_point:
+        return head_point
+    older: Final = _run(["git", "merge-base", head_point, merge_point], cwd=cwd).strip()
+    return merge_point if older == head_point else head_point
 
 
 def _check(root: Path, checker: Path) -> list:
@@ -160,7 +179,7 @@ def cmd_check(base: str) -> None:
     if not over_ceiling(head_counts, budget):
         print(f"OK: every LIT rule is within its codebase ceiling (base {base})")
         return
-    base_point = _run(["git", "merge-base", base, "HEAD"]).strip() or base
+    base_point = resolve_base_point(base)
     breaches = evaluate(head_counts, base_counts(base_point), budget)
     if not breaches:
         print(f"OK: every LIT rule is within its codebase ceiling (base {base})")
@@ -225,7 +244,7 @@ def cmd_update(base_ref: str = DEFAULT_BASE) -> None:
     fixes tighten its own ceilings by exactly what they cleared since it diverged.
     """
     budget = json.loads(BUDGET_PATH.read_text())
-    base_point = _run(["git", "merge-base", base_ref, "HEAD"]).strip() or base_ref
+    base_point = resolve_base_point(base_ref)
     seeded = frozenset(budget) - _base_budget_rules(base_point)
     updated = ratcheted_budget(
         budget, count_by_rule(head_violations()), base_counts(base_point), seeded

--- a/tests/test_litellm/test_ruff_strict_gate.py
+++ b/tests/test_litellm/test_ruff_strict_gate.py
@@ -1,4 +1,5 @@
 import importlib.util
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -110,3 +111,43 @@ def test_over_ceiling_ignores_rules_missing_from_the_budget():
 def test_over_ceiling_is_independent_across_rules():
     budget = {**rule("ANN001", 150), **rule("C901", 10)}
     assert gate.over_ceiling({"ANN001": 130, "C901": 11}, budget) == frozenset({"C901"})
+
+
+def _git(cwd, *args):
+    proc = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip()
+
+
+def _commit(cwd, name):
+    (cwd / name).write_text(name)
+    _git(cwd, "add", "-A")
+    _git(cwd, "commit", "-q", "-m", name)
+    return _git(cwd, "rev-parse", "HEAD")
+
+
+def _branched_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "gate@example.com")
+    _git(repo, "config", "user.name", "gate")
+    _git(repo, "config", "commit.gpgsign", "false")
+    branch_point = _commit(repo, "shared.txt")
+    _git(repo, "checkout", "-q", "-b", "feature")
+    _commit(repo, "feature.txt")
+    _git(repo, "checkout", "-q", "main")
+    base_tip = _commit(repo, "drift.txt")
+    _git(repo, "checkout", "-q", "feature")
+    return repo, branch_point, base_tip
+
+
+def test_base_point_is_the_branch_point_when_no_merge_is_in_progress(tmp_path):
+    repo, branch_point, _ = _branched_repo(tmp_path)
+    assert gate.resolve_base_point("main", cwd=repo) == branch_point
+
+
+def test_base_point_mid_merge_advances_to_the_merged_in_base_tip(tmp_path):
+    repo, _, base_tip = _branched_repo(tmp_path)
+    _git(repo, "merge", "--no-commit", "--no-ff", "main")
+    assert gate.resolve_base_point("main", cwd=repo) == base_tip

--- a/tests/test_litellm/test_type_check_gate.py
+++ b/tests/test_litellm/test_type_check_gate.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import subprocess
 from pathlib import Path
 
 _MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "type_check_gate.py"
@@ -287,3 +288,61 @@ def test_an_empty_base_pass_is_never_cached(tmp_path):
     assert gate.base_counts_cached("abc123", cache_dir=tmp_path, compute=crashed) == {}
     assert calls == ["abc123", "abc123"]
     assert list(tmp_path.iterdir()) == []
+
+
+def _git(cwd, *args):
+    proc = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip()
+
+
+def _commit(cwd, name):
+    (cwd / name).write_text(name)
+    _git(cwd, "add", "-A")
+    _git(cwd, "commit", "-q", "-m", name)
+    return _git(cwd, "rev-parse", "HEAD")
+
+
+def _init_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "gate@example.com")
+    _git(repo, "config", "user.name", "gate")
+    _git(repo, "config", "commit.gpgsign", "false")
+    return repo
+
+
+def _branched_repo(tmp_path):
+    repo = _init_repo(tmp_path)
+    branch_point = _commit(repo, "shared.txt")
+    _git(repo, "checkout", "-q", "-b", "feature")
+    _commit(repo, "feature.txt")
+    _git(repo, "checkout", "-q", "main")
+    base_tip = _commit(repo, "drift.txt")
+    _git(repo, "checkout", "-q", "feature")
+    return repo, branch_point, base_tip
+
+
+def test_base_point_is_the_branch_point_when_no_merge_is_in_progress(tmp_path):
+    repo, branch_point, _ = _branched_repo(tmp_path)
+    assert gate.resolve_base_point("main", cwd=repo) == branch_point
+
+
+def test_base_point_mid_merge_advances_to_the_merged_in_base_tip(tmp_path):
+    repo, _, base_tip = _branched_repo(tmp_path)
+    _git(repo, "merge", "--no-commit", "--no-ff", "main")
+    assert gate.resolve_base_point("main", cwd=repo) == base_tip
+
+
+def test_base_point_mid_merge_of_an_older_side_branch_keeps_the_newer_branch_point(tmp_path):
+    repo = _init_repo(tmp_path)
+    _commit(repo, "shared.txt")
+    _git(repo, "checkout", "-q", "-b", "old-side")
+    _commit(repo, "old.txt")
+    _git(repo, "checkout", "-q", "main")
+    newer_point = _commit(repo, "drift.txt")
+    _git(repo, "checkout", "-q", "-b", "feature")
+    _commit(repo, "feature.txt")
+    _git(repo, "merge", "--no-commit", "--no-ff", "old-side")
+    assert gate.resolve_base_point("main", cwd=repo) == newer_point

--- a/tests/test_litellm/test_type_discipline_gate.py
+++ b/tests/test_litellm/test_type_discipline_gate.py
@@ -6,6 +6,7 @@ drift-safe breach check). Both are pinned here.
 """
 
 import importlib.util
+import subprocess
 from pathlib import Path
 
 _MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "type_discipline_gate.py"
@@ -63,3 +64,43 @@ def test_update_leaves_rules_seeded_on_this_branch_untouched():
         "LIT001": {"limit": 85},
         "LIT010": {"limit": 24600},
     }
+
+
+def _git(cwd, *args):
+    proc = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip()
+
+
+def _commit(cwd, name):
+    (cwd / name).write_text(name)
+    _git(cwd, "add", "-A")
+    _git(cwd, "commit", "-q", "-m", name)
+    return _git(cwd, "rev-parse", "HEAD")
+
+
+def _branched_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "gate@example.com")
+    _git(repo, "config", "user.name", "gate")
+    _git(repo, "config", "commit.gpgsign", "false")
+    branch_point = _commit(repo, "shared.txt")
+    _git(repo, "checkout", "-q", "-b", "feature")
+    _commit(repo, "feature.txt")
+    _git(repo, "checkout", "-q", "main")
+    base_tip = _commit(repo, "drift.txt")
+    _git(repo, "checkout", "-q", "feature")
+    return repo, branch_point, base_tip
+
+
+def test_base_point_is_the_branch_point_when_no_merge_is_in_progress(tmp_path):
+    repo, branch_point, _ = _branched_repo(tmp_path)
+    assert gate.resolve_base_point("main", cwd=repo) == branch_point
+
+
+def test_base_point_mid_merge_advances_to_the_merged_in_base_tip(tmp_path):
+    repo, _, base_tip = _branched_repo(tmp_path)
+    _git(repo, "merge", "--no-commit", "--no-ff", "main")
+    assert gate.resolve_base_point("main", cwd=repo) == base_tip


### PR DESCRIPTION
## TLDR

Problem this solves:

- Mid-merge, the lint gates blame the PR for base branch drift
- merge-base(base, HEAD) is stale while MERGE_HEAD exists

How it solves it:

- Gates pick the newer of HEAD's and MERGE_HEAD's merge-base
- Same fix in all three budget gates, with regression tests

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The gates resolve their base snapshot as merge-base(base, HEAD). While a merge is in progress HEAD still sits on the pre-merge tip, so that snapshot is the old branch point and every violation the base branch accrued since then gets counted as "this change added N". This reproduction recreates the exact state where it was hit: a branch tip that predates recent base drift, mid-merge with the base

```
git worktree add --detach ../gate-proof-scratch 1dad33749c
cd ../gate-proof-scratch
git merge origin/litellm_internal_staging
git checkout --theirs litellm/litellm_core_utils/streaming_chunk_builder_utils.py
git add litellm/litellm_core_utils/streaming_chunk_builder_utils.py
git rev-parse MERGE_HEAD
```

The merge stops on one content conflict; after resolving and staging it the merge is still in progress, with MERGE_HEAD at the base tip d64e79bf05f73497f1c67013b93d1bf0f55a9665

The snapshot the gate picks in that state, before the fix (the literal expression the old code ran) versus after (the new resolver, run from this PR at 96c8c9cee1 with its cwd pointed at the mid-merge worktree):

```
$ git merge-base origin/litellm_internal_staging HEAD
ad79b314c56a41c037512c0d8dcffc23f9882e4f

$ python -c "
import importlib.util
from pathlib import Path
spec = importlib.util.spec_from_file_location('gate', 'scripts/type_check_gate.py')
gate = importlib.util.module_from_spec(spec)
spec.loader.exec_module(gate)
print(gate.resolve_base_point('origin/litellm_internal_staging', cwd=Path.cwd()))
"
d64e79bf05f73497f1c67013b93d1bf0f55a9665
```

ad79b314 is the stale branch point; d64e79bf05 is the base tip actually being merged in

Full gate run in that same mid-merge state, with basedpyright captured once and the identical output piped into both script versions (env matches make lint-basedpyright: the worktree venv's basedpyright on PATH, NODE_OPTIONS=--max-old-space-size=12288):

```
basedpyright --outputjson > /tmp/head_bpr.json
```

Before, scripts/type_check_gate.py as of 1dad33749c:

```
$ python scripts/type_check_gate.py --base origin/litellm_internal_staging < /tmp/head_bpr.json
FAIL: basedpyright errors exceed the per-rule limit:
  reportPossiblyUnboundVariable: total 70 over limit 56 (this change added 14)
  reportUnusedImport: total 610 over limit 588 (this change added 22)
Reduce the new errors or remove an equal number elsewhere; the ceiling is the limit in basedpyright-code-budget.json.
BREACHED RULES: reportPossiblyUnboundVariable 70/56 (+14); reportUnusedImport 610/588 (+22)
$ echo $?
1
```

Every one of those "added" violations is drift that was already in the base; the branch added none of them

After, scripts/type_check_gate.py as of 96c8c9cee1, same mid-merge state, same captured basedpyright output, base counts recomputed from scratch at the corrected snapshot:

```
$ python scripts/type_check_gate.py --base origin/litellm_internal_staging < /tmp/head_bpr.json
OK: every rule is within its basedpyright limit or no higher than base (149718 errors total)
$ echo $?
0
```

## Type

🐛 Bug Fix

## Changes

All three budget gates (scripts/type_check_gate.py, scripts/ruff_strict_gate.py, scripts/type_discipline_gate.py) resolved their base snapshot with `merge-base(base, HEAD)`, which is stale during an in-progress merge. Each script now has a `resolve_base_point` helper (duplicated per script the same way `_run` already is, since the gates are deliberately self-contained) that also computes `merge-base(base, MERGE_HEAD)` when MERGE_HEAD exists and returns whichever of the two points is the descendant, falling back to the HEAD side when they diverge or a lookup comes back empty

All six call sites (check and update in each gate) go through the helper, so the corrected commit also feeds the basedpyright base-count cache key, the changed-lines diff attribution in the ruff and type-discipline gates, and the budget ratchet. The regression tests in the three mapped test files build a throwaway git repository with a merge in progress and assert the chosen snapshot commit: it advances to the incoming base tip mid-merge, stays at the branch point otherwise, and does not regress to an older point when the branch being merged in is older than the current branch point

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
