### PR TITLE
test: skip a streaming test that passes and fails on the same commit

### DIFF
--- a/tests/local_testing/test_streaming.py
+++ b/tests/local_testing/test_streaming.py
@@ -1807,6 +1807,15 @@ async def test_openai_stream_options_call(model, sync):
     )
 
 
+@pytest.mark.skip(
+    reason=(
+        "LIT-TBD: ModelResponseStream.model_dump() intermittently raises \"'MockValSer' object is "
+        "not an instance of 'SchemaSerializer'\", which the stream wrapper resurfaces as an "
+        "InternalServerError. Failed on 3c0b1db6 and passed on the rerun of that same commit. The "
+        "cause is unconfirmed: e8356c18d0 fixed a MockValSer crash in this same handler by "
+        "normalizing provider logprobs, so this may be a serialization bug rather than test pollution"
+    )
+)
 def test_openai_stream_options_call_text_completion():
     litellm.set_verbose = False
     for idx in range(3):


### PR DESCRIPTION
## TLDR

Problem this solves:

- One streaming test passes and fails on the same commit
- Its failures make CircleCI unusable as a merge signal

How it solves it:

- Skips that one test, with the evidence in the reason
- No other test is touched

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

No tests are added: this removes one from the run rather than adding behavior. The other two are not yet knowable, since CI has not run on this branch and Greptile reviews on open

## Skipped test, failure rate, and evidence

`tests/local_testing/test_streaming.py::test_openai_stream_options_call_text_completion`

**Observed failure rate: 1 of 8 runs (12.5%).** That is every run CircleCI retains for this project, so it is a small sample and worth reading as such

The evidence is a same-commit disagreement rather than the rate. On commit `3c0b1db6` the job `local_testing_part2` failed in workflow `556313cc-e2d8-41b2-8da2-8513c8dc83a2` (job `a2a70857`), and the rerun of that same commit, workflow `8665db04-a372-4ab6-bfbb-5f7cce696ff5` (job `8eefa345`), passed. Same tree, same test, opposite outcomes. It passed in the other six runs

`ModelResponseStream.model_dump()` raises `TypeError: 'MockValSer' object is not an instance of 'SchemaSerializer'` at `litellm/litellm_core_utils/streaming_handler.py:1768`, and the stream wrapper remaps it through `MidStreamFallbackError` into an `InternalServerError`

**The cause is not confirmed, and that is the open question here.** `MockValSer` is pydantic's placeholder for a model whose schema was never built, which can come from cross-test pollution in an xdist worker or from a provider response shape that reaches an un-rebuilt model. Commit `e8356c18d0` fixed a MockValSer crash in this same handler by normalizing provider logprobs, so the second reading has direct precedent and this test calls the live OpenAI API

That matters because skipping a real product bug is worse than living with a flaky test. If it turns out to be the serialization bug, the fix belongs in `streaming_handler.py` and this skip should come off rather than stay

## Screenshots / Proof of Fix

This change has no runtime surface. It adds no endpoint and no provider behavior, and touches nothing the proxy serves, so there is no request to curl against a live instance. What it does, captured at `2d118fc562`:

```
$ python -m pytest "tests/local_testing/test_streaming.py::test_openai_stream_options_call_text_completion" -rs
tests/local_testing/test_streaming.py s                                  [100%]
SKIPPED [1] tests/local_testing/test_streaming.py:1810: LIT-TBD: ModelResponseStream.model_dump()
intermittently raises "'MockValSer' object is not an instance of 'SchemaSerializer'" ...
1 skipped in 0.06s
```

The file carries 139 pre-existing ruff errors on both sides of this change, so the nine added lines introduce none:

```
base: Found 139 errors
now : Found 139 errors
```

## Type

✅ Test

## Changes

One `@pytest.mark.skip` on `test_openai_stream_options_call_text_completion`, nine lines in one file. The reason carries the ticket, the failing and passing workflow ids for the same commit, and the competing explanation for the cause, so whoever picks it up does not have to re-derive any of it

`LIT-TBD` is a placeholder. It needs the real ticket before this merges

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

This change cannot alter product behavior, so it cannot introduce a customer-facing regression. It does remove one test from the signal, which is the cost being accepted here
