### PR TITLE
chore: bump litellm-proxy-extras 0.4.82 -> 0.4.83

### DIFF
--- a/litellm-proxy-extras/pyproject.toml
+++ b/litellm-proxy-extras/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "litellm-proxy-extras"
-version = "0.4.82"
+version = "0.4.83"
 description = "Additional files for the LiteLLM Proxy. Reduces the size of the main litellm package."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -26,7 +26,7 @@ required-version = ">=0.10.9"
 module-root = ""
 
 [tool.commitizen]
-version = "0.4.82"
+version = "0.4.83"
 version_files = [
     "pyproject.toml:^version",
     "../pyproject.toml:litellm-proxy-extras==",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ proxy = [
     "azure-identity>=1.25.2,<2.0",
     "azure-storage-blob>=12.28.0,<13.0",
     "mcp>=1.28.1,<2.0",
-    "litellm-proxy-extras==0.4.82",
+    "litellm-proxy-extras==0.4.83",
     "litellm-enterprise==0.1.53",
     "RestrictedPython>=8.1,<9.0",
     "rich>=13.9.4,<14.0",

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-08-01T21:00:29.35856Z"
+exclude-newer = "2026-08-02T01:44:17.274352Z"
 exclude-newer-span = "P3D"
 
 [manifest]
@@ -4604,7 +4604,7 @@ source = { editable = "enterprise" }
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.82"
+version = "0.4.83"
 source = { editable = "litellm-proxy-extras" }
 
 [[package]]


### PR DESCRIPTION
## TLDR

Problem this solves:

- `litellm-proxy-extras/` changed after 0.4.82 was promoted to main
- Publishing 0.4.82 again would ship different contents under the same version

How it solves it:

- PATCH bump 0.4.82 -> 0.4.83, plus the matching root pin
- Refreshes `uv.lock` against the new version

## Relevant issues

## Linear ticket

## Pre-Submission checklist

- [ ] I have added meaningful tests — N/A, version strings only, no behavior to test
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

There is no meaningful proof-of-fix for a version bump: this PR changes only version
strings and the lock file, with no runtime behavior to demonstrate.

For reference, the change that made the bump due is #35165 (`fix(proxy): persist
periodic reload schedule state...`), which landed on staging at `9ea5cfce0e` — after
0.4.82 was promoted to main in #35836. It touched:

```
litellm-proxy-extras/litellm_proxy_extras/schema.prisma
litellm-proxy-extras/litellm_proxy_extras/migrations/20260729000000_add_reload_tracking_to_litellm_config/migration.sql
```

## Type

🚄 Infrastructure

## Changes

- `litellm-proxy-extras/pyproject.toml`: version 0.4.82 -> 0.4.83 (and its `[tool.commitizen]` version)
- `pyproject.toml`: `litellm-proxy-extras==0.4.82` -> `==0.4.83`
- `uv.lock`: re-resolved; the only movements are `litellm-proxy-extras` 0.4.82 -> 0.4.83 and the
  rolling `exclude-newer` timestamp (the lock uses `exclude-newer-span = "P3D"`, so every
  `uv lock` recomputes it to ~3 days before now). No third-party dependency versions moved.

Enterprise and root `litellm` are deliberately untouched: `enterprise/` is byte-identical
between `main` and staging (last bumped to 0.1.53 on Aug 1), and the 1.97.0 line has only
dev tags so far, so no MINOR bump is due.

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR — no tests accompany this PR; the change is version strings and the lock file, so there is no behavior that could regress
