### PR TITLE
fix(ui): derive auto-router preset tests from the bundled preset JSON

### DIFF
--- a/ui/litellm-dashboard/src/autorouter_presets.json
+++ b/ui/litellm-dashboard/src/autorouter_presets.json
@@ -16,7 +16,7 @@
   },
   "openai_family": {
     "label": "OpenAI Family",
-    "description": "Routes across the GPT model family: gpt-5-nano for simple queries, gpt-5-mini for medium, gpt-5 for complex, o3 for reasoning-heavy requests.",
+    "description": "Routes across the GPT model family: gpt-5.4-nano for simple queries, gpt-5.4-mini for medium, gpt-5.4 for complex, o3 for reasoning-heavy requests.",
     "complexity_router_config": {
       "tiers": {
         "SIMPLE": ["gpt-5.4-nano"],

--- a/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/add_auto_router_tab.test.tsx
@@ -7,18 +7,20 @@ import { handleAddAutoRouterSubmit } from "./handle_add_auto_router_submit";
 import { getMissingTiersError } from "./build_complexity_router_config";
 import { testAutoRouterRouting } from "../networking";
 import { ModelGroup } from "@/components/llm_calls/fetch_models";
+import { getAllPresets, getPresetByKey, getRequiredModelsInPreset } from "@/lib/autorouter_presets";
 
-// Every model referenced by both bundled family presets. A caller holding all of these can select
-// either preset; dropping any one greys out the preset that names it.
+const ANTHROPIC_PRESET = getPresetByKey("anthropic_family")!;
+const ANTHROPIC_TIERS = ANTHROPIC_PRESET.complexity_router_config.tiers;
+
+// Every model referenced by the bundled family presets, derived from the presets themselves so
+// that renaming a preset's models in autorouter_presets.json does not red these tests. A caller
+// holding all of these can select either preset; dropping any one greys out the preset that
+// names it.
 const ALL_FAMILY_MODELS: ModelGroup[] = [
-  { model_group: "claude-haiku-4-5", mode: "chat" },
-  { model_group: "claude-sonnet-4-5", mode: "chat" },
-  { model_group: "claude-opus-5", mode: "chat" },
-  { model_group: "gpt-5-nano", mode: "chat" },
-  { model_group: "gpt-5-mini", mode: "chat" },
-  { model_group: "gpt-5", mode: "chat" },
-  { model_group: "o3", mode: "chat" },
-];
+  ...new Set(getAllPresets().flatMap((preset) => [...getRequiredModelsInPreset(preset)])),
+].map((model_group) => ({ model_group, mode: "chat" }));
+
+const ANTHROPIC_ONLY_MODEL = ANTHROPIC_TIERS.COMPLEX[0];
 
 const openTemplateDropdown = (): void => {
   fireEvent.mouseDown(screen.getByTestId("template-selector").querySelector(".ant-select-selector")!);
@@ -428,13 +430,15 @@ describe("AddAutoRouterTab", () => {
     });
 
     it("disables a preset missing one of its models, naming the missing model", async () => {
-      mockFetchAvailableModels.mockResolvedValue(ALL_FAMILY_MODELS.filter((m) => m.model_group !== "claude-opus-5"));
+      mockFetchAvailableModels.mockResolvedValue(
+        ALL_FAMILY_MODELS.filter((m) => m.model_group !== ANTHROPIC_ONLY_MODEL),
+      );
 
       renderWithProviders(<Harness />);
       openTemplateDropdown();
 
       await waitFor(() => {
-        expect(optionByLabel("Anthropic Family")!.textContent).toContain("Missing: claude-opus-5");
+        expect(optionByLabel("Anthropic Family")!.textContent).toContain(`Missing: ${ANTHROPIC_ONLY_MODEL}`);
       });
       expect(isOptionDisabled(optionByLabel("Anthropic Family")!)).toBe(true);
     });
@@ -458,7 +462,8 @@ describe("AddAutoRouterTab", () => {
       expect(screen.queryByText("Advanced: Keyword/Semantic Matching")).not.toBeInTheDocument();
       expect(
         screen.getByText(
-          "Simple: claude-haiku-4-5 · Medium: claude-sonnet-4-5 · Complex: claude-opus-5 · Reasoning: claude-opus-5",
+          `Simple: ${ANTHROPIC_TIERS.SIMPLE.join(", ")} · Medium: ${ANTHROPIC_TIERS.MEDIUM.join(", ")} · ` +
+            `Complex: ${ANTHROPIC_TIERS.COMPLEX.join(", ")} · Reasoning: ${ANTHROPIC_TIERS.REASONING.join(", ")}`,
         ),
       ).toBeInTheDocument();
     });
@@ -500,15 +505,8 @@ describe("AddAutoRouterTab", () => {
 
       await waitFor(() => expect(handleAddAutoRouterSubmit).toHaveBeenCalled());
       expect(vi.mocked(handleAddAutoRouterSubmit).mock.calls.at(-1)?.[0]).toMatchObject({
-        auto_router_default_model: "claude-sonnet-4-5",
-        complexity_router_config: {
-          tiers: {
-            SIMPLE: ["claude-haiku-4-5"],
-            MEDIUM: ["claude-sonnet-4-5"],
-            COMPLEX: ["claude-opus-5"],
-            REASONING: ["claude-opus-5"],
-          },
-        },
+        auto_router_default_model: ANTHROPIC_TIERS.MEDIUM[0],
+        complexity_router_config: { tiers: ANTHROPIC_TIERS },
       });
     });
 

--- a/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
+++ b/ui/litellm-dashboard/src/lib/autorouter_presets.test.ts
@@ -50,20 +50,24 @@ describe("autorouter_presets", () => {
   it("reports only the models the caller is missing, and none when the family is fully available", () => {
     const preset = getPresetByKey("openai_family")!;
     const required = [...getRequiredModelsInPreset(preset)];
+    const [held] = required;
 
-    expect(getMissingModelsInPreset(preset, new Set(["gpt-5-nano"]))).toEqual(
-      required.filter((m) => m !== "gpt-5-nano").sort(),
-    );
+    expect(getMissingModelsInPreset(preset, new Set([held]))).toEqual(required.filter((m) => m !== held).sort());
     expect(getMissingModelsInPreset(preset, new Set(required))).toEqual([]);
   });
 
   // Admins spell version numbers with either "-" or "." (claude-sonnet-4-5 vs claude-sonnet-4.5);
-  // a caller who only registered one form still satisfies a preset that names the other.
+  // a caller who only registered one form still satisfies a preset that names the other. The
+  // caller's spellings are derived from the preset itself so that renaming a preset's models in
+  // autorouter_presets.json can't quietly turn this into a no-op (the inequality below fails
+  // instead, if no preset model carries a version number at all).
   it("treats a preset's model as available under either version-separator spelling", () => {
     const preset = getPresetByKey("anthropic_family")!;
-    expect(
-      getMissingModelsInPreset(preset, new Set(["claude-haiku-4.5", "claude-sonnet-4.5", "claude-opus-5"])),
-    ).toEqual([]);
+    const required = [...getRequiredModelsInPreset(preset)];
+    const dottedSpellings = required.map((model) => model.replace(/(\d)-(\d)/g, "$1.$2"));
+
+    expect(dottedSpellings).not.toEqual(required);
+    expect(getMissingModelsInPreset(preset, new Set(dottedSpellings))).toEqual([]);
   });
 
   // The two-arm mirror: a differently-punctuated preset model must not be reported missing.


### PR DESCRIPTION
## TLDR

Problem this solves:

`litellm_internal_staging` is red on `ui-unit-tests`. #35746 merged three minutes after its last commit turned the job red, so the failure landed on staging: 6 failures in `add_auto_router_tab.test.tsx` and 1 in `autorouter_presets.test.ts`

The cause is that both test files hardcoded the exact model names the bundled presets happened to ship with. The last commit on that PR edited `autorouter_presets.json` to name newer models (`claude-sonnet-5`, the `gpt-5.4` family), so the fixture no longer covered what the presets ask for, every preset stayed greyed out as "missing models", and the six `waitFor` calls that wait for a preset to become selectable timed out

How it solves it:

The fixtures now derive from the preset JSON instead of restating it. `ALL_FAMILY_MODELS` is built from `getRequiredModelsInPreset` over `getAllPresets()`, the tier summary and payload assertions read the Anthropic preset's own tiers, and the version-separator test rewrites the preset's own model names into their dotted spelling rather than listing three literals. Editing the JSON to name whatever models are current can no longer red these tests

Also fixes the OpenAI preset's `description`, which that commit left describing gpt-5-nano/gpt-5-mini/gpt-5 while its tiers moved to the gpt-5.4 family. The description is what an admin reads in the Template dropdown, so it was showing model names the preset no longer configures

## Relevant issues

- Fixes the `ui-unit-tests` failure introduced by #35746 (commit ad6e974)
- Follows the same file this test suite was built in, #35199

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Screenshots / Proof of Fix

This is a test-only fix for a red CI job, so the proof is the job itself going green on this PR, plus the mutation check below

Before, on staging (`ui/litellm-dashboard`):

```
$ git stash && npx vitest run src/lib/autorouter_presets.test.ts src/components/add_model/add_auto_router_tab.test.tsx
 FAIL  src/lib/autorouter_presets.test.ts > autorouter_presets > treats a preset's model as available under either version-separator spelling
 FAIL  src/components/add_model/add_auto_router_tab.test.tsx > AddAutoRouterTab > template presets > disables every preset while the model list is loading
 FAIL  src/components/add_model/add_auto_router_tab.test.tsx > AddAutoRouterTab > template presets > enables a preset once every model it needs is available
 FAIL  src/components/add_model/add_auto_router_tab.test.tsx > AddAutoRouterTab > template presets > collapses detailed configuration and shows a tier summary once a preset is applied
 FAIL  src/components/add_model/add_auto_router_tab.test.tsx > AddAutoRouterTab > template presets > lets a caller manually re-expand a detailed configuration a preset just collapsed
 FAIL  src/components/add_model/add_auto_router_tab.test.tsx > AddAutoRouterTab > template presets > carries a selected preset's tiers through to the create payload
 FAIL  src/components/add_model/add_auto_router_tab.test.tsx > AddAutoRouterTab > template presets > blocks a form submit when a referenced model disappears after the tiers are filled in
```

After, with this branch:

```
$ npx vitest run src/lib/autorouter_presets.test.ts src/components/add_model/add_auto_router_tab.test.tsx
 Test Files  2 passed (2)
      Tests  43 passed (43)
```

Deriving assertions from the same source the component reads risks writing a test that passes no matter what, so both rewritten assertions were mutation checked against `add_auto_router_tab.tsx`. Changing `tierConfigSummary`'s `" · "` join to `", "`, and the default model from `tiers.MEDIUM[0]` to `tiers.SIMPLE[0]`, kills exactly the two tests that cover them:

```
 × AddAutoRouterTab > template presets > collapses detailed configuration and shows a tier summary once a preset is applied
 × AddAutoRouterTab > template presets > carries a selected preset's tiers through to the create payload
      Tests  2 failed | 8 passed | 13 skipped (23)
```

The presets test guards itself the same way: `expect(dottedSpellings).not.toEqual(required)` fails if no preset model carries a version number anymore, rather than letting the separator test quietly assert nothing

## Type

🐛 Bug Fix
✅ Test

## Changes

`add_auto_router_tab.test.tsx` builds its model fixture from the presets, and reads the Anthropic preset's tiers for the summary string, the missing-model name, and the create payload. `autorouter_presets.test.ts` takes the model it "holds" from the preset's own required set, and derives the dotted spellings from the preset instead of listing them. `autorouter_presets.json` gets its OpenAI description resynced with its tiers

## QA runbook

Nothing to click through; this is a test and copy fix. If you want to see the description change, open the Admin UI, go to Models, Add Model, the Auto Router tab, and open the Template dropdown: the OpenAI Family entry should describe the gpt-5.4 models its tiers actually name

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
