### PR TITLE
fix(bootstrap): switch to the dashboard node floor via nvm or fnm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ install-dev:
 bootstrap:
 	$(UV) sync --inexact --frozen --extra proxy --group proxy-dev --group e2e-dev
 	$(UV_RUN) python scripts/prisma_generate_if_needed.py
-	cd ui/litellm-dashboard && npm install --no-audit --no-fund
+	cd ui/litellm-dashboard && ../../scripts/with_dashboard_node.sh npm install --no-audit --no-fund
 	@main_root=$$(git worktree list --porcelain | head -1 | sed 's/^worktree //'); \
 	if [ "$$main_root" != "$$(git rev-parse --show-toplevel)" ] && [ -f "$$main_root/.env" ] && [ ! -f .env ]; then \
 		cp "$$main_root/.env" .env && echo "bootstrap: copied .env from $$main_root"; \

--- a/scripts/with_dashboard_node.sh
+++ b/scripts/with_dashboard_node.sh
@@ -28,9 +28,9 @@ nvm_script="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
 if [ -r "$nvm_script" ]; then
     echo "with_dashboard_node: node ${current:-missing} is below the dashboard floor $floor; switching to $pinned via nvm" >&2
     set +eu
-    . "$nvm_script" --no-use
-    nvm install "$pinned" >&2
-    nvm use "$pinned" >&2
+    . "$nvm_script" --no-use || { echo "with_dashboard_node: could not load nvm from $nvm_script" >&2; exit 1; }
+    nvm install "$pinned" >&2 || { echo "with_dashboard_node: nvm install $pinned failed" >&2; exit 1; }
+    nvm use "$pinned" >&2 || { echo "with_dashboard_node: nvm use $pinned failed" >&2; exit 1; }
     set -eu
     exec "$@"
 fi

