### PR TITLE
fix: carry functionDeclaration parameters into google_genai tool translation

### DIFF
--- a/litellm/google_genai/adapters/transformation.py
+++ b/litellm/google_genai/adapters/transformation.py
@@ -320,6 +320,8 @@ class GoogleGenAIAdapter:
                         function_chunk["description"] = func_decl["description"]
                     if "parametersJsonSchema" in func_decl:
                         function_chunk["parameters"] = func_decl["parametersJsonSchema"]
+                    elif "parameters" in func_decl:
+                        function_chunk["parameters"] = func_decl["parameters"]
 
                     openai_tool = {"type": "function", "function": function_chunk}
                     openai_tools.append(openai_tool)

--- a/tests/test_litellm/google_genai/test_google_genai_adapter_fixes.py
+++ b/tests/test_litellm/google_genai/test_google_genai_adapter_fixes.py
@@ -82,6 +82,98 @@ def test_parameters_json_schema_transformation():
     assert "location" in tool["function"]["parameters"]["properties"]
 
 
+def test_parameters_schema_transformation():
+    """Test that a functionDeclaration's `parameters` Schema is carried over and normalized.
+
+    Google GenAI function declarations carry their argument schema in `parameters`
+    (a Schema, whose type enums are uppercase) as well as in the newer
+    `parametersJsonSchema`. Only reading the latter silently dropped the whole
+    argument schema, leaving the model with a tool it could not call correctly.
+    """
+    adapter = GoogleGenAIAdapter()
+
+    tools = [
+        {
+            "functionDeclarations": [
+                {
+                    "name": "get_weather",
+                    "description": "Get current weather information",
+                    "parameters": {
+                        "type": "OBJECT",
+                        "properties": {
+                            "location": {
+                                "type": "STRING",
+                                "description": "The city name",
+                            },
+                            "days": {"type": "INTEGER"},
+                        },
+                        "required": ["location"],
+                    },
+                }
+            ]
+        }
+    ]
+
+    openai_tools = adapter._transform_google_genai_tools_to_openai(tools)
+
+    assert len(openai_tools) == 1
+    function = openai_tools[0]["function"]
+    assert function["name"] == "get_weather"
+
+    parameters = function["parameters"]
+    assert parameters["type"] == "object"
+    assert parameters["properties"]["location"]["type"] == "string"
+    assert parameters["properties"]["location"]["description"] == "The city name"
+    assert parameters["properties"]["days"]["type"] == "integer"
+    assert parameters["required"] == ["location"]
+
+
+def test_parameters_json_schema_takes_precedence_over_parameters():
+    """Test that parametersJsonSchema still wins when both fields are present."""
+    adapter = GoogleGenAIAdapter()
+
+    tools = [
+        {
+            "functionDeclarations": [
+                {
+                    "name": "get_weather",
+                    "parametersJsonSchema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                    "parameters": {
+                        "type": "OBJECT",
+                        "properties": {"location": {"type": "STRING"}},
+                    },
+                }
+            ]
+        }
+    ]
+
+    openai_tools = adapter._transform_google_genai_tools_to_openai(tools)
+
+    parameters = openai_tools[0]["function"]["parameters"]
+    assert "city" in parameters["properties"]
+    assert "location" not in parameters["properties"]
+
+
+def test_function_declaration_without_parameters():
+    """Test that a functionDeclaration with no argument schema stays parameter-less."""
+    adapter = GoogleGenAIAdapter()
+
+    tools = [
+        {
+            "functionDeclarations": [
+                {"name": "get_time", "description": "Get the current time"}
+            ]
+        }
+    ]
+
+    openai_tools = adapter._transform_google_genai_tools_to_openai(tools)
+
+    assert "parameters" not in openai_tools[0]["function"]
+
+
 def test_streaming_tool_call_with_empty_args():
     """Test that streaming tool calls with empty arguments are handled correctly"""
     from litellm.google_genai.adapters.transformation import (

--- a/tests/test_litellm/google_genai/test_google_genai_adapter_fixes.py
+++ b/tests/test_litellm/google_genai/test_google_genai_adapter_fixes.py
@@ -83,13 +83,7 @@ def test_parameters_json_schema_transformation():
 
 
 def test_parameters_schema_transformation():
-    """Test that a functionDeclaration's `parameters` Schema is carried over and normalized.
-
-    Google GenAI function declarations carry their argument schema in `parameters`
-    (a Schema, whose type enums are uppercase) as well as in the newer
-    `parametersJsonSchema`. Only reading the latter silently dropped the whole
-    argument schema, leaving the model with a tool it could not call correctly.
-    """
+    """Test that a functionDeclaration's `parameters` Schema is carried over and normalized"""
     adapter = GoogleGenAIAdapter()
 
     tools = [


### PR DESCRIPTION
## TLDR

Problem this solves:

- Gemini tools using `parameters` lose their argument schema
- The model then invents its own argument names
- `normalize_tool_schema` never receives the uppercase types it handles

How it solves it:

- Read `parameters` when `parametersJsonSchema` is absent
- `normalize_tool_schema` then lowercases the Schema type enums
- `parametersJsonSchema` still wins when both are present

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The adapter only runs when the backing provider has no native generateContent config, so the
config below points a Gemini model at Google's OpenAI compatible endpoint. That routes the request
through `GoogleGenAIAdapter` rather than the native Gemini path, which is the code this PR changes

```yaml
model_list:
  - model_name: bridged-model
    litellm_params:
      model: openai/gemini-3.6-flash
      api_base: https://generativelanguage.googleapis.com/v1beta/openai
      api_key: os.environ/GEMINI_API_KEY

general_settings:
  master_key: sk-1234
```

```bash
python litellm/proxy/proxy_cli.py --config config.yaml --port 4000
```

The tool below declares `zx_ident` and `rev_no` in `parameters`. Those names cannot be guessed, so
whether the schema survived translation is visible in the response

```bash
curl -s http://localhost:4000/v1beta/models/bridged-model:generateContent \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer sk-1234' \
  -d '{"contents":[{"role":"user","parts":[{"text":"Fetch record ABC-123 at revision 7."}]}],"tools":[{"functionDeclarations":[{"name":"fetch_record","description":"Fetch a stored record","parameters":{"type":"OBJECT","properties":{"zx_ident":{"type":"STRING","description":"Record identifier"},"rev_no":{"type":"INTEGER","description":"Revision number"}},"required":["zx_ident","rev_no"]}}]}]}'
```

Before, at `4fcaf7d`:

```json
{"candidates":[{"content":{"parts":[{"functionCall":{"name":"fetch_record","args":{"id":"ABC-123","revision":7}}}],"role":"model"},"finishReason":"STOP","index":0,"safetyRatings":[]}],"usageMetadata":{"promptTokenCount":30,"candidatesTokenCount":24,"totalTokenCount":421}}
```

The model returned `id` and `revision`, which it invented, because it never saw the declared names.
A caller dispatching on `zx_ident` and `rev_no` gets nothing it can use

After, at `0c44266`:

```json
{"candidates":[{"content":{"parts":[{"functionCall":{"name":"fetch_record","args":{"zx_ident":"ABC-123","rev_no":7}}}],"role":"model"},"finishReason":"STOP","index":0,"safetyRatings":[]}],"usageMetadata":{"promptTokenCount":88,"candidatesTokenCount":28,"totalTokenCount":209}}
```

The argument names now match the declaration. `promptTokenCount` going from 30 to 88 is the schema
itself reaching the model, and the uppercase `OBJECT`, `STRING` and `INTEGER` enums were lowercased
on the way through by the existing `normalize_tool_schema` call

## Type

🐛 Bug Fix

## Changes

Google GenAI function declarations carry their argument schema in `parameters`, a Schema whose type
enums are uppercase, as well as in the newer `parametersJsonSchema`. `_transform_google_genai_tools_to_openai`
only read `parametersJsonSchema`, so a tool declared with `parameters` was translated into an OpenAI
tool carrying no `parameters` key at all

The same method already calls `normalize_tool_schema`, whose job is lowercasing uppercase Schema
type enums. Nothing on this path could produce uppercase types, since `parametersJsonSchema` is
already standard JSON Schema, so that normalizer was unreachable for the input it was written for.
Reading `parameters` fixes the dropped schema and makes the existing normalization do its job

`litellm/google_genai/adapters/transformation.py` gains a two line fallback. `parametersJsonSchema`
keeps precedence when both fields are present, so existing behavior is unchanged

`tests/test_litellm/google_genai/test_google_genai_adapter_fixes.py` gains three tests covering the
`parameters` path including uppercase type normalization, the precedence rule, and a declaration
carrying no argument schema

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR