### PR TITLE
fix(minimax): normalize Anthropic message URLs

### DIFF
--- a/litellm/llms/minimax/messages/transformation.py
+++ b/litellm/llms/minimax/messages/transformation.py
@@ -2,6 +2,8 @@
 MiniMax Anthropic transformation config - extends AnthropicConfig for MiniMax's Anthropic-compatible API
 """
 
+from urllib.parse import urlsplit, urlunsplit
+
 import litellm
 from litellm.llms.anthropic.experimental_pass_through.messages.transformation import (
     AnthropicMessagesConfig,
@@ -60,15 +62,26 @@ class MinimaxMessagesConfig(AnthropicMessagesConfig):
         Get the complete URL for MiniMax API.
         Override to ensure we use MiniMax's endpoint, not Anthropic's.
         """
-        # Get the base URL (either provided or default MiniMax endpoint)
         base_url = self.get_api_base(api_base=api_base)
-
-        # If the base URL already includes the full path, return it
-        if base_url.endswith("/v1/messages"):
-            return base_url
-
-        # Otherwise append the messages endpoint
-        if base_url.endswith("/"):
-            return f"{base_url}v1/messages"
-        else:
-            return f"{base_url}/v1/messages"
+        parsed_url = urlsplit(base_url)
+        path_parts = tuple(part for part in parsed_url.path.split("/") if part)
+        base_path_parts = (
+            path_parts[:-2]
+            if path_parts[-2:] == ("v1", "messages")
+            else path_parts[:-1]
+            if path_parts[-1:] in (("v1",), ("messages",))
+            else path_parts
+        )
+        provider_path_parts = (
+            base_path_parts if base_path_parts[-1:] == ("anthropic",) else (*base_path_parts, "anthropic")
+        )
+        path = "/" + "/".join((*provider_path_parts, "v1", "messages"))
+        return urlunsplit(
+            (
+                parsed_url.scheme,
+                parsed_url.netloc,
+                path,
+                parsed_url.query,
+                parsed_url.fragment,
+            )
+        )

--- a/tests/test_litellm/llms/minimax/messages/test_transformation.py
+++ b/tests/test_litellm/llms/minimax/messages/test_transformation.py
@@ -8,9 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-sys.path.insert(
-    0, os.path.abspath("../")
-)  # Adds the parent directory to the system path
+sys.path.insert(0, os.path.abspath("../"))  # Adds the parent directory to the system path
 
 import litellm
 from litellm import completion
@@ -29,10 +27,59 @@ def test_minimax_anthropic_config():
     assert api_base == "https://api.minimax.io/anthropic/v1/messages"
 
     # Test get_api_base with custom value
-    custom_base = config.get_api_base(
-        api_base="https://api.minimaxi.com/anthropic/v1/messages"
-    )
+    custom_base = config.get_api_base(api_base="https://api.minimaxi.com/anthropic/v1/messages")
     assert custom_base == "https://api.minimaxi.com/anthropic/v1/messages"
+
+
+@pytest.mark.parametrize(
+    ("api_base", "expected_url"),
+    [
+        (
+            "https://api.minimax.io",
+            "https://api.minimax.io/anthropic/v1/messages",
+        ),
+        (
+            "https://api.minimax.io/",
+            "https://api.minimax.io/anthropic/v1/messages",
+        ),
+        (
+            "https://api.minimax.io/v1",
+            "https://api.minimax.io/anthropic/v1/messages",
+        ),
+        (
+            "https://api.minimax.io/v1/messages",
+            "https://api.minimax.io/anthropic/v1/messages",
+        ),
+        (
+            "https://api.minimax.io/anthropic",
+            "https://api.minimax.io/anthropic/v1/messages",
+        ),
+        (
+            "https://api.minimax.io/anthropic/v1",
+            "https://api.minimax.io/anthropic/v1/messages",
+        ),
+        (
+            "https://api.minimax.io/anthropic/v1/messages",
+            "https://api.minimax.io/anthropic/v1/messages",
+        ),
+        (
+            "https://gateway.example/minimax?region=global#messages",
+            "https://gateway.example/minimax/anthropic/v1/messages?region=global#messages",
+        ),
+    ],
+)
+def test_minimax_messages_complete_url_normalizes_api_base(api_base: str, expected_url: str):
+    config = MinimaxMessagesConfig()
+
+    complete_url = config.get_complete_url(
+        api_base=api_base,
+        api_key="test-key",
+        model="MiniMax-M2.1",
+        optional_params={},
+        litellm_params={},
+    )
+
+    assert complete_url == expected_url
 
 
 def test_minimax_provider_routing():


### PR DESCRIPTION
## Summary

Normalize MiniMax Anthropic-compatible message URLs without duplicating endpoint segments.

## Why

The public transformation could construct an invalid URL when the configured base already contained the compatible message path.

## Scope

MiniMax Messages URL construction and public regression tests only.

## Validation

- Focused tests: 11 passed, 3 skipped
- Full `make pre-commit`: passed
- Parent: `491eda319cd1cd1f75a2ef165c6b06ce6129c282`

Source audit entry: `9eb7cb1264`.
