### PR TITLE
Bedrock rust provider

### DIFF
--- a/litellm-rust/INTERVIEW_TASK.md
+++ b/litellm-rust/INTERVIEW_TASK.md
@@ -1,12 +1,44 @@
 # Task: serve AWS Bedrock on `POST /v1/messages`
 
 The gateway in this workspace already serves the Anthropic Messages API for
-Anthropic and Azure. Your job is to make it serve AWS Bedrock too, well enough
-that the Claude Code CLI can point `ANTHROPIC_BASE_URL` at this gateway and
-complete a turn against a Bedrock-hosted Claude
+Anthropic and Azure. Your job is to make it serve AWS Bedrock too
+
+The bar is not "the tests go green". The bar is that we finish the day
+confident that real Claude Code traffic can run through the Rust gateway
+against a Bedrock-hosted Claude, and that nothing that worked before is
+broken. LiteLLM's Python implementation of this endpoint is the thing Rust is
+replacing: the Python entry point should stop doing the work itself and
+delegate to your Rust code instead, with the same behavior on the other side
 
 Claude Code always sends `stream: true`, so streaming is part of the job, not a
 stretch goal
+
+## Start here
+
+The starter branch is
+[`litellm_bedrock_messages_interview_starter`](https://github.com/ishaan-berri/litellm/tree/litellm_bedrock_messages_interview_starter).
+It has the scaffolding in place, the placeholders you will fill in, and the
+tests that specify the behavior
+
+```bash
+git clone https://github.com/ishaan-berri/litellm.git
+cd litellm
+git checkout litellm_bedrock_messages_interview_starter
+make bootstrap                      # provisions everything the tests and the proxy need
+```
+
+Two builds matter, and they are separate. `cargo build` inside `litellm-rust`
+compiles the gateway. The Python bridge is a native extension that has to be
+rebuilt and reinstalled every time you change Rust, or Python will keep running
+the last build you made and your edits will appear to do nothing:
+
+```bash
+uv run --with maturin==1.9.4 maturin develop \
+  --manifest-path litellm-rust/crates/python-bridge/Cargo.toml   # from the repo root
+```
+
+Read `CLAUDE.md` and `AGENTS.md` in this directory before you start. They are
+the standards this code is held to
 
 ## What you are given
 
@@ -17,6 +49,10 @@ Credentials and target, already in your environment:
 - Region `us-west-2`, model `us.anthropic.claude-sonnet-4-5-20250929-v1:0`.
   The Claude 3.5 and 3.7 Bedrock ids are end of life and return 404
 
+Unset `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` in any shell you test
+from. If they are present, the code takes the SigV4 path instead of the bearer
+path and you will chase a 403 that has nothing to do with your change
+
 Already wired up, so you should not need to touch it:
 
 - provider registration, the `BEDROCK_MODEL` startup config, the bearer and
@@ -26,16 +62,62 @@ Already wired up, so you should not need to touch it:
 - `bedrock_messages_harness.sh`, a one-command live check against real Bedrock
 - failing tests that specify the behavior you need to produce
 
-Two facts about Bedrock that would otherwise cost you an hour of reading:
+## Talk to Bedrock directly first
 
-- non-streaming requests go to `POST /model/{modelId}/invoke`; streaming goes
-  to `POST /model/{modelId}/invoke-with-response-stream`. The model id is in
-  the path, not the body
-- the streaming response is `application/vnd.amazon.eventstream`, a binary
-  framing format, not SSE. Each frame's payload is
-  `{"bytes": "<base64 of one Anthropic event as JSON>"}`.
-  `aws_smithy_eventstream::frame::MessageFrameDecoder` parses the framing for
-  you and is already a dependency
+Before touching Rust, spend two minutes confirming what the upstream API
+actually does. The model id lives in the URL path, not the body, and the two
+verbs differ only by the last path segment
+
+Non-streaming:
+
+```bash
+export MODEL_ID='us.anthropic.claude-sonnet-4-5-20250929-v1:0'
+
+curl -sS -X POST \
+  "https://bedrock-runtime.us-west-2.amazonaws.com/model/${MODEL_ID}/invoke" \
+  -H "Authorization: Bearer ${AWS_BEARER_TOKEN_BEDROCK}" \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 64,
+        "messages": [{"role": "user", "content": "Say hello in five words"}]
+      }'
+```
+
+returns a plain Anthropic Messages response, with no `model` field in the
+request body and `anthropic_version` in its place:
+
+```json
+{"model":"claude-sonnet-4-5-20250929","id":"msg_bdrk_01UoJmSqSyXtTHfSNA7kWg3B","type":"message","role":"assistant","content":[{"type":"text","text":"Hello, how are you doing?"}],"stop_reason":"end_turn","usage":{"input_tokens":12,"output_tokens":10}}
+```
+
+Streaming, same body, different path segment:
+
+```bash
+curl -sS -X POST \
+  "https://bedrock-runtime.us-west-2.amazonaws.com/model/${MODEL_ID}/invoke-with-response-stream" \
+  -H "Authorization: Bearer ${AWS_BEARER_TOKEN_BEDROCK}" \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "anthropic_version": "bedrock-2023-05-31",
+        "max_tokens": 32,
+        "messages": [{"role": "user", "content": "Say hello"}]
+      }' | xxd | head
+```
+
+returns `application/vnd.amazon.eventstream`, a binary framing format rather
+than SSE. Piping it through `xxd` shows the shape you have to decode:
+
+```
+00000000: 0000 02b5 0000 004b 11c3 611e 0b3a 6576  .......K..a..:ev
+00000010: 656e 742d 7479 7065 0700 0563 6875 6e6b  ent-type...chunk
+00000050: 0005 6576 656e 747b 2262 7974 6573 223a  ..event{"bytes":
+00000060: 2265 794a 3065 5842 6c49 6a6f 6962 5756  "eyJ0eXBlIjoibWV
+```
+
+Each frame's payload is `{"bytes": "<base64 of one Anthropic event as JSON>"}`.
+`aws_smithy_eventstream::frame::MessageFrameDecoder` parses the framing for
+you and is already a dependency
 
 ## What is yours to write
 
@@ -54,6 +136,8 @@ tell you is missing:
 
 ## Running it
 
+The Rust side, gateway plus a live check against real Bedrock:
+
 ```bash
 cd litellm-rust
 cargo run -p litellm-ai-gateway --features server   # BEDROCK_MODEL, PORT, LITELLM_MASTER_KEY from env
@@ -63,25 +147,102 @@ cargo run -p litellm-ai-gateway --features server   # BEDROCK_MODEL, PORT, LITEL
 The harness runs four scenarios: a non-streaming turn, a streaming turn, a
 tool_use round trip, and an invalid model id
 
+The Rust unit tests, which are the written spec for the transformation:
+
+```bash
+cd litellm-rust
+cargo test -p litellm-core --features bedrock-auth
+```
+
+On the starter branch that reports 123 passed and 5 failed, every failure a
+`not yet implemented` panic from one of the placeholders you are filling in
+
+## The Python side
+
+This is the half the old version of this brief left out, and it is where
+"Rust replaces Python" actually gets proven
+
+`litellm.anthropic.messages.acreate(..., rust=True)` routes the call through
+the native bridge in `litellm/rust_bridge/` instead of the Python
+implementation, and stamps `x-litellm-rust: true` on the response so a caller
+can tell which engine served it. The live test for that path is
+`tests/test_litellm/anthropic_interface/test_bedrock_rust_bridge_e2e.py`, one
+non-streaming case and one streaming case against real Bedrock:
+
+```bash
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
+export AWS_BEARER_TOKEN_BEDROCK='...'
+uv run pytest tests/test_litellm/anthropic_interface/test_bedrock_rust_bridge_e2e.py -v
+```
+
+Both tests skip when the token is absent, so a green run with no token means
+nothing ran. On the starter branch, with a token, they fail on a missing
+`x-litellm-rust` key. Read that failure carefully, because it is the trap in
+this task: when your Rust code panics on a `todo!()`, the bridge catches it and
+silently falls back to the Python implementation. The request succeeds, you get
+a real answer from Bedrock, and the only evidence that Rust never ran is the
+missing header. Any time a test passes here, confirm it passed through Rust
+
+The mocked companion,
+`tests/test_litellm/anthropic_interface/test_rust_bridge_messages.py`, covers
+the gate itself (the `rust=True` and `LITELLM_RUST` switches, streaming
+forwarding, the header, and the fallback) and needs no credentials
+
+Beyond the SDK entry point, we have Python end-to-end suites that drive
+`POST /v1/messages` on a live proxy. You are not expected to make all of these
+pass today, but read them: they are the regression bar this work is eventually
+measured against, and they will tell you what real Claude Code traffic looks
+like
+
+- `tests/e2e/claude_code/` is a feature x provider matrix that drives the
+  actual `claude` CLI against a running proxy. The Bedrock Invoke column is the
+  one you care about, for example
+  `tests/e2e/claude_code/basic_messaging_non_streaming/test_bedrock_invoke.py`
+  and `.../basic_messaging_streaming/test_bedrock_invoke.py`, with further rows
+  for tool use, thinking, structured outputs, prompt caching, and token counting
+- `tests/e2e/llm_translation/test_messages_e2e.py` covers `/v1/messages`
+  non-streaming, streaming, tool use, and cost logging against Anthropic
+- `tests/e2e/llm_translation/test_messages_azure_foundry_e2e.py` already
+  asserts the `x-litellm-rust` header when `E2E_EXPECT_RUST=1`, which is the
+  pattern for proving a route has moved to Rust
+- `tests/e2e/CONTRIBUTING.md` explains how to bring up the proxy these need
+
 ## Definition of done
 
-1. all four harness scenarios behave correctly against live Bedrock
-2. the Bedrock tests in core and in the messages route pass
-3. `cargo test --workspace` is green, including the roughly 150 tests that
-   existed before you started
-4. `cargo fmt --check` and
+Success is a Claude Code session running against Bedrock Invoke through the
+Rust gateway, with evidence that Rust served it and evidence that nothing else
+regressed. Concretely:
+
+1. Claude Code, pointed at the gateway, completes a turn against Bedrock. Set
+   `ANTHROPIC_BASE_URL` to the gateway's address, `ANTHROPIC_AUTH_TOKEN` to the
+   gateway master key, and `ANTHROPIC_MODEL` to the Bedrock model id, with
+   `ANTHROPIC_API_KEY` unset
+2. all four `bedrock_messages_harness.sh` scenarios behave correctly against
+   live Bedrock
+3. both tests in `test_bedrock_rust_bridge_e2e.py` pass, and pass *through
+   Rust*: the `x-litellm-rust` assertion holds, so the Python implementation is
+   no longer doing the work
+4. the Bedrock tests in core and in the messages route pass
+5. `cargo test --workspace` is green, including the roughly 150 tests that
+   existed before you started, and
+   `uv run pytest tests/test_litellm/anthropic_interface/ -v` is green
+6. `cargo fmt --check` and
    `cargo clippy -p litellm-ai-gateway --all-targets --features server -- -D warnings`
    are clean
-5. Claude Code, pointed at the gateway, completes a turn
 
-To point Claude Code at the gateway, set `ANTHROPIC_BASE_URL` to the gateway's
-address, `ANTHROPIC_AUTH_TOKEN` to the gateway master key, and `ANTHROPIC_MODEL`
-to the Bedrock model id, with `ANTHROPIC_API_KEY` unset
+Zero regressions is a hard requirement, not a nice-to-have. If you change the
+shared trait in `crates/core/src/messages/transformation.rs` to fit Bedrock,
+Anthropic and Azure ride on that same trait, and you own proving they still
+work
+
+We will spend the last part of the day on how confident you are and why. Come
+prepared to say which behaviors you proved, which you inferred, and where you
+would still expect this to break in production
 
 ## Not in scope
 
-`POST /v1/messages/count_tokens`, multi-deployment routing, and Python-side
-integration. If you find yourself in any of those, come up for air
-
-Read `CLAUDE.md` and `AGENTS.md` in this directory before you start. They are
-the standards this code is held to
+`POST /v1/messages/count_tokens`, multi-deployment routing, and migrating any
+endpoint other than Messages. The Python work is limited to making the existing
+bridge tests pass through Rust; you do not need to change the proxy, the
+router, or the Python Bedrock implementation itself. If you find yourself in
+any of those, come up for air

--- a/litellm-rust/bedrock_claude_code_harness.sh
+++ b/litellm-rust/bedrock_claude_code_harness.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export AWS_REGION_NAME="${AWS_REGION_NAME:-us-west-2}"
+export BEDROCK_MODEL="${BEDROCK_MODEL:-us.anthropic.claude-sonnet-4-5-20250929-v1:0}"
+export LITELLM_MASTER_KEY="${LITELLM_MASTER_KEY:-harness-master-key}"
+export PORT="${PORT:-4001}"
+
+if [[ -z "${AWS_BEARER_TOKEN_BEDROCK:-}" ]]; then
+  echo "AWS_BEARER_TOKEN_BEDROCK is required" >&2
+  exit 1
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "claude CLI not found on PATH" >&2
+  exit 1
+fi
+
+workspace="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+log=/tmp/litellm-bedrock-claude-code-gateway.log
+ready_url="http://127.0.0.1:${PORT}/health/readiness"
+
+if curl -sf "$ready_url" >/dev/null 2>&1; then
+  echo "reusing the gateway already listening on ${PORT} (its model_list is whatever it was started with, not this script's BEDROCK_MODEL)"
+else
+  cargo run --manifest-path "${workspace}/Cargo.toml" -p litellm-ai-gateway --features server >"$log" 2>&1 &
+  gateway_pid=$!
+  trap 'kill "$gateway_pid" 2>/dev/null || true' EXIT
+
+  for _ in {1..180}; do
+    if ! kill -0 "$gateway_pid" 2>/dev/null; then
+      echo "gateway exited before becoming ready; see $log" >&2
+      tail -20 "$log" >&2
+      exit 1
+    fi
+    curl -sf "$ready_url" >/dev/null && break
+    sleep 1
+  done
+
+  if ! curl -sf "$ready_url" >/dev/null; then
+    echo "gateway never became ready; see $log" >&2
+    tail -20 "$log" >&2
+    exit 1
+  fi
+fi
+
+echo "smoke"
+smoke_body=/tmp/litellm-bedrock-claude-code-smoke.json
+smoke_code="$(curl -sS -o "$smoke_body" -w '%{http_code}' \
+  -H "authorization: Bearer ${LITELLM_MASTER_KEY}" -H "content-type: application/json" \
+  "http://127.0.0.1:${PORT}/v1/messages" \
+  -d "{\"model\":\"${BEDROCK_MODEL}\",\"max_tokens\":16,\"messages\":[{\"role\":\"user\",\"content\":\"Reply with one word: hello\"}]}")"
+if [[ "$smoke_code" != "200" ]]; then
+  echo "smoke request failed with HTTP ${smoke_code}; not starting a claude session" >&2
+  cat "$smoke_body" >&2
+  echo >&2
+  exit 1
+fi
+jq '{type,model,usage}' "$smoke_body"
+
+unset ANTHROPIC_API_KEY
+export ANTHROPIC_BASE_URL="http://127.0.0.1:${PORT}"
+export ANTHROPIC_AUTH_TOKEN="${LITELLM_MASTER_KEY}"
+export ANTHROPIC_MODEL="${BEDROCK_MODEL}"
+# The gateway's env-built router holds exactly one deployment ($BEDROCK_MODEL),
+# so every model slot Claude Code can reach for has to point at that same id.
+export ANTHROPIC_SMALL_FAST_MODEL="${BEDROCK_MODEL}"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="${BEDROCK_MODEL}"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="${BEDROCK_MODEL}"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="${BEDROCK_MODEL}"
+export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+
+echo "claude session against ${ANTHROPIC_BASE_URL} (model ${ANTHROPIC_MODEL}); gateway log: $log"
+claude "$@"

--- a/litellm-rust/crates/ai-gateway/src/constants.rs
+++ b/litellm-rust/crates/ai-gateway/src/constants.rs
@@ -40,3 +40,9 @@ pub(crate) const MESSAGES_ROUTE_PATH: &str = "/v1/messages";
 #[cfg(feature = "server")]
 pub(crate) const MESSAGES_HEADERS_NOT_FORWARDED: &[&str] =
     &["authorization", "connection", "content-length", "host"];
+
+#[cfg(feature = "server")]
+pub(crate) const EVENT_STREAM_MESSAGE_TYPE_HEADER: &str = ":message-type";
+
+#[cfg(feature = "server")]
+pub(crate) const EVENT_STREAM_ERROR_MESSAGE_TYPES: &[&str] = &["exception", "error"];

--- a/litellm-rust/crates/ai-gateway/src/routes/messages/mod.rs
+++ b/litellm-rust/crates/ai-gateway/src/routes/messages/mod.rs
@@ -14,13 +14,12 @@ use bytes::Bytes;
 use futures_util::StreamExt;
 use futures_util::stream::{self, BoxStream};
 use litellm_core::CoreError;
+use litellm_core::constants::BEDROCK_MESSAGES_PROVIDER;
 use litellm_core::logging::stream::count_forwarded_stream;
 use serde_json::{Map, Value};
 
 use crate::auth::RequireMasterKey;
-use crate::constants::{
-    BEDROCK_MESSAGES_PROVIDER, MESSAGES_HEADERS_NOT_FORWARDED, MESSAGES_ROUTE_PATH,
-};
+use crate::constants::{MESSAGES_HEADERS_NOT_FORWARDED, MESSAGES_ROUTE_PATH};
 use crate::state::AppState;
 
 /// This route's contribution to the app router.

--- a/litellm-rust/crates/ai-gateway/src/routes/messages/mod.rs
+++ b/litellm-rust/crates/ai-gateway/src/routes/messages/mod.rs
@@ -2,7 +2,8 @@
 
 mod service;
 
-use aws_smithy_eventstream::frame::MessageFrameDecoder;
+use aws_smithy_eventstream::frame::{DecodedFrame, MessageFrameDecoder};
+use aws_smithy_types::event_stream::Message;
 use axum::Router;
 use axum::body::Body;
 use axum::extract::{Json, State};
@@ -19,7 +20,10 @@ use litellm_core::logging::stream::count_forwarded_stream;
 use serde_json::{Map, Value};
 
 use crate::auth::RequireMasterKey;
-use crate::constants::{MESSAGES_HEADERS_NOT_FORWARDED, MESSAGES_ROUTE_PATH};
+use crate::constants::{
+    EVENT_STREAM_ERROR_MESSAGE_TYPES, EVENT_STREAM_MESSAGE_TYPE_HEADER,
+    MESSAGES_HEADERS_NOT_FORWARDED, MESSAGES_ROUTE_PATH,
+};
 use crate::state::AppState;
 
 /// This route's contribution to the app router.
@@ -89,7 +93,6 @@ fn stream_response(
     })
 }
 
-#[allow(dead_code)]
 struct EventStreamState {
     upstream: BoxStream<'static, Result<Bytes, reqwest::Error>>,
     buffer: bytes::BytesMut,
@@ -107,14 +110,53 @@ fn bedrock_sse_stream(
             decoder: MessageFrameDecoder::new(),
             terminated: false,
         },
-        |_state| async move {
-            todo!("decode Bedrock EventStream frames and emit normalized Anthropic SSE")
+        |mut state| async move {
+            if state.terminated {
+                return None;
+            }
+            loop {
+                let frame = state.decoder.decode_frame(&mut state.buffer);
+                match frame {
+                    Ok(DecodedFrame::Complete(message)) => {
+                        let is_error = is_error_frame(&message);
+                        let rendered = if is_error {
+                            sse_error(message.payload())
+                        } else {
+                            sse_data(message.payload())
+                        };
+                        state.terminated = is_error;
+                        return Some((Ok(Bytes::from(rendered)), state));
+                    }
+                    Ok(DecodedFrame::Incomplete) => match state.upstream.next().await {
+                        Some(Ok(chunk)) => state.buffer.extend_from_slice(&chunk),
+                        Some(Err(error)) => {
+                            state.terminated = true;
+                            let rendered = sse_error(error.to_string().as_bytes());
+                            return Some((Ok(Bytes::from(rendered)), state));
+                        }
+                        None => return None,
+                    },
+                    Err(error) => {
+                        state.terminated = true;
+                        let rendered = sse_error(error.to_string().as_bytes());
+                        return Some((Ok(Bytes::from(rendered)), state));
+                    }
+                }
+            }
         },
     )
     .boxed()
 }
 
-#[allow(dead_code)]
+fn is_error_frame(message: &Message) -> bool {
+    message
+        .headers()
+        .iter()
+        .find(|header| header.name().as_str() == EVENT_STREAM_MESSAGE_TYPE_HEADER)
+        .and_then(|header| header.value().as_string().ok())
+        .is_some_and(|value| EVENT_STREAM_ERROR_MESSAGE_TYPES.contains(&value.as_str()))
+}
+
 fn sse_data(payload: &[u8]) -> String {
     let value = serde_json::from_slice::<serde_json::Value>(payload)
         .ok()
@@ -131,7 +173,6 @@ fn sse_data(payload: &[u8]) -> String {
     format!("event: {event}\ndata: {value}\n\n")
 }
 
-#[allow(dead_code)]
 fn sse_error(payload: &[u8]) -> String {
     let message = String::from_utf8_lossy(payload);
     format!(
@@ -264,6 +305,7 @@ mod tests {
             master_key: master_key.map(Arc::from),
             loggers: Arc::new(Vec::new()),
             realtime_pool: RealtimePool::disabled(),
+            logging_sink: None,
         }
     }
 
@@ -797,7 +839,8 @@ mod tests {
         assert!(body.contains("input_json_delta"));
         assert!(body.contains("event: message_stop"));
         let request = server.await.expect("server task completes");
-        let (_, request_body) = request.split_once("\r\n\r\n").expect("request body");
+        let (head, request_body) = request.split_once("\r\n\r\n").expect("request body");
+        assert!(head.starts_with("POST /model/claude-test/invoke-with-response-stream "));
         let request_body: serde_json::Value =
             serde_json::from_str(request_body).expect("request json");
         assert_eq!(request_body["tools"][0]["name"], "get_weather");

--- a/litellm-rust/crates/core/src/constants.rs
+++ b/litellm-rust/crates/core/src/constants.rs
@@ -17,3 +17,6 @@ pub(crate) const MESSAGES_ERROR_BODY_MAX_CHARS: usize = 256;
 /// Provider name used for Anthropic Messages when a deployment's provider model
 /// does not carry an explicit provider prefix.
 pub const ANTHROPIC_MESSAGES_PROVIDER: &str = "anthropic";
+
+/// Provider name used for Anthropic Messages served through Bedrock.
+pub const BEDROCK_MESSAGES_PROVIDER: &str = "bedrock";

--- a/litellm-rust/crates/core/src/logging/console.rs
+++ b/litellm-rust/crates/core/src/logging/console.rs
@@ -7,7 +7,7 @@ use colored_json::{ColorMode, ColoredFormatter, Output, PrettyFormatter};
 use super::{LogEvent, LogSink};
 
 #[derive(Clone, Copy)]
-enum RenderMode {
+pub enum RenderMode {
     Compact,
     Pretty,
 }
@@ -20,21 +20,17 @@ pub struct ConsoleDebugHook {
 
 impl ConsoleDebugHook {
     pub fn from_env() -> Self {
-        Self::with_writer(Box::new(std::io::stderr()))
+        Self::new(
+            Box::new(std::io::stderr()),
+            *render_mode(),
+            ColorMode::Auto(Output::StdErr),
+        )
     }
 
-    pub fn with_writer(writer: Box<dyn Write + Send>) -> Self {
-        Self::with_writer_and_mode(writer, matches!(*render_mode(), RenderMode::Pretty))
-    }
-
-    pub fn with_writer_and_mode(writer: Box<dyn Write + Send>, pretty: bool) -> Self {
+    pub fn new(writer: Box<dyn Write + Send>, mode: RenderMode, color_mode: ColorMode) -> Self {
         Self {
-            mode: if pretty {
-                RenderMode::Pretty
-            } else {
-                RenderMode::Compact
-            },
-            color_mode: ColorMode::Auto(Output::StdErr).eval(),
+            mode,
+            color_mode: color_mode.eval(),
             output: Mutex::new(writer),
         }
     }
@@ -159,11 +155,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn compact_output_is_canonical_json() {
-        let buffer = Arc::new(Mutex::new(Vec::new()));
-        let hook = ConsoleDebugHook::with_writer_and_mode(Box::new(Buffer(buffer.clone())), false);
-        let event = LogEvent::Request(ProviderRequestEvent {
+    fn sample_event() -> LogEvent {
+        LogEvent::Request(ProviderRequestEvent {
             source: "litellm-rust",
             call_id: "call_01".to_string(),
             provider: "anthropic".to_string(),
@@ -175,11 +168,22 @@ mod tests {
             body: json!({"prompt": "visible"}),
             body_truncated: None,
             body_original_bytes: None,
-        });
+        })
+    }
+
+    fn emit_to_string(event: &LogEvent, mode: RenderMode, color_mode: ColorMode) -> String {
+        let buffer = Arc::new(Mutex::new(Vec::new()));
+        let hook = ConsoleDebugHook::new(Box::new(Buffer(buffer.clone())), mode, color_mode);
+        hook.emit(event);
+        let bytes = buffer.lock().expect("buffer lock").clone();
+        String::from_utf8(bytes).expect("output is utf8")
+    }
+
+    #[test]
+    fn compact_output_is_canonical_json() {
+        let event = sample_event();
         let expected = serde_json::to_value(&event).expect("event serializes");
-        hook.emit(&event);
-        let output =
-            String::from_utf8(buffer.lock().expect("buffer lock").clone()).expect("output is utf8");
+        let output = emit_to_string(&event, RenderMode::Compact, ColorMode::Off);
         assert_eq!(
             serde_json::from_str::<serde_json::Value>(output.trim()).expect("output is JSON"),
             expected
@@ -188,24 +192,8 @@ mod tests {
 
     #[test]
     fn pretty_output_has_header_separator_and_indented_payload() {
-        let buffer = Arc::new(Mutex::new(Vec::new()));
-        let hook = ConsoleDebugHook::with_writer_and_mode(Box::new(Buffer(buffer.clone())), true);
-        let event = LogEvent::Request(ProviderRequestEvent {
-            source: "litellm-rust",
-            call_id: "call_01".to_string(),
-            provider: "anthropic".to_string(),
-            model: "claude".to_string(),
-            stream: false,
-            method: "POST",
-            url: "https://example.test".to_string(),
-            headers: Default::default(),
-            body: json!({"prompt": "visible"}),
-            body_truncated: None,
-            body_original_bytes: None,
-        });
-        hook.emit(&event);
-        let output =
-            String::from_utf8(buffer.lock().expect("buffer lock").clone()).expect("output is utf8");
+        let event = sample_event();
+        let output = emit_to_string(&event, RenderMode::Pretty, ColorMode::Off);
         assert!(!output.contains('\x1b'));
         let payload = &output
             [output.find('{').expect("payload starts")..=output.rfind('}').expect("payload ends")];
@@ -218,5 +206,42 @@ mod tests {
         assert!(output.contains("provider.request call_01 anthropic"));
         assert!(output.contains("────────────────"));
         assert!(output.contains("\n  \"event\""));
+    }
+
+    fn strip_ansi(text: &str) -> String {
+        text.split('\x1b')
+            .enumerate()
+            .map(|(index, chunk)| {
+                if index == 0 {
+                    return chunk;
+                }
+                chunk
+                    .split_once(|character: char| character.is_ascii_alphabetic())
+                    .map_or("", |(_, rest)| rest)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn color_mode_is_injected_not_read_from_process_stderr() {
+        let event = sample_event();
+        let colored = emit_to_string(&event, RenderMode::Pretty, ColorMode::On);
+        let plain = emit_to_string(&event, RenderMode::Pretty, ColorMode::Off);
+
+        let payload_start = colored.find('{').expect("payload starts");
+        let colored_header = format!("\x1b[36m{}\x1b[0m", header(&event));
+
+        assert!(colored.contains(&colored_header));
+        assert!(colored.contains("\x1b[2m────────"));
+        assert!(colored[payload_start..].contains('\x1b'));
+        assert_eq!(strip_ansi(&colored), plain);
+        assert!(!plain.contains('\x1b'));
+    }
+
+    #[test]
+    fn compact_output_is_never_colored() {
+        let event = sample_event();
+        let output = emit_to_string(&event, RenderMode::Compact, ColorMode::On);
+        assert!(!output.contains('\x1b'));
     }
 }

--- a/litellm-rust/crates/core/src/messages/common_utils.rs
+++ b/litellm-rust/crates/core/src/messages/common_utils.rs
@@ -3,6 +3,8 @@ use serde_json::{Map, Value};
 use crate::error::{CoreError, CoreResult, json_type_name};
 use crate::providers::anthropic::messages::transformation::ANTHROPIC_MESSAGES_CONFIG;
 use crate::providers::azure_ai::messages::transformation::AZURE_ANTHROPIC_MESSAGES_CONFIG;
+#[cfg(feature = "bedrock-auth")]
+use crate::providers::bedrock::messages::transformation::BEDROCK_MESSAGES_CONFIG;
 
 use super::transformation::AnthropicMessagesProviderConfig;
 
@@ -12,6 +14,8 @@ pub(super) fn messages_provider_config(
     match provider {
         "anthropic" => Some(&ANTHROPIC_MESSAGES_CONFIG),
         "azure_ai" => Some(&AZURE_ANTHROPIC_MESSAGES_CONFIG),
+        #[cfg(feature = "bedrock-auth")]
+        "bedrock" => Some(&BEDROCK_MESSAGES_CONFIG),
         _ => None,
     }
 }

--- a/litellm-rust/crates/core/src/messages/handler.rs
+++ b/litellm-rust/crates/core/src/messages/handler.rs
@@ -1,12 +1,54 @@
-use crate::error::CoreResult;
+#[cfg(feature = "bedrock-auth")]
+use std::collections::BTreeMap;
+#[cfg(feature = "bedrock-auth")]
+use std::time::SystemTime;
+
+use crate::error::{CoreError, CoreResult};
 use crate::logging::http::{JsonRequest, execute_json, execute_stream};
+#[cfg(feature = "bedrock-auth")]
+use crate::providers::bedrock::aws_base::{AwsAuthConfig, resolve_credentials, sign_bedrock_post};
 
 use super::client::http_client;
+use super::common_utils::has_bearer_auth;
 use super::types::{AnthropicMessagesResponse, ProviderMessagesRequest};
+
+async fn upstream_headers(request: &ProviderMessagesRequest) -> CoreResult<Vec<(String, String)>> {
+    if request.provider != "bedrock" || has_bearer_auth(&request.upstream_headers) {
+        return Ok(request.upstream_headers.clone());
+    }
+
+    #[cfg(feature = "bedrock-auth")]
+    {
+        let body = serde_json::to_vec(&request.body)
+            .map_err(|error| CoreError::InvalidRequest(format!("invalid messages request body: {error}")))?;
+        let env_lookup = |key: &str| std::env::var(key).ok();
+        let region = request
+            .config
+            .signing_region(None, &env_lookup)
+            .ok_or_else(|| CoreError::Auth("Bedrock signing region is unavailable".to_string()))?;
+        let headers = BTreeMap::from_iter(request.upstream_headers.iter().cloned());
+        let credentials = resolve_credentials(AwsAuthConfig::default(), &env_lookup).await?;
+        let signed_headers = sign_bedrock_post(
+            &request.url,
+            &body,
+            &headers,
+            &region,
+            &credentials,
+            SystemTime::now(),
+        )?;
+        Ok(headers.into_iter().chain(signed_headers).collect())
+    }
+
+    #[cfg(not(feature = "bedrock-auth"))]
+    Err(CoreError::Auth(
+        "Bedrock SigV4 authentication requires the `bedrock-auth` feature".to_string(),
+    ))
+}
 
 pub(super) async fn execute_messages_provider_call(
     request: ProviderMessagesRequest,
 ) -> CoreResult<AnthropicMessagesResponse> {
+    let headers = upstream_headers(&request).await?;
     let response = execute_json::<AnthropicMessagesResponse>(
         http_client(),
         JsonRequest {
@@ -14,7 +56,7 @@ pub(super) async fn execute_messages_provider_call(
             model: request.model.clone(),
             stream: false,
             url: request.url,
-            headers: request.upstream_headers,
+            headers,
             body: request.body,
             timeout: request.timeout,
         },
@@ -26,6 +68,7 @@ pub(super) async fn execute_messages_provider_call(
 pub(super) async fn execute_messages_provider_stream(
     request: ProviderMessagesRequest,
 ) -> CoreResult<super::types::MessagesStreamResponse> {
+    let headers = upstream_headers(&request).await?;
     let provider = request.provider;
     let logger = request.logger.clone();
     let response = execute_stream(
@@ -35,7 +78,7 @@ pub(super) async fn execute_messages_provider_stream(
             model: request.model,
             stream: true,
             url: request.url,
-            headers: request.upstream_headers,
+            headers,
             body: request.body,
             timeout: request.timeout,
         },

--- a/litellm-rust/crates/core/src/messages/mod.rs
+++ b/litellm-rust/crates/core/src/messages/mod.rs
@@ -21,11 +21,11 @@ use prepare::prepare_messages_call;
 use types::{AnthropicMessagesResponse, MessagesRequest, MessagesStreamResponse};
 
 pub async fn messages(request: MessagesRequest<'_>) -> CoreResult<AnthropicMessagesResponse> {
-    execute_messages_provider_call(prepare_messages_call(request)?).await
+    execute_messages_provider_call(prepare_messages_call(request, false)?).await
 }
 
 pub async fn messages_stream(request: MessagesRequest<'_>) -> CoreResult<MessagesStreamResponse> {
-    execute_messages_provider_stream(prepare_messages_call(request)?).await
+    execute_messages_provider_stream(prepare_messages_call(request, true)?).await
 }
 
 #[cfg(test)]

--- a/litellm-rust/crates/core/src/messages/mod.rs
+++ b/litellm-rust/crates/core/src/messages/mod.rs
@@ -21,7 +21,6 @@ use prepare::prepare_messages_call;
 use types::{AnthropicMessagesResponse, MessagesRequest, MessagesStreamResponse};
 
 pub async fn messages(request: MessagesRequest<'_>) -> CoreResult<AnthropicMessagesResponse> {
-    println!("ENTERED RUST MESSAGES");
     execute_messages_provider_call(prepare_messages_call(request)?).await
 }
 

--- a/litellm-rust/crates/core/src/messages/prepare.rs
+++ b/litellm-rust/crates/core/src/messages/prepare.rs
@@ -41,12 +41,15 @@ pub(super) fn prepare_messages_call(
     if !already_authorized {
         let api_key = config.resolve_api_key(request.api_key, &env_lookup)?;
         let auth_header = match auth_strategy {
-            MessagesAuthStrategy::Bearer => {
-                ("authorization".to_string(), format!("Bearer {api_key}"))
+            MessagesAuthStrategy::Bearer => Some(("authorization".to_string(), format!("Bearer {api_key}"))),
+            MessagesAuthStrategy::BearerOrSigV4 => {
+                (!api_key.is_empty()).then(|| ("authorization".to_string(), format!("Bearer {api_key}")))
             }
-            MessagesAuthStrategy::Header(name) => (name.to_string(), api_key),
+            MessagesAuthStrategy::Header(name) => Some((name.to_string(), api_key)),
         };
-        headers.push(auth_header);
+        if let Some(auth_header) = auth_header {
+            headers.push(auth_header);
+        }
     }
 
     for (name, value) in config.default_headers() {

--- a/litellm-rust/crates/core/src/messages/prepare.rs
+++ b/litellm-rust/crates/core/src/messages/prepare.rs
@@ -63,11 +63,7 @@ pub(super) fn prepare_messages_call(
         CoreError::InvalidRequest(format!("invalid Anthropic messages request: {err}"))
     })?;
     let transformed = config.transform_request(typed_request)?;
-    let body = serde_json::to_value(transformed).map_err(|err| {
-        CoreError::InvalidRequest(format!(
-            "failed to serialize Anthropic messages request: {err}"
-        ))
-    })?;
+    let body = config.serialize_request(transformed)?;
 
     let call_id = request
         .litellm_call_id

--- a/litellm-rust/crates/core/src/messages/prepare.rs
+++ b/litellm-rust/crates/core/src/messages/prepare.rs
@@ -11,6 +11,7 @@ use super::types::{MessagesRequest, ProviderMessagesRequest};
 
 pub(super) fn prepare_messages_call(
     request: MessagesRequest<'_>,
+    stream: bool,
 ) -> CoreResult<ProviderMessagesRequest> {
     let provider_info = get_custom_llm_provider(request.model, request.custom_llm_provider)
         .or_else(|| {
@@ -61,7 +62,7 @@ pub(super) fn prepare_messages_call(
         headers.push(("content-type".to_string(), "application/json".to_string()));
     }
 
-    let url = config.complete_url(request.api_base, &model, &env_lookup)?;
+    let url = config.complete_url(request.api_base, &model, stream, &env_lookup)?;
     let typed_request = serde_json::from_value(request.body).map_err(|err| {
         CoreError::InvalidRequest(format!("invalid Anthropic messages request: {err}"))
     })?;

--- a/litellm-rust/crates/core/src/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/messages/transformation.rs
@@ -6,13 +6,14 @@ use super::types::{AnthropicMessagesRequest, AnthropicMessagesResponse};
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MessagesAuthStrategy {
     Bearer,
+    BearerOrSigV4,
     Header(&'static str),
 }
 
 impl MessagesAuthStrategy {
     pub fn header_name(self) -> &'static str {
         match self {
-            Self::Bearer => "authorization",
+            Self::Bearer | Self::BearerOrSigV4 => "authorization",
             Self::Header(header_name) => header_name,
         }
     }

--- a/litellm-rust/crates/core/src/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/messages/transformation.rs
@@ -1,4 +1,5 @@
-use crate::error::CoreResult;
+use crate::error::{CoreError, CoreResult};
+use serde_json::Value;
 
 use super::types::{AnthropicMessagesRequest, AnthropicMessagesResponse};
 
@@ -59,6 +60,12 @@ pub trait AnthropicMessagesProviderConfig: Sync {
         request: AnthropicMessagesRequest,
     ) -> CoreResult<AnthropicMessagesRequest> {
         Ok(request)
+    }
+
+    fn serialize_request(&self, request: AnthropicMessagesRequest) -> CoreResult<Value> {
+        serde_json::to_value(request).map_err(|err| {
+            CoreError::InvalidRequest(format!("failed to serialize Anthropic messages request: {err}"))
+        })
     }
 
     fn transform_response(

--- a/litellm-rust/crates/core/src/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/messages/transformation.rs
@@ -24,6 +24,7 @@ pub trait AnthropicMessagesProviderConfig: Sync {
         &self,
         api_base: Option<&str>,
         model: &str,
+        stream: bool,
         env_lookup: &dyn Fn(&str) -> Option<String>,
     ) -> CoreResult<String>;
 

--- a/litellm-rust/crates/core/src/messages/types.rs
+++ b/litellm-rust/crates/core/src/messages/types.rs
@@ -80,7 +80,7 @@ pub struct AnthropicMessage {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AnthropicMessagesRequest {
-    #[serde(skip_serializing_if = "String::is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub model: String,
     pub messages: Vec<AnthropicMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/litellm-rust/crates/core/src/providers/anthropic/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/anthropic/messages/transformation.rs
@@ -51,6 +51,7 @@ impl AnthropicMessagesProviderConfig for AnthropicMessagesConfig {
         &self,
         api_base: Option<&str>,
         _model: &str,
+        _stream: bool,
         env_lookup: &dyn Fn(&str) -> Option<String>,
     ) -> CoreResult<String> {
         Ok(complete_anthropic_url(api_base, env_lookup))

--- a/litellm-rust/crates/core/src/providers/azure_ai/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/azure_ai/messages/transformation.rs
@@ -146,6 +146,7 @@ impl AnthropicMessagesProviderConfig for AzureAnthropicMessagesConfig {
         &self,
         api_base: Option<&str>,
         _model: &str,
+        _stream: bool,
         env_lookup: &dyn Fn(&str) -> Option<String>,
     ) -> CoreResult<String> {
         complete_azure_anthropic_url(api_base, env_lookup)

--- a/litellm-rust/crates/core/src/providers/bedrock/constants.rs
+++ b/litellm-rust/crates/core/src/providers/bedrock/constants.rs
@@ -14,5 +14,6 @@ pub const AWS_EXTERNAL_ID: &str = "AWS_EXTERNAL_ID";
 pub const BEDROCK_SERVICE: &str = "bedrock";
 pub const DEFAULT_SESSION_NAME_PREFIX: &str = "litellm-session";
 pub const DEFAULT_BEDROCK_REGION: &str = "us-west-2";
+pub const BEDROCK_ANTHROPIC_VERSION: &str = "bedrock-2023-05-31";
 pub const BEDROCK_RUNTIME_ENDPOINT_TEMPLATE: &str =
     "https://bedrock-runtime.{region}.amazonaws.com";

--- a/litellm-rust/crates/core/src/providers/bedrock/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/bedrock/messages/transformation.rs
@@ -1,7 +1,93 @@
-use crate::error::CoreResult;
+use crate::error::{CoreError, CoreResult};
 use crate::messages::transformation::{AnthropicMessagesProviderConfig, MessagesAuthStrategy};
-use crate::messages::types::{AnthropicMessagesRequest, AnthropicMessagesResponse};
-use crate::providers::bedrock::constants::{AWS_REGION, AWS_REGION_NAME, DEFAULT_BEDROCK_REGION};
+use crate::messages::types::{
+    AnthropicMessage, AnthropicMessagesRequest, AnthropicMessagesResponse, SystemPrompt,
+};
+use crate::providers::anthropic::messages::transformation::ANTHROPIC_MESSAGES_CONFIG;
+use crate::providers::bedrock::constants::{
+    AWS_REGION, AWS_REGION_NAME, BEDROCK_ANTHROPIC_VERSION, DEFAULT_BEDROCK_REGION,
+};
+use serde::Serialize;
+use serde_json::Value;
+
+#[derive(Serialize)]
+struct BedrockInvokeAnthropicMessagesRequest {
+    anthropic_version: Value,
+    max_tokens: u64,
+    messages: Vec<AnthropicMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    anthropic_beta: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<SystemPrompt>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop_sequences: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    temperature: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_p: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    top_k: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    output_config: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    context_management: Option<Value>,
+}
+
+impl TryFrom<AnthropicMessagesRequest> for BedrockInvokeAnthropicMessagesRequest {
+    type Error = CoreError;
+
+    fn try_from(request: AnthropicMessagesRequest) -> CoreResult<Self> {
+        let AnthropicMessagesRequest {
+            max_tokens,
+            messages,
+            system,
+            metadata,
+            stop_sequences,
+            temperature,
+            top_p,
+            top_k,
+            tools,
+            tool_choice,
+            thinking,
+            output_config,
+            context_management,
+            mut extra,
+            ..
+        } = request;
+        let anthropic_version = extra
+            .remove("anthropic_version")
+            .unwrap_or_else(|| Value::String(BEDROCK_ANTHROPIC_VERSION.to_string()));
+
+        Ok(Self {
+            anthropic_version,
+            max_tokens: max_tokens.ok_or_else(|| {
+                CoreError::InvalidRequest("Bedrock Anthropic Messages requires `max_tokens`".to_string())
+            })?,
+            messages,
+            anthropic_beta: extra.remove("anthropic_beta"),
+            system,
+            stop_sequences,
+            temperature,
+            top_p,
+            top_k,
+            tools,
+            tool_choice,
+            thinking,
+            metadata,
+            output_config,
+            context_management,
+        })
+    }
+}
+
 pub struct BedrockMessagesConfig;
 
 pub const BEDROCK_MESSAGES_CONFIG: BedrockMessagesConfig = BedrockMessagesConfig;
@@ -55,8 +141,17 @@ impl AnthropicMessagesProviderConfig for BedrockMessagesConfig {
         &self,
         request: AnthropicMessagesRequest,
     ) -> CoreResult<AnthropicMessagesRequest> {
-        let _ = request;
-        todo!("implement Bedrock request body filtering and anthropic_version injection")
+        ANTHROPIC_MESSAGES_CONFIG.transform_request(request)
+    }
+
+    fn serialize_request(&self, request: AnthropicMessagesRequest) -> CoreResult<Value> {
+        serde_json::to_value(BedrockInvokeAnthropicMessagesRequest::try_from(request)?).map_err(
+            |err| {
+                CoreError::InvalidRequest(format!(
+                    "failed to serialize Bedrock Anthropic Messages request: {err}"
+                ))
+            },
+        )
     }
 
     fn transform_response(
@@ -76,8 +171,6 @@ mod tests {
         AWS_REGION, AWS_REGION_NAME, DEFAULT_BEDROCK_REGION,
     };
     use serde_json::{Value, json};
-
-    const ANTHROPIC_VERSION: &str = "bedrock-2023-05-31";
 
     fn request(value: Value) -> AnthropicMessagesRequest {
         serde_json::from_value(value).expect("valid request")
@@ -123,23 +216,60 @@ mod tests {
     }
 
     #[test]
-    fn request_removes_path_and_unsupported_fields() {
+    fn request_serialization_allows_only_bedrock_fields() {
         let transformed = BEDROCK_MESSAGES_CONFIG
             .transform_request(request(json!({
                 "model": "claude",
                 "stream": true,
                 "max_tokens": 10,
                 "messages": [{"role": "user", "content": "hello"}],
-                "metadata": {"user_id": "ignored"},
-                "tools": [{"name": "search"}]
+                "metadata": {"user_id": "retained"},
+                "tools": [{"name": "search"}],
+                "anthropic_beta": ["fine-grained-tool-streaming-2025-05-14"],
+                "output_config": {"effort": "high"},
+                "context_management": {"edits": []},
+                "service_tier": "auto",
+                "container": {"id": "container"},
+                "mcp_servers": [{"name": "server"}],
+                "output_format": {"type": "json_schema"},
+                "speed": "fast",
+                "inference_geo": "us",
+                "unknown_field": true
             })))
             .expect("transform");
-        let value = serde_json::to_value(transformed).expect("json");
-        assert!(value.get("model").is_none());
-        assert!(value.get("stream").is_none());
-        assert!(value.get("metadata").is_none());
-        assert_eq!(value["anthropic_version"], ANTHROPIC_VERSION);
+        let value = BEDROCK_MESSAGES_CONFIG
+            .serialize_request(transformed)
+            .expect("serialize");
+
+        assert_eq!(value["anthropic_version"], BEDROCK_ANTHROPIC_VERSION);
+        assert_eq!(value["metadata"], json!({"user_id": "retained"}));
         assert!(value.get("tools").is_some());
+        assert!(value.get("anthropic_beta").is_some());
+        assert!(value.get("output_config").is_some());
+        assert!(value.get("context_management").is_some());
+        for field in [
+            "model",
+            "stream",
+            "service_tier",
+            "container",
+            "mcp_servers",
+            "output_format",
+            "speed",
+            "inference_geo",
+            "unknown_field",
+        ] {
+            assert!(value.get(field).is_none(), "{field} must be omitted");
+        }
+    }
+
+    #[test]
+    fn request_serialization_requires_max_tokens() {
+        let err = BEDROCK_MESSAGES_CONFIG
+            .serialize_request(request(json!({
+                "messages": [{"role": "user", "content": "hello"}]
+            })))
+            .expect_err("missing max_tokens should be rejected");
+        assert!(matches!(err, CoreError::InvalidRequest(_)));
     }
 
     #[test]

--- a/litellm-rust/crates/core/src/providers/bedrock/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/bedrock/messages/transformation.rs
@@ -191,8 +191,14 @@ impl AnthropicMessagesProviderConfig for BedrockMessagesConfig {
         model: &str,
         response: AnthropicMessagesResponse,
     ) -> CoreResult<AnthropicMessagesResponse> {
-        let _ = (model, response);
-        todo!("restamp the requested model when Bedrock omits it")
+        if response.model.is_empty() {
+            return Ok(AnthropicMessagesResponse {
+                model: model.to_string(),
+                ..response
+            });
+        }
+
+        Ok(response)
     }
 }
 
@@ -317,12 +323,13 @@ mod tests {
             "stop_sequence": null
         }))
         .expect("response");
-        assert_eq!(
-            BEDROCK_MESSAGES_CONFIG
-                .transform_response("claude", response)
-                .expect("response")
-                .model,
-            "claude"
-        );
+        let response = BEDROCK_MESSAGES_CONFIG
+            .transform_response("claude", response)
+            .expect("response");
+        assert_eq!(response.model, "claude");
+
+        let serialized = serde_json::to_value(response).expect("serialize");
+        assert!(serialized["stop_reason"].is_null());
+        assert!(serialized["stop_sequence"].is_null());
     }
 }

--- a/litellm-rust/crates/core/src/providers/bedrock/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/bedrock/messages/transformation.rs
@@ -8,6 +8,8 @@ use crate::providers::bedrock::constants::{
     AWS_REGION, AWS_REGION_NAME, BEDROCK_ANTHROPIC_VERSION, BEDROCK_RUNTIME_ENDPOINT_TEMPLATE,
     DEFAULT_BEDROCK_REGION,
 };
+
+const AWS_BEARER_TOKEN_BEDROCK: &str = "AWS_BEARER_TOKEN_BEDROCK";
 use serde::Serialize;
 use serde_json::Value;
 
@@ -157,16 +159,24 @@ impl AnthropicMessagesProviderConfig for BedrockMessagesConfig {
 
     fn resolve_api_key(
         &self,
-        _api_key: Option<&str>,
-        _env_lookup: &dyn Fn(&str) -> Option<String>,
+        api_key: Option<&str>,
+        env_lookup: &dyn Fn(&str) -> Option<String>,
     ) -> CoreResult<String> {
-        Ok(String::new())
+        Ok(match api_key {
+            Some(value) if !value.trim().is_empty() => value.trim().to_string(),
+            Some(_) => String::new(),
+            None => env_lookup(AWS_BEARER_TOKEN_BEDROCK)
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or_default(),
+        })
     }
 
     fn auth_strategy(&self) -> MessagesAuthStrategy {
-        todo!(
-            "Bedrock authenticates with a bearer token or a signed request, not a static api key header"
-        )
+        MessagesAuthStrategy::BearerOrSigV4
+    }
+
+    fn default_headers(&self) -> &'static [(&'static str, &'static str)] {
+        &[("content-type", "application/json")]
     }
 
     fn transform_request(
@@ -250,6 +260,40 @@ mod tests {
         assert_eq!(
             BEDROCK_MESSAGES_CONFIG.signing_region(None, &|_| None),
             Some(DEFAULT_BEDROCK_REGION.to_string())
+        );
+    }
+
+    #[test]
+    fn auth_uses_an_explicit_bearer_token_or_falls_back_to_sigv4() {
+        let env = |key: &str| {
+            (key == AWS_BEARER_TOKEN_BEDROCK).then(|| "env-token".to_string())
+        };
+
+        assert_eq!(
+            BEDROCK_MESSAGES_CONFIG.auth_strategy(),
+            MessagesAuthStrategy::BearerOrSigV4
+        );
+        assert_eq!(
+            BEDROCK_MESSAGES_CONFIG
+                .resolve_api_key(Some("request-token"), &env)
+                .expect("token"),
+            "request-token"
+        );
+        assert_eq!(
+            BEDROCK_MESSAGES_CONFIG
+                .resolve_api_key(None, &env)
+                .expect("token"),
+            "env-token"
+        );
+        assert!(
+            BEDROCK_MESSAGES_CONFIG
+                .resolve_api_key(Some(" "), &env)
+                .expect("token")
+                .is_empty()
+        );
+        assert_eq!(
+            BEDROCK_MESSAGES_CONFIG.default_headers(),
+            &[("content-type", "application/json")]
         );
     }
 

--- a/litellm-rust/crates/core/src/providers/bedrock/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/bedrock/messages/transformation.rs
@@ -142,9 +142,10 @@ impl AnthropicMessagesProviderConfig for BedrockMessagesConfig {
         &self,
         api_base: Option<&str>,
         model: &str,
+        stream: bool,
         env_lookup: &dyn Fn(&str) -> Option<String>,
     ) -> CoreResult<String> {
-        complete_bedrock_url(api_base, model, false, env_lookup)
+        complete_bedrock_url(api_base, model, stream, env_lookup)
     }
 
     fn signing_region(

--- a/litellm-rust/crates/core/src/providers/bedrock/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/bedrock/messages/transformation.rs
@@ -5,7 +5,8 @@ use crate::messages::types::{
 };
 use crate::providers::anthropic::messages::transformation::ANTHROPIC_MESSAGES_CONFIG;
 use crate::providers::bedrock::constants::{
-    AWS_REGION, AWS_REGION_NAME, BEDROCK_ANTHROPIC_VERSION, DEFAULT_BEDROCK_REGION,
+    AWS_REGION, AWS_REGION_NAME, BEDROCK_ANTHROPIC_VERSION, BEDROCK_RUNTIME_ENDPOINT_TEMPLATE,
+    DEFAULT_BEDROCK_REGION,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -98,8 +99,40 @@ pub fn complete_bedrock_url(
     stream: bool,
     env_lookup: &dyn Fn(&str) -> Option<String>,
 ) -> CoreResult<String> {
-    let _ = (api_base, model, stream, env_lookup);
-    todo!("implement Bedrock InvokeModel URL construction and model path encoding")
+    let model = model.trim();
+    if model.is_empty() {
+        return Err(CoreError::InvalidRequest(
+            "Bedrock model must not be empty".to_string(),
+        ));
+    }
+
+    let region = env_lookup(AWS_REGION_NAME)
+        .or_else(|| env_lookup(AWS_REGION))
+        .unwrap_or_else(|| DEFAULT_BEDROCK_REGION.to_string());
+    let endpoint = api_base
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .unwrap_or_else(|| BEDROCK_RUNTIME_ENDPOINT_TEMPLATE.replace("{region}", &region));
+    let model = model
+        .bytes()
+        .map(|byte| match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                (byte as char).to_string()
+            }
+            _ => format!("%{byte:02X}"),
+        })
+        .collect::<String>();
+    let operation = if stream {
+        "invoke-with-response-stream"
+    } else {
+        "invoke"
+    };
+
+    Ok(format!(
+        "{}/model/{model}/{operation}",
+        endpoint.trim_end_matches('/')
+    ))
 }
 
 impl AnthropicMessagesProviderConfig for BedrockMessagesConfig {
@@ -109,8 +142,7 @@ impl AnthropicMessagesProviderConfig for BedrockMessagesConfig {
         model: &str,
         env_lookup: &dyn Fn(&str) -> Option<String>,
     ) -> CoreResult<String> {
-        let _ = (api_base, model, env_lookup);
-        todo!("Bedrock InvokeModel URLs carry the model id and the streaming mode in the path")
+        complete_bedrock_url(api_base, model, false, env_lookup)
     }
 
     fn signing_region(

--- a/litellm-rust/crates/core/src/providers/bedrock/messages/transformation.rs
+++ b/litellm-rust/crates/core/src/providers/bedrock/messages/transformation.rs
@@ -1,6 +1,7 @@
 use crate::error::CoreResult;
 use crate::messages::transformation::{AnthropicMessagesProviderConfig, MessagesAuthStrategy};
 use crate::messages::types::{AnthropicMessagesRequest, AnthropicMessagesResponse};
+use crate::providers::bedrock::constants::{AWS_REGION, AWS_REGION_NAME, DEFAULT_BEDROCK_REGION};
 pub struct BedrockMessagesConfig;
 
 pub const BEDROCK_MESSAGES_CONFIG: BedrockMessagesConfig = BedrockMessagesConfig;
@@ -28,11 +29,12 @@ impl AnthropicMessagesProviderConfig for BedrockMessagesConfig {
 
     fn signing_region(
         &self,
-        api_base: Option<&str>,
+        _api_base: Option<&str>,
         env_lookup: &dyn Fn(&str) -> Option<String>,
     ) -> Option<String> {
-        let _ = (api_base, env_lookup);
-        todo!("resolve the AWS region the request is signed and routed for")
+        env_lookup(AWS_REGION_NAME)
+            .or_else(|| env_lookup(AWS_REGION))
+            .or_else(|| Some(DEFAULT_BEDROCK_REGION.to_string()))
     }
 
     fn resolve_api_key(
@@ -70,7 +72,9 @@ impl AnthropicMessagesProviderConfig for BedrockMessagesConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::providers::bedrock::constants::{AWS_REGION, AWS_REGION_NAME};
+    use crate::providers::bedrock::constants::{
+        AWS_REGION, AWS_REGION_NAME, DEFAULT_BEDROCK_REGION,
+    };
     use serde_json::{Value, json};
 
     const ANTHROPIC_VERSION: &str = "bedrock-2023-05-31";
@@ -95,23 +99,26 @@ mod tests {
     }
 
     #[test]
-    fn api_base_region_wins_over_environment() {
-        let env = |key: &str| (key == AWS_REGION_NAME).then(|| "us-west-2".to_string());
+    fn signing_region_uses_aws_region_name_before_aws_region_and_ignores_api_base() {
+        let env = |key: &str| match key {
+            AWS_REGION_NAME => Some("us-west-2".to_string()),
+            AWS_REGION => Some("eu-west-1".to_string()),
+            _ => None,
+        };
         assert_eq!(
             BEDROCK_MESSAGES_CONFIG.signing_region(
                 Some("https://bedrock-runtime.ap-south-1.amazonaws.com"),
                 &env
             ),
-            Some("ap-south-1".to_string())
+            Some("us-west-2".to_string())
         );
     }
 
     #[test]
-    fn non_bedrock_api_base_does_not_supply_a_region() {
-        let env = |key: &str| (key == AWS_REGION).then(|| "eu-west-1".to_string());
+    fn signing_region_falls_back_to_default_bedrock_region() {
         assert_eq!(
-            BEDROCK_MESSAGES_CONFIG.signing_region(Some("http://127.0.0.1:8080"), &env),
-            Some("eu-west-1".to_string())
+            BEDROCK_MESSAGES_CONFIG.signing_region(None, &|_| None),
+            Some(DEFAULT_BEDROCK_REGION.to_string())
         );
     }
 

--- a/litellm-rust/harness-run-legacy.txt
+++ b/litellm-rust/harness-run-legacy.txt
@@ -1,0 +1,46 @@
+simple
+{
+  "type": "message",
+  "id": "msg_bdrk_01Tj4s75hFRkNccHzV4T2pVR",
+  "model": "claude-sonnet-4-5-20250929",
+  "usage": {
+    "cache_creation": {
+      "ephemeral_1h_input_tokens": 0,
+      "ephemeral_5m_input_tokens": 0
+    },
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "input_tokens": 13,
+    "output_tokens": 4
+  }
+}
+streaming
+event: message_start
+data: {"message":{"content":[],"id":"msg_bdrk_01Y9t1VBXMxM7EZWp6eqZr5r","model":"claude-sonnet-4-5-20250929","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":13,"output_tokens":1}},"type":"message_start"}
+event: content_block_start
+data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+event: content_block_delta
+data: {"delta":{"text":"Hello","type":"text_delta"},"index":0,"type":"content_block_delta"}
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
+event: message_delta
+data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":13,"output_tokens":4}}
+event: message_stop
+data: {"amazon-bedrock-invocationMetrics":{"firstByteLatency":1512,"inputTokenCount":13,"invocationLatency":1677,"outputTokenCount":4},"type":"message_stop"}
+tool_use
+{
+  "type": "message",
+  "model": "claude-sonnet-4-5-20250929",
+  "content": [
+    {
+      "id": "toolu_bdrk_011tbyx3MYhBSxVvheA7U9Ez",
+      "input": {
+        "city": "Paris"
+      },
+      "name": "get_weather",
+      "type": "tool_use"
+    }
+  ]
+}
+bad-model
+HTTP 404

--- a/litellm-rust/harness-run-rust-bridge.txt
+++ b/litellm-rust/harness-run-rust-bridge.txt
@@ -1,0 +1,46 @@
+simple
+{
+  "type": "message",
+  "id": "msg_bdrk_01WgPPtBW9FxBU285d7TQ1QS",
+  "model": "claude-sonnet-4-5-20250929",
+  "usage": {
+    "cache_creation": {
+      "ephemeral_1h_input_tokens": 0,
+      "ephemeral_5m_input_tokens": 0
+    },
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "input_tokens": 13,
+    "output_tokens": 4
+  }
+}
+streaming
+event: message_start
+data: {"message":{"content":[],"id":"msg_bdrk_01AKvc93kzLG6YRNEVNXCfHi","model":"claude-sonnet-4-5-20250929","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":13,"output_tokens":1}},"type":"message_start"}
+event: content_block_start
+data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+event: content_block_delta
+data: {"delta":{"text":"Hello","type":"text_delta"},"index":0,"type":"content_block_delta"}
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
+event: message_delta
+data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":13,"output_tokens":4}}
+event: message_stop
+data: {"amazon-bedrock-invocationMetrics":{"firstByteLatency":1602,"inputTokenCount":13,"invocationLatency":1749,"outputTokenCount":4},"type":"message_stop"}
+tool_use
+{
+  "type": "message",
+  "model": "claude-sonnet-4-5-20250929",
+  "content": [
+    {
+      "id": "toolu_bdrk_014usrpvs6iMXvs1Qydcycwq",
+      "input": {
+        "city": "Paris"
+      },
+      "name": "get_weather",
+      "type": "tool_use"
+    }
+  ]
+}
+bad-model
+HTTP 404

--- a/litellm-rust/harness-run-rust-gateway.txt
+++ b/litellm-rust/harness-run-rust-gateway.txt
@@ -1,0 +1,46 @@
+simple
+{
+  "type": "message",
+  "id": "msg_bdrk_01UyMSHSetYfpcEnXaGhTYpd",
+  "model": "claude-sonnet-4-5-20250929",
+  "usage": {
+    "cache_creation": {
+      "ephemeral_1h_input_tokens": 0,
+      "ephemeral_5m_input_tokens": 0
+    },
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0,
+    "input_tokens": 13,
+    "output_tokens": 4
+  }
+}
+streaming
+event: message_start
+data: {"message":{"content":[],"id":"msg_bdrk_016U4CmVaCZ4RcLDfn91s4WB","model":"claude-sonnet-4-5-20250929","role":"assistant","stop_details":null,"stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":13,"output_tokens":1}},"type":"message_start"}
+event: content_block_start
+data: {"content_block":{"text":"","type":"text"},"index":0,"type":"content_block_start"}
+event: content_block_delta
+data: {"delta":{"text":"Hello","type":"text_delta"},"index":0,"type":"content_block_delta"}
+event: content_block_stop
+data: {"index":0,"type":"content_block_stop"}
+event: message_delta
+data: {"delta":{"stop_details":null,"stop_reason":"end_turn","stop_sequence":null},"type":"message_delta","usage":{"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":13,"output_tokens":4}}
+event: message_stop
+data: {"amazon-bedrock-invocationMetrics":{"firstByteLatency":1790,"inputTokenCount":13,"invocationLatency":1942,"outputTokenCount":4},"type":"message_stop"}
+tool_use
+{
+  "type": "message",
+  "model": "claude-sonnet-4-5-20250929",
+  "content": [
+    {
+      "id": "toolu_bdrk_01Mt95wcBeKZRLDnwte1ktUy",
+      "input": {
+        "city": "Paris"
+      },
+      "name": "get_weather",
+      "type": "tool_use"
+    }
+  ]
+}
+bad-model
+HTTP 404

--- a/litellm-rust/run_messages_dev.sh
+++ b/litellm-rust/run_messages_dev.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <rust|rust-bridge|legacy> --port <port>" >&2
+}
+
+mode="${1:-}"
+if [[ "$mode" == "-h" || "$mode" == "--help" ]]; then
+  usage
+  exit 0
+fi
+if [[ -z "$mode" ]]; then
+  usage
+  exit 2
+fi
+shift
+
+port=""
+while (($# > 0)); do
+  case "$1" in
+    --port)
+      if (($# < 2)); then
+        usage
+        exit 2
+      fi
+      port="$2"
+      shift 2
+      ;;
+    --port=*)
+      port="${1#*=}"
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+case "$mode" in
+  rust | rust-bridge | legacy) ;;
+  *)
+    echo "unknown mode: $mode" >&2
+    usage
+    exit 2
+    ;;
+esac
+
+if [[ ! "$port" =~ ^[0-9]+$ ]] || ((10#$port < 1 || 10#$port > 65535)); then
+  echo "--port must be an integer between 1 and 65535" >&2
+  exit 2
+fi
+
+for name in AWS_BEARER_TOKEN_BEDROCK BEDROCK_MODEL LITELLM_MASTER_KEY; do
+  if [[ -z "${!name:-}" ]]; then
+    echo "$name is required" >&2
+    exit 1
+  fi
+done
+
+if [[ ! "$BEDROCK_MODEL" =~ ^[A-Za-z0-9._:/-]+$ ]]; then
+  echo "BEDROCK_MODEL contains unsupported characters" >&2
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(dirname "$script_dir")"
+export AWS_REGION_NAME="${AWS_REGION_NAME:-us-west-2}"
+unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+
+echo "starting $mode on http://127.0.0.1:$port with model $BEDROCK_MODEL"
+
+if [[ "$mode" == "rust" ]]; then
+  if ! command -v cargo >/dev/null 2>&1; then
+    echo "cargo is required for rust mode" >&2
+    exit 1
+  fi
+  cd "$script_dir"
+  PORT="$port" REALTIME_POOL_SIZE=0 exec cargo run -p litellm-ai-gateway --features server
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "uv is required for $mode mode" >&2
+  exit 1
+fi
+
+cd "$repo_root"
+if [[ "$mode" == "rust-bridge" ]]; then
+  uv run --with maturin==1.9.4 maturin develop \
+    --manifest-path "$script_dir/crates/python-bridge/Cargo.toml"
+  export LITELLM_RUST=1
+else
+  export LITELLM_RUST=0
+fi
+
+dev_runtime_dir="$(mktemp -d)"
+proxy_config="$dev_runtime_dir/config.yaml"
+cleanup() {
+  rm -f -- "$proxy_config"
+  rmdir -- "$dev_runtime_dir" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+cat >"$proxy_config" <<EOF
+model_list:
+  - model_name: "$BEDROCK_MODEL"
+    litellm_params:
+      model: "bedrock/$BEDROCK_MODEL"
+      api_key: os.environ/AWS_BEARER_TOKEN_BEDROCK
+      aws_region_name: "$AWS_REGION_NAME"
+EOF
+
+uv run litellm --config "$proxy_config" --port "$port" --run_hypercorn

--- a/tests/test_litellm/anthropic_interface/test_bedrock_rust_bridge_e2e.py
+++ b/tests/test_litellm/anthropic_interface/test_bedrock_rust_bridge_e2e.py
@@ -1,8 +1,39 @@
+import logging
 import os
+from collections.abc import Iterator
 
 import pytest
 
 import litellm
+from litellm._logging import verbose_logger
+
+# Captured at import, before conftest's isolate_host_aws_config strips it.
+BEARER_TOKEN = os.getenv("AWS_BEARER_TOKEN_BEDROCK")
+
+pytestmark = pytest.mark.skipif(
+    BEARER_TOKEN is None,
+    reason="requires AWS_BEARER_TOKEN_BEDROCK for a live Bedrock call",
+)
+
+
+@pytest.fixture(autouse=True)
+def restore_bedrock_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", BEARER_TOKEN or "")
+    monkeypatch.setenv("AWS_REGION_NAME", "us-west-2")
+
+
+@pytest.fixture(autouse=True)
+def rust_debug_only() -> Iterator[None]:
+    level = verbose_logger.level
+    handlers = tuple(verbose_logger.handlers)
+    propagate = verbose_logger.propagate
+    verbose_logger.setLevel(logging.DEBUG)
+    verbose_logger.handlers.clear()
+    verbose_logger.propagate = False
+    yield
+    verbose_logger.setLevel(level)
+    verbose_logger.handlers.extend(handlers)
+    verbose_logger.propagate = propagate
 
 
 @pytest.mark.asyncio
@@ -11,7 +42,7 @@ async def test_bedrock_messages_with_rust() -> None:
         model="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
         messages=[{"role": "user", "content": "Say hello"}],
         max_tokens=20,
-        api_key=os.getenv("AWS_BEARER_TOKEN_BEDROCK"),
+        api_key=BEARER_TOKEN,
         aws_region_name="us-west-2",
         rust=True,
     )
@@ -27,7 +58,7 @@ async def test_bedrock_messages_streaming_with_rust() -> None:
         messages=[{"role": "user", "content": "Say hello"}],
         max_tokens=20,
         stream=True,
-        api_key=os.getenv("AWS_BEARER_TOKEN_BEDROCK"),
+        api_key=BEARER_TOKEN,
         aws_region_name="us-west-2",
         rust=True,
     )


### PR DESCRIPTION
## TLDR

<!-- Fill in the bullets below and keep each one short and concrete: one line per bullet, roughly 10 words max
     This section must be extremely human parsable, comprehensible, and readable: its target audience is humans, not AI agents -->

Problem this solves:

- <blah>
- ...

How it solves it:

- <blah>
- ...

## Relevant issues

<!-- e.g., "Fixes #000" -->

## Linear ticket

<!-- if you are an internal contributor, add "Resolves " followed by the Linear ticket e.g., "Resolves LIT-1234" to link the Linear ticket to the GitHub PR. If you don't have one, leave the section blank rather than guessing -->

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [ ] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

<!-- Include screenshots, screen recordings, or command (e.g., curl) + output demonstrating that your changes work as expected
     The proof must be completely e2e with no mocks, using, for example, actual LLM calls costing real $. `pytest` commands are not enough
     For bug fixes: show reproduction before the fix and passing behavior after
     Include the commit hash each proof was captured at, for both the before and the after runs
     If the change applies to all three LLM endpoints (/v1/responses, /v1/chat/completions, /v1/messages), include proof for every single one of them, not just one
     For new features: show the feature working end-to-end
     For UI changes: include before/after screenshots -->

## Type

<!-- Select the type of Pull Request -->
<!-- Keep only the necessary ones -->

🆕 New Feature
🐛 Bug Fix
🧹 Refactoring
📖 Documentation
🚄 Infrastructure
✅ Test

## Changes

## QA runbook

<!-- Only needed when your PR edits tests/e2e; delete this section otherwise

For each e2e test you added or changed, list the manual steps a reviewer can follow to reproduce it by hand against a live proxy, mapping 1:1 to what the test asserts: one top-level bullet per test giving its pytest node id followed by what it proves in plain words, then a nested "- [ ]" checklist where each item is a concrete action (route, request body, expected response) and the final item is the sanity-check step shown in the examples. Note environment prerequisites (provider credentials, config flags) and any nuances a manual run will hit. See PRs #32914 and #32963 for full examples

Example checklists:

- tests/e2e/quota_management/ratelimit/test_rate_limit_e2e.py::TestKeyRateLimits::test_rpm_limit_blocks_over_limit - a key allowed 2 requests a minute serves exactly 2 and refuses the 3rd
  - [ ] Generate a limited key: curl -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -d '{"rpm_limit": 2}'
  - [ ] Send three /v1/chat/completions requests with that key inside one minute
  - [ ] Expect the first two to return 200 and the third to return 429 naming the rpm limit
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky

- tests/e2e/management/test_management_e2e.py::TestModelRoutes::test_model_create_appears_in_ui - a deployment created through the API shows up on the Admin UI models page
  - [ ] POST /model/new with the master key, a bedrock model, and aws_region_name (needs STORE_MODEL_IN_DB=True and AWS credentials)
  - [ ] Open http://localhost:4000/ui/?page=models and expect a deployment row showing the returned model id
  - [ ] Sanity check: this test makes sense to add and is not hand-wavey (e.g., assert actual expected spend instead of just spend > 0) or potentially flaky
-->

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
