### PR TITLE
fix(router): preserve requested model for wildcard deployments

### DIFF
--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4491,9 +4491,6 @@ class Router:
 
             data: Final = deployment["litellm_params"].copy()
             deployment_model_name: Final = data["model"]
-            # Wildcard deployments provide provider credentials but must keep
-            # the concrete model requested by the caller. Passing the wildcard
-            # through prevents model-cost lookups and Responses API bridging.
             model_name = (
                 model
                 if "*" in deployment_model_name and "*" not in model

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -4490,7 +4490,15 @@ class Router:
             self._update_kwargs_with_deployment(deployment=deployment, kwargs=kwargs, function_name=function_name)
 
             data: Final = deployment["litellm_params"].copy()
-            model_name: Final = data["model"]
+            deployment_model_name: Final = data["model"]
+            # Wildcard deployments provide provider credentials but must keep
+            # the concrete model requested by the caller. Passing the wildcard
+            # through prevents model-cost lookups and Responses API bridging.
+            model_name = (
+                model
+                if "*" in deployment_model_name and "*" not in model
+                else deployment_model_name
+            )
             self.total_calls[model_name] += 1
 
             self._add_deployment_model_to_endpoint_for_llm_passthrough_route(

--- a/tests/router_unit_tests/test_router_wildcard_model.py
+++ b/tests/router_unit_tests/test_router_wildcard_model.py
@@ -1,0 +1,36 @@
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
+import pytest
+
+from litellm import Router
+
+
+@pytest.mark.asyncio
+async def test_wildcard_deployment_preserves_requested_model() -> None:
+    """Provider wildcard credentials must not replace the concrete request model."""
+    router = Router(model_list=[])
+    deployment = {
+        "model_name": "openai/*",
+        "litellm_params": {"model": "openai/*", "api_key": "sk-test"},
+        "model_info": {"id": "wildcard-deployment"},
+    }
+    original_function = AsyncMock(return_value="response")
+
+    with (
+        patch.object(
+            router,
+            "async_get_available_deployment",
+            new=AsyncMock(return_value=deployment),
+        ),
+        patch.object(router, "async_routing_strategy_pre_call_checks", new=AsyncMock()),
+        patch.object(router, "_get_client", return_value=None),
+    ):
+        result = await router._ageneric_api_call_with_fallbacks_helper(
+            model="openai/gpt-5.3-codex",
+            original_generic_function=original_function,
+            messages=[{"role": "user", "content": "ping"}],
+        )
+
+    assert result == "response"
+    assert original_function.await_args.kwargs["model"] == "openai/gpt-5.3-codex"

--- a/tests/router_unit_tests/test_router_wildcard_model.py
+++ b/tests/router_unit_tests/test_router_wildcard_model.py
@@ -1,5 +1,4 @@
 from unittest.mock import AsyncMock
-from unittest.mock import patch
 
 import pytest
 
@@ -9,28 +8,22 @@ from litellm import Router
 @pytest.mark.asyncio
 async def test_wildcard_deployment_preserves_requested_model() -> None:
     """Provider wildcard credentials must not replace the concrete request model."""
-    router = Router(model_list=[])
-    deployment = {
-        "model_name": "openai/*",
-        "litellm_params": {"model": "openai/*", "api_key": "sk-test"},
-        "model_info": {"id": "wildcard-deployment"},
-    }
+    router = Router(
+        model_list=[
+            {
+                "model_name": "openai/*",
+                "litellm_params": {"model": "openai/*", "api_key": "sk-test"},
+                "model_info": {"id": "wildcard-deployment"},
+            }
+        ]
+    )
     original_function = AsyncMock(return_value="response")
 
-    with (
-        patch.object(
-            router,
-            "async_get_available_deployment",
-            new=AsyncMock(return_value=deployment),
-        ),
-        patch.object(router, "async_routing_strategy_pre_call_checks", new=AsyncMock()),
-        patch.object(router, "_get_client", return_value=None),
-    ):
-        result = await router._ageneric_api_call_with_fallbacks_helper(
-            model="openai/gpt-5.3-codex",
-            original_generic_function=original_function,
-            messages=[{"role": "user", "content": "ping"}],
-        )
+    result = await router._ageneric_api_call_with_fallbacks_helper(
+        model="openai/gpt-5.3-codex",
+        original_generic_function=original_function,
+        messages=[{"role": "user", "content": "ping"}],
+    )
 
     assert result == "response"
     assert original_function.await_args.kwargs["model"] == "openai/gpt-5.3-codex"


### PR DESCRIPTION
## Summary

When the Router selects an openai/* deployment, the deployment model is provider configuration, not the concrete model requested by the caller. Passing the wildcard through prevents model-cost resolution and the Responses API bridge from seeing the requested model.

Keep wildcard deployments for credentials and matching, but pass the caller's concrete model to the generic API function and call accounting.

## Validation

- uv run pytest tests/router_unit_tests/test_router_wildcard_model.py -q (1 passed)
- Ruff check passed for the changed router and test files
- git diff --check

Fixes #35879