--- a/scripts/with_dashboard_node.sh
+++ b/scripts/with_dashboard_node.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -eu
+
+[ $# -gt 0 ] || { echo "usage: $0 <command> [args...]" >&2; exit 2; }
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+dashboard="$repo_root/ui/litellm-dashboard"
+floor=$(sed -n 's/.*"node": *">=\([0-9][0-9.]*\)".*/\1/p' "$dashboard/package.json")
+pinned=$(tr -d '[:space:]' < "$dashboard/.nvmrc")
+floor="${floor:-$pinned}"
+
+meets_floor() {
+    awk -v have="$1" -v need="$2" 'BEGIN {
+        split(have, h, "."); split(need, n, ".")
+        for (i = 1; i <= 3; i++) {
+            if (h[i] + 0 < n[i] + 0) exit 1
+            if (h[i] + 0 > n[i] + 0) exit 0
+        }
+    }'
+}
+
+current=$(node --version 2>/dev/null | tr -d 'v' || true)
+if [ -n "$current" ] && meets_floor "$current" "$floor"; then
+    exec "$@"
+fi
+
+nvm_script="${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+if [ -r "$nvm_script" ]; then
+    echo "with_dashboard_node: node ${current:-missing} is below the dashboard floor $floor; switching to $pinned via nvm" >&2
+    set +eu
+    . "$nvm_script" --no-use
+    nvm install "$pinned" >&2
+    nvm use "$pinned" >&2
+    set -eu
+    exec "$@"
+fi
+
+if command -v fnm > /dev/null 2>&1; then
+    echo "with_dashboard_node: node ${current:-missing} is below the dashboard floor $floor; switching to $pinned via fnm" >&2
+    fnm install "$pinned" >&2
+    eval "$(fnm env)"
+    fnm use "$pinned" >&2
+    exec "$@"
+fi
+
+cat >&2 <<EOF
+with_dashboard_node: node ${current:-missing} does not meet ui/litellm-dashboard's engines floor (>= $floor) and neither nvm nor fnm is available to switch automatically.
+Fix it with one of:
+  - install nvm (https://github.com/nvm-sh/nvm) and re-run; it will pick up node $pinned for you
+  - or install/upgrade node yourself to >= $floor (e.g. brew install node), then re-run
+EOF
+exit 1

--- a/tests/test_litellm/test_with_dashboard_node.py
+++ b/tests/test_litellm/test_with_dashboard_node.py
@@ -1,0 +1,106 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "with_dashboard_node.sh"
+
+
+def _floor() -> str:
+    pkg = json.loads((ROOT / "ui" / "litellm-dashboard" / "package.json").read_text())
+    return pkg["engines"]["node"].removeprefix(">=")
+
+
+def _bump_major(version: str, delta: int) -> str:
+    major, minor, patch = version.split(".")
+    return f"{int(major) + delta}.{minor}.{patch}"
+
+
+def _fake_node(bin_dir: Path, version: str) -> Path:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    node = bin_dir / "node"
+    node.write_text(f'#!/bin/sh\necho "v{version}"\n')
+    node.chmod(0o755)
+    return bin_dir
+
+
+def _run(bin_dirs: list[Path], home: Path) -> subprocess.CompletedProcess[str]:
+    path = os.pathsep.join([*(str(b) for b in bin_dirs), "/usr/bin", "/bin"])
+    home.mkdir(parents=True, exist_ok=True)
+    return subprocess.run(
+        [str(SCRIPT), "sh", "-c", "node --version"],
+        capture_output=True,
+        text=True,
+        env={"PATH": path, "HOME": str(home)},
+    )
+
+
+def test_node_meeting_the_floor_runs_the_command_as_is(tmp_path):
+    bins = _fake_node(tmp_path / "bin", _floor())
+    proc = _run([bins], tmp_path / "home")
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == f"v{_floor()}"
+
+
+def test_node_above_the_floor_runs_the_command_as_is(tmp_path):
+    above = _bump_major(_floor(), 1)
+    bins = _fake_node(tmp_path / "bin", above)
+    proc = _run([bins], tmp_path / "home")
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == f"v{above}"
+
+
+def test_old_node_without_any_manager_fails_with_instructions(tmp_path):
+    bins = _fake_node(tmp_path / "bin", _bump_major(_floor(), -1))
+    proc = _run([bins], tmp_path / "home")
+    assert proc.returncode == 1
+    assert "does not meet" in proc.stderr
+    assert _floor() in proc.stderr
+    assert "nvm" in proc.stderr
+
+
+def test_missing_node_without_any_manager_fails_with_instructions(tmp_path):
+    proc = _run([], tmp_path / "home")
+    assert proc.returncode == 1
+    assert "missing" in proc.stderr
+
+
+def test_old_node_switches_via_nvm_when_present(tmp_path):
+    old = _fake_node(tmp_path / "old-bin", _bump_major(_floor(), -1))
+    new = _fake_node(tmp_path / "new-bin", "99.0.0")
+    home = tmp_path / "home"
+    nvm_dir = home / ".nvm"
+    nvm_dir.mkdir(parents=True)
+    (nvm_dir / "nvm.sh").write_text(
+        f'nvm() {{ [ "$1" = use ] && PATH="{new}:$PATH"; return 0; }}\n'
+    )
+    proc = _run([old], home)
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "v99.0.0"
+    assert "via nvm" in proc.stderr
+
+
+def test_old_node_switches_via_fnm_when_nvm_is_absent(tmp_path):
+    old = _fake_node(tmp_path / "old-bin", _bump_major(_floor(), -1))
+    new = _fake_node(tmp_path / "new-bin", "99.0.0")
+    fnm = tmp_path / "old-bin" / "fnm"
+    fnm.write_text(
+        f'#!/bin/sh\n[ "$1" = env ] && echo \'export PATH="{new}:$PATH"\'\nexit 0\n'
+    )
+    fnm.chmod(0o755)
+    proc = _run([old], tmp_path / "home")
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "v99.0.0"
+    assert "via fnm" in proc.stderr
+
+
+def test_no_command_is_a_usage_error(tmp_path):
+    proc = subprocess.run(
+        [str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(tmp_path)},
+    )
+    assert proc.returncode == 2
+    assert "usage" in proc.stderr

--- a/tests/test_litellm/test_with_dashboard_node.py
+++ b/tests/test_litellm/test_with_dashboard_node.py
@@ -95,6 +95,38 @@ def test_old_node_switches_via_fnm_when_nvm_is_absent(tmp_path):
     assert "via fnm" in proc.stderr
 
 
+def _nvm_home(tmp_path, nvm_sh: str) -> Path:
+    home = tmp_path / "home"
+    nvm_dir = home / ".nvm"
+    nvm_dir.mkdir(parents=True)
+    (nvm_dir / "nvm.sh").write_text(nvm_sh)
+    return home
+
+
+def test_failing_nvm_load_stops_before_running_the_command(tmp_path):
+    old = _fake_node(tmp_path / "old-bin", _bump_major(_floor(), -1))
+    proc = _run([old], _nvm_home(tmp_path, "false\n"))
+    assert proc.returncode == 1
+    assert "could not load nvm" in proc.stderr
+    assert proc.stdout == ""
+
+
+def test_failing_nvm_install_stops_before_running_the_command(tmp_path):
+    old = _fake_node(tmp_path / "old-bin", _bump_major(_floor(), -1))
+    proc = _run([old], _nvm_home(tmp_path, 'nvm() { [ "$1" = install ] && return 1; return 0; }\n'))
+    assert proc.returncode == 1
+    assert "nvm install" in proc.stderr
+    assert proc.stdout == ""
+
+
+def test_failing_nvm_use_stops_before_running_the_command(tmp_path):
+    old = _fake_node(tmp_path / "old-bin", _bump_major(_floor(), -1))
+    proc = _run([old], _nvm_home(tmp_path, 'nvm() { [ "$1" = use ] && return 1; return 0; }\n'))
+    assert proc.returncode == 1
+    assert "nvm use" in proc.stderr
+    assert proc.stdout == ""
+
+
 def test_no_command_is_a_usage_error(tmp_path):
     proc = subprocess.run(
         [str(SCRIPT)],


### PR DESCRIPTION
## TLDR

Problem this solves:

- make bootstrap dies with EBADENGINE when the shell's node is old
- the dashboard .nvmrc pins 24.19.0 but make never reads it

How it solves it:

- npm install now runs through scripts/with_dashboard_node.sh
- the wrapper activates the .nvmrc node via nvm or fnm
- if nvm fails to load, install, or activate the pin it exits 1 instead of running npm on the old node
- without a manager it fails fast with install instructions

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before, at 31a86daa85 (the branch point), in a shell whose default node is v20.20.2, the npm install leg that bootstrap runs verbatim fails the engines check:

```
$ node --version
v20.20.2
$ cd ui/litellm-dashboard && npm install --no-audit --no-fund
npm error code EBADENGINE
npm error engine Unsupported engine
npm error notsup Required: {"node":">=24.14.1","npm":">=11.10.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

After, at c418ea59ae, the same shell runs make bootstrap end to end: the wrapper spots the old node, activates the pinned version through nvm, and the install proceeds:

```
$ node --version
v20.20.2
$ make bootstrap
cd ui/litellm-dashboard && ../../scripts/with_dashboard_node.sh npm install --no-audit --no-fund
with_dashboard_node: node 20.20.2 is below the dashboard floor 24.14.1; switching to 24.19.0 via nvm
Now using node v24.19.0 (npm v11.17.0)
up to date in 723ms
bootstrap: done
$ echo $?
0
```

A node already at or above the floor is exec'd as is with no manager involved, and with neither nvm nor fnm present the wrapper exits 1 with copy-paste install steps instead of npm's opaque EBADENGINE

## Type

🐛 Bug Fix
🚄 Infrastructure

## Changes

Makefile's bootstrap target wraps its npm install in the new scripts/with_dashboard_node.sh. The wrapper reads the engines floor from ui/litellm-dashboard/package.json (falling back to .nvmrc), execs the command untouched when the current node already meets it, otherwise sources nvm (or uses fnm) to install and activate the pinned .nvmrc version, failing fast with the step that broke if nvm cannot load, install, or activate it, and when no version manager exists it prints exact remediation steps and fails fast

tests/test_litellm/test_with_dashboard_node.py covers the pass-through at and above the floor, the nvm and fnm switching paths via fake managers on PATH, the no-manager failure with instructions for both old and missing node, the failing nvm load, install, and use paths each stopping before the wrapped command runs, and the usage error

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

