### PR TITLE
fix(google-genai): forward explicit model identifiers

### DIFF
--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -284,7 +284,7 @@ class GoogleGenAIAdapter:
         Returns:
             Dict[str, Any]
         """
-        allowed_fields = GenericLiteLLMParams.model_fields.keys()
+        allowed_fields = frozenset((*GenericLiteLLMParams.model_fields, "model_id"))
         if litellm_params:
             litellm_dict = litellm_params.model_dump(exclude_none=True)
             for key, value in litellm_dict.items():

--- a/tests/test_litellm/google_genai/test_google_genai_adapter.py
+++ b/tests/test_litellm/google_genai/test_google_genai_adapter.py
@@ -1276,3 +1276,26 @@ def test_inline_data_backward_compatibility_text_only():
         content, str
     ), "Content should be a string for text-only messages (backward compatibility)"
     assert content == "Hello, how are you?"
+
+
+def test_add_generic_litellm_params_forwards_only_explicit_extra_fields():
+    from litellm.google_genai.adapters.transformation import GoogleGenAIAdapter
+    from litellm.types.router import GenericLiteLLMParams
+
+    model_id = "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/test-profile"
+    litellm_params = GenericLiteLLMParams.model_validate(
+        {
+            "model_id": model_id,
+            "api_base": "https://example.com",
+            "provider_internal_value": "not-forwarded",
+        }
+    )
+
+    result = GoogleGenAIAdapter()._add_generic_litellm_params_to_request(
+        completion_request_dict={},
+        litellm_params=litellm_params,
+    )
+
+    assert result["model_id"] == model_id
+    assert result["api_base"] == "https://example.com"
+    assert "provider_internal_value" not in result


### PR DESCRIPTION
## Summary

Forward an explicitly supplied model identifier through the Google GenAI adapter.

## Why

The adapter could discard the caller's explicit model identifier, which is required for provider-side model selection in the public contract.

## Scope

Google GenAI transformation and public adapter regression tests only.

## Validation

- Focused tests: 29 passed, 1 existing warning
- Full `make pre-commit`: passed
- Parent: `491eda319cd1cd1f75a2ef165c6b06ce6129c282`

Source audit entry: `309bc74e58`.
