### PR TITLE
fix(router): preserve disabled pre-call checks

### DIFF
--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -128,6 +128,7 @@ class UpdateRouterConfig(BaseModel):
     fallbacks: Optional[List[dict]] = None
     context_window_fallbacks: Optional[List[dict]] = None
     model_group_alias: Optional[Dict[str, Union[str, Dict]]] = {}
+    enable_pre_call_checks: Optional[bool] = None
     enable_tag_filtering: Optional[bool] = None
 
     model_config = ConfigDict(protected_namespaces=())

--- a/tests/test_litellm/test_router_retry_policy_update.py
+++ b/tests/test_litellm/test_router_retry_policy_update.py
@@ -66,6 +66,12 @@ def test_update_router_config_accepts_retry_policy_payload():
     assert dumped["retry_policy"]["TimeoutErrorRetries"] == 3
 
 
+def test_update_router_config_preserves_disabled_pre_call_checks():
+    config = UpdateRouterConfig(enable_pre_call_checks=False)
+
+    assert config.model_dump(exclude_none=True)["enable_pre_call_checks"] is False
+
+
 def test_update_router_config_rejects_malformed_retry_policy():
     """The field is typed as RetryPolicy, so /config/update validates the
     payload at the boundary and rejects non-numeric counts with a 422 instead

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -32870,6 +32870,8 @@ export interface components {
             }[] | null;
             /** Cooldown Time */
             cooldown_time?: number | null;
+            /** Enable Pre Call Checks */
+            enable_pre_call_checks?: boolean | null;
             /** Enable Tag Filtering */
             enable_tag_filtering?: boolean | null;
             /** Fallbacks */


### PR DESCRIPTION
## Summary

Preserve an explicitly disabled `enable_pre_call_checks=false` setting when router configuration is hot-reloaded.

## Why

The reload path previously dropped the false value, allowing pre-call checks to become enabled unexpectedly.

## Scope

Public router configuration and its regression test only. No AthenAI routing policy or provider behavior.

## Validation

- Mapped tests: 11 passed
- Full `make pre-commit`: passed
- Parent: `491eda319cd1cd1f75a2ef165c6b06ce6129c282`

Source audit entry: `21c7657962`.
