### PR TITLE
fix(openai): map missing credentials to 401

### DIFF
--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -371,12 +371,12 @@ def _map_openai_exception(
     elif (
         "The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable"
         in error_str
+        or ("Missing credentials" in error_str and "api_key" in error_str)
     ):
         raise AuthenticationError(
             message=f"AuthenticationError: {exception_provider} - {message}",
             llm_provider=custom_llm_provider,
             model=model,
-            response=getattr(original_exception, "response", None),
             litellm_debug_info=extra_information,
         )
     elif "Mistral API raised a streaming error" in error_str:

--- a/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
+++ b/tests/test_litellm/litellm_core_utils/test_exception_mapping_utils.py
@@ -300,6 +300,27 @@ def test_lemonade_context_window_error_mapping():
     assert excinfo.value.model == model
 
 
+def test_openai_missing_credentials_maps_to_authentication_error():
+    original_exception = OpenAIError(
+        status_code=500,
+        message=(
+            "Missing credentials. Please pass an `api_key`, `workload_identity`, "
+            "`admin_api_key`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` "
+            "environment variable."
+        ),
+    )
+
+    with pytest.raises(litellm.AuthenticationError) as excinfo:
+        exception_type(
+            model="gpt-4o-mini",
+            original_exception=original_exception,
+            custom_llm_provider="openai",
+        )
+
+    assert excinfo.value.status_code == 401
+    assert excinfo.value.llm_provider == "openai"
+
+
 @pytest.mark.parametrize(
     "error_message",
     [


### PR DESCRIPTION
## TLDR

Problem this solves:

- Missing OpenAI credentials can retain a fabricated 500 response
- Newer credential wording can bypass authentication classification

How it solves it:

- Recognize both OpenAI SDK missing-credential messages
- Rebuild local authentication failures with a 401 response

## Relevant issues

Fixes #35860

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA)

## Screenshots / Proof of Fix

The public SDK call was run with every OpenAI credential source cleared, so credential validation exits before a provider request

At base commit 420d9a7e9f:

```text
AuthenticationError
500
litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
```

At fix commit 7c5ce2471f:

```text
AuthenticationError
401
litellm.AuthenticationError: AuthenticationError: OpenAIException - The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
```

Regression suite:

```text
63 passed in 4.46s
```

## Type

Bug Fix

## Changes

The existing OpenAI authentication branch now recognizes the newer "Missing credentials" message in addition to the older "api_key client option" wording

Local credential failures no longer reuse the wrapper's synthetic 500 response, so the resulting AuthenticationError exposes status 401 and is not treated as a transient server failure

A regression test covers the newer SDK message after it has been wrapped with status 500

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
