### PR TITLE
chore(lint): zero stale ruff and LIT headroom and strip inert type: ignore comments

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -1269,8 +1269,8 @@ from .llms.xai.common_utils import XAIModelInfo
 from litellm.types.utils import LlmProviders
 
 ## Lazy loading this is not straightforward, will leave it here for now.
-from .main import *  # type: ignore
-from .compression import compress  # type: ignore[no-redef]
+from .main import *
+from .compression import compress
 
 # Skills API
 from .skills.main import (
@@ -1341,7 +1341,7 @@ from .assistants.main import *
 from .batches.main import *
 from .images.main import *
 from .videos.main import *
-from .batch_completion.main import *  # type: ignore
+from .batch_completion.main import *
 from .rerank_api.main import *
 from .llms.anthropic.experimental_pass_through.messages.handler import *
 from .responses.main import *
@@ -2054,7 +2054,7 @@ if TYPE_CHECKING:
     supports_reasoning: Callable[..., bool]
     acreate: Callable[..., Any]
     get_max_tokens: Callable[..., int]
-    get_model_info: Callable[..., _ModelInfoType]  # type: ignore[no-redef]
+    get_model_info: Callable[..., _ModelInfoType]
     register_prompt_template: Callable[..., None]
     validate_environment: Callable[..., dict]
     check_valid_key: Callable[..., bool]

--- a/litellm/_redis.py
+++ b/litellm/_redis.py
@@ -15,8 +15,8 @@ import os
 from collections.abc import Callable
 from typing import Final
 
-import redis  # type: ignore
-import redis.asyncio as async_redis  # type: ignore
+import redis
+import redis.asyncio as async_redis
 
 from litellm import get_secret, get_secret_str
 from litellm._redis_credential_provider import (
@@ -153,7 +153,7 @@ def _redis_kwargs_from_environment():
 
     return_dict: Final = {}
     for k, v in mapping.items():
-        value = get_secret(k, default_value=None)  # type: ignore
+        value = get_secret(k, default_value=None)
         if value is not None:
             return_dict[v] = value
     return return_dict
@@ -317,7 +317,7 @@ def create_azure_ad_redis_connect_func(
     # AzureADCredentialProvider for refresh-aware token retrieval. The raw
     # client_id/tenant_id/secret are intentionally NOT exposed here — the
     # credential closure already holds them.
-    ad_connect._azure_credential = credential  # type: ignore[attr-defined]
+    ad_connect._azure_credential = credential
     return ad_connect
 
 
@@ -351,7 +351,7 @@ def _get_redis_client_logic(**env_overrides):
     for k, v in env_overrides.items():
         if isinstance(v, str) and v.startswith("os.environ/"):
             v = v.replace("os.environ/", "")
-            value = get_secret(v)  # type: ignore
+            value = get_secret(v)
             env_overrides[k] = value
 
     environment_kwargs: Final = _redis_kwargs_from_environment()
@@ -370,7 +370,7 @@ def _get_redis_client_logic(**env_overrides):
         **env_overrides,
     }
 
-    _startup_nodes: Final[str | list | None] = redis_kwargs.get("startup_nodes", None) or get_secret(  # type: ignore
+    _startup_nodes: Final[str | list | None] = redis_kwargs.get("startup_nodes", None) or get_secret(
         "REDIS_CLUSTER_NODES"
     )
 
@@ -381,7 +381,7 @@ def _get_redis_client_logic(**env_overrides):
     elif _startup_nodes is None:
         redis_kwargs.pop("startup_nodes", None)
 
-    _sentinel_nodes: Final[str | list | None] = redis_kwargs.get("sentinel_nodes", None) or get_secret(  # type: ignore
+    _sentinel_nodes: Final[str | list | None] = redis_kwargs.get("sentinel_nodes", None) or get_secret(
         "REDIS_SENTINEL_NODES"
     )
 
@@ -395,7 +395,7 @@ def _get_redis_client_logic(**env_overrides):
     if _sentinel_password is not None:
         redis_kwargs["sentinel_password"] = _sentinel_password
 
-    _service_name: Final[str | None] = redis_kwargs.get("service_name", None) or get_secret(  # type: ignore
+    _service_name: Final[str | None] = redis_kwargs.get("service_name", None) or get_secret(
         "REDIS_SERVICE_NAME"
     )
 
@@ -412,7 +412,7 @@ def _get_redis_client_logic(**env_overrides):
             service_account=_gcp_service_account, ssl_ca_certs=_gcp_ssl_ca_certs
         )
         # Store GCP service account in redis_connect_func for async cluster access
-        redis_kwargs["redis_connect_func"]._gcp_service_account = _gcp_service_account  # type: ignore[attr-defined]
+        redis_kwargs["redis_connect_func"]._gcp_service_account = _gcp_service_account
 
         # Remove GCP-specific kwargs that shouldn't be passed to Redis client
         redis_kwargs.pop("gcp_service_account", None)
@@ -449,7 +449,7 @@ def _get_redis_client_logic(**env_overrides):
         # `create_azure_ad_redis_connect_func`; the raw client_id/tenant_id/secret
         # are intentionally NOT exposed on the function to avoid leaking
         # credentials via inspection or logging.
-        redis_kwargs["redis_connect_func"]._azure_redis_ad_token = True  # type: ignore[attr-defined]
+        redis_kwargs["redis_connect_func"]._azure_redis_ad_token = True
 
     # Always remove Azure-specific kwargs that shouldn't be passed to Redis client
     redis_kwargs.pop("azure_redis_ad_token", None)
@@ -481,7 +481,7 @@ def _get_redis_client_logic(**env_overrides):
 
 
 def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:
-    _redis_cluster_nodes_in_env: Final[str | None] = get_secret("REDIS_CLUSTER_NODES")  # type: ignore
+    _redis_cluster_nodes_in_env: Final[str | None] = get_secret("REDIS_CLUSTER_NODES")
     if _redis_cluster_nodes_in_env is not None:
         try:
             redis_kwargs["startup_nodes"] = json.loads(_redis_cluster_nodes_in_env)
@@ -505,7 +505,7 @@ def init_redis_cluster(redis_kwargs) -> redis.RedisCluster:
         new_startup_nodes.append(ClusterNode(**item))
 
     cluster_kwargs.pop("startup_nodes", None)
-    return redis.RedisCluster(startup_nodes=new_startup_nodes, **cluster_kwargs)  # type: ignore
+    return redis.RedisCluster(startup_nodes=new_startup_nodes, **cluster_kwargs)
 
 
 def _get_redis_sentinel_connection_kwargs(redis_kwargs: dict) -> dict:
@@ -638,7 +638,7 @@ def get_redis_async_client(
         # Create async RedisCluster with IAM token as password if available
         cluster_client: Final = async_redis.RedisCluster(
             startup_nodes=new_startup_nodes,
-            **cluster_kwargs,  # type: ignore
+            **cluster_kwargs,
         )
 
         return cluster_client

--- a/litellm/_redis_credential_provider.py
+++ b/litellm/_redis_credential_provider.py
@@ -3,7 +3,7 @@ import threading
 import time
 from typing import Any, Final
 
-from redis.credentials import CredentialProvider  # type: ignore[attr-defined]
+from redis.credentials import CredentialProvider
 
 # Azure AD scope for Redis Cache for Azure.
 AZURE_REDIS_SCOPE: Final = "https://redis.azure.com/.default"

--- a/litellm/_uuid.py
+++ b/litellm/_uuid.py
@@ -4,7 +4,7 @@ Internal unified UUID helper.
 Always uses fastuuid for performance.
 """
 
-import fastuuid as _uuid  # type: ignore
+import fastuuid as _uuid
 
 # Expose a module-like alias so callers can use: uuid.uuid4()
 uuid = _uuid

--- a/litellm/a2a_protocol/card_resolver.py
+++ b/litellm/a2a_protocol/card_resolver.py
@@ -18,8 +18,8 @@ AGENT_CARD_WELL_KNOWN_PATH: str = "/.well-known/agent-card.json"
 PREV_AGENT_CARD_WELL_KNOWN_PATH: str = "/.well-known/agent.json"
 
 try:
-    from a2a.client import A2ACardResolver as _A2ACardResolver  # type: ignore[no-redef]
-    from a2a.utils.constants import (  # type: ignore[no-redef]
+    from a2a.client import A2ACardResolver as _A2ACardResolver
+    from a2a.utils.constants import (
         AGENT_CARD_WELL_KNOWN_PATH,
         PREV_AGENT_CARD_WELL_KNOWN_PATH,
     )
@@ -102,7 +102,7 @@ def fix_agent_card_url(agent_card: "AgentCard", base_url: str) -> "AgentCard":
     return agent_card
 
 
-class LiteLLMA2ACardResolver(_A2ACardResolver):  # type: ignore[misc]
+class LiteLLMA2ACardResolver(_A2ACardResolver):
     """
     Custom A2A card resolver that supports multiple well-known paths.
 

--- a/litellm/a2a_protocol/exception_mapping_utils.py
+++ b/litellm/a2a_protocol/exception_mapping_utils.py
@@ -29,9 +29,9 @@ try:
     A2A_SDK_AVAILABLE = True
 except ImportError:
     A2A_SDK_AVAILABLE = False
-    Client = None  # type: ignore[misc, assignment]
-    ClientConfig = None  # type: ignore[misc, assignment]
-    create_client = None  # type: ignore[misc, assignment]
+    Client = None
+    ClientConfig = None
+    create_client = None
 
 
 class A2AExceptionCheckers:
@@ -219,6 +219,6 @@ async def handle_a2a_localhost_retry(
             streaming=is_streaming,
         ),
     )
-    new_client._litellm_httpx_client = httpx_client  # type: ignore[attr-defined]
-    new_client._litellm_agent_card = agent_card  # type: ignore[attr-defined]
+    new_client._litellm_httpx_client = httpx_client
+    new_client._litellm_agent_card = agent_card
     return new_client

--- a/litellm/a2a_protocol/litellm_completion_bridge/handler.py
+++ b/litellm/a2a_protocol/litellm_completion_bridge/handler.py
@@ -271,7 +271,7 @@ class A2ACompletionBridgeHandler:
         # 3. Accumulate content and emit artifact update
         accumulated_text = ""
         chunk_count = 0
-        async for chunk in response:  # type: ignore[union-attr]
+        async for chunk in response:
             chunk_count += 1
 
             # Extract delta content

--- a/litellm/a2a_protocol/main.py
+++ b/litellm/a2a_protocol/main.py
@@ -59,9 +59,9 @@ try:
 
     A2A_SDK_AVAILABLE = True
 except ImportError:
-    Client = None  # type: ignore[misc, assignment]
-    ClientConfig = None  # type: ignore[misc, assignment]
-    create_client = None  # type: ignore[misc, assignment]
+    Client = None
+    ClientConfig = None
+    create_client = None
 
 # Import our custom card resolver that supports multiple well-known paths
 from litellm.a2a_protocol.card_resolver import (
@@ -788,10 +788,10 @@ async def create_a2a_client(
     # Stash LiteLLM-owned handles on the client so the localhost-retry path can reuse
     # the configured httpx client (with this agent's trace-id/auth headers) without
     # excavating a2a-sdk private internals.
-    a2a_client._litellm_httpx_client = httpx_client  # type: ignore[attr-defined]
+    a2a_client._litellm_httpx_client = httpx_client
     agent_card: Final = getattr(a2a_client, "_card", None)
     if agent_card is not None:
-        a2a_client._litellm_agent_card = agent_card  # type: ignore[attr-defined]
+        a2a_client._litellm_agent_card = agent_card
 
     verbose_logger.info("A2A client created for %s", base_url)
 

--- a/litellm/anthropic_interface/exceptions/exception_mapping_utils.py
+++ b/litellm/anthropic_interface/exceptions/exception_mapping_utils.py
@@ -153,7 +153,7 @@ class AnthropicExceptionMapping:
             # Optionally add request_id if provided and not present
             if request_id and "request_id" not in parsed:
                 parsed["request_id"] = request_id
-            return parsed  # type: ignore
+            return parsed
 
         # Extract message - use parsed dict if available, otherwise raw string
         if parsed is not None:

--- a/litellm/assistants/main.py
+++ b/litellm/assistants/main.py
@@ -51,9 +51,7 @@ async def aget_assistants(
         ctx: Final = contextvars.copy_context()
         func_with_context: Final = partial(ctx.run, func)
 
-        _, custom_llm_provider, _, _ = get_llm_provider(  # type: ignore
-            model="", custom_llm_provider=custom_llm_provider
-        )  # type: ignore
+        _, custom_llm_provider, _, _ = get_llm_provider(model="", custom_llm_provider=custom_llm_provider)
 
         # Await normally
         init_response: Final = await loop.run_in_executor(None, func_with_context)
@@ -61,7 +59,7 @@ async def aget_assistants(
             response = await init_response
         else:
             response = init_response
-        return response  # type: ignore
+        return response
     except Exception as e:
         raise exception_type(
             model="",
@@ -98,7 +96,7 @@ def get_assistants(
         read_timeout: Final = timeout.read or 600
         timeout = read_timeout  # default 10 min timeout
     elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-        timeout = float(timeout)  # type: ignore
+        timeout = float(timeout)
     elif timeout is None:
         timeout = 600.0
 
@@ -132,12 +130,12 @@ def get_assistants(
             max_retries=optional_params.max_retries,
             organization=organization,
             client=client,
-            aget_assistants=aget_assistants,  # type: ignore
-        )  # type: ignore
+            aget_assistants=aget_assistants,
+        )
     elif custom_llm_provider == "azure":
-        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")  # type: ignore
+        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")
 
-        api_version = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")  # type: ignore
+        api_version = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")
 
         api_key = (
             optional_params.api_key
@@ -145,14 +143,14 @@ def get_assistants(
             or litellm.azure_key
             or get_secret("AZURE_OPENAI_API_KEY")
             or get_secret("AZURE_API_KEY")
-        )  # type: ignore
+        )
 
         extra_body: Final = optional_params.get("extra_body", {})
         azure_ad_token: str | None = None
         if extra_body is not None:
             azure_ad_token = extra_body.pop("azure_ad_token", None)
         else:
-            azure_ad_token = get_secret("AZURE_AD_TOKEN")  # type: ignore
+            azure_ad_token = get_secret("AZURE_AD_TOKEN")
 
         response = azure_assistants_api.get_assistants(
             api_base=api_base,
@@ -162,7 +160,7 @@ def get_assistants(
             timeout=timeout,
             max_retries=optional_params.max_retries,
             client=client,
-            aget_assistants=aget_assistants,  # type: ignore
+            aget_assistants=aget_assistants,
             litellm_params=litellm_params_dict,
         )
     else:
@@ -173,7 +171,7 @@ def get_assistants(
             response=httpx.Response(
                 status_code=400,
                 content="Unsupported provider",
-                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
             ),
         )
 
@@ -185,7 +183,7 @@ def get_assistants(
             response=httpx.Response(
                 status_code=400,
                 content="Unsupported provider",
-                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
             ),
         )
 
@@ -210,9 +208,7 @@ async def acreate_assistants(
         ctx: Final = contextvars.copy_context()
         func_with_context: Final = partial(ctx.run, func)
 
-        _, custom_llm_provider, _, _ = get_llm_provider(  # type: ignore
-            model=model, custom_llm_provider=custom_llm_provider
-        )  # type: ignore
+        _, custom_llm_provider, _, _ = get_llm_provider(model=model, custom_llm_provider=custom_llm_provider)
 
         # Await normally
         init_response: Final = await loop.run_in_executor(None, func_with_context)
@@ -220,7 +216,7 @@ async def acreate_assistants(
             response = await init_response
         else:
             response = init_response
-        return response  # type: ignore
+        return response
     except Exception as e:
         raise exception_type(
             model=model,
@@ -267,7 +263,7 @@ def create_assistants(
         read_timeout: Final = timeout.read or 600
         timeout = read_timeout  # default 10 min timeout
     elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-        timeout = float(timeout)  # type: ignore
+        timeout = float(timeout)
     elif timeout is None:
         timeout = 600.0
 
@@ -318,12 +314,12 @@ def create_assistants(
             organization=organization,
             create_assistant_data=create_assistant_data,
             client=client,
-            async_create_assistants=async_create_assistants,  # type: ignore
-        )  # type: ignore
+            async_create_assistants=async_create_assistants,
+        )
     elif custom_llm_provider == "azure":
-        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")  # type: ignore
+        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")
 
-        api_version = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")  # type: ignore
+        api_version = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")
 
         api_key = (
             optional_params.api_key
@@ -331,14 +327,14 @@ def create_assistants(
             or litellm.azure_key
             or get_secret("AZURE_OPENAI_API_KEY")
             or get_secret("AZURE_API_KEY")
-        )  # type: ignore
+        )
 
         extra_body: Final = optional_params.get("extra_body", {})
         azure_ad_token: str | None = None
         if extra_body is not None:
             azure_ad_token = extra_body.pop("azure_ad_token", None)
         else:
-            azure_ad_token = get_secret("AZURE_AD_TOKEN")  # type: ignore
+            azure_ad_token = get_secret("AZURE_AD_TOKEN")
 
         if isinstance(client, OpenAI):
             client = None  # only pass client if it's AzureOpenAI
@@ -363,7 +359,7 @@ def create_assistants(
             response=httpx.Response(
                 status_code=400,
                 content="Unsupported provider",
-                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
             ),
         )
     if response is None:
@@ -392,9 +388,7 @@ async def adelete_assistant(
         ctx: Final = contextvars.copy_context()
         func_with_context: Final = partial(ctx.run, func)
 
-        _, custom_llm_provider, _, _ = get_llm_provider(  # type: ignore
-            model="", custom_llm_provider=custom_llm_provider
-        )  # type: ignore
+        _, custom_llm_provider, _, _ = get_llm_provider(model="", custom_llm_provider=custom_llm_provider)
 
         # Await normally
         init_response: Final = await loop.run_in_executor(None, func_with_context)
@@ -402,7 +396,7 @@ async def adelete_assistant(
             response = await init_response
         else:
             response = init_response
-        return response  # type: ignore
+        return response
     except Exception as e:
         raise exception_type(
             model="",
@@ -442,7 +436,7 @@ def delete_assistant(
         read_timeout: Final = timeout.read or 600
         timeout = read_timeout  # default 10 min timeout
     elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-        timeout = float(timeout)  # type: ignore
+        timeout = float(timeout)
     elif timeout is None:
         timeout = 600.0
 
@@ -472,9 +466,9 @@ def delete_assistant(
             async_delete_assistants=async_delete_assistants,
         )
     elif custom_llm_provider == "azure":
-        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")  # type: ignore
+        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")
 
-        api_version = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")  # type: ignore
+        api_version = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")
 
         api_key = (
             optional_params.api_key
@@ -482,14 +476,14 @@ def delete_assistant(
             or litellm.azure_key
             or get_secret("AZURE_OPENAI_API_KEY")
             or get_secret("AZURE_API_KEY")
-        )  # type: ignore
+        )
 
         extra_body: Final = optional_params.get("extra_body", {})
         azure_ad_token: str | None = None
         if extra_body is not None:
             azure_ad_token = extra_body.pop("azure_ad_token", None)
         else:
-            azure_ad_token = get_secret("AZURE_AD_TOKEN")  # type: ignore
+            azure_ad_token = get_secret("AZURE_AD_TOKEN")
 
         if isinstance(client, OpenAI):
             client = None  # only pass client if it's AzureOpenAI
@@ -541,9 +535,7 @@ async def acreate_thread(custom_llm_provider: Literal["openai", "azure"], **kwar
         ctx: Final = contextvars.copy_context()
         func_with_context: Final = partial(ctx.run, func)
 
-        _, custom_llm_provider, _, _ = get_llm_provider(  # type: ignore
-            model="", custom_llm_provider=custom_llm_provider
-        )  # type: ignore
+        _, custom_llm_provider, _, _ = get_llm_provider(model="", custom_llm_provider=custom_llm_provider)
 
         # Await normally
         init_response: Final = await loop.run_in_executor(None, func_with_context)
@@ -551,7 +543,7 @@ async def acreate_thread(custom_llm_provider: Literal["openai", "azure"], **kwar
             response = await init_response
         else:
             response = init_response
-        return response  # type: ignore
+        return response
     except Exception as e:
         raise exception_type(
             model="",
@@ -608,7 +600,7 @@ def create_thread(
         read_timeout: Final = timeout.read or 600
         timeout = read_timeout  # default 10 min timeout
     elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-        timeout = float(timeout)  # type: ignore
+        timeout = float(timeout)
     elif timeout is None:
         timeout = 600.0
 
@@ -649,7 +641,7 @@ def create_thread(
             acreate_thread=acreate_thread,
         )
     elif custom_llm_provider == "azure":
-        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")  # type: ignore
+        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")
 
         api_key = (
             optional_params.api_key
@@ -657,16 +649,16 @@ def create_thread(
             or litellm.azure_key
             or get_secret("AZURE_OPENAI_API_KEY")
             or get_secret("AZURE_API_KEY")
-        )  # type: ignore
+        )
 
-        api_version: str | None = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")  # type: ignore
+        api_version: str | None = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")
 
         extra_body: Final = optional_params.get("extra_body", {})
         azure_ad_token: str | None = None
         if extra_body is not None:
             azure_ad_token = extra_body.pop("azure_ad_token", None)
         else:
-            azure_ad_token = get_secret("AZURE_AD_TOKEN")  # type: ignore
+            azure_ad_token = get_secret("AZURE_AD_TOKEN")
 
         if isinstance(client, OpenAI):
             client = None  # only pass client if it's AzureOpenAI
@@ -692,10 +684,10 @@ def create_thread(
             response=httpx.Response(
                 status_code=400,
                 content="Unsupported provider",
-                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
             ),
         )
-    return response  # type: ignore
+    return response
 
 
 async def aget_thread(
@@ -715,9 +707,7 @@ async def aget_thread(
         ctx: Final = contextvars.copy_context()
         func_with_context: Final = partial(ctx.run, func)
 
-        _, custom_llm_provider, _, _ = get_llm_provider(  # type: ignore
-            model="", custom_llm_provider=custom_llm_provider
-        )  # type: ignore
+        _, custom_llm_provider, _, _ = get_llm_provider(model="", custom_llm_provider=custom_llm_provider)
 
         # Await normally
         init_response: Final = await loop.run_in_executor(None, func_with_context)
@@ -725,7 +715,7 @@ async def aget_thread(
             response = await init_response
         else:
             response = init_response
-        return response  # type: ignore
+        return response
     except Exception as e:
         raise exception_type(
             model="",
@@ -758,7 +748,7 @@ def get_thread(
         read_timeout: Final = timeout.read or 600
         timeout = read_timeout  # default 10 min timeout
     elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-        timeout = float(timeout)  # type: ignore
+        timeout = float(timeout)
     elif timeout is None:
         timeout = 600.0
     api_base: str | None = None
@@ -797,9 +787,9 @@ def get_thread(
             aget_thread=aget_thread,
         )
     elif custom_llm_provider == "azure":
-        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")  # type: ignore
+        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")
 
-        api_version: str | None = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")  # type: ignore
+        api_version: str | None = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")
 
         api_key = (
             optional_params.api_key
@@ -807,14 +797,14 @@ def get_thread(
             or litellm.azure_key
             or get_secret("AZURE_OPENAI_API_KEY")
             or get_secret("AZURE_API_KEY")
-        )  # type: ignore
+        )
 
         extra_body: Final = optional_params.get("extra_body", {})
         azure_ad_token: str | None = None
         if extra_body is not None:
             azure_ad_token = extra_body.pop("azure_ad_token", None)
         else:
-            azure_ad_token = get_secret("AZURE_AD_TOKEN")  # type: ignore
+            azure_ad_token = get_secret("AZURE_AD_TOKEN")
 
         if isinstance(client, OpenAI):
             client = None  # only pass client if it's AzureOpenAI
@@ -839,10 +829,10 @@ def get_thread(
             response=httpx.Response(
                 status_code=400,
                 content="Unsupported provider",
-                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
             ),
         )
-    return response  # type: ignore
+    return response
 
 
 ### MESSAGES ###
@@ -879,9 +869,7 @@ async def a_add_message(
         ctx: Final = contextvars.copy_context()
         func_with_context: Final = partial(ctx.run, func)
 
-        _, custom_llm_provider, _, _ = get_llm_provider(  # type: ignore
-            model="", custom_llm_provider=custom_llm_provider
-        )  # type: ignore
+        _, custom_llm_provider, _, _ = get_llm_provider(model="", custom_llm_provider=custom_llm_provider)
 
         # Await normally
         init_response: Final = await loop.run_in_executor(None, func_with_context)
@@ -890,7 +878,7 @@ async def a_add_message(
         else:
             # Call the synchronous function using run_in_executor
             response = init_response
-        return response  # type: ignore
+        return response
     except Exception as e:
         raise exception_type(
             model="",
@@ -937,7 +925,7 @@ def add_message(
         read_timeout: Final = timeout.read or 600
         timeout = read_timeout  # default 10 min timeout
     elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-        timeout = float(timeout)  # type: ignore
+        timeout = float(timeout)
     elif timeout is None:
         timeout = 600.0
     api_key: str | None = None
@@ -976,9 +964,9 @@ def add_message(
             a_add_message=a_add_message,
         )
     elif custom_llm_provider == "azure":
-        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")  # type: ignore
+        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")
 
-        api_version: str | None = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")  # type: ignore
+        api_version: str | None = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")
 
         api_key = (
             optional_params.api_key
@@ -986,14 +974,14 @@ def add_message(
             or litellm.azure_key
             or get_secret("AZURE_OPENAI_API_KEY")
             or get_secret("AZURE_API_KEY")
-        )  # type: ignore
+        )
 
         extra_body: Final = optional_params.get("extra_body", {})
         azure_ad_token: str | None = None
         if extra_body is not None:
             azure_ad_token = extra_body.pop("azure_ad_token", None)
         else:
-            azure_ad_token = get_secret("AZURE_AD_TOKEN")  # type: ignore
+            azure_ad_token = get_secret("AZURE_AD_TOKEN")
 
         response = azure_assistants_api.add_message(
             thread_id=thread_id,
@@ -1016,11 +1004,11 @@ def add_message(
             response=httpx.Response(
                 status_code=400,
                 content="Unsupported provider",
-                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
             ),
         )
 
-    return response  # type: ignore
+    return response
 
 
 async def aget_messages(
@@ -1046,9 +1034,7 @@ async def aget_messages(
         ctx: Final = contextvars.copy_context()
         func_with_context: Final = partial(ctx.run, func)
 
-        _, custom_llm_provider, _, _ = get_llm_provider(  # type: ignore
-            model="", custom_llm_provider=custom_llm_provider
-        )  # type: ignore
+        _, custom_llm_provider, _, _ = get_llm_provider(model="", custom_llm_provider=custom_llm_provider)
 
         # Await normally
         init_response: Final = await loop.run_in_executor(None, func_with_context)
@@ -1057,7 +1043,7 @@ async def aget_messages(
         else:
             # Call the synchronous function using run_in_executor
             response = init_response
-        return response  # type: ignore
+        return response
     except Exception as e:
         raise exception_type(
             model="",
@@ -1090,7 +1076,7 @@ def get_messages(
         read_timeout: Final = timeout.read or 600
         timeout = read_timeout  # default 10 min timeout
     elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-        timeout = float(timeout)  # type: ignore
+        timeout = float(timeout)
     elif timeout is None:
         timeout = 600.0
 
@@ -1129,9 +1115,9 @@ def get_messages(
             aget_messages=aget_messages,
         )
     elif custom_llm_provider == "azure":
-        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")  # type: ignore
+        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")
 
-        api_version: str | None = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")  # type: ignore
+        api_version: str | None = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")
 
         api_key = (
             optional_params.api_key
@@ -1139,14 +1125,14 @@ def get_messages(
             or litellm.azure_key
             or get_secret("AZURE_OPENAI_API_KEY")
             or get_secret("AZURE_API_KEY")
-        )  # type: ignore
+        )
 
         extra_body: Final = optional_params.get("extra_body", {})
         azure_ad_token: str | None = None
         if extra_body is not None:
             azure_ad_token = extra_body.pop("azure_ad_token", None)
         else:
-            azure_ad_token = get_secret("AZURE_AD_TOKEN")  # type: ignore
+            azure_ad_token = get_secret("AZURE_AD_TOKEN")
 
         response = azure_assistants_api.get_messages(
             thread_id=thread_id,
@@ -1168,11 +1154,11 @@ def get_messages(
             response=httpx.Response(
                 status_code=400,
                 content="Unsupported provider",
-                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
             ),
         )
 
-    return response  # type: ignore
+    return response
 
 
 ### RUNS ###
@@ -1182,7 +1168,7 @@ def arun_thread_stream(
     **kwargs,
 ) -> AsyncAssistantStreamManager[AsyncAssistantEventHandler]:
     kwargs["arun_thread"] = True
-    return run_thread(stream=True, event_handler=event_handler, **kwargs)  # type: ignore
+    return run_thread(stream=True, event_handler=event_handler, **kwargs)
 
 
 async def arun_thread(
@@ -1222,9 +1208,7 @@ async def arun_thread(
         ctx: Final = contextvars.copy_context()
         func_with_context: Final = partial(ctx.run, func)
 
-        _, custom_llm_provider, _, _ = get_llm_provider(  # type: ignore
-            model="", custom_llm_provider=custom_llm_provider
-        )  # type: ignore
+        _, custom_llm_provider, _, _ = get_llm_provider(model="", custom_llm_provider=custom_llm_provider)
 
         # Await normally
         init_response: Final = await loop.run_in_executor(None, func_with_context)
@@ -1233,7 +1217,7 @@ async def arun_thread(
         else:
             # Call the synchronous function using run_in_executor
             response = init_response
-        return response  # type: ignore
+        return response
     except Exception as e:
         raise exception_type(
             model="",
@@ -1249,7 +1233,7 @@ def run_thread_stream(
     event_handler: AssistantEventHandler | None = None,
     **kwargs,
 ) -> AssistantStreamManager[AssistantEventHandler]:
-    return run_thread(stream=True, event_handler=event_handler, **kwargs)  # type: ignore
+    return run_thread(stream=True, event_handler=event_handler, **kwargs)
 
 
 def run_thread(
@@ -1283,7 +1267,7 @@ def run_thread(
         read_timeout: Final = timeout.read or 600
         timeout = read_timeout  # default 10 min timeout
     elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-        timeout = float(timeout)  # type: ignore
+        timeout = float(timeout)
     elif timeout is None:
         timeout = 600.0
 
@@ -1329,9 +1313,9 @@ def run_thread(
             event_handler=event_handler,
         )
     elif custom_llm_provider == "azure":
-        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")  # type: ignore
+        api_base = optional_params.api_base or litellm.api_base or get_secret("AZURE_API_BASE")
 
-        api_version = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")  # type: ignore
+        api_version = optional_params.api_version or litellm.api_version or get_secret("AZURE_API_VERSION")
 
         api_key = (
             optional_params.api_key
@@ -1339,14 +1323,14 @@ def run_thread(
             or litellm.azure_key
             or get_secret("AZURE_OPENAI_API_KEY")
             or get_secret("AZURE_API_KEY")
-        )  # type: ignore
+        )
 
         extra_body: Final = optional_params.get("extra_body", {})
         azure_ad_token = None
         if extra_body is not None:
             azure_ad_token = extra_body.pop("azure_ad_token", None)
         else:
-            azure_ad_token = get_secret("AZURE_AD_TOKEN")  # type: ignore
+            azure_ad_token = get_secret("AZURE_AD_TOKEN")
 
         response = azure_assistants_api.run_thread(
             thread_id=thread_id,
@@ -1366,7 +1350,7 @@ def run_thread(
             client=client,
             arun_thread=arun_thread,
             litellm_params=litellm_params_dict,
-        )  # type: ignore
+        )
     else:
         raise litellm.exceptions.BadRequestError(
             message=f"LiteLLM doesn't support {custom_llm_provider} for 'run_thread'. Only 'openai' is supported.",
@@ -1375,7 +1359,7 @@ def run_thread(
             response=httpx.Response(
                 status_code=400,
                 content="Unsupported provider",
-                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
             ),
         )
-    return response  # type: ignore
+    return response

--- a/litellm/batches/batch_utils.py
+++ b/litellm/batches/batch_utils.py
@@ -274,7 +274,7 @@ async def _fetch_batch_output_file_content(
     credentials: Final = _extract_file_access_credentials(litellm_params)
     file_content_kwargs.update(credentials)
 
-    _file_content: Final = await afile_content(**file_content_kwargs)  # type: ignore[reportArgumentType]
+    _file_content: Final = await afile_content(**file_content_kwargs)
     return _file_content.content
 
 

--- a/litellm/batches/main.py
+++ b/litellm/batches/main.py
@@ -287,7 +287,7 @@ def create_batch(
             if extra_body is not None:
                 extra_body.pop("azure_ad_token", None)
             else:
-                get_secret_str("AZURE_AD_TOKEN")  # type: ignore
+                get_secret_str("AZURE_AD_TOKEN")
 
             response = azure_batches_instance.create_batch(
                 _is_async=_is_async,
@@ -327,7 +327,7 @@ def create_batch(
                 response=httpx.Response(
                     status_code=400,
                     content="Unsupported provider",
-                    request=httpx.Request(method="create_batch", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                    request=httpx.Request(method="create_batch", url="https://github.com/BerriAI/litellm"),
                 ),
             )
         return response
@@ -370,7 +370,7 @@ async def aretrieve_batch(
         if asyncio.iscoroutine(init_response):
             response = await init_response
         else:
-            response = init_response  # type: ignore
+            response = init_response
 
         return response
     except Exception as e:
@@ -436,7 +436,7 @@ def _handle_retrieve_batch_providers_without_provider_config(
         if extra_body is not None:
             extra_body.pop("azure_ad_token", None)
         else:
-            get_secret_str("AZURE_AD_TOKEN")  # type: ignore
+            get_secret_str("AZURE_AD_TOKEN")
 
         response = azure_batches_instance.retrieve_batch(
             _is_async=_is_async,
@@ -498,7 +498,7 @@ def _handle_retrieve_batch_providers_without_provider_config(
             response=httpx.Response(
                 status_code=400,
                 content="Unsupported provider",
-                request=httpx.Request(method="retrieve_batch", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                request=httpx.Request(method="retrieve_batch", url="https://github.com/BerriAI/litellm"),
             ),
         )
     return response
@@ -545,7 +545,7 @@ def retrieve_batch(
             read_timeout: Final = timeout.read or 600
             timeout = read_timeout  # default 10 min timeout
         elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-            timeout = float(timeout)  # type: ignore
+            timeout = float(timeout)
         elif timeout is None:
             timeout = 600.0
 
@@ -677,7 +677,7 @@ async def alist_batches(
         if asyncio.iscoroutine(init_response):
             response = await init_response
         else:
-            response = init_response  # type: ignore
+            response = init_response
 
         return response
     except Exception as e:
@@ -723,7 +723,7 @@ def list_batches(
             read_timeout: Final = timeout.read or 600
             timeout = read_timeout  # default 10 min timeout
         elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-            timeout = float(timeout)  # type: ignore
+            timeout = float(timeout)
         elif timeout is None:
             timeout = 600.0
 
@@ -755,7 +755,7 @@ def list_batches(
                 max_retries=optional_params.max_retries,
             )
         elif custom_llm_provider == "azure":
-            api_base = optional_params.api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")  # type: ignore
+            api_base = optional_params.api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")
             api_version = optional_params.api_version or litellm.api_version or get_secret_str("AZURE_API_VERSION")
 
             api_key = (
@@ -770,7 +770,7 @@ def list_batches(
             if extra_body is not None:
                 extra_body.pop("azure_ad_token", None)
             else:
-                get_secret_str("AZURE_AD_TOKEN")  # type: ignore
+                get_secret_str("AZURE_AD_TOKEN")
 
             response = azure_batches_instance.list_batches(
                 _is_async=_is_async,
@@ -813,7 +813,7 @@ def list_batches(
                 response=httpx.Response(
                     status_code=400,
                     content="Unsupported provider",
-                    request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                    request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
                 ),
             )
         return response
@@ -909,7 +909,7 @@ def cancel_batch(
             read_timeout: Final = timeout.read or 600
             timeout = read_timeout  # default 10 min timeout
         elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-            timeout = float(timeout)  # type: ignore
+            timeout = float(timeout)
         elif timeout is None:
             timeout = 600.0
 
@@ -959,7 +959,7 @@ def cancel_batch(
             if extra_body is not None:
                 extra_body.pop("azure_ad_token", None)
             else:
-                get_secret_str("AZURE_AD_TOKEN")  # type: ignore
+                get_secret_str("AZURE_AD_TOKEN")
 
             response = azure_batches_instance.cancel_batch(
                 _is_async=_is_async,
@@ -999,7 +999,7 @@ def cancel_batch(
                 response=httpx.Response(
                     status_code=400,
                     content="Unsupported provider",
-                    request=httpx.Request(method="cancel_batch", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                    request=httpx.Request(method="cancel_batch", url="https://github.com/BerriAI/litellm"),
                 ),
             )
         return response

--- a/litellm/caching/caching.py
+++ b/litellm/caching/caching.py
@@ -534,11 +534,9 @@ class Cache:
                 if isinstance(cached_response, dict):
                     pass
                 else:
-                    cached_response = json.loads(
-                        cached_response  # type: ignore
-                    )  # Convert string to dictionary
+                    cached_response = json.loads(cached_response)  # Convert string to dictionary
             except Exception:
-                cached_response = ast.literal_eval(cached_response)  # type: ignore
+                cached_response = ast.literal_eval(cached_response)
             return cached_response
         return cached_result
 

--- a/litellm/caching/caching_handler.py
+++ b/litellm/caching/caching_handler.py
@@ -242,7 +242,7 @@ class LLMCachingHandler:
                         or litellm.cache.get_cache_key(**self.request_kwargs)
                     )
                     if hasattr(cached_result, "_hidden_params"):
-                        cached_result._hidden_params["cache_key"] = cache_key  # type: ignore
+                        cached_result._hidden_params["cache_key"] = cache_key
                     return CachingHandlerResponse(cached_result=cached_result)
                 elif (
                     call_type == CallTypes.aembedding.value
@@ -356,7 +356,7 @@ class LLMCachingHandler:
                         or litellm.cache.get_cache_key(**self.request_kwargs)
                     )
                     if hasattr(cached_result, "_hidden_params"):
-                        cached_result._hidden_params["cache_key"] = cache_key  # type: ignore
+                        cached_result._hidden_params["cache_key"] = cache_key
                     return CachingHandlerResponse(cached_result=cached_result)
         return CachingHandlerResponse(cached_result=cached_result)
 

--- a/litellm/caching/disk_cache.py
+++ b/litellm/caching/disk_cache.py
@@ -44,7 +44,7 @@ class DiskCache(BaseCache):
         original_cached_response: Final = self.disk_cache.get(key)
         if original_cached_response:
             try:
-                cached_response = json.loads(original_cached_response)  # type: ignore
+                cached_response = json.loads(original_cached_response)
             except Exception:
                 cached_response = original_cached_response
             return cached_response

--- a/litellm/caching/redis_cache.py
+++ b/litellm/caching/redis_cache.py
@@ -242,7 +242,7 @@ async def _run_under_circuit_breaker(
     return result
 
 
-def _redis_circuit_breaker_guard(method):  # type: ignore
+def _redis_circuit_breaker_guard(method):
     """
     Decorator for RedisCache async methods.
     Checks the circuit breaker before each call; records success/failure after.
@@ -256,7 +256,7 @@ def _redis_circuit_breaker_guard(method):  # type: ignore
     """
 
     @functools.wraps(method)
-    async def wrapper(self, *args, **kwargs):  # type: ignore
+    async def wrapper(self, *args, **kwargs):
         return await _run_under_circuit_breaker(
             self._circuit_breaker, method.__name__, lambda: method(self, *args, **kwargs)
         )
@@ -319,7 +319,7 @@ class RedisCache(BaseCache):
         self.redis_version = "Unknown"
         try:
             if not coroutine_checker.is_async_callable(self.redis_client):
-                self.redis_version = self.redis_client.info()["redis_version"]  # type: ignore
+                self.redis_version = self.redis_client.info()["redis_version"]
         except Exception:
             pass
 
@@ -355,7 +355,7 @@ class RedisCache(BaseCache):
         # SYNC HEALTH PING
         try:
             if hasattr(self.redis_client, "ping"):
-                self.redis_client.ping()  # type: ignore
+                self.redis_client.ping()
         except Exception as e:
             verbose_logger.error("Error connecting to Sync Redis client", extra={"error": str(e)})
             self._handle_sync_ping_error(e)
@@ -423,7 +423,7 @@ class RedisCache(BaseCache):
             redis_async_client = get_redis_async_client(connection_pool=self.async_redis_conn_pool, **self.redis_kwargs)
             in_memory_llm_clients_cache.set_cache(key=cache_key, value=redis_async_client)
 
-        self.redis_async_client = redis_async_client  # type: ignore
+        self.redis_async_client = redis_async_client
         return redis_async_client
 
     def check_and_fix_namespace(self, key: str) -> str:
@@ -431,7 +431,7 @@ class RedisCache(BaseCache):
         Make sure each key starts with the given namespace
         """
         if key is None:
-            return key  # type: ignore[return-value]
+            return key
         if self.namespace is not None and not key.startswith(self.namespace):
             key = self.namespace + ":" + key
 
@@ -493,7 +493,7 @@ class RedisCache(BaseCache):
         key = self.check_and_fix_namespace(key=key)
         try:
             start_time = time.time()
-            result: Final[int] = _redis_client.incr(name=key, amount=value)  # type: ignore
+            result: Final[int] = _redis_client.incr(name=key, amount=value)
             end_time = time.time()
             _duration = end_time - start_time
             self.service_logger_obj.service_success_hook(
@@ -520,7 +520,7 @@ class RedisCache(BaseCache):
                 if current_ttl == -1:
                     # Key has no expiration
                     start_time = time.time()
-                    _redis_client.expire(key, set_ttl)  # type: ignore
+                    _redis_client.expire(key, set_ttl)
                     end_time = time.time()
                     _duration = end_time - start_time
                     self.service_logger_obj.service_success_hook(
@@ -555,7 +555,7 @@ class RedisCache(BaseCache):
                 return []
 
             pattern = self.check_and_fix_namespace(key=pattern)
-            async for key in _redis_client.scan_iter(match=pattern + "*", count=count):  # type: ignore
+            async for key in _redis_client.scan_iter(match=pattern + "*", count=count):
                 keys.append(key)
                 if len(keys) >= count:
                     break
@@ -680,7 +680,7 @@ class RedisCache(BaseCache):
 
         start_time: Final = time.time()
         try:
-            _redis_client: Final[Redis] = self.init_async_client()  # type: ignore
+            _redis_client: Final[Redis] = self.init_async_client()
         except Exception as e:
             end_time = time.time()
             _duration = end_time - start_time
@@ -773,7 +773,7 @@ class RedisCache(BaseCache):
             _td: timedelta | None = None
             if ttl is not None:
                 _td = timedelta(seconds=ttl)
-            pipe.set(  # type: ignore
+            pipe.set(
                 name=cache_key,
                 value=json_cache_value,
                 ex=_td,
@@ -849,7 +849,7 @@ class RedisCache(BaseCache):
         """Helper function for async_set_cache_sadd. Separated for testing."""
         ttl = self.get_ttl(ttl=ttl)
         try:
-            await redis_client.sadd(key, *value)  # type: ignore
+            await redis_client.sadd(key, *value)
             if ttl is not None:
                 _td: Final = timedelta(seconds=ttl)
                 await redis_client.expire(key, _td)
@@ -862,7 +862,7 @@ class RedisCache(BaseCache):
 
         start_time: Final = time.time()
         try:
-            _redis_client: Final[Redis] = self.init_async_client()  # type: ignore
+            _redis_client: Final[Redis] = self.init_async_client()
         except Exception as e:
             end_time = time.time()
             _duration = end_time - start_time
@@ -945,7 +945,7 @@ class RedisCache(BaseCache):
     ) -> float:
         from redis.asyncio import Redis
 
-        _redis_client: Final[Redis] = self.init_async_client()  # type: ignore
+        _redis_client: Final[Redis] = self.init_async_client()
         start_time: Final = time.time()
         _used_ttl: Final = self.get_ttl(ttl=ttl)
         key = self.check_and_fix_namespace(key=key)
@@ -1080,7 +1080,7 @@ class RedisCache(BaseCache):
 
         We use a wrapper so RedisCluster can override this method
         """
-        return self.redis_client.mget(keys=keys)  # type: ignore
+        return self.redis_client.mget(keys=keys)
 
     async def _async_run_redis_mget_operation(self, keys: list[str]) -> list[Any]:
         """
@@ -1089,7 +1089,7 @@ class RedisCache(BaseCache):
         We use a wrapper so RedisCluster can override this method
         """
         async_redis_client: Final = self.init_async_client()
-        return await async_redis_client.mget(keys=keys)  # type: ignore
+        return await async_redis_client.mget(keys=keys)
 
     def batch_get_cache(
         self,
@@ -1147,7 +1147,7 @@ class RedisCache(BaseCache):
     async def async_get_cache(self, key, parent_otel_span: Span | None = None, **kwargs):
         from redis.asyncio import Redis
 
-        _redis_client: Final[Redis] = self.init_async_client()  # type: ignore
+        _redis_client: Final[Redis] = self.init_async_client()
         key = self.check_and_fix_namespace(key=key)
         start_time: Final = time.time()
 
@@ -1269,7 +1269,7 @@ class RedisCache(BaseCache):
         print_verbose("Pinging Sync Redis Cache")
         start_time: Final = time.time()
         try:
-            response: Final[bool] = self.redis_client.ping()  # type: ignore
+            response: Final[bool] = self.redis_client.ping()
             print_verbose(f"Redis Cache PING: {response}")
             ## LOGGING ##
             end_time = time.time()
@@ -1339,7 +1339,7 @@ class RedisCache(BaseCache):
         await _redis_client.delete(*keys)
 
     def client_list(self) -> list:
-        client_list: Final[list] = self.redis_client.client_list()  # type: ignore
+        client_list: Final[list] = self.redis_client.client_list()
         return client_list
 
     def info(self):
@@ -1376,10 +1376,10 @@ class RedisCache(BaseCache):
             redis_client: Final = redis_async.Redis(**self.redis_kwargs)
 
             # Test the connection
-            ping_result: Final = await redis_client.ping()  # type: ignore[misc]
+            ping_result: Final = await redis_client.ping()
 
             # Close the connection
-            await redis_client.aclose()  # type: ignore[attr-defined]
+            await redis_client.aclose()
 
             if ping_result:
                 return {
@@ -1448,7 +1448,7 @@ class RedisCache(BaseCache):
 
         from redis.asyncio import Redis
 
-        _redis_client: Final[Redis] = self.init_async_client()  # type: ignore
+        _redis_client: Final[Redis] = self.init_async_client()
         start_time: Final = time.time()
 
         print_verbose(f"Increment Async Redis Cache Pipeline: increment list: {increment_list}")
@@ -1769,7 +1769,7 @@ class RedisCache(BaseCache):
                         or None
                     )
                 except Exception:
-                    decoded_results.append(r)  # type: ignore
+                    decoded_results.append(r)
             else:
                 decoded_results.append(None)
         return decoded_results

--- a/litellm/caching/redis_cluster_cache.py
+++ b/litellm/caching/redis_cluster_cache.py
@@ -47,14 +47,14 @@ class RedisClusterCache(RedisCache):
         """
         Overrides `_run_redis_mget_operation` in redis_cache.py
         """
-        return self.redis_client.mget_nonatomic(keys=keys)  # type: ignore
+        return self.redis_client.mget_nonatomic(keys=keys)
 
     async def _async_run_redis_mget_operation(self, keys: list[str]) -> list[Any]:
         """
         Overrides `_async_run_redis_mget_operation` in redis_cache.py
         """
         async_redis_cluster_client: Final = self.init_async_client()
-        return await async_redis_cluster_client.mget_nonatomic(keys=keys)  # type: ignore
+        return await async_redis_cluster_client.mget_nonatomic(keys=keys)
 
     async def test_connection(self) -> dict:
         """
@@ -78,14 +78,14 @@ class RedisClusterCache(RedisCache):
             # Create a fresh Redis Cluster client with current settings
             redis_client: Final = redis_async.RedisCluster(
                 startup_nodes=new_startup_nodes,
-                **cluster_kwargs,  # type: ignore
+                **cluster_kwargs,
             )
 
             # Test the connection
-            ping_result: Final = await redis_client.ping()  # type: ignore[attr-defined, misc]
+            ping_result: Final = await redis_client.ping()
 
             # Close the connection
-            await redis_client.aclose()  # type: ignore[attr-defined]
+            await redis_client.aclose()
 
             if ping_result:
                 return {

--- a/litellm/caching/redis_semantic_cache.py
+++ b/litellm/caching/redis_semantic_cache.py
@@ -126,8 +126,8 @@ class RedisSemanticCache(BaseCache):
         # CustomTextVectorizer probes its embedding dimension at construction by
         # embedding "dimension test", so the first cache request issues one extra
         # billable embedding on top of the request's own.
-        from redisvl.extensions.llmcache import SemanticCache  # type: ignore[import-not-found, import-untyped]
-        from redisvl.utils.vectorize import CustomTextVectorizer  # type: ignore[import-not-found, import-untyped]
+        from redisvl.extensions.llmcache import SemanticCache
+        from redisvl.utils.vectorize import CustomTextVectorizer
 
         try:
             cache_vectorizer: Final = CustomTextVectorizer(self._get_embedding)
@@ -207,7 +207,7 @@ class RedisSemanticCache(BaseCache):
         return {self.CACHE_KEY_FIELD_NAME: str(key)}
 
     def _get_cache_key_filter_expression(self, key: str) -> Any:
-        from redisvl.query.filter import Tag  # type: ignore[import-not-found, import-untyped]
+        from redisvl.query.filter import Tag
 
         return Tag(self.CACHE_KEY_FIELD_NAME) == str(key)
 

--- a/litellm/caching/s3_cache.py
+++ b/litellm/caching/s3_cache.py
@@ -146,7 +146,7 @@ class S3Cache(BaseCache):
             )
 
             return cached_response
-        except botocore.exceptions.ClientError as e:  # type: ignore
+        except botocore.exceptions.ClientError as e:
             if e.response["Error"]["Code"] == "NoSuchKey":
                 verbose_logger.debug("S3 Cache: The specified key '%s' does not exist in the S3 bucket.", key)
                 return None

--- a/litellm/caching/valkey_semantic_cache.py
+++ b/litellm/caching/valkey_semantic_cache.py
@@ -85,12 +85,8 @@ class ValkeySemanticCache(RedisSemanticCache):
         resolved_url = None
         if sync_client is None or async_client is None:
             resolved_url = redis_url or self._build_valkey_url(host, port, password, ssl)
-        self.sync_client = (
-            sync_client if sync_client is not None else Redis.from_url(resolved_url)  # type: ignore[arg-type]
-        )
-        self.async_client = (
-            async_client if async_client is not None else AsyncRedis.from_url(resolved_url)  # type: ignore[arg-type]
-        )
+        self.sync_client = sync_client if sync_client is not None else Redis.from_url(resolved_url)
+        self.async_client = async_client if async_client is not None else AsyncRedis.from_url(resolved_url)
 
         print_verbose(f"Valkey semantic-cache initializing index - {self.index_name}")
 

--- a/litellm/completion_extras/litellm_responses_transformation/handler.py
+++ b/litellm/completion_extras/litellm_responses_transformation/handler.py
@@ -238,7 +238,7 @@ class ResponsesToCompletionBridgeHandler:
             if self._is_preformatted_cached_chat_stream(result):
                 return self._apply_post_stream_processing(result, model, custom_llm_provider)
             completion_stream: Final = self.transformation_handler.get_model_response_iterator(
-                streaming_response=result,  # type: ignore
+                streaming_response=result,
                 sync_stream=True,
                 json_mode=kwargs.get("json_mode"),
             )
@@ -336,7 +336,7 @@ class ResponsesToCompletionBridgeHandler:
             if self._is_preformatted_cached_chat_stream(result):
                 return self._apply_post_stream_processing(result, model, custom_llm_provider)
             completion_stream: Final = self.transformation_handler.get_model_response_iterator(
-                streaming_response=result,  # type: ignore
+                streaming_response=result,
                 sync_stream=False,
                 json_mode=kwargs.get("json_mode"),
             )

--- a/litellm/completion_extras/litellm_responses_transformation/transformation.py
+++ b/litellm/completion_extras/litellm_responses_transformation/transformation.py
@@ -63,9 +63,9 @@ def _get_reasoning_items(
     msg: "AllMessageValues",
 ) -> list[ChatCompletionReasoningItem]:
     """Extract reasoning_items from a message dict with proper typing."""
-    items: Final = msg.get("reasoning_items")  # type: ignore[union-attr]
+    items: Final = msg.get("reasoning_items")
     if items:
-        return items  # type: ignore[return-value]
+        return items
     return []
 
 
@@ -261,8 +261,8 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                             "type": "message",
                             "role": role,
                             "content": self._convert_content_to_responses_format(
-                                content,  # type: ignore[arg-type]
-                                role,  # type: ignore
+                                content,
+                                role,
                             ),
                         }
                     )
@@ -336,7 +336,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     {
                         "type": "message",
                         "role": role,
-                        "content": self._convert_content_to_responses_format(content, cast(str, role)),  # type: ignore[arg-type]
+                        "content": self._convert_content_to_responses_format(content, cast(str, role)),
                     }
                 )
 
@@ -360,17 +360,15 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
             elif key == "response_format":
                 text_format = self._transform_response_format_to_text_format(value)
                 if text_format:
-                    responses_api_request["text"] = text_format  # type: ignore
+                    responses_api_request["text"] = text_format
             elif key == "tool_choice":
-                responses_api_request["tool_choice"] = (  # type: ignore[assignment]
-                    self._normalize_tool_choice_for_responses_api(value)
-                )
+                responses_api_request["tool_choice"] = self._normalize_tool_choice_for_responses_api(value)
             elif key == "stream_options":
                 stream_options = normalize_responses_api_stream_options(value)
                 if stream_options is not None:
                     responses_api_request["stream_options"] = stream_options
             elif key in ResponsesAPIOptionalRequestParams.__annotations__.keys():
-                responses_api_request[key] = value  # type: ignore
+                responses_api_request[key] = value
             elif key == "previous_response_id":
                 responses_api_request["previous_response_id"] = value
             elif key == "reasoning_effort":
@@ -524,7 +522,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                 ResponseApplyPatchToolCall,
             )
         except ImportError:
-            ResponseApplyPatchToolCall = None  # type: ignore[assignment,misc]
+            ResponseApplyPatchToolCall = None
 
         from litellm.types.utils import Choices, Message
 
@@ -942,7 +940,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     flat_custom["format"] = convert_custom_tool_format_to_responses_shape(custom_payload["format"])
                 responses_tools.append(flat_custom)
             else:
-                responses_tools.append(tool)  # type: ignore
+                responses_tools.append(tool)
 
         return cast(list["ALL_RESPONSES_API_TOOL_PARAMS"], responses_tools)
 
@@ -978,7 +976,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
     def _map_reasoning_effort(self, reasoning_effort: str | dict[str, Any]) -> Reasoning | None:
         # If dict is passed, convert it directly to Reasoning object
         if isinstance(reasoning_effort, dict):
-            return Reasoning(**reasoning_effort)  # type: ignore[typeddict-item]
+            return Reasoning(**reasoning_effort)
 
         # Check if auto-summary is enabled via flag or environment variable
         # Priority: litellm.reasoning_auto_summary flag > LITELLM_REASONING_AUTO_SUMMARY env var
@@ -988,11 +986,11 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
 
         # If string is passed, map with optional summary based on flag/env var
         if reasoning_effort == "none":
-            return Reasoning(effort="none", summary="detailed") if auto_summary_enabled else Reasoning(effort="none")  # type: ignore
+            return Reasoning(effort="none", summary="detailed") if auto_summary_enabled else Reasoning(effort="none")
         elif reasoning_effort == "high":
             return Reasoning(effort="high", summary="detailed") if auto_summary_enabled else Reasoning(effort="high")
         elif reasoning_effort == "xhigh":
-            return Reasoning(effort="xhigh", summary="detailed") if auto_summary_enabled else Reasoning(effort="xhigh")  # type: ignore[typeddict-item]
+            return Reasoning(effort="xhigh", summary="detailed") if auto_summary_enabled else Reasoning(effort="xhigh")
         elif reasoning_effort == "medium":
             return (
                 Reasoning(effort="medium", summary="detailed") if auto_summary_enabled else Reasoning(effort="medium")
@@ -1108,7 +1106,7 @@ class LiteLLMResponsesTransformationHandler(CompletionTransformationBridge):
                     verbose_logger.debug("Skipping unsupported annotation type: %s", type(annotation))
                     continue
 
-                result.append(annotation_dict)  # type: ignore
+                result.append(annotation_dict)
             except Exception as e:
                 # Skip malformed annotations
                 verbose_logger.debug("Skipping malformed annotation: %s, error: %s", annotation, e)
@@ -1254,7 +1252,7 @@ class OpenAiResponsesToChatCompletionStreamIterator(BaseModelResponseIterator):
                     function=function_chunk,
                 )
                 if provider_specific_fields:
-                    tool_call_chunk.provider_specific_fields = provider_specific_fields  # type: ignore
+                    tool_call_chunk.provider_specific_fields = provider_specific_fields
 
                 return ModelResponseStream(
                     choices=[

--- a/litellm/compression/scoring/bm25.py
+++ b/litellm/compression/scoring/bm25.py
@@ -84,7 +84,7 @@ def bm25_score_messages(
     # document tokens that start with that term (min 4 chars match).  This lets
     # "cook" match "cooking" and "auth" match "authentication" without a full
     # stemmer dependency.
-    def _expand_tf(query_term: str, tf_counts: Counter) -> int:  # type: ignore[type-arg]
+    def _expand_tf(query_term: str, tf_counts: Counter) -> int:
         """Sum TF across all doc tokens that are prefixed by query_term."""
         exact: Final = tf_counts.get(query_term, 0)
         if exact:

--- a/litellm/containers/main.py
+++ b/litellm/containers/main.py
@@ -187,7 +187,7 @@ def create_container(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id")
         _is_async: Final = kwargs.pop("async_call", False) is True
 
@@ -405,7 +405,7 @@ def list_containers(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id")
         _is_async: Final = kwargs.pop("async_call", False) is True
 
@@ -596,7 +596,7 @@ def retrieve_container(
     local_vars: Final = locals()
     try:
         resolved_custom_llm_provider: str = custom_llm_provider
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id")
         _is_async: Final = kwargs.pop("async_call", False) is True
 
@@ -811,7 +811,7 @@ def delete_container(
     local_vars: Final = locals()
     try:
         resolved_custom_llm_provider: str = custom_llm_provider
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id")
         _is_async: Final = kwargs.pop("async_call", False) is True
 
@@ -1040,7 +1040,7 @@ def list_container_files(
     local_vars: Final = locals()
     try:
         resolved_custom_llm_provider: str = custom_llm_provider
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id")
         _is_async: Final = kwargs.pop("async_call", False) is True
 
@@ -1291,7 +1291,7 @@ def upload_container_file(
     local_vars: Final = locals()
     try:
         resolved_custom_llm_provider: str = custom_llm_provider
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id")
         _is_async: Final = kwargs.pop("async_call", False) is True
 

--- a/litellm/containers/utils.py
+++ b/litellm/containers/utils.py
@@ -53,7 +53,7 @@ class ContainerRequestUtils:
 
         for param in valid_params:
             if param in passed_params and passed_params[param] is not None:
-                container_create_optional_params[param] = passed_params[param]  # type: ignore
+                container_create_optional_params[param] = passed_params[param]
 
         return container_create_optional_params
 
@@ -69,7 +69,7 @@ class ContainerRequestUtils:
         filtered_params: Final = {k: v for k, v in container_create_optional_params.items() if k in supported_params}
 
         return container_provider_config.map_openai_params(
-            container_create_optional_params=filtered_params,  # type: ignore
+            container_create_optional_params=filtered_params,
             drop_params=False,
         )
 
@@ -90,7 +90,7 @@ class ContainerRequestUtils:
 
         for param in valid_params:
             if param in passed_params and passed_params[param] is not None:
-                container_list_optional_params[param] = passed_params[param]  # type: ignore
+                container_list_optional_params[param] = passed_params[param]
 
         return container_list_optional_params
 

--- a/litellm/cost_calculator.py
+++ b/litellm/cost_calculator.py
@@ -329,7 +329,7 @@ def cost_per_token(
     response: Any | None = None,
     ### REQUEST MODEL ###
     request_model: str | None = None,  # original request model for router detection
-) -> tuple[float, float]:  # type: ignore
+) -> tuple[float, float]:
     """
     Calculates the cost per token for a given model, prompt tokens, and completion tokens.
 
@@ -1514,7 +1514,7 @@ def completion_cost(
                 # see https://replicate.com/pricing
                 elif (model in litellm.replicate_models or "replicate" in model) and model not in litellm.model_cost:
                     # for unmapped replicate model, default to replicate's time tracking logic
-                    return get_replicate_completion_pricing(completion_response, total_time)  # type: ignore
+                    return get_replicate_completion_pricing(completion_response, total_time)
 
                 if model is None:
                     raise ValueError(

--- a/litellm/evals/main.py
+++ b/litellm/evals/main.py
@@ -141,7 +141,7 @@ def create_eval(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("acreate_eval", False) is True
 
@@ -153,7 +153,7 @@ def create_eval(
             custom_llm_provider = "openai"
 
         # Get provider config
-        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(  # type: ignore
+        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
@@ -162,15 +162,15 @@ def create_eval(
 
         # Build create request
         create_request: Final[CreateEvalRequest] = {
-            "data_source_config": data_source_config,  # type: ignore
-            "testing_criteria": testing_criteria,  # type: ignore
+            "data_source_config": data_source_config,
+            "testing_criteria": testing_criteria,
         }
         if name is not None:
             create_request["name"] = name
 
         # Merge extra_body if provided
         if extra_body:
-            create_request.update(extra_body)  # type: ignore
+            create_request.update(extra_body)
 
         # Validate environment and get headers
         headers = extra_headers or {}
@@ -199,7 +199,7 @@ def create_eval(
         )
 
         # Make HTTP request
-        response: Final = base_llm_http_handler.create_eval_handler(  # type: ignore
+        response: Final = base_llm_http_handler.create_eval_handler(
             url=url,
             request_body=request_body,
             evals_api_provider_config=evals_api_provider_config,
@@ -326,7 +326,7 @@ def list_evals(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("alist_evals", False) is True
 
@@ -338,7 +338,7 @@ def list_evals(
             custom_llm_provider = "openai"
 
         # Get provider config
-        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(  # type: ignore
+        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
@@ -354,13 +354,13 @@ def list_evals(
         if before is not None:
             list_params["before"] = before
         if order is not None:
-            list_params["order"] = order  # type: ignore
+            list_params["order"] = order
         if order_by is not None:
-            list_params["order_by"] = order_by  # type: ignore
+            list_params["order_by"] = order_by
 
         # Merge extra_query if provided
         if extra_query:
-            list_params.update(extra_query)  # type: ignore
+            list_params.update(extra_query)
 
         # Validate environment and get headers
         headers = extra_headers or {}
@@ -385,7 +385,7 @@ def list_evals(
         )
 
         # Make HTTP request
-        response: Final = base_llm_http_handler.list_evals_handler(  # type: ignore
+        response: Final = base_llm_http_handler.list_evals_handler(
             url=url,
             query_params=query_params,
             evals_api_provider_config=evals_api_provider_config,
@@ -492,7 +492,7 @@ def get_eval(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("aget_eval", False) is True
 
@@ -504,7 +504,7 @@ def get_eval(
             custom_llm_provider = "openai"
 
         # Get provider config
-        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(  # type: ignore
+        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
@@ -536,7 +536,7 @@ def get_eval(
         )
 
         # Make HTTP request
-        response: Final = base_llm_http_handler.get_eval_handler(  # type: ignore
+        response: Final = base_llm_http_handler.get_eval_handler(
             url=url,
             evals_api_provider_config=evals_api_provider_config,
             custom_llm_provider=custom_llm_provider,
@@ -657,7 +657,7 @@ def update_eval(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("aupdate_eval", False) is True
 
@@ -669,7 +669,7 @@ def update_eval(
             custom_llm_provider = "openai"
 
         # Get provider config
-        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(  # type: ignore
+        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
@@ -723,7 +723,7 @@ def update_eval(
 
         # Merge extra_body if provided
         if extra_body:
-            update_request.update(extra_body)  # type: ignore
+            update_request.update(extra_body)
 
         # Validate environment and get headers
         headers = extra_headers or {}
@@ -755,7 +755,7 @@ def update_eval(
         )
 
         # Make HTTP request
-        response: Final = base_llm_http_handler.update_eval_handler(  # type: ignore
+        response: Final = base_llm_http_handler.update_eval_handler(
             url=url,
             request_body=request_body,
             evals_api_provider_config=evals_api_provider_config,
@@ -862,7 +862,7 @@ def delete_eval(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("adelete_eval", False) is True
 
@@ -874,7 +874,7 @@ def delete_eval(
             custom_llm_provider = "openai"
 
         # Get provider config
-        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(  # type: ignore
+        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
@@ -906,7 +906,7 @@ def delete_eval(
         )
 
         # Make HTTP request
-        response: Final = base_llm_http_handler.delete_eval_handler(  # type: ignore
+        response: Final = base_llm_http_handler.delete_eval_handler(
             url=url,
             evals_api_provider_config=evals_api_provider_config,
             custom_llm_provider=custom_llm_provider,
@@ -1012,7 +1012,7 @@ def cancel_eval(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("acancel_eval", False) is True
 
@@ -1024,7 +1024,7 @@ def cancel_eval(
             custom_llm_provider = "openai"
 
         # Get provider config
-        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(  # type: ignore
+        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
@@ -1060,7 +1060,7 @@ def cancel_eval(
         )
 
         # Make HTTP request
-        response: Final = base_llm_http_handler.cancel_eval_handler(  # type: ignore
+        response: Final = base_llm_http_handler.cancel_eval_handler(
             url=url,
             evals_api_provider_config=evals_api_provider_config,
             custom_llm_provider=custom_llm_provider,
@@ -1191,7 +1191,7 @@ def create_run(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("acreate_run", False) is True
 
@@ -1203,7 +1203,7 @@ def create_run(
             custom_llm_provider = "openai"
 
         # Get provider config
-        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(  # type: ignore
+        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
@@ -1212,7 +1212,7 @@ def create_run(
 
         # Build create request
         create_request: Final[CreateRunRequest] = {
-            "data_source": data_source,  # type: ignore
+            "data_source": data_source,
         }
         if name is not None:
             create_request["name"] = name
@@ -1221,7 +1221,7 @@ def create_run(
 
         # Merge extra_body if provided
         if extra_body:
-            create_request.update(extra_body)  # type: ignore
+            create_request.update(extra_body)
 
         # Validate environment and get headers
         headers = extra_headers or {}
@@ -1248,7 +1248,7 @@ def create_run(
         )
 
         # Make HTTP request (default 600s timeout for long-running operations)
-        response: Final = base_llm_http_handler.create_run_handler(  # type: ignore
+        response: Final = base_llm_http_handler.create_run_handler(
             url=url,
             request_body=request_body,
             evals_api_provider_config=evals_api_provider_config,
@@ -1375,7 +1375,7 @@ def list_runs(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("alist_runs", False) is True
 
@@ -1387,7 +1387,7 @@ def list_runs(
             custom_llm_provider = "openai"
 
         # Get provider config
-        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(  # type: ignore
+        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
@@ -1403,11 +1403,11 @@ def list_runs(
         if before is not None:
             list_params["before"] = before
         if order is not None:
-            list_params["order"] = order  # type: ignore
+            list_params["order"] = order
 
         # Merge extra_query if provided
         if extra_query:
-            list_params.update(extra_query)  # type: ignore
+            list_params.update(extra_query)
 
         # Validate environment and get headers
         headers = extra_headers or {}
@@ -1433,7 +1433,7 @@ def list_runs(
         )
 
         # Make HTTP request
-        response: Final = base_llm_http_handler.list_runs_handler(  # type: ignore
+        response: Final = base_llm_http_handler.list_runs_handler(
             url=url,
             query_params=query_params,
             evals_api_provider_config=evals_api_provider_config,
@@ -1545,7 +1545,7 @@ def get_run(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("aget_run", False) is True
 
@@ -1557,7 +1557,7 @@ def get_run(
             custom_llm_provider = "openai"
 
         # Get provider config
-        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(  # type: ignore
+        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
@@ -1590,7 +1590,7 @@ def get_run(
         )
 
         # Make HTTP request
-        response: Final = base_llm_http_handler.get_run_handler(  # type: ignore
+        response: Final = base_llm_http_handler.get_run_handler(
             url=url,
             evals_api_provider_config=evals_api_provider_config,
             custom_llm_provider=custom_llm_provider,
@@ -1701,7 +1701,7 @@ def cancel_run(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("acancel_run", False) is True
 
@@ -1713,7 +1713,7 @@ def cancel_run(
             custom_llm_provider = "openai"
 
         # Get provider config
-        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(  # type: ignore
+        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
@@ -1750,7 +1750,7 @@ def cancel_run(
         )
 
         # Make HTTP request
-        response: Final = base_llm_http_handler.cancel_run_handler(  # type: ignore
+        response: Final = base_llm_http_handler.cancel_run_handler(
             url=url,
             evals_api_provider_config=evals_api_provider_config,
             custom_llm_provider=custom_llm_provider,
@@ -1866,7 +1866,7 @@ def delete_run(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("adelete_run", False) is True
 
@@ -1878,7 +1878,7 @@ def delete_run(
             custom_llm_provider = "openai"
 
         # Get provider config
-        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(  # type: ignore
+        evals_api_provider_config: BaseEvalsAPIConfig | None = ProviderConfigManager.get_provider_evals_api_config(
             provider=litellm.LlmProviders(custom_llm_provider),
         )
 
@@ -1915,7 +1915,7 @@ def delete_run(
         )
 
         # Make HTTP request
-        response: Final = base_llm_http_handler.delete_run_handler(  # type: ignore
+        response: Final = base_llm_http_handler.delete_run_handler(
             url=url,
             evals_api_provider_config=evals_api_provider_config,
             custom_llm_provider=custom_llm_provider,

--- a/litellm/exceptions.py
+++ b/litellm/exceptions.py
@@ -126,7 +126,7 @@ def _get_minimal_error_response() -> httpx.Response:
     return _MINIMAL_ERROR_RESPONSE
 
 
-class AuthenticationError(openai.AuthenticationError):  # type: ignore
+class AuthenticationError(openai.AuthenticationError):
     def __init__(
         self,
         message,
@@ -170,7 +170,7 @@ class AuthenticationError(openai.AuthenticationError):  # type: ignore
 
 
 # raise when invalid models passed, example gpt-8
-class NotFoundError(openai.NotFoundError):  # type: ignore
+class NotFoundError(openai.NotFoundError):
     def __init__(
         self,
         message,
@@ -213,7 +213,7 @@ class NotFoundError(openai.NotFoundError):  # type: ignore
         return _message
 
 
-class BadRequestError(openai.BadRequestError):  # type: ignore
+class BadRequestError(openai.BadRequestError):
     def __init__(
         self,
         message,
@@ -288,7 +288,7 @@ class ImageFetchError(BadRequestError):
         )
 
 
-class UnprocessableEntityError(openai.UnprocessableEntityError):  # type: ignore
+class UnprocessableEntityError(openai.UnprocessableEntityError):
     def __init__(
         self,
         message,
@@ -327,7 +327,7 @@ class UnprocessableEntityError(openai.UnprocessableEntityError):  # type: ignore
         return _message
 
 
-class Timeout(openai.APITimeoutError):  # type: ignore
+class Timeout(openai.APITimeoutError):
     def __init__(
         self,
         message,
@@ -371,7 +371,7 @@ class Timeout(openai.APITimeoutError):  # type: ignore
         return _message
 
 
-class PermissionDeniedError(openai.PermissionDeniedError):  # type: ignore
+class PermissionDeniedError(openai.PermissionDeniedError):
     def __init__(
         self,
         message,
@@ -410,7 +410,7 @@ class PermissionDeniedError(openai.PermissionDeniedError):  # type: ignore
         return _message
 
 
-class RateLimitError(openai.RateLimitError):  # type: ignore
+class RateLimitError(openai.RateLimitError):
     """
     Unified rate-limit error.
 
@@ -501,7 +501,7 @@ class RateLimitError(openai.RateLimitError):  # type: ignore
 
 
 # sub class of rate limit error - meant to give more granularity for error handling context window exceeded errors
-class ContextWindowExceededError(BadRequestError):  # type: ignore
+class ContextWindowExceededError(BadRequestError):
     def __init__(
         self,
         message,
@@ -516,8 +516,8 @@ class ContextWindowExceededError(BadRequestError):  # type: ignore
         self.litellm_debug_info = litellm_debug_info
         super().__init__(
             message=message,
-            model=self.model,  # type: ignore
-            llm_provider=self.llm_provider,  # type: ignore
+            model=self.model,
+            llm_provider=self.llm_provider,
             response=response,
             litellm_debug_info=self.litellm_debug_info,
         )  # Call the base class constructor with the parameters it needs
@@ -543,7 +543,7 @@ class ContextWindowExceededError(BadRequestError):  # type: ignore
 
 
 # sub class of bad request error - meant to help us catch guardrails-related errors on proxy.
-class RejectedRequestError(BadRequestError):  # type: ignore
+class RejectedRequestError(BadRequestError):
     def __init__(
         self,
         message,
@@ -562,8 +562,8 @@ class RejectedRequestError(BadRequestError):  # type: ignore
         response: Final = httpx.Response(status_code=400, request=request)
         super().__init__(
             message=self.message,
-            model=self.model,  # type: ignore
-            llm_provider=self.llm_provider,  # type: ignore
+            model=self.model,
+            llm_provider=self.llm_provider,
             response=response,
             litellm_debug_info=self.litellm_debug_info,
         )  # Call the base class constructor with the parameters it needs
@@ -585,7 +585,7 @@ class RejectedRequestError(BadRequestError):  # type: ignore
         return _message
 
 
-class ContentPolicyViolationError(BadRequestError):  # type: ignore
+class ContentPolicyViolationError(BadRequestError):
     #  Error code: 400 - {'error': {'code': 'content_policy_violation', 'message': 'Your request was rejected as a result of our safety system. Image descriptions generated from your prompt may contain text that is not allowed by our safety system. If you believe this was done in error, your request may succeed if retried, or by adjusting your prompt.', 'param': None, 'type': 'invalid_request_error'}}
     def __init__(
         self,
@@ -605,8 +605,8 @@ class ContentPolicyViolationError(BadRequestError):  # type: ignore
         self.provider_specific_fields = provider_specific_fields
         super().__init__(
             message=self.message,
-            model=self.model,  # type: ignore
-            llm_provider=self.llm_provider,  # type: ignore
+            model=self.model,
+            llm_provider=self.llm_provider,
             response=response,
             litellm_debug_info=self.litellm_debug_info,
             body=body,
@@ -630,7 +630,7 @@ class ContentPolicyViolationError(BadRequestError):  # type: ignore
         return _message
 
 
-class ServiceUnavailableError(openai.APIStatusError):  # type: ignore
+class ServiceUnavailableError(openai.APIStatusError):
     def __init__(
         self,
         message,
@@ -678,7 +678,7 @@ class ServiceUnavailableError(openai.APIStatusError):  # type: ignore
         return _message
 
 
-class BadGatewayError(openai.APIStatusError):  # type: ignore
+class BadGatewayError(openai.APIStatusError):
     def __init__(
         self,
         message,
@@ -726,7 +726,7 @@ class BadGatewayError(openai.APIStatusError):  # type: ignore
         return _message
 
 
-class InternalServerError(openai.InternalServerError):  # type: ignore
+class InternalServerError(openai.InternalServerError):
     def __init__(
         self,
         message,
@@ -775,7 +775,7 @@ class InternalServerError(openai.InternalServerError):  # type: ignore
 
 
 # raise this when the API returns an invalid response object - https://github.com/openai/openai-python/blob/1be14ee34a0f8e42d3f9aa5451aa4cb161f1781f/openai/api_requestor.py#L401
-class APIError(openai.APIError):  # type: ignore
+class APIError(openai.APIError):
     def __init__(
         self,
         status_code: int,
@@ -796,7 +796,7 @@ class APIError(openai.APIError):  # type: ignore
         self.num_retries = num_retries
         if request is None:
             request = httpx.Request(method="POST", url="https://api.openai.com/v1")
-        super().__init__(self.message, request=request, body=None)  # type: ignore
+        super().__init__(self.message, request=request, body=None)
 
     def __str__(self):
         _message = self.message
@@ -816,7 +816,7 @@ class APIError(openai.APIError):  # type: ignore
 
 
 # raised if an invalid request (not get, delete, put, post) is made
-class APIConnectionError(openai.APIConnectionError):  # type: ignore
+class APIConnectionError(openai.APIConnectionError):
     def __init__(
         self,
         message,
@@ -855,7 +855,7 @@ class APIConnectionError(openai.APIConnectionError):  # type: ignore
 
 
 # raised if an invalid request (not get, delete, put, post) is made
-class APIResponseValidationError(openai.APIResponseValidationError):  # type: ignore
+class APIResponseValidationError(openai.APIResponseValidationError):
     def __init__(
         self,
         message,
@@ -902,7 +902,7 @@ class JSONSchemaValidationError(APIResponseValidationError):
         super().__init__(model=model, message=message, llm_provider=llm_provider)
 
 
-class OpenAIError(openai.OpenAIError):  # type: ignore
+class OpenAIError(openai.OpenAIError):
     def __init__(self, original_exception=None):
         super().__init__()
         self.llm_provider = "openai"
@@ -987,7 +987,7 @@ class BudgetExceededError(Exception):
 
 
 ## DEPRECATED ##
-class InvalidRequestError(openai.BadRequestError):  # type: ignore
+class InvalidRequestError(openai.BadRequestError):
     def __init__(self, message, model, llm_provider):
         self.status_code = 400
         self.message = message
@@ -1024,7 +1024,7 @@ class MockException(openai.APIError):
         self.num_retries = num_retries
         if request is None:
             request = httpx.Request(method="POST", url="https://api.openai.com/v1")
-        super().__init__(self.message, request=request, body=None)  # type: ignore
+        super().__init__(self.message, request=request, body=None)
 
 
 class LiteLLMUnknownProvider(BadRequestError):
@@ -1070,7 +1070,7 @@ class BlockedPiiEntityError(Exception):
         super().__init__(self.message)
 
 
-class MidStreamFallbackError(ServiceUnavailableError):  # type: ignore
+class MidStreamFallbackError(ServiceUnavailableError):
     def __init__(
         self,
         message: str,

--- a/litellm/experimental_mcp_client/client.py
+++ b/litellm/experimental_mcp_client/client.py
@@ -15,7 +15,7 @@ from mcp.client.stdio import stdio_client
 
 streamable_http_client: Any | None = None
 try:
-    import mcp.client.streamable_http as streamable_http_module  # type: ignore
+    import mcp.client.streamable_http as streamable_http_module
 
     streamable_http_client = getattr(streamable_http_module, "streamable_http_client", None)
 except ImportError:

--- a/litellm/files/main.py
+++ b/litellm/files/main.py
@@ -131,7 +131,7 @@ async def acreate_file(
         if asyncio.iscoroutine(init_response):
             response = await init_response
         else:
-            response = init_response  # type: ignore
+            response = init_response
 
         return response
     except Exception as e:
@@ -176,7 +176,7 @@ def create_file(
             read_timeout: Final = timeout.read or 600
             timeout = read_timeout  # default 10 min timeout
         elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-            timeout = float(timeout)  # type: ignore
+            timeout = float(timeout)
         elif timeout is None:
             timeout = 600.0
 
@@ -252,7 +252,7 @@ def create_file(
                 response=httpx.Response(
                     status_code=400,
                     content="Unsupported provider",
-                    request=httpx.Request(method="create_file", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                    request=httpx.Request(method="create_file", url="https://github.com/BerriAI/litellm"),
                 ),
             )
         return response
@@ -328,7 +328,7 @@ def file_retrieve(
             read_timeout: Final = timeout.read or 600
             timeout = read_timeout  # default 10 min timeout
         elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-            timeout = float(timeout)  # type: ignore
+            timeout = float(timeout)
         elif timeout is None:
             timeout = 600.0
 
@@ -419,7 +419,7 @@ def file_retrieve(
                         request=httpx.Request(
                             method="create_thread",
                             url="https://github.com/BerriAI/litellm",
-                        ),  # type: ignore
+                        ),
                     ),
                 )
 
@@ -465,9 +465,9 @@ async def afile_delete(
         if asyncio.iscoroutine(init_response):
             response = await init_response
         else:
-            response = init_response  # type: ignore
+            response = init_response
 
-        return cast(FileDeleted, response)  # type: ignore
+        return cast(FileDeleted, response)
     except Exception as e:
         raise e
 
@@ -511,7 +511,7 @@ def file_delete(
             read_timeout: Final = timeout.read or 600
             timeout = read_timeout  # default 10 min timeout
         elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-            timeout = float(timeout)  # type: ignore
+            timeout = float(timeout)
         elif timeout is None:
             timeout = 600.0
         _is_async: Final = kwargs.pop("is_async", False) is True
@@ -596,7 +596,7 @@ def file_delete(
                         request=httpx.Request(
                             method="create_thread",
                             url="https://github.com/BerriAI/litellm",
-                        ),  # type: ignore
+                        ),
                     ),
                 )
         return cast(FileDeleted, response)
@@ -639,7 +639,7 @@ async def afile_list(
         if asyncio.iscoroutine(init_response):
             response = await init_response
         else:
-            response = init_response  # type: ignore
+            response = init_response
 
         return response
     except Exception as e:
@@ -673,7 +673,7 @@ def file_list(
             read_timeout: Final = timeout.read or 600
             timeout = read_timeout  # default 10 min timeout
         elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-            timeout = float(timeout)  # type: ignore
+            timeout = float(timeout)
         elif timeout is None:
             timeout = 600.0
 
@@ -755,7 +755,7 @@ def file_list(
                 response=httpx.Response(
                     status_code=400,
                     content="Unsupported provider",
-                    request=httpx.Request(method="file_list", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                    request=httpx.Request(method="file_list", url="https://github.com/BerriAI/litellm"),
                 ),
             )
         return response
@@ -803,7 +803,7 @@ async def afile_content(
         if asyncio.iscoroutine(init_response):
             response = await init_response
         else:
-            response = init_response  # type: ignore
+            response = init_response
 
         return response
     except Exception as e:
@@ -857,7 +857,7 @@ def file_content(
             read_timeout: Final = timeout.read or 600
             timeout = read_timeout  # default 10 min timeout
         elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-            timeout = float(timeout)  # type: ignore
+            timeout = float(timeout)
         elif timeout is None:
             timeout = 600.0
 
@@ -987,7 +987,7 @@ def file_content(
                 response=httpx.Response(
                     status_code=400,
                     content="Unsupported provider",
-                    request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                    request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
                 ),
             )
         return response
@@ -1065,7 +1065,7 @@ def file_content_streaming(
             response=httpx.Response(
                 status_code=400,
                 content="Unsupported provider",
-                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
             ),
         )
 

--- a/litellm/files/streaming.py
+++ b/litellm/files/streaming.py
@@ -93,9 +93,9 @@ class FileContentStreamingResponse:
         # are released promptly on client disconnects.
         with anyio.CancelScope(shield=True):
             if hasattr(stream_to_close, "aclose"):
-                await cast(AsyncIterator[bytes], stream_to_close).aclose()  # type: ignore[attr-defined]
+                await cast(AsyncIterator[bytes], stream_to_close).aclose()
             elif hasattr(stream_to_close, "close"):
-                result: Final = cast(Iterator[bytes], stream_to_close).close()  # type: ignore[attr-defined]
+                result: Final = cast(Iterator[bytes], stream_to_close).close()
                 if result is not None:
                     await result
 
@@ -109,7 +109,7 @@ class FileContentStreamingResponse:
         self.stream_iterator = cast(Iterator[bytes] | AsyncIterator[bytes], iter(()))
 
         if hasattr(stream_to_close, "close"):
-            cast(Iterator[bytes], stream_to_close).close()  # type: ignore[attr-defined]
+            cast(Iterator[bytes], stream_to_close).close()
 
     def _build_logging_response(self) -> dict[str, str]:
         response: Final = {

--- a/litellm/fine_tuning/main.py
+++ b/litellm/fine_tuning/main.py
@@ -119,7 +119,7 @@ async def acreate_fine_tuning_job(
         if asyncio.iscoroutine(init_response):
             response = await init_response
         else:
-            response = init_response  # type: ignore
+            response = init_response
         return response
     except Exception as e:
         raise e
@@ -242,9 +242,9 @@ def create_fine_tuning_job(
             )
         # Azure OpenAI
         elif custom_llm_provider == "azure":
-            api_base = optional_params.api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")  # type: ignore
+            api_base = optional_params.api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")
 
-            api_version = optional_params.api_version or litellm.api_version or get_secret_str("AZURE_API_VERSION")  # type: ignore
+            api_version = optional_params.api_version or litellm.api_version or get_secret_str("AZURE_API_VERSION")
 
             api_key = (
                 optional_params.api_key
@@ -252,7 +252,7 @@ def create_fine_tuning_job(
                 or litellm.azure_key
                 or get_secret_str("AZURE_OPENAI_API_KEY")
                 or get_secret_str("AZURE_API_KEY")
-            )  # type: ignore
+            )
 
             extra_body = optional_params.get("extra_body", {})
             if extra_body is not None:
@@ -321,7 +321,7 @@ def create_fine_tuning_job(
                 response=httpx.Response(
                     status_code=400,
                     content="Unsupported provider",
-                    request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                    request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
                 ),
             )
         return response
@@ -362,7 +362,7 @@ async def acancel_fine_tuning_job(
         if asyncio.iscoroutine(init_response):
             response = await init_response
         else:
-            response = init_response  # type: ignore
+            response = init_response
         return response
     except Exception as e:
         raise e
@@ -396,7 +396,7 @@ def cancel_fine_tuning_job(
             read_timeout: Final = timeout.read or 600
             timeout = read_timeout  # default 10 min timeout
         elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-            timeout = float(timeout)  # type: ignore
+            timeout = float(timeout)
         elif timeout is None:
             timeout = 600.0
 
@@ -441,7 +441,7 @@ def cancel_fine_tuning_job(
         elif custom_llm_provider == "azure":
             api_base = optional_params.api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")
 
-            api_version = optional_params.api_version or litellm.api_version or get_secret_str("AZURE_API_VERSION")  # type: ignore
+            api_version = optional_params.api_version or litellm.api_version or get_secret_str("AZURE_API_VERSION")
 
             api_key = (
                 optional_params.api_key
@@ -449,7 +449,7 @@ def cancel_fine_tuning_job(
                 or litellm.azure_key
                 or get_secret_str("AZURE_OPENAI_API_KEY")
                 or get_secret_str("AZURE_API_KEY")
-            )  # type: ignore
+            )
 
             extra_body = optional_params.get("extra_body", {})
             if extra_body is not None:
@@ -473,7 +473,7 @@ def cancel_fine_tuning_job(
                 response=httpx.Response(
                     status_code=400,
                     content="Unsupported provider",
-                    request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                    request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
                 ),
             )
         return response
@@ -514,7 +514,7 @@ async def alist_fine_tuning_jobs(
         if asyncio.iscoroutine(init_response):
             response = await init_response
         else:
-            response = init_response  # type: ignore
+            response = init_response
         return response
     except Exception as e:
         raise e
@@ -550,7 +550,7 @@ def list_fine_tuning_jobs(
             read_timeout: Final = timeout.read or 600
             timeout = read_timeout  # default 10 min timeout
         elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-            timeout = float(timeout)  # type: ignore
+            timeout = float(timeout)
         elif timeout is None:
             timeout = 600.0
 
@@ -594,9 +594,9 @@ def list_fine_tuning_jobs(
             )
         # Azure OpenAI
         elif custom_llm_provider == "azure":
-            api_base = optional_params.api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")  # type: ignore
+            api_base = optional_params.api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")
 
-            api_version = optional_params.api_version or litellm.api_version or get_secret_str("AZURE_API_VERSION")  # type: ignore
+            api_version = optional_params.api_version or litellm.api_version or get_secret_str("AZURE_API_VERSION")
 
             api_key = (
                 optional_params.api_key
@@ -604,7 +604,7 @@ def list_fine_tuning_jobs(
                 or litellm.azure_key
                 or get_secret_str("AZURE_OPENAI_API_KEY")
                 or get_secret_str("AZURE_API_KEY")
-            )  # type: ignore
+            )
 
             extra_body = optional_params.get("extra_body", {})
             if extra_body is not None:
@@ -629,7 +629,7 @@ def list_fine_tuning_jobs(
                 response=httpx.Response(
                     status_code=400,
                     content="Unsupported provider",
-                    request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                    request=httpx.Request(method="create_thread", url="https://github.com/BerriAI/litellm"),
                 ),
             )
         return response
@@ -669,7 +669,7 @@ async def aretrieve_fine_tuning_job(
         if asyncio.iscoroutine(init_response):
             response = await init_response
         else:
-            response = init_response  # type: ignore
+            response = init_response
         return response
     except Exception as e:
         raise e
@@ -700,7 +700,7 @@ def retrieve_fine_tuning_job(
             read_timeout: Final = timeout.read or 600
             timeout = read_timeout  # default 10 min timeout
         elif timeout is not None and not isinstance(timeout, httpx.Timeout):
-            timeout = float(timeout)  # type: ignore
+            timeout = float(timeout)
         elif timeout is None:
             timeout = 600.0
 
@@ -733,9 +733,9 @@ def retrieve_fine_tuning_job(
             )
         # Azure OpenAI
         elif custom_llm_provider == "azure":
-            api_base = optional_params.api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")  # type: ignore
+            api_base = optional_params.api_base or litellm.api_base or get_secret_str("AZURE_API_BASE")
 
-            api_version = optional_params.api_version or litellm.api_version or get_secret_str("AZURE_API_VERSION")  # type: ignore
+            api_version = optional_params.api_version or litellm.api_version or get_secret_str("AZURE_API_VERSION")
 
             api_key = (
                 optional_params.api_key
@@ -743,7 +743,7 @@ def retrieve_fine_tuning_job(
                 or litellm.azure_key
                 or get_secret_str("AZURE_OPENAI_API_KEY")
                 or get_secret_str("AZURE_API_KEY")
-            )  # type: ignore
+            )
 
             extra_body = optional_params.get("extra_body", {})
             if extra_body is not None:
@@ -770,7 +770,7 @@ def retrieve_fine_tuning_job(
                     request=httpx.Request(
                         method="retrieve_fine_tuning_job",
                         url="https://github.com/BerriAI/litellm",
-                    ),  # type: ignore
+                    ),
                 ),
             )
         return response

--- a/litellm/google_genai/main.py
+++ b/litellm/google_genai/main.py
@@ -156,7 +156,7 @@ class GenerateContentHelper:
                 model=model,
                 custom_llm_provider=custom_llm_provider,
                 request_body={},  # Will be handled by adapter
-                generate_content_provider_config=None,  # type: ignore
+                generate_content_provider_config=None,
                 generate_content_config_dict=dict(config or {}),
                 native_request_fields={},
                 litellm_params=litellm_params,
@@ -350,7 +350,7 @@ def generate_content(
             # Use the adapter to convert to completion format
             return GenerateContentToCompletionHandler.generate_content_handler(
                 model=model,
-                contents=contents,  # type: ignore
+                contents=contents,
                 config=setup_result.generate_content_config_dict,
                 tools=tools,
                 _is_async=_is_async,
@@ -444,7 +444,7 @@ async def agenerate_content_stream(
             # Use the adapter to convert to completion format
             return await GenerateContentToCompletionHandler.async_generate_content_handler(
                 model=model,
-                contents=contents,  # type: ignore
+                contents=contents,
                 config=setup_result.generate_content_config_dict,
                 litellm_params=setup_result.litellm_params,
                 tools=tools,
@@ -534,7 +534,7 @@ def generate_content_stream(
             # Use the adapter to convert to completion format
             return GenerateContentToCompletionHandler.generate_content_handler(
                 model=model,
-                contents=contents,  # type: ignore
+                contents=contents,
                 config=setup_result.generate_content_config_dict,
                 _is_async=_is_async,
                 litellm_params=setup_result.litellm_params,

--- a/litellm/images/main.py
+++ b/litellm/images/main.py
@@ -28,7 +28,7 @@ from litellm.utils import exception_type, get_litellm_params
 
 #################### Initialize provider clients ####################
 llm_http_handler: BaseLLMHTTPHandler = BaseLLMHTTPHandler()
-from openai.types.audio.transcription_create_params import FileTypes  # type: ignore
+from openai.types.audio.transcription_create_params import FileTypes
 
 # BFL handlers
 from litellm.llms.black_forest_labs.image_edit.handler import bfl_image_edit
@@ -112,7 +112,7 @@ async def aimage_generation(*args, **kwargs) -> ImageResponse:
         elif isinstance(init_response, ImageResponse):  ## CACHING SCENARIO
             response = init_response
         elif asyncio.iscoroutine(init_response):
-            response = await init_response  # type: ignore
+            response = await init_response
 
         if response is None:
             raise ValueError("Unable to get Image Response. Please pass a valid llm_provider.")
@@ -207,12 +207,12 @@ def image_generation(
         aimg_generation: Final = kwargs.get("aimg_generation", False)
         litellm_call_id: Final = kwargs.get("litellm_call_id", None)
         logger_fn: Final = kwargs.get("logger_fn", None)
-        mock_response: Final[str | None] = kwargs.get("mock_response", None)  # type: ignore
+        mock_response: Final[str | None] = kwargs.get("mock_response", None)
         proxy_server_request: Final = kwargs.get("proxy_server_request", None)
         azure_ad_token_provider = kwargs.get("azure_ad_token_provider", None)
         model_info: Final = kwargs.get("model_info", None)
         metadata: Final = kwargs.get("metadata", {})
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         client: Final = kwargs.get("client", None)
         extra_headers: Final = kwargs.get("extra_headers", None)
         headers: Final[dict] = kwargs.get("headers", None) or {}
@@ -223,7 +223,7 @@ def image_generation(
         dynamic_api_key: str | None = None
         if model is not None or custom_llm_provider is not None:
             model, custom_llm_provider, dynamic_api_key, api_base = get_llm_provider(
-                model=model,  # type: ignore
+                model=model,
                 custom_llm_provider=custom_llm_provider,
                 api_base=api_base,
             )
@@ -479,7 +479,7 @@ def image_generation(
         elif custom_llm_provider == "bedrock":
             if model is None:
                 raise Exception("Model needs to be set for bedrock")
-            model_response = bedrock_image_generation.image_generation(  # type: ignore
+            model_response = bedrock_image_generation.image_generation(
                 model=model,
                 prompt=prompt,
                 timeout=timeout,
@@ -508,7 +508,7 @@ def image_generation(
                     async_custom_client = client
 
                 ## CALL FUNCTION
-                model_response = custom_handler.aimage_generation(  # type: ignore
+                model_response = custom_handler.aimage_generation(
                     model=model,
                     prompt=prompt,
                     api_key=api_key,
@@ -584,7 +584,7 @@ async def aimage_variation(*args, **kwargs) -> ImageResponse:
                 init_response = ImageResponse(**init_response)
             response = init_response
         elif asyncio.iscoroutine(init_response):
-            response = await init_response  # type: ignore
+            response = await init_response
         else:
             # Call the synchronous function using run_in_executor
             response = await loop.run_in_executor(None, func_with_context)
@@ -745,7 +745,7 @@ def image_edit(
         non_default_params: Final = {
             k: v for k, v in kwargs.items() if k not in default_params
         }  # model-specific params - pass them straight to the model/provider
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         model_info: Final = kwargs.get("model_info", None)
         metadata: Final = kwargs.get("metadata", {})
@@ -860,7 +860,7 @@ def image_edit(
             if model is None:
                 raise Exception("Model needs to be set for bedrock")
             image_edit_request_params.update(non_default_params)
-            return bedrock_image_edit.image_edit(  # type: ignore
+            return bedrock_image_edit.image_edit(
                 model=model,
                 image=images,
                 prompt=prompt,

--- a/litellm/integrations/SlackAlerting/slack_alerting.py
+++ b/litellm/integrations/SlackAlerting/slack_alerting.py
@@ -709,7 +709,7 @@ class SlackAlerting(CustomBatchLogger):
         """Format an alert message for slack"""
         headers: Final = {f"{key} Name": key_val, "Provider": provider}
         if api_base is not None:
-            headers["API Base"] = api_base  # type: ignore
+            headers["API Base"] = api_base
 
         headers_str = "\n"
         for k, v in headers.items():
@@ -767,14 +767,11 @@ class SlackAlerting(CustomBatchLogger):
 
         # Convert deployment_ids back to set if it was stored as a list
         if outage_value is not None:
-            outage_value = self._restore_outage_value_from_cache(outage_value)  # type: ignore
+            outage_value = self._restore_outage_value_from_cache(outage_value)
 
         if (
             getattr(exception, "status_code", None) is None
-            or (
-                exception.status_code != 408  # type: ignore
-                and exception.status_code < 500  # type: ignore
-            )
+            or (exception.status_code != 408 and exception.status_code < 500)
             or self.llm_router is None
         ):
             return
@@ -784,7 +781,7 @@ class SlackAlerting(CustomBatchLogger):
             _deployment_set.add(deployment_id)
             outage_value = ProviderRegionOutageModel(
                 provider_region_id=cache_key,
-                alerts=[exception.status_code],  # type: ignore
+                alerts=[exception.status_code],
                 minor_alert_sent=False,
                 major_alert_sent=False,
                 last_updated_at=time.time(),
@@ -802,7 +799,7 @@ class SlackAlerting(CustomBatchLogger):
             return
 
         if len(outage_value["alerts"]) < self.alerting_args.max_outage_alert_list_size:
-            outage_value["alerts"].append(exception.status_code)  # type: ignore
+            outage_value["alerts"].append(exception.status_code)
         else:  # prevent memory leaks
             pass
         _deployment_set = outage_value["deployment_ids"]
@@ -884,13 +881,10 @@ class SlackAlerting(CustomBatchLogger):
         max_alerts_size = 10
         """
         try:
-            outage_value: OutageModel | None = await self.internal_usage_cache.async_get_cache(key=deployment_id)  # type: ignore
+            outage_value: OutageModel | None = await self.internal_usage_cache.async_get_cache(key=deployment_id)
             if (
                 getattr(exception, "status_code", None) is None
-                or (
-                    exception.status_code != 408  # type: ignore
-                    and exception.status_code < 500  # type: ignore
-                )
+                or (exception.status_code != 408 and exception.status_code < 500)
                 or self.llm_router is None
             ):
                 return
@@ -912,7 +906,7 @@ class SlackAlerting(CustomBatchLogger):
             if outage_value is None:
                 outage_value = OutageModel(
                     model_id=deployment_id,
-                    alerts=[exception.status_code],  # type: ignore
+                    alerts=[exception.status_code],
                     minor_alert_sent=False,
                     major_alert_sent=False,
                     last_updated_at=time.time(),
@@ -927,7 +921,7 @@ class SlackAlerting(CustomBatchLogger):
                 return
 
             if len(outage_value["alerts"]) < self.alerting_args.max_outage_alert_list_size:
-                outage_value["alerts"].append(exception.status_code)  # type: ignore
+                outage_value["alerts"].append(exception.status_code)
             else:  # prevent memory leaks
                 pass
 
@@ -1483,10 +1477,10 @@ Model Info:
 
                 if isinstance(response_obj, litellm.ModelResponse) and (
                     hasattr(response_obj, "usage")
-                    and response_obj.usage is not None  # type: ignore
-                    and hasattr(response_obj.usage, "completion_tokens")  # type: ignore
+                    and response_obj.usage is not None
+                    and hasattr(response_obj.usage, "completion_tokens")
                 ):
-                    completion_tokens: Final = response_obj.usage.completion_tokens  # type: ignore
+                    completion_tokens: Final = response_obj.usage.completion_tokens
                     if completion_tokens is not None and completion_tokens > 0:
                         final_value = float(response_s.total_seconds() / completion_tokens)
                 if isinstance(final_value, timedelta):

--- a/litellm/integrations/anthropic_cache_control_hook.py
+++ b/litellm/integrations/anthropic_cache_control_hook.py
@@ -225,11 +225,11 @@ class AnthropicCacheControlHook(CustomPromptManagement):
 
         # 1. if string, insert cache control in the message
         if isinstance(message_content, str):
-            message["cache_control"] = control  # type: ignore
+            message["cache_control"] = control
         # 2. list of objects - only apply to last item per Anthropic spec
         elif isinstance(message_content, list):
             if len(message_content) > 0 and isinstance(message_content[-1], dict):
-                message_content[-1]["cache_control"] = control  # type: ignore
+                message_content[-1]["cache_control"] = control
         return message
 
     @staticmethod

--- a/litellm/integrations/argilla.py
+++ b/litellm/integrations/argilla.py
@@ -10,7 +10,7 @@ import types
 from typing import Any, Final
 
 import httpx
-from pydantic import BaseModel  # type: ignore
+from pydantic import BaseModel
 
 import litellm
 from litellm._logging import verbose_logger
@@ -56,8 +56,8 @@ class ArgillaLogger(CustomBatchLogger):
             argilla_base_url=argilla_base_url,
         )
         self.sampling_rate: float = (
-            float(os.getenv("ARGILLA_SAMPLING_RATE"))  # type: ignore
-            if os.getenv("ARGILLA_SAMPLING_RATE") is not None and os.getenv("ARGILLA_SAMPLING_RATE").strip().isdigit()  # type: ignore
+            float(os.getenv("ARGILLA_SAMPLING_RATE"))
+            if os.getenv("ARGILLA_SAMPLING_RATE") is not None and os.getenv("ARGILLA_SAMPLING_RATE").strip().isdigit()
             else 1.0
         )
 
@@ -196,9 +196,9 @@ class ArgillaLogger(CustomBatchLogger):
     def log_success_event(self, kwargs, response_obj, start_time, end_time):
         try:
             sampling_rate: Final = (
-                float(os.getenv("LANGSMITH_SAMPLING_RATE"))  # type: ignore
+                float(os.getenv("LANGSMITH_SAMPLING_RATE"))
                 if os.getenv("LANGSMITH_SAMPLING_RATE") is not None
-                and os.getenv("LANGSMITH_SAMPLING_RATE").strip().isdigit()  # type: ignore
+                and os.getenv("LANGSMITH_SAMPLING_RATE").strip().isdigit()
                 else 1.0
             )
             random_sample: Final = random.random()

--- a/litellm/integrations/arize/arize_phoenix.py
+++ b/litellm/integrations/arize/arize_phoenix.py
@@ -40,14 +40,14 @@ else:
         )
     except ImportError:
         LITELLM_TRACER_NAME = "litellm"
-        OpenTelemetry = None  # type: ignore
+        OpenTelemetry = None
 
 
 ARIZE_HOSTED_PHOENIX_ENDPOINT: Final = "https://otlp.arize.com/v1/traces"
 _MAX_PROJECT_PROVIDERS: Final = 64
 
 
-class ArizePhoenixLogger(OpenTelemetry):  # type: ignore
+class ArizePhoenixLogger(OpenTelemetry):
     """
     Arize Phoenix logger that sends traces to a Phoenix endpoint.
 
@@ -139,7 +139,7 @@ class ArizePhoenixLogger(OpenTelemetry):  # type: ignore
             project_attributes["deployment.environment"] = deployment_environment
 
         env_resource: Final = OTELResourceDetector().detect()
-        project_resource: Final = Resource.create(project_attributes)  # type: ignore[arg-type]
+        project_resource: Final = Resource.create(project_attributes)
         return env_resource.merge(project_resource)
 
     def _build_tracer_provider_for_project(self, project_name: str) -> TracerProvider:

--- a/litellm/integrations/arize/arize_phoenix_prompt_manager.py
+++ b/litellm/integrations/arize/arize_phoenix_prompt_manager.py
@@ -174,9 +174,7 @@ class ArizePhoenixTemplateManager:
             # Combine rendered content
             final_content = " ".join(rendered_content_parts)
 
-            rendered_messages.append(
-                {"role": role, "content": final_content}  # type: ignore
-            )
+            rendered_messages.append({"role": role, "content": final_content})
 
         return rendered_messages
 

--- a/litellm/integrations/bitbucket/__init__.py
+++ b/litellm/integrations/bitbucket/__init__.py
@@ -27,7 +27,7 @@ def set_global_bitbucket_config(config: dict) -> None:
     """
     import litellm
 
-    litellm.global_bitbucket_config = config  # type: ignore
+    litellm.global_bitbucket_config = config
 
 
 def prompt_initializer(litellm_params: "PromptLiteLLMParams", prompt_spec: "PromptSpec") -> "CustomPromptManagement":

--- a/litellm/integrations/bitbucket/bitbucket_prompt_manager.py
+++ b/litellm/integrations/bitbucket/bitbucket_prompt_manager.py
@@ -292,9 +292,7 @@ class BitBucketPromptManager(CustomPromptManagement):
                 final_messages: list[AllMessageValues] = parsed_messages
             else:
                 # If no messages were parsed, prepend the prompt to existing messages
-                final_messages = [
-                    {"role": "user", "content": rendered_prompt}  # type: ignore
-                ] + messages
+                final_messages = [{"role": "user", "content": rendered_prompt}] + messages
 
             # Update litellm_params with prompt metadata
             if litellm_params is None:
@@ -345,7 +343,7 @@ class BitBucketPromptManager(CustomPromptManagement):
                         {
                             "role": current_role,
                             "content": "\n".join(current_content).strip(),
-                        }  # type: ignore
+                        }
                     )
                 current_role = "system"
                 current_content = [line[7:].strip()]  # Remove "System:" prefix
@@ -355,7 +353,7 @@ class BitBucketPromptManager(CustomPromptManagement):
                         {
                             "role": current_role,
                             "content": "\n".join(current_content).strip(),
-                        }  # type: ignore
+                        }
                     )
                 current_role = "user"
                 current_content = [line[5:].strip()]  # Remove "User:" prefix
@@ -365,7 +363,7 @@ class BitBucketPromptManager(CustomPromptManagement):
                         {
                             "role": current_role,
                             "content": "\n".join(current_content).strip(),
-                        }  # type: ignore
+                        }
                     )
                 current_role = "assistant"
                 current_content = [line[10:].strip()]  # Remove "Assistant:" prefix
@@ -379,9 +377,9 @@ class BitBucketPromptManager(CustomPromptManagement):
 
         # If no role indicators found, treat as a single user message
         if not messages and prompt_content.strip():
-            messages = [{"role": "user", "content": prompt_content.strip()}]  # type: ignore
+            messages = [{"role": "user", "content": prompt_content.strip()}]
 
-        return messages  # type: ignore
+        return messages
 
     def post_call_hook(
         self,

--- a/litellm/integrations/braintrust_logging.py
+++ b/litellm/integrations/braintrust_logging.py
@@ -28,9 +28,9 @@ def get_utc_datetime():
     import datetime as dt
 
     if hasattr(dt, "UTC"):
-        return datetime.now(dt.UTC)  # type: ignore
+        return datetime.now(dt.UTC)
     else:
-        return datetime.utcnow()  # type: ignore
+        return datetime.utcnow()
 
 
 class BraintrustLogger(CustomLogger):
@@ -43,7 +43,7 @@ class BraintrustLogger(CustomLogger):
         self.validate_environment(api_key=api_key)
         self.api_base = api_base or os.getenv("BRAINTRUST_API_BASE") or API_BASE
         self.default_project_id = None
-        self.api_key: str = api_key or os.getenv("BRAINTRUST_API_KEY")  # type: ignore
+        self.api_key: str = api_key or os.getenv("BRAINTRUST_API_KEY")
         self.headers = {
             "Authorization": "Bearer " + self.api_key,
             "Content-Type": "application/json",

--- a/litellm/integrations/braintrust_mock_client.py
+++ b/litellm/integrations/braintrust_mock_client.py
@@ -150,7 +150,7 @@ def create_mock_braintrust_client():
 
     if _original_http_handler_post is None:
         _original_http_handler_post = HTTPHandler.post
-        HTTPHandler.post = _mock_http_handler_post  # type: ignore
+        HTTPHandler.post = _mock_http_handler_post
         verbose_logger.debug("[BRAINTRUST MOCK] Patched HTTPHandler.post")
 
     # CRITICAL: Call the factory's initialization function to patch AsyncHTTPHandler.post

--- a/litellm/integrations/compression_interception/handler.py
+++ b/litellm/integrations/compression_interception/handler.py
@@ -133,7 +133,7 @@ class CompressionInterceptionLogger(CustomLogger):
 
         self._prune_expired_cache()
 
-        compressed: Final = compress(  # type: ignore
+        compressed: Final = compress(
             messages=messages,
             model=model,
             call_type=CallTypes.anthropic_messages,

--- a/litellm/integrations/custom_guardrail.py
+++ b/litellm/integrations/custom_guardrail.py
@@ -34,7 +34,7 @@ from litellm.types.utils import (
 try:
     from fastapi.exceptions import HTTPException
 except ImportError:
-    HTTPException = None  # type: ignore
+    HTTPException = None
 
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLoggingObj
@@ -410,7 +410,7 @@ class CustomGuardrail(CustomLogger):
         if self.should_route_on_sensitive_data():
             try:
                 self.raise_sensitive_data_route_exception(
-                    route_to_model=self.sensitive_data_route_to_model,  # type: ignore
+                    route_to_model=self.sensitive_data_route_to_model,
                     request_data=request_data,
                     detection_info=detection_info,
                 )
@@ -892,9 +892,9 @@ class CustomGuardrail(CustomLogger):
         if event_type is not None:
             guardrail_mode = event_type
         elif isinstance(self.event_hook, Mode):
-            guardrail_mode = GuardrailMode(**dict(self.event_hook.model_dump()))  # type: ignore[typeddict-item]
+            guardrail_mode = GuardrailMode(**dict(self.event_hook.model_dump()))
         else:
-            guardrail_mode = self.event_hook  # type: ignore[assignment]
+            guardrail_mode = self.event_hook
 
         from litellm.litellm_core_utils.core_helpers import (
             filter_exceptions_from_params,

--- a/litellm/integrations/custom_logger.py
+++ b/litellm/integrations/custom_logger.py
@@ -783,13 +783,11 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
             - Converting to string and then truncating the logged content catches this
         2. We want to avoid modifying the original `messages`, `response`, and `error_str` in the logging payload since these are in kwargs and could be returned to the user
         """
-        field_value: Final = standard_logging_object.get(field_name)  # type: ignore
+        field_value: Final = standard_logging_object.get(field_name)
         if field_value:
             str_value: Final = str(field_value)
             if len(str_value) > max_length:
-                standard_logging_object[field_name] = self._truncate_text(  # type: ignore
-                    text=str_value, max_length=max_length
-                )
+                standard_logging_object[field_name] = self._truncate_text(text=str_value, max_length=max_length)
 
     def _truncate_text(self, text: str, max_length: int) -> str:
         """Truncate text if it exceeds max_length"""
@@ -911,7 +909,7 @@ class CustomLogger:  # https://docs.litellm.ai/docs/observability/custom_callbac
             for callback_obj in all_callbacks:
                 if hasattr(callback_obj, "increment_callback_logging_failure"):
                     verbose_logger.debug("Incrementing callback failure metric for %s", callback_name)
-                    callback_obj.increment_callback_logging_failure(callback_name=callback_name)  # type: ignore
+                    callback_obj.increment_callback_logging_failure(callback_name=callback_name)
                     return
 
             verbose_logger.debug(

--- a/litellm/integrations/datadog/datadog.py
+++ b/litellm/integrations/datadog/datadog.py
@@ -500,7 +500,7 @@ class DataDogLogger(
 
             response: Final = self.sync_client.post(
                 url=self.intake_url,
-                json=dd_payload,  # type: ignore
+                json=dd_payload,
                 headers=headers,
             )
 
@@ -616,7 +616,7 @@ class DataDogLogger(
 
         response: Final = await self.async_client.post(
             url=self.intake_url,
-            data=compressed_data,  # type: ignore
+            data=compressed_data,
             headers=headers,
         )
         return response

--- a/litellm/integrations/datadog/datadog_metrics.py
+++ b/litellm/integrations/datadog/datadog_metrics.py
@@ -91,9 +91,9 @@ class DatadogMetricsLogger(CustomBatchLogger):
         metadata: Final = log.get("metadata", {}) or {}
         team_tag: Final = (
             metadata.get("user_api_key_team_alias")
-            or metadata.get("team_alias")  # type: ignore
+            or metadata.get("team_alias")
             or metadata.get("user_api_key_team_id")
-            or metadata.get("team_id")  # type: ignore
+            or metadata.get("team_id")
         )
 
         if team_tag:
@@ -193,7 +193,7 @@ class DatadogMetricsLogger(CustomBatchLogger):
             # Extract status code from error information
             status_code = "500"  # default
             error_information: Final = standard_logging_object.get("error_information", {}) or {}
-            error_code: Final = error_information.get("error_code")  # type: ignore
+            error_code: Final = error_information.get("error_code")
             if error_code is not None:
                 status_code = str(error_code)
 
@@ -237,7 +237,7 @@ class DatadogMetricsLogger(CustomBatchLogger):
         response: Final = await self.async_client.post(
             self.upload_url,
             content=compressed_data,
-            headers=headers,  # type: ignore
+            headers=headers,
         )
 
         response.raise_for_status()

--- a/litellm/integrations/dotprompt/__init__.py
+++ b/litellm/integrations/dotprompt/__init__.py
@@ -24,7 +24,7 @@ def set_global_prompt_directory(directory: str) -> None:
     """
     import litellm
 
-    litellm.global_prompt_directory = directory  # type: ignore
+    litellm.global_prompt_directory = directory
 
 
 def _get_prompt_data_from_dotprompt_content(dotprompt_content: str) -> dict:

--- a/litellm/integrations/dotprompt/dotprompt_manager.py
+++ b/litellm/integrations/dotprompt/dotprompt_manager.py
@@ -311,7 +311,7 @@ class DotpromptManager(CustomPromptManagement):
     def _create_message(self, role: str, content: str) -> AllMessageValues:
         """Create a message with the specified role and content."""
         return {
-            "role": role,  # type: ignore
+            "role": role,
             "content": content,
         }
 

--- a/litellm/integrations/dotprompt/prompt_manager.py
+++ b/litellm/integrations/dotprompt/prompt_manager.py
@@ -253,7 +253,7 @@ class PromptManager:
             "dict": dict,
         }
 
-        return type_mapping.get(schema_type.lower(), str)  # type: ignore
+        return type_mapping.get(schema_type.lower(), str)
 
     def get_prompt(self, prompt_id: str, version: int | None = None) -> PromptTemplate | None:
         """

--- a/litellm/integrations/gcs_bucket/gcs_bucket.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket.py
@@ -42,9 +42,7 @@ class GCSBucketLogger(GCSBucketBase, AdditionalLoggingUtils):
             batch_size=self.batch_size,
             flush_interval=self.flush_interval,
         )
-        self.log_queue: asyncio.Queue[GCSLogQueueItem] = asyncio.Queue(  # type: ignore[assignment]
-            maxsize=LITELLM_ASYNCIO_QUEUE_MAXSIZE
-        )
+        self.log_queue: asyncio.Queue[GCSLogQueueItem] = asyncio.Queue(maxsize=LITELLM_ASYNCIO_QUEUE_MAXSIZE)
         asyncio.create_task(self.periodic_flush())
         AdditionalLoggingUtils.__init__(self)
 

--- a/litellm/integrations/gcs_bucket/gcs_bucket_mock_client.py
+++ b/litellm/integrations/gcs_bucket/gcs_bucket_mock_client.py
@@ -167,12 +167,12 @@ def create_mock_gcs_client():
 
     if _original_async_handler_get is None:
         _original_async_handler_get = AsyncHTTPHandler.get
-        AsyncHTTPHandler.get = _mock_async_handler_get  # type: ignore
+        AsyncHTTPHandler.get = _mock_async_handler_get
         verbose_logger.debug("[GCS MOCK] Patched AsyncHTTPHandler.get")
 
     if _original_async_handler_delete is None:
         _original_async_handler_delete = AsyncHTTPHandler.delete
-        AsyncHTTPHandler.delete = _mock_async_handler_delete  # type: ignore
+        AsyncHTTPHandler.delete = _mock_async_handler_delete
         verbose_logger.debug("[GCS MOCK] Patched AsyncHTTPHandler.delete")
 
     verbose_logger.debug(f"[GCS MOCK] Mock latency set to {_MOCK_LATENCY_SECONDS * 1000:.0f}ms")
@@ -227,9 +227,9 @@ def mock_vertex_auth_methods():
             return ("mock-gcs-token", "https://storage.googleapis.com")
 
         # Patch the methods
-        VertexBase._ensure_access_token_async = _mock_ensure_access_token_async  # type: ignore
-        VertexBase._ensure_access_token = _mock_ensure_access_token  # type: ignore
-        VertexBase._get_token_and_url = _mock_get_token_and_url  # type: ignore
+        VertexBase._ensure_access_token_async = _mock_ensure_access_token_async
+        VertexBase._ensure_access_token = _mock_ensure_access_token
+        VertexBase._get_token_and_url = _mock_get_token_and_url
 
         verbose_logger.debug("[GCS MOCK] Patched Vertex AI auth methods")
 

--- a/litellm/integrations/generic_api/generic_api_callback.py
+++ b/litellm/integrations/generic_api/generic_api_callback.py
@@ -382,7 +382,7 @@ class GenericAPILogger(CustomBatchLogger):
                         verbose_logger.debug(
                             "Generic API Logger - sent log %s, status: %s",
                             idx,
-                            result.status_code,  # type: ignore
+                            result.status_code,
                         )
             else:
                 # Format the payload based on log_format

--- a/litellm/integrations/generic_prompt_management/__init__.py
+++ b/litellm/integrations/generic_prompt_management/__init__.py
@@ -28,7 +28,7 @@ def set_global_generic_prompt_config(config: dict) -> None:
     """
     import litellm
 
-    litellm.global_generic_prompt_config = config  # type: ignore
+    litellm.global_generic_prompt_config = config
 
 
 def prompt_initializer(litellm_params: "PromptLiteLLMParams", prompt_spec: "PromptSpec") -> "CustomPromptManagement":

--- a/litellm/integrations/generic_prompt_management/generic_prompt_manager.py
+++ b/litellm/integrations/generic_prompt_management/generic_prompt_manager.py
@@ -366,14 +366,14 @@ class GenericPromptManager(CustomPromptManagement):
         # Create a copy of the prompt template with variables applied
         updated_messages: Final[list[AllMessageValues]] = []
         for message in prompt_client["prompt_template"]:
-            updated_message = dict(message)  # type: ignore
+            updated_message = dict(message)
             if "content" in updated_message and isinstance(updated_message["content"], str):
                 content = updated_message["content"]
                 for key, value in variables.items():
                     content = content.replace(f"{{{key}}}", str(value))
                     content = content.replace(f"{{{{{key}}}}}", str(value))  # Also support {{key}}
                 updated_message["content"] = content
-            updated_messages.append(updated_message)  # type: ignore
+            updated_messages.append(updated_message)
 
         return PromptManagementClient(
             prompt_id=prompt_client["prompt_id"],

--- a/litellm/integrations/gitlab/__init__.py
+++ b/litellm/integrations/gitlab/__init__.py
@@ -28,7 +28,7 @@ def set_global_gitlab_config(config: dict) -> None:
     """
     import litellm
 
-    litellm.global_gitlab_config = config  # type: ignore
+    litellm.global_gitlab_config = config
 
 
 def prompt_initializer(litellm_params: "PromptLiteLLMParams", prompt_spec: "PromptSpec") -> "CustomPromptManagement":

--- a/litellm/integrations/gitlab/gitlab_prompt_manager.py
+++ b/litellm/integrations/gitlab/gitlab_prompt_manager.py
@@ -257,7 +257,7 @@ class GitLabTemplateManager:
                     and str(f.get("path", "")).endswith(".prompt")
                     and "path" in f
                 ):
-                    files.append(f["path"])  # type: ignore
+                    files.append(f["path"])
 
             return [self._repo_path_to_id(p) for p in files]
 
@@ -357,7 +357,7 @@ class GitLabPromptManager(CustomPromptManagement):
             if parsed_messages:
                 final_messages: list[AllMessageValues] = parsed_messages
             else:
-                final_messages = [{"role": "user", "content": rendered_prompt}] + messages  # type: ignore
+                final_messages = [{"role": "user", "content": rendered_prompt}] + messages
 
             if litellm_params is None:
                 litellm_params = {}
@@ -400,7 +400,7 @@ class GitLabPromptManager(CustomPromptManagement):
                             "role": current_role,
                             "content": "\n".join(current_content).strip(),
                         }
-                    )  # type: ignore
+                    )
                 current_role = "system"
                 current_content = [line[7:].strip()]
             elif low.startswith("user:"):
@@ -410,7 +410,7 @@ class GitLabPromptManager(CustomPromptManagement):
                             "role": current_role,
                             "content": "\n".join(current_content).strip(),
                         }
-                    )  # type: ignore
+                    )
                 current_role = "user"
                 current_content = [line[5:].strip()]
             elif low.startswith("assistant:"):
@@ -420,16 +420,16 @@ class GitLabPromptManager(CustomPromptManagement):
                             "role": current_role,
                             "content": "\n".join(current_content).strip(),
                         }
-                    )  # type: ignore
+                    )
                 current_role = "assistant"
                 current_content = [line[10:].strip()]
             else:
                 current_content.append(line)
 
         if current_role and current_content:
-            messages.append({"role": current_role, "content": "\n".join(current_content).strip()})  # type: ignore
+            messages.append({"role": current_role, "content": "\n".join(current_content).strip()})
         if not messages and prompt_content.strip():
-            messages = [{"role": "user", "content": prompt_content.strip()}]  # type: ignore
+            messages = [{"role": "user", "content": prompt_content.strip()}]
         return messages
 
     def post_call_hook(

--- a/litellm/integrations/lago.py
+++ b/litellm/integrations/lago.py
@@ -23,9 +23,9 @@ def get_utc_datetime():
     from datetime import datetime
 
     if hasattr(dt, "UTC"):
-        return datetime.now(dt.UTC)  # type: ignore
+        return datetime.now(dt.UTC)
     else:
-        return datetime.utcnow()  # type: ignore
+        return datetime.utcnow()
 
 
 class LagoLogger(CustomLogger):
@@ -92,7 +92,7 @@ class LagoLogger(CustomLogger):
                 "user_id",
                 "team_id",
             ]:
-                charge_by = os.environ["LAGO_API_CHARGE_BY"]  # type: ignore
+                charge_by = os.environ["LAGO_API_CHARGE_BY"]
             else:
                 raise Exception("invalid LAGO_API_CHARGE_BY set")
 

--- a/litellm/integrations/langfuse/langfuse.py
+++ b/litellm/integrations/langfuse/langfuse.py
@@ -433,14 +433,14 @@ class LangFuseLogger:
         input,
         response_obj,
     ):
-        from langfuse.model import CreateGeneration, CreateTrace  # type: ignore
+        from langfuse.model import CreateGeneration, CreateTrace
 
         verbose_logger.warning(
             "Please upgrade langfuse to v2.0.0 or higher: https://github.com/langfuse/langfuse-python/releases/tag/v2.0.1"
         )
 
-        trace: Final = self.Langfuse.trace(  # type: ignore
-            CreateTrace(  # type: ignore
+        trace: Final = self.Langfuse.trace(
+            CreateTrace(
                 name=metadata.get("generation_name", "litellm-completion"),
                 input=input,
                 output=output,
@@ -959,8 +959,8 @@ class LangFuseLogger:
                     "guardrail_mode": guardrail_entry.get("guardrail_mode", None),
                     "guardrail_masked_entity_count": guardrail_entry.get("masked_entity_count", None),
                 },
-                start_time=guardrail_entry.get("start_time", None),  # type: ignore
-                end_time=guardrail_entry.get("end_time", None),  # type: ignore
+                start_time=guardrail_entry.get("start_time", None),
+                end_time=guardrail_entry.get("end_time", None),
             )
 
             verbose_logger.debug("Logged guardrail information as span: %s", span)
@@ -1006,7 +1006,7 @@ def _add_prompt_to_generation_params(
                 if "labels" in prompt_text_params and "tags" in prompt_text_params:
                     _data["labels"] = user_prompt.get("labels", []) or []
                     _data["tags"] = user_prompt.get("tags", []) or []
-                _prompt_obj = Prompt_Text(**_data)  # type: ignore
+                _prompt_obj = Prompt_Text(**_data)
                 generation_params["prompt"] = TextPromptClient(prompt=_prompt_obj)
 
             elif isinstance(user_prompt["prompt"], list):
@@ -1021,7 +1021,7 @@ def _add_prompt_to_generation_params(
                     _data["labels"] = user_prompt.get("labels", []) or []
                     _data["tags"] = user_prompt.get("tags", []) or []
 
-                _prompt_obj = Prompt_Chat(**_data)  # type: ignore
+                _prompt_obj = Prompt_Chat(**_data)
 
                 generation_params["prompt"] = ChatPromptClient(prompt=_prompt_obj)
             else:

--- a/litellm/integrations/langfuse/langfuse_otel.py
+++ b/litellm/integrations/langfuse/langfuse_otel.py
@@ -74,7 +74,7 @@ class LangfuseOtelLogger(OpenTelemetry):
                 LangFuseLogger as _LFLogger,
             )
 
-            metadata = _LFLogger.add_metadata_from_header(litellm_params, metadata)  # type: ignore
+            metadata = _LFLogger.add_metadata_from_header(litellm_params, metadata)
         except Exception:
             # Fallback silently if import fails; header enrichment just won't happen
             pass

--- a/litellm/integrations/langsmith.py
+++ b/litellm/integrations/langsmith.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, Final
 
 import httpx
-from pydantic import BaseModel  # type: ignore
+from pydantic import BaseModel
 
 import litellm
 from litellm._logging import verbose_logger
@@ -63,9 +63,9 @@ class LangsmithLogger(CustomBatchLogger):
             langsmith_tenant_id=langsmith_tenant_id,
         )
         self.sampling_rate: float = (
-            langsmith_sampling_rate or float(os.getenv("LANGSMITH_SAMPLING_RATE"))  # type: ignore
+            langsmith_sampling_rate or float(os.getenv("LANGSMITH_SAMPLING_RATE"))
             if os.getenv("LANGSMITH_SAMPLING_RATE") is not None
-            and os.getenv("LANGSMITH_SAMPLING_RATE").strip().isdigit()  # type: ignore
+            and os.getenv("LANGSMITH_SAMPLING_RATE").strip().isdigit()
             else 1.0
         )
         self.langsmith_default_run_name = os.getenv("LANGSMITH_DEFAULT_RUN_NAME", "LLMRun")

--- a/litellm/integrations/lunary.py
+++ b/litellm/integrations/lunary.py
@@ -80,9 +80,9 @@ class LunaryLogger:
         try:
             import lunary
 
-            version: Final = importlib.metadata.version("lunary")  # type: ignore
+            version: Final = importlib.metadata.version("lunary")
             # if version < 0.1.43 then raise ImportError
-            if packaging.version.Version(version) < packaging.version.Version("0.1.43"):  # type: ignore
+            if packaging.version.Version(version) < packaging.version.Version("0.1.43"):
                 print(  # noqa: T201
                     "Lunary version outdated. Required: >= 0.1.43. Upgrade via 'pip install lunary --upgrade'"
                 )
@@ -151,7 +151,7 @@ class LunaryLogger:
             else:
                 error_obj = None
 
-            self.lunary_client.track_event(  # type: ignore
+            self.lunary_client.track_event(
                 type,
                 "start",
                 run_id,
@@ -167,7 +167,7 @@ class LunaryLogger:
                 params=extra,
             )
 
-            self.lunary_client.track_event(  # type: ignore
+            self.lunary_client.track_event(
                 type,
                 event,
                 run_id,

--- a/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
+++ b/litellm/integrations/mavvrik_focus/mavvrik_focus_logger.py
@@ -275,7 +275,7 @@ class MavvrikFocusLogger(FocusLogger):
 
         logger: Final = loggers[0]
         trigger_kwargs: Final = logger._build_scheduler_trigger()
-        scheduler.add_job(  # type: ignore[attr-defined]
+        scheduler.add_job(
             logger.initialize_mavvrik_focus_export_job,
             id=MAVVRIK_FOCUS_EXPORT_JOB_NAME,
             replace_existing=True,

--- a/litellm/integrations/mlflow.py
+++ b/litellm/integrations/mlflow.py
@@ -54,8 +54,8 @@ class MlflowLogger(CustomLogger):
     def _extract_and_set_chat_attributes(self, span, kwargs, response_obj):
         try:
             from mlflow.tracing.utils import (
-                set_span_chat_messages,  # type: ignore
-                set_span_chat_tools,  # type: ignore
+                set_span_chat_messages,
+                set_span_chat_tools,
             )
         except ImportError:
             return
@@ -88,7 +88,7 @@ class MlflowLogger(CustomLogger):
 
             # Record exception info as event
             if exception := kwargs.get("exception"):
-                span.add_event(SpanEvent.from_exception(exception))  # type: ignore
+                span.add_event(SpanEvent.from_exception(exception))
 
             self._extract_and_set_chat_attributes(span, kwargs, response_obj)
             self._end_span_or_trace(
@@ -244,7 +244,7 @@ class MlflowLogger(CustomLogger):
         inputs: Final = self._construct_input(kwargs)
         attributes: Final = self._extract_attributes(kwargs)
 
-        if active_span := mlflow.get_current_active_span():  # type: ignore
+        if active_span := mlflow.get_current_active_span():
             return self._client.start_span(
                 name=span_name,
                 trace_id=active_span.request_id,

--- a/litellm/integrations/mock_client_factory.py
+++ b/litellm/integrations/mock_client_factory.py
@@ -242,19 +242,19 @@ def create_mock_client_factory(config: MockClientConfig):
             from litellm.llms.custom_httpx.http_handler import AsyncHTTPHandler
 
             _original_async_handler_post = AsyncHTTPHandler.post
-            AsyncHTTPHandler.post = _mock_async_handler_post  # type: ignore
+            AsyncHTTPHandler.post = _mock_async_handler_post
             verbose_logger.debug("[%s MOCK] Patched AsyncHTTPHandler.post", config.name)
 
         if config.patch_sync_client and _original_sync_client_post is None:
             _original_sync_client_post = httpx.Client.post
-            httpx.Client.post = _mock_sync_client_post  # type: ignore
+            httpx.Client.post = _mock_sync_client_post
             verbose_logger.debug("[%s MOCK] Patched httpx.Client.post", config.name)
 
         if config.patch_http_handler and _original_http_handler_post is None:
             from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
             _original_http_handler_post = HTTPHandler.post
-            HTTPHandler.post = _mock_http_handler_post  # type: ignore
+            HTTPHandler.post = _mock_http_handler_post
             verbose_logger.debug("[%s MOCK] Patched HTTPHandler.post", config.name)
 
         verbose_logger.debug(f"[{config.name} MOCK] Mock latency set to {_MOCK_LATENCY_SECONDS * 1000:.0f}ms")

--- a/litellm/integrations/newrelic/newrelic.py
+++ b/litellm/integrations/newrelic/newrelic.py
@@ -60,7 +60,7 @@ from litellm.types.utils import Message, ModelResponse, StandardLoggingPayload
 try:
     import newrelic.agent as _newrelic_agent
 except ImportError:
-    _newrelic_agent = None  # type: ignore
+    _newrelic_agent = None
 
 
 class NewRelicLogger(CustomLogger):

--- a/litellm/integrations/openmeter.py
+++ b/litellm/integrations/openmeter.py
@@ -21,9 +21,9 @@ def get_utc_datetime():
     from datetime import datetime
 
     if hasattr(dt, "UTC"):
-        return datetime.now(dt.UTC)  # type: ignore
+        return datetime.now(dt.UTC)
     else:
-        return datetime.utcnow()  # type: ignore
+        return datetime.utcnow()
 
 
 class OpenMeterLogger(CustomLogger):

--- a/litellm/integrations/opentelemetry.py
+++ b/litellm/integrations/opentelemetry.py
@@ -370,7 +370,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             "model_id": config.model_id or config.service_name,
         }
 
-        base_resource: Final = Resource.create(base_attributes)  # type: ignore[arg-type]
+        base_resource: Final = Resource.create(base_attributes)
         otel_resource_detector: Final = OTELResourceDetector()
         env_resource: Final = otel_resource_detector.detect()
         return base_resource.merge(env_resource)
@@ -640,9 +640,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
         def create_logger_provider():
             provider: Final = OTLoggerProvider(resource=self._get_litellm_resource(self.config))
             log_exporter: Final = self._get_log_exporter()
-            provider.add_log_record_processor(
-                BatchLogRecordProcessor(log_exporter)  # type: ignore[arg-type]
-            )
+            provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter))
             return provider
 
         self._logger_provider = self._get_or_create_provider(
@@ -2455,7 +2453,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                             message = choice.get("message")
                             tool_calls = message.get("tool_calls")
                             if tool_calls:
-                                kv_pairs = OpenTelemetry._tool_calls_kv_pair(tool_calls)  # type: ignore
+                                kv_pairs = OpenTelemetry._tool_calls_kv_pair(tool_calls)
                                 for key, value in kv_pairs.items():
                                     self.safe_set_attribute(
                                         span=span,
@@ -2495,7 +2493,7 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
                                 }
                             )
                     if tool_calls:
-                        kv_pairs = OpenTelemetry._tool_calls_kv_pair(tool_calls)  # type: ignore
+                        kv_pairs = OpenTelemetry._tool_calls_kv_pair(tool_calls)
                         for key, value in kv_pairs.items():
                             self.safe_set_attribute(
                                 span=span,
@@ -2616,10 +2614,10 @@ class OpenTelemetry(OTELGenAISemconvMixin, CustomLogger):
             return obj
         if hasattr(obj, "get"):
             # BaseLiteLLMOpenAIResponseObject duck-type
-            return obj  # type: ignore[return-value]
+            return obj
         if hasattr(obj, "model_dump"):
             # Raw Pydantic v2 model (e.g. openai SDK types)
-            return obj.model_dump()  # type: ignore[union-attr]
+            return obj.model_dump()
         return None
 
     def _transform_responses_api_output_to_otel(self, output: list) -> list[dict]:

--- a/litellm/integrations/opik/opik.py
+++ b/litellm/integrations/opik/opik.py
@@ -168,7 +168,7 @@ class OpikLogger(CustomBatchLogger):
             response: Final = self.sync_httpx_client.post(
                 url=url,
                 headers=headers,
-                json=batch,  # type: ignore
+                json=batch,
             )
             response.raise_for_status()
             if response.status_code != 204:
@@ -252,7 +252,7 @@ class OpikLogger(CustomBatchLogger):
             response: Final = await self.async_httpx_client.post(
                 url=url,
                 headers=headers,
-                json=batch,  # type: ignore
+                json=batch,
             )
             response.raise_for_status()
 

--- a/litellm/integrations/otel/plumbing/context.py
+++ b/litellm/integrations/otel/plumbing/context.py
@@ -194,7 +194,7 @@ def resolve_parent_context(threaded: Span | None = None) -> Context:
     """
     ctx = get_current()
     if is_recordable_span(threaded) and not is_recordable_span(get_current_span(ctx)):
-        ctx = context_from_span(threaded, context=ctx)  # type: ignore[arg-type]
+        ctx = context_from_span(threaded, context=ctx)
     return ctx
 
 

--- a/litellm/integrations/prometheus.py
+++ b/litellm/integrations/prometheus.py
@@ -1352,7 +1352,7 @@ class PrometheusLogger(CustomLogger):
             # why type ignore below?
             # 1. We just checked if isinstance(standard_logging_payload, dict). Pyright complains.
             # 2. Pyright does not allow us to run isinstance(standard_logging_payload, StandardLoggingPayload) <- this would be ideal
-            standard_logging_payload=standard_logging_payload,  # type: ignore
+            standard_logging_payload=standard_logging_payload,
             end_user_id=end_user_id,
             user_api_key=user_api_key,
             user_api_key_alias=user_api_key_alias,
@@ -1416,14 +1416,14 @@ class PrometheusLogger(CustomLogger):
         # model_group, derive remaining from configured-limit minus current usage so
         # the same metric is populated for any provider.
         await self._async_set_router_remaining_metrics(
-            standard_logging_payload=standard_logging_payload,  # type: ignore
+            standard_logging_payload=standard_logging_payload,
             enum_values=enum_values,
             label_context=label_context,
         )
 
         # cache metrics
         self._increment_cache_metrics(
-            standard_logging_payload=standard_logging_payload,  # type: ignore
+            standard_logging_payload=standard_logging_payload,
             enum_values=enum_values,
             label_context=label_context,
         )
@@ -3050,7 +3050,7 @@ class PrometheusLogger(CustomLogger):
         try:
             from litellm.exceptions import BudgetExceededError
         except ImportError:
-            BudgetExceededError = None  # type: ignore[assignment,misc]
+            BudgetExceededError = None
 
         if BudgetExceededError is not None and isinstance(exception, BudgetExceededError):
             return "BudgetExceededError"

--- a/litellm/integrations/prometheus_helpers/prometheus_api.py
+++ b/litellm/integrations/prometheus_helpers/prometheus_api.py
@@ -14,8 +14,8 @@ from litellm.llms.custom_httpx.http_handler import (
     httpxSpecialProvider,
 )
 
-PROMETHEUS_URL: Final[str | None] = get_secret("PROMETHEUS_URL")  # type: ignore
-PROMETHEUS_SELECTED_INSTANCE: Final[str | None] = get_secret("PROMETHEUS_SELECTED_INSTANCE")  # type: ignore
+PROMETHEUS_URL: Final[str | None] = get_secret("PROMETHEUS_URL")
+PROMETHEUS_SELECTED_INSTANCE: Final[str | None] = get_secret("PROMETHEUS_SELECTED_INSTANCE")
 async_http_handler: Final = get_async_httpx_client(llm_provider=httpxSpecialProvider.LoggingCallback)
 
 

--- a/litellm/integrations/rubrik.py
+++ b/litellm/integrations/rubrik.py
@@ -882,7 +882,7 @@ class RubrikLogger(CustomGuardrail, CustomBatchLogger):
         payload["id"] = self._correlation_id(call_details) or f"chatcmpl-{uuid.uuid4()}"
         self._prepend_system_prompt(payload, call_details)
 
-        return payload  # type: ignore[return-value]
+        return payload
 
     @staticmethod
     def _caller_metadata(user_api_key_dict: "UserAPIKeyAuth") -> StandardLoggingUserAPIKeyMetadata:

--- a/litellm/integrations/supabase.py
+++ b/litellm/integrations/supabase.py
@@ -28,9 +28,7 @@ class Supabase:
             raise ValueError(
                 "LiteLLM Error, trying to use Supabase but url or key not passed. Create a table and set `litellm.supabase_url=<your-url>` and `litellm.supabase_key=<your-key>`"
             )
-        self.supabase_client = supabase.create_client(  # type: ignore
-            self.supabase_url, self.supabase_key
-        )
+        self.supabase_client = supabase.create_client(self.supabase_url, self.supabase_key)
 
     def input_log_event(self, model, messages, end_user, litellm_call_id, print_verbose):
         try:

--- a/litellm/integrations/traceloop.py
+++ b/litellm/integrations/traceloop.py
@@ -85,7 +85,7 @@ class TraceloopLogger:
                     )
                 if "temperature" in optional_params:
                     span.set_attribute(
-                        SpanAttributes.LLM_REQUEST_TEMPERATURE,  # type: ignore
+                        SpanAttributes.LLM_REQUEST_TEMPERATURE,
                         kwargs.get("temperature"),
                     )
 

--- a/litellm/integrations/weights_biases.py
+++ b/litellm/integrations/weights_biases.py
@@ -21,7 +21,7 @@ try:
     K = TypeVar("K", bound=str)
     V = TypeVar("V")
 
-    class OpenAIResponse(Protocol[K, V]):  # type: ignore
+    class OpenAIResponse(Protocol[K, V]):
         # contains a (known) object attribute
         object: Literal["chat.completion", "edit", "text_completion"]
 
@@ -70,7 +70,7 @@ try:
             end_time_ms: Final = start_time_ms + int(round(time_elapsed * 1000))
             span: Final = trace_tree.Span(
                 name=f"{response.get('model', 'openai')}_{response['object']}_{response.get('created')}",
-                attributes=dict(response),  # type: ignore
+                attributes=dict(response),
                 start_time_ms=start_time_ms,
                 end_time_ms=end_time_ms,
                 span_kind=trace_tree.SpanKind.LLM,

--- a/litellm/interactions/agents/main.py
+++ b/litellm/interactions/agents/main.py
@@ -77,7 +77,7 @@ def _make_logging_obj(
     call_type: str,
     optional_params: dict[str, Any],
 ) -> LiteLLMLoggingObj:
-    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
     litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
     litellm_logging_obj.update_from_kwargs(
         kwargs=kwargs,

--- a/litellm/interactions/main.py
+++ b/litellm/interactions/main.py
@@ -171,7 +171,7 @@ async def acreate(
         else:
             response = init_response
 
-        return response  # type: ignore
+        return response
     except Exception as e:
         raise litellm.exception_type(
             model=model,
@@ -255,7 +255,7 @@ def create(
     local_vars: Final = locals()
 
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("acreate_interaction", False) is True
 
@@ -378,7 +378,7 @@ async def aget(
         else:
             response = init_response
 
-        return response  # type: ignore
+        return response
     except Exception as e:
         raise litellm.exception_type(
             model=None,
@@ -402,7 +402,7 @@ def get(
     custom_llm_provider = custom_llm_provider or "gemini"
 
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("aget_interaction", False) is True
 
@@ -480,7 +480,7 @@ async def adelete(
         else:
             response = init_response
 
-        return response  # type: ignore
+        return response
     except Exception as e:
         raise litellm.exception_type(
             model=None,
@@ -504,7 +504,7 @@ def delete(
     custom_llm_provider = custom_llm_provider or "gemini"
 
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("adelete_interaction", False) is True
 
@@ -582,7 +582,7 @@ async def acancel(
         else:
             response = init_response
 
-        return response  # type: ignore
+        return response
     except Exception as e:
         raise litellm.exception_type(
             model=None,
@@ -606,7 +606,7 @@ def cancel(
     custom_llm_provider = custom_llm_provider or "gemini"
 
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("acancel_interaction", False) is True
 

--- a/litellm/litellm_core_utils/audio_utils/utils.py
+++ b/litellm/litellm_core_utils/audio_utils/utils.py
@@ -99,10 +99,10 @@ def process_audio_file(audio_file: FileTypes) -> ProcessedAudioFile:
     elif hasattr(audio_file, "read") and not isinstance(audio_file, (str, bytes, bytearray, tuple, os.PathLike)):
         # File-like object (IO) - check this after all other types
         filename = getattr(audio_file, "name", "audio.wav")
-        file_content = audio_file.read()  # type: ignore
+        file_content = audio_file.read()
         # Reset file pointer if possible
         if hasattr(audio_file, "seek"):
-            audio_file.seek(0)  # type: ignore
+            audio_file.seek(0)
     else:
         raise ValueError(f"Unsupported audio_file type: {type(audio_file)}")
 
@@ -211,9 +211,9 @@ def get_audio_file_content_hash(file_obj: FileTypes) -> str:
                 current_position: Final = file_content_obj.tell() if hasattr(file_content_obj, "tell") else None
                 if hasattr(file_content_obj, "seek"):
                     file_content_obj.seek(0)
-                file_content = file_content_obj.read()  # type: ignore
+                file_content = file_content_obj.read()
                 if current_position is not None and hasattr(file_content_obj, "seek"):
-                    file_content_obj.seek(current_position)  # type: ignore
+                    file_content_obj.seek(current_position)
             except (OSError, AttributeError):
                 file_content = None
         else:

--- a/litellm/litellm_core_utils/completion_timeout.py
+++ b/litellm/litellm_core_utils/completion_timeout.py
@@ -65,6 +65,6 @@ class CompletionTimeout:
                 float(read_timeout) if read_timeout is not None else COMPLETION_HTTP_FALLBACK_SECONDS
             )  # default 10 min timeout
         elif not isinstance(resolved, httpx.Timeout):
-            resolved = float(resolved)  # type: ignore
+            resolved = float(resolved)
 
         return resolved

--- a/litellm/litellm_core_utils/default_encoding.py
+++ b/litellm/litellm_core_utils/default_encoding.py
@@ -10,7 +10,7 @@ try:
     filename = str(resources.files(litellm).joinpath("litellm_core_utils/tokenizers"))
 except (ImportError, AttributeError):
     # Old way to access resources, which setuptools deprecated some time ago
-    import pkg_resources  # type: ignore
+    import pkg_resources
 
     filename = pkg_resources.resource_filename(__name__, "litellm_core_utils/tokenizers")
 

--- a/litellm/litellm_core_utils/exception_mapping_utils.py
+++ b/litellm/litellm_core_utils/exception_mapping_utils.py
@@ -1109,7 +1109,7 @@ def _map_vertex_exception(
             response=httpx.Response(
                 status_code=500,
                 content=str(original_exception),
-                request=httpx.Request(method="completion", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                request=httpx.Request(method="completion", url="https://github.com/BerriAI/litellm"),
             ),
             litellm_debug_info=extra_information,
         )
@@ -1270,7 +1270,7 @@ def _map_vertex_exception(
                 response=httpx.Response(
                     status_code=500,
                     content=str(original_exception),
-                    request=httpx.Request(method="completion", url="https://github.com/BerriAI/litellm"),  # type: ignore
+                    request=httpx.Request(method="completion", url="https://github.com/BerriAI/litellm"),
                 ),
             )
         if original_exception.status_code == 502:
@@ -1872,15 +1872,13 @@ def _map_azure_exception(
         body_dict: Final = getattr(original_exception, "body", None) or {}
         if isinstance(body_dict, dict):
             if isinstance(body_dict.get("error"), dict):
-                azure_error_code = body_dict["error"].get("code")  # type: ignore[index]
+                azure_error_code = body_dict["error"].get("code")
                 # Also check inner_error for
                 # ResponsibleAIPolicyViolation which indicates a
                 # content policy violation even when the top-level
                 # code is generic (e.g. "invalid_request_error").
                 if azure_error_code != "content_policy_violation":
-                    _inner: Final = body_dict["error"].get("inner_error") or body_dict[  # type: ignore[index]
-                        "error"
-                    ].get("innererror")  # type: ignore[index]
+                    _inner: Final = body_dict["error"].get("inner_error") or body_dict["error"].get("innererror")
                     if isinstance(_inner, dict) and _inner.get("code") == "ResponsibleAIPolicyViolation":
                         azure_error_code = "content_policy_violation"
             else:
@@ -2156,7 +2154,7 @@ def _map_openrouter_exception(
         )
 
 
-def exception_type(  # type: ignore
+def exception_type(
     model,
     original_exception,
     custom_llm_provider,

--- a/litellm/litellm_core_utils/get_llm_provider_logic.py
+++ b/litellm/litellm_core_utils/get_llm_provider_logic.py
@@ -354,7 +354,7 @@ def get_llm_provider(
                         raise Exception(f"api base needs to be a string. api_base={api_base}")
                     if dynamic_api_key is not None and not isinstance(dynamic_api_key, str):
                         raise Exception(f"dynamic_api_key needs to be a string. dynamic_api_key={dynamic_api_key}")
-                    return model, custom_llm_provider, dynamic_api_key, api_base  # type: ignore
+                    return model, custom_llm_provider, dynamic_api_key, api_base
 
         # check if model in known model provider list  -> for huggingface models, raise exception as they don't have a fixed provider (can be togetherai, anyscale, baseten, runpod, et.)
         ## openai - chatcompletion + text completion
@@ -412,7 +412,7 @@ def get_llm_provider(
         ## ai21
         elif model in litellm.ai21_chat_models or model in litellm.ai21_models:
             custom_llm_provider = "ai21_chat"
-            api_base = api_base or get_secret("AI21_API_BASE") or "https://api.ai21.com/studio/v1"  # type: ignore
+            api_base = api_base or get_secret("AI21_API_BASE") or "https://api.ai21.com/studio/v1"
             dynamic_api_key = api_key or get_secret("AI21_API_KEY")
         ## aleph_alpha
         elif model in litellm.aleph_alpha_models:
@@ -486,7 +486,7 @@ def get_llm_provider(
                 print()  # noqa: T201
             error_str = f"LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model={model}\n Pass model as E.g. For 'Huggingface' inference endpoints pass in `completion(model='huggingface/starcoder',..)` Learn more: https://docs.litellm.ai/docs/providers"
             # maps to openai.NotFoundError, this is raised when openai does not recognize the llm
-            raise litellm.exceptions.BadRequestError(  # type: ignore
+            raise litellm.exceptions.BadRequestError(
                 message=error_str,
                 model=model,
                 response=None,
@@ -502,7 +502,7 @@ def get_llm_provider(
             raise e
         else:
             error_str = f"GetLLMProvider Exception - {e}\n\noriginal model: {model}"
-            raise litellm.exceptions.BadRequestError(  # type: ignore
+            raise litellm.exceptions.BadRequestError(
                 message=f"GetLLMProvider Exception - {e}\n\noriginal model: {model}",
                 model=model,
                 response=None,
@@ -551,7 +551,7 @@ def _get_openai_compatible_provider_info(
         return model, "aiohttp_openai", api_key, api_base
     elif custom_llm_provider == "anyscale":
         # anyscale is openai compatible, we just need to set this to custom_openai and have the api_base be https://api.endpoints.anyscale.com/v1
-        api_base = api_base or get_secret_str("ANYSCALE_API_BASE") or "https://api.endpoints.anyscale.com/v1"  # type: ignore
+        api_base = api_base or get_secret_str("ANYSCALE_API_BASE") or "https://api.endpoints.anyscale.com/v1"
         dynamic_api_key = api_key or get_secret_str("ANYSCALE_API_KEY")
     elif custom_llm_provider == "deepinfra":
         (
@@ -559,7 +559,7 @@ def _get_openai_compatible_provider_info(
             dynamic_api_key,
         ) = litellm.DeepInfraConfig()._get_openai_compatible_provider_info(api_base, api_key)
     elif custom_llm_provider == "empower":
-        api_base = api_base or get_secret("EMPOWER_API_BASE") or "https://app.empower.dev/api/v1"  # type: ignore
+        api_base = api_base or get_secret("EMPOWER_API_BASE") or "https://app.empower.dev/api/v1"
         dynamic_api_key = api_key or get_secret_str("EMPOWER_API_KEY")
     elif custom_llm_provider == "groq":
         (
@@ -575,13 +575,13 @@ def _get_openai_compatible_provider_info(
         )
     elif custom_llm_provider == "nvidia_nim":
         # nvidia_nim is openai compatible, we just need to set this to custom_openai and have the api_base be https://api.endpoints.anyscale.com/v1
-        api_base = api_base or get_secret("NVIDIA_NIM_API_BASE") or "https://integrate.api.nvidia.com/v1"  # type: ignore
+        api_base = api_base or get_secret("NVIDIA_NIM_API_BASE") or "https://integrate.api.nvidia.com/v1"
         dynamic_api_key = api_key or get_secret_str("NVIDIA_NIM_API_KEY")
     elif custom_llm_provider == "nvidia_riva":
         # NVIDIA Riva is gRPC-based; api_base must be a host:port like
         # `grpc.nvcf.nvidia.com:443` or `localhost:50051`. There is no
         # public-default endpoint, so we do not fill one in here.
-        api_base = api_base or get_secret_str("NVIDIA_RIVA_API_BASE")  # type: ignore
+        api_base = api_base or get_secret_str("NVIDIA_RIVA_API_BASE")
         # Fall back to NVIDIA_NIM_API_KEY because users running both NVCF
         # services typically reuse the same nvapi-* key.
         dynamic_api_key = api_key or get_secret_str("NVIDIA_RIVA_API_KEY") or get_secret_str("NVIDIA_NIM_API_KEY")
@@ -589,7 +589,7 @@ def _get_openai_compatible_provider_info(
         api_base = api_base or get_secret_str("SONIOX_API_BASE") or "https://api.soniox.com"
         dynamic_api_key = api_key or get_secret_str("SONIOX_API_KEY")
     elif custom_llm_provider == "cerebras":
-        api_base = api_base or get_secret("CEREBRAS_API_BASE") or "https://api.cerebras.ai/v1"  # type: ignore
+        api_base = api_base or get_secret("CEREBRAS_API_BASE") or "https://api.cerebras.ai/v1"
         dynamic_api_key = api_key or get_secret_str("CEREBRAS_API_KEY")
     elif custom_llm_provider == "baseten":
         # Use BasetenConfig to determine the appropriate API base URL
@@ -599,28 +599,28 @@ def _get_openai_compatible_provider_info(
             api_base = api_base or get_secret_str("BASETEN_API_BASE") or "https://inference.baseten.co/v1"
         dynamic_api_key = api_key or get_secret_str("BASETEN_API_KEY")
     elif custom_llm_provider == "sambanova":
-        api_base = api_base or get_secret("SAMBANOVA_API_BASE") or "https://api.sambanova.ai/v1"  # type: ignore
+        api_base = api_base or get_secret("SAMBANOVA_API_BASE") or "https://api.sambanova.ai/v1"
         dynamic_api_key = api_key or get_secret_str("SAMBANOVA_API_KEY")
     elif custom_llm_provider == "meta_llama":
-        api_base = api_base or get_secret("LLAMA_API_BASE") or "https://api.llama.com/compat/v1"  # type: ignore
+        api_base = api_base or get_secret("LLAMA_API_BASE") or "https://api.llama.com/compat/v1"
         dynamic_api_key = api_key or get_secret_str("LLAMA_API_KEY")
     elif custom_llm_provider == "nebius":
-        api_base = api_base or get_secret("NEBIUS_API_BASE") or "https://api.studio.nebius.ai/v1"  # type: ignore
+        api_base = api_base or get_secret("NEBIUS_API_BASE") or "https://api.studio.nebius.ai/v1"
         dynamic_api_key = api_key or get_secret_str("NEBIUS_API_KEY")
     elif custom_llm_provider == "ollama":
-        api_base = api_base or get_secret("OLLAMA_API_BASE") or "http://localhost:11434"  # type: ignore
+        api_base = api_base or get_secret("OLLAMA_API_BASE") or "http://localhost:11434"
         dynamic_api_key = api_key or get_secret_str("OLLAMA_API_KEY")
     elif (custom_llm_provider == "ai21_chat") or (custom_llm_provider == "ai21" and model in litellm.ai21_chat_models):
-        api_base = api_base or get_secret("AI21_API_BASE") or "https://api.ai21.com/studio/v1"  # type: ignore
+        api_base = api_base or get_secret("AI21_API_BASE") or "https://api.ai21.com/studio/v1"
         dynamic_api_key = api_key or get_secret_str("AI21_API_KEY")
         custom_llm_provider = "ai21_chat"
     elif custom_llm_provider == "volcengine":
         # volcengine is openai compatible, we just need to set this to custom_openai and have the api_base be https://api.endpoints.anyscale.com/v1
-        api_base = api_base or get_secret("VOLCENGINE_API_BASE") or "https://ark.cn-beijing.volces.com/api/v3"  # type: ignore
+        api_base = api_base or get_secret("VOLCENGINE_API_BASE") or "https://ark.cn-beijing.volces.com/api/v3"
         dynamic_api_key = api_key or get_secret_str("VOLCENGINE_API_KEY")
     elif custom_llm_provider == "codestral":
         # codestral is openai compatible, we just need to set this to custom_openai and have the api_base be https://codestral.mistral.ai/v1
-        api_base = api_base or get_secret("CODESTRAL_API_BASE") or "https://codestral.mistral.ai/v1"  # type: ignore
+        api_base = api_base or get_secret("CODESTRAL_API_BASE") or "https://codestral.mistral.ai/v1"
         dynamic_api_key = api_key or get_secret_str("CODESTRAL_API_KEY")
     elif custom_llm_provider == "hosted_vllm":
         # vllm is openai compatible, we just need to set this to custom_openai
@@ -648,7 +648,7 @@ def _get_openai_compatible_provider_info(
         ) = litellm.LMStudioChatConfig()._get_openai_compatible_provider_info(api_base, api_key)
     elif custom_llm_provider == "deepseek":
         # deepseek is openai compatible, we just need to set this to custom_openai and have the api_base be https://api.deepseek.com/v1
-        api_base = api_base or get_secret("DEEPSEEK_API_BASE") or "https://api.deepseek.com/beta"  # type: ignore
+        api_base = api_base or get_secret("DEEPSEEK_API_BASE") or "https://api.deepseek.com/beta"
 
         dynamic_api_key = api_key or get_secret_str("DEEPSEEK_API_KEY")
     elif custom_llm_provider == "tencent":
@@ -704,7 +704,7 @@ def _get_openai_compatible_provider_info(
             dynamic_api_key,
         ) = litellm.ZAIChatConfig()._get_openai_compatible_provider_info(api_base, api_key)
     elif custom_llm_provider == "together_ai":
-        api_base = api_base or get_secret_str("TOGETHER_AI_API_BASE") or "https://api.together.xyz/v1"  # type: ignore
+        api_base = api_base or get_secret_str("TOGETHER_AI_API_BASE") or "https://api.together.xyz/v1"
         dynamic_api_key = api_key or (
             get_secret_str("TOGETHER_API_KEY")
             or get_secret_str("TOGETHER_AI_API_KEY")
@@ -712,10 +712,10 @@ def _get_openai_compatible_provider_info(
             or get_secret_str("TOGETHER_AI_TOKEN")
         )
     elif custom_llm_provider == "friendliai":
-        api_base = api_base or get_secret("FRIENDLI_API_BASE") or "https://api.friendli.ai/serverless/v1"  # type: ignore
+        api_base = api_base or get_secret("FRIENDLI_API_BASE") or "https://api.friendli.ai/serverless/v1"
         dynamic_api_key = api_key or get_secret_str("FRIENDLIAI_API_KEY") or get_secret_str("FRIENDLI_TOKEN")
     elif custom_llm_provider == "galadriel":
-        api_base = api_base or get_secret("GALADRIEL_API_BASE") or "https://api.galadriel.com/v1"  # type: ignore
+        api_base = api_base or get_secret("GALADRIEL_API_BASE") or "https://api.galadriel.com/v1"
         dynamic_api_key = api_key or get_secret_str("GALADRIEL_API_KEY")
     elif custom_llm_provider == "github_copilot":
         (
@@ -732,7 +732,7 @@ def _get_openai_compatible_provider_info(
             custom_llm_provider,
         ) = litellm.ChatGPTConfig()._get_openai_compatible_provider_info(model, api_base, api_key, custom_llm_provider)
     elif custom_llm_provider == "novita":
-        api_base = api_base or get_secret("NOVITA_API_BASE") or "https://api.novita.ai/v3/openai"  # type: ignore
+        api_base = api_base or get_secret("NOVITA_API_BASE") or "https://api.novita.ai/v3/openai"
         dynamic_api_key = api_key or get_secret_str("NOVITA_API_KEY")
     elif custom_llm_provider == "snowflake":
         (
@@ -816,7 +816,7 @@ def _get_openai_compatible_provider_info(
             dynamic_api_key,
         ) = litellm.AIMLChatConfig()._get_openai_compatible_provider_info(api_base, api_key)
     elif custom_llm_provider == "wandb":
-        api_base = api_base or get_secret("WANDB_API_BASE") or "https://api.inference.wandb.ai/v1"  # type: ignore
+        api_base = api_base or get_secret("WANDB_API_BASE") or "https://api.inference.wandb.ai/v1"
         dynamic_api_key = api_key or get_secret_str("WANDB_API_KEY")
     elif custom_llm_provider == "lemonade":
         (

--- a/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
+++ b/litellm/litellm_core_utils/initialize_dynamic_callback_params.py
@@ -121,7 +121,7 @@ def initialize_standard_callback_dynamic_params(
             if param in kwargs:
                 _param_value = kwargs.get(param)
                 validate_no_callback_env_reference(param, _param_value, source="request body")
-                standard_callback_dynamic_params[param] = _param_value  # type: ignore
+                standard_callback_dynamic_params[param] = _param_value
 
         for slot_label, metadata in iter_client_callback_metadata_dicts(kwargs):
             for param in _supported_callback_params:
@@ -130,6 +130,6 @@ def initialize_standard_callback_dynamic_params(
                 if param not in standard_callback_dynamic_params and param in metadata:
                     _param_value = metadata.get(param)
                     validate_no_callback_env_reference(param, _param_value, source=slot_label)
-                    standard_callback_dynamic_params[param] = _param_value  # type: ignore
+                    standard_callback_dynamic_params[param] = _param_value
 
     return standard_callback_dynamic_params

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -196,12 +196,12 @@ try:
     )
 except Exception as e:
     verbose_logger.debug("[Non-Blocking] Unable to import GenericAPILogger - LiteLLM Enterprise Feature - %s", e)
-    GenericAPILogger = CustomLogger  # type: ignore
-    ResendEmailLogger = CustomLogger  # type: ignore
-    SendGridEmailLogger = CustomLogger  # type: ignore
-    SMTPEmailLogger = CustomLogger  # type: ignore
-    PagerDutyAlerting = CustomLogger  # type: ignore
-    EnterpriseCallbackControls = None  # type: ignore
+    GenericAPILogger = CustomLogger
+    ResendEmailLogger = CustomLogger
+    SendGridEmailLogger = CustomLogger
+    SMTPEmailLogger = CustomLogger
+    PagerDutyAlerting = CustomLogger
+    EnterpriseCallbackControls = None
     EnterpriseStandardLoggingPayloadSetupVAR = None
 _in_memory_loggers: Final[list[Any]] = []
 
@@ -462,9 +462,9 @@ class Logging(LiteLLMLoggingBaseClass):
                     _custom_logger_init_args = {k: v for k, v in self._trusted_callback_vars if k.startswith("dd_")}
 
                 callback_class = _init_custom_logger_compatible_class(
-                    callback,  # type: ignore[arg-type]
+                    callback,
                     internal_usage_cache=None,
-                    llm_router=None,  # type: ignore
+                    llm_router=None,
                     custom_logger_init_args=_custom_logger_init_args,
                 )
                 if callback_class is not None:
@@ -1756,7 +1756,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     self.model_call_details["litellm_params"]["metadata"] = {}
                 self.model_call_details["litellm_params"]["metadata"]["hidden_params"] = getattr(
                     logging_result, "_hidden_params", {}
-                )  # type: ignore
+                )
 
         if self.model_call_details.get("cache_hit") is True:
             self.model_call_details["response_cost"] = 0.0
@@ -1815,7 +1815,7 @@ class Logging(LiteLLMLoggingBaseClass):
             result = result.model_copy()
             transformed_usage = TranscriptionUsageObjectTransformation.transform_transcription_usage_object(
                 result.usage
-            )  # type: ignore
+            )
             setattr(result, "usage", transformed_usage)
         return result
 
@@ -2137,7 +2137,7 @@ class Logging(LiteLLMLoggingBaseClass):
                             start_time=start_time,
                             end_time=end_time,
                             print_verbose=print_verbose,
-                            level=LogfireLevel.INFO.value,  # type: ignore
+                            level=LogfireLevel.INFO.value,
                         )
 
                     if callback == "lunary" and lunaryLogger is not None:
@@ -2699,7 +2699,7 @@ class Logging(LiteLLMLoggingBaseClass):
 
             for callback_obj in all_callbacks:
                 if hasattr(callback_obj, "increment_callback_logging_failure"):
-                    callback_obj.increment_callback_logging_failure(callback_name=callback_name)  # type: ignore
+                    callback_obj.increment_callback_logging_failure(callback_name=callback_name)
                     break  # Only increment once
 
         except Exception as e:
@@ -2779,7 +2779,7 @@ class Logging(LiteLLMLoggingBaseClass):
                     exception=exception,
                     original_model_group=model_group,
                     kwargs=self.model_call_details,
-                )  # type: ignore
+                )
 
     def failure_handler(self, exception, traceback_exception, start_time=None, end_time=None):
         verbose_logger.debug("Logging Details LiteLLM-Failure Call: %s", litellm.failure_callback)
@@ -2934,7 +2934,7 @@ class Logging(LiteLLMLoggingBaseClass):
                             response_obj=result,
                             start_time=start_time,
                             end_time=end_time,
-                            level=LogfireLevel.ERROR.value,  # type: ignore
+                            level=LogfireLevel.ERROR.value,
                             print_verbose=print_verbose,
                         )
 
@@ -2988,7 +2988,7 @@ class Logging(LiteLLMLoggingBaseClass):
                         response_obj=result,
                         start_time=start_time,
                         end_time=end_time,
-                    )  # type: ignore
+                    )
                 if callable(callback):  # custom logger functions
                     global customLogger
                     if customLogger is None:
@@ -3478,7 +3478,7 @@ def set_callbacks(callback_list, function_id=None):
                 )
                 sentry_sdk_instance.init(
                     dsn=os.environ.get("SENTRY_DSN"),
-                    traces_sample_rate=float(sentry_trace_rate),  # type: ignore
+                    traces_sample_rate=float(sentry_trace_rate),
                     sample_rate=float(sentry_sample_rate if sentry_sample_rate else 1.0),
                     send_default_pii=False,  # Prevent sending Personal Identifiable Information
                     event_scrubber=EventScrubber(denylist=SENTRY_DENYLIST, pii_denylist=SENTRY_PII_DENYLIST),
@@ -3552,90 +3552,90 @@ def _init_custom_logger_compatible_class(
         if logging_integration == "agentops":  # Add AgentOps initialization
             _v2 = _maybe_construct_otel_v2("agentops", _in_memory_loggers)
             if _v2 is not None:
-                return _v2  # type: ignore
+                return _v2
             for callback in _in_memory_loggers:
                 if isinstance(callback, AgentOps):
-                    return callback  # type: ignore
+                    return callback
 
             agentops_logger: Final = AgentOps()
             _in_memory_loggers.append(agentops_logger)
-            return agentops_logger  # type: ignore
+            return agentops_logger
         elif logging_integration == "lago":
             for callback in _in_memory_loggers:
                 if isinstance(callback, LagoLogger):
-                    return callback  # type: ignore
+                    return callback
 
             lago_logger: Final = LagoLogger()
             _in_memory_loggers.append(lago_logger)
-            return lago_logger  # type: ignore
+            return lago_logger
         elif logging_integration == "openmeter":
             for callback in _in_memory_loggers:
                 if isinstance(callback, OpenMeterLogger):
-                    return callback  # type: ignore
+                    return callback
 
             _openmeter_logger: Final = OpenMeterLogger()
             _in_memory_loggers.append(_openmeter_logger)
-            return _openmeter_logger  # type: ignore
+            return _openmeter_logger
         elif logging_integration == "posthog":
             for callback in _in_memory_loggers:
                 if isinstance(callback, PostHogLogger):
-                    return callback  # type: ignore
+                    return callback
 
             _posthog_logger: Final = PostHogLogger()
             _in_memory_loggers.append(_posthog_logger)
-            return _posthog_logger  # type: ignore
+            return _posthog_logger
         elif logging_integration == "braintrust":
             from litellm.integrations.braintrust_logging import BraintrustLogger
 
             for callback in _in_memory_loggers:
                 if isinstance(callback, BraintrustLogger):
-                    return callback  # type: ignore
+                    return callback
 
             braintrust_logger: Final = BraintrustLogger()
             _in_memory_loggers.append(braintrust_logger)
-            return braintrust_logger  # type: ignore
+            return braintrust_logger
         elif logging_integration == "langsmith":
             for callback in _in_memory_loggers:
                 if isinstance(callback, LangsmithLogger):
-                    return callback  # type: ignore
+                    return callback
 
             _langsmith_logger: Final = LangsmithLogger()
             _in_memory_loggers.append(_langsmith_logger)
-            return _langsmith_logger  # type: ignore
+            return _langsmith_logger
         elif logging_integration == "argilla":
             for callback in _in_memory_loggers:
                 if isinstance(callback, ArgillaLogger):
-                    return callback  # type: ignore
+                    return callback
 
             _argilla_logger: Final = ArgillaLogger()
             _in_memory_loggers.append(_argilla_logger)
-            return _argilla_logger  # type: ignore
+            return _argilla_logger
         elif logging_integration == "literalai":
             for callback in _in_memory_loggers:
                 if isinstance(callback, LiteralAILogger):
-                    return callback  # type: ignore
+                    return callback
 
             _literalai_logger: Final = LiteralAILogger()
             _in_memory_loggers.append(_literalai_logger)
-            return _literalai_logger  # type: ignore
+            return _literalai_logger
         elif logging_integration == "litellm_agent":
             for callback in _in_memory_loggers:
                 if isinstance(callback, LiteLLMAgentModelResolver):
-                    return callback  # type: ignore
+                    return callback
 
             _litellm_agent_resolver: Final = LiteLLMAgentModelResolver()
             _in_memory_loggers.append(_litellm_agent_resolver)
-            return _litellm_agent_resolver  # type: ignore
+            return _litellm_agent_resolver
         elif logging_integration == "prometheus":
             PrometheusLogger: Final = _get_cached_prometheus_logger()
 
             for callback in _in_memory_loggers:
                 if isinstance(callback, PrometheusLogger):
-                    return callback  # type: ignore
+                    return callback
 
             _prometheus_logger: Final = PrometheusLogger()
             _in_memory_loggers.append(_prometheus_logger)
-            return _prometheus_logger  # type: ignore
+            return _prometheus_logger
         elif logging_integration == "datadog":
             # Check if team-scoped credentials are provided
             _dd_api_key: Final = custom_logger_init_args.get("dd_api_key")
@@ -3650,82 +3650,82 @@ def _init_custom_logger_compatible_class(
                 )
 
                 return DataDogHandler.get_datadog_logger_for_request(
-                    standard_callback_dynamic_params=custom_logger_init_args,  # type: ignore
+                    standard_callback_dynamic_params=custom_logger_init_args,
                     in_memory_dynamic_logger_cache=in_memory_dynamic_logger_cache,
                 )
 
             # Global (env-var based): reuse cached instance
             for callback in _in_memory_loggers:
                 if isinstance(callback, DataDogLogger):
-                    return callback  # type: ignore
+                    return callback
 
             _datadog_logger: Final = DataDogLogger()
             _in_memory_loggers.append(_datadog_logger)
-            return _datadog_logger  # type: ignore
+            return _datadog_logger
         elif logging_integration == "datadog_metrics":
             for callback in _in_memory_loggers:
                 if isinstance(callback, DatadogMetricsLogger):
-                    return callback  # type: ignore
+                    return callback
 
             _datadog_metrics_logger: Final = DatadogMetricsLogger()
             _in_memory_loggers.append(_datadog_metrics_logger)
-            return _datadog_metrics_logger  # type: ignore
+            return _datadog_metrics_logger
         elif logging_integration == "datadog_llm_observability":
             _datadog_llm_obs_logger: Final = DataDogLLMObsLogger()
             _in_memory_loggers.append(_datadog_llm_obs_logger)
-            return _datadog_llm_obs_logger  # type: ignore
+            return _datadog_llm_obs_logger
         elif logging_integration == "azure_sentinel":
             for callback in _in_memory_loggers:
                 if isinstance(callback, AzureSentinelLogger):
-                    return callback  # type: ignore
+                    return callback
 
             _azure_sentinel_logger: Final = AzureSentinelLogger()
             _in_memory_loggers.append(_azure_sentinel_logger)
-            return _azure_sentinel_logger  # type: ignore
+            return _azure_sentinel_logger
         elif logging_integration == "gcs_bucket":
             for callback in _in_memory_loggers:
                 if isinstance(callback, GCSBucketLogger):
-                    return callback  # type: ignore
+                    return callback
 
             _gcs_bucket_logger: Final = GCSBucketLogger()
             _in_memory_loggers.append(_gcs_bucket_logger)
-            return _gcs_bucket_logger  # type: ignore
+            return _gcs_bucket_logger
         elif logging_integration == "s3_v2":
             for callback in _in_memory_loggers:
                 if isinstance(callback, S3V2Logger):
-                    return callback  # type: ignore
+                    return callback
 
             _s3_v2_logger: Final = S3V2Logger()
             _in_memory_loggers.append(_s3_v2_logger)
-            return _s3_v2_logger  # type: ignore
+            return _s3_v2_logger
         elif logging_integration == "aws_sqs":
             for callback in _in_memory_loggers:
                 if isinstance(callback, SQSLogger):
-                    return callback  # type: ignore
+                    return callback
 
             _aws_sqs_logger: Final = SQSLogger()
             _in_memory_loggers.append(_aws_sqs_logger)
-            return _aws_sqs_logger  # type: ignore
+            return _aws_sqs_logger
         elif logging_integration == "azure_storage":
             for callback in _in_memory_loggers:
                 if isinstance(callback, AzureBlobStorageLogger):
-                    return callback  # type: ignore
+                    return callback
 
             _azure_storage_logger: Final = AzureBlobStorageLogger()
             _in_memory_loggers.append(_azure_storage_logger)
-            return _azure_storage_logger  # type: ignore
+            return _azure_storage_logger
         elif logging_integration == "opik":
             for callback in _in_memory_loggers:
                 if isinstance(callback, OpikLogger):
-                    return callback  # type: ignore
+                    return callback
 
             _opik_logger: Final = OpikLogger()
             _in_memory_loggers.append(_opik_logger)
-            return _opik_logger  # type: ignore
+            return _opik_logger
         elif logging_integration == "arize":
             _v2 = _maybe_construct_otel_v2("arize", _in_memory_loggers)
             if _v2 is not None:
-                return _v2  # type: ignore
+                return _v2
             from litellm.integrations.opentelemetry import (
                 OpenTelemetry,
                 OpenTelemetryConfig,
@@ -3747,14 +3747,14 @@ def _init_custom_logger_compatible_class(
             )
             for callback in _in_memory_loggers:
                 if isinstance(callback, ArizeLogger) and callback.callback_name == "arize":
-                    return callback  # type: ignore
+                    return callback
             _arize_otel_logger: Final = ArizeLogger(config=otel_config, callback_name="arize")
             _in_memory_loggers.append(_arize_otel_logger)
-            return _arize_otel_logger  # type: ignore
+            return _arize_otel_logger
         elif logging_integration == "arize_phoenix":
             _v2 = _maybe_construct_otel_v2("arize_phoenix", _in_memory_loggers)
             if _v2 is not None:
-                return _v2  # type: ignore
+                return _v2
             from litellm.integrations.opentelemetry import (
                 OpenTelemetry,
                 OpenTelemetryConfig,
@@ -3773,14 +3773,14 @@ def _init_custom_logger_compatible_class(
 
             for callback in _in_memory_loggers:
                 if isinstance(callback, ArizePhoenixLogger) and callback.callback_name == "arize_phoenix":
-                    return callback  # type: ignore
+                    return callback
             _arize_phoenix_otel_logger: Final = ArizePhoenixLogger(config=otel_config, callback_name="arize_phoenix")
             _in_memory_loggers.append(_arize_phoenix_otel_logger)
-            return _arize_phoenix_otel_logger  # type: ignore
+            return _arize_phoenix_otel_logger
         elif logging_integration == "levo":
             _v2 = _maybe_construct_otel_v2("levo", _in_memory_loggers)
             if _v2 is not None:
-                return _v2  # type: ignore
+                return _v2
             from litellm.integrations.levo.levo import LevoLogger
             from litellm.integrations.opentelemetry import (
                 OpenTelemetry,
@@ -3797,11 +3797,11 @@ def _init_custom_logger_compatible_class(
             # Check if LevoLogger instance already exists
             for callback in _in_memory_loggers:
                 if isinstance(callback, LevoLogger) and callback.callback_name == "levo":
-                    return callback  # type: ignore
+                    return callback
 
             _levo_otel_logger: Final = LevoLogger(config=otel_config, callback_name="levo")
             _in_memory_loggers.append(_levo_otel_logger)
-            return _levo_otel_logger  # type: ignore
+            return _levo_otel_logger
         elif logging_integration == "otel":
             # Gate the new typed V2 adapter behind LITELLM_OTEL_V2. When off,
             # the legacy 3,227-line god-class is used unchanged. The two are
@@ -3815,19 +3815,19 @@ def _init_custom_logger_compatible_class(
 
                 for callback in _in_memory_loggers:
                     if type(callback) is OpenTelemetryV2:
-                        return callback  # type: ignore
+                        return callback
                 otel_logger_v2: Final = OpenTelemetryV2(
                     **_get_custom_logger_settings_from_proxy_server(callback_name=logging_integration)
                 )
                 _in_memory_loggers.append(otel_logger_v2)
                 _maybe_auto_initialize_arize_phoenix(_in_memory_loggers)
-                return otel_logger_v2  # type: ignore
+                return otel_logger_v2
 
             from litellm.integrations.opentelemetry import OpenTelemetry
 
             for callback in _in_memory_loggers:
                 if type(callback) is OpenTelemetry:
-                    return callback  # type: ignore
+                    return callback
             otel_logger: Final = OpenTelemetry(
                 **_get_custom_logger_settings_from_proxy_server(callback_name=logging_integration)
             )
@@ -3838,34 +3838,34 @@ def _init_custom_logger_compatible_class(
             # by only specifying "otel" in callbacks
             _maybe_auto_initialize_arize_phoenix(_in_memory_loggers)
 
-            return otel_logger  # type: ignore
+            return otel_logger
 
         elif logging_integration == "galileo":
             for callback in _in_memory_loggers:
                 if isinstance(callback, GalileoObserve):
-                    return callback  # type: ignore
+                    return callback
 
             galileo_logger: Final = GalileoObserve()
             _in_memory_loggers.append(galileo_logger)
-            return galileo_logger  # type: ignore
+            return galileo_logger
         elif logging_integration == "cloudzero":
             from litellm.integrations.cloudzero.cloudzero import CloudZeroLogger
 
             for callback in _in_memory_loggers:
                 if isinstance(callback, CloudZeroLogger):
-                    return callback  # type: ignore
+                    return callback
             cloudzero_logger: Final = CloudZeroLogger()
             _in_memory_loggers.append(cloudzero_logger)
-            return cloudzero_logger  # type: ignore
+            return cloudzero_logger
         elif logging_integration == "focus":
             from litellm.integrations.focus.focus_logger import FocusLogger
 
             for callback in _in_memory_loggers:
                 if type(callback) is FocusLogger:  # exact match; exclude subclasses like VantageLogger
-                    return callback  # type: ignore
+                    return callback
             focus_logger: Final = FocusLogger()
             _in_memory_loggers.append(focus_logger)
-            return focus_logger  # type: ignore
+            return focus_logger
         elif logging_integration == "mavvrik":
             from litellm.integrations.mavvrik_focus.mavvrik_focus_logger import (
                 MavvrikFocusLogger,
@@ -3873,26 +3873,26 @@ def _init_custom_logger_compatible_class(
 
             for callback in _in_memory_loggers:
                 if type(callback) is MavvrikFocusLogger:
-                    return callback  # type: ignore
+                    return callback
             mavvrik_focus_logger: Final = MavvrikFocusLogger()
             _in_memory_loggers.append(mavvrik_focus_logger)
-            return mavvrik_focus_logger  # type: ignore
+            return mavvrik_focus_logger
         elif logging_integration == "vantage":
             from litellm.integrations.vantage.vantage_logger import VantageLogger
 
             for callback in _in_memory_loggers:
                 if isinstance(callback, VantageLogger):
-                    return callback  # type: ignore
+                    return callback
             vantage_logger: Final = VantageLogger()
             _in_memory_loggers.append(vantage_logger)
-            return vantage_logger  # type: ignore
+            return vantage_logger
         elif logging_integration == "deepeval":
             for callback in _in_memory_loggers:
                 if isinstance(callback, DeepEvalLogger):
-                    return callback  # type: ignore
+                    return callback
             deepeval_logger: Final = DeepEvalLogger()
             _in_memory_loggers.append(deepeval_logger)
-            return deepeval_logger  # type: ignore
+            return deepeval_logger
 
         elif logging_integration == "logfire":
             if "LOGFIRE_TOKEN" not in os.environ:
@@ -3911,10 +3911,10 @@ def _init_custom_logger_compatible_class(
             for callback in _in_memory_loggers:
                 # Use exact type check to avoid matching ArizePhoenixLogger (subclass)
                 if type(callback) is OpenTelemetry:
-                    return callback  # type: ignore
+                    return callback
             _otel_logger = OpenTelemetry(config=otel_config)
             _in_memory_loggers.append(_otel_logger)
-            return _otel_logger  # type: ignore
+            return _otel_logger
         elif logging_integration == "dynamic_rate_limiter":
             from litellm.proxy.hooks.dynamic_rate_limiter import (
                 _PROXY_DynamicRateLimitHandler,
@@ -3922,7 +3922,7 @@ def _init_custom_logger_compatible_class(
 
             for callback in _in_memory_loggers:
                 if isinstance(callback, _PROXY_DynamicRateLimitHandler):
-                    return callback  # type: ignore
+                    return callback
 
             if internal_usage_cache is None:
                 raise Exception(f"Internal Error: Cache cannot be empty - internal_usage_cache={internal_usage_cache}")
@@ -3932,7 +3932,7 @@ def _init_custom_logger_compatible_class(
             if llm_router is not None and isinstance(llm_router, litellm.Router):
                 dynamic_rate_limiter_obj.update_variables(llm_router=llm_router)
             _in_memory_loggers.append(dynamic_rate_limiter_obj)
-            return dynamic_rate_limiter_obj  # type: ignore
+            return dynamic_rate_limiter_obj
         elif logging_integration == "dynamic_rate_limiter_v3":
             from litellm.proxy.hooks.dynamic_rate_limiter_v3 import (
                 _PROXY_DynamicRateLimitHandlerV3,
@@ -3940,7 +3940,7 @@ def _init_custom_logger_compatible_class(
 
             for callback in _in_memory_loggers:
                 if isinstance(callback, _PROXY_DynamicRateLimitHandlerV3):
-                    return callback  # type: ignore
+                    return callback
 
             if internal_usage_cache is None:
                 raise Exception(f"Internal Error: Cache cannot be empty - internal_usage_cache={internal_usage_cache}")
@@ -3950,13 +3950,13 @@ def _init_custom_logger_compatible_class(
             if llm_router is not None and isinstance(llm_router, litellm.Router):
                 dynamic_rate_limiter_obj_v3.update_variables(llm_router=llm_router)
             _in_memory_loggers.append(dynamic_rate_limiter_obj_v3)
-            return dynamic_rate_limiter_obj_v3  # type: ignore
+            return dynamic_rate_limiter_obj_v3
         elif logging_integration == "langtrace":
             if "LANGTRACE_API_KEY" not in os.environ:
                 raise ValueError("LANGTRACE_API_KEY not found in environment variables")
             _v2 = _maybe_construct_otel_v2("langtrace", _in_memory_loggers)
             if _v2 is not None:
-                return _v2  # type: ignore
+                return _v2
 
             from litellm.integrations.opentelemetry import (
                 OpenTelemetry,
@@ -3970,19 +3970,19 @@ def _init_custom_logger_compatible_class(
             os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = f"api_key={os.getenv('LANGTRACE_API_KEY')}"
             for callback in _in_memory_loggers:
                 if isinstance(callback, OpenTelemetry) and callback.callback_name == "langtrace":
-                    return callback  # type: ignore
+                    return callback
             _otel_logger = OpenTelemetry(config=otel_config, callback_name="langtrace")
             _in_memory_loggers.append(_otel_logger)
-            return _otel_logger  # type: ignore
+            return _otel_logger
 
         elif logging_integration == "mlflow":
             for callback in _in_memory_loggers:
                 if isinstance(callback, MlflowLogger):
-                    return callback  # type: ignore
+                    return callback
 
             _mlflow_logger: Final = MlflowLogger()
             _in_memory_loggers.append(_mlflow_logger)
-            return _mlflow_logger  # type: ignore
+            return _mlflow_logger
         elif logging_integration == "langfuse":
             for callback in _in_memory_loggers:
                 if isinstance(callback, LangfusePromptManagement):
@@ -3990,25 +3990,25 @@ def _init_custom_logger_compatible_class(
 
             langfuse_logger: Final = LangfusePromptManagement()
             _in_memory_loggers.append(langfuse_logger)
-            return langfuse_logger  # type: ignore
+            return langfuse_logger
         elif logging_integration == "langfuse_otel":
             _v2 = _maybe_construct_otel_v2("langfuse_otel", _in_memory_loggers)
             if _v2 is not None:
-                return _v2  # type: ignore
+                return _v2
             from litellm.integrations.langfuse.langfuse_otel import LangfuseOtelLogger
 
             for callback in _in_memory_loggers:
                 if isinstance(callback, LangfuseOtelLogger) and callback.callback_name == "langfuse_otel":
-                    return callback  # type: ignore
+                    return callback
             # Allow LangfuseOtelLogger to initialize its own config safely
             # This prevents startup crashes if LANGFUSE keys are not in env (e.g. for dynamic usage)
             _otel_logger = LangfuseOtelLogger(config=None, callback_name="langfuse_otel")
             _in_memory_loggers.append(_otel_logger)
-            return _otel_logger  # type: ignore
+            return _otel_logger
         elif logging_integration == "weave_otel":
             _v2 = _maybe_construct_otel_v2("weave_otel", _in_memory_loggers)
             if _v2 is not None:
-                return _v2  # type: ignore
+                return _v2
             from litellm.integrations.opentelemetry import OpenTelemetryConfig
             from litellm.integrations.weave.weave_otel import (
                 WeaveOtelLogger,
@@ -4025,24 +4025,24 @@ def _init_custom_logger_compatible_class(
 
             for callback in _in_memory_loggers:
                 if isinstance(callback, WeaveOtelLogger) and callback.callback_name == "weave_otel":
-                    return callback  # type: ignore
+                    return callback
             _otel_logger = WeaveOtelLogger(config=otel_config, callback_name="weave_otel")
             _in_memory_loggers.append(_otel_logger)
-            return _otel_logger  # type: ignore
+            return _otel_logger
         elif logging_integration == "pagerduty":
             for callback in _in_memory_loggers:
                 if isinstance(callback, PagerDutyAlerting):
                     return callback
             pagerduty_logger: Final = PagerDutyAlerting(**custom_logger_init_args)
             _in_memory_loggers.append(pagerduty_logger)
-            return pagerduty_logger  # type: ignore
+            return pagerduty_logger
         elif logging_integration == "anthropic_cache_control_hook":
             for callback in _in_memory_loggers:
                 if isinstance(callback, AnthropicCacheControlHook):
                     return callback
             anthropic_cache_control_hook: Final = AnthropicCacheControlHook()
             _in_memory_loggers.append(anthropic_cache_control_hook)
-            return anthropic_cache_control_hook  # type: ignore
+            return anthropic_cache_control_hook
         elif logging_integration == "vector_store_pre_call_hook":
             from litellm.integrations.vector_store_integrations.vector_store_pre_call_hook import (
                 VectorStorePreCallHook,
@@ -4053,42 +4053,42 @@ def _init_custom_logger_compatible_class(
                     return callback
             vector_store_pre_call_hook: Final = VectorStorePreCallHook()
             _in_memory_loggers.append(vector_store_pre_call_hook)
-            return vector_store_pre_call_hook  # type: ignore
+            return vector_store_pre_call_hook
         elif logging_integration == "gcs_pubsub":
             for callback in _in_memory_loggers:
                 if isinstance(callback, GcsPubSubLogger):
                     return callback
             _gcs_pubsub_logger: Final = GcsPubSubLogger()
             _in_memory_loggers.append(_gcs_pubsub_logger)
-            return _gcs_pubsub_logger  # type: ignore
+            return _gcs_pubsub_logger
         elif logging_integration == "generic_api":
             for callback in _in_memory_loggers:
                 if isinstance(callback, GenericAPILogger):
                     return callback
             generic_api_logger: Final = GenericAPILogger()
             _in_memory_loggers.append(generic_api_logger)
-            return generic_api_logger  # type: ignore
+            return generic_api_logger
         elif logging_integration == "resend_email":
             for callback in _in_memory_loggers:
                 if isinstance(callback, ResendEmailLogger):
                     return callback
             resend_email_logger: Final = ResendEmailLogger()
             _in_memory_loggers.append(resend_email_logger)
-            return resend_email_logger  # type: ignore
+            return resend_email_logger
         elif logging_integration == "sendgrid_email":
             for callback in _in_memory_loggers:
                 if isinstance(callback, SendGridEmailLogger):
                     return callback
             sendgrid_email_logger: Final = SendGridEmailLogger()
             _in_memory_loggers.append(sendgrid_email_logger)
-            return sendgrid_email_logger  # type: ignore
+            return sendgrid_email_logger
         elif logging_integration == "smtp_email":
             for callback in _in_memory_loggers:
                 if isinstance(callback, SMTPEmailLogger):
                     return callback
             smtp_email_logger: Final = SMTPEmailLogger()
             _in_memory_loggers.append(smtp_email_logger)
-            return smtp_email_logger  # type: ignore
+            return smtp_email_logger
         elif logging_integration == "humanloop":
             for callback in _in_memory_loggers:
                 if isinstance(callback, HumanloopLogger):
@@ -4096,7 +4096,7 @@ def _init_custom_logger_compatible_class(
 
             humanloop_logger: Final = HumanloopLogger()
             _in_memory_loggers.append(humanloop_logger)
-            return humanloop_logger  # type: ignore
+            return humanloop_logger
         elif logging_integration == "dotprompt":
             for callback in _in_memory_loggers:
                 if isinstance(callback, DotpromptManager):
@@ -4104,7 +4104,7 @@ def _init_custom_logger_compatible_class(
 
             dotprompt_logger: Final = DotpromptManager()
             _in_memory_loggers.append(dotprompt_logger)
-            return dotprompt_logger  # type: ignore
+            return dotprompt_logger
         elif logging_integration == "bitbucket":
             from litellm.integrations.bitbucket.bitbucket_prompt_manager import (
                 BitBucketPromptManager,
@@ -4121,7 +4121,7 @@ def _init_custom_logger_compatible_class(
 
             bitbucket_logger: Final = BitBucketPromptManager(bitbucket_config=bitbucket_config)
             _in_memory_loggers.append(bitbucket_logger)
-            return bitbucket_logger  # type: ignore
+            return bitbucket_logger
         elif logging_integration == "gitlab":
             from litellm.integrations.gitlab.gitlab_prompt_manager import (
                 GitLabPromptManager,
@@ -4138,14 +4138,14 @@ def _init_custom_logger_compatible_class(
 
             gitlab_logger: Final = GitLabPromptManager(gitlab_config=gitlab_config)
             _in_memory_loggers.append(gitlab_logger)
-            return gitlab_logger  # type: ignore
+            return gitlab_logger
         elif logging_integration == "newrelic":
             for callback in _in_memory_loggers:
                 if isinstance(callback, NewRelicLogger):
-                    return callback  # type: ignore
+                    return callback
             newrelic_logger: Final = NewRelicLogger()
             _in_memory_loggers.append(newrelic_logger)
-            return newrelic_logger  # type: ignore
+            return newrelic_logger
         return None
     except Exception as e:
         verbose_logger.exception("[Non-Blocking Error] Error initializing custom logger: %s", e)
@@ -4322,7 +4322,7 @@ def get_custom_logger_compatible_class(
                     return callback
             _aws_sqs_logger: Final = SQSLogger()
             _in_memory_loggers.append(_aws_sqs_logger)
-            return _aws_sqs_logger  # type: ignore
+            return _aws_sqs_logger
         elif logging_integration == "azure_storage":
             for callback in _in_memory_loggers:
                 if isinstance(callback, AzureBlobStorageLogger):
@@ -4356,7 +4356,7 @@ def get_custom_logger_compatible_class(
             for callback in _in_memory_loggers:
                 # Use exact type check to avoid matching ArizePhoenixLogger (subclass)
                 if type(callback) is OpenTelemetry:
-                    return callback  # type: ignore
+                    return callback
 
         elif logging_integration == "dynamic_rate_limiter":
             from litellm.proxy.hooks.dynamic_rate_limiter import (
@@ -4365,7 +4365,7 @@ def get_custom_logger_compatible_class(
 
             for callback in _in_memory_loggers:
                 if isinstance(callback, _PROXY_DynamicRateLimitHandler):
-                    return callback  # type: ignore
+                    return callback
         elif logging_integration == "dynamic_rate_limiter_v3":
             from litellm.proxy.hooks.dynamic_rate_limiter_v3 import (
                 _PROXY_DynamicRateLimitHandlerV3,
@@ -4373,7 +4373,7 @@ def get_custom_logger_compatible_class(
 
             for callback in _in_memory_loggers:
                 if isinstance(callback, _PROXY_DynamicRateLimitHandlerV3):
-                    return callback  # type: ignore
+                    return callback
 
         elif logging_integration == "langtrace":
             from litellm.integrations.opentelemetry import OpenTelemetry
@@ -4663,7 +4663,7 @@ class StandardLoggingPayloadSetup:
         )
         if isinstance(metadata, dict):
             for key in metadata.keys() & _STANDARD_LOGGING_METADATA_KEYS:
-                clean_metadata[key] = metadata[key]  # type: ignore
+                clean_metadata[key] = metadata[key]
 
             user_api_key: Final = metadata.get("user_api_key")
             if user_api_key and isinstance(user_api_key, str) and is_valid_sha256_hash(user_api_key):
@@ -4763,7 +4763,7 @@ class StandardLoggingPayloadSetup:
     ) -> StandardLoggingModelInformation:
         model_cost_name: Final = _select_model_name_for_cost_calc(
             model=base_model if custom_pricing else None,
-            completion_response=init_response_obj,  # type: ignore
+            completion_response=init_response_obj,
             base_model=base_model,
             custom_pricing=custom_pricing,
         )
@@ -4832,14 +4832,14 @@ class StandardLoggingPayloadSetup:
             typed_keys[_key] = key
             if _key in additiona_headers:
                 try:
-                    additional_logging_headers[key] = int(additiona_headers[_key])  # type: ignore
+                    additional_logging_headers[key] = int(additiona_headers[_key])
                 except (ValueError, TypeError):
-                    additional_logging_headers[key] = additiona_headers[_key]  # type: ignore
+                    additional_logging_headers[key] = additiona_headers[_key]
 
         # Preserve all remaining headers verbatim (e.g. llm_provider-x-request-id)
         for k, v in additiona_headers.items():
             if k.lower() not in typed_keys:
-                additional_logging_headers[k] = v  # type: ignore
+                additional_logging_headers[k] = v
 
         return additional_logging_headers
 
@@ -4866,7 +4866,7 @@ class StandardLoggingPayloadSetup:
                             hidden_params[key]
                         )
                     else:
-                        clean_hidden_params[key] = hidden_params[key]  # type: ignore
+                        clean_hidden_params[key] = hidden_params[key]
         return clean_hidden_params
 
     @staticmethod
@@ -5310,7 +5310,7 @@ def get_standard_logging_object_payload(
             saved_cache_cost = (
                 logging_obj._response_cost_calculator(
                     result=init_response_obj,
-                    cache_hit=False,  # type: ignore
+                    cache_hit=False,
                 )
                 or 0.0
             )
@@ -5503,7 +5503,7 @@ def get_standard_logging_metadata(
         # Update the clean_metadata with values from input metadata that match StandardLoggingMetadata fields
         for key in StandardLoggingMetadata.__annotations__.keys():
             if key in metadata:
-                clean_metadata[key] = metadata[key]  # type: ignore
+                clean_metadata[key] = metadata[key]
 
         if metadata.get("user_api_key") is not None:
             if is_valid_sha256_hash(str(metadata.get("user_api_key"))):
@@ -5555,7 +5555,7 @@ def create_dummy_standard_logging_payload() -> StandardLoggingPayload:
     # First create the nested objects with proper typing
     model_info: Final = StandardLoggingModelInformation(model_map_key="gpt-3.5-turbo", model_map_value=None)
 
-    metadata: Final = StandardLoggingMetadata(  # type: ignore
+    metadata: Final = StandardLoggingMetadata(
         user_api_key_hash="test_hash",
         user_api_key_alias="test_alias",
         user_api_key_team_id="test_team",
@@ -5596,7 +5596,7 @@ def create_dummy_standard_logging_payload() -> StandardLoggingPayload:
     response: Final[dict[str, list[dict[str, dict[str, str]]]]] = {"choices": [{"message": {"content": "Hi there!"}}]}
 
     # Main payload initialization
-    return StandardLoggingPayload(  # type: ignore
+    return StandardLoggingPayload(
         id="test_id",
         call_type="completion",
         stream=False,

--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -188,13 +188,13 @@ class StandardBuiltInToolCostTracking:
 
             if storage_gb_val is not None:
                 try:
-                    storage_gb = float(storage_gb_val)  # type: ignore
+                    storage_gb = float(storage_gb_val)
                 except (TypeError, ValueError):
                     storage_gb = None
 
             if days_val is not None:
                 try:
-                    days = float(days_val)  # type: ignore
+                    days = float(days_val)
                 except (TypeError, ValueError):
                     days = None
 
@@ -286,7 +286,7 @@ class StandardBuiltInToolCostTracking:
         """Safely convert a value to int."""
         if value is not None:
             try:
-                return int(value)  # type: ignore
+                return int(value)
             except (TypeError, ValueError):
                 return None
         return None

--- a/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
+++ b/litellm/litellm_core_utils/llm_response_utils/convert_dict_to_response.py
@@ -146,7 +146,7 @@ def _clear_later_replay_slice_metadata(choice: StreamingChoices) -> None:
     # streamed deltas collect it once per slice, and a field added to Delta
     # later can't silently re-introduce the duplication.
     choice.delta = Delta(content=choice.delta.content)
-    choice.logprobs = None  # type: ignore[assignment]
+    choice.logprobs = None
     if hasattr(choice, "enhancements"):
         del choice.enhancements
 
@@ -270,9 +270,7 @@ async def convert_to_streaming_response_async(
         slice_chunk.choices[0].delta.content = piece
         if i > 0:
             _clear_later_replay_slice_metadata(slice_chunk.choices[0])
-        slice_chunk.choices[0].finish_reason = (
-            original_finish_reason if i == last_idx else None  # type: ignore[assignment]
-        )
+        slice_chunk.choices[0].finish_reason = original_finish_reason if i == last_idx else None
         if i == last_idx and original_usage is not None:
             setattr(slice_chunk, "usage", original_usage)
         yield slice_chunk
@@ -322,9 +320,9 @@ def convert_to_streaming_response(
 
     if "usage" in response_object and response_object["usage"] is not None:
         setattr(model_response_object, "usage", Usage())
-        model_response_object.usage.completion_tokens = response_object["usage"].get("completion_tokens", 0)  # type: ignore
-        model_response_object.usage.prompt_tokens = response_object["usage"].get("prompt_tokens", 0)  # type: ignore
-        model_response_object.usage.total_tokens = response_object["usage"].get("total_tokens", 0)  # type: ignore
+        model_response_object.usage.completion_tokens = response_object["usage"].get("completion_tokens", 0)
+        model_response_object.usage.prompt_tokens = response_object["usage"].get("prompt_tokens", 0)
+        model_response_object.usage.total_tokens = response_object["usage"].get("total_tokens", 0)
 
     if "id" in response_object:
         model_response_object.id = response_object["id"]
@@ -358,9 +356,7 @@ def convert_to_streaming_response(
         slice_chunk.choices[0].delta.content = piece
         if i > 0:
             _clear_later_replay_slice_metadata(slice_chunk.choices[0])
-        slice_chunk.choices[0].finish_reason = (
-            original_finish_reason if i == last_idx else None  # type: ignore[assignment]
-        )
+        slice_chunk.choices[0].finish_reason = original_finish_reason if i == last_idx else None
         if i == last_idx and original_usage is not None:
             setattr(slice_chunk, "usage", original_usage)
         yield slice_chunk
@@ -715,7 +711,7 @@ def convert_to_model_response_object(
                     provider_specific_fields=provider_specific_fields,
                 )
                 choice_list.append(choice)
-            model_response_object.choices = choice_list  # type: ignore
+            model_response_object.choices = choice_list
 
             if "usage" in response_object and response_object["usage"] is not None:
                 usage_object: Final = litellm.Usage(**response_object["usage"])
@@ -740,9 +736,7 @@ def convert_to_model_response_object(
 
             if start_time is not None and end_time is not None:
                 if isinstance(start_time, type(end_time)):
-                    model_response_object._response_ms = (  # type: ignore
-                        end_time - start_time
-                    ).total_seconds() * 1000
+                    model_response_object._response_ms = (end_time - start_time).total_seconds() * 1000
 
             if hidden_params is not None:
                 if model_response_object._hidden_params is None:
@@ -775,12 +769,12 @@ def convert_to_model_response_object(
             model_response_object.data = response_object["data"]
 
             if "usage" in response_object and response_object["usage"] is not None:
-                model_response_object.usage.completion_tokens = response_object["usage"].get("completion_tokens", 0)  # type: ignore
-                model_response_object.usage.prompt_tokens = response_object["usage"].get("prompt_tokens", 0)  # type: ignore
-                model_response_object.usage.total_tokens = response_object["usage"].get("total_tokens", 0)  # type: ignore
+                model_response_object.usage.completion_tokens = response_object["usage"].get("completion_tokens", 0)
+                model_response_object.usage.prompt_tokens = response_object["usage"].get("prompt_tokens", 0)
+                model_response_object.usage.total_tokens = response_object["usage"].get("total_tokens", 0)
 
             if start_time is not None and end_time is not None:
-                model_response_object._response_ms = (  # type: ignore
+                model_response_object._response_ms = (
                     end_time - start_time
                 ).total_seconds() * 1000  # return response latency in ms like openai
 

--- a/litellm/litellm_core_utils/logging_callback_manager.py
+++ b/litellm/litellm_core_utils/logging_callback_manager.py
@@ -62,7 +62,7 @@ class LoggingCallbackManager:
         """
         self._safe_add_callback_to_list(
             callback=callback,
-            parent_list=litellm.callbacks,  # type: ignore
+            parent_list=litellm.callbacks,
         )
 
     def add_litellm_success_callback(self, callback: CustomLogger | str | Callable):

--- a/litellm/litellm_core_utils/prompt_templates/common_utils.py
+++ b/litellm/litellm_core_utils/prompt_templates/common_utils.py
@@ -99,7 +99,7 @@ def strip_name_from_message(message: AllMessageValues, allowed_name_roles: list[
     """
     msg_copy: Final = message.copy()
     if msg_copy.get("role") not in allowed_name_roles:
-        msg_copy.pop("name", None)  # type: ignore
+        msg_copy.pop("name", None)
     return msg_copy
 
 
@@ -114,7 +114,7 @@ def strip_name_from_messages(
         msg_role = message.get("role")
         msg_copy = message.copy()
         if msg_role not in allowed_name_roles:
-            msg_copy.pop("name", None)  # type: ignore
+            msg_copy.pop("name", None)
         new_messages.append(msg_copy)
     return new_messages
 
@@ -1511,9 +1511,7 @@ def convert_prefix_message_to_non_prefix_messages(
                     "content": "You are a helpful assistant. You are given a message and you need to respond to it. You are also given a generated content. You need to respond to the message in continuation of the generated content. Do not repeat the same content. Your response should be in continuation of this text: ",
                 }
             )
-            new_messages.append(
-                {**{k: v for k, v in message.items() if k != "prefix"}}  # type: ignore
-            )
+            new_messages.append({**{k: v for k, v in message.items() if k != "prefix"}})
         else:
             new_messages.append(message)
     return new_messages

--- a/litellm/litellm_core_utils/prompt_templates/factory.py
+++ b/litellm/litellm_core_utils/prompt_templates/factory.py
@@ -380,7 +380,7 @@ def _render_chat_template(env, chat_template: str, bos_token: str, eos_token: st
         Rendered template string
     """
     try:
-        template: Final = env.from_string(chat_template)  # type: ignore
+        template: Final = env.from_string(chat_template)
     except Exception as e:
         raise e
 
@@ -471,7 +471,7 @@ async def _afetch_and_extract_template(
             and isinstance(tokenizer_config["tokenizer"], dict)
             and "chat_template" in tokenizer_config["tokenizer"]
         ):
-            tokenizer_data: dict = tokenizer_config["tokenizer"]  # type: ignore
+            tokenizer_data: dict = tokenizer_config["tokenizer"]
             bos_token = _extract_token_value(token_value=tokenizer_data.get("bos_token"))
             eos_token = _extract_token_value(token_value=tokenizer_data.get("eos_token"))
             chat_template = tokenizer_data["chat_template"]
@@ -486,13 +486,13 @@ async def _afetch_and_extract_template(
                     and "tokenizer" in tokenizer_config
                     and isinstance(tokenizer_config["tokenizer"], dict)
                 ):
-                    tokenizer_data: dict = tokenizer_config["tokenizer"]  # type: ignore
+                    tokenizer_data: dict = tokenizer_config["tokenizer"]
                     bos_token = _extract_token_value(token_value=tokenizer_data.get("bos_token"))
                     eos_token = _extract_token_value(token_value=tokenizer_data.get("eos_token"))
             else:
                 raise Exception("No chat template found")
 
-    return chat_template, bos_token, eos_token  # type: ignore
+    return chat_template, bos_token, eos_token
 
 
 def _fetch_and_extract_template(
@@ -525,7 +525,7 @@ def _fetch_and_extract_template(
             and isinstance(tokenizer_config["tokenizer"], dict)
             and "chat_template" in tokenizer_config["tokenizer"]
         ):
-            tokenizer_data: dict = tokenizer_config["tokenizer"]  # type: ignore
+            tokenizer_data: dict = tokenizer_config["tokenizer"]
             bos_token = _extract_token_value(token_value=tokenizer_data.get("bos_token"))
             eos_token = _extract_token_value(token_value=tokenizer_data.get("eos_token"))
             chat_template = tokenizer_data["chat_template"]
@@ -540,13 +540,13 @@ def _fetch_and_extract_template(
                     and "tokenizer" in tokenizer_config
                     and isinstance(tokenizer_config["tokenizer"], dict)
                 ):
-                    tokenizer_data: dict = tokenizer_config["tokenizer"]  # type: ignore
+                    tokenizer_data: dict = tokenizer_config["tokenizer"]
                     bos_token = _extract_token_value(token_value=tokenizer_data.get("bos_token"))
                     eos_token = _extract_token_value(token_value=tokenizer_data.get("eos_token"))
             else:
                 raise Exception("No chat template found")
 
-    return chat_template, bos_token, eos_token  # type: ignore
+    return chat_template, bos_token, eos_token
 
 
 async def ahf_chat_template(model: str, messages: list, chat_template: Any | None = None):
@@ -1067,9 +1067,7 @@ def anthropic_messages_pt_xml(messages: list):
         while msg_i < len(messages) and messages[msg_i]["role"] == "assistant":
             assistant_text = messages[msg_i].get("content") or ""  # either string or none
             if messages[msg_i].get("tool_calls", []):  # support assistant tool invoke conversion
-                assistant_text += convert_to_anthropic_tool_invoke_xml(  # type: ignore
-                    messages[msg_i]["tool_calls"]
-                )
+                assistant_text += convert_to_anthropic_tool_invoke_xml(messages[msg_i]["tool_calls"])
 
             assistant_content.append({"type": "text", "text": assistant_text})
             msg_i += 1
@@ -1124,7 +1122,7 @@ def convert_to_azure_openai_messages(
         if m["role"] == "user" and isinstance(m.get("content"), list):
             for content in m.get("content", []):
                 if isinstance(content, dict) and content.get("type") == "image_url":
-                    _azure_image_url_helper(content)  # type: ignore
+                    _azure_image_url_helper(content)
     return messages
 
 
@@ -1475,7 +1473,7 @@ def convert_to_gemini_tool_call_result(
                             )
                         except Exception as e:
                             verbose_logger.warning("Failed to process file in tool response: %s", e)
-    name: str | None = message.get("name", "")  # type: ignore
+    name: str | None = message.get("name", "")
 
     # Recover name from last message with tool calls
     if last_message_with_tool_calls:
@@ -1521,7 +1519,7 @@ def convert_to_gemini_tool_call_result(
     # error call result so default to the successful result template
     _function_response: Final = VertexFunctionResponse(
         name=name,
-        response=response_data,  # type: ignore
+        response=response_data,
     )
     if gemini_call_id:
         _function_response["id"] = gemini_call_id
@@ -1693,7 +1691,7 @@ def convert_to_anthropic_tool_result(
     if anthropic_tool_result is None:
         raise Exception(f"Unable to parse anthropic tool result for message: {message}")
     if cache_control is not None:
-        anthropic_tool_result["cache_control"] = cache_control  # type: ignore
+        anthropic_tool_result["cache_control"] = cache_control
     return anthropic_tool_result
 
 
@@ -1841,7 +1839,7 @@ def add_cache_control_to_content(
 ):
     cache_control_param: Final = original_content_element.get("cache_control")
     if cache_control_param is not None and isinstance(cache_control_param, dict):
-        transformed_param: Final = ChatCompletionCachedContent(**cache_control_param)  # type: ignore
+        transformed_param: Final = ChatCompletionCachedContent(**cache_control_param)
 
         anthropic_content_element["cache_control"] = transformed_param
 
@@ -2020,7 +2018,7 @@ def _sanitize_empty_text_content(
 
         if rewrote_any:
             message = cast(AllMessageValues, dict(message))  # Make a copy
-            message["content"] = new_blocks  # type: ignore
+            message["content"] = new_blocks
             verbose_logger.debug(
                 "_sanitize_empty_text_content: Replaced empty text block(s) in %s message", message.get("role")
             )
@@ -2396,12 +2394,12 @@ def anthropic_messages_pt(
         user_content: list[AnthropicMessagesUserMessageValues] = []
         init_msg_i = msg_i
         if isinstance(messages[msg_i], BaseModel):
-            messages[msg_i] = dict(messages[msg_i])  # type: ignore
+            messages[msg_i] = dict(messages[msg_i])
         ## MERGE CONSECUTIVE USER CONTENT ##
         while msg_i < len(messages) and messages[msg_i]["role"] in user_message_types:
             user_message_types_block: (
                 ChatCompletionToolMessage | ChatCompletionUserMessage | ChatCompletionFunctionMessage
-            ) = messages[msg_i]  # type: ignore
+            ) = messages[msg_i]
             if user_message_types_block["role"] == "user":
                 if isinstance(user_message_types_block["content"], list):
                     for m in user_message_types_block["content"]:
@@ -2507,7 +2505,7 @@ def anthropic_messages_pt(
         assistant_content: list[AnthropicMessagesAssistantMessageValues] = []
         ## MERGE CONSECUTIVE ASSISTANT CONTENT ##
         while msg_i < len(messages) and messages[msg_i]["role"] == "assistant":
-            assistant_content_block: ChatCompletionAssistantMessage = messages[msg_i]  # type: ignore
+            assistant_content_block: ChatCompletionAssistantMessage = messages[msg_i]
 
             # Extract compaction_blocks from provider_specific_fields and add them first
             _provider_specific_fields_raw = assistant_content_block.get("provider_specific_fields")
@@ -2515,7 +2513,7 @@ def anthropic_messages_pt(
                 _compaction_blocks = _provider_specific_fields_raw.get("compaction_blocks")
                 if _compaction_blocks and isinstance(_compaction_blocks, list):
                     # Add compaction blocks at the beginning of assistant content : https://platform.claude.com/docs/en/build-with-claude/compaction
-                    assistant_content.extend(_compaction_blocks)  # type: ignore
+                    assistant_content.extend(_compaction_blocks)
 
             _raw_thinking_blocks = assistant_content_block.get("thinking_blocks", None)
             thinking_blocks = (
@@ -2555,7 +2553,7 @@ def anthropic_messages_pt(
                 _web_search_results_tc = _provider_specific_fields_tc.get("web_search_results")
                 _tool_results_tc = _provider_specific_fields_tc.get("tool_results")
                 tool_invoke_results = convert_to_anthropic_tool_invoke(
-                    assistant_tool_calls,  # type: ignore
+                    assistant_tool_calls,
                     web_search_results=_web_search_results_tc,
                     tool_results=_tool_results_tc,
                 )
@@ -2706,7 +2704,7 @@ def anthropic_messages_pt(
                         # handle server_tool_use blocks (tool search, web search, etc.)
                         # Pass through as-is since these are Anthropic-native content types
                         elif m.get("type", "") == "server_tool_use" or m.get("type", "").endswith("_tool_result"):
-                            assistant_content.append(m)  # type: ignore
+                            assistant_content.append(m)
                 elif (
                     "content" in assistant_content_block
                     and isinstance(assistant_content_block["content"], str)
@@ -2834,10 +2832,10 @@ def parse_xml_params(xml_content, json_schema: dict | None = None):
             if child is not None and child.text is not None:
                 try:
                     # Attempt to decode the element's text as JSON
-                    params[child.tag] = json.loads(child.text)  # type: ignore
+                    params[child.tag] = json.loads(child.text)
                 except json.JSONDecodeError:
                     # If JSON decoding fails, use the original text
-                    params[child.tag] = child.text  # type: ignore
+                    params[child.tag] = child.text
 
     return params
 
@@ -3282,7 +3280,7 @@ def gemini_text_image_pt(messages: list):
     }
     """
     try:
-        pass  # type: ignore
+        pass
     except Exception:
         raise Exception("Importing google.generativeai failed, please run 'pip install -q google-generativeai")
 
@@ -4063,9 +4061,7 @@ def get_user_message_block_or_continue_message(
         if content_block.strip():
             return message
         else:
-            return ChatCompletionUserMessage(
-                **(user_continue_message or DEFAULT_USER_CONTINUE_MESSAGE)  # type: ignore
-            )
+            return ChatCompletionUserMessage(**(user_continue_message or DEFAULT_USER_CONTINUE_MESSAGE))
 
     # Handle list case
     if isinstance(content_block, list):
@@ -4079,9 +4075,7 @@ def get_user_message_block_or_continue_message(
             ],
         """
         if not content_block:
-            return ChatCompletionUserMessage(
-                **(user_continue_message or DEFAULT_USER_CONTINUE_MESSAGE)  # type: ignore
-            )
+            return ChatCompletionUserMessage(**(user_continue_message or DEFAULT_USER_CONTINUE_MESSAGE))
         # Create a copy of the message to avoid modifying the original
         modified_content_block: Final = content_block.copy()
 
@@ -4091,7 +4085,7 @@ def get_user_message_block_or_continue_message(
                 if not item["text"].strip():
                     # Replace empty text with continue message
                     _user_continue_message = ChatCompletionUserMessage(
-                        **(user_continue_message or DEFAULT_USER_CONTINUE_MESSAGE)  # type: ignore
+                        **(user_continue_message or DEFAULT_USER_CONTINUE_MESSAGE)
                     )
                     text = convert_content_list_to_str(_user_continue_message)
                     item["text"] = text
@@ -4178,14 +4172,12 @@ def skip_empty_text_blocks(
 
         # Type-specific casting based on message role
         if message["role"] == "assistant":
-            modified_message_alt["content"] = cast(  # type: ignore
+            modified_message_alt["content"] = cast(
                 list[OpenAIMessageContentListBlock] | None,
                 modified_content_block or None,
             )
         elif message["role"] == "user" and modified_content_block is not None:
-            modified_message_alt["content"] = cast(  # type: ignore
-                list[ChatCompletionTextObject] | None, modified_content_block
-            )
+            modified_message_alt["content"] = cast(list[ChatCompletionTextObject] | None, modified_content_block)
 
         return modified_message_alt
 
@@ -4356,10 +4348,10 @@ class BedrockConverseMessagesProcessor:
                                     format = element["image_url"].get("format")
                                 else:
                                     image_url = element["image_url"]
-                                _part = await BedrockImageProcessor.process_image_async(  # type: ignore
+                                _part = await BedrockImageProcessor.process_image_async(
                                     image_url=image_url, format=format
                                 )
-                                _parts.append(_part)  # type: ignore
+                                _parts.append(_part)
                             elif element["type"] == "file":
                                 _part = await BedrockConverseMessagesProcessor._async_process_file_message(
                                     message=cast(ChatCompletionFileObject, element)
@@ -4501,9 +4493,7 @@ class BedrockConverseMessagesProcessor:
                                     image_url = element["image_url"]["url"]
                                 else:
                                     image_url = element["image_url"]
-                                assistants_part = await BedrockImageProcessor.process_image_async(  # type: ignore
-                                    image_url=image_url
-                                )
+                                assistants_part = await BedrockImageProcessor.process_image_async(image_url=image_url)
                                 assistants_parts.append(assistants_part)
                                 # Add cache point block for assistant content elements
                         _cache_point_block = litellm.AmazonConverseConfig()._get_cache_point_block(
@@ -4730,11 +4720,11 @@ def _bedrock_converse_messages_pt(
                                 format = element["image_url"].get("format")
                             else:
                                 image_url = element["image_url"]
-                            _part = BedrockImageProcessor.process_image_sync(  # type: ignore
+                            _part = BedrockImageProcessor.process_image_sync(
                                 image_url=image_url,
                                 format=format,
                             )
-                            _parts.append(_part)  # type: ignore
+                            _parts.append(_part)
                         elif element["type"] == "file":
                             _part = BedrockConverseMessagesProcessor._process_file_message(
                                 message=cast(ChatCompletionFileObject, element)
@@ -4881,9 +4871,7 @@ def _bedrock_converse_messages_pt(
                                 image_url = element["image_url"]["url"]
                             else:
                                 image_url = element["image_url"]
-                            assistants_part = BedrockImageProcessor.process_image_sync(  # type: ignore
-                                image_url=image_url
-                            )
+                            assistants_part = BedrockImageProcessor.process_image_sync(image_url=image_url)
                             assistants_parts.append(assistants_part)
                         # Add cache point block for assistant content elements
                         _cache_point_block = litellm.AmazonConverseConfig()._get_cache_point_block(
@@ -5060,7 +5048,7 @@ def _bedrock_tools_pt(tools: list, model: str | None = None) -> list[BedrockTool
         # Check if tool is already a BedrockToolBlock (e.g., systemTool for Nova grounding)
         if _is_bedrock_tool_block(tool):
             # Already a BedrockToolBlock, pass it through
-            tool_block_list.append(tool)  # type: ignore
+            tool_block_list.append(tool)
             continue
 
         # Responses built-in tools (web_search, image_generation, namespace, tool_search,
@@ -5539,8 +5527,5 @@ def resolve_structured_messages(
     for handler in handlers_to_try:
         structured = handler.get_structured_messages(request_kwargs)
         if structured:
-            return [
-                msg if isinstance(msg, dict) else msg.model_dump()  # type: ignore
-                for msg in structured
-            ]
+            return [msg if isinstance(msg, dict) else msg.model_dump() for msg in structured]
     return None

--- a/litellm/litellm_core_utils/realtime_streaming.py
+++ b/litellm/litellm_core_utils/realtime_streaming.py
@@ -173,13 +173,13 @@ class RealTimeStreaming:
         try:
             event_type: Final = message_obj.get("type", "")
             if event_type in self._SESSION_EVENT_TYPES:
-                typed_obj: OpenAIRealtimeEvents = OpenAIRealtimeStreamSessionEvents(**message_obj)  # type: ignore
+                typed_obj: OpenAIRealtimeEvents = OpenAIRealtimeStreamSessionEvents(**message_obj)
             else:
                 # Catch-all base object so unknown/new event names never raise.
-                typed_obj = OpenAIRealtimeStreamResponseBaseObject(**message_obj)  # type: ignore
+                typed_obj = OpenAIRealtimeStreamResponseBaseObject(**message_obj)
         except Exception as e:
             verbose_logger.debug("Error parsing message for logging: %s", e)
-            self.messages.append(message_obj)  # type: ignore[arg-type]
+            self.messages.append(message_obj)
             return
         self.messages.append(typed_obj)
 
@@ -346,7 +346,7 @@ class RealTimeStreaming:
                         verbose_logger.debug("Dropping follow-up setup after content was already sent to backend")
                         continue
                     msg = self._maybe_inject_guardrail_auto_response_disable(msg)
-                    await self.backend_ws.send(msg)  # type: ignore[union-attr, attr-defined]
+                    await self.backend_ws.send(msg)
                     self._cache_session_configuration_request(msg)
                     sent = True
                 else:
@@ -357,13 +357,13 @@ class RealTimeStreaming:
                     # content before send would leave the session believing the
                     # backend received a setup/content frame it never got, causing
                     # subsequent client session.update messages to be dropped.
-                    await self.backend_ws.send(msg)  # type: ignore[union-attr, attr-defined]
+                    await self.backend_ws.send(msg)
                     self._cache_session_configuration_request(msg)
                     if is_content_message:
                         self._content_sent_after_setup = True
                     sent = True
             return sent
-        await self.backend_ws.send(message)  # type: ignore[union-attr, attr-defined]
+        await self.backend_ws.send(message)
         return True
 
     def _enforce_transcription_session_model(self, message: str) -> str:
@@ -816,7 +816,7 @@ class RealTimeStreaming:
                         "[realtime guardrail] ending session after violation %d",
                         self._violation_count,
                     )
-                    await self.backend_ws.close()  # type: ignore[union-attr, attr-defined]
+                    await self.backend_ws.close()
 
                 verbose_logger.warning(
                     "[realtime guardrail] BLOCKED transcript (violation %d): %r",
@@ -828,7 +828,7 @@ class RealTimeStreaming:
 
     async def _handle_provider_config_message(self, raw_response) -> None:
         """Process a backend message when a provider_config is set (transformed path)."""
-        returned_object: Final = self.provider_config.transform_realtime_response(  # type: ignore[union-attr]
+        returned_object: Final = self.provider_config.transform_realtime_response(
             raw_response,
             self.model,
             self.logging_obj,
@@ -964,11 +964,9 @@ class RealTimeStreaming:
         try:
             while True:
                 try:
-                    raw_response = await self.backend_ws.recv(  # type: ignore[union-attr]
-                        decode=False
-                    )
+                    raw_response = await self.backend_ws.recv(decode=False)
                 except TypeError:
-                    raw_response = await self.backend_ws.recv()  # type: ignore[union-attr, assignment]
+                    raw_response = await self.backend_ws.recv()
 
                 if isinstance(raw_response, bytes):
                     try:
@@ -1007,7 +1005,7 @@ class RealTimeStreaming:
                         continue
                     await self.websocket.send_text(json.dumps(translated))
 
-        except websockets.exceptions.ConnectionClosed as e:  # type: ignore
+        except websockets.exceptions.ConnectionClosed as e:
             verbose_logger.exception("Connection closed in backend to client send messages - %s", e)
         except Exception as e:
             verbose_logger.exception("Error in backend to client send messages: %s", e)
@@ -1410,7 +1408,7 @@ class RealTimeStreaming:
         forward_task: Final = asyncio.create_task(self.backend_to_client_send_messages())
         try:
             await self.client_ack_messages()
-        except self.websocket.exceptions.ConnectionClosed:  # type: ignore
+        except self.websocket.exceptions.ConnectionClosed:
             verbose_logger.debug("Connection closed")
             forward_task.cancel()
         finally:

--- a/litellm/litellm_core_utils/rules.py
+++ b/litellm/litellm_core_utils/rules.py
@@ -35,7 +35,7 @@ class Rules:
                         message="LLM Response failed post-call-rule check",
                         llm_provider="",
                         model=model,
-                    )  # type: ignore
+                    )
         return True
 
     def post_call_rules(self, input: str | None, model: str) -> bool:
@@ -50,10 +50,10 @@ class Rules:
                             message="LLM Response failed post-call-rule check",
                             llm_provider="",
                             model=model,
-                        )  # type: ignore
+                        )
                 elif isinstance(decision, dict):
                     decision_val = decision.get("decision", True)
                     decision_message = decision.get("message", "LLM Response failed post-call-rule check")
                     if decision_val is False:
-                        raise litellm.APIResponseValidationError(message=decision_message, llm_provider="", model=model)  # type: ignore
+                        raise litellm.APIResponseValidationError(message=decision_message, llm_provider="", model=model)
         return True

--- a/litellm/litellm_core_utils/streaming_handler.py
+++ b/litellm/litellm_core_utils/streaming_handler.py
@@ -893,7 +893,7 @@ class CustomStreamWrapper:
                         for choice in original_chunk.choices:
                             try:
                                 if isinstance(choice, BaseModel):
-                                    choice_json = choice.model_dump()  # type: ignore
+                                    choice_json = choice.model_dump()
                                     choice_json.pop(
                                         "finish_reason", None
                                     )  # for mistral etc. which return a value in their last chunk (not-openai compatible).
@@ -1050,7 +1050,7 @@ class CustomStreamWrapper:
                 # Strip finish_reason from the content chunk so it appears
                 # only on the trailing empty-delta chunk (OpenAI spec).
                 # finish_reason_handler() will emit the proper terminal chunk.
-                chunk.choices[0].finish_reason = None  # type: ignore[assignment]
+                chunk.choices[0].finish_reason = None
             return _ProviderChunkEarlyReturn(chunk)
 
         if (
@@ -1139,19 +1139,17 @@ class CustomStreamWrapper:
                     self.received_finish_reason = "stop"
         elif self.custom_llm_provider == "vertex_ai" and not isinstance(chunk, ModelResponseStream):
             chunk = cast(Any, chunk)
-            import proto  # type: ignore
+            import proto
 
             if hasattr(chunk, "candidates") is True:
                 try:
                     try:
-                        completion_obj["content"] = chunk.text  # type: ignore
+                        completion_obj["content"] = chunk.text
                     except Exception as e:
                         original_exception: Final = e
                         if "Part has no text." in str(e):
                             ## check for function calling
-                            function_call: Final = (
-                                chunk.candidates[0].content.parts[0].function_call  # type: ignore
-                            )
+                            function_call: Final = chunk.candidates[0].content.parts[0].function_call
 
                             args_dict: Final = {}
 
@@ -1159,7 +1157,7 @@ class CustomStreamWrapper:
                             for key, val in function_call.args.items():
                                 if isinstance(
                                     val,
-                                    proto.marshal.collections.repeated.RepeatedComposite,  # type: ignore
+                                    proto.marshal.collections.repeated.RepeatedComposite,
                                 ):
                                     # If so, convert to list
                                     args_dict[key] = [v for v in val]
@@ -1190,15 +1188,12 @@ class CustomStreamWrapper:
                         else:
                             raise original_exception
                     if (
-                        hasattr(chunk.candidates[0], "finish_reason")  # type: ignore
-                        and chunk.candidates[0].finish_reason.name  # type: ignore
-                        != "FINISH_REASON_UNSPECIFIED"
+                        hasattr(chunk.candidates[0], "finish_reason")
+                        and chunk.candidates[0].finish_reason.name != "FINISH_REASON_UNSPECIFIED"
                     ):  # every non-final chunk in vertex ai has this
-                        self.received_finish_reason = map_finish_reason(  # type: ignore
-                            chunk.candidates[0].finish_reason.name
-                        )
+                        self.received_finish_reason = map_finish_reason(chunk.candidates[0].finish_reason.name)
                 except Exception:
-                    if chunk.candidates[0].finish_reason.name == "SAFETY":  # type: ignore
+                    if chunk.candidates[0].finish_reason.name == "SAFETY":
                         raise Exception(f"The response was blocked by VertexAI. {chunk}")
             else:
                 completion_obj["content"] = str(chunk)
@@ -1352,7 +1347,7 @@ class CustomStreamWrapper:
                     )
         return _ProviderChunkParsed(response_obj)
 
-    def chunk_creator(self, chunk: Any):  # type: ignore
+    def chunk_creator(self, chunk: Any):
         if hasattr(chunk, "id"):
             self.response_id = chunk.id
         model_response = self.model_response_creator()
@@ -1460,7 +1455,7 @@ class CustomStreamWrapper:
             ## RETURN ARG
             result: Final = self.return_processed_chunk_logic(
                 completion_obj=completion_obj,
-                model_response=model_response,  # type: ignore
+                model_response=model_response,
                 response_obj=response_obj,
             )
             return result
@@ -1702,7 +1697,7 @@ class CustomStreamWrapper:
                 ):
                     chunk = self.completion_stream
                 else:
-                    chunk = next(self.completion_stream)  # type: ignore[arg-type]
+                    chunk = next(self.completion_stream)
                 if chunk is not None and chunk != b"":
                     print_verbose(
                         f"PROCESSED CHUNK PRE CHUNK CREATOR: {chunk.decode('utf-8', errors='replace') if isinstance(chunk, bytes) else chunk}; custom_llm_provider: {self.custom_llm_provider}"
@@ -1951,7 +1946,7 @@ class CustomStreamWrapper:
                     if self.sent_last_chunk is True:
                         processed_chunk = await self._call_post_streaming_deployment_hook(processed_chunk)
                         # Add MCP metadata to final chunk if present (after hooks)
-                        processed_chunk = self._add_mcp_metadata_to_final_chunk(processed_chunk)  # type: ignore[reportArgumentType]
+                        processed_chunk = self._add_mcp_metadata_to_final_chunk(processed_chunk)
 
                     return processed_chunk
                 raise StopAsyncIteration
@@ -1961,7 +1956,7 @@ class CustomStreamWrapper:
                     if isinstance(self.completion_stream, str) or isinstance(self.completion_stream, bytes):
                         chunk = self.completion_stream
                     else:
-                        chunk = await asyncio.to_thread(_next_sync_or_exhausted, self.completion_stream)  # type: ignore[arg-type]
+                        chunk = await asyncio.to_thread(_next_sync_or_exhausted, self.completion_stream)
                         if chunk is _SYNC_ITER_EXHAUSTED:
                             raise StopAsyncIteration
                     if chunk is not None and chunk != b"":
@@ -2069,7 +2064,7 @@ class CustomStreamWrapper:
                 # end-of-stream blocks complete.  Scheduling here via
                 # create_task would race with unified_guardrail's
                 # end-of-stream block for short-stream providers.
-                self.logging_obj._deferred_stream_complete_args = (  # type: ignore[attr-defined]
+                self.logging_obj._deferred_stream_complete_args = (
                     complete_streaming_response,
                     cache_hit,
                 )

--- a/litellm/litellm_core_utils/token_counter.py
+++ b/litellm/litellm_core_utils/token_counter.py
@@ -524,7 +524,7 @@ def _get_count_function(
     from litellm.utils import _select_tokenizer, print_verbose
 
     if model is not None or custom_tokenizer is not None:
-        tokenizer_json: Final = custom_tokenizer or _select_tokenizer(model)  # type: ignore
+        tokenizer_json: Final = custom_tokenizer or _select_tokenizer(model)
         if tokenizer_json["type"] == "huggingface_tokenizer":
 
             def count_tokens(text: str) -> int:
@@ -532,7 +532,7 @@ def _get_count_function(
                 return len(enc.ids)
 
         elif tokenizer_json["type"] == "openai_tokenizer":
-            model_to_use: Final = _fix_model_name(model)  # type: ignore
+            model_to_use: Final = _fix_model_name(model)
             try:
                 if "gpt-4o" in model_to_use:
                     encoding = tiktoken.get_encoding("o200k_base")
@@ -561,7 +561,7 @@ def _fix_model_name(model: str) -> str:
         # azure llms use gpt-35-turbo instead of gpt-3.5-turbo 🙃
         return model.replace("-35", "-3.5")
     elif model in litellm.open_ai_chat_completion_models:
-        return model  # type: ignore
+        return model
     else:
         return "gpt-3.5-turbo"
 
@@ -592,7 +592,7 @@ def _count_image_tokens(
             raise ValueError("Missing required key 'url' in image_url dict.")
         return calculate_img_tokens(
             data=url,
-            mode=detail,  # type: ignore
+            mode=detail,
             use_default_image_token_count=use_default_image_token_count,
         )
     elif isinstance(image_url, str):
@@ -669,7 +669,7 @@ def _count_anthropic_content(
             elif isinstance(field_value, list):
                 tokens += _count_content_list(
                     count_function,
-                    field_value,  # type: ignore
+                    field_value,
                     use_default_image_token_count,
                     default_token_count,
                 )

--- a/litellm/llms/a2a/common_utils.py
+++ b/litellm/llms/a2a/common_utils.py
@@ -53,7 +53,7 @@ def convert_messages_to_prompt(messages: list[AllMessageValues]) -> str:
         elif isinstance(msg, dict):
             role = msg.get("role", "user")
         else:
-            role = dict(msg).get("role", "user")  # type: ignore
+            role = dict(msg).get("role", "user")
 
         if content_text:
             conversation_parts.append(f"{role}: {content_text}")

--- a/litellm/llms/aiml/chat/transformation.py
+++ b/litellm/llms/aiml/chat/transformation.py
@@ -15,6 +15,6 @@ class AIMLChatConfig(OpenAIGPTConfig):
         # AIML is openai compatible, we just need to set the api_base
         api_base = (
             api_base or get_secret_str("AIML_API_BASE") or "https://api.aimlapi.com/v1"  # Default AIML API base URL
-        )  # type: ignore
+        )
         dynamic_api_key: Final = api_key or get_secret_str("AIML_API_KEY")
         return api_base, dynamic_api_key

--- a/litellm/llms/aiohttp_openai/chat/transformation.py
+++ b/litellm/llms/aiohttp_openai/chat/transformation.py
@@ -56,7 +56,7 @@ class AiohttpOpenAIChatConfig(OpenAILikeChatConfig):
     ) -> dict:
         return {"Authorization": f"Bearer {api_key}"}
 
-    async def transform_response(  # type: ignore
+    async def transform_response(
         self,
         model: str,
         raw_response: ClientResponse,

--- a/litellm/llms/amazon_nova/chat/transformation.py
+++ b/litellm/llms/amazon_nova/chat/transformation.py
@@ -52,7 +52,7 @@ class AmazonNovaChatConfig(OpenAILikeChatConfig):
         self, api_base: str | None, api_key: str | None
     ) -> tuple[str | None, str | None]:
         # Amazon Nova is openai compatible, we just need to set this to custom_openai and have the api_base be Nova's endpoint
-        api_base = api_base or get_secret_str("AMAZON_NOVA_API_BASE") or "https://api.nova.amazon.com/v1"  # type: ignore
+        api_base = api_base or get_secret_str("AMAZON_NOVA_API_BASE") or "https://api.nova.amazon.com/v1"
 
         # Get API key from multiple sources
         key: Final = api_key or litellm.amazon_nova_api_key or get_secret_str("AMAZON_NOVA_API_KEY") or litellm.api_key

--- a/litellm/llms/anthropic/chat/guardrail_translation/handler.py
+++ b/litellm/llms/anthropic/chat/guardrail_translation/handler.py
@@ -469,7 +469,7 @@ class AnthropicMessagesHandler(BaseTranslation):
             openai_tools: Final = self.adapter.translate_anthropic_tools_to_openai(
                 tools=cast(list[AllAnthropicToolsValues], tools)
             )
-            tools_to_check.extend(openai_tools)  # type: ignore
+            tools_to_check.extend(openai_tools)
 
     async def _apply_guardrail_responses_to_input(
         self,

--- a/litellm/llms/anthropic/chat/handler.py
+++ b/litellm/llms/anthropic/chat/handler.py
@@ -7,7 +7,7 @@ import json
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Final, Literal, Union, cast
 
-import httpx  # type: ignore
+import httpx
 
 import litellm
 import litellm.litellm_core_utils
@@ -444,7 +444,7 @@ class AnthropicChatCompletion(BaseLLM):
                 completion_stream, headers = make_sync_call(
                     client=client,
                     api_base=api_base,
-                    headers=headers,  # type: ignore
+                    headers=headers,
                     data=json.dumps(data),
                     model=model,
                     messages=messages,
@@ -587,7 +587,7 @@ class ModelResponseIterator:
 
         for block in self.content_blocks:
             if block["delta"]["type"] == "input_json_delta":
-                args += block["delta"].get("partial_json", "")  # type: ignore
+                args += block["delta"].get("partial_json", "")
 
         if len(args) == 0:
             return True
@@ -617,7 +617,7 @@ class ModelResponseIterator:
         tool_use: ChatCompletionToolCallChunk | None = None
         provider_specific_fields: Final = {}
         reasoning_content: str | None = None
-        content_block: Final = ContentBlockDelta(**chunk)  # type: ignore
+        content_block: Final = ContentBlockDelta(**chunk)
         thinking_blocks: list[ChatCompletionThinkingBlock | ChatCompletionRedactedThinkingBlock] = []
 
         self.content_blocks.append(content_block)
@@ -697,7 +697,7 @@ class ModelResponseIterator:
         thinking_blocks: Final = [
             ChatCompletionRedactedThinkingBlock(
                 type="redacted_thinking",
-                data=content_block_start["content_block"]["data"],  # type: ignore
+                data=content_block_start["content_block"]["data"],
             )
         ]
         provider_specific_fields["thinking_blocks"] = thinking_blocks
@@ -711,9 +711,9 @@ class ModelResponseIterator:
         )
 
         if chunk.get("content_block", {}).get("type") == "tool_use":
-            content_block_start = ContentBlockStartToolUse(**chunk)  # type: ignore
+            content_block_start = ContentBlockStartToolUse(**chunk)
         else:
-            content_block_start = ContentBlockStartText(**chunk)  # type: ignore
+            content_block_start = ContentBlockStartText(**chunk)
 
         return content_block_start
 
@@ -822,12 +822,12 @@ class ModelResponseIterator:
                     if "caller" in content_block_start["content_block"]:
                         caller_data: Final = content_block_start["content_block"]["caller"]
                         if caller_data:
-                            tool_use["caller"] = cast(dict[str, Any], caller_data)  # type: ignore[typeddict-item]
+                            tool_use["caller"] = cast(dict[str, Any], caller_data)
                 elif content_block_start["content_block"]["type"] == "redacted_thinking":
                     (
                         thinking_blocks,
                         provider_specific_fields,
-                    ) = self._handle_redacted_thinking_content(  # type: ignore
+                    ) = self._handle_redacted_thinking_content(
                         content_block_start=content_block_start,
                         provider_specific_fields=provider_specific_fields,
                     )
@@ -868,16 +868,16 @@ class ModelResponseIterator:
                         provider_specific_fields["code_interpreter_results"] = self._build_code_interpreter_results()
 
             elif type_chunk == "content_block_stop":
-                ContentBlockStop(**chunk)  # type: ignore
+                ContentBlockStop(**chunk)
                 # check if tool call content block - only for tool_use and server_tool_use blocks
                 if self.current_content_block_type in ("tool_use", "server_tool_use"):
                     is_empty: Final = self.check_empty_tool_call_args()
                     if is_empty:
                         tool_use = ChatCompletionToolCallChunk(
-                            id=None,  # type: ignore[typeddict-item]
+                            id=None,
                             type="function",
                             function=ChatCompletionToolCallFunctionChunk(
-                                name=None,  # type: ignore[typeddict-item]
+                                name=None,
                                 arguments="{}",
                             ),
                             index=self.tool_index,
@@ -936,7 +936,7 @@ class ModelResponseIterator:
                     }
                 }
                 """
-                message_start_block: Final = MessageStartBlock(**chunk)  # type: ignore
+                message_start_block: Final = MessageStartBlock(**chunk)
                 if "usage" in message_start_block["message"]:
                     usage = self._handle_usage(anthropic_usage_chunk=message_start_block["message"]["usage"])
             elif type_chunk == "error":
@@ -1031,7 +1031,7 @@ class ModelResponseIterator:
         Returns:
             Tuple of (finish_reason, usage, container)
         """
-        message_delta: Final = MessageBlockDelta(**chunk)  # type: ignore
+        message_delta: Final = MessageBlockDelta(**chunk)
         finish_reason = map_finish_reason(finish_reason=message_delta["delta"].get("stop_reason", "stop") or "stop")
         # Override finish_reason to "stop" if we converted response_format tools
         # (matches OpenAI behavior and non-streaming Anthropic implementation)

--- a/litellm/llms/anthropic/chat/transformation.py
+++ b/litellm/llms/anthropic/chat/transformation.py
@@ -317,7 +317,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
         )
         # Include caller information if present (for programmatic tool calling)
         if "caller" in anthropic_tool_content:
-            tool_call["caller"] = cast(dict[str, Any], anthropic_tool_content["caller"])  # type: ignore[typeddict-item]
+            tool_call["caller"] = cast(dict[str, Any], anthropic_tool_content["caller"])
         return tool_call
 
     @staticmethod
@@ -719,10 +719,10 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             returned_tool = AnthropicHostedTools(
                 type=tool["type"],
                 name=function_name,
-                **additional_tool_params,  # type: ignore
+                **additional_tool_params,
             )
         elif tool["type"] == "url":  # mcp server tool
-            mcp_server = AnthropicMcpServerTool(**tool)  # type: ignore
+            mcp_server = AnthropicMcpServerTool(**tool)
         elif tool["type"] == "mcp":
             mcp_server = self._map_openai_mcp_server_tool(cast(OpenAIMcpServerTool, tool))
         elif tool["type"] == "tool_search_tool_regex_20251119":
@@ -765,7 +765,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 _advisor_tool["max_uses"] = _tool_dict["max_uses"]
             if _tool_dict.get("caching") is not None:
                 _advisor_tool["caching"] = _tool_dict["caching"]
-            returned_tool = _advisor_tool  # type: ignore[assignment]
+            returned_tool = _advisor_tool
         if returned_tool is None and mcp_server is None:
             raise ValueError(f"Unsupported tool type: {tool['type']}")
 
@@ -780,11 +780,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 "tool_search_tool_bm25_20251119",
             ):
                 if _cache_control is not None:
-                    returned_tool["cache_control"] = _cache_control  # type: ignore[typeddict-item]
+                    returned_tool["cache_control"] = _cache_control
                 elif _cache_control_function is not None and isinstance(_cache_control_function, dict):
-                    returned_tool["cache_control"] = ChatCompletionCachedContent(  # type: ignore[typeddict-item]
-                        **_cache_control_function  # type: ignore
-                    )
+                    returned_tool["cache_control"] = ChatCompletionCachedContent(**_cache_control_function)
 
         ## check if defer_loading is set in the tool
         _defer_loading: Final = tool.get("defer_loading", None)
@@ -801,11 +799,11 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                 if _defer_loading is not None:
                     if not isinstance(_defer_loading, bool):
                         raise ValueError("defer_loading must be a boolean")
-                    returned_tool["defer_loading"] = _defer_loading  # type: ignore[typeddict-item]
+                    returned_tool["defer_loading"] = _defer_loading
                 elif _defer_loading_function is not None:
                     if not isinstance(_defer_loading_function, bool):
                         raise ValueError("defer_loading must be a boolean")
-                    returned_tool["defer_loading"] = _defer_loading_function  # type: ignore[typeddict-item]
+                    returned_tool["defer_loading"] = _defer_loading_function
 
         ## check if allowed_callers is set in the tool
         _allowed_callers: Final = tool.get("allowed_callers", None)
@@ -824,13 +822,13 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
                         isinstance(item, str) for item in _allowed_callers
                     ):
                         raise ValueError("allowed_callers must be a list of strings")
-                    returned_tool["allowed_callers"] = _allowed_callers  # type: ignore[typeddict-item]
+                    returned_tool["allowed_callers"] = _allowed_callers
                 elif _allowed_callers_function is not None:
                     if not isinstance(_allowed_callers_function, list) or not all(
                         isinstance(item, str) for item in _allowed_callers_function
                     ):
                         raise ValueError("allowed_callers must be a list of strings")
-                    returned_tool["allowed_callers"] = _allowed_callers_function  # type: ignore[typeddict-item]
+                    returned_tool["allowed_callers"] = _allowed_callers_function
 
         ## check if input_examples is set in the tool
         _input_examples: Final = tool.get("input_examples", None)
@@ -840,9 +838,9 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             tool_type = returned_tool.get("type", "")
             if tool_type == "custom" or (tool_type == "" and "name" in returned_tool):
                 if _input_examples is not None and isinstance(_input_examples, list):
-                    returned_tool["input_examples"] = _input_examples  # type: ignore[typeddict-item]
+                    returned_tool["input_examples"] = _input_examples
                 elif _input_examples_function is not None and isinstance(_input_examples_function, list):
-                    returned_tool["input_examples"] = _input_examples_function  # type: ignore[typeddict-item]
+                    returned_tool["input_examples"] = _input_examples_function
 
         return returned_tool, mcp_server
 
@@ -1324,7 +1322,7 @@ class AnthropicConfig(AnthropicModelInfo, BaseConfig):
             if user_location_approximate is not None:
                 for key, user_location_value in user_location_approximate.items():
                     if key in anthropic_user_location_keys and key != "type":
-                        anthropic_user_location[key] = user_location_value  # type: ignore
+                        anthropic_user_location[key] = user_location_value
                 hosted_web_search_tool["user_location"] = anthropic_user_location
 
         ## MAP SEARCH CONTEXT SIZE

--- a/litellm/llms/anthropic/completion/transformation.py
+++ b/litellm/llms/anthropic/completion/transformation.py
@@ -198,9 +198,7 @@ class AnthropicTextConfig(BaseConfig):
             )
         else:
             if len(completion_response["completion"]) > 0:
-                model_response.choices[0].message.content = completion_response[  # type: ignore
-                    "completion"
-                ]
+                model_response.choices[0].message.content = completion_response["completion"]
             model_response.choices[0].finish_reason = completion_response["stop_reason"]
 
         ## CALCULATING USAGE

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/streaming_iterator.py
@@ -366,7 +366,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
                 "output_tokens": output_tokens,
             }
             iterations.append(message_iteration)
-        augmented_usage["iterations"] = iterations  # type: ignore[typeddict-unknown-key]
+        augmented_usage["iterations"] = iterations
         augmented["usage"] = augmented_usage
         return augmented
 
@@ -997,7 +997,7 @@ class AnthropicStreamWrapper(AdapterCompletionStreamWrapper):
             block_type,
             content_block_start,
         ) = LiteLLMAnthropicMessagesAdapter()._translate_streaming_openai_chunk_to_anthropic_content_block(
-            choices=chunk.choices  # type: ignore
+            choices=chunk.choices
         )
 
         # Restore original tool name if it was truncated for OpenAI's 64-char limit

--- a/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/adapters/transformation.py
@@ -302,7 +302,7 @@ class LiteLLMAnthropicMessagesAdapter:
             # TypedDict objects support dict operations at runtime
             # Use type ignore consistent with codebase pattern (see anthropic/chat/transformation.py:432)
             if isinstance(target, dict):
-                target["cache_control"] = cache_control  # type: ignore[typeddict-item]
+                target["cache_control"] = cache_control
             else:
                 # Fallback for non-dict objects (shouldn't happen in practice)
                 cast(dict[str, Any], target)["cache_control"] = cache_control
@@ -362,7 +362,7 @@ class LiteLLMAnthropicMessagesAdapter:
                         if content.get("type") == "text":
                             text_obj = ChatCompletionTextObject(type="text", text=content.get("text", ""))
                             self._add_cache_control_if_applicable(content, text_obj, model)
-                            new_user_content_list.append(text_obj)  # type: ignore
+                            new_user_content_list.append(text_obj)
                         elif content.get("type") == "image":
                             # Convert Anthropic image format to OpenAI format
                             source = content.get("source", {})
@@ -372,7 +372,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                 image_url_obj = ChatCompletionImageUrlObject(url=openai_image_url)
                                 image_obj = ChatCompletionImageObject(type="image_url", image_url=image_url_obj)
                                 self._add_cache_control_if_applicable(content, image_obj, model)
-                                new_user_content_list.append(image_obj)  # type: ignore
+                                new_user_content_list.append(image_obj)
                         elif content.get("type") == "document":
                             # Convert Anthropic document format (PDF, etc.) to OpenAI format
                             source = content.get("source", {})
@@ -382,7 +382,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                 image_url_obj = ChatCompletionImageUrlObject(url=openai_image_url)
                                 doc_obj = ChatCompletionImageObject(type="image_url", image_url=image_url_obj)
                                 self._add_cache_control_if_applicable(content, doc_obj, model)
-                                new_user_content_list.append(doc_obj)  # type: ignore
+                                new_user_content_list.append(doc_obj)
                         elif content.get("type") == "tool_result":
                             if "content" not in content:
                                 tool_result = ChatCompletionToolMessage(
@@ -391,7 +391,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                     content="",
                                 )
                                 self._add_cache_control_if_applicable(content, tool_result, model)
-                                tool_message_list.append(tool_result)  # type: ignore[arg-type]
+                                tool_message_list.append(tool_result)
                             elif isinstance(content.get("content"), str):
                                 tool_result = ChatCompletionToolMessage(
                                     role="tool",
@@ -399,7 +399,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                     content=str(content.get("content", "")),
                                 )
                                 self._add_cache_control_if_applicable(content, tool_result, model)
-                                tool_message_list.append(tool_result)  # type: ignore[arg-type]
+                                tool_message_list.append(tool_result)
                             elif isinstance(content.get("content"), list):
                                 # Combine all content items into a single tool message
                                 # to avoid creating multiple tool_result blocks with the same ID
@@ -416,7 +416,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                             content=c,
                                         )
                                         self._add_cache_control_if_applicable(content, tool_result, model)
-                                        tool_message_list.append(tool_result)  # type: ignore[arg-type]
+                                        tool_message_list.append(tool_result)
                                     elif isinstance(c, dict):
                                         if c.get("type") == "text":
                                             tool_result = ChatCompletionToolMessage(
@@ -425,7 +425,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                                 content=c.get("text", ""),
                                             )
                                             self._add_cache_control_if_applicable(content, tool_result, model)
-                                            tool_message_list.append(tool_result)  # type: ignore[arg-type]
+                                            tool_message_list.append(tool_result)
                                         elif c.get("type") == "image":
                                             source = c.get("source", {})
                                             openai_image_url = (
@@ -437,7 +437,7 @@ class LiteLLMAnthropicMessagesAdapter:
                                                 content=openai_image_url,
                                             )
                                             self._add_cache_control_if_applicable(content, tool_result, model)
-                                            tool_message_list.append(tool_result)  # type: ignore[arg-type]
+                                            tool_message_list.append(tool_result)
                                 else:
                                     # For multiple content items, combine into a single tool message
                                     # with list content to preserve all items while having one tool_use_id
@@ -474,10 +474,10 @@ class LiteLLMAnthropicMessagesAdapter:
                                         tool_result = ChatCompletionToolMessage(
                                             role="tool",
                                             tool_call_id=content.get("tool_use_id", ""),
-                                            content=combined_content_parts,  # type: ignore
+                                            content=combined_content_parts,
                                         )
                                         self._add_cache_control_if_applicable(content, tool_result, model)
-                                        tool_message_list.append(tool_result)  # type: ignore[arg-type]
+                                        tool_message_list.append(tool_result)
 
             if len(tool_message_list) > 0:
                 new_messages.extend(tool_message_list)
@@ -486,7 +486,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 new_messages.append(user_message)
 
             if len(new_user_content_list) > 0:
-                new_messages.append({"role": "user", "content": new_user_content_list})  # type: ignore
+                new_messages.append({"role": "user", "content": new_user_content_list})
 
             ## ASSISTANT MESSAGE ##
             assistant_message_str: str | None = None
@@ -571,9 +571,9 @@ class LiteLLMAnthropicMessagesAdapter:
                     thinking_blocks=(thinking_blocks if len(thinking_blocks) > 0 else None),
                 )
                 if len(tool_calls) > 0:
-                    assistant_message["tool_calls"] = tool_calls  # type: ignore
+                    assistant_message["tool_calls"] = tool_calls
                 if len(thinking_blocks) > 0:
-                    assistant_message["thinking_blocks"] = thinking_blocks  # type: ignore
+                    assistant_message["thinking_blocks"] = thinking_blocks
                 new_messages.append(assistant_message)
 
         return new_messages
@@ -744,7 +744,7 @@ class LiteLLMAnthropicMessagesAdapter:
             tool_type = tool.get("type", "")
             if any(tool_type.startswith(t.value) for t in ANTHROPIC_HOSTED_TOOLS):
                 # Keep Anthropic-native tools in their original format
-                new_tools.append(tool)  # type: ignore[arg-type]
+                new_tools.append(tool)
                 continue
 
             raw_name = tool.get("name")
@@ -762,18 +762,18 @@ class LiteLLMAnthropicMessagesAdapter:
                 name=truncated_name,
             )
             if "input_schema" in tool:
-                function_chunk["parameters"] = tool["input_schema"]  # type: ignore
+                function_chunk["parameters"] = tool["input_schema"]
             if "description" in tool:
-                function_chunk["description"] = tool["description"]  # type: ignore
+                function_chunk["description"] = tool["description"]
 
             for k, v in tool.items():
                 if k not in mapped_tool_params:  # pass additional computer kwargs
                     function_chunk.setdefault("parameters", {}).update({k: v})
             tool_param = ChatCompletionToolParam(type="function", function=function_chunk)
             self._add_cache_control_if_applicable(tool, tool_param, model)
-            new_tools.append(tool_param)  # type: ignore[arg-type]
+            new_tools.append(tool_param)
 
-        return new_tools, tool_name_mapping  # type: ignore[return-value]
+        return new_tools, tool_name_mapping
 
     def translate_anthropic_output_format_to_openai(self, output_format: Any) -> dict[str, Any] | None:
         """
@@ -880,7 +880,7 @@ class LiteLLMAnthropicMessagesAdapter:
             if openai_system_content:
                 new_messages.insert(
                     0,
-                    ChatCompletionSystemMessage(role="system", content=openai_system_content),  # type: ignore
+                    ChatCompletionSystemMessage(role="system", content=openai_system_content),
                 )
 
     def _translate_metadata_to_openai(
@@ -948,7 +948,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 regular_tools.append(cast(AllAnthropicToolsValues, tool))
 
         if web_search_tools:
-            new_kwargs["web_search_options"] = {}  # type: ignore
+            new_kwargs["web_search_options"] = {}
 
         if not regular_tools:
             return {}
@@ -975,7 +975,7 @@ class LiteLLMAnthropicMessagesAdapter:
 
         model: Final = new_kwargs.get("model", "")
         if self.is_anthropic_claude_model(model) or self.is_bedrock_arn_model(model):
-            new_kwargs["thinking"] = thinking  # type: ignore
+            new_kwargs["thinking"] = thinking
             return
 
         reasoning_effort = self.translate_anthropic_thinking_to_reasoning_effort(cast(dict[str, Any], thinking))
@@ -1031,7 +1031,7 @@ class LiteLLMAnthropicMessagesAdapter:
         translatable_params: Final = self.translatable_anthropic_params()
         for k, v in anthropic_message_request.items():
             if k not in translatable_params:  # pass remaining params as is
-                new_kwargs[k] = v  # type: ignore
+                new_kwargs[k] = v
 
     def translate_anthropic_to_openai(
         self, anthropic_message_request: AnthropicMessagesRequest
@@ -1309,16 +1309,16 @@ class LiteLLMAnthropicMessagesAdapter:
         """
         ## translate content block
         anthropic_content: Final = self._translate_openai_content_to_anthropic(
-            choices=response.choices,  # type: ignore
+            choices=response.choices,
             tool_name_mapping=tool_name_mapping,
         )
 
         if polyfill_result is not None and polyfill_result.compaction_block is not None:
-            anthropic_content.insert(0, polyfill_result.compaction_block)  # type: ignore[arg-type]
+            anthropic_content.insert(0, polyfill_result.compaction_block)
 
         ## extract finish reason
         anthropic_finish_reason: Final = self._translate_openai_finish_reason_to_anthropic(
-            openai_finish_reason=response.choices[0].finish_reason  # type: ignore
+            openai_finish_reason=response.choices[0].finish_reason
         )
         # extract usage
         usage: Final[Usage] = getattr(response, "usage")
@@ -1330,7 +1330,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 "input_tokens": anthropic_usage["input_tokens"],
                 "output_tokens": usage.completion_tokens or 0,
             }
-            anthropic_usage["iterations"] = list(polyfill_result.iterations_usage) + [message_iteration]  # type: ignore[typeddict-unknown-key]
+            anthropic_usage["iterations"] = list(polyfill_result.iterations_usage) + [message_iteration]
 
         translated_obj: Final = AnthropicMessagesResponse(
             id=response.id,
@@ -1338,8 +1338,8 @@ class LiteLLMAnthropicMessagesAdapter:
             role="assistant",
             model=response.model or "unknown-model",
             stop_sequence=None,
-            usage=anthropic_usage,  # type: ignore
-            content=anthropic_content,  # type: ignore
+            usage=anthropic_usage,
+            content=anthropic_content,
             stop_reason=anthropic_finish_reason,
         )
 
@@ -1467,7 +1467,7 @@ class LiteLLMAnthropicMessagesAdapter:
                 stop_reason=self._translate_openai_finish_reason_to_anthropic(response.choices[0].finish_reason),
             )
             if getattr(response, "usage", None) is not None:
-                litellm_usage_chunk: Usage | None = response.usage  # type: ignore
+                litellm_usage_chunk: Usage | None = response.usage
             elif hasattr(response, "_hidden_params") and "usage" in response._hidden_params:
                 litellm_usage_chunk = response._hidden_params["usage"]
             else:
@@ -1479,7 +1479,7 @@ class LiteLLMAnthropicMessagesAdapter:
             message_block: Final = MessageBlockDelta(
                 type="message_delta",
                 delta=delta,
-                usage=usage_delta,  # type: ignore
+                usage=usage_delta,
             )
             if applied_edits:
                 message_block["context_management"] = ContextManagementResponse(applied_edits=list(applied_edits))
@@ -1487,9 +1487,7 @@ class LiteLLMAnthropicMessagesAdapter:
         (
             type_of_content,
             content_block_delta,
-        ) = self._translate_streaming_openai_chunk_to_anthropic(
-            choices=response.choices  # type: ignore
-        )
+        ) = self._translate_streaming_openai_chunk_to_anthropic(choices=response.choices)
         return ContentBlockDelta(
             type="content_block_delta",
             index=current_content_block_index,

--- a/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/handler.py
@@ -427,7 +427,7 @@ def anthropic_messages_handler(
     local_vars: Final = locals()
     is_async: Final = kwargs.pop("is_async", False)
     # Use provided client or create a new one
-    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
 
     # Store original model name before get_llm_provider strips the provider prefix
     # This is needed by agentic hooks (e.g., websearch_interception) to make follow-up requests

--- a/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/messages/transformation.py
@@ -552,7 +552,7 @@ class AnthropicMessagesConfig(BaseAnthropicMessagesConfig):
         _tools: Final = anthropic_messages_optional_request_params.get("tools") or []
         _has_advisor: Final = any(isinstance(t, dict) and t.get("type") == ANTHROPIC_ADVISOR_TOOL_TYPE for t in _tools)
         if not _has_advisor:
-            messages = strip_advisor_blocks_from_messages(messages)  # type: ignore[assignment]
+            messages = strip_advisor_blocks_from_messages(messages)
 
         anthropic_messages_request: Final[AnthropicMessagesRequest] = AnthropicMessagesRequest(
             messages=messages,

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/handler.py
@@ -70,7 +70,7 @@ def _build_responses_kwargs(
     if output_format:
         request_data["output_format"] = output_format
 
-    anthropic_request: Final = AnthropicMessagesRequest(**request_data)  # type: ignore[typeddict-item]
+    anthropic_request: Final = AnthropicMessagesRequest(**request_data)
     responses_kwargs: Final = _ADAPTER.translate_request(anthropic_request)
 
     # Normalize reasoning effort based on model capabilities

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/streaming_iterator.py
@@ -240,8 +240,8 @@ class AnthropicResponsesStreamWrapper:
                 if usage is not None:
                     input_tokens = getattr(usage, "input_tokens", 0) or 0
                     output_tokens = getattr(usage, "output_tokens", 0) or 0
-                    cache_creation_tokens = getattr(usage, "input_tokens_details", None)  # type: ignore[assignment]
-                    cache_read_tokens = getattr(usage, "output_tokens_details", None)  # type: ignore[assignment]
+                    cache_creation_tokens = getattr(usage, "input_tokens_details", None)
+                    cache_read_tokens = getattr(usage, "output_tokens_details", None)
                     # Prefer direct cache fields if present
                     cache_creation_tokens = int(getattr(usage, "cache_creation_input_tokens", 0) or 0)
                     cache_read_tokens = int(getattr(usage, "cache_read_input_tokens", 0) or 0)

--- a/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
+++ b/litellm/llms/anthropic/experimental_pass_through/responses_adapters/transformation.py
@@ -342,7 +342,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
         output_format: Any = anthropic_request.get("output_format")
         output_config = anthropic_request.get("output_config")
         if not isinstance(output_format, dict) and isinstance(output_config, dict):
-            output_format = output_config.get("format")  # type: ignore[assignment]
+            output_format = output_config.get("format")
         if isinstance(output_format, dict) and output_format.get("type") == "json_schema":
             schema: Final = output_format.get("schema")
             if schema:
@@ -469,7 +469,7 @@ class LiteLLMAnthropicToResponsesAPIAdapter:
             role="assistant",
             model=response.model or "unknown-model",
             stop_sequence=None,
-            usage=anthropic_usage,  # type: ignore
-            content=content,  # type: ignore
+            usage=anthropic_usage,
+            content=content,
             stop_reason=stop_reason,
         )

--- a/litellm/llms/anthropic/files/handler.py
+++ b/litellm/llms/anthropic/files/handler.py
@@ -296,7 +296,7 @@ class AnthropicFilesHandler:
                     index=0,
                     message=litellm.Message(content="", role="assistant"),
                 )
-            ]  # type: ignore
+            ]
 
             # Create a logging object for transformation
             logging_obj: Final = Logging(

--- a/litellm/llms/azure/assistants.py
+++ b/litellm/llms/azure/assistants.py
@@ -46,7 +46,7 @@ class AzureAssistantsAPI(BaseAzureLLM):
                 api_version=api_version,
                 is_async=False,
             )
-            azure_openai_client = AzureOpenAI(**azure_client_params)  # type: ignore
+            azure_openai_client = AzureOpenAI(**azure_client_params)
         else:
             azure_openai_client = client
 
@@ -74,7 +74,7 @@ class AzureAssistantsAPI(BaseAzureLLM):
             )
 
             azure_openai_client = AsyncAzureOpenAI(**azure_client_params)
-            # azure_openai_client = AsyncAzureOpenAI(**data)  # type: ignore
+            # azure_openai_client = AsyncAzureOpenAI(**data)
         else:
             azure_openai_client = client
 
@@ -204,9 +204,9 @@ class AzureAssistantsAPI(BaseAzureLLM):
             litellm_params=litellm_params,
         )
 
-        thread_message: Final[OpenAIMessage] = await openai_client.beta.threads.messages.create(  # type: ignore
+        thread_message: Final[OpenAIMessage] = await openai_client.beta.threads.messages.create(
             thread_id,
-            **message_data,  # type: ignore
+            **message_data,
         )
 
         response_obj: OpenAIMessage | None = None
@@ -293,9 +293,9 @@ class AzureAssistantsAPI(BaseAzureLLM):
             litellm_params=litellm_params,
         )
 
-        thread_message: Final[OpenAIMessage] = openai_client.beta.threads.messages.create(  # type: ignore
+        thread_message: Final[OpenAIMessage] = openai_client.beta.threads.messages.create(
             thread_id,
-            **message_data,  # type: ignore
+            **message_data,
         )
 
         response_obj: OpenAIMessage | None = None
@@ -437,11 +437,11 @@ class AzureAssistantsAPI(BaseAzureLLM):
 
         data: Final = {}
         if messages is not None:
-            data["messages"] = messages  # type: ignore
+            data["messages"] = messages
         if metadata is not None:
-            data["metadata"] = metadata  # type: ignore
+            data["metadata"] = metadata
 
-        message_thread: Final = await openai_client.beta.threads.create(**data)  # type: ignore
+        message_thread: Final = await openai_client.beta.threads.create(**data)
 
         return Thread(**message_thread.dict())
 
@@ -533,11 +533,11 @@ class AzureAssistantsAPI(BaseAzureLLM):
 
         data: Final = {}
         if messages is not None:
-            data["messages"] = messages  # type: ignore
+            data["messages"] = messages
         if metadata is not None:
-            data["metadata"] = metadata  # type: ignore
+            data["metadata"] = metadata
 
-        message_thread: Final = azure_openai_client.beta.threads.create(**data)  # type: ignore
+        message_thread: Final = azure_openai_client.beta.threads.create(**data)
 
         return Thread(**message_thread.dict())
 
@@ -679,12 +679,12 @@ class AzureAssistantsAPI(BaseAzureLLM):
             litellm_params=litellm_params,
         )
 
-        response: Final = await openai_client.beta.threads.runs.create_and_poll(  # type: ignore
+        response: Final = await openai_client.beta.threads.runs.create_and_poll(
             thread_id=thread_id,
             assistant_id=assistant_id,
             additional_instructions=additional_instructions,
             instructions=instructions,
-            metadata=metadata,  # type: ignore
+            metadata=metadata,
             model=model,
             tools=tools,
         )
@@ -715,7 +715,7 @@ class AzureAssistantsAPI(BaseAzureLLM):
         }
         if event_handler is not None:
             data["event_handler"] = event_handler
-        return client.beta.threads.runs.stream(**data)  # type: ignore
+        return client.beta.threads.runs.stream(**data)
 
     def run_thread_stream(
         self,
@@ -741,7 +741,7 @@ class AzureAssistantsAPI(BaseAzureLLM):
         }
         if event_handler is not None:
             data["event_handler"] = event_handler
-        return client.beta.threads.runs.stream(**data)  # type: ignore
+        return client.beta.threads.runs.stream(**data)
 
     # fmt: off
 
@@ -841,7 +841,7 @@ class AzureAssistantsAPI(BaseAzureLLM):
                 assistant_id=assistant_id,
                 additional_instructions=additional_instructions,
                 instructions=instructions,
-                metadata=metadata,  # type: ignore
+                metadata=metadata,
                 model=model,
                 stream=stream,
                 tools=tools,
@@ -879,12 +879,12 @@ class AzureAssistantsAPI(BaseAzureLLM):
                 litellm_params=litellm_params,
             )
 
-        response: Final = openai_client.beta.threads.runs.create_and_poll(  # type: ignore
+        response: Final = openai_client.beta.threads.runs.create_and_poll(
             thread_id=thread_id,
             assistant_id=assistant_id,
             additional_instructions=additional_instructions,
             instructions=instructions,
-            metadata=metadata,  # type: ignore
+            metadata=metadata,
             model=model,
             tools=tools,
         )

--- a/litellm/llms/azure/audio_transcriptions.py
+++ b/litellm/llms/azure/audio_transcriptions.py
@@ -81,7 +81,7 @@ class AzureAudioTranscription(AzureChatCompletion):
 
         response: Final = azure_client.audio.transcriptions.create(
             **data,
-            timeout=timeout,  # type: ignore
+            timeout=timeout,
         )
 
         if isinstance(response, BaseModel):
@@ -102,7 +102,7 @@ class AzureAudioTranscription(AzureChatCompletion):
             model_response_object=model_response,
             hidden_params=hidden_params,
             response_type="audio_transcription",
-        )  # type: ignore
+        )
         return final_response
 
     async def async_audio_transcriptions(
@@ -151,7 +151,7 @@ class AzureAudioTranscription(AzureChatCompletion):
 
             raw_response: Final = await async_azure_client.audio.transcriptions.with_raw_response.create(
                 **data, timeout=timeout
-            )  # type: ignore
+            )
 
             headers: Final = dict(raw_response.headers)
             response = raw_response.parse()

--- a/litellm/llms/azure/azure.py
+++ b/litellm/llms/azure/azure.py
@@ -4,7 +4,7 @@ import time
 from collections.abc import Callable, Coroutine
 from typing import Any, Final
 
-import httpx  # type: ignore
+import httpx
 from openai import (
     APITimeoutError,
     AsyncAzureOpenAI,
@@ -790,7 +790,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 )
 
             ## COMPLETION CALL
-            raw_response = azure_client.embeddings.with_raw_response.create(**data, timeout=timeout)  # type: ignore
+            raw_response = azure_client.embeddings.with_raw_response.create(**data, timeout=timeout)
             headers = dict(raw_response.headers)
             response: Final = raw_response.parse()
             if isinstance(response, str):
@@ -811,7 +811,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 model_response_object=model_response,
                 response_type="embedding",
                 _response_headers=process_azure_headers(headers),
-            )  # type: ignore
+            )
         except AzureOpenAIError as e:
             raise e
         except Exception as e:
@@ -853,7 +853,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 params=_params,
             )
         else:
-            async_handler = client  # type: ignore
+            async_handler = client
 
         if (
             "images/generations" in api_base
@@ -975,9 +975,9 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             else:
                 _params["timeout"] = httpx.Timeout(timeout=600.0, connect=5.0)
 
-            sync_handler = HTTPHandler(**_params, client=litellm.client_session)  # type: ignore
+            sync_handler = HTTPHandler(**_params, client=litellm.client_session)
         else:
-            sync_handler = client  # type: ignore
+            sync_handler = client
 
         if (
             "images/generations" in api_base
@@ -1180,7 +1180,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     additional_args={"complete_input_dict": data},
                     original_response=stringified_response,
                 )
-                return convert_to_model_response_object(  # type: ignore
+                return convert_to_model_response_object(
                     response_object=stringified_response,
                     model_response_object=model_response,
                     response_type="image_generation",
@@ -1263,7 +1263,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                     timeout=timeout,
                     headers=headers,
                     model=model,
-                )  # type: ignore
+                )
 
             img_gen_api_base: Final = self.create_azure_base_url(
                 azure_client_params=azure_client_params,
@@ -1317,7 +1317,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 response_object=response,
                 model_response_object=model_response,
                 response_type="image_generation",
-            )  # type: ignore
+            )
         except AzureOpenAIError as e:
             raise e
         except Exception as e:
@@ -1362,7 +1362,7 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
                 timeout=timeout,
                 client=client,
                 litellm_params=litellm_params,
-            )  # type: ignore
+            )
 
         azure_client: Final[AzureOpenAI] = self.get_azure_openai_client(
             api_base=api_base,
@@ -1372,11 +1372,11 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             _is_async=False,
             client=client,
             litellm_params=litellm_params,
-        )  # type: ignore
+        )
 
         response: Final = azure_client.audio.speech.create(
             model=model,
-            voice=voice,  # type: ignore
+            voice=voice,
             input=input,
             **optional_params,
         )
@@ -1406,11 +1406,11 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             _is_async=True,
             client=client,
             litellm_params=litellm_params,
-        )  # type: ignore
+        )
 
         azure_response: Final = await azure_client.audio.speech.create(
             model=model,
-            voice=voice,  # type: ignore
+            voice=voice,
             input=input,
             **optional_params,
         )
@@ -1463,8 +1463,8 @@ class AzureChatCompletion(BaseAzureLLM, BaseLLM):
             messages = [{"role": "user", "content": "Hey"}]
         try:
             completion = client.chat.completions.with_raw_response.create(
-                model=model,  # type: ignore
-                messages=messages,  # type: ignore
+                model=model,
+                messages=messages,
             )
         except Exception as e:
             raise e

--- a/litellm/llms/azure/batches/handler.py
+++ b/litellm/llms/azure/batches/handler.py
@@ -36,7 +36,7 @@ class AzureBatchesAPI(BaseAzureLLM):
         create_batch_data: CreateBatchRequest,
         azure_client: AsyncAzureOpenAI | AsyncOpenAI,
     ) -> LiteLLMBatch:
-        response: Final = await azure_client.batches.create(**create_batch_data)  # type: ignore[arg-type]
+        response: Final = await azure_client.batches.create(**create_batch_data)
         return LiteLLMBatch.model_validate(response.model_dump())
 
     def create_batch(
@@ -69,10 +69,8 @@ class AzureBatchesAPI(BaseAzureLLM):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.acreate_batch(  # type: ignore
-                create_batch_data=create_batch_data, azure_client=azure_client
-            )
-        response = cast(AzureOpenAI | OpenAI, azure_client).batches.create(**create_batch_data)  # type: ignore[arg-type]
+            return self.acreate_batch(create_batch_data=create_batch_data, azure_client=azure_client)
+        response = cast(AzureOpenAI | OpenAI, azure_client).batches.create(**create_batch_data)
         return LiteLLMBatch.model_validate(response.model_dump())
 
     async def aretrieve_batch(
@@ -80,7 +78,7 @@ class AzureBatchesAPI(BaseAzureLLM):
         retrieve_batch_data: RetrieveBatchRequest,
         client: AsyncAzureOpenAI | AsyncOpenAI,
     ) -> LiteLLMBatch:
-        response: Final = await client.batches.retrieve(**retrieve_batch_data)  # type: ignore[arg-type]
+        response: Final = await client.batches.retrieve(**retrieve_batch_data)
         return LiteLLMBatch.model_validate(response.model_dump())
 
     def retrieve_batch(
@@ -113,9 +111,7 @@ class AzureBatchesAPI(BaseAzureLLM):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.aretrieve_batch(  # type: ignore
-                retrieve_batch_data=retrieve_batch_data, client=azure_client
-            )
+            return self.aretrieve_batch(retrieve_batch_data=retrieve_batch_data, client=azure_client)
         response: Final = cast(AzureOpenAI | OpenAI, azure_client).batches.retrieve(**retrieve_batch_data)
         return LiteLLMBatch.model_validate(response.model_dump())
 
@@ -157,9 +153,7 @@ class AzureBatchesAPI(BaseAzureLLM):
                 raise ValueError(
                     "Azure client is not an instance of AsyncAzureOpenAI or AsyncOpenAI. Make sure you passed an async client."
                 )
-            return self.acancel_batch(  # type: ignore
-                cancel_batch_data=cancel_batch_data, client=azure_client
-            )
+            return self.acancel_batch(cancel_batch_data=cancel_batch_data, client=azure_client)
 
         # At this point, azure_client is guaranteed to be a sync client
         if not isinstance(azure_client, (AzureOpenAI, OpenAI)):
@@ -175,7 +169,7 @@ class AzureBatchesAPI(BaseAzureLLM):
         after: str | None = None,
         limit: int | None = None,
     ):
-        response: Final = await client.batches.list(after=after, limit=limit)  # type: ignore
+        response: Final = await client.batches.list(after=after, limit=limit)
         return response
 
     def list_batches(
@@ -209,8 +203,6 @@ class AzureBatchesAPI(BaseAzureLLM):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.alist_batches(  # type: ignore
-                client=azure_client, after=after, limit=limit
-            )
-        response: Final = azure_client.batches.list(after=after, limit=limit)  # type: ignore
+            return self.alist_batches(client=azure_client, after=after, limit=limit)
+        response: Final = azure_client.batches.list(after=after, limit=limit)
         return response

--- a/litellm/llms/azure/common_utils.py
+++ b/litellm/llms/azure/common_utils.py
@@ -485,15 +485,15 @@ class BaseAzureLLM(BaseOpenAILLM):
                 verbose_logger.debug("Using Azure v1 API with base_url: %s", v1_params["base_url"])
 
                 if _is_async is True:
-                    openai_client = AsyncOpenAI(**v1_params)  # type: ignore
+                    openai_client = AsyncOpenAI(**v1_params)
                 else:
-                    openai_client = OpenAI(**v1_params)  # type: ignore
+                    openai_client = OpenAI(**v1_params)
             else:
                 # Traditional Azure API uses AzureOpenAI client
                 if _is_async is True:
                     openai_client = AsyncAzureOpenAI(**azure_client_params)
                 else:
-                    openai_client = AzureOpenAI(**azure_client_params)  # type: ignore
+                    openai_client = AzureOpenAI(**azure_client_params)
         else:
             openai_client = client
             if (
@@ -659,9 +659,9 @@ class BaseAzureLLM(BaseOpenAILLM):
                 azure_client_params["azure_ad_token_provider"] = azure_ad_token_provider
 
             if acompletion is True:
-                client = AsyncAzureOpenAI(**azure_client_params)  # type: ignore
+                client = AsyncAzureOpenAI(**azure_client_params)
             else:
-                client = AzureOpenAI(**azure_client_params)  # type: ignore
+                client = AzureOpenAI(**azure_client_params)
         return client
 
     @staticmethod

--- a/litellm/llms/azure/completion/handler.py
+++ b/litellm/llms/azure/completion/handler.py
@@ -75,7 +75,7 @@ class AzureTextCompletion(BaseAzureLLM):
                 data = {"model": None, "prompt": prompt, **optional_params}
             else:
                 data = {
-                    "model": model,  # type: ignore
+                    "model": model,
                     "prompt": prompt,
                     **optional_params,
                 }

--- a/litellm/llms/azure/exception_mapping.py
+++ b/litellm/llms/azure/exception_mapping.py
@@ -69,7 +69,7 @@ class AzureOpenAIExceptionMapping:
         # Some SDKs place the payload under "error".
         azure_error: dict[str, Any]
         if isinstance(body_dict.get("error"), dict):
-            azure_error = body_dict.get("error", {})  # type: ignore[assignment]
+            azure_error = body_dict.get("error", {})
         else:
             azure_error = body_dict
 

--- a/litellm/llms/azure/files/handler.py
+++ b/litellm/llms/azure/files/handler.py
@@ -46,7 +46,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
         openai_client: AsyncAzureOpenAI | AsyncOpenAI,
     ) -> OpenAIFileObject:
         verbose_logger.debug("create_file_data=%s", create_file_data)
-        response = await openai_client.files.create(**self._prepare_create_file_data(create_file_data))  # type: ignore[arg-type]
+        response = await openai_client.files.create(**self._prepare_create_file_data(create_file_data))
         verbose_logger.debug("create_file_response=%s", response)
         return OpenAIFileObject(**response.model_dump())
 
@@ -83,7 +83,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
             return self.acreate_file(create_file_data=create_file_data, openai_client=openai_client)
         response: Final = cast(AzureOpenAI | OpenAI, openai_client).files.create(
             **self._prepare_create_file_data(create_file_data)
-        )  # type: ignore[arg-type]
+        )
         return OpenAIFileObject(**response.model_dump())
 
     async def afile_content(
@@ -124,7 +124,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
                 raise ValueError(
                     "AzureOpenAI client is not an instance of AsyncAzureOpenAI. Make sure you passed an AsyncAzureOpenAI client."
                 )
-            return self.afile_content(  # type: ignore
+            return self.afile_content(
                 file_content_request=file_content_request,
                 openai_client=openai_client,
             )
@@ -170,7 +170,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
                 raise ValueError(
                     "AzureOpenAI client is not an instance of AsyncAzureOpenAI. Make sure you passed an AsyncAzureOpenAI client."
                 )
-            return self.aretrieve_file(  # type: ignore
+            return self.aretrieve_file(
                 file_id=file_id,
                 openai_client=openai_client,
             )
@@ -220,7 +220,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
                 raise ValueError(
                     "AzureOpenAI client is not an instance of AsyncAzureOpenAI. Make sure you passed an AsyncAzureOpenAI client."
                 )
-            return self.adelete_file(  # type: ignore
+            return self.adelete_file(
                 file_id=file_id,
                 openai_client=openai_client,
             )
@@ -272,7 +272,7 @@ class AzureOpenAIFilesAPI(BaseAzureLLM):
                 raise ValueError(
                     "AzureOpenAI client is not an instance of AsyncAzureOpenAI. Make sure you passed an AsyncAzureOpenAI client."
                 )
-            return self.alist_files(  # type: ignore
+            return self.alist_files(
                 purpose=purpose,
                 openai_client=openai_client,
             )

--- a/litellm/llms/azure/realtime/handler.py
+++ b/litellm/llms/azure/realtime/handler.py
@@ -25,7 +25,7 @@ async def forward_messages(client_ws: Any, backend_ws: Any):
         while True:
             message = await backend_ws.recv()
             await client_ws.send_text(message)
-    except websockets.exceptions.ConnectionClosed:  # type: ignore
+    except websockets.exceptions.ConnectionClosed:
         pass
 
 
@@ -119,10 +119,10 @@ class AzureOpenAIRealtime(AzureChatCompletion):
 
         try:
             ssl_context: Final = get_shared_realtime_ssl_context()
-            async with websockets.connect(  # type: ignore
+            async with websockets.connect(
                 url,
                 additional_headers={
-                    "api-key": api_key,  # type: ignore
+                    "api-key": api_key,
                 },
                 max_size=REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
                 ssl=ssl_context,
@@ -141,7 +141,7 @@ class AzureOpenAIRealtime(AzureChatCompletion):
                 )
                 await realtime_streaming.bidirectional_forward()
 
-        except websockets.exceptions.InvalidStatusCode as e:  # type: ignore
+        except websockets.exceptions.InvalidStatusCode as e:
             await websocket.close(code=e.status_code, reason=_redact_string(str(e)))
         except Exception:
             verbose_proxy_logger.exception("Error in AzureOpenAIRealtime.async_realtime")

--- a/litellm/llms/azure_ai/anthropic/handler.py
+++ b/litellm/llms/azure_ai/anthropic/handler.py
@@ -154,7 +154,7 @@ class AzureAnthropicChatCompletion(AnthropicChatCompletion):
                 completion_stream, response_headers = make_sync_call(
                     client=client,
                     api_base=api_base,
-                    headers=headers,  # type: ignore
+                    headers=headers,
                     data=json.dumps(data),
                     model=model,
                     messages=messages,

--- a/litellm/llms/azure_ai/embed/handler.py
+++ b/litellm/llms/azure_ai/embed/handler.py
@@ -45,7 +45,7 @@ class AzureAIEmbedding(OpenAIChatCompletion):
         elif text_embedding_responses is not None:
             model_response.data = text_embedding_responses
 
-        response: Final = AzureAICohereConfig()._transform_response(response=model_response)  # type: ignore
+        response: Final = AzureAICohereConfig()._transform_response(response=model_response)
 
         return response
 
@@ -71,13 +71,13 @@ class AzureAIEmbedding(OpenAIChatCompletion):
 
         response: Final = await client.post(
             url=url,
-            json=data,  # type: ignore
+            json=data,
             headers={"Authorization": f"Bearer {api_key}"},
         )
 
         embedding_response: Final = response.json()
         embedding_headers: Final = dict(response.headers)
-        returned_response: Final[EmbeddingResponse] = convert_to_model_response_object(  # type: ignore
+        returned_response: Final[EmbeddingResponse] = convert_to_model_response_object(
             response_object=embedding_response,
             model_response_object=model_response,
             response_type="embedding",
@@ -114,13 +114,13 @@ class AzureAIEmbedding(OpenAIChatCompletion):
 
         response: Final = client.post(
             url=url,
-            json=data,  # type: ignore
+            json=data,
             headers={"Authorization": f"Bearer {api_key}"},
         )
 
         embedding_response: Final = response.json()
         embedding_headers: Final = dict(response.headers)
-        returned_response: Final[EmbeddingResponse] = convert_to_model_response_object(  # type: ignore
+        returned_response: Final[EmbeddingResponse] = convert_to_model_response_object(
             response_object=embedding_response,
             model_response_object=model_response,
             response_type="embedding",
@@ -168,7 +168,7 @@ class AzureAIEmbedding(OpenAIChatCompletion):
                 raise Exception("/image/embeddings route returned None Embeddings.")
 
         if v1_embeddings_request["input"]:
-            response: Final[EmbeddingResponse] = await super().embedding(  # type: ignore
+            response: Final[EmbeddingResponse] = await super().embedding(
                 model=model,
                 input=input,
                 timeout=timeout,
@@ -215,7 +215,7 @@ class AzureAIEmbedding(OpenAIChatCompletion):
         assemble result in-order, and return
         """
         if aembedding is True:
-            return self.async_embedding(  # type: ignore
+            return self.async_embedding(
                 model,
                 input,
                 timeout,
@@ -254,7 +254,7 @@ class AzureAIEmbedding(OpenAIChatCompletion):
                 raise Exception("/image/embeddings route returned None Embeddings.")
 
         if v1_embeddings_request["input"]:
-            response: Final[EmbeddingResponse] = super().embedding(  # type: ignore
+            response: Final[EmbeddingResponse] = super().embedding(
                 model,
                 input,
                 timeout,

--- a/litellm/llms/azure_ai/image_edit/flux2_transformation.py
+++ b/litellm/llms/azure_ai/image_edit/flux2_transformation.py
@@ -136,7 +136,7 @@ class AzureFoundryFlux2ImageEditConfig(OpenAIImageEditConfig):
         elif isinstance(image, bytes):
             image_bytes = image
         elif hasattr(image, "read"):
-            image_bytes = image.read()  # type: ignore
+            image_bytes = image.read()
         else:
             raise ValueError(f"Unsupported image type: {type(image)}")
 

--- a/litellm/llms/azure_ai/image_generation/mai_transformation.py
+++ b/litellm/llms/azure_ai/image_generation/mai_transformation.py
@@ -226,5 +226,5 @@ class AzureFoundryMAIImageGenerationConfig(BaseImageGenerationConfig):
 
         width: Final = optional_params.get("width", self.DEFAULT_WIDTH)
         height: Final = optional_params.get("height", self.DEFAULT_HEIGHT)
-        image_response.size = f"{width}x{height}"  # type: ignore[assignment]
+        image_response.size = f"{width}x{height}"
         return image_response

--- a/litellm/llms/base.py
+++ b/litellm/llms/base.py
@@ -73,7 +73,7 @@ class BaseLLM:
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if hasattr(self, "_aclient_session"):
-            await self._aclient_session.aclose()  # type: ignore
+            await self._aclient_session.aclose()
 
     def validate_environment(self, *args, **kwargs) -> Any | None:  # set up the environment required to run the model
         return None

--- a/litellm/llms/base_llm/managed_resources/base_managed_resource.py
+++ b/litellm/llms/base_llm/managed_resources/base_managed_resource.py
@@ -188,7 +188,7 @@ class BaseManagedResource(ABC, Generic[ResourceObjectType]):
         if resource_object is not None:
             # Handle both dict and Pydantic models
             if hasattr(resource_object, "model_dump_json"):
-                db_data["resource_object"] = resource_object.model_dump_json()  # type: ignore
+                db_data["resource_object"] = resource_object.model_dump_json()
             elif isinstance(resource_object, dict):
                 db_data["resource_object"] = json.dumps(resource_object)
 

--- a/litellm/llms/bedrock/chat/agentcore/transformation.py
+++ b/litellm/llms/bedrock/chat/agentcore/transformation.py
@@ -313,7 +313,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
 
         metadata: Final = event_payload.get("metadata")
         if metadata and "usage" in metadata:
-            return metadata["usage"]  # type: ignore
+            return metadata["usage"]
 
         return None
 
@@ -412,18 +412,16 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
         # Strategy 1: {"result": {"content": [{"text": "..."}]}} - standard AgentCore format
         if "result" in response_json and isinstance(response_json["result"], dict):
             result: Final = response_json["result"]
-            content = self._extract_content_from_message(result)  # type: ignore
+            content = self._extract_content_from_message(result)
             return AgentCoreParsedResponse(
                 content=content,
                 usage=None,
-                final_message=result,  # type: ignore
+                final_message=result,
             )
 
         # Strategy 2: {"response": [{"text": "..."}]} - Strands agent content blocks
         if "response" in response_json and isinstance(response_json["response"], list):
-            content = self._extract_content_from_message(
-                {"content": response_json["response"]}  # type: ignore
-            )
+            content = self._extract_content_from_message({"content": response_json["response"]})
             return AgentCoreParsedResponse(
                 content=content,
                 usage=None,
@@ -503,7 +501,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
 
             # Check for final complete message
             if "message" in data and isinstance(data["message"], dict):
-                final_message = data["message"]  # type: ignore
+                final_message = data["message"]
                 verbose_logger.debug("Found final message")
 
             # Process event data
@@ -597,7 +595,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                                     delta=Delta(),
                                 )
                             ]
-                            usage_data: AgentCoreUsage = metadata["usage"]  # type: ignore
+                            usage_data: AgentCoreUsage = metadata["usage"]
                             setattr(
                                 chunk,
                                 "usage",
@@ -810,7 +808,7 @@ class AmazonAgentCoreConfig(BaseConfig, BaseAWSLLM):
                                     delta=Delta(),
                                 )
                             ]
-                            usage_data: AgentCoreUsage = metadata["usage"]  # type: ignore
+                            usage_data: AgentCoreUsage = metadata["usage"]
                             setattr(
                                 chunk,
                                 "usage",

--- a/litellm/llms/bedrock/chat/converse_handler.py
+++ b/litellm/llms/bedrock/chat/converse_handler.py
@@ -60,7 +60,7 @@ def make_sync_call(
             data=data,
             messages=messages,
             encoding=litellm.encoding,
-        )  # type: ignore
+        )
         completion_stream: Any = MockResponseIterator(model_response=model_response, json_mode=json_mode)
     else:
         decoder: Final = AWSEventStreamDecoder(model=model, json_mode=json_mode)
@@ -209,7 +209,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                 _params["timeout"] = timeout
             client = get_async_httpx_client(params=_params, llm_provider=litellm.LlmProviders.BEDROCK)
         else:
-            client = client  # type: ignore
+            client = client
 
         try:
             response: Final = await client.post(
@@ -217,7 +217,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                 headers=headers,
                 data=data,
                 logging_obj=logging_obj,
-            )  # type: ignore
+            )
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
@@ -378,7 +378,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                     credentials=credentials,
                     api_key=api_key,
                     stream_chunk_size=stream_chunk_size,
-                )  # type: ignore
+                )
             ### ASYNC COMPLETION
             return self.async_completion(
                 model=model,
@@ -388,7 +388,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                 encoding=encoding,
                 logging_obj=logging_obj,
                 optional_params=optional_params,
-                stream=stream,  # type: ignore
+                stream=stream,
                 litellm_params=litellm_params,
                 logger_fn=logger_fn,
                 headers=headers,
@@ -396,7 +396,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                 client=client,
                 credentials=credentials,
                 api_key=api_key,
-            )  # type: ignore
+            )
 
         ## TRANSFORMATION ##
 
@@ -435,7 +435,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                 if isinstance(timeout, float) or isinstance(timeout, int):
                     timeout = httpx.Timeout(timeout)
                 _params["timeout"] = timeout
-            client = _get_httpx_client(_params)  # type: ignore
+            client = _get_httpx_client(_params)
         else:
             client = client
 
@@ -443,7 +443,7 @@ class BedrockConverseLLM(BaseAWSLLM):
             completion_stream: Final = make_sync_call(
                 client=(client if client is not None and isinstance(client, HTTPHandler) else None),
                 api_base=proxy_endpoint_url,
-                headers=prepped.headers,  # type: ignore
+                headers=prepped.headers,
                 data=data,
                 model=model,
                 messages=messages,
@@ -469,7 +469,7 @@ class BedrockConverseLLM(BaseAWSLLM):
                 headers=prepped.headers,
                 data=data,
                 logging_obj=logging_obj,
-            )  # type: ignore
+            )
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code

--- a/litellm/llms/bedrock/chat/converse_transformation.py
+++ b/litellm/llms/bedrock/chat/converse_transformation.py
@@ -178,17 +178,15 @@ class AmazonConverseConfig(BaseConfig):
                 new_content = []
                 for item in content:
                     if isinstance(item, dict) and item.get("type") == "text":
-                        new_item = {"type": "guarded_text", "text": item["text"]}  # type: ignore
+                        new_item = {"type": "guarded_text", "text": item["text"]}
                         new_content.append(new_item)
                     else:
                         new_content.append(item)
 
-                messages_copy[user_message_index]["content"] = new_content  # type: ignore
+                messages_copy[user_message_index]["content"] = new_content
             elif isinstance(content, str):
                 # If content is a string, convert it to guarded_text
-                messages_copy[user_message_index]["content"] = [  # type: ignore
-                    {"type": "guarded_text", "text": content}  # type: ignore
-                ]
+                messages_copy[user_message_index]["content"] = [{"type": "guarded_text", "text": content}]
 
         return messages_copy
 
@@ -886,7 +884,7 @@ class AmazonConverseConfig(BaseConfig):
                 _tool_choice_value = self.map_tool_choice_values(
                     model=model,
                     tool_choice=value,
-                    drop_params=drop_params,  # type: ignore
+                    drop_params=drop_params,
                 )
                 if _tool_choice_value is not None:
                     optional_params["tool_choice"] = _tool_choice_value
@@ -959,7 +957,7 @@ class AmazonConverseConfig(BaseConfig):
 
     def _map_request_metadata_param(self, value: Any, optional_params: dict) -> None:
         if value is not None and isinstance(value, dict):
-            self._validate_request_metadata(value)  # type: ignore
+            self._validate_request_metadata(value)
             optional_params["requestMetadata"] = value
 
     def _map_context_management_param(self, value: dict | list, optional_params: dict) -> None:
@@ -1597,7 +1595,7 @@ class AmazonConverseConfig(BaseConfig):
         for config_name, config_class in self.get_config_blocks().items():
             config_value = inference_params.pop(config_name, None)
             if config_value is not None:
-                data[config_name] = config_class(**config_value)  # type: ignore
+                data[config_name] = config_class(**config_value)
 
         # Tool Config
         if bedrock_tool_config is not None:
@@ -2085,7 +2083,7 @@ class AmazonConverseConfig(BaseConfig):
         json_mode: Final[bool | None] = optional_params.get("json_mode", None)
         ## RESPONSE OBJECT
         try:
-            completion_response: Final = ConverseResponseBlock(**response.json())  # type: ignore
+            completion_response: Final = ConverseResponseBlock(**response.json())
         except Exception as e:
             raise BedrockError(
                 message=f"Error converting to valid response block={e}. File an issue if litellm error - https://github.com/BerriAI/litellm/issues",

--- a/litellm/llms/bedrock/chat/invoke_agent/transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_agent/transformation.py
@@ -295,7 +295,7 @@ class AmazonInvokeAgentConfig(BaseConfig, BaseAWSLLM):
 
             if event_type == "chunk" and payload:
                 # Extract base64 encoded content from chunk events
-                chunk_payload: InvokeAgentChunkPayload = payload  # type: ignore
+                chunk_payload: InvokeAgentChunkPayload = payload
                 encoded_bytes = chunk_payload.get("bytes", "")
                 if encoded_bytes:
                     try:
@@ -352,7 +352,7 @@ class AmazonInvokeAgentConfig(BaseConfig, BaseAWSLLM):
         if not payload:
             return None
 
-        trace_payload: Final[InvokeAgentTracePayload] = payload  # type: ignore
+        trace_payload: Final[InvokeAgentTracePayload] = payload
         return trace_payload.get("trace", {})
 
     def _extract_and_update_preprocessing_usage(

--- a/litellm/llms/bedrock/chat/invoke_handler.py
+++ b/litellm/llms/bedrock/chat/invoke_handler.py
@@ -2,7 +2,7 @@ import types
 from collections.abc import AsyncIterator, Iterator
 from typing import Final, cast
 
-import httpx  # type: ignore
+import httpx
 
 import litellm
 from litellm import verbose_logger
@@ -198,7 +198,7 @@ async def make_call(
                 data=data,
                 messages=messages,
                 encoding=litellm.encoding,
-            )  # type: ignore
+            )
             completion_stream: Any = MockResponseIterator(model_response=model_response, json_mode=json_mode)
         elif bedrock_invoke_provider == "anthropic":
             decoder: AWSEventStreamDecoder = AmazonAnthropicClaudeStreamDecoder(
@@ -282,7 +282,7 @@ def make_sync_call(
                 data=data,
                 messages=messages,
                 encoding=litellm.encoding,
-            )  # type: ignore
+            )
             completion_stream: Any = MockResponseIterator(model_response=model_response, json_mode=json_mode)
         elif bedrock_invoke_provider == "anthropic":
             decoder: AWSEventStreamDecoder = AmazonAnthropicClaudeStreamDecoder(
@@ -693,13 +693,13 @@ class AWSEventStreamDecoder:
             chunk = parsed_response.get("chunk")
             if not chunk:
                 return None
-            return chunk.get("bytes").decode()  # type: ignore[no-any-return]
+            return chunk.get("bytes").decode()
         else:
             chunk = response_dict.get("body")
             if not chunk:
                 return None
 
-            return chunk.decode()  # type: ignore[no-any-return]
+            return chunk.decode()
 
 
 class AmazonAnthropicClaudeStreamDecoder(AWSEventStreamDecoder):
@@ -786,7 +786,7 @@ class MockResponseIterator:  # for returning ai21 streaming responses
     def _chunk_parser(self, chunk_data: ModelResponse) -> GChunk:
         try:
             chunk_usage: Final[Usage] = getattr(chunk_data, "usage")
-            text = chunk_data.choices[0].message.content or ""  # type: ignore
+            text = chunk_data.choices[0].message.content or ""
             tool_use = None
             _model_response_tool_call: Final = cast(
                 List[ChatCompletionMessageToolCall] | None,
@@ -795,7 +795,7 @@ class MockResponseIterator:  # for returning ai21 streaming responses
             if self.json_mode is True:
                 text, tool_use = self._handle_json_mode_chunk(
                     text=text,
-                    tool_calls=chunk_data.choices[0].message.tool_calls,  # type: ignore
+                    tool_calls=chunk_data.choices[0].message.tool_calls,
                 )
             elif _model_response_tool_call is not None:
                 tool_use = ChatCompletionToolCallChunk(

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_deepseek_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_deepseek_transformation.py
@@ -86,7 +86,7 @@ class AmazonDeepseekR1ResponseIterator(BaseModelResponseIterator):
         Deepseek r1 starts by thinking, then it generates the response.
         """
         try:
-            typed_chunk: Final = AmazonDeepSeekR1StreamingResponse(**chunk)  # type: ignore
+            typed_chunk: Final = AmazonDeepSeekR1StreamingResponse(**chunk)
             generated_content = typed_chunk["generation"]
             if generated_content == "</think>" and not self.has_finished_thinking:
                 verbose_logger.debug("Deepseek r1: </think> received, setting has_finished_thinking to True")

--- a/litellm/llms/bedrock/chat/invoke_transformations/amazon_twelvelabs_pegasus_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/amazon_twelvelabs_pegasus_transformation.py
@@ -231,7 +231,7 @@ class AmazonTwelveLabsPegasusConfig(AmazonInvokeConfig, BaseConfig):
                 and hasattr(model_response.choices[0], "message")
                 and getattr(model_response.choices[0].message, "tool_calls", None) is None
             ):
-                model_response.choices[0].message.content = message_content  # type: ignore
+                model_response.choices[0].message.content = message_content
                 model_response.choices[0].finish_reason = finish_reason
             else:
                 raise Exception("Unable to set message content")
@@ -250,7 +250,7 @@ class AmazonTwelveLabsPegasusConfig(AmazonInvokeConfig, BaseConfig):
         completion_tokens: Final = int(
             bedrock_output_tokens
             or litellm.token_counter(
-                text=model_response.choices[0].message.content,  # type: ignore
+                text=model_response.choices[0].message.content,
                 count_response_tokens=True,
             )
         )

--- a/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
+++ b/litellm/llms/bedrock/chat/invoke_transformations/base_invoke_transformation.py
@@ -300,7 +300,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
         try:
             if provider == "cohere":
                 if "text" in completion_response:
-                    outputText = completion_response["text"]  # type: ignore
+                    outputText = completion_response["text"]
                 elif "generations" in completion_response:
                     outputText = completion_response["generations"][0]["text"]
                     model_response.choices[0].finish_reason = map_finish_reason(
@@ -365,14 +365,12 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
                 outputText is not None
                 and len(outputText) > 0
                 and hasattr(model_response.choices[0], "message")
-                and getattr(model_response.choices[0].message, "tool_calls", None)  # type: ignore
-                is None
+                and getattr(model_response.choices[0].message, "tool_calls", None) is None
             ):
-                model_response.choices[0].message.content = outputText  # type: ignore
+                model_response.choices[0].message.content = outputText
             elif (
                 hasattr(model_response.choices[0], "message")
-                and getattr(model_response.choices[0].message, "tool_calls", None)  # type: ignore
-                is not None
+                and getattr(model_response.choices[0].message, "tool_calls", None) is not None
             ):
                 pass
             else:
@@ -392,7 +390,7 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
         completion_tokens: Final = int(
             bedrock_output_tokens
             or litellm.token_counter(
-                text=model_response.choices[0].message.content,  # type: ignore
+                text=model_response.choices[0].message.content,
                 count_response_tokens=True,
             )
         )
@@ -610,4 +608,4 @@ class AmazonInvokeConfig(BaseConfig, BaseAWSLLM):
                         prompt += f"{message['content']}"
                 else:
                     prompt += f"{message['content']}"
-        return prompt, chat_history  # type: ignore
+        return prompt, chat_history

--- a/litellm/llms/bedrock/common_utils.py
+++ b/litellm/llms/bedrock/common_utils.py
@@ -373,7 +373,7 @@ def init_bedrock_client(
     # Iterate over parameters and update if needed
     for i, param in enumerate(params_to_check):
         if param and param.startswith("os.environ/"):
-            params_to_check[i] = get_secret(param)  # type: ignore
+            params_to_check[i] = get_secret(param)
     # Assign updated values back to parameters
     (
         aws_access_key_id,
@@ -415,13 +415,11 @@ def init_bedrock_client(
     import boto3
 
     if isinstance(timeout, float):
-        config = boto3.session.Config(connect_timeout=timeout, read_timeout=timeout)  # type: ignore
+        config = boto3.session.Config(connect_timeout=timeout, read_timeout=timeout)
     elif isinstance(timeout, httpx.Timeout):
-        config = boto3.session.Config(  # type: ignore
-            connect_timeout=timeout.connect, read_timeout=timeout.read
-        )
+        config = boto3.session.Config(connect_timeout=timeout.connect, read_timeout=timeout.read)
     else:
-        config = boto3.session.Config()  # type: ignore
+        config = boto3.session.Config()
 
     ### CHECK STS ###
     if aws_web_identity_token is not None and aws_role_name is not None and aws_session_name is not None:
@@ -784,7 +782,7 @@ def _get_bedrock_output_config_effort_ceiling(
 
     ceiling = model_info.get("bedrock_output_config_effort_ceiling")
     if isinstance(ceiling, str) and ceiling in _BEDROCK_OUTPUT_CONFIG_EFFORT_ORDER:
-        return ceiling  # type: ignore[return-value]
+        return ceiling
 
     model_cost_key: Final = model_info.get("key")
     if not isinstance(model_cost_key, str):
@@ -793,7 +791,7 @@ def _get_bedrock_output_config_effort_ceiling(
     local_model_info: Final = _get_local_model_cost_map().get(model_cost_key, {})
     ceiling = local_model_info.get("bedrock_output_config_effort_ceiling")
     if isinstance(ceiling, str) and ceiling in _BEDROCK_OUTPUT_CONFIG_EFFORT_ORDER:
-        return ceiling  # type: ignore[return-value]
+        return ceiling
     return None
 
 
@@ -1258,13 +1256,13 @@ class BedrockEventStreamDecoderBase:
             chunk = parsed_response.get("chunk")
             if not chunk:
                 return None
-            return chunk.get("bytes").decode()  # type: ignore[no-any-return]
+            return chunk.get("bytes").decode()
         else:
             chunk = response_dict.get("body")
             if not chunk:
                 return None
 
-            return chunk.decode()  # type: ignore[no-any-return]
+            return chunk.decode()
 
 
 def get_anthropic_beta_from_headers(headers: dict) -> list[str]:

--- a/litellm/llms/bedrock/embed/amazon_titan_g1_transformation.py
+++ b/litellm/llms/bedrock/embed/amazon_titan_g1_transformation.py
@@ -64,7 +64,7 @@ class AmazonTitanG1Config:
 
         transformed_responses: Final[list[Embedding]] = []
         for index, response in enumerate(response_list):
-            _parsed_response = AmazonTitanG1EmbeddingResponse(**response)  # type: ignore
+            _parsed_response = AmazonTitanG1EmbeddingResponse(**response)
             transformed_responses.append(
                 Embedding(
                     embedding=_parsed_response["embedding"],

--- a/litellm/llms/bedrock/embed/amazon_titan_multimodal_transformation.py
+++ b/litellm/llms/bedrock/embed/amazon_titan_multimodal_transformation.py
@@ -49,7 +49,7 @@ class AmazonTitanMultimodalEmbeddingG1Config:
             transformed_request = AmazonTitanMultimodalEmbeddingRequest(inputText=input)
 
         for k, v in inference_params.items():
-            transformed_request[k] = v  # type: ignore
+            transformed_request[k] = v
         return transformed_request
 
     def _transform_response(
@@ -61,7 +61,7 @@ class AmazonTitanMultimodalEmbeddingG1Config:
         total_prompt_tokens = 0
         transformed_responses: Final[list[Embedding]] = []
         for index, response in enumerate(response_list):
-            _parsed_response = AmazonTitanMultimodalEmbeddingResponse(**response)  # type: ignore
+            _parsed_response = AmazonTitanMultimodalEmbeddingResponse(**response)
             transformed_responses.append(
                 Embedding(
                     embedding=_parsed_response["embedding"],

--- a/litellm/llms/bedrock/embed/amazon_titan_v2_transformation.py
+++ b/litellm/llms/bedrock/embed/amazon_titan_v2_transformation.py
@@ -74,14 +74,14 @@ class AmazonTitanV2Config:
         return optional_params
 
     def _transform_request(self, input: str, inference_params: dict) -> AmazonTitanV2EmbeddingRequest:
-        return AmazonTitanV2EmbeddingRequest(inputText=input, **inference_params)  # type: ignore
+        return AmazonTitanV2EmbeddingRequest(inputText=input, **inference_params)
 
     def _transform_response(self, response_list: list[dict], model: str) -> EmbeddingResponse:
         total_prompt_tokens = 0
 
         transformed_responses: Final[list[Embedding]] = []
         for index, response in enumerate(response_list):
-            _parsed_response = AmazonTitanV2EmbeddingResponse(**response)  # type: ignore
+            _parsed_response = AmazonTitanV2EmbeddingResponse(**response)
 
             # According to AWS docs, embeddingsByType is always present
             # If binary was requested (encoding_format="base64"), use binary data

--- a/litellm/llms/bedrock/embed/cohere_transformation.py
+++ b/litellm/llms/bedrock/embed/cohere_transformation.py
@@ -36,6 +36,6 @@ class BedrockCohereEmbeddingConfig:
         )
         for k in CohereEmbeddingRequest.__annotations__.keys():
             if k in transformed_request:
-                new_transformed_request[k] = transformed_request[k]  # type: ignore
+                new_transformed_request[k] = transformed_request[k]
 
         return new_transformed_request

--- a/litellm/llms/bedrock/embed/embedding.py
+++ b/litellm/llms/bedrock/embed/embedding.py
@@ -74,7 +74,7 @@ class BedrockEmbedding(BaseAWSLLM):
             if aws_region_name is None:
                 aws_region_name = "us-west-2"
 
-        credentials: Final[Credentials] = self.get_credentials(  # type: ignore
+        credentials: Final[Credentials] = self.get_credentials(
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
             aws_session_token=aws_session_token,
@@ -104,11 +104,11 @@ class BedrockEmbedding(BaseAWSLLM):
                 if isinstance(timeout, float) or isinstance(timeout, int):
                     timeout = httpx.Timeout(timeout)
                 _params["timeout"] = timeout
-            client = _get_httpx_client(_params)  # type: ignore
+            client = _get_httpx_client(_params)
         else:
             client = client
         try:
-            response: Final = client.post(url=api_base, headers=headers, data=json.dumps(data))  # type: ignore
+            response: Final = client.post(url=api_base, headers=headers, data=json.dumps(data))
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
@@ -137,7 +137,7 @@ class BedrockEmbedding(BaseAWSLLM):
             client = client
 
         try:
-            response: Final = await client.post(url=api_base, headers=headers, data=json.dumps(data))  # type: ignore
+            response: Final = await client.post(url=api_base, headers=headers, data=json.dumps(data))
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
@@ -244,7 +244,7 @@ class BedrockEmbedding(BaseAWSLLM):
             if extra_headers is not None:
                 headers = {"Content-Type": "application/json", **extra_headers}
 
-            prepped = self.get_request_headers(  # type: ignore  # type: ignore
+            prepped = self.get_request_headers(
                 credentials=credentials,
                 aws_region_name=aws_region_name,
                 extra_headers=extra_headers,
@@ -312,7 +312,7 @@ class BedrockEmbedding(BaseAWSLLM):
             if extra_headers is not None:
                 headers = {"Content-Type": "application/json", **extra_headers}
 
-            prepped = self.get_request_headers(  # type: ignore  # type: ignore
+            prepped = self.get_request_headers(
                 credentials=credentials,
                 aws_region_name=aws_region_name,
                 extra_headers=extra_headers,
@@ -485,7 +485,7 @@ class BedrockEmbedding(BaseAWSLLM):
 
         if batch_data is not None:
             if aembedding:
-                return self._async_single_func_embeddings(  # type: ignore
+                return self._async_single_func_embeddings(
                     client=(client if client is not None and isinstance(client, AsyncHTTPHandler) else None),
                     timeout=timeout,
                     batch_data=batch_data,
@@ -523,7 +523,7 @@ class BedrockEmbedding(BaseAWSLLM):
         if extra_headers is not None:
             headers = {"Content-Type": "application/json", **extra_headers}
 
-        prepped: Final = self.get_request_headers(  # type: ignore
+        prepped: Final = self.get_request_headers(
             credentials=credentials,
             aws_region_name=aws_region_name,
             extra_headers=extra_headers,
@@ -543,7 +543,7 @@ class BedrockEmbedding(BaseAWSLLM):
             logging_obj=logging_obj,
             optional_params=optional_params,
             encoding=encoding,
-            data=data,  # type: ignore
+            data=data,
             complete_api_base=prepped.url,
             api_key=None,
             aembedding=aembedding,

--- a/litellm/llms/bedrock/embed/twelvelabs_marengo_transformation.py
+++ b/litellm/llms/bedrock/embed/twelvelabs_marengo_transformation.py
@@ -140,7 +140,7 @@ class TwelveLabsMarengoEmbeddingConfig:
                 "mediaSource",
                 "bucketOwner",  # Don't include bucketOwner in the request
             ]:  # Don't override core fields
-                transformed_request[k] = v  # type: ignore
+                transformed_request[k] = v
 
         # If async invoke route, wrap in the async invoke format
         if async_invoke_route and model_id:

--- a/litellm/llms/bedrock/image_edit/amazon_nova_canvas_image_edit_transformation.py
+++ b/litellm/llms/bedrock/image_edit/amazon_nova_canvas_image_edit_transformation.py
@@ -134,8 +134,8 @@ def _file_types_to_b64(image: FileTypes | None) -> str:
         raise ValueError("Nova Canvas image edit requires an image input")
     if hasattr(image, "read") and callable(getattr(image, "read", None)):
         if hasattr(image, "seek"):
-            image.seek(0)  # type: ignore[union-attr]
-        image_bytes: Final = image.read()  # type: ignore[union-attr]
+            image.seek(0)
+        image_bytes: Final = image.read()
         return base64.b64encode(image_bytes).decode("utf-8")
     if isinstance(image, bytes):
         return base64.b64encode(image).decode("utf-8")
@@ -149,7 +149,7 @@ def _file_types_to_b64(image: FileTypes | None) -> str:
             "Nova Canvas image edit does not support tuple FileTypes. "
             "Pass a file-like object, bytes, or a base64-encoded string."
         )
-    return base64.b64encode(bytes(image)).decode("utf-8")  # type: ignore[arg-type]
+    return base64.b64encode(bytes(image)).decode("utf-8")
 
 
 def _supports_nova_canvas_image_edit_from_model_cost(model: str) -> bool:
@@ -310,7 +310,7 @@ class BedrockAmazonNovaCanvasImageEditConfig(BaseImageEditConfig):
         mask_raw: Final = op.pop("mask", None)
         mask_b64: str | None = None
         if mask_raw is not None:
-            mask_b64 = _file_types_to_b64(mask_raw)  # type: ignore[arg-type]
+            mask_b64 = _file_types_to_b64(mask_raw)
 
         _size: Final = op.pop("size", None)
         width = op.pop("width", None)

--- a/litellm/llms/bedrock/image_edit/handler.py
+++ b/litellm/llms/bedrock/image_edit/handler.py
@@ -110,7 +110,7 @@ class BedrockImageEdit(BaseAWSLLM):
                 url=prepared_request.endpoint_url,
                 headers=prepared_request.prepped.headers,
                 data=prepared_request.body,
-            )  # type: ignore
+            )
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
@@ -152,7 +152,7 @@ class BedrockImageEdit(BaseAWSLLM):
                 url=prepared_request.endpoint_url,
                 headers=prepared_request.prepped.headers,
                 data=prepared_request.body,
-            )  # type: ignore
+            )
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code

--- a/litellm/llms/bedrock/image_edit/stability_transformation.py
+++ b/litellm/llms/bedrock/image_edit/stability_transformation.py
@@ -122,7 +122,7 @@ class BedrockStabilityImageEditConfig(BaseImageEditConfig):
             if k in param_mapping:
                 # Map param if mapping exists and value is valid
                 if k == "size" and v in OPENAI_SIZE_TO_STABILITY_ASPECT_RATIO:
-                    mapped_params[param_mapping[k]] = OPENAI_SIZE_TO_STABILITY_ASPECT_RATIO[v]  # type: ignore
+                    mapped_params[param_mapping[k]] = OPENAI_SIZE_TO_STABILITY_ASPECT_RATIO[v]
                 # Don't copy "size" itself to final dict
             elif k == "n":
                 # Store for logic but do not add to outgoing params
@@ -176,8 +176,8 @@ class BedrockStabilityImageEditConfig(BaseImageEditConfig):
             image_b64: str
             if hasattr(image, "read") and callable(getattr(image, "read", None)):
                 # File-like object (e.g., BufferedReader from open())
-                image_bytes: Final = image.read()  # type: ignore
-                image_b64 = base64.b64encode(image_bytes).decode("utf-8")  # type: ignore
+                image_bytes: Final = image.read()
+                image_b64 = base64.b64encode(image_bytes).decode("utf-8")
             elif isinstance(image, bytes):
                 # Raw bytes
                 image_b64 = base64.b64encode(image).decode("utf-8")
@@ -186,7 +186,7 @@ class BedrockStabilityImageEditConfig(BaseImageEditConfig):
                 image_b64 = image
             else:
                 # Try to handle as bytes
-                image_b64 = base64.b64encode(bytes(image)).decode("utf-8")  # type: ignore
+                image_b64 = base64.b64encode(bytes(image)).decode("utf-8")
 
             # For style-transfer models, map image to init_image
             model_lower: Final = model.lower()
@@ -196,7 +196,7 @@ class BedrockStabilityImageEditConfig(BaseImageEditConfig):
                 data["image"] = image_b64
 
         # Add optional params (already mapped in map_openai_params)
-        for key, value in image_edit_optional_request_params.items():  # type: ignore
+        for key, value in image_edit_optional_request_params.items():
             # Skip internal params (prefixed with _)
             if key.startswith("_") or value is None:
                 continue
@@ -209,7 +209,7 @@ class BedrockStabilityImageEditConfig(BaseImageEditConfig):
                     file_value = value[0]
 
                 if hasattr(file_value, "read") and callable(getattr(file_value, "read", None)):
-                    file_bytes = file_value.read()  # type: ignore
+                    file_bytes = file_value.read()
                 elif isinstance(file_value, bytes):
                     file_bytes = file_value
                 elif isinstance(file_value, str):
@@ -217,7 +217,7 @@ class BedrockStabilityImageEditConfig(BaseImageEditConfig):
                     data[key] = file_value
                     continue
                 else:
-                    file_bytes = file_value  # type: ignore
+                    file_bytes = file_value
 
                 if isinstance(file_bytes, bytes):
                     file_b64 = base64.b64encode(file_bytes).decode("utf-8")
@@ -242,15 +242,15 @@ class BedrockStabilityImageEditConfig(BaseImageEditConfig):
             if key in numeric_int_fields:
                 # Convert to int (these are pixel values for outpaint)
                 try:
-                    data[key] = int(value)  # type: ignore
+                    data[key] = int(value)
                 except (ValueError, TypeError):
-                    data[key] = value  # type: ignore
+                    data[key] = value
             elif key in numeric_float_fields:
                 # Convert to float
                 try:
-                    data[key] = float(value)  # type: ignore
+                    data[key] = float(value)
                 except (ValueError, TypeError):
-                    data[key] = value  # type: ignore
+                    data[key] = value
 
             # Supported text fields
             elif key in [
@@ -263,7 +263,7 @@ class BedrockStabilityImageEditConfig(BaseImageEditConfig):
                 "select_prompt",
                 "search_prompt",
             ]:
-                data[key] = value  # type: ignore
+                data[key] = value
 
         return data, {}
 

--- a/litellm/llms/bedrock/image_generation/amazon_nova_canvas_transformation.py
+++ b/litellm/llms/bedrock/image_generation/amazon_nova_canvas_transformation.py
@@ -76,9 +76,7 @@ class AmazonNovaCanvasConfig:
             text_to_image_params: dict[str, Any] = image_generation_config.pop("textToImageParams", {})
             text_to_image_params = {"text": text, **text_to_image_params}
             try:
-                text_to_image_params_typed: Final = AmazonNovaCanvasTextToImageParams(
-                    **text_to_image_params  # type: ignore
-                )
+                text_to_image_params_typed: Final = AmazonNovaCanvasTextToImageParams(**text_to_image_params)
             except Exception as e:
                 raise ValueError(
                     f"Error transforming text to image params: {e}. Got params: {text_to_image_params}, Expected params: {AmazonNovaCanvasTextToImageParams.__annotations__}"
@@ -106,7 +104,7 @@ class AmazonNovaCanvasConfig:
             }
             try:
                 color_guided_generation_params_typed: Final = AmazonNovaCanvasColorGuidedGenerationParams(
-                    **color_guided_generation_params  # type: ignore
+                    **color_guided_generation_params
                 )
             except Exception as e:
                 raise ValueError(
@@ -129,9 +127,7 @@ class AmazonNovaCanvasConfig:
             inpainting_params: dict[str, Any] = image_generation_config.pop("inpaintingParams", {})
             inpainting_params = {"text": text, **inpainting_params}
             try:
-                inpainting_params_typed: Final = AmazonNovaCanvasInpaintingParams(
-                    **inpainting_params  # type: ignore
-                )
+                inpainting_params_typed: Final = AmazonNovaCanvasInpaintingParams(**inpainting_params)
             except Exception as e:
                 raise ValueError(
                     f"Error transforming inpainting params: {e}. Got params: {inpainting_params}, Expected params: {AmazonNovaCanvasInpaintingParams.__annotations__}"

--- a/litellm/llms/bedrock/image_generation/amazon_titan_transformation.py
+++ b/litellm/llms/bedrock/image_generation/amazon_titan_transformation.py
@@ -121,7 +121,7 @@ class AmazonTitanImageGenerationConfig:
         }
         return AmazonTitanImageGenerationRequestBody(
             taskType=task_type,
-            textToImageParams=AmazonTitanTextToImageParams(**text_to_image_params),  # type: ignore
+            textToImageParams=AmazonTitanTextToImageParams(**text_to_image_params),
             imageGenerationConfig=AmazonNovaCanvasImageGenerationConfig(**image_generation_config),
         )
 

--- a/litellm/llms/bedrock/image_generation/image_handler.py
+++ b/litellm/llms/bedrock/image_generation/image_handler.py
@@ -115,7 +115,7 @@ class BedrockImageGeneration(BaseAWSLLM):
                 url=prepared_request.endpoint_url,
                 headers=prepared_request.prepped.headers,
                 data=prepared_request.body,
-            )  # type: ignore
+            )
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
@@ -158,7 +158,7 @@ class BedrockImageGeneration(BaseAWSLLM):
                 url=prepared_request.endpoint_url,
                 headers=prepared_request.prepped.headers,
                 data=prepared_request.body,
-            )  # type: ignore
+            )
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code

--- a/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
+++ b/litellm/llms/bedrock/messages/invoke_transformations/anthropic_claude3_transformation.py
@@ -865,7 +865,7 @@ class AmazonAnthropicClaudeMessagesConfig(
                 )
 
                 if delta_usage:
-                    pending_delta["usage"] = delta_usage  # type: ignore[arg-type]
+                    pending_delta["usage"] = delta_usage
 
                 yield pending_delta
                 pending_delta = None
@@ -884,7 +884,7 @@ class AmazonAnthropicClaudeMessagesConfig(
                 delta_usage, start_usage_snapshot
             )
             if delta_usage:
-                pending_delta["usage"] = delta_usage  # type: ignore[arg-type]
+                pending_delta["usage"] = delta_usage
             yield pending_delta
 
 

--- a/litellm/llms/bedrock/passthrough/guardrail_translation/handler.py
+++ b/litellm/llms/bedrock/passthrough/guardrail_translation/handler.py
@@ -311,7 +311,7 @@ class BedrockPassthroughGuardrailHandler(BaseTranslation):
         processed: Final = await proxy_logging_obj.post_call_success_hook(
             data=data,
             user_api_key_dict=user_api_key_dict,
-            response=synthetic_response,  # type: ignore[arg-type]
+            response=synthetic_response,
         )
 
         if not isinstance(processed, dict):
@@ -323,7 +323,7 @@ class BedrockPassthroughGuardrailHandler(BaseTranslation):
             return body_bytes
 
         try:
-            processed_blocks: Final = processed["output"]["message"]["content"]  # type: ignore[index]
+            processed_blocks: Final = processed["output"]["message"]["content"]
             de_anonymized_texts: Final = [processed_blocks[i]["text"] for i in range(len(active_groups))]
         except (KeyError, IndexError, TypeError):
             return body_bytes

--- a/litellm/llms/bedrock/rerank/handler.py
+++ b/litellm/llms/bedrock/rerank/handler.py
@@ -100,7 +100,7 @@ class BedrockRerankHandler(BaseAWSLLM):
                 prepared_request,
                 timeout=timeout,
                 client=client if client is not None and isinstance(client, AsyncHTTPHandler) else None,
-            )  # type: ignore
+            )
 
         if client is None or not isinstance(client, HTTPHandler):
             client = _get_httpx_client()

--- a/litellm/llms/brave/search/transformation.py
+++ b/litellm/llms/brave/search/transformation.py
@@ -10,7 +10,7 @@ from datetime import datetime, timezone
 from typing import Final, Literal, TypedDict
 
 import httpx
-from dateutil import parser  # type: ignore[import-untyped]
+from dateutil import parser
 
 _ISO_YMD: Final = re.compile(r"^\s*\d{4}[-/]\d{1,2}[-/]\d{1,2}\s*$")
 _UNIX_TIMESTAMP: Final = re.compile(r"^\s*-?\d+(\.\d+)?\s*$")

--- a/litellm/llms/bytez/chat/transformation.py
+++ b/litellm/llms/bytez/chat/transformation.py
@@ -165,7 +165,7 @@ class BytezChatConfig(BaseConfig):
         if optional_params.get("stream"):
             del optional_params["stream"]
 
-        messages = adapt_messages_to_bytez_standard(messages=messages)  # type: ignore
+        messages = adapt_messages_to_bytez_standard(messages=messages)
 
         data: Final = {
             "messages": messages,
@@ -206,14 +206,14 @@ class BytezChatConfig(BaseConfig):
         # Add the output
         output: Final = json.get("output")
 
-        message: Final = model_response.choices[0].message  # type: ignore
+        message: Final = model_response.choices[0].message
 
         message.content = output["content"][0]["text"]
 
-        messages = adapt_messages_to_bytez_standard(messages=messages)  # type: ignore
+        messages = adapt_messages_to_bytez_standard(messages=messages)
 
         # NOTE We are approximating tokens, to get the true values we will need to update our BE
-        prompt_tokens: Final = get_tokens_from_messages(messages)  # type: ignore
+        prompt_tokens: Final = get_tokens_from_messages(messages)
 
         output_messages: Final = adapt_messages_to_bytez_standard(messages=[output])
 
@@ -227,7 +227,7 @@ class BytezChatConfig(BaseConfig):
             total_tokens=total_tokens,
         )
 
-        model_response.usage = usage  # type: ignore
+        model_response.usage = usage
 
         model_response._hidden_params["additional_headers"] = raw_response.headers
         message.provider_specific_fields = {
@@ -348,7 +348,7 @@ class BytezCustomStreamWrapper(CustomStreamWrapper):
 
             return self.return_processed_chunk_logic(
                 completion_obj=completion_obj,
-                model_response=model_response,  # type: ignore
+                model_response=model_response,
                 response_obj=response_obj,
             )
 

--- a/litellm/llms/codestral/completion/handler.py
+++ b/litellm/llms/codestral/completion/handler.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from functools import partial
 from typing import Final
 
-import httpx  # type: ignore
+import httpx
 
 import litellm
 from litellm.litellm_core_utils.litellm_logging import Logging as LiteLLMLogging
@@ -268,7 +268,7 @@ class CodestralTextCompletion:
                     logger_fn=logger_fn,
                     headers=headers,
                     timeout=timeout,
-                )  # type: ignore
+                )
             else:
                 ### ASYNC COMPLETION
                 return self.async_completion(
@@ -287,7 +287,7 @@ class CodestralTextCompletion:
                     logger_fn=logger_fn,
                     headers=headers,
                     timeout=timeout,
-                )  # type: ignore
+                )
 
         ### SYNC STREAMING
         if stream is True:
@@ -316,7 +316,7 @@ class CodestralTextCompletion:
             response=response,
             model_response=model_response,
             stream=optional_params.get("stream", False),
-            logging_obj=logging_obj,  # type: ignore
+            logging_obj=logging_obj,
             optional_params=optional_params,
             api_key=api_key,
             data=data,

--- a/litellm/llms/cohere/chat/transformation.py
+++ b/litellm/llms/cohere/chat/transformation.py
@@ -231,7 +231,7 @@ class CohereChatConfig(BaseConfig):
     ) -> ModelResponse:
         try:
             raw_response_json: Final = raw_response.json()
-            model_response.choices[0].message.content = raw_response_json["text"]  # type: ignore
+            model_response.choices[0].message.content = raw_response_json["text"]
         except Exception:
             raise CohereError(message=raw_response.text, status_code=raw_response.status_code)
 
@@ -261,7 +261,7 @@ class CohereChatConfig(BaseConfig):
                 tool_calls=tool_calls,
                 content=None,
             )
-            model_response.choices[0].message = _message  # type: ignore
+            model_response.choices[0].message = _message
 
         ## CALCULATING USAGE - use cohere `billed_units` for returning usage
         billed_units: Final = raw_response_json.get("meta", {}).get("billed_units", {})

--- a/litellm/llms/cohere/chat/v2_transformation.py
+++ b/litellm/llms/cohere/chat/v2_transformation.py
@@ -199,13 +199,13 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
             raise CohereError(message=raw_response.text, status_code=raw_response.status_code)
 
         try:
-            cohere_v2_chat_response: Final = CohereV2ChatResponse(**raw_response_json)  # type: ignore
+            cohere_v2_chat_response: Final = CohereV2ChatResponse(**raw_response_json)
         except Exception:
             raise CohereError(message=raw_response.text, status_code=422)
 
         cohere_content: Final = cohere_v2_chat_response["message"].get("content", None)
         if cohere_content is not None:
-            model_response.choices[0].message.content = "".join(  # type: ignore
+            model_response.choices[0].message.content = "".join(
                 [content.get("text", "") for content in cohere_content if content is not None]
             )
 
@@ -226,7 +226,7 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
             tool_calls: Final[list[ChatCompletionToolCallChunk]] = []
             for index, tool in enumerate(cohere_tools_response):
                 tool_call: ChatCompletionToolCallChunk = {
-                    **tool,  # type: ignore
+                    **tool,
                     "index": index,
                 }
                 tool_calls.append(tool_call)
@@ -235,10 +235,10 @@ class CohereV2ChatConfig(OpenAIGPTConfig):
                 content=None,
                 annotations=annotations,
             )
-            model_response.choices[0].message = _message  # type: ignore
+            model_response.choices[0].message = _message
         else:
             if annotations:
-                current_message: Final = model_response.choices[0].message  # type: ignore
+                current_message: Final = model_response.choices[0].message
                 current_message.annotations = annotations
 
         ## CALCULATING USAGE - use cohere `billed_units` for returning usage

--- a/litellm/llms/cohere/common_utils.py
+++ b/litellm/llms/cohere/common_utils.py
@@ -246,7 +246,7 @@ class CohereV2ModelResponseIterator:
                     "name": tool_calls[0].get("name", ""),
                     "arguments": tool_calls[0].get("arguments", ""),
                 },
-            }  # type: ignore
+            }
         return None
 
     def _parse_tool_plan_delta(self, chunk: dict) -> dict | None:

--- a/litellm/llms/cohere/embed/transformation.py
+++ b/litellm/llms/cohere/embed/transformation.py
@@ -111,7 +111,7 @@ class CohereEmbeddingConfig(BaseEmbeddingConfig):
             )
 
         for k, v in inference_params.items():
-            transformed_request[k] = v  # type: ignore
+            transformed_request[k] = v
 
         return transformed_request
 

--- a/litellm/llms/cohere/embed/v1_transformation.py
+++ b/litellm/llms/cohere/embed/v1_transformation.py
@@ -57,7 +57,7 @@ class CohereEmbeddingConfig:
             )
 
         for k, v in inference_params.items():
-            transformed_request[k] = v  # type: ignore
+            transformed_request[k] = v
 
         return transformed_request
 

--- a/litellm/llms/custom_httpx/aiohttp_handler.py
+++ b/litellm/llms/custom_httpx/aiohttp_handler.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Final, cast
 
 import aiohttp
-import httpx  # type: ignore
+import httpx
 from aiohttp import ClientSession, FormData
 
 import litellm
@@ -275,9 +275,9 @@ class BaseLLMAIOHTTPHandler:
             litellm_params=litellm_params,
             stream=False,
         )
-        _transformed_response: Final = await provider_config.transform_response(  # type: ignore
+        _transformed_response: Final = await provider_config.transform_response(
             model=model,
-            raw_response=_response,  # type: ignore
+            raw_response=_response,
             model_response=model_response,
             logging_obj=logging_obj,
             api_key=api_key,
@@ -377,7 +377,7 @@ class BaseLLMAIOHTTPHandler:
             completion_stream, headers = self.make_sync_call(
                 provider_config=provider_config,
                 api_base=api_base,
-                headers=headers,  # type: ignore
+                headers=headers,
                 data=data,
                 model=model,
                 messages=messages,
@@ -616,7 +616,7 @@ class BaseLLMAIOHTTPHandler:
                 litellm_params=litellm_params,
                 image=image,
                 provider_config=provider_config,
-            )  # type: ignore
+            )
 
         if client is None or not isinstance(client, HTTPHandler):
             sync_httpx_client = _get_httpx_client()

--- a/litellm/llms/custom_httpx/aiohttp_transport.py
+++ b/litellm/llms/custom_httpx/aiohttp_transport.py
@@ -65,7 +65,7 @@ def map_aiohttp_exceptions() -> typing.Iterator[None]:
         mapped_exc = None
 
         for from_exc, to_exc in AIOHTTP_EXC_MAP.items():
-            if not isinstance(exc, from_exc):  # type: ignore
+            if not isinstance(exc, from_exc):
                 continue
             if mapped_exc is None or issubclass(to_exc, mapped_exc):
                 mapped_exc = to_exc
@@ -340,7 +340,7 @@ class LiteLLMAiohttpTransport(AiohttpTransport):
             # requests (e.g. DELETE /responses/{id}), which upstream APIs reject.
             data = request.content or None
         except httpx.RequestNotRead:
-            data = request.stream  # type: ignore
+            data = request.stream
             request.headers.pop("transfer-encoding", None)  # handled by aiohttp
 
         # Only pass ssl kwarg when explicitly configured, to avoid

--- a/litellm/llms/custom_httpx/http_handler.py
+++ b/litellm/llms/custom_httpx/http_handler.py
@@ -603,8 +603,8 @@ class AsyncHTTPHandler:
         response: Final = await self.client.get(
             url,
             params=params,
-            headers=headers,  # type: ignore
-            follow_redirects=_follow_redirects,  # type: ignore
+            headers=headers,
+            follow_redirects=_follow_redirects,
             timeout=timeout if timeout is not None else USE_CLIENT_DEFAULT,
         )
         return response
@@ -613,7 +613,7 @@ class AsyncHTTPHandler:
     async def post(
         self,
         url: str,
-        data: dict | str | bytes | None = None,  # type: ignore
+        data: dict | str | bytes | None = None,
         json: dict | None = None,
         params: dict | None = None,
         headers: dict | None = None,
@@ -683,7 +683,7 @@ class AsyncHTTPHandler:
     async def put(
         self,
         url: str,
-        data: dict | str | bytes | None = None,  # type: ignore
+        data: dict | str | bytes | None = None,
         json: dict | None = None,
         params: dict | None = None,
         headers: dict | None = None,
@@ -706,7 +706,7 @@ class AsyncHTTPHandler:
                 params=params,
                 headers=headers,
                 timeout=timeout,
-                content=request_content,  # type: ignore
+                content=request_content,
             )
             response: Final = await self.client.send(req)
             response.raise_for_status()
@@ -747,7 +747,7 @@ class AsyncHTTPHandler:
     async def patch(
         self,
         url: str,
-        data: dict | str | bytes | None = None,  # type: ignore
+        data: dict | str | bytes | None = None,
         json: dict | None = None,
         params: dict | None = None,
         headers: dict | None = None,
@@ -770,7 +770,7 @@ class AsyncHTTPHandler:
                 params=params,
                 headers=headers,
                 timeout=timeout,
-                content=request_content,  # type: ignore
+                content=request_content,
             )
             response: Final = await self.client.send(req)
             response.raise_for_status()
@@ -811,7 +811,7 @@ class AsyncHTTPHandler:
     async def delete(
         self,
         url: str,
-        data: dict | str | bytes | None = None,  # type: ignore
+        data: dict | str | bytes | None = None,
         json: dict | None = None,
         params: dict | None = None,
         headers: dict | None = None,
@@ -834,7 +834,7 @@ class AsyncHTTPHandler:
                 params=params,
                 headers=headers,
                 timeout=timeout,
-                content=request_content,  # type: ignore
+                content=request_content,
             )
             response: Final = await self.client.send(req, stream=stream)
             response.raise_for_status()
@@ -863,7 +863,7 @@ class AsyncHTTPHandler:
         self,
         url: str,
         client: httpx.AsyncClient,
-        data: dict | str | bytes | None = None,  # type: ignore
+        data: dict | str | bytes | None = None,
         json: dict | None = None,
         params: dict | None = None,
         headers: dict | None = None,
@@ -885,7 +885,7 @@ class AsyncHTTPHandler:
             json=json,
             params=params,
             headers=headers,
-            content=request_content,  # type: ignore
+            content=request_content,
         )
         response: Final = await client.send(req, stream=stream)
         response.raise_for_status()
@@ -1191,13 +1191,13 @@ class HTTPHandler:
                 req = self.client.build_request(
                     "POST",
                     url,
-                    data=request_data,  # type: ignore
+                    data=request_data,
                     json=json,
                     params=params,
                     headers=headers,
                     timeout=timeout,
                     files=files,
-                    content=request_content,  # type: ignore
+                    content=request_content,
                 )
             else:
                 req = self.client.build_request(
@@ -1208,7 +1208,7 @@ class HTTPHandler:
                     params=params,
                     headers=headers,
                     files=files,
-                    content=request_content,  # type: ignore
+                    content=request_content,
                 )
             response: Final = self.client.send(req, stream=stream)
             response.raise_for_status()
@@ -1248,7 +1248,7 @@ class HTTPHandler:
                     params=params,
                     headers=headers,
                     timeout=timeout,
-                    content=request_content,  # type: ignore
+                    content=request_content,
                 )
             else:
                 req = self.client.build_request(
@@ -1258,7 +1258,7 @@ class HTTPHandler:
                     json=json,
                     params=params,
                     headers=headers,
-                    content=request_content,  # type: ignore
+                    content=request_content,
                 )
             response: Final = self.client.send(req, stream=stream)
             response.raise_for_status()
@@ -1298,7 +1298,7 @@ class HTTPHandler:
                     params=params,
                     headers=headers,
                     timeout=timeout,
-                    content=request_content,  # type: ignore
+                    content=request_content,
                 )
             else:
                 req = self.client.build_request(
@@ -1308,7 +1308,7 @@ class HTTPHandler:
                     json=json,
                     params=params,
                     headers=headers,
-                    content=request_content,  # type: ignore
+                    content=request_content,
                 )
             response: Final = self.client.send(req, stream=stream)
             return response
@@ -1326,7 +1326,7 @@ class HTTPHandler:
     def delete(
         self,
         url: str,
-        data: dict | str | bytes | None = None,  # type: ignore
+        data: dict | str | bytes | None = None,
         json: dict | None = None,
         params: dict | None = None,
         headers: dict | None = None,
@@ -1347,7 +1347,7 @@ class HTTPHandler:
                     params=params,
                     headers=headers,
                     timeout=timeout,
-                    content=request_content,  # type: ignore
+                    content=request_content,
                 )
             else:
                 req = self.client.build_request(
@@ -1357,7 +1357,7 @@ class HTTPHandler:
                     json=json,
                     params=params,
                     headers=headers,
-                    content=request_content,  # type: ignore
+                    content=request_content,
                 )
             response: Final = self.client.send(req, stream=stream)
             response.raise_for_status()

--- a/litellm/llms/custom_httpx/httpx_handler.py
+++ b/litellm/llms/custom_httpx/httpx_handler.py
@@ -55,7 +55,7 @@ class HTTPHandler:
                 url,
                 data=data,
                 params=params,
-                headers=headers,  # type: ignore
+                headers=headers,
             )
             return response
         except Exception as e:

--- a/litellm/llms/custom_httpx/llm_http_handler.py
+++ b/litellm/llms/custom_httpx/llm_http_handler.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, TypeVar, Union, cast, get_type_hints
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
-import httpx  # type: ignore
+import httpx
 from openai.types.file_deleted import FileDeleted
 
 import litellm
@@ -217,7 +217,7 @@ def _custom_logger_callbacks(logging_obj: LiteLLMLoggingObj) -> list["CustomLogg
     custom_loggers: Final[list[CustomLogger]] = []
     for cb in callbacks:
         if isinstance(cb, str):
-            resolved = get_custom_logger_compatible_class(cb)  # type: ignore[arg-type]
+            resolved = get_custom_logger_compatible_class(cb)
             if resolved is None:
                 continue
             cb = resolved
@@ -574,7 +574,7 @@ class BaseLLMHTTPHandler:
             completion_stream, headers = self.make_sync_call(
                 provider_config=provider_config,
                 api_base=api_base,
-                headers=headers,  # type: ignore
+                headers=headers,
                 data=data,
                 signed_json_body=signed_json_body,
                 original_data=data,
@@ -926,7 +926,7 @@ class BaseLLMHTTPHandler:
         )
 
         if aembedding is True:
-            return self.aembedding(  # type: ignore
+            return self.aembedding(
                 request_data=data,
                 api_base=api_base,
                 headers=headers,
@@ -1083,7 +1083,7 @@ class BaseLLMHTTPHandler:
         )
 
         if _is_async is True:
-            return self.arerank(  # type: ignore
+            return self.arerank(
                 model=model,
                 request_data=data,
                 custom_llm_provider=custom_llm_provider,
@@ -1267,7 +1267,7 @@ class BaseLLMHTTPHandler:
             raise ValueError(f"No provider config found for model: {model} and provider: {custom_llm_provider}")
 
         if atranscription is True:
-            return self.async_audio_transcriptions(  # type: ignore
+            return self.async_audio_transcriptions(
                 model=model,
                 audio_file=audio_file,
                 optional_params=optional_params,
@@ -1859,7 +1859,7 @@ class BaseLLMHTTPHandler:
                 response = await async_httpx_client.post(
                     url=complete_url,
                     headers=headers,
-                    json=data,  # type: ignore
+                    json=data,
                     timeout=timeout,
                 )
         except Exception as e:
@@ -5897,7 +5897,7 @@ class BaseLLMHTTPHandler:
 
                 await realtime_streaming.bidirectional_forward()
 
-        except websockets.exceptions.InvalidStatusCode as e:  # type: ignore
+        except websockets.exceptions.InvalidStatusCode as e:
             verbose_logger.exception("Error connecting to backend: %s", e)
             await websocket.close(code=e.status_code, reason=_redact_string(str(e)))
         except Exception as e:
@@ -6238,7 +6238,7 @@ class BaseLLMHTTPHandler:
                         yield rust_backend
                         return
 
-                async with websockets.connect(  # type: ignore
+                async with websockets.connect(
                     ws_url,
                     additional_headers=headers,
                     max_size=REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
@@ -6294,7 +6294,7 @@ class BaseLLMHTTPHandler:
                 )
                 await streaming.bidirectional_forward()
 
-        except websockets.exceptions.InvalidStatusCode as e:  # type: ignore
+        except websockets.exceptions.InvalidStatusCode as e:
             verbose_logger.exception("Error connecting to responses WS backend: %s", e)
             await websocket.close(code=e.status_code, reason=_redact_string(str(e)))
         except Exception as e:

--- a/litellm/llms/dashscope/chat/transformation.py
+++ b/litellm/llms/dashscope/chat/transformation.py
@@ -50,7 +50,7 @@ class DashScopeChatConfig(OpenAIGPTConfig):
     ) -> tuple[str | None, str | None]:
         api_base = (
             api_base or get_secret_str("DASHSCOPE_API_BASE") or "https://dashscope.aliyuncs.com/compatible-mode/v1"
-        )  # type: ignore
+        )
         dynamic_api_key: Final = api_key or get_secret_str("DASHSCOPE_API_KEY")
         return api_base, dynamic_api_key
 

--- a/litellm/llms/dashscope/rerank/transformation.py
+++ b/litellm/llms/dashscope/rerank/transformation.py
@@ -223,7 +223,7 @@ class DashScopeRerankConfig(BaseRerankConfig):
 
         return RerankResponse(
             id=response_json.get("id") or str(uuid.uuid4()),
-            results=transformed_results,  # type: ignore
+            results=transformed_results,
             meta=meta,
         )
 

--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -538,7 +538,7 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
             if tool_calls is not None:
                 _openai_tool_calls = []
                 for _tc in tool_calls:
-                    _openai_tc = ChatCompletionMessageToolCall(**_tc)  # type: ignore
+                    _openai_tc = ChatCompletionMessageToolCall(**_tc)
                     _openai_tool_calls.append(_openai_tc)
                 fixed_tool_calls = _handle_invalid_parallel_tool_calls(_openai_tool_calls)
 
@@ -620,7 +620,7 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
 
         ## RESPONSE OBJECT
         try:
-            completion_response: Final = DatabricksResponse(**raw_response.json())  # type: ignore
+            completion_response: Final = DatabricksResponse(**raw_response.json())
         except Exception as e:
             response_headers: Final = getattr(raw_response, "headers", None)
             raise DatabricksException(
@@ -636,7 +636,7 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
         model_response.created = completion_response["created"]
         setattr(model_response, "usage", Usage(**completion_response["usage"]))
 
-        model_response.choices = self._transform_dbrx_choices(  # type: ignore
+        model_response.choices = self._transform_dbrx_choices(
             choices=completion_response["choices"],
             json_mode=json_mode,
         )

--- a/litellm/llms/databricks/streaming_utils.py
+++ b/litellm/llms/databricks/streaming_utils.py
@@ -47,26 +47,21 @@ class ModelResponseIterator:
                     index=0,
                 )
 
-            if processed_chunk.choices[0].delta.content is not None:  # type: ignore
-                text = processed_chunk.choices[0].delta.content  # type: ignore
+            if processed_chunk.choices[0].delta.content is not None:
+                text = processed_chunk.choices[0].delta.content
 
             if (
-                processed_chunk.choices[0].delta.tool_calls is not None  # type: ignore
-                and len(processed_chunk.choices[0].delta.tool_calls) > 0  # type: ignore
-                and processed_chunk.choices[0].delta.tool_calls[0].function is not None  # type: ignore
-                and processed_chunk.choices[0].delta.tool_calls[0].function.arguments  # type: ignore
-                is not None
+                processed_chunk.choices[0].delta.tool_calls is not None
+                and len(processed_chunk.choices[0].delta.tool_calls) > 0
+                and processed_chunk.choices[0].delta.tool_calls[0].function is not None
+                and processed_chunk.choices[0].delta.tool_calls[0].function.arguments is not None
             ):
                 tool_use = ChatCompletionToolCallChunk(
-                    id=processed_chunk.choices[0].delta.tool_calls[0].id,  # type: ignore
+                    id=processed_chunk.choices[0].delta.tool_calls[0].id,
                     type="function",
                     function=ChatCompletionToolCallFunctionChunk(
-                        name=processed_chunk.choices[0]
-                        .delta.tool_calls[0]  # type: ignore
-                        .function.name,
-                        arguments=processed_chunk.choices[0]
-                        .delta.tool_calls[0]  # type: ignore
-                        .function.arguments,
+                        name=processed_chunk.choices[0].delta.tool_calls[0].function.name,
+                        arguments=processed_chunk.choices[0].delta.tool_calls[0].function.arguments,
                     ),
                     index=processed_chunk.choices[0].delta.tool_calls[0].index,
                 )

--- a/litellm/llms/datarobot/chat/transformation.py
+++ b/litellm/llms/datarobot/chat/transformation.py
@@ -86,4 +86,4 @@ class DataRobotConfig(OpenAILikeChatConfig):
         Returns:
             str: The complete URL for the API call.
         """
-        return str(api_base)  # type: ignore
+        return str(api_base)

--- a/litellm/llms/deepinfra/rerank/transformation.py
+++ b/litellm/llms/deepinfra/rerank/transformation.py
@@ -122,7 +122,7 @@ class DeepinfraRerankConfig(BaseRerankConfig):
                     optional_rerank_params["instruction"] = v
                 elif k == "webhook" and v is not None:
                     optional_rerank_params["webhook"] = v
-        return OptionalRerankParams(**optional_rerank_params)  # type: ignore
+        return OptionalRerankParams(**optional_rerank_params)
 
     def transform_rerank_request(
         self,

--- a/litellm/llms/deepseek/chat/transformation.py
+++ b/litellm/llms/deepseek/chat/transformation.py
@@ -259,7 +259,7 @@ class DeepSeekChatConfig(OpenAIGPTConfig):
     def _get_openai_compatible_provider_info(
         self, api_base: str | None, api_key: str | None
     ) -> tuple[str | None, str | None]:
-        api_base = api_base or get_secret_str("DEEPSEEK_API_BASE") or "https://api.deepseek.com/beta"  # type: ignore
+        api_base = api_base or get_secret_str("DEEPSEEK_API_BASE") or "https://api.deepseek.com/beta"
         dynamic_api_key: Final = api_key or get_secret_str("DEEPSEEK_API_KEY")
         return api_base, dynamic_api_key
 

--- a/litellm/llms/deprecated_providers/aleph_alpha.py
+++ b/litellm/llms/deprecated_providers/aleph_alpha.py
@@ -4,7 +4,7 @@ import types
 from collections.abc import Callable
 from typing import Final
 
-import httpx  # type: ignore
+import httpx
 
 import litellm
 from litellm.utils import Choices, Message, ModelResponse, Usage
@@ -268,7 +268,7 @@ def completion(
                         message=message_obj,
                     )
                     choices_list.append(choice_obj)
-                model_response.choices = choices_list  # type: ignore
+                model_response.choices = choices_list
             except Exception:
                 raise AlephAlphaError(
                     message=json.dumps(completion_response),

--- a/litellm/llms/deprecated_providers/palm.py
+++ b/litellm/llms/deprecated_providers/palm.py
@@ -99,7 +99,7 @@ def completion(
     logger_fn=None,
 ):
     try:
-        import google.generativeai as palm  # type: ignore
+        import google.generativeai as palm
     except Exception:
         raise Exception("Importing google.generativeai failed, please run 'pip install -q google-generativeai")
     palm.configure(api_key=api_key)
@@ -136,7 +136,7 @@ def completion(
     )
     ## COMPLETION CALL
     try:
-        response: Final = palm.generate_text(prompt=prompt, **inference_params)  # type: ignore[attr-defined]
+        response: Final = palm.generate_text(prompt=prompt, **inference_params)
     except Exception as e:
         raise PalmError(
             message=str(e),
@@ -162,7 +162,7 @@ def completion(
                 message_obj = Message(content=None)
             choice_obj = Choices(index=idx + 1, message=message_obj)
             choices_list.append(choice_obj)
-        model_response.choices = choices_list  # type: ignore
+        model_response.choices = choices_list
     except Exception:
         raise PalmError(message=traceback.format_exc(), status_code=response.status_code)
 

--- a/litellm/llms/docker_model_runner/chat/transformation.py
+++ b/litellm/llms/docker_model_runner/chat/transformation.py
@@ -60,7 +60,7 @@ class DockerModelRunnerChatConfig(OpenAIGPTConfig):
         """
         api_base = (
             api_base or get_secret_str("DOCKER_MODEL_RUNNER_API_BASE") or "http://localhost:22088/engines/llama.cpp"
-        )  # type: ignore
+        )
         # Docker Model Runner may not require authentication for local instances
         dynamic_api_key: Final = api_key or get_secret_str("DOCKER_MODEL_RUNNER_API_KEY") or "dummy-key"
         return api_base, dynamic_api_key

--- a/litellm/llms/elevenlabs/text_to_speech/transformation.py
+++ b/litellm/llms/elevenlabs/text_to_speech/transformation.py
@@ -147,7 +147,7 @@ class ElevenLabsTextToSpeechConfig(BaseTextToSpeechConfig):
                 speed_value = None
             if speed_value is not None:
                 if isinstance(params.get("voice_settings"), dict):
-                    params["voice_settings"]["speed"] = speed_value  # type: ignore[index]
+                    params["voice_settings"]["speed"] = speed_value
                 else:
                     params["voice_settings"] = {"speed": speed_value}
 

--- a/litellm/llms/fireworks_ai/chat/transformation.py
+++ b/litellm/llms/fireworks_ai/chat/transformation.py
@@ -581,7 +581,7 @@ class FireworksAIConfig(FireworksAIMixin, OpenAIGPTConfig):
     def _get_openai_compatible_provider_info(
         self, api_base: str | None, api_key: str | None
     ) -> tuple[str | None, str | None]:
-        api_base = api_base or get_secret_str("FIREWORKS_API_BASE") or "https://api.fireworks.ai/inference/v1"  # type: ignore
+        api_base = api_base or get_secret_str("FIREWORKS_API_BASE") or "https://api.fireworks.ai/inference/v1"
         dynamic_api_key: Final = api_key or (
             get_secret_str("FIREWORKS_API_KEY")
             or get_secret_str("FIREWORKS_AI_API_KEY")

--- a/litellm/llms/fireworks_ai/rerank/transformation.py
+++ b/litellm/llms/fireworks_ai/rerank/transformation.py
@@ -96,7 +96,7 @@ class FireworksAIRerankConfig(FireworksAIMixin, BaseRerankConfig):
 
         return params
 
-    def validate_environment(  # type: ignore[override]
+    def validate_environment(
         self,
         headers: dict,
         model: str,

--- a/litellm/llms/gemini/chat/transformation.py
+++ b/litellm/llms/gemini/chat/transformation.py
@@ -123,21 +123,21 @@ class GoogleAIStudioGeminiConfig(VertexGeminiConfig):
                         format: str | None = None
                         detail: str | None = None
                         if isinstance(img_element.get("image_url"), dict):
-                            _image_url = img_element["image_url"].get("url")  # type: ignore
-                            format = img_element["image_url"].get("format")  # type: ignore
-                            detail = img_element["image_url"].get("detail")  # type: ignore
+                            _image_url = img_element["image_url"].get("url")
+                            format = img_element["image_url"].get("format")
+                            detail = img_element["image_url"].get("detail")
                         else:
-                            _image_url = img_element.get("image_url")  # type: ignore
+                            _image_url = img_element.get("image_url")
                         if _image_url and "https://" in _image_url:
                             image_obj = convert_to_anthropic_image_obj(_image_url, format=format)
                             converted_image_url = convert_generic_image_chunk_to_openai_image_obj(image_obj)
                             if detail is not None:
-                                img_element["image_url"] = {  # type: ignore
+                                img_element["image_url"] = {
                                     "url": converted_image_url,
                                     "detail": detail,
                                 }
                             else:
-                                img_element["image_url"] = converted_image_url  # type: ignore
+                                img_element["image_url"] = converted_image_url
                     elif element.get("type") == "file":
                         file_element = cast(ChatCompletionFileObject, element)
                         _file_field = file_element.get("file")
@@ -152,8 +152,8 @@ class GoogleAIStudioGeminiConfig(VertexGeminiConfig):
                             # Convert HTTP/HTTPS file URL to base64 data
                             try:
                                 base64_data = convert_url_to_base64(file_id)
-                                _file_field["file_data"] = base64_data  # type: ignore
-                                _file_field.pop("file_id", None)  # type: ignore
+                                _file_field["file_data"] = base64_data
+                                _file_field.pop("file_id", None)
                             except Exception:
                                 # If conversion fails, leave as is and let the API handle it
                                 pass

--- a/litellm/llms/gemini/files/transformation.py
+++ b/litellm/llms/gemini/files/transformation.py
@@ -166,9 +166,7 @@ class GoogleAIStudioFilesHandler(GeminiModelInfo, BaseFilesConfig):
         try:
             response_json: Final = raw_response.json()
 
-            response_object: Final = GeminiCreateFilesResponseObject(
-                **response_json.get("file", {})  # type: ignore
-            )
+            response_object: Final = GeminiCreateFilesResponseObject(**response_json.get("file", {}))
 
             # Extract file information from Gemini response
 

--- a/litellm/llms/gemini/image_edit/transformation.py
+++ b/litellm/llms/gemini/image_edit/transformation.py
@@ -46,7 +46,7 @@ class GeminiImageEditConfig(BaseImageEditConfig):
         drop_params: bool,
     ) -> dict[str, Any]:
         return map_openai_image_params_to_gemini(
-            params=image_edit_optional_params,  # type: ignore[arg-type]
+            params=image_edit_optional_params,
             model=model,
             supported_params=self.get_supported_openai_params(model),
             parse_image_config_string=True,
@@ -82,7 +82,7 @@ class GeminiImageEditConfig(BaseImageEditConfig):
         base_url = base_url.rstrip("/")
         return f"{base_url}/models/{model}:generateContent"
 
-    def transform_image_edit_request(  # type: ignore[override]
+    def transform_image_edit_request(
         self,
         model: str,
         prompt: str | None,

--- a/litellm/llms/gemini/image_generation/transformation.py
+++ b/litellm/llms/gemini/image_generation/transformation.py
@@ -42,7 +42,7 @@ class GoogleImageGenConfig(BaseImageGenerationConfig):
         supported_params: Final = ["n", "size"]
         if is_gemini_image_model(model):
             supported_params.extend(["imageConfig", "tools", "web_search_options"])
-        return supported_params  # type: ignore[return-value]
+        return supported_params
 
     def map_openai_params(
         self,

--- a/litellm/llms/gemini/realtime/transformation.py
+++ b/litellm/llms/gemini/realtime/transformation.py
@@ -1011,7 +1011,7 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
                 object="realtime.response",
                 id=current_response_id,
                 status="completed",
-                status_details=None,  # type: ignore[typeddict-item]
+                status_details=None,
                 output=([output_item["item"] for output_item in output_items] if output_items else []),
                 conversation_id=current_conversation_id,
                 modalities=_modalities,
@@ -1410,7 +1410,7 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
                         id=current_response_id,
                         object="realtime.response",
                         status="completed",
-                        status_details=None,  # type: ignore[typeddict-item]
+                        status_details=None,
                         output=[
                             {
                                 "id": te["item_id"],
@@ -1452,7 +1452,7 @@ class GeminiRealtimeConfig(BaseRealtimeConfig):
                     server_content_handled = True
                     continue
                 transformed_response_done_event = self.transform_response_done_event(
-                    message=BidiGenerateContentServerMessage(**json_message),  # type: ignore
+                    message=BidiGenerateContentServerMessage(**json_message),
                     current_response_id=current_response_id,
                     current_conversation_id=current_conversation_id,
                     session_configuration_request=session_configuration_request,

--- a/litellm/llms/gigachat/chat/transformation.py
+++ b/litellm/llms/gigachat/chat/transformation.py
@@ -469,7 +469,7 @@ class GigaChatConfig(BaseConfig):
         model_response.id = response_json.get("id", f"chatcmpl-{uuid.uuid4().hex[:12]}")
         model_response.created = response_json.get("created", int(time.time()))
         model_response.model = model
-        model_response.choices = choices  # type: ignore
+        model_response.choices = choices
         setattr(model_response, "usage", usage)
 
         return model_response

--- a/litellm/llms/groq/chat/transformation.py
+++ b/litellm/llms/groq/chat/transformation.py
@@ -147,7 +147,7 @@ class GroqChatConfig(OpenAILikeChatConfig):
                 new_message = ChatCompletionAssistantMessage(role="assistant")
                 for k, v in _message.items():
                     if v is not None:
-                        new_message[k] = v  # type: ignore
+                        new_message[k] = v
                 messages[idx] = new_message
 
         if is_async:
@@ -159,7 +159,7 @@ class GroqChatConfig(OpenAILikeChatConfig):
         self, api_base: str | None, api_key: str | None
     ) -> tuple[str | None, str | None]:
         # groq is openai compatible, we just need to set this to custom_openai and have the api_base be https://api.groq.com/openai/v1
-        api_base = api_base or get_secret_str("GROQ_API_BASE") or "https://api.groq.com/openai/v1"  # type: ignore
+        api_base = api_base or get_secret_str("GROQ_API_BASE") or "https://api.groq.com/openai/v1"
         dynamic_api_key: Final = api_key or get_secret_str("GROQ_API_KEY")
         return api_base, dynamic_api_key
 

--- a/litellm/llms/hosted_vllm/chat/transformation.py
+++ b/litellm/llms/hosted_vllm/chat/transformation.py
@@ -221,7 +221,7 @@ class HostedVLLMChatConfig(OpenAIGPTConfig):
                             message["tool_calls"] = tool_calls
                     content_str = "\n".join(text_parts)
                     new_content = content_blocks if has_structured_content else content_str
-                    message["content"] = new_content  # type: ignore[typeddict-item]
+                    message["content"] = new_content
             elif message["role"] == "user":
                 message_content = message.get("content")
                 if message_content and isinstance(message_content, list):

--- a/litellm/llms/huggingface/embedding/handler.py
+++ b/litellm/llms/huggingface/embedding/handler.py
@@ -158,7 +158,7 @@ class HuggingFaceEmbedding(BaseLLM):
             if call_type == "sync":
                 hf_task: Final = get_hf_task_embedding_for_model(model=model, task_type=task_type, api_base=HF_HUB_URL)
             elif call_type == "async":
-                return self._async_transform_input(model=model, task_type=task_type, embed_url=embed_url, input=input)  # type: ignore
+                return self._async_transform_input(model=model, task_type=task_type, embed_url=embed_url, input=input)
 
             data = self._transform_input_on_pipeline_tag(input=input, pipeline_tag=hf_task)
 
@@ -334,7 +334,7 @@ class HuggingFaceEmbedding(BaseLLM):
                 timeout=timeout,
                 logging_obj=logging_obj,
                 headers=headers,
-                api_base=embed_url,  # type: ignore
+                api_base=embed_url,
                 api_key=api_key,
                 client=client if isinstance(client, AsyncHTTPHandler) else None,
                 model=model,

--- a/litellm/llms/huggingface/embedding/transformation.py
+++ b/litellm/llms/huggingface/embedding/transformation.py
@@ -185,7 +185,7 @@ class HuggingFaceEmbeddingConfig(BaseConfig):
         # read the file called "huggingface_llms_metadata/hf_text_generation_models.txt"
         if model.split("/")[0] in hf_task_list:
             split_model: Final = model.split("/", 1)
-            return split_model[0], split_model[1]  # type: ignore
+            return split_model[0], split_model[1]
         tgi_models, conversational_models = self.read_tgi_conv_models()
 
         if model in tgi_models:
@@ -270,13 +270,13 @@ class HuggingFaceEmbeddingConfig(BaseConfig):
             else:
                 prompt = prompt_factory(model=model, messages=messages)
             data = {
-                "inputs": prompt,  # type: ignore
+                "inputs": prompt,
                 "parameters": optional_params,
-                "stream": (  # type: ignore
+                "stream": (
                     True
                     if "stream" in optional_params
                     and isinstance(optional_params["stream"], bool)
-                    and optional_params["stream"] is True  # type: ignore
+                    and optional_params["stream"] is True
                     else False
                 ),
             }
@@ -300,15 +300,11 @@ class HuggingFaceEmbeddingConfig(BaseConfig):
             inference_params.pop("details")
             inference_params.pop("return_full_text")
             data = {
-                "inputs": prompt,  # type: ignore
+                "inputs": prompt,
             }
             if task == "text-generation-inference":
                 data["parameters"] = inference_params
-                data["stream"] = (  # type: ignore
-                    True  # type: ignore
-                    if "stream" in optional_params and optional_params["stream"] is True
-                    else False
-                )
+                data["stream"] = True if "stream" in optional_params and optional_params["stream"] is True else False
 
         ### RE-ADD SPECIAL PARAMS
         if len(special_params_dict.keys()) > 0:
@@ -381,10 +377,8 @@ class HuggingFaceEmbeddingConfig(BaseConfig):
             task = "text-generation-inference"  # default to tgi
 
         if task == "conversational":
-            if len(completion_response["generated_text"]) > 0:  # type: ignore
-                model_response.choices[0].message.content = completion_response[  # type: ignore
-                    "generated_text"
-                ]
+            if len(completion_response["generated_text"]) > 0:
+                model_response.choices[0].message.content = completion_response["generated_text"]
         elif task == "text-generation-inference":
             if (
                 not isinstance(completion_response, list)
@@ -398,9 +392,7 @@ class HuggingFaceEmbeddingConfig(BaseConfig):
                 )
 
             if len(completion_response[0]["generated_text"]) > 0:
-                model_response.choices[0].message.content = output_parser(  # type: ignore
-                    completion_response[0]["generated_text"]
-                )
+                model_response.choices[0].message.content = output_parser(completion_response[0]["generated_text"])
             ## GETTING LOGPROBS + FINISH REASON
             if "details" in completion_response[0] and "tokens" in completion_response[0]["details"]:
                 model_response.choices[0].finish_reason = completion_response[0]["details"]["finish_reason"]
@@ -408,7 +400,7 @@ class HuggingFaceEmbeddingConfig(BaseConfig):
                 for token in completion_response[0]["details"]["tokens"]:
                     if token["logprob"] is not None:
                         sum_logprob += token["logprob"]
-                setattr(model_response.choices[0].message, "_logprob", sum_logprob)  # type: ignore
+                setattr(model_response.choices[0].message, "_logprob", sum_logprob)
             if "best_of" in optional_params and optional_params["best_of"] > 1:
                 if "details" in completion_response[0] and "best_of_sequences" in completion_response[0]["details"]:
                     choices_list: Final = []
@@ -432,14 +424,10 @@ class HuggingFaceEmbeddingConfig(BaseConfig):
                         choices_list.append(choice_obj)
                     model_response.choices.extend(choices_list)
         elif task == "text-classification":
-            model_response.choices[0].message.content = json.dumps(  # type: ignore
-                completion_response
-            )
+            model_response.choices[0].message.content = json.dumps(completion_response)
         else:
             if isinstance(completion_response, list) and len(completion_response[0]["generated_text"]) > 0:
-                model_response.choices[0].message.content = output_parser(  # type: ignore
-                    completion_response[0]["generated_text"]
-                )
+                model_response.choices[0].message.content = output_parser(completion_response[0]["generated_text"])
         ## CALCULATING USAGE
         prompt_tokens = 0
         try:
@@ -521,7 +509,7 @@ class HuggingFaceEmbeddingConfig(BaseConfig):
 
         if isinstance(completion_response, dict) and "error" in completion_response:
             raise HuggingFaceError(
-                message=completion_response["error"],  # type: ignore
+                message=completion_response["error"],
                 status_code=raw_response.status_code,
             )
         return self.convert_to_model_response_object(

--- a/litellm/llms/huggingface/rerank/transformation.py
+++ b/litellm/llms/huggingface/rerank/transformation.py
@@ -115,7 +115,7 @@ class HuggingFaceRerankConfig(BaseRerankConfig):
                 elif k == "query" and v is not None:
                     optional_rerank_params["query"] = v
 
-        return OptionalRerankParams(**optional_rerank_params)  # type: ignore
+        return OptionalRerankParams(**optional_rerank_params)
 
     def validate_environment(
         self,

--- a/litellm/llms/hyperbolic/chat/transformation.py
+++ b/litellm/llms/hyperbolic/chat/transformation.py
@@ -26,7 +26,7 @@ class HyperbolicChatConfig(OpenAILikeChatConfig):
             api_base
             or get_secret_str("HYPERBOLIC_API_BASE")
             or "https://api.hyperbolic.xyz/v1"  # Default Hyperbolic API base URL
-        )  # type: ignore
+        )
         dynamic_api_key: Final = api_key or get_secret_str("HYPERBOLIC_API_KEY")
         return api_base, dynamic_api_key
 

--- a/litellm/llms/inception/chat/transformation.py
+++ b/litellm/llms/inception/chat/transformation.py
@@ -45,7 +45,7 @@ class InceptionChatConfig(OpenAILikeChatConfig):
         self, api_base: str | None, api_key: str | None
     ) -> tuple[str | None, str | None]:
         passed_api_base: Final = api_base
-        api_base = api_base or get_secret_str("INCEPTION_API_BASE") or "https://api.inceptionlabs.ai/v1"  # type: ignore
+        api_base = api_base or get_secret_str("INCEPTION_API_BASE") or "https://api.inceptionlabs.ai/v1"
         dynamic_api_key = api_key
         if passed_api_base is None or api_key:
             dynamic_api_key = api_key or litellm.inception_key or get_secret_str("INCEPTION_API_KEY")

--- a/litellm/llms/jina_ai/embedding/transformation.py
+++ b/litellm/llms/jina_ai/embedding/transformation.py
@@ -80,7 +80,7 @@ class JinaAIEmbeddingConfig(BaseEmbeddingConfig):
                 - api_base: str
                 - dynamic_api_key: str
         """
-        api_base = api_base or get_secret_str("JINA_AI_API_BASE") or "https://api.jina.ai/v1"  # type: ignore
+        api_base = api_base or get_secret_str("JINA_AI_API_BASE") or "https://api.jina.ai/v1"
         dynamic_api_key: Final = api_key or (
             get_secret_str("JINA_AI_API_KEY")
             or get_secret_str("JINA_AI_API_KEY")

--- a/litellm/llms/jina_ai/rerank/transformation.py
+++ b/litellm/llms/jina_ai/rerank/transformation.py
@@ -129,7 +129,7 @@ class JinaAIRerankConfig(BaseRerankConfig):
 
         return RerankResponse(
             id=_json_response.get("id") or str(uuid.uuid4()),
-            results=transformed_results,  # type: ignore
+            results=transformed_results,
             meta=rerank_meta,
         )  # Return response
 

--- a/litellm/llms/lambda_ai/chat/transformation.py
+++ b/litellm/llms/lambda_ai/chat/transformation.py
@@ -24,6 +24,6 @@ class LambdaAIChatConfig(OpenAILikeChatConfig):
         # Lambda AI is openai compatible, we just need to set the api_base
         api_base = (
             api_base or get_secret_str("LAMBDA_API_BASE") or "https://api.lambda.ai/v1"  # Default Lambda API base URL
-        )  # type: ignore
+        )
         dynamic_api_key: Final = api_key or get_secret_str("LAMBDA_API_KEY")
         return api_base, dynamic_api_key

--- a/litellm/llms/lemonade/chat/transformation.py
+++ b/litellm/llms/lemonade/chat/transformation.py
@@ -207,7 +207,7 @@ class LemonadeChatConfig(OpenAILikeChatConfig):
     ) -> tuple[str | None, str | None]:
         # lemonade is openai compatible, we just need to set this to custom_openai and have the api_base be lemonade's endpoint
         passed_api_base: Final = api_base
-        api_base = api_base or get_secret_str("LEMONADE_API_BASE") or "http://localhost:8000/api/v1"  # type: ignore
+        api_base = api_base or get_secret_str("LEMONADE_API_BASE") or "http://localhost:8000/api/v1"
         key = self._DEFAULT_API_KEY
         if passed_api_base is None or api_key:
             key = api_key or litellm.lemonade_key or get_secret_str("LEMONADE_API_KEY") or self._DEFAULT_API_KEY

--- a/litellm/llms/litellm_proxy/chat/transformation.py
+++ b/litellm/llms/litellm_proxy/chat/transformation.py
@@ -38,7 +38,7 @@ class LiteLLMProxyChatConfig(OpenAIGPTConfig):
     def _get_openai_compatible_provider_info(
         self, api_base: str | None, api_key: str | None
     ) -> tuple[str | None, str | None]:
-        api_base = api_base or get_secret_str("LITELLM_PROXY_API_BASE")  # type: ignore
+        api_base = api_base or get_secret_str("LITELLM_PROXY_API_BASE")
         dynamic_api_key: Final = api_key or get_secret_str("LITELLM_PROXY_API_KEY")
         return api_base, dynamic_api_key
 

--- a/litellm/llms/litellm_proxy/skills/code_execution.py
+++ b/litellm/llms/litellm_proxy/skills/code_execution.py
@@ -151,8 +151,8 @@ class CodeExecutionHandler:
                 **kwargs,
             )
 
-            assistant_message = response.choices[0].message  # type: ignore
-            stop_reason = response.choices[0].finish_reason  # type: ignore
+            assistant_message = response.choices[0].message
+            stop_reason = response.choices[0].finish_reason
 
             # Build assistant message for conversation history
             assistant_msg_dict: dict[str, Any] = {

--- a/litellm/llms/llamafile/chat/transformation.py
+++ b/litellm/llms/llamafile/chat/transformation.py
@@ -25,7 +25,7 @@ class LlamafileChatConfig(OpenAIGPTConfig):
         If both are None, a default Llamafile server URL is returned.
         See: https://github.com/Mozilla-Ocho/llamafile/blob/bd1bbe9aabb1ee12dbdcafa8936db443c571eb9d/README.md#L61
         """
-        return api_base or get_secret_str("LLAMAFILE_API_BASE") or "http://127.0.0.1:8080/v1"  # type: ignore
+        return api_base or get_secret_str("LLAMAFILE_API_BASE") or "http://127.0.0.1:8080/v1"
 
     def _get_openai_compatible_provider_info(
         self, api_base: str | None, api_key: str | None

--- a/litellm/llms/lm_studio/chat/transformation.py
+++ b/litellm/llms/lm_studio/chat/transformation.py
@@ -13,7 +13,7 @@ class LMStudioChatConfig(OpenAIGPTConfig):
     def _get_openai_compatible_provider_info(
         self, api_base: str | None, api_key: str | None
     ) -> tuple[str | None, str | None]:
-        api_base = api_base or get_secret_str("LM_STUDIO_API_BASE")  # type: ignore
+        api_base = api_base or get_secret_str("LM_STUDIO_API_BASE")
         dynamic_api_key: Final = (
             api_key or get_secret_str("LM_STUDIO_API_KEY") or "fake-api-key"
         )  # LM Studio does not require an api key, but OpenAI client requires non-None value

--- a/litellm/llms/mistral/chat/transformation.py
+++ b/litellm/llms/mistral/chat/transformation.py
@@ -184,7 +184,7 @@ class MistralConfig(OpenAIGPTConfig):
             api_base
             or get_secret_str("MISTRAL_AZURE_API_BASE")  # for Azure AI Mistral
             or "https://api.mistral.ai/v1"
-        )  # type: ignore
+        )
 
         # if api_base does not end with /v1 we add it
         if api_base is not None and not api_base.endswith("/v1"):  # Mistral always needs a /v1 at the end
@@ -292,7 +292,7 @@ class MistralConfig(OpenAIGPTConfig):
                         file_id = file_content.get("file", {}).get("file_id")
                         if file_id:
                             # Replace 'file' with 'file_id'
-                            file_content["file_id"] = file_id  # type: ignore
+                            file_content["file_id"] = file_id
                             file_content.pop("file", None)
         return messages
 
@@ -398,12 +398,12 @@ class MistralConfig(OpenAIGPTConfig):
         If role == tool, then we keep `name` if it's not an empty string
         Otherwise, we drop `name`
         """
-        _name: Final = message.get("name")  # type: ignore
+        _name: Final = message.get("name")
 
         if _name is not None:
             # Remove name if not a tool message
             if message["role"] != "tool" or isinstance(_name, str) and len(_name.strip()) == 0:
-                message.pop("name", None)  # type: ignore
+                message.pop("name", None)
 
         return message
 
@@ -419,10 +419,10 @@ class MistralConfig(OpenAIGPTConfig):
                 _tool_call_message = MistralToolCallMessage(
                     id=_tool.get("id"),
                     type="function",
-                    function=_tool.get("function"),  # type: ignore
+                    function=_tool.get("function"),
                 )
                 mistral_tool_calls.append(_tool_call_message)
-            message["tool_calls"] = mistral_tool_calls  # type: ignore
+            message["tool_calls"] = mistral_tool_calls
         return message
 
     @classmethod

--- a/litellm/llms/mistral/ocr/guardrail_translation/handler.py
+++ b/litellm/llms/mistral/ocr/guardrail_translation/handler.py
@@ -137,7 +137,7 @@ class OCRHandler(BaseTranslation):
             if user_metadata:
                 # Preserve original behavior: inject metadata into inputs for
                 # third-party guardrail providers that read it from there
-                inputs.update(user_metadata)  # type: ignore
+                inputs.update(user_metadata)
                 # Also store in request_data for the logging pipeline
                 if "litellm_metadata" not in request_data:
                     request_data["litellm_metadata"] = user_metadata

--- a/litellm/llms/modelscope/chat/transformation.py
+++ b/litellm/llms/modelscope/chat/transformation.py
@@ -62,7 +62,7 @@ class ModelScopeChatConfig(OpenAIGPTConfig):
     def _get_openai_compatible_provider_info(
         self, api_base: str | None, api_key: str | None
     ) -> tuple[str | None, str | None]:
-        api_base = api_base or get_secret_str("MODELSCOPE_API_BASE") or self.DEFAULT_BASE_URL  # type: ignore
+        api_base = api_base or get_secret_str("MODELSCOPE_API_BASE") or self.DEFAULT_BASE_URL
         dynamic_api_key: Final = api_key or get_secret_str("MODELSCOPE_API_KEY")
         return api_base, dynamic_api_key
 

--- a/litellm/llms/modelscope/image_generation/transformation.py
+++ b/litellm/llms/modelscope/image_generation/transformation.py
@@ -214,25 +214,25 @@ class ModelScopeImageGenerationConfig(BaseImageGenerationConfig):
         )
 
         if status_code == 400:
-            return BadRequestError(  # type: ignore[return-value]
+            return BadRequestError(
                 message=error_message,
                 model="",
                 llm_provider="modelscope",
             )
         elif status_code == 401:
-            return AuthenticationError(  # type: ignore[return-value]
+            return AuthenticationError(
                 message=error_message,
                 model="",
                 llm_provider="modelscope",
             )
         elif status_code >= 500:
-            return InternalServerError(  # type: ignore[return-value]
+            return InternalServerError(
                 message=error_message,
                 model="",
                 llm_provider="modelscope",
             )
         else:
-            return BadRequestError(  # type: ignore[return-value]
+            return BadRequestError(
                 message=error_message,
                 model="",
                 llm_provider="modelscope",

--- a/litellm/llms/moonshot/chat/transformation.py
+++ b/litellm/llms/moonshot/chat/transformation.py
@@ -61,7 +61,7 @@ class MoonshotChatConfig(OpenAIGPTConfig):
     def _get_openai_compatible_provider_info(
         self, api_base: str | None, api_key: str | None
     ) -> tuple[str | None, str | None]:
-        api_base = api_base or get_secret_str("MOONSHOT_API_BASE") or "https://api.moonshot.ai/v1"  # type: ignore
+        api_base = api_base or get_secret_str("MOONSHOT_API_BASE") or "https://api.moonshot.ai/v1"
         dynamic_api_key: Final = api_key or get_secret_str("MOONSHOT_API_KEY")
         return api_base, dynamic_api_key
 

--- a/litellm/llms/nlp_cloud/chat/transformation.py
+++ b/litellm/llms/nlp_cloud/chat/transformation.py
@@ -198,9 +198,7 @@ class NLPCloudConfig(BaseConfig):
         else:
             try:
                 if len(completion_response["generated_text"]) > 0:
-                    model_response.choices[0].message.content = (  # type: ignore
-                        completion_response["generated_text"]
-                    )
+                    model_response.choices[0].message.content = completion_response["generated_text"]
             except Exception:
                 raise NLPCloudError(
                     message=json.dumps(completion_response),

--- a/litellm/llms/nvidia_nim/rerank/transformation.py
+++ b/litellm/llms/nvidia_nim/rerank/transformation.py
@@ -232,15 +232,15 @@ class NvidiaNimRerankConfig(BaseRerankConfig):
         }
 
         # Add optional top_k parameter if provided (already mapped from top_n in map_cohere_rerank_params)
-        if "top_k" in optional_rerank_params and optional_rerank_params.get("top_k") is not None:  # type: ignore
-            request_data["top_k"] = optional_rerank_params.get("top_k")  # type: ignore
+        if "top_k" in optional_rerank_params and optional_rerank_params.get("top_k") is not None:
+            request_data["top_k"] = optional_rerank_params.get("top_k")
 
         # Add Nvidia-specific truncate parameter if provided
         # This is passed through from non_default_params, not in base OptionalRerankParams
-        if "truncate" in optional_rerank_params and optional_rerank_params.get("truncate") is not None:  # type: ignore
-            truncate_value: Final = optional_rerank_params.get("truncate")  # type: ignore
+        if "truncate" in optional_rerank_params and optional_rerank_params.get("truncate") is not None:
+            truncate_value: Final = optional_rerank_params.get("truncate")
             if truncate_value in ["NONE", "END"]:
-                request_data["truncate"] = truncate_value  # type: ignore
+                request_data["truncate"] = truncate_value
 
         return dict(request_data)
 
@@ -307,7 +307,7 @@ class NvidiaNimRerankConfig(BaseRerankConfig):
             # Include document if it was in the original request
             index: int = ranking["index"]
             if index < len(original_passages):
-                result_item["document"] = {"text": original_passages[index]["text"]}  # type: ignore
+                result_item["document"] = {"text": original_passages[index]["text"]}
 
             results.append(result_item)
 

--- a/litellm/llms/nvidia_riva/audio_transcription/audio_utils.py
+++ b/litellm/llms/nvidia_riva/audio_transcription/audio_utils.py
@@ -48,7 +48,7 @@ def resample_to_riva_pcm(file_bytes: bytes) -> ResampledAudio:
     seconds (used for cost calculation when Riva does not return usage).
     """
     try:
-        import numpy as np  # type: ignore
+        import numpy as np
     except ImportError as e:
         raise NvidiaRivaException(
             status_code=500,
@@ -93,11 +93,11 @@ def _decode_to_float32(file_bytes: bytes) -> tuple["FloatArray", int]:
     ``audioread`` for compressed formats. Raises a clear error if neither
     works.
     """
-    import numpy as np  # type: ignore
+    import numpy as np
 
     sf_error: Exception | None = None
     try:
-        import soundfile as sf  # type: ignore
+        import soundfile as sf
 
         with io.BytesIO(file_bytes) as buf:
             data, source_rate = sf.read(buf, dtype="float32", always_2d=False)
@@ -110,7 +110,7 @@ def _decode_to_float32(file_bytes: bytes) -> tuple["FloatArray", int]:
         sf_error = e
 
     try:
-        import audioread  # type: ignore
+        import audioread
     except ImportError as e:
         raise NvidiaRivaException(
             status_code=400,
@@ -172,13 +172,13 @@ def _resample(samples: "FloatArray", source_rate: int, target_rate: int) -> "Flo
     band). Falls back to linear interpolation if neither is installed —
     acceptable for speech-only mono input but lossy for wideband content.
     """
-    import numpy as np  # type: ignore
+    import numpy as np
 
     if source_rate == target_rate or samples.size == 0:
         return samples
 
     try:
-        import soxr  # type: ignore
+        import soxr
 
         return cast(
             "FloatArray",
@@ -190,7 +190,7 @@ def _resample(samples: "FloatArray", source_rate: int, target_rate: int) -> "Flo
     try:
         from math import gcd
 
-        from scipy.signal import resample_poly  # type: ignore
+        from scipy.signal import resample_poly
 
         g: Final = gcd(int(source_rate), int(target_rate))
         up: Final = int(target_rate) // g
@@ -204,7 +204,7 @@ def _resample(samples: "FloatArray", source_rate: int, target_rate: int) -> "Flo
 
 def _linear_resample(samples: "FloatArray", source_rate: int, target_rate: int) -> "FloatArray":
     """Linear-interpolation fallback. See :func:`_resample` for caveats."""
-    import numpy as np  # type: ignore
+    import numpy as np
 
     duration: Final = samples.size / float(source_rate)
     target_length: Final = int(round(duration * target_rate))

--- a/litellm/llms/nvidia_riva/audio_transcription/handler.py
+++ b/litellm/llms/nvidia_riva/audio_transcription/handler.py
@@ -263,7 +263,7 @@ class NvidiaRivaAudioTranscription:
             "audio_transcription_duration": resampled.duration_seconds,
         }
 
-        final_response: Final[TranscriptionResponse] = convert_to_model_response_object(  # type: ignore
+        final_response: Final[TranscriptionResponse] = convert_to_model_response_object(
             response_object=stringified_response,
             model_response_object=model_response,
             hidden_params=hidden_params,
@@ -399,14 +399,14 @@ def _import_riva():
     module separately when the SDK packaging changes between versions.
     """
     try:
-        import riva.client as riva_client  # type: ignore
+        import riva.client as riva_client
     except ImportError as e:
         raise NvidiaRivaException(status_code=500, message=_RIVA_INSTALL_HINT) from e
 
     riva_asr_module = riva_client
     if not hasattr(riva_asr_module, "RecognitionConfig"):
         try:
-            from riva.client.proto import riva_asr_pb2  # type: ignore
+            from riva.client.proto import riva_asr_pb2
 
             riva_asr_module = riva_asr_pb2
         except ImportError as e:

--- a/litellm/llms/oci/chat/cohere.py
+++ b/litellm/llms/oci/chat/cohere.py
@@ -108,7 +108,7 @@ def adapt_messages_to_cohere_standard(
         content = _extract_text_content(msg.get("content"))
 
         tool_calls: list[CohereToolCall] | None = None
-        if role == "assistant" and msg.get("tool_calls"):  # type: ignore[union-attr,typeddict-item]
+        if role == "assistant" and msg.get("tool_calls"):
             tool_calls = []
             for tc in msg["tool_calls"]:  # pyright: ignore[reportOptionalIterable]  # truthiness check above rules out None
                 raw_arguments: Any = tc.get("function", {}).get("arguments", {})
@@ -246,13 +246,13 @@ def handle_cohere_response(
 
     usage_info: Final = cohere_response.chatResponse.usage
     if usage_info is not None:
-        model_response.usage = Usage(  # type: ignore[attr-defined]
+        model_response.usage = Usage(
             prompt_tokens=usage_info.promptTokens,
             completion_tokens=usage_info.completionTokens,
             total_tokens=usage_info.totalTokens,
         )
     else:
-        model_response.usage = Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)  # type: ignore[attr-defined]
+        model_response.usage = Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
 
     return model_response
 

--- a/litellm/llms/oci/chat/generic.py
+++ b/litellm/llms/oci/chat/generic.py
@@ -325,7 +325,7 @@ def handle_generic_response(
         )
 
     response_choice: Final = completion_response.chatResponse.choices[0]
-    message: Final = model_response.choices[0].message  # type: ignore
+    message: Final = model_response.choices[0].message
     response_message: Final = response_choice.message
     if response_message is not None:
         if response_message.content:
@@ -341,15 +341,13 @@ def handle_generic_response(
         if response_message.toolCalls:
             message.tool_calls = adapt_tools_to_openai_standard(response_message.toolCalls)
 
-    model_response.choices[0].finish_reason = _normalize_oci_finish_reason(  # type: ignore[union-attr,assignment]
-        response_choice.finishReason
-    )
+    model_response.choices[0].finish_reason = _normalize_oci_finish_reason(response_choice.finishReason)
 
     oci_usage: Final = completion_response.chatResponse.usage
     reasoning_tokens: int | None = None
     if oci_usage.completionTokensDetails and oci_usage.completionTokensDetails.reasoningTokens is not None:
         reasoning_tokens = oci_usage.completionTokensDetails.reasoningTokens
-    model_response.usage = Usage(  # type: ignore[attr-defined]
+    model_response.usage = Usage(
         prompt_tokens=oci_usage.promptTokens,
         completion_tokens=oci_usage.completionTokens or 0,
         total_tokens=oci_usage.totalTokens,

--- a/litellm/llms/oci/chat/transformation.py
+++ b/litellm/llms/oci/chat/transformation.py
@@ -476,9 +476,9 @@ class OCIChatConfig(BaseConfig):
             if target in selected_params:
                 continue
             if openai_key in optional_params:
-                selected_params[target] = optional_params[openai_key]  # type: ignore[index]
+                selected_params[target] = optional_params[openai_key]
             elif oci_alias in optional_params:
-                selected_params[target] = optional_params[oci_alias]  # type: ignore[index]
+                selected_params[target] = optional_params[oci_alias]
 
         # OCI's server-side default token cap is tiny (~20 tokens), so an
         # omitted max_tokens silently truncates the response mid-string. Most
@@ -499,13 +499,11 @@ class OCIChatConfig(BaseConfig):
 
         if "tools" in selected_params:
             if vendor == OCIVendors.COHERE:
-                selected_params["tools"] = adapt_tool_definitions_to_cohere_standard(  # type: ignore[assignment]
-                    selected_params["tools"]  # type: ignore[arg-type]
-                )
+                selected_params["tools"] = adapt_tool_definitions_to_cohere_standard(selected_params["tools"])
             else:
-                selected_params["tools"] = adapt_tool_definition_to_oci_standard(  # type: ignore[assignment]
+                selected_params["tools"] = adapt_tool_definition_to_oci_standard(
                     selected_params["tools"],
-                    vendor,  # type: ignore[arg-type]
+                    vendor,
                 )
 
         # Normalise tool_choice to OCI's flat uppercase dict form

--- a/litellm/llms/oci/common_utils.py
+++ b/litellm/llms/oci/common_utils.py
@@ -115,11 +115,11 @@ def build_signature_string(method: str, path: str, headers: dict, signed_headers
 
 def load_private_key_from_str(key_str: str) -> Any:
     _require_cryptography()
-    key: Final = serialization.load_pem_private_key(  # type: ignore[union-attr]
+    key: Final = serialization.load_pem_private_key(
         key_str.encode("utf-8"),
         password=None,
     )
-    if not isinstance(key, rsa.RSAPrivateKey):  # type: ignore[union-attr]
+    if not isinstance(key, rsa.RSAPrivateKey):
         raise TypeError("The provided private key is not an RSA key, which is required for OCI signing.")
     return key
 
@@ -329,8 +329,8 @@ def sign_with_manual_credentials(
 
     signature: Final = private_key.sign(
         signing_string.encode("utf-8"),
-        padding.PKCS1v15(),  # type: ignore[union-attr]
-        hashes.SHA256(),  # type: ignore[union-attr]
+        padding.PKCS1v15(),
+        hashes.SHA256(),
     )
     signature_b64: Final = base64.b64encode(signature).decode()
 

--- a/litellm/llms/ollama/chat/transformation.py
+++ b/litellm/llms/ollama/chat/transformation.py
@@ -253,7 +253,7 @@ class OllamaChatConfig(BaseConfig):
             if tool_calls is not None and isinstance(tool_calls, list):
                 new_tools = []
                 for tool in tool_calls:
-                    typed_tool = ChatCompletionAssistantToolCall(**tool)  # type: ignore
+                    typed_tool = ChatCompletionAssistantToolCall(**tool)
                     if typed_tool["type"] == "function":
                         arguments = {}
                         if "arguments" in typed_tool["function"]:
@@ -375,18 +375,18 @@ class OllamaChatConfig(BaseConfig):
                 ],
                 reasoning_content=response_json_message.get("reasoning_content"),
             )
-            model_response.choices[0].message = message  # type: ignore
+            model_response.choices[0].message = message
             model_response.choices[0].finish_reason = "tool_calls"
         else:
             _message: Final = litellm.Message(**response_json_message)
-            model_response.choices[0].message = _message  # type: ignore
+            model_response.choices[0].message = _message
             # Set finish_reason to "tool_calls" when tool_calls are present
             # Fixes: https://github.com/BerriAI/litellm/issues/18922
             if _message.tool_calls:
                 model_response.choices[0].finish_reason = "tool_calls"
         model_response.created = int(time.time())
         model_response.model = "ollama_chat/" + model
-        prompt_tokens = response_json.get("prompt_eval_count", litellm.token_counter(messages=messages))  # type: ignore
+        prompt_tokens = response_json.get("prompt_eval_count", litellm.token_counter(messages=messages))
         completion_tokens: Final = response_json.get(
             "eval_count",
             litellm.token_counter(text=response_json["message"]["content"]),

--- a/litellm/llms/ollama/completion/transformation.py
+++ b/litellm/llms/ollama/completion/transformation.py
@@ -264,7 +264,7 @@ class OllamaConfig(BaseConfig):
             if not response_text or not response_text.strip():
                 # Handle empty response gracefully - set empty content
                 message = litellm.Message(content="")
-                model_response.choices[0].message = message  # type: ignore
+                model_response.choices[0].message = message
                 model_response.choices[0].finish_reason = "stop"
             else:
                 try:
@@ -291,14 +291,14 @@ class OllamaConfig(BaseConfig):
                                 }
                             ],
                         )
-                        model_response.choices[0].message = message  # type: ignore
+                        model_response.choices[0].message = message
                         model_response.choices[0].finish_reason = "tool_calls"
                     else:
                         # Handle as regular JSON (new behavior)
                         message = litellm.Message(
                             content=json.dumps(response_content),
                         )
-                        model_response.choices[0].message = message  # type: ignore
+                        model_response.choices[0].message = message
                         model_response.choices[0].finish_reason = "stop"
                 except json.JSONDecodeError:
                     # If JSON parsing fails, treat as regular text response
@@ -308,7 +308,7 @@ class OllamaConfig(BaseConfig):
                     if response_text is not None:
                         reasoning_content, content = _parse_content_for_reasoning(response_text)
                     message = litellm.Message(content=content, reasoning_content=reasoning_content)
-                    model_response.choices[0].message = message  # type: ignore
+                    model_response.choices[0].message = message
                     model_response.choices[0].finish_reason = "stop"
         else:
             response_text = response_json.get("response", "")
@@ -317,15 +317,15 @@ class OllamaConfig(BaseConfig):
             if response_text is not None and isinstance(response_text, str):
                 reasoning_content, content = _parse_content_for_reasoning(response_text)
             else:
-                content = response_text  # type: ignore
-            model_response.choices[0].message.content = content  # type: ignore
-            model_response.choices[0].message.reasoning_content = reasoning_content  # type: ignore
+                content = response_text
+            model_response.choices[0].message.content = content
+            model_response.choices[0].message.reasoning_content = reasoning_content
         model_response.created = int(time.time())
         model_response.model = "ollama/" + model
         _prompt: Final = request_data.get("prompt", "")
         prompt_tokens: Final = response_json.get(
             "prompt_eval_count",
-            len(encoding.encode(_prompt, disallowed_special=())),  # type: ignore
+            len(encoding.encode(_prompt, disallowed_special=())),
         )
         completion_tokens: Final = response_json.get(
             "eval_count", len(response_json.get("message", dict()).get("content", ""))

--- a/litellm/llms/oobabooga/chat/transformation.py
+++ b/litellm/llms/oobabooga/chat/transformation.py
@@ -61,7 +61,7 @@ class OobaboogaConfig(OpenAIGPTConfig):
             )
         else:
             try:
-                model_response.choices[0].message.content = completion_response["choices"][0]["message"]["content"]  # type: ignore
+                model_response.choices[0].message.content = completion_response["choices"][0]["message"]["content"]
             except Exception as e:
                 raise OobaboogaError(
                     message=str(e),

--- a/litellm/llms/openai/chat/gpt_transformation.py
+++ b/litellm/llms/openai/chat/gpt_transformation.py
@@ -258,9 +258,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
                 }
             elif isinstance(content_item["image_url"], dict):
                 new_image_url_obj: Final = ChatCompletionImageUrlObject(
-                    **{  # type: ignore
-                        k: v for k, v in content_item["image_url"].items() if k not in litellm_specific_params
-                    }
+                    **{k: v for k, v in content_item["image_url"].items() if k not in litellm_specific_params}
                 )
                 content_item["image_url"] = new_image_url_obj
         elif content_item.get("type") == "file":
@@ -273,9 +271,7 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
                     llm_provider="openai",
                 )
             new_file_obj: Final = ChatCompletionFileObjectFile(
-                **{  # type: ignore
-                    k: v for k, v in file_obj.items() if k not in litellm_specific_params
-                }
+                **{k: v for k, v in file_obj.items() if k not in litellm_specific_params}
             )
             content_item["file"] = new_file_obj
 
@@ -379,13 +375,13 @@ class OpenAIGPTConfig(BaseLLMModelInfo, BaseConfig):
         for i, message in enumerate(messages):
             messages[i] = cast(
                 AllMessageValues,
-                filter_value_from_dict(message, "cache_control"),  # type: ignore
+                filter_value_from_dict(message, "cache_control"),
             )
         if tools is not None:
             for i, tool in enumerate(tools):
                 tools[i] = cast(
                     ChatCompletionToolParam,
-                    filter_value_from_dict(tool, "cache_control"),  # type: ignore
+                    filter_value_from_dict(tool, "cache_control"),
                 )
         return messages, tools
 

--- a/litellm/llms/openai/chat/guardrail_translation/handler.py
+++ b/litellm/llms/openai/chat/guardrail_translation/handler.py
@@ -109,7 +109,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if images_to_check:
                 inputs["images"] = images_to_check
             if tool_calls_to_check:
-                inputs["tool_calls"] = tool_calls_to_check  # type: ignore
+                inputs["tool_calls"] = tool_calls_to_check
             structured_messages = self.get_structured_messages(data)
             if structured_messages:
                 if skip_system:
@@ -159,7 +159,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
                 if guardrailed_tool_calls:
                     await self._apply_guardrail_responses_to_input_tool_calls(
                         messages=messages,
-                        tool_calls=guardrailed_tool_calls,  # type: ignore
+                        tool_calls=guardrailed_tool_calls,
                         task_mappings=tool_call_task_mappings,
                     )
 
@@ -364,7 +364,7 @@ class OpenAIChatCompletionsHandler(BaseTranslation):
             if images_to_check:
                 inputs["images"] = images_to_check
             if tool_calls_to_check:
-                inputs["tool_calls"] = tool_calls_to_check  # type: ignore
+                inputs["tool_calls"] = tool_calls_to_check
             # Include model information from the response if available
             if hasattr(response, "model") and response.model:
                 inputs["model"] = response.model

--- a/litellm/llms/openai/common_utils.py
+++ b/litellm/llms/openai/common_utils.py
@@ -27,7 +27,7 @@ from litellm.llms.custom_httpx.http_handler import (
 
 def _get_client_init_params(cls: type) -> tuple[str, ...]:
     """Extract __init__ parameter names (excluding 'self') from a class."""
-    return tuple(p for p in inspect.signature(cls.__init__).parameters if p != "self")  # type: ignore[misc]
+    return tuple(p for p in inspect.signature(cls.__init__).parameters if p != "self")
 
 
 _OPENAI_INIT_PARAMS: Final[tuple[str, ...]] = _get_client_init_params(OpenAI)

--- a/litellm/llms/openai/completion/handler.py
+++ b/litellm/llms/openai/completion/handler.py
@@ -109,7 +109,7 @@ class OpenAITextCompletion(BaseLLM):
                         max_retries=max_retries,
                         organization=organization,
                         client=client,
-                    )  # type: ignore
+                    )
             elif optional_params.get("stream", False):
                 return self.streaming(
                     logging_obj=logging_obj,
@@ -120,7 +120,7 @@ class OpenAITextCompletion(BaseLLM):
                     model_response=model_response,
                     model=model,
                     timeout=timeout,
-                    max_retries=max_retries,  # type: ignore
+                    max_retries=max_retries,
                     client=client,
                     organization=organization,
                 )
@@ -131,13 +131,13 @@ class OpenAITextCompletion(BaseLLM):
                         base_url=api_base,
                         http_client=litellm.client_session,
                         timeout=timeout,
-                        max_retries=max_retries,  # type: ignore
+                        max_retries=max_retries,
                         organization=organization,
                     )
                 else:
                     openai_client = client
 
-                raw_response: Final = openai_client.completions.with_raw_response.create(**data)  # type: ignore
+                raw_response: Final = openai_client.completions.with_raw_response.create(**data)
                 response: Final = raw_response.parse()
                 response_json: Final = response.model_dump()
 
@@ -235,7 +235,7 @@ class OpenAITextCompletion(BaseLLM):
                 base_url=api_base,
                 http_client=litellm.client_session,
                 timeout=timeout,
-                max_retries=max_retries,  # type: ignore
+                max_retries=max_retries,
                 organization=organization,
             )
         else:

--- a/litellm/llms/openai/completion/transformation.py
+++ b/litellm/llms/openai/completion/transformation.py
@@ -100,7 +100,7 @@ class OpenAITextCompletionConfig(BaseTextCompletionConfig, OpenAIGPTConfig):
                     logprobs=choice.get("logprobs", None),
                 )
                 choice_list.append(choice)
-            model_response_object.choices = choice_list  # type: ignore
+            model_response_object.choices = choice_list
 
             if "usage" in response_object:
                 setattr(model_response_object, "usage", response_object["usage"])

--- a/litellm/llms/openai/containers/transformation.py
+++ b/litellm/llms/openai/containers/transformation.py
@@ -114,7 +114,7 @@ class OpenAIContainerConfig(BaseContainerConfig):
         response_data: Final = raw_response.json()
 
         # Transform the response data
-        container_obj: Final = ContainerObject(**response_data)  # type: ignore[arg-type]
+        container_obj: Final = ContainerObject(**response_data)
 
         # Add cost for container creation (OpenAI containers are code interpreter sessions)
         # https://platform.openai.com/docs/pricing
@@ -174,7 +174,7 @@ class OpenAIContainerConfig(BaseContainerConfig):
         response_data: Final = raw_response.json()
 
         # Transform the response data
-        container_list: Final = ContainerListResponse(**response_data)  # type: ignore[arg-type]
+        container_list: Final = ContainerListResponse(**response_data)
 
         return container_list
 
@@ -203,7 +203,7 @@ class OpenAIContainerConfig(BaseContainerConfig):
         """Transform the OpenAI container retrieve response."""
         response_data: Final = raw_response.json()
         # Transform the response data
-        container_obj: Final = ContainerObject(**response_data)  # type: ignore[arg-type]
+        container_obj: Final = ContainerObject(**response_data)
 
         return container_obj
 
@@ -237,7 +237,7 @@ class OpenAIContainerConfig(BaseContainerConfig):
         response_data: Final = raw_response.json()
 
         # Transform the response data
-        delete_result: Final = DeleteContainerResult(**response_data)  # type: ignore[arg-type]
+        delete_result: Final = DeleteContainerResult(**response_data)
 
         return delete_result
 
@@ -285,7 +285,7 @@ class OpenAIContainerConfig(BaseContainerConfig):
         response_data: Final = raw_response.json()
 
         # Transform the response data
-        file_list: Final = ContainerFileListResponse(**response_data)  # type: ignore[arg-type]
+        file_list: Final = ContainerFileListResponse(**response_data)
 
         return file_list
 

--- a/litellm/llms/openai/embeddings/guardrail_translation/handler.py
+++ b/litellm/llms/openai/embeddings/guardrail_translation/handler.py
@@ -120,7 +120,7 @@ class OpenAIEmbeddingsHandler(BaseTranslation):
             return data
 
         # List of strings - apply guardrail
-        inputs: Final = GenericGuardrailAPIInputs(texts=input_data)  # type: ignore
+        inputs: Final = GenericGuardrailAPIInputs(texts=input_data)
         if model := data.get("model"):
             inputs["model"] = model
 

--- a/litellm/llms/openai/fine_tuning/handler.py
+++ b/litellm/llms/openai/fine_tuning/handler.py
@@ -85,7 +85,7 @@ class OpenAIFineTuningAPI:
             if _is_async is True:
                 openai_client = AsyncOpenAI(**data)
             else:
-                openai_client = OpenAI(**data)  # type: ignore
+                openai_client = OpenAI(**data)
         else:
             openai_client = client
 
@@ -132,7 +132,7 @@ class OpenAIFineTuningAPI:
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.acreate_fine_tuning_job(  # type: ignore
+            return self.acreate_fine_tuning_job(
                 create_fine_tuning_job_data=create_fine_tuning_job_data,
                 openai_client=openai_client,
             )
@@ -180,7 +180,7 @@ class OpenAIFineTuningAPI:
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.acancel_fine_tuning_job(  # type: ignore
+            return self.acancel_fine_tuning_job(
                 fine_tuning_job_id=fine_tuning_job_id,
                 openai_client=openai_client,
             )
@@ -194,7 +194,7 @@ class OpenAIFineTuningAPI:
         after: str | None = None,
         limit: int | None = None,
     ):
-        response: Final = await openai_client.fine_tuning.jobs.list(after=after, limit=limit)  # type: ignore
+        response: Final = await openai_client.fine_tuning.jobs.list(after=after, limit=limit)
         return response
 
     def list_fine_tuning_jobs(
@@ -230,13 +230,13 @@ class OpenAIFineTuningAPI:
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.alist_fine_tuning_jobs(  # type: ignore
+            return self.alist_fine_tuning_jobs(
                 after=after,
                 limit=limit,
                 openai_client=openai_client,
             )
         verbose_logger.debug("list fine tuning job, after= %s, limit= %s", after, limit)
-        response: Final = openai_client.fine_tuning.jobs.list(after=after, limit=limit)  # type: ignore
+        response: Final = openai_client.fine_tuning.jobs.list(after=after, limit=limit)
         return response
 
     async def aretrieve_fine_tuning_job(
@@ -279,7 +279,7 @@ class OpenAIFineTuningAPI:
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.aretrieve_fine_tuning_job(  # type: ignore
+            return self.aretrieve_fine_tuning_job(
                 fine_tuning_job_id=fine_tuning_job_id,
                 openai_client=openai_client,
             )

--- a/litellm/llms/openai/image_generation/dall_e_2_transformation.py
+++ b/litellm/llms/openai/image_generation/dall_e_2_transformation.py
@@ -65,7 +65,7 @@ class DallE2ImageGenerationConfig(BaseImageGenerationConfig):
             additional_args={"complete_input_dict": request_data},
             original_response=stringified_response,
         )
-        image_response: Final[ImageResponse] = convert_to_model_response_object(  # type: ignore
+        image_response: Final[ImageResponse] = convert_to_model_response_object(
             response_object=stringified_response,
             model_response_object=model_response,
             response_type="image_generation",

--- a/litellm/llms/openai/image_generation/dall_e_3_transformation.py
+++ b/litellm/llms/openai/image_generation/dall_e_3_transformation.py
@@ -65,7 +65,7 @@ class DallE3ImageGenerationConfig(BaseImageGenerationConfig):
             additional_args={"complete_input_dict": request_data},
             original_response=stringified_response,
         )
-        image_response: Final[ImageResponse] = convert_to_model_response_object(  # type: ignore
+        image_response: Final[ImageResponse] = convert_to_model_response_object(
             response_object=stringified_response,
             model_response_object=model_response,
             response_type="image_generation",

--- a/litellm/llms/openai/image_generation/gpt_transformation.py
+++ b/litellm/llms/openai/image_generation/gpt_transformation.py
@@ -74,7 +74,7 @@ class GPTImageGenerationConfig(BaseImageGenerationConfig):
             additional_args={"complete_input_dict": request_data},
             original_response=stringified_response,
         )
-        image_response: Final[ImageResponse] = convert_to_model_response_object(  # type: ignore
+        image_response: Final[ImageResponse] = convert_to_model_response_object(
             response_object=stringified_response,
             model_response_object=model_response,
             response_type="image_generation",

--- a/litellm/llms/openai/image_variations/handler.py
+++ b/litellm/llms/openai/image_variations/handler.py
@@ -64,13 +64,13 @@ class OpenAIImageVariationsHandler:
                 "base_url": api_base,
                 "http_client": litellm.client_session,
                 "timeout": timeout,
-                "max_retries": max_retries,  # type: ignore
+                "max_retries": max_retries,
                 "organization": organization,
             }
 
             client = self.get_async_client(client=client, init_client_params=init_client_params)
 
-            raw_response: Final = await client.images.with_raw_response.create_variation(**data)  # type: ignore
+            raw_response: Final = await client.images.with_raw_response.create_variation(**data)
             response: Final = raw_response.parse()
             response_json: Final = response.model_dump()
 
@@ -174,20 +174,20 @@ class OpenAIImageVariationsHandler:
                     image=image,
                     optional_params=optional_params,
                     litellm_params=litellm_params,
-                )  # type: ignore
+                )
 
             init_client_params: Final = {
                 "api_key": api_key,
                 "base_url": api_base,
                 "http_client": litellm.client_session,
                 "timeout": timeout,
-                "max_retries": max_retries,  # type: ignore
+                "max_retries": max_retries,
                 "organization": organization,
             }
 
             client = self.get_sync_client(client=client, init_client_params=init_client_params)
 
-            raw_response: Final = client.images.with_raw_response.create_variation(**json_data)  # type: ignore
+            raw_response: Final = client.images.with_raw_response.create_variation(**json_data)
             response: Final = raw_response.parse()
             response_json: Final = response.model_dump()
 

--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -568,7 +568,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
 
         return streaming_response
 
-    def completion(  # type: ignore
+    def completion(
         self,
         model_response: ModelResponse,
         timeout: float | httpx.Timeout,
@@ -703,7 +703,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                     else:
                         if not isinstance(max_retries, int):
                             raise OpenAIError(status_code=422, message="max retries must be an int")
-                        openai_client: OpenAI = self._get_openai_client(  # type: ignore
+                        openai_client: OpenAI = self._get_openai_client(
                             is_async=False,
                             api_key=api_key,
                             api_base=api_base,
@@ -777,7 +777,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                             print_verbose("openai.py: REFORMATS THE MESSAGE!")
                         # reformat messages to ensure user/assistant are alternating, if there's either 2 consecutive 'user' messages or 2 consecutive 'assistant' message, add a blank 'user' or 'assistant' message to ensure compatibility
                         new_messages = []
-                        for i in range(len(messages) - 1):  # type: ignore
+                        for i in range(len(messages) - 1):
                             new_messages.append(messages[i])
                             if messages[i]["role"] == messages[i + 1]["role"]:
                                 if messages[i]["role"] == "user":
@@ -843,7 +843,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         )
         for _ in range(2):  # if call fails due to alternating messages, retry with reformatted message
             try:
-                openai_aclient: AsyncOpenAI = self._get_openai_client(  # type: ignore
+                openai_aclient: AsyncOpenAI = self._get_openai_client(
                     is_async=True,
                     api_key=api_key,
                     api_base=api_base,
@@ -952,7 +952,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         data["stream"] = True
         data.update(self.get_stream_options(stream_options=stream_options, api_base=api_base))
 
-        openai_client: Final[OpenAI] = self._get_openai_client(  # type: ignore
+        openai_client: Final[OpenAI] = self._get_openai_client(
             is_async=False,
             api_key=api_key,
             api_base=api_base,
@@ -1023,7 +1023,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         data.update(self.get_stream_options(stream_options=stream_options, api_base=api_base))
         for _ in range(2):
             try:
-                openai_aclient: AsyncOpenAI = self._get_openai_client(  # type: ignore
+                openai_aclient: AsyncOpenAI = self._get_openai_client(
                     is_async=True,
                     api_key=api_key,
                     api_base=api_base,
@@ -1083,7 +1083,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 if response is not None and hasattr(response, "text"):
                     raise OpenAIError(
                         status_code=status_code,
-                        message=f"{e}\n\nOriginal Response: {response.text}",  # type: ignore
+                        message=f"{e}\n\nOriginal Response: {response.text}",
                         headers=error_headers,
                         body=exception_body,
                     )
@@ -1137,7 +1137,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         - call embeddings.create by default
         """
         try:
-            raw_response = await openai_aclient.embeddings.with_raw_response.create(**data, timeout=timeout)  # type: ignore
+            raw_response = await openai_aclient.embeddings.with_raw_response.create(**data, timeout=timeout)
             headers: Final = dict(raw_response.headers)
             response: Final = raw_response.parse()
             return headers, response
@@ -1158,7 +1158,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         - call embeddings.create by default
         """
         try:
-            raw_response = openai_client.embeddings.with_raw_response.create(**data, timeout=timeout)  # type: ignore
+            raw_response = openai_client.embeddings.with_raw_response.create(**data, timeout=timeout)
 
             headers: Final = dict(raw_response.headers)
             response: Final = raw_response.parse()
@@ -1180,7 +1180,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         shared_session: Optional["ClientSession"] = None,
     ):
         try:
-            openai_aclient: Final[AsyncOpenAI] = self._get_openai_client(  # type: ignore
+            openai_aclient: Final[AsyncOpenAI] = self._get_openai_client(
                 is_async=True,
                 api_key=api_key,
                 api_base=api_base,
@@ -1209,7 +1209,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 model_response_object=model_response,
                 response_type="embedding",
                 _response_headers=headers,
-            )  # type: ignore
+            )
             return returned_response
         except OpenAIError as e:
             ## LOGGING
@@ -1236,7 +1236,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 error_headers = getattr(error_response, "headers", None)
             raise OpenAIError(status_code=status_code, message=error_text, headers=error_headers)
 
-    def embedding(  # type: ignore
+    def embedding(
         self,
         model: str,
         input: list,
@@ -1265,7 +1265,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             )
 
             if aembedding is True:
-                return self.aembedding(  # type: ignore
+                return self.aembedding(
                     data=data,
                     input=input,
                     logging_obj=logging_obj,
@@ -1278,7 +1278,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                     shared_session=shared_session,
                 )
 
-            openai_client: Final[OpenAI] = self._get_openai_client(  # type: ignore
+            openai_client: Final[OpenAI] = self._get_openai_client(
                 is_async=False,
                 api_key=api_key,
                 api_base=api_base,
@@ -1294,7 +1294,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 data=data,
                 timeout=timeout,
                 logging_obj=logging_obj,
-            )  # type: ignore
+            )
 
             ## LOGGING
             logging_obj.model_call_details["response_headers"] = headers
@@ -1309,7 +1309,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 model_response_object=model_response,
                 _response_headers=headers,
                 response_type="embedding",
-            )  # type: ignore
+            )
             return response
         except OpenAIError as e:
             raise e
@@ -1350,7 +1350,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
 
             if headers:
                 data["extra_headers"] = headers
-            response = await openai_aclient.images.generate(**data, timeout=timeout)  # type: ignore
+            response = await openai_aclient.images.generate(**data, timeout=timeout)
             stringified_response: Final = response.model_dump()
             ## LOGGING
             logging_obj.post_call(
@@ -1363,7 +1363,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 response_object=stringified_response,
                 model_response_object=model_response,
                 response_type="image_generation",
-            )  # type: ignore
+            )
         except Exception as e:
             ## LOGGING
             logging_obj.post_call(
@@ -1408,9 +1408,9 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                     max_retries=max_retries,
                     organization=organization,
                     headers=headers,
-                )  # type: ignore
+                )
 
-            openai_client: Final[OpenAI] = self._get_openai_client(  # type: ignore
+            openai_client: Final[OpenAI] = self._get_openai_client(
                 is_async=False,
                 api_key=api_key,
                 api_base=api_base,
@@ -1435,7 +1435,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
             ## COMPLETION CALL
             if headers:
                 data["extra_headers"] = headers
-            _response: Final = openai_client.images.generate(**data, timeout=timeout)  # type: ignore
+            _response: Final = openai_client.images.generate(**data, timeout=timeout)
 
             response: Final = _response.model_dump()
             ## LOGGING
@@ -1449,7 +1449,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 response_object=response,
                 model_response_object=model_response,
                 response_type="image_generation",
-            )  # type: ignore
+            )
         except OpenAIError as e:
             ## LOGGING
             logging_obj.post_call(
@@ -1502,7 +1502,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 timeout=timeout,
                 client=client,
                 shared_session=shared_session,
-            )  # type: ignore
+            )
 
         openai_client: Final = self._get_openai_client(
             is_async=False,
@@ -1516,7 +1516,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
 
         response: Final = cast(OpenAI, openai_client).audio.speech.create(
             model=model,
-            voice=voice,  # type: ignore
+            voice=voice,
             input=input,
             **optional_params,
         )
@@ -1552,7 +1552,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
 
         response: Final = await openai_client.audio.speech.create(
             model=model,
-            voice=voice,  # type: ignore
+            voice=voice,
             input=input,
             **optional_params,
         )
@@ -1598,7 +1598,7 @@ class OpenAIFilesAPI(BaseLLM):
             if _is_async is True:
                 openai_client = AsyncOpenAI(**data)
             else:
-                openai_client = OpenAI(**data)  # type: ignore
+                openai_client = OpenAI(**data)
         else:
             openai_client = client
 
@@ -1609,7 +1609,7 @@ class OpenAIFilesAPI(BaseLLM):
         create_file_data: CreateFileRequest,
         openai_client: AsyncOpenAI,
     ) -> OpenAIFileObject:
-        response: Final = await openai_client.files.create(**create_file_data)  # type: ignore[arg-type]
+        response: Final = await openai_client.files.create(**create_file_data)
         return OpenAIFileObject.model_validate(response.model_dump())
 
     def create_file(
@@ -1642,10 +1642,8 @@ class OpenAIFilesAPI(BaseLLM):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.acreate_file(  # type: ignore
-                create_file_data=create_file_data, openai_client=openai_client
-            )
-        response: Final = cast(OpenAI, openai_client).files.create(**create_file_data)  # type: ignore[arg-type]
+            return self.acreate_file(create_file_data=create_file_data, openai_client=openai_client)
+        response: Final = cast(OpenAI, openai_client).files.create(**create_file_data)
         return OpenAIFileObject.model_validate(response.model_dump())
 
     async def afile_content(
@@ -1686,7 +1684,7 @@ class OpenAIFilesAPI(BaseLLM):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.afile_content(  # type: ignore
+            return self.afile_content(
                 file_content_request=file_content_request,
                 openai_client=openai_client,
             )
@@ -1751,7 +1749,7 @@ class OpenAIFilesAPI(BaseLLM):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.afile_content_streaming(  # type: ignore
+            return self.afile_content_streaming(
                 file_content_request=file_content_request,
                 openai_client=openai_client,
                 chunk_size=chunk_size,
@@ -1814,7 +1812,7 @@ class OpenAIFilesAPI(BaseLLM):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.aretrieve_file(  # type: ignore
+            return self.aretrieve_file(
                 file_id=file_id,
                 openai_client=openai_client,
             )
@@ -1860,7 +1858,7 @@ class OpenAIFilesAPI(BaseLLM):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.adelete_file(  # type: ignore
+            return self.adelete_file(
                 file_id=file_id,
                 openai_client=openai_client,
             )
@@ -1909,7 +1907,7 @@ class OpenAIFilesAPI(BaseLLM):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.alist_files(  # type: ignore
+            return self.alist_files(
                 purpose=purpose,
                 openai_client=openai_client,
             )
@@ -1958,7 +1956,7 @@ class OpenAIBatchesAPI(BaseLLM):
             if _is_async is True:
                 openai_client = AsyncOpenAI(**data)
             else:
-                openai_client = OpenAI(**data)  # type: ignore
+                openai_client = OpenAI(**data)
         else:
             openai_client = client
 
@@ -1969,7 +1967,7 @@ class OpenAIBatchesAPI(BaseLLM):
         create_batch_data: CreateBatchRequest,
         openai_client: AsyncOpenAI,
     ) -> LiteLLMBatch:
-        response: Final = await openai_client.batches.create(**create_batch_data)  # type: ignore[arg-type]
+        response: Final = await openai_client.batches.create(**create_batch_data)
         return LiteLLMBatch.model_validate(response.model_dump())
 
     def create_batch(
@@ -2002,10 +2000,8 @@ class OpenAIBatchesAPI(BaseLLM):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.acreate_batch(  # type: ignore
-                create_batch_data=create_batch_data, openai_client=openai_client
-            )
-        response: Final = cast(OpenAI, openai_client).batches.create(**create_batch_data)  # type: ignore[arg-type]
+            return self.acreate_batch(create_batch_data=create_batch_data, openai_client=openai_client)
+        response: Final = cast(OpenAI, openai_client).batches.create(**create_batch_data)
 
         return LiteLLMBatch.model_validate(response.model_dump())
 
@@ -2015,7 +2011,7 @@ class OpenAIBatchesAPI(BaseLLM):
         openai_client: AsyncOpenAI,
     ) -> LiteLLMBatch:
         verbose_logger.debug("retrieving batch, args= %s", retrieve_batch_data)
-        response: Final = await openai_client.batches.retrieve(**retrieve_batch_data)  # type: ignore[arg-type]
+        response: Final = await openai_client.batches.retrieve(**retrieve_batch_data)
         return LiteLLMBatch.model_validate(response.model_dump())
 
     def retrieve_batch(
@@ -2048,10 +2044,8 @@ class OpenAIBatchesAPI(BaseLLM):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.aretrieve_batch(  # type: ignore
-                retrieve_batch_data=retrieve_batch_data, openai_client=openai_client
-            )
-        response: Final = cast(OpenAI, openai_client).batches.retrieve(**retrieve_batch_data)  # type: ignore[arg-type]
+            return self.aretrieve_batch(retrieve_batch_data=retrieve_batch_data, openai_client=openai_client)
+        response: Final = cast(OpenAI, openai_client).batches.retrieve(**retrieve_batch_data)
         return LiteLLMBatch.model_validate(response.model_dump())
 
     async def acancel_batch(
@@ -2093,9 +2087,7 @@ class OpenAIBatchesAPI(BaseLLM):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.acancel_batch(  # type: ignore
-                cancel_batch_data=cancel_batch_data, openai_client=openai_client
-            )
+            return self.acancel_batch(cancel_batch_data=cancel_batch_data, openai_client=openai_client)
 
         # At this point, openai_client is guaranteed to be a sync OpenAI client
         if not isinstance(openai_client, OpenAI):
@@ -2110,7 +2102,7 @@ class OpenAIBatchesAPI(BaseLLM):
         limit: int | None = None,
     ):
         verbose_logger.debug("listing batches, after= %s, limit= %s", after, limit)
-        response: Final = await openai_client.batches.list(after=after, limit=limit)  # type: ignore
+        response: Final = await openai_client.batches.list(after=after, limit=limit)
         return response
 
     def list_batches(
@@ -2144,10 +2136,8 @@ class OpenAIBatchesAPI(BaseLLM):
                 raise ValueError(
                     "OpenAI client is not an instance of AsyncOpenAI. Make sure you passed an AsyncOpenAI client."
                 )
-            return self.alist_batches(  # type: ignore
-                openai_client=openai_client, after=after, limit=limit
-            )
-        response: Final = openai_client.batches.list(after=after, limit=limit)  # type: ignore
+            return self.alist_batches(openai_client=openai_client, after=after, limit=limit)
+        response: Final = openai_client.batches.list(after=after, limit=limit)
         return response
 
 
@@ -2174,7 +2164,7 @@ class OpenAIAssistantsAPI(BaseLLM):
                     data["base_url"] = v
                 elif v is not None:
                     data[k] = v
-            openai_client = OpenAI(**data)  # type: ignore
+            openai_client = OpenAI(**data)
         else:
             openai_client = client
 
@@ -2199,7 +2189,7 @@ class OpenAIAssistantsAPI(BaseLLM):
                     data["base_url"] = v
                 elif v is not None:
                     data[k] = v
-            openai_client = AsyncOpenAI(**data)  # type: ignore
+            openai_client = AsyncOpenAI(**data)
         else:
             openai_client = client
 
@@ -2237,7 +2227,7 @@ class OpenAIAssistantsAPI(BaseLLM):
         if after:
             request_params["after"] = after
 
-        response: Final = await openai_client.beta.assistants.list(**request_params)  # type: ignore
+        response: Final = await openai_client.beta.assistants.list(**request_params)
 
         return response
 
@@ -2313,7 +2303,7 @@ class OpenAIAssistantsAPI(BaseLLM):
         if after:
             request_params["after"] = after
 
-        response: Final = openai_client.beta.assistants.list(**request_params)  # type: ignore
+        response: Final = openai_client.beta.assistants.list(**request_params)
 
         return response
 
@@ -2453,9 +2443,9 @@ class OpenAIAssistantsAPI(BaseLLM):
             client=client,
         )
 
-        thread_message: Final[OpenAIMessage] = await openai_client.beta.threads.messages.create(  # type: ignore
+        thread_message: Final[OpenAIMessage] = await openai_client.beta.threads.messages.create(
             thread_id,
-            **message_data,  # type: ignore
+            **message_data,
         )
 
         response_obj: OpenAIMessage | None = None
@@ -2532,9 +2522,9 @@ class OpenAIAssistantsAPI(BaseLLM):
             client=client,
         )
 
-        thread_message: Final[OpenAIMessage] = openai_client.beta.threads.messages.create(  # type: ignore
+        thread_message: Final[OpenAIMessage] = openai_client.beta.threads.messages.create(
             thread_id,
-            **message_data,  # type: ignore
+            **message_data,
         )
 
         response_obj: OpenAIMessage | None = None
@@ -2658,11 +2648,11 @@ class OpenAIAssistantsAPI(BaseLLM):
 
         data: Final = {}
         if messages is not None:
-            data["messages"] = messages  # type: ignore
+            data["messages"] = messages
         if metadata is not None:
-            data["metadata"] = metadata  # type: ignore
+            data["metadata"] = metadata
 
-        message_thread: Final = await openai_client.beta.threads.create(**data)  # type: ignore
+        message_thread: Final = await openai_client.beta.threads.create(**data)
 
         return Thread(**message_thread.dict())
 
@@ -2744,11 +2734,11 @@ class OpenAIAssistantsAPI(BaseLLM):
 
         data: Final = {}
         if messages is not None:
-            data["messages"] = messages  # type: ignore
+            data["messages"] = messages
         if metadata is not None:
-            data["metadata"] = metadata  # type: ignore
+            data["metadata"] = metadata
 
-        message_thread: Final = openai_client.beta.threads.create(**data)  # type: ignore
+        message_thread: Final = openai_client.beta.threads.create(**data)
 
         return Thread(**message_thread.dict())
 
@@ -2872,7 +2862,7 @@ class OpenAIAssistantsAPI(BaseLLM):
             client=client,
         )
 
-        response: Final = await openai_client.beta.threads.runs.create_and_poll(  # type: ignore
+        response: Final = await openai_client.beta.threads.runs.create_and_poll(
             thread_id=thread_id,
             assistant_id=assistant_id,
             additional_instructions=additional_instructions,
@@ -2907,7 +2897,7 @@ class OpenAIAssistantsAPI(BaseLLM):
         }
         if event_handler is not None:
             data["event_handler"] = event_handler
-        return client.beta.threads.runs.stream(**data)  # type: ignore
+        return client.beta.threads.runs.stream(**data)
 
     def run_thread_stream(
         self,
@@ -2932,7 +2922,7 @@ class OpenAIAssistantsAPI(BaseLLM):
         }
         if event_handler is not None:
             data["event_handler"] = event_handler
-        return client.beta.threads.runs.stream(**data)  # type: ignore
+        return client.beta.threads.runs.stream(**data)
 
     # fmt: off
 
@@ -3060,7 +3050,7 @@ class OpenAIAssistantsAPI(BaseLLM):
                 event_handler=event_handler,
             )
 
-        response: Final = openai_client.beta.threads.runs.create_and_poll(  # type: ignore
+        response: Final = openai_client.beta.threads.runs.create_and_poll(
             thread_id=thread_id,
             assistant_id=assistant_id,
             additional_instructions=additional_instructions,

--- a/litellm/llms/openai/realtime/handler.py
+++ b/litellm/llms/openai/realtime/handler.py
@@ -154,9 +154,9 @@ class OpenAIRealtime(OpenAIChatCompletion):
                     "complete_input_dict": {"query_params": query_params},
                 },
             )
-            async with websockets.connect(  # type: ignore
+            async with websockets.connect(
                 url,
-                additional_headers=headers,  # type: ignore
+                additional_headers=headers,
                 max_size=REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
                 ssl=ssl_config,
             ) as backend_ws:
@@ -174,7 +174,7 @@ class OpenAIRealtime(OpenAIChatCompletion):
                 )
                 await realtime_streaming.bidirectional_forward()
 
-        except websockets.exceptions.InvalidStatusCode as e:  # type: ignore
+        except websockets.exceptions.InvalidStatusCode as e:
             await websocket.close(code=e.status_code, reason=_redact_string(str(e)))
         except Exception as e:
             try:

--- a/litellm/llms/openai/responses/guardrail_translation/handler.py
+++ b/litellm/llms/openai/responses/guardrail_translation/handler.py
@@ -117,7 +117,7 @@ class OpenAIResponsesHandler(BaseTranslation):
                 if tools_to_check:
                     inputs["tools"] = tools_to_check
             if structured_messages:
-                inputs["structured_messages"] = structured_messages  # type: ignore
+                inputs["structured_messages"] = structured_messages
             # Include model information if available
             model = data.get("model")
             if model:
@@ -166,7 +166,7 @@ class OpenAIResponsesHandler(BaseTranslation):
             if tools_to_check:
                 inputs["tools"] = tools_to_check
             if structured_messages:
-                inputs["structured_messages"] = structured_messages  # type: ignore
+                inputs["structured_messages"] = structured_messages
             # Include model information if available
             model = data.get("model")
             if model:
@@ -225,9 +225,7 @@ class OpenAIResponsesHandler(BaseTranslation):
             (
                 transformed_tools,
                 _,
-            ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
-                tools  # type: ignore
-            )
+            ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(tools)
             tools_to_check.extend(cast(list[ChatCompletionToolParam], transformed_tools))
 
     def _remap_tools_to_responses_api_format(self, guardrailed_tools: list[Any]) -> list[dict[str, Any]]:
@@ -236,7 +234,7 @@ class OpenAIResponsesHandler(BaseTranslation):
         Responses API request tool format.
         """
         return LiteLLMCompletionResponsesConfig.transform_chat_completion_tool_params_to_responses_api_tools(
-            guardrailed_tools  # type: ignore
+            guardrailed_tools
         )
 
     def _merge_tools_after_guardrail(
@@ -696,8 +694,8 @@ class OpenAIResponsesHandler(BaseTranslation):
                     content = generic_response_output_item.content
             except Exception:
                 # Try to extract content directly from output_item if validation fails
-                if hasattr(output_item, "content") and output_item.content:  # type: ignore
-                    content = output_item.content  # type: ignore
+                if hasattr(output_item, "content") and output_item.content:
+                    content = output_item.content
                 else:
                     return
         elif isinstance(output_item, dict):
@@ -770,10 +768,10 @@ class OpenAIResponsesHandler(BaseTranslation):
                         if isinstance(content_item, OutputText):
                             content_item.text = guardrail_response
                             # Update the original response output
-                            if hasattr(output_item, "content") and output_item.content:  # type: ignore
-                                original_content = output_item.content[content_idx]  # type: ignore
+                            if hasattr(output_item, "content") and output_item.content:
+                                original_content = output_item.content[content_idx]
                                 if hasattr(original_content, "text"):
-                                    original_content.text = guardrail_response  # type: ignore
+                                    original_content.text = guardrail_response
                 except Exception:
                     pass
             elif isinstance(output_item, dict):

--- a/litellm/llms/openai/responses/transformation.py
+++ b/litellm/llms/openai/responses/transformation.py
@@ -219,7 +219,7 @@ class OpenAIResponsesAPIConfig(BaseResponsesAPIConfig):
                     validated_input.append(filtered_item)
                 else:
                     validated_input.append(item)
-            return validated_input  # type: ignore
+            return validated_input
         # Input is expected to be either str or List, no single BaseModel expected
         return input
 

--- a/litellm/llms/openai/transcriptions/handler.py
+++ b/litellm/llms/openai/transcriptions/handler.py
@@ -37,7 +37,7 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
         - call openai_aclient.audio.transcriptions.create by default
         """
         try:
-            raw_response = await openai_aclient.audio.transcriptions.with_raw_response.create(**data, timeout=timeout)  # type: ignore
+            raw_response = await openai_aclient.audio.transcriptions.with_raw_response.create(**data, timeout=timeout)
             headers: Final = dict(raw_response.headers)
             response: Final = raw_response.parse()
 
@@ -58,12 +58,12 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
         """
         try:
             if litellm.return_response_headers is True:
-                raw_response = openai_client.audio.transcriptions.with_raw_response.create(**data, timeout=timeout)  # type: ignore
+                raw_response = openai_client.audio.transcriptions.with_raw_response.create(**data, timeout=timeout)
                 headers: Final = dict(raw_response.headers)
                 response = raw_response.parse()
                 return headers, response
             else:
-                response = openai_client.audio.transcriptions.create(**data, timeout=timeout)  # type: ignore
+                response = openai_client.audio.transcriptions.create(**data, timeout=timeout)
                 return None, response
         except Exception as e:
             raise e
@@ -101,7 +101,7 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
             data = {"model": model, "file": audio_file, **optional_params}
 
         if atranscription is True:
-            return self.async_audio_transcriptions(  # type: ignore
+            return self.async_audio_transcriptions(
                 audio_file=audio_file,
                 data=data,
                 model_response=model_response,
@@ -114,7 +114,7 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
                 shared_session=shared_session,
             )
 
-        openai_client: Final[OpenAI] = self._get_openai_client(  # type: ignore
+        openai_client: Final[OpenAI] = self._get_openai_client(
             is_async=False,
             api_key=api_key,
             api_base=api_base,
@@ -157,7 +157,7 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
             model_response_object=model_response,
             hidden_params=hidden_params,
             response_type="audio_transcription",
-        )  # type: ignore
+        )
         return final_response
 
     async def async_audio_transcriptions(
@@ -174,7 +174,7 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
         shared_session: Optional["ClientSession"] = None,
     ):
         try:
-            openai_aclient: Final[AsyncOpenAI] = self._get_openai_client(  # type: ignore
+            openai_aclient: Final[AsyncOpenAI] = self._get_openai_client(
                 is_async=True,
                 api_key=api_key,
                 api_base=api_base,
@@ -222,7 +222,7 @@ class OpenAIAudioTranscription(OpenAIChatCompletion):
                 model_response_object=model_response,
                 hidden_params=hidden_params,
                 response_type="audio_transcription",
-            )  # type: ignore
+            )
         except Exception as e:
             ## LOGGING
             logging_obj.post_call(

--- a/litellm/llms/openai_like/chat/handler.py
+++ b/litellm/llms/openai_like/chat/handler.py
@@ -343,7 +343,7 @@ class OpenAILikeChatHandler(OpenAILikeBase):
                 )
             else:
                 if client is None or not isinstance(client, HTTPHandler):
-                    client = HTTPHandler(timeout=timeout)  # type: ignore
+                    client = HTTPHandler(timeout=timeout)
                 try:
                     response: Final = client.post(url=api_base, headers=headers, data=json.dumps(data))
                     response.raise_for_status()

--- a/litellm/llms/openai_like/chat/transformation.py
+++ b/litellm/llms/openai_like/chat/transformation.py
@@ -26,7 +26,7 @@ class OpenAILikeChatConfig(OpenAIGPTConfig):
         api_base: str | None,
         api_key: str | None,
     ) -> tuple[str | None, str | None]:
-        api_base = api_base or get_secret_str("OPENAI_LIKE_API_BASE")  # type: ignore
+        api_base = api_base or get_secret_str("OPENAI_LIKE_API_BASE")
         dynamic_api_key = api_key or get_secret_str("OPENAI_LIKE_API_KEY") or ""  # vllm does not require an api key
         return api_base, dynamic_api_key
 

--- a/litellm/llms/openai_like/dynamic_config.py
+++ b/litellm/llms/openai_like/dynamic_config.py
@@ -23,7 +23,7 @@ def create_config_class(provider: SimpleProviderConfig):
     # Choose base class
     base_class: Final[type] = OpenAIGPTConfig if provider.base_class == "openai_gpt" else OpenAILikeChatConfig
 
-    class JSONProviderConfig(base_class):  # type: ignore[valid-type,misc]
+    class JSONProviderConfig(base_class):
         @overload
         def _transform_messages(
             self, messages: list[AllMessageValues], model: str, is_async: Literal[True]
@@ -190,7 +190,7 @@ def create_responses_config_class(provider: SimpleProviderConfig):
 
     class JSONProviderResponsesConfig(OpenAILikeResponsesConfig):
         @property
-        def custom_llm_provider(self):  # type: ignore[override]
+        def custom_llm_provider(self):
             return provider.slug
 
         def validate_environment(

--- a/litellm/llms/openai_like/embedding/handler.py
+++ b/litellm/llms/openai_like/embedding/handler.py
@@ -48,7 +48,7 @@ class OpenAILikeEmbeddingHandler(OpenAILikeBase):
                     api_base,
                     headers=headers,
                     data=json.dumps(data),
-                )  # type: ignore
+                )
 
                 response.raise_for_status()
 
@@ -124,9 +124,9 @@ class OpenAILikeEmbeddingHandler(OpenAILikeBase):
                 timeout=timeout,
                 client=client,
                 headers=headers,
-            )  # type: ignore
+            )
         if client is None or isinstance(client, AsyncHTTPHandler):
-            self.client = HTTPHandler(timeout=timeout)  # type: ignore
+            self.client = HTTPHandler(timeout=timeout)
         else:
             self.client = client
 
@@ -136,11 +136,11 @@ class OpenAILikeEmbeddingHandler(OpenAILikeBase):
                 api_base,
                 headers=headers,
                 data=json.dumps(data),
-            )  # type: ignore
+            )
 
-            response.raise_for_status()  # type: ignore
+            response.raise_for_status()
 
-            response_json: Final = response.json()  # type: ignore
+            response_json: Final = response.json()
         except httpx.HTTPStatusError as e:
             raise OpenAILikeError(
                 status_code=e.response.status_code,

--- a/litellm/llms/openai_like/responses/transformation.py
+++ b/litellm/llms/openai_like/responses/transformation.py
@@ -24,7 +24,7 @@ class OpenAILikeResponsesConfig(OpenAIResponsesAPIConfig):
     """
 
     @property
-    def custom_llm_provider(self) -> str | LlmProviders:  # type: ignore[override]
+    def custom_llm_provider(self) -> str | LlmProviders:
         return "openai_like"
 
     def validate_environment(

--- a/litellm/llms/perplexity/chat/transformation.py
+++ b/litellm/llms/perplexity/chat/transformation.py
@@ -23,7 +23,7 @@ class PerplexityChatConfig(OpenAIGPTConfig):
     def _get_openai_compatible_provider_info(
         self, api_base: str | None, api_key: str | None
     ) -> tuple[str | None, str | None]:
-        api_base = api_base or get_secret_str("PERPLEXITY_API_BASE") or "https://api.perplexity.ai"  # type: ignore
+        api_base = api_base or get_secret_str("PERPLEXITY_API_BASE") or "https://api.perplexity.ai"
         dynamic_api_key = api_key or get_secret_str("PERPLEXITYAI_API_KEY") or get_secret_str("PERPLEXITY_API_KEY")
         return api_base, dynamic_api_key
 
@@ -108,11 +108,9 @@ class PerplexityChatConfig(OpenAIGPTConfig):
         """
         if not hasattr(model_response, "usage") or model_response.usage is None:
             # Create a usage object if it doesn't exist (when usage was None)
-            model_response.usage = Usage(  # type: ignore[attr-defined]
-                prompt_tokens=0, completion_tokens=0, total_tokens=0
-            )
+            model_response.usage = Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
 
-        usage: Final = model_response.usage  # type: ignore[attr-defined]
+        usage: Final = model_response.usage
 
         # Extract citation tokens count
         citations: Final = raw_response_json.get("citations", [])

--- a/litellm/llms/perplexity/cost_calculator.py
+++ b/litellm/llms/perplexity/cost_calculator.py
@@ -39,7 +39,7 @@ def cost_per_token(model: str, usage: Usage) -> tuple[float, float]:
         if value is None:
             return default
         try:
-            return float(value)  # type: ignore
+            return float(value)
         except (ValueError, TypeError):
             return default
 

--- a/litellm/llms/petals/completion/handler.py
+++ b/litellm/llms/petals/completion/handler.py
@@ -89,7 +89,7 @@ def completion(
 
     else:
         try:
-            from petals import AutoDistributedModelForCausalLM  # type: ignore
+            from petals import AutoDistributedModelForCausalLM
             from transformers import AutoTokenizer
         except Exception:
             raise Exception(
@@ -125,7 +125,7 @@ def completion(
         output_text = tokenizer.decode(outputs[0])
 
     if output_text is not None and len(output_text) > 0:
-        model_response.choices[0].message.content = output_text  # type: ignore
+        model_response.choices[0].message.content = output_text
 
     prompt_tokens: Final = len(encoding.encode(prompt))
     completion_tokens: Final = len(encoding.encode(model_response["choices"][0]["message"].get("content")))

--- a/litellm/llms/predibase/chat/handler.py
+++ b/litellm/llms/predibase/chat/handler.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from functools import partial
 from typing import Final
 
-import httpx  # type: ignore
+import httpx
 
 import litellm
 from litellm.llms.custom_httpx.http_handler import (
@@ -130,7 +130,7 @@ class PredibaseChatCompletion:
                     logger_fn=logger_fn,
                     headers=headers,
                     timeout=timeout,
-                )  # type: ignore
+                )
             else:
                 ### ASYNC COMPLETION
                 return self.async_completion(
@@ -150,7 +150,7 @@ class PredibaseChatCompletion:
                     headers=headers,
                     timeout=timeout,
                     predibase_config=predibase_config,
-                )  # type: ignore
+                )
 
         ### SYNC STREAMING
         if stream is True:
@@ -159,7 +159,7 @@ class PredibaseChatCompletion:
                 headers=headers,
                 data=json.dumps(data),
                 stream=stream,
-                timeout=timeout,  # type: ignore
+                timeout=timeout,
             )
             _response: Final = CustomStreamWrapper(
                 response.iter_lines(),
@@ -174,13 +174,13 @@ class PredibaseChatCompletion:
                 url=completion_url,
                 headers=headers,
                 data=json.dumps(data),
-                timeout=timeout,  # type: ignore
+                timeout=timeout,
             )
         return predibase_config.transform_response(
             model=model,
             raw_response=response,
             model_response=model_response,
-            logging_obj=logging_obj,  # type: ignore
+            logging_obj=logging_obj,
             optional_params=request_optional_params,
             api_key=api_key,
             request_data=data,

--- a/litellm/llms/predibase/chat/transformation.py
+++ b/litellm/llms/predibase/chat/transformation.py
@@ -165,9 +165,7 @@ class PredibaseConfig(BaseConfig):
             )
 
         if len(completion_response["generated_text"]) > 0:
-            model_response.choices[0].message.content = self.output_parser(  # type: ignore
-                completion_response["generated_text"]
-            )
+            model_response.choices[0].message.content = self.output_parser(completion_response["generated_text"])
 
         if "details" in completion_response and "tokens" in completion_response["details"]:
             model_response.choices[0].finish_reason = map_finish_reason(completion_response["details"]["finish_reason"])
@@ -176,7 +174,7 @@ class PredibaseConfig(BaseConfig):
                 if token["logprob"] is not None:
                     sum_logprob += token["logprob"]
             setattr(
-                model_response.choices[0].message,  # type: ignore
+                model_response.choices[0].message,
                 "_logprob",
                 sum_logprob,  # [TODO] move this to using the actual logprobs
             )
@@ -238,7 +236,7 @@ class PredibaseConfig(BaseConfig):
             completion_tokens=completion_tokens,
             total_tokens=total_tokens,
         )
-        model_response.usage = usage  # type: ignore
+        model_response.usage = usage
 
         predibase_headers: Final = raw_response.headers
         response_headers: Final = {}

--- a/litellm/llms/replicate/chat/handler.py
+++ b/litellm/llms/replicate/chat/handler.py
@@ -169,7 +169,7 @@ def completion(
             logging_obj=logging_obj,
             print_verbose=print_verbose,
             headers=headers,
-        )  # type: ignore
+        )
     ## COMPLETION CALL
     model_response.created = int(time.time())  # for pricing this must remain right before calling api
 
@@ -203,7 +203,7 @@ def completion(
             headers=headers,
             http_client=httpx_client,
         )
-        return CustomStreamWrapper(_response, model, logging_obj=logging_obj, custom_llm_provider="replicate")  # type: ignore
+        return CustomStreamWrapper(_response, model, logging_obj=logging_obj, custom_llm_provider="replicate")
     else:
         for retry in range(litellm.DEFAULT_REPLICATE_POLLING_RETRIES):
             time.sleep(
@@ -272,7 +272,7 @@ async def async_completion(
             headers=headers,
             http_client=async_handler,
         )
-        return CustomStreamWrapper(_response, model, logging_obj=logging_obj, custom_llm_provider="replicate")  # type: ignore
+        return CustomStreamWrapper(_response, model, logging_obj=logging_obj, custom_llm_provider="replicate")
 
     for retry in range(litellm.DEFAULT_REPLICATE_POLLING_RETRIES):
         await asyncio.sleep(

--- a/litellm/llms/replicate/chat/transformation.py
+++ b/litellm/llms/replicate/chat/transformation.py
@@ -259,7 +259,7 @@ class ReplicateConfig(BaseConfig):
 
         ## Building RESPONSE OBJECT
         if len(response_str) >= 1:
-            model_response.choices[0].message.content = response_str  # type: ignore
+            model_response.choices[0].message.content = response_str
 
         # Calculate usage
         prompt_tokens: Final = token_counter(model=model, messages=messages)

--- a/litellm/llms/runwayml/videos/transformation.py
+++ b/litellm/llms/runwayml/videos/transformation.py
@@ -254,7 +254,7 @@ class RunwayMLVideoConfig(BaseVideoConfig):
             if "duration" in request_data:
                 video_data["seconds"] = str(request_data["duration"])
 
-        video_obj: Final = VideoObject(**video_data)  # type: ignore[arg-type]
+        video_obj: Final = VideoObject(**video_data)
 
         if custom_llm_provider and video_obj.id:
             video_obj.id = encode_video_id_with_provider(video_obj.id, custom_llm_provider, model)
@@ -501,7 +501,7 @@ class RunwayMLVideoConfig(BaseVideoConfig):
             object="video",
             status="cancelled",
             created_at=self._parse_runway_timestamp(response_data.get("createdAt")),
-        )  # type: ignore[arg-type]
+        )
 
         return video_obj
 
@@ -565,7 +565,7 @@ class RunwayMLVideoConfig(BaseVideoConfig):
                 "message": response_data.get("failure", "Video generation failed"),
             }
 
-        video_obj: Final = VideoObject(**video_data)  # type: ignore[arg-type]
+        video_obj: Final = VideoObject(**video_data)
 
         if custom_llm_provider and video_obj.id:
             video_obj.id = encode_video_id_with_provider(video_obj.id, custom_llm_provider, None)

--- a/litellm/llms/sagemaker/chat/handler.py
+++ b/litellm/llms/sagemaker/chat/handler.py
@@ -162,9 +162,9 @@ class SagemakerChatHandler(BaseAWSLLM):
             logger_fn=logger_fn,
             timeout=timeout,
             encoding=encoding,
-            headers=prepared_request.headers,  # type: ignore
+            headers=prepared_request.headers,
             custom_endpoint=True,
             custom_llm_provider="sagemaker_chat",
-            streaming_decoder=custom_stream_decoder,  # type: ignore
+            streaming_decoder=custom_stream_decoder,
             client=client,
         )

--- a/litellm/llms/sagemaker/common_utils.py
+++ b/litellm/llms/sagemaker/common_utils.py
@@ -210,10 +210,10 @@ class AWSEventStreamDecoder:
             chunk = parsed_response.get("chunk")
             if not chunk:
                 return None
-            return chunk.get("bytes").decode()  # type: ignore[no-any-return]
+            return chunk.get("bytes").decode()
         else:
             chunk = response_dict.get("body")
             if not chunk:
                 return None
 
-            return chunk.decode()  # type: ignore[no-any-return]
+            return chunk.decode()

--- a/litellm/llms/sagemaker/completion/handler.py
+++ b/litellm/llms/sagemaker/completion/handler.py
@@ -203,7 +203,7 @@ class SagemakerLLM(BaseAWSLLM):
                     prepared_request.headers.update({"X-Amzn-SageMaker-Inference-Component": model_id})
                 completion_stream: Final = self.make_sync_call(
                     api_base=prepared_request.url,
-                    headers=prepared_request.headers,  # type: ignore
+                    headers=prepared_request.headers,
                     data=cast(str, prepared_request.body),  # cast-ok: signed body is a JSON str, mirrors async path
                     logging_obj=logging_obj,
                 )
@@ -285,7 +285,7 @@ class SagemakerLLM(BaseAWSLLM):
             try:
                 sync_response: Final = sync_handler.post(
                     url=prepared_request.url,
-                    headers=prepared_request.headers,  # type: ignore
+                    headers=prepared_request.headers,
                     data=prepared_request.body,
                     timeout=timeout,
                 )
@@ -433,7 +433,7 @@ class SagemakerLLM(BaseAWSLLM):
 
         completion_stream: Final = await self.make_async_call(
             api_base=prepared_request.url,
-            headers=prepared_request.headers,  # type: ignore
+            headers=prepared_request.headers,
             data=cast(str, prepared_request.body),
             logging_obj=logging_obj,
         )
@@ -512,7 +512,7 @@ class SagemakerLLM(BaseAWSLLM):
             try:
                 response: Final = await async_handler.post(
                     url=prepared_request.url,
-                    headers=prepared_request.headers,  # type: ignore
+                    headers=prepared_request.headers,
                     data=prepared_request.body,
                     timeout=timeout,
                 )
@@ -601,7 +601,7 @@ class SagemakerLLM(BaseAWSLLM):
             ContentType="application/json",
             Body=f"{data!r}",  # Use !r for safe representation
             CustomAttributes="accept_eula=true",
-        )"""  # type: ignore
+        )"""
         logging_obj.pre_call(
             input=input,
             api_key="",

--- a/litellm/llms/sagemaker/completion/transformation.py
+++ b/litellm/llms/sagemaker/completion/transformation.py
@@ -144,7 +144,7 @@ class SagemakerConfig(BaseConfig):
             hf_model_name = (
                 hf_model_name or model
             )  # pass in hf model name for pulling it's prompt template - (e.g. `hf_model_name="meta-llama/Llama-2-7b-chat-hf` applies the llama2 chat template to the prompt)
-            prompt: str = prompt_factory(model=hf_model_name, messages=messages)  # type: ignore
+            prompt: str = prompt_factory(model=hf_model_name, messages=messages)
 
         return prompt
 
@@ -227,7 +227,7 @@ class SagemakerConfig(BaseConfig):
             if completion_output.startswith(prompt) and "<s>" in prompt:
                 completion_output = completion_output.replace(prompt, "", 1)
 
-            model_response.choices[0].message.content = completion_output  # type: ignore
+            model_response.choices[0].message.content = completion_output
         except Exception:
             raise SagemakerError(
                 message=f"LiteLLM Error: Unable to parse sagemaker RAW RESPONSE {json.dumps(completion_response)}",

--- a/litellm/llms/sap/chat/transformation.py
+++ b/litellm/llms/sap/chat/transformation.py
@@ -55,7 +55,7 @@ def validate_dict(data: dict, model) -> dict:
     return model(**data).model_dump(by_alias=True, exclude_unset=True)
 
 
-def _messages_to_sap_template(messages: list[dict[str, str]]) -> list:  # type: ignore[type-arg]
+def _messages_to_sap_template(messages: list[dict[str, str]]) -> list:
     template: Final = []
     for message in messages:
         if message["role"] == "user":
@@ -137,7 +137,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
 
     def run_env_setup(self, service_key: str | None = None) -> None:
         try:
-            self.token_creator, self._base_url, self._resource_group = get_token_creator(service_key)  # type: ignore
+            self.token_creator, self._base_url, self._resource_group = get_token_creator(service_key)
         except ValueError as err:
             raise GenAIHubOrchestrationError(status_code=400, message=err.args[0])
 
@@ -157,13 +157,13 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
     def base_url(self) -> str:
         if self._base_url is None:
             self.run_env_setup()
-        return self._base_url  # type: ignore
+        return self._base_url
 
     @property
     def resource_group(self) -> str:
         if self._resource_group is None:
             self.run_env_setup()
-        return self._resource_group  # type: ignore
+        return self._resource_group
 
     @cached_property
     def deployment_url(self) -> str:
@@ -309,7 +309,7 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
     def transform_request(
         self,
         model: str,
-        messages: list[dict[str, str]],  # type: ignore
+        messages: list[dict[str, str]],
         optional_params: dict,
         litellm_params: dict,
         headers: dict,
@@ -430,6 +430,6 @@ class GenAIHubOrchestrationConfig(OpenAIGPTConfig):
         json_mode: bool | None = False,
     ):
         if sync_stream:
-            return SAPStreamIterator(response=streaming_response)  # type: ignore
+            return SAPStreamIterator(response=streaming_response)
         else:
-            return AsyncSAPStreamIterator(response=streaming_response)  # type: ignore
+            return AsyncSAPStreamIterator(response=streaming_response)

--- a/litellm/llms/sap/credentials.py
+++ b/litellm/llms/sap/credentials.py
@@ -281,7 +281,7 @@ def fetch_credentials(
                 if vcap_service
                 else None
             ),
-        ),  # type: ignore[arg-type]
+        ),
     ]
 
     credentials: Final = resolve_credentials(sources)
@@ -360,11 +360,11 @@ def _request_token(
         if cert_pair:
             with httpx.Client(cert=cert_pair) as raw_client:
                 handler = HTTPHandler(client=raw_client)
-                resp = handler.post(auth_url, data=data, timeout=timeout)  # type: ignore[arg-type]
+                resp = handler.post(auth_url, data=data, timeout=timeout)
                 payload = resp.json()
         else:
             handler = _get_httpx_client()
-            resp = handler.post(auth_url, data=data, timeout=timeout)  # type: ignore[arg-type]
+            resp = handler.post(auth_url, data=data, timeout=timeout)
             payload = resp.json()
         access_token: Final = payload["access_token"]
         expires_in: Final = int(payload.get("expires_in", 3600))
@@ -434,8 +434,8 @@ def get_token_creator(
         # Case 1: secret-based auth
         if client_secret:
             return _request_token(
-                auth_url=auth_url,  # type: ignore[arg-type]
-                client_id=client_id,  # type: ignore[arg-type]
+                auth_url=auth_url,
+                client_id=client_id,
                 timeout=timeout,
                 client_secret=client_secret,
             )
@@ -451,16 +451,16 @@ def get_token_creator(
                 with open(key_path, "w") as f:
                     f.write(key_str_fixed)
                 return _request_token(
-                    auth_url=auth_url,  # type: ignore[arg-type]
-                    client_id=client_id,  # type: ignore[arg-type]
+                    auth_url=auth_url,
+                    client_id=client_id,
                     timeout=timeout,
                     cert_pair=(cert_path, key_path),
                 )
         # Case 3: file-based cert/key
         if cert_file_path is not None and key_file_path is not None:
             return _request_token(
-                auth_url=auth_url,  # type: ignore[arg-type]
-                client_id=client_id,  # type: ignore[arg-type]
+                auth_url=auth_url,
+                client_id=client_id,
                 timeout=timeout,
                 cert_pair=(cert_file_path, key_file_path),
             )

--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -172,11 +172,11 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
                     system_parts.append("\n".join(b.get("text", "") for b in content if b.get("type") == "text"))
             elif role == "assistant":
                 tool_calls = msg.get("tool_calls") if isinstance(msg, dict) else getattr(msg, "tool_calls", None)
-                if tool_calls:  # type: ignore[truthy-bool]
+                if tool_calls:
                     content_blocks: list[dict[str, Any]] = []
                     if content:
                         content_blocks.append({"type": "text", "text": content})
-                    for tc in tool_calls:  # type: ignore[attr-defined]
+                    for tc in tool_calls:
                         func = tc.get("function", {}) if isinstance(tc, dict) else getattr(tc, "function", {})
                         tc_id = tc.get("id", "") if isinstance(tc, dict) else getattr(tc, "id", "")
                         func_name = func.get("name", "") if isinstance(func, dict) else getattr(func, "name", "")
@@ -436,7 +436,7 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
         )
 
         model_response.choices = [choice]
-        model_response.usage = usage  # type: ignore[attr-defined]
+        model_response.usage = usage
         model_response.model = "snowflake/" + response_json.get("model", model)
         model_response.id = response_json.get("id", "")
 

--- a/litellm/llms/stability/image_edit/transformations.py
+++ b/litellm/llms/stability/image_edit/transformations.py
@@ -80,7 +80,7 @@ class StabilityImageEditConfig(BaseImageEditConfig):
             if k in param_mapping:
                 # Map param if mapping exists and value is valid
                 if k == "size" and v in OPENAI_SIZE_TO_STABILITY_ASPECT_RATIO:
-                    mapped_params[param_mapping[k]] = OPENAI_SIZE_TO_STABILITY_ASPECT_RATIO[v]  # type: ignore
+                    mapped_params[param_mapping[k]] = OPENAI_SIZE_TO_STABILITY_ASPECT_RATIO[v]
                 # Don't copy "size" itself to final dict
             elif k == "n":
                 # Store for logic but do not add to outgoing params
@@ -190,14 +190,14 @@ class StabilityImageEditConfig(BaseImageEditConfig):
         if prompt is not None and prompt != "":
             data["prompt"] = prompt
         # Handle image parameter - could be a single file or list
-        image_file = image[0] if isinstance(image, list) else image  # type: ignore
+        image_file = image[0] if isinstance(image, list) else image
         files: Final[dict[str, Any]] = {}
         if image is not None:
-            image_file = image[0] if isinstance(image, list) else image  # type: ignore
+            image_file = image[0] if isinstance(image, list) else image
             files["image"] = image_file
 
         # Add optional params (already mapped in map_openai_params)
-        for key, value in image_edit_optional_request_params.items():  # type: ignore
+        for key, value in image_edit_optional_request_params.items():
             # Skip internal params (prefixed with _)
             if key.startswith("_") or value is None:
                 continue
@@ -208,7 +208,7 @@ class StabilityImageEditConfig(BaseImageEditConfig):
                 mask_value = value
                 if isinstance(value, list) and len(value) > 0:
                     mask_value = value[0]
-                files["mask"] = mask_value  # type: ignore
+                files["mask"] = mask_value
                 continue
 
             # File-like optional params (init_image, style_image, etc.)
@@ -217,7 +217,7 @@ class StabilityImageEditConfig(BaseImageEditConfig):
                 file_value = value
                 if isinstance(value, list) and len(value) > 0:
                     file_value = value[0]
-                files[key] = file_value  # type: ignore
+                files[key] = file_value
                 continue
 
             # Supported text fields
@@ -240,7 +240,7 @@ class StabilityImageEditConfig(BaseImageEditConfig):
                 "composition_fidelity",
                 "change_strength",
             ]:
-                data[key] = value  # type: ignore
+                data[key] = value
 
         return data, files
 

--- a/litellm/llms/stability/image_generation/transformation.py
+++ b/litellm/llms/stability/image_generation/transformation.py
@@ -192,7 +192,7 @@ class StabilityImageGenerationConfig(BaseImageGenerationConfig):
                 "strength",
                 "style_preset",
             ]:
-                stability_request[key] = value  # type: ignore
+                stability_request[key] = value
 
         return dict(stability_request)
 

--- a/litellm/llms/together_ai/rerank/handler.py
+++ b/litellm/llms/together_ai/rerank/handler.py
@@ -46,7 +46,7 @@ class TogetherAIRerank(BaseLLM):
             raise ValueError("TogetherAI does not support max_chunks_per_doc")
 
         if _is_async:
-            return self.async_rerank(request_data_dict, api_key)  # type: ignore # Call async method
+            return self.async_rerank(request_data_dict, api_key)  # Call async method
 
         response: Final = client.post(
             "https://api.together.xyz/v1/rerank",

--- a/litellm/llms/v0/chat/transformation.py
+++ b/litellm/llms/v0/chat/transformation.py
@@ -24,7 +24,7 @@ class V0ChatConfig(OpenAILikeChatConfig):
         # v0 is openai compatible, we just need to set the api_base
         api_base = (
             api_base or get_secret_str("V0_API_BASE") or "https://api.v0.dev/v1"  # Default v0 API base URL
-        )  # type: ignore
+        )
         dynamic_api_key: Final = api_key or get_secret_str("V0_API_KEY")
         return api_base, dynamic_api_key
 

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -763,10 +763,7 @@ def filter_schema_fields(schema_dict: dict[str, Any], valid_fields: set[str], pr
         elif key == "items" and isinstance(value, dict):
             result[key] = filter_schema_fields(value, valid_fields, processed)
         elif key == "anyOf" and isinstance(value, list):
-            result[key] = [
-                filter_schema_fields(item, valid_fields, processed)
-                for item in value  # type: ignore
-            ]
+            result[key] = [filter_schema_fields(item, valid_fields, processed) for item in value]
         else:
             result[key] = value
 

--- a/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
+++ b/litellm/llms/vertex_ai/context_caching/vertex_ai_context_caching.py
@@ -62,7 +62,7 @@ class ContextCachingEndpoints(VertexBase):
         """
         auth_header: str | None
         if custom_llm_provider == "gemini":
-            auth_header = {"x-goog-api-key": gemini_api_key}  # type: ignore[assignment]
+            auth_header = {"x-goog-api-key": gemini_api_key}
             endpoint = "cachedContents"
             url = f"https://generativelanguage.googleapis.com/v1beta/{endpoint}"
         elif custom_llm_provider == "vertex_ai":
@@ -361,7 +361,7 @@ class ContextCachingEndpoints(VertexBase):
                 if isinstance(timeout, float) or isinstance(timeout, int):
                     timeout = httpx.Timeout(timeout)
                 _params["timeout"] = timeout
-            client = HTTPHandler(**_params)  # type: ignore
+            client = HTTPHandler(**_params)
         else:
             client = client
 
@@ -414,7 +414,7 @@ class ContextCachingEndpoints(VertexBase):
             response: Final = client.post(
                 url=url,
                 headers=headers,
-                json=cached_content_request_body,  # type: ignore
+                json=cached_content_request_body,
             )
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
@@ -569,7 +569,7 @@ class ContextCachingEndpoints(VertexBase):
             response: Final = await client.post(
                 url=url,
                 headers=headers,
-                json=cached_content_request_body,  # type: ignore
+                json=cached_content_request_body,
             )
             response.raise_for_status()
         except httpx.HTTPStatusError as err:

--- a/litellm/llms/vertex_ai/files/transformation.py
+++ b/litellm/llms/vertex_ai/files/transformation.py
@@ -466,7 +466,7 @@ class VertexAIFilesConfig(VertexBase, BaseFilesConfig):
         response_json: Final = raw_response.json()
 
         try:
-            response_object: Final = GcsBucketResponse(**response_json)  # type: ignore
+            response_object: Final = GcsBucketResponse(**response_json)
         except Exception as e:
             raise VertexAIError(
                 status_code=raw_response.status_code,

--- a/litellm/llms/vertex_ai/fine_tuning/handler.py
+++ b/litellm/llms/vertex_ai/fine_tuning/handler.py
@@ -172,7 +172,7 @@ class VertexFineTuningAPI(VertexLLM):
             response: Final = await self.async_handler.post(
                 headers=headers,
                 url=fine_tuning_url,
-                json=request_data,  # type: ignore
+                json=request_data,
             )
 
             if response.status_code != 200:
@@ -182,7 +182,7 @@ class VertexFineTuningAPI(VertexLLM):
 
             verbose_logger.debug("got response from creating fine tuning job: %s", response.json())
 
-            vertex_response: Final = ResponseTuningJob(  # type: ignore
+            vertex_response: Final = ResponseTuningJob(
                 **response.json(),
             )
 
@@ -241,7 +241,7 @@ class VertexFineTuningAPI(VertexLLM):
         base_url: Final = get_vertex_base_url(vertex_location)
         fine_tuning_url: Final = f"{base_url}/v1/projects/{vertex_project}/locations/{vertex_location}/tuningJobs"
         if _is_async is True:
-            return self.acreate_fine_tuning_job(  # type: ignore
+            return self.acreate_fine_tuning_job(
                 fine_tuning_url=fine_tuning_url,
                 headers=headers,
                 request_data=fine_tune_job,
@@ -256,7 +256,7 @@ class VertexFineTuningAPI(VertexLLM):
         response: Final = sync_handler.post(
             headers=headers,
             url=fine_tuning_url,
-            json=fine_tune_job,  # type: ignore
+            json=fine_tune_job,
         )
 
         if response.status_code != 200:
@@ -265,7 +265,7 @@ class VertexFineTuningAPI(VertexLLM):
             )
 
         verbose_logger.debug("got response from creating fine tuning job: %s", response.json())
-        vertex_response: Final = ResponseTuningJob(  # type: ignore
+        vertex_response: Final = ResponseTuningJob(
             **response.json(),
         )
 
@@ -333,7 +333,7 @@ class VertexFineTuningAPI(VertexLLM):
         response: Final = await self.async_handler.post(
             headers=headers,
             url=url,
-            json=request_data,  # type: ignore
+            json=request_data,
         )
 
         if response.status_code != 200:

--- a/litellm/llms/vertex_ai/gemini/transformation.py
+++ b/litellm/llms/vertex_ai/gemini/transformation.py
@@ -259,7 +259,7 @@ def _image_url_payload_may_need_sync_gcs_metadata_fetch(
     fmt: str | None = None
     url: str | None = None
     if isinstance(raw_image_url, dict):
-        url = raw_image_url.get("url")  # type: ignore[assignment]
+        url = raw_image_url.get("url")
         if not isinstance(url, str):
             return False
         fmt = raw_image_url.get("format") or raw_image_url.get("mime_type") or raw_image_url.get("content_type")
@@ -873,10 +873,10 @@ def _gemini_convert_messages_with_history(
             ## MERGE CONSECUTIVE ASSISTANT CONTENT ##
             while msg_i < len(messages) and messages[msg_i]["role"] == "assistant":
                 if isinstance(messages[msg_i], BaseModel):
-                    msg_dict: ChatCompletionAssistantMessage | dict = messages[msg_i].model_dump()  # type: ignore
+                    msg_dict: ChatCompletionAssistantMessage | dict = messages[msg_i].model_dump()
                 else:
-                    msg_dict = messages[msg_i]  # type: ignore
-                assistant_msg = ChatCompletionAssistantMessage(**msg_dict)  # type: ignore
+                    msg_dict = messages[msg_i]
+                assistant_msg = ChatCompletionAssistantMessage(**msg_dict)
                 _message_content = assistant_msg.get("content", None)
                 reasoning_content = assistant_msg.get("reasoning_content", None)
                 thinking_blocks = assistant_msg.get("thinking_blocks")
@@ -937,9 +937,9 @@ def _gemini_convert_messages_with_history(
                                 text=assistant_text,
                                 thoughtSignature=thought_signatures[0],
                             )
-                        )  # type: ignore
+                        )
                     else:
-                        assistant_content.append(PartType(text=assistant_text))  # type: ignore
+                        assistant_content.append(PartType(text=assistant_text))
 
                 ## HANDLE ASSISTANT IMAGES FIELD
                 # Process images field if present (for generated images from assistant)
@@ -1012,7 +1012,7 @@ def _gemini_convert_messages_with_history(
                             }
                             if "thought_signature" in invocation:
                                 tc_part["thoughtSignature"] = invocation["thought_signature"]
-                            assistant_content.append(tc_part)  # type: ignore
+                            assistant_content.append(tc_part)
 
                             # Re-inject toolResponse part if response is present
                             if "response" in invocation:
@@ -1025,7 +1025,7 @@ def _gemini_convert_messages_with_history(
                                 tr_part: dict[str, Any] = {"toolResponse": tr_dict}
                                 if "response_thought_signature" in invocation:
                                     tr_part["thoughtSignature"] = invocation["response_thought_signature"]
-                                assistant_content.append(tr_part)  # type: ignore
+                                assistant_content.append(tr_part)
 
                 msg_i += 1
 
@@ -1036,8 +1036,8 @@ def _gemini_convert_messages_with_history(
             tool_call_message_roles = ["tool", "function"]
             if msg_i < len(messages) and messages[msg_i]["role"] in tool_call_message_roles:
                 _part = convert_to_gemini_tool_call_result(
-                    messages[msg_i],  # type: ignore
-                    last_message_with_tool_calls,  # type: ignore
+                    messages[msg_i],
+                    last_message_with_tool_calls,
                     forward_function_call_id=forward_function_call_id,
                 )
                 msg_i += 1
@@ -1081,7 +1081,7 @@ def _pop_and_merge_extra_body(data: RequestBody, optional_params: dict) -> None:
     """Pop extra_body from optional_params and shallow-merge into data, deep-merging dict values."""
     extra_body: Final[dict | None] = optional_params.pop("extra_body", None)
     if extra_body is not None:
-        data_dict: Final[dict] = data  # type: ignore[assignment]
+        data_dict: Final[dict] = data
         for k, v in extra_body.items():
             if k in _LITELLM_INTERNAL_EXTRA_BODY_KEYS:
                 continue
@@ -1123,15 +1123,15 @@ def _rewrite_mime_type_to_response_format(generation_config: GenerationConfig) -
             }
         }
     """
-    schema = generation_config.pop("response_json_schema", None)  # type: ignore[misc]
+    schema = generation_config.pop("response_json_schema", None)
     if schema is None:
-        schema = generation_config.pop("response_schema", None)  # type: ignore[misc]
-    generation_config.pop("response_mime_type", None)  # type: ignore[misc]
+        schema = generation_config.pop("response_schema", None)
+    generation_config.pop("response_mime_type", None)
 
     response_format: Final[dict[str, Any]] = {"text": {"mimeType": "APPLICATION_JSON"}}
     if schema is not None:
         response_format["text"]["schema"] = schema
-    generation_config["responseFormat"] = response_format  # type: ignore[typeddict-unknown-key]
+    generation_config["responseFormat"] = response_format
 
 
 def _rewrite_google_maps_response_format(data: RequestBody) -> None:
@@ -1166,7 +1166,7 @@ def _transform_request_body(
         if supports_response_schema is False:
             user_response_schema_message: Final = response_schema_prompt(
                 model=model,
-                response_schema=optional_params.get("response_schema"),  # type: ignore
+                response_schema=optional_params.get("response_schema"),
             )
             messages.append({"role": "user", "content": user_response_schema_message})
             optional_params.pop("response_schema")
@@ -1193,7 +1193,7 @@ def _transform_request_body(
         tools: Final[Tools | None] = optional_params.pop("tools", None)
         tool_choice: Final[ToolConfig | None] = optional_params.pop("tool_choice", None)
         include_server_side_tool_invocations: bool = optional_params.pop("include_server_side_tool_invocations", False)
-        safety_settings: list[SafetSettingsConfig] | None = optional_params.pop("safety_settings", None)  # type: ignore
+        safety_settings: list[SafetSettingsConfig] | None = optional_params.pop("safety_settings", None)
         # Drop output_config as it's not supported by Vertex AI
         optional_params.pop("output_config", None)
         config_fields: Final = GenerationConfig.__annotations__.keys()
@@ -1317,7 +1317,7 @@ async def async_transform_request_body(
     timeout: float | httpx.Timeout | None,
     extra_headers: dict | None,
     optional_params: dict,
-    logging_obj: litellm.litellm_core_utils.litellm_logging.Logging,  # type: ignore
+    logging_obj: litellm.litellm_core_utils.litellm_logging.Logging,
     custom_llm_provider: Literal["vertex_ai", "vertex_ai_beta", "gemini"],
     litellm_params: dict,
     vertex_project: str | None,

--- a/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
+++ b/litellm/llms/vertex_ai/gemini/vertex_and_google_ai_studio_gemini.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from functools import partial
 from typing import TYPE_CHECKING, Any, Final, Literal, Optional, Union, cast
 
-import httpx  # type: ignore
+import httpx
 
 import litellm
 import litellm.litellm_core_utils
@@ -594,9 +594,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         for tool in value:
             openai_function_object: ChatCompletionToolParamFunctionChunk | None = None
             if "function" in tool:  # tools list
-                _openai_function_object = ChatCompletionToolParamFunctionChunk(  # type: ignore
-                    **tool["function"]
-                )
+                _openai_function_object = ChatCompletionToolParamFunctionChunk(**tool["function"])
 
                 if (
                     "parameters" in _openai_function_object
@@ -608,7 +606,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 openai_function_object = _openai_function_object
 
             elif "name" in tool:  # functions list
-                openai_function_object = ChatCompletionToolParamFunctionChunk(**tool)  # type: ignore
+                openai_function_object = ChatCompletionToolParamFunctionChunk(**tool)
 
             if "type" in tool and tool["type"] == "computer_use":
                 computer_use_config = {k: v for k, v in tool.items() if k != "type"}
@@ -1121,7 +1119,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                     optional_params["stop_sequences"] = value
             elif param == "max_tokens" or param == "max_completion_tokens":
                 optional_params["max_output_tokens"] = value
-            elif param == "response_format" and isinstance(value, dict):  # type: ignore
+            elif param == "response_format" and isinstance(value, dict):
                 self.apply_response_schema_transformation(value=value, optional_params=optional_params, model=model)
             elif param == "frequency_penalty":
                 if self._supports_penalty_parameters(model):
@@ -1140,7 +1138,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
             elif param == "tool_choice" and (isinstance(value, str) or isinstance(value, dict)):
                 _tool_choice_value = self.map_tool_choice_values(
                     model=model,
-                    tool_choice=value,  # type: ignore
+                    tool_choice=value,
                 )
                 if _tool_choice_value is not None:
                     optional_params["tool_choice"] = _tool_choice_value
@@ -1592,9 +1590,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                         _tool_response_chunk["id"] = gemini_call_id
                     # Embed thought signature in ID for OpenAI client compatibility
                     if thought_signature:
-                        _tool_response_chunk["provider_specific_fields"] = {  # type: ignore
-                            "thought_signature": thought_signature
-                        }
+                        _tool_response_chunk["provider_specific_fields"] = {"thought_signature": thought_signature}
                         _tool_response_chunk["id"] = _encode_tool_call_id_with_signature(
                             _tool_response_chunk["id"] or "", thought_signature
                         )
@@ -1647,7 +1643,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         choice: Final = litellm.Choices(
             finish_reason="content_filter",
             index=0,
-            message=chat_completion_message,  # type: ignore
+            message=chat_completion_message,
             logprobs=None,
             enhancements=None,
         )
@@ -2010,8 +2006,8 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         """
         from litellm.types.utils import Delta, StreamingChoices
 
-        annotations: Final = chat_completion_message.get("annotations")  # type: ignore
-        provider_specific_fields: Final = chat_completion_message.get("provider_specific_fields")  # type: ignore
+        annotations: Final = chat_completion_message.get("annotations")
+        provider_specific_fields: Final = chat_completion_message.get("provider_specific_fields")
         # create a streaming choice object
         choice: Final = StreamingChoices(
             finish_reason=VertexGeminiConfig._check_finish_reason(
@@ -2024,7 +2020,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 tool_calls=tools,
                 images=image_response,
                 function_call=functions,
-                annotations=annotations,  # type: ignore
+                annotations=annotations,
                 provider_specific_fields=provider_specific_fields,
             ),
             logprobs=chat_completion_logprobs,
@@ -2052,9 +2048,9 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         if "groundingMetadata" in candidate:
             if isinstance(candidate["groundingMetadata"], list):
-                grounding_metadata.extend(candidate["groundingMetadata"])  # type: ignore
+                grounding_metadata.extend(candidate["groundingMetadata"])
             else:
-                grounding_metadata.append(candidate["groundingMetadata"])  # type: ignore
+                grounding_metadata.append(candidate["groundingMetadata"])
 
         if "safetyRatings" in candidate:
             safety_ratings.append(candidate["safetyRatings"])
@@ -2098,18 +2094,18 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         safety_ratings: list[dict],
         citation_metadata: list[dict],
     ) -> None:
-        setattr(model_response, "vertex_ai_grounding_metadata", grounding_metadata)  # type: ignore
+        setattr(model_response, "vertex_ai_grounding_metadata", grounding_metadata)
         if grounding_metadata:
             model_response._hidden_params["vertex_ai_grounding_metadata"] = grounding_metadata
-        setattr(model_response, "vertex_ai_url_context_metadata", url_context_metadata)  # type: ignore
+        setattr(model_response, "vertex_ai_url_context_metadata", url_context_metadata)
         if url_context_metadata:
             model_response._hidden_params["vertex_ai_url_context_metadata"] = url_context_metadata
-        setattr(model_response, "vertex_ai_safety_ratings", safety_ratings)  # type: ignore
-        setattr(model_response, "vertex_ai_safety_results", safety_ratings)  # type: ignore
+        setattr(model_response, "vertex_ai_safety_ratings", safety_ratings)
+        setattr(model_response, "vertex_ai_safety_results", safety_ratings)
         if safety_ratings:
             model_response._hidden_params["vertex_ai_safety_ratings"] = safety_ratings
             model_response._hidden_params["vertex_ai_safety_results"] = safety_ratings
-        setattr(model_response, "vertex_ai_citation_metadata", citation_metadata)  # type: ignore
+        setattr(model_response, "vertex_ai_citation_metadata", citation_metadata)
         if citation_metadata:
             model_response._hidden_params["vertex_ai_citation_metadata"] = citation_metadata
 
@@ -2285,7 +2281,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                         content_text=content,
                     )
                     if annotations:
-                        chat_completion_message["annotations"] = annotations  # type: ignore
+                        chat_completion_message["annotations"] = annotations
                 (
                     functions,
                     tools,
@@ -2308,7 +2304,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                 chat_completion_message["function_call"] = functions
 
             if thinking_blocks is not None:
-                chat_completion_message["thinking_blocks"] = thinking_blocks  # type: ignore
+                chat_completion_message["thinking_blocks"] = thinking_blocks
 
                 # Convert thinking_blocks to reasoning_content for streaming
                 # This ensures reasoning_content is available in streaming responses
@@ -2345,18 +2341,18 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
                     chat_completion_logprobs=chat_completion_logprobs,
                     image_response=image_response,
                 )
-                model_response.choices.append(choice)  # type: ignore[arg-type]
+                model_response.choices.append(choice)
             elif isinstance(model_response, ModelResponse):
                 choice = litellm.Choices(
                     finish_reason=VertexGeminiConfig._check_finish_reason(
                         chat_completion_message, candidate.get("finishReason")
                     ),
                     index=candidate.get("index", idx),
-                    message=chat_completion_message,  # type: ignore
+                    message=chat_completion_message,
                     logprobs=chat_completion_logprobs,
                     enhancements=None,
                 )
-                model_response.choices.append(choice)  # type: ignore[arg-type]
+                model_response.choices.append(choice)
 
         return (
             grounding_metadata,
@@ -2390,7 +2386,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
 
         ## RESPONSE OBJECT
         try:
-            completion_response: Final = GenerateContentResponseBody(**raw_response.json())  # type: ignore
+            completion_response: Final = GenerateContentResponseBody(**raw_response.json())
         except Exception as e:
             raise VertexAIError(
                 message=f"Error converting to valid response block={e}. File an issue if litellm error - https://github.com/BerriAI/litellm/issues",
@@ -2418,7 +2414,7 @@ class VertexGeminiConfig(VertexAIBaseConfig, BaseConfig):
         Transforms a Google GenAI generate content response to an OpenAI model response.
         """
         if isinstance(completion_response, dict):
-            completion_response = GenerateContentResponseBody(**completion_response)  # type: ignore
+            completion_response = GenerateContentResponseBody(**completion_response)
 
         ## GET MODEL ##
         model_response.model = model
@@ -2719,7 +2715,7 @@ class VertexLLM(VertexBase):
             vertex_project=vertex_project,
             vertex_location=vertex_location,
             vertex_auth_header=auth_header,
-        )  # type: ignore
+        )
 
         ## LOGGING
         logging_obj.pre_call(
@@ -2815,7 +2811,7 @@ class VertexLLM(VertexBase):
             vertex_project=vertex_project,
             vertex_location=vertex_location,
             vertex_auth_header=auth_header,
-        )  # type: ignore
+        )
 
         _async_client_params: Final = {}
         if timeout:
@@ -2823,7 +2819,7 @@ class VertexLLM(VertexBase):
         if client is None or not isinstance(client, AsyncHTTPHandler):
             client = get_async_httpx_client(params=_async_client_params, llm_provider=litellm.LlmProviders.VERTEX_AI)
         else:
-            client = client  # type: ignore
+            client = client
         ## LOGGING
         logging_obj.pre_call(
             input=messages,
@@ -2841,7 +2837,7 @@ class VertexLLM(VertexBase):
                 headers=headers,
                 json=cast(dict, request_body),
                 logging_obj=logging_obj,
-            )  # type: ignore
+            )
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
@@ -2894,7 +2890,7 @@ class VertexLLM(VertexBase):
         client: AsyncHTTPHandler | HTTPHandler | None = None,
         api_base: str | None = None,
     ) -> ModelResponse | CustomStreamWrapper:
-        stream: Final[bool | None] = optional_params.pop("stream", None)  # type: ignore
+        stream: Final[bool | None] = optional_params.pop("stream", None)
 
         transform_request_params: Final = {
             "gemini_api_key": gemini_api_key,
@@ -2927,7 +2923,7 @@ class VertexLLM(VertexBase):
                     litellm_params=litellm_params,
                     logger_fn=logger_fn,
                     timeout=timeout,
-                    client=client,  # type: ignore
+                    client=client,
                     data=transform_request_params,
                     vertex_project=vertex_project,
                     vertex_location=vertex_location,
@@ -2940,7 +2936,7 @@ class VertexLLM(VertexBase):
             return self.async_completion(
                 model=model,
                 messages=messages,
-                data=transform_request_params,  # type: ignore
+                data=transform_request_params,
                 api_base=api_base,
                 model_response=model_response,
                 print_verbose=print_verbose,
@@ -2951,7 +2947,7 @@ class VertexLLM(VertexBase):
                 litellm_params=litellm_params,
                 logger_fn=logger_fn,
                 timeout=timeout,
-                client=client,  # type: ignore
+                client=client,
                 vertex_project=vertex_project,
                 vertex_location=vertex_location,
                 vertex_credentials=vertex_credentials,
@@ -3046,7 +3042,7 @@ class VertexLLM(VertexBase):
             client = client
 
         try:
-            response: Final = client.post(url=url, headers=headers, json=data, logging_obj=logging_obj)  # type: ignore
+            response: Final = client.post(url=url, headers=headers, json=data, logging_obj=logging_obj)
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
@@ -3070,7 +3066,7 @@ class VertexLLM(VertexBase):
             optional_params=optional_params,
             litellm_params=litellm_params,
             api_key="",
-            request_data=data,  # type: ignore
+            request_data=data,
             messages=messages,
             encoding=encoding,
         )
@@ -3244,7 +3240,7 @@ class ModelResponseIterator:
 
             from litellm.types.utils import ModelResponseStream
 
-            processed_chunk: Final = GenerateContentResponseBody(**chunk)  # type: ignore
+            processed_chunk: Final = GenerateContentResponseBody(**chunk)
             response_id: Final = processed_chunk.get("responseId")
             model_response = ModelResponseStream(choices=[], id=response_id)
 
@@ -3272,7 +3268,7 @@ class ModelResponseIterator:
 
             usage: Final = self._apply_stream_usage_metadata(processed_chunk, model_response, grounding_metadata)
 
-            setattr(model_response, "usage", usage)  # type: ignore
+            setattr(model_response, "usage", usage)
 
             model_response._hidden_params["is_finished"] = False
             return model_response

--- a/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_handler.py
+++ b/litellm/llms/vertex_ai/gemini_embeddings/batch_embed_content_handler.py
@@ -152,9 +152,9 @@ class GoogleBatchEmbeddings(VertexLLM):
             else:
                 _params["timeout"] = httpx.Timeout(timeout=600.0, connect=5.0)
 
-            sync_handler: HTTPHandler = HTTPHandler(**_params)  # type: ignore
+            sync_handler: HTTPHandler = HTTPHandler(**_params)
         else:
-            sync_handler = client  # type: ignore
+            sync_handler = client
 
         optional_params = optional_params or {}
 
@@ -191,7 +191,7 @@ class GoogleBatchEmbeddings(VertexLLM):
             headers.update(extra_headers)
 
         if aembedding is True:
-            return self.async_batch_embeddings(  # type: ignore
+            return self.async_batch_embeddings(
                 model=model,
                 api_base=api_base,
                 url=url,
@@ -268,7 +268,7 @@ class GoogleBatchEmbeddings(VertexLLM):
                 resolved_files=resolved_files,
             )
         else:
-            _predictions: Final = VertexAIBatchEmbeddingsResponseObject(**_json_response)  # type: ignore
+            _predictions: Final = VertexAIBatchEmbeddingsResponseObject(**_json_response)
             return process_response(
                 model=model,
                 model_response=model_response,
@@ -306,7 +306,7 @@ class GoogleBatchEmbeddings(VertexLLM):
                 params={"timeout": timeout},
             )
         else:
-            async_handler = client  # type: ignore
+            async_handler = client
 
         ### TRANSFORMATION (async path) ###
         if use_embed_content:
@@ -372,7 +372,7 @@ class GoogleBatchEmbeddings(VertexLLM):
                 resolved_files=resolved_files,
             )
         else:
-            _predictions: Final = VertexAIBatchEmbeddingsResponseObject(**_json_response)  # type: ignore
+            _predictions: Final = VertexAIBatchEmbeddingsResponseObject(**_json_response)
             return process_response(
                 model=model,
                 model_response=model_response,

--- a/litellm/llms/vertex_ai/image_edit/vertex_gemini_transformation.py
+++ b/litellm/llms/vertex_ai/image_edit/vertex_gemini_transformation.py
@@ -53,9 +53,7 @@ class VertexAIGeminiImageEditConfig(BaseImageEditConfig, VertexLLM):
         mapped_params: Final[dict[str, Any]] = {}
 
         if "size" in filtered_params:
-            mapped_params["aspectRatio"] = self._map_size_to_aspect_ratio(
-                filtered_params["size"]  # type: ignore[arg-type]
-            )
+            mapped_params["aspectRatio"] = self._map_size_to_aspect_ratio(filtered_params["size"])
 
         return mapped_params
 
@@ -145,7 +143,7 @@ class VertexAIGeminiImageEditConfig(BaseImageEditConfig, VertexLLM):
 
         return f"{base_url}/v1/projects/{vertex_project}/locations/{vertex_location}/publishers/google/models/{model_name}:generateContent"
 
-    def transform_image_edit_request(  # type: ignore[override]
+    def transform_image_edit_request(
         self,
         model: str,
         prompt: str | None,

--- a/litellm/llms/vertex_ai/image_edit/vertex_imagen_transformation.py
+++ b/litellm/llms/vertex_ai/image_edit/vertex_imagen_transformation.py
@@ -58,9 +58,7 @@ class VertexAIImagenImageEditConfig(BaseImageEditConfig, VertexLLM):
             mapped_params["sampleCount"] = filtered_params["n"]
 
         if "size" in filtered_params:
-            mapped_params["aspectRatio"] = self._map_size_to_aspect_ratio(
-                filtered_params["size"]  # type: ignore[arg-type]
-            )
+            mapped_params["aspectRatio"] = self._map_size_to_aspect_ratio(filtered_params["size"])
 
         if "mask" in filtered_params:
             mapped_params["mask"] = filtered_params["mask"]
@@ -145,7 +143,7 @@ class VertexAIImagenImageEditConfig(BaseImageEditConfig, VertexLLM):
 
         return f"{base_url}/v1/projects/{vertex_project}/locations/{vertex_location}/publishers/google/models/{model_name}:predict"
 
-    def transform_image_edit_request(  # type: ignore[override]
+    def transform_image_edit_request(
         self,
         model: str,
         prompt: str | None,

--- a/litellm/llms/vertex_ai/image_generation/image_generation_handler.py
+++ b/litellm/llms/vertex_ai/image_generation/image_generation_handler.py
@@ -83,7 +83,7 @@ class VertexImageGeneration(VertexLLM):
         extra_headers: dict | None = None,
     ) -> ImageResponse:
         if aimg_generation is True:
-            return self.aimage_generation(  # type: ignore
+            return self.aimage_generation(
                 prompt=prompt,
                 api_base=api_base,
                 vertex_project=vertex_project,
@@ -106,9 +106,9 @@ class VertexImageGeneration(VertexLLM):
             else:
                 _params["timeout"] = httpx.Timeout(timeout=600.0, connect=5.0)
 
-            sync_handler: HTTPHandler = HTTPHandler(**_params)  # type: ignore
+            sync_handler: HTTPHandler = HTTPHandler(**_params)
         else:
-            sync_handler = client  # type: ignore
+            sync_handler = client
 
         # url = f"https://{vertex_location}-aiplatform.googleapis.com/v1/projects/{vertex_project}/locations/{vertex_location}/publishers/google/models/{model}:predict"
 
@@ -195,7 +195,7 @@ class VertexImageGeneration(VertexLLM):
                 params={"timeout": timeout},
             )
         else:
-            self.async_handler = client  # type: ignore
+            self.async_handler = client
 
         # make POST request to
         # https://us-central1-aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/us-central1/publishers/google/models/imagegeneration:predict

--- a/litellm/llms/vertex_ai/multimodal_embeddings/embedding_handler.py
+++ b/litellm/llms/vertex_ai/multimodal_embeddings/embedding_handler.py
@@ -79,9 +79,9 @@ class VertexMultimodalEmbedding(VertexLLM):
             else:
                 _params["timeout"] = httpx.Timeout(timeout=600.0, connect=5.0)
 
-            sync_handler: HTTPHandler = HTTPHandler(**_params)  # type: ignore
+            sync_handler: HTTPHandler = HTTPHandler(**_params)
         else:
-            sync_handler = client  # type: ignore
+            sync_handler = client
 
         request_data: Final = vertex_multimodal_embedding_handler.transform_embedding_request(
             model, input, optional_params, headers
@@ -109,7 +109,7 @@ class VertexMultimodalEmbedding(VertexLLM):
         )
 
         if aembedding is True:
-            return self.async_multimodal_embedding(  # type: ignore
+            return self.async_multimodal_embedding(
                 model=model,
                 api_base=url,
                 data=request_data,
@@ -165,10 +165,10 @@ class VertexMultimodalEmbedding(VertexLLM):
                 params={"timeout": timeout},
             )
         else:
-            client = client  # type: ignore
+            client = client
 
         try:
-            response: Final = await client.post(api_base, headers=headers, json=data)  # type: ignore
+            response: Final = await client.post(api_base, headers=headers, json=data)
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code

--- a/litellm/llms/vertex_ai/rag_engine/ingestion.py
+++ b/litellm/llms/vertex_ai/rag_engine/ingestion.py
@@ -170,7 +170,7 @@ class VertexAIRAGIngestion(BaseRAGIngestion):
         """
         try:
             from vertexai import init as vertexai_init
-            from vertexai import rag  # type: ignore[import-not-found]
+            from vertexai import rag
         except ImportError:
             raise ImportError(
                 "vertexai.rag module not found. Vertex AI RAG requires "
@@ -212,7 +212,7 @@ class VertexAIRAGIngestion(BaseRAGIngestion):
         Uses chunking_strategy from ingest_options (not vector_store).
         """
         try:
-            from vertexai import rag  # type: ignore[import-not-found]
+            from vertexai import rag
         except ImportError:
             raise ImportError(
                 "vertexai.rag module not found. Vertex AI RAG requires "

--- a/litellm/llms/vertex_ai/text_to_speech/text_to_speech_handler.py
+++ b/litellm/llms/vertex_ai/text_to_speech/text_to_speech_handler.py
@@ -139,15 +139,13 @@ class VertexTextToSpeechAPI(VertexLLM):
         ########## End of logging ############
         ####### Send the request ###################
         if _is_async is True:
-            return self.async_audio_speech(  # type: ignore
-                logging_obj=logging_obj, url=url, headers=headers, request=request
-            )
+            return self.async_audio_speech(logging_obj=logging_obj, url=url, headers=headers, request=request)
         sync_handler: Final = _get_httpx_client()
 
         response = sync_handler.post(
             url=url,
             headers=headers,
-            json=request,  # type: ignore
+            json=request,
         )
         if response.status_code != 200:
             raise Exception(f"Request failed with status code {response.status_code}, {response.text}")
@@ -183,7 +181,7 @@ class VertexTextToSpeechAPI(VertexLLM):
         response = await async_handler.post(
             url=url,
             headers=headers,
-            json=request,  # type: ignore
+            json=request,
         )
 
         if response.status_code != 200:

--- a/litellm/llms/vertex_ai/vertex_ai_non_gemini.py
+++ b/litellm/llms/vertex_ai/vertex_ai_non_gemini.py
@@ -109,13 +109,13 @@ def completion(
             message="""Upgrade vertex ai. Run `pip install "google-cloud-aiplatform>=1.38"`""",
         )
     try:
-        import google.auth  # type: ignore
-        from google.cloud import aiplatform  # type: ignore
+        import google.auth
+        from google.cloud import aiplatform
         from google.cloud.aiplatform_v1beta1.types import (
-            content as gapic_content_types,  # type: ignore
+            content as gapic_content_types,
         )
-        from google.protobuf import json_format  # type: ignore
-        from google.protobuf.struct_pb2 import Value  # type: ignore
+        from google.protobuf import json_format
+        from google.protobuf.struct_pb2 import Value
         from vertexai.language_models import CodeGenerationModel, TextGenerationModel
         from vertexai.preview.generative_models import GenerativeModel
         from vertexai.preview.language_models import ChatModel, CodeChatModel
@@ -218,10 +218,7 @@ def completion(
 
             instances = [optional_params.copy()]
             instances[0]["prompt"] = prompt
-            instances = [
-                json_format.ParseDict(instance_dict, Value())  # type: ignore[misc]
-                for instance_dict in instances
-            ]
+            instances = [json_format.ParseDict(instance_dict, Value()) for instance_dict in instances]
             # Will determine the API used based on async parameter
             llm_model = None
 
@@ -337,7 +334,7 @@ def completion(
             )
             llm_model = aiplatform.gapic.PredictionServiceClient(
                 client_options=client_options,
-                credentials=creds,  # type: ignore[arg-type]
+                credentials=creds,
             )
             request_str += f"llm_model = aiplatform.gapic.PredictionServiceClient(client_options={client_options}, credentials=...)\n"
             endpoint_path = llm_model.endpoint_path(project=vertex_project, location=vertex_location, endpoint=model)
@@ -382,16 +379,14 @@ def completion(
 
         ## RESPONSE OBJECT
         if isinstance(completion_response, litellm.Message):
-            model_response.choices[0].message = completion_response  # type: ignore
+            model_response.choices[0].message = completion_response
         elif len(str(completion_response)) > 0:
-            model_response.choices[0].message.content = str(completion_response)  # type: ignore
+            model_response.choices[0].message.content = str(completion_response)
         model_response.created = int(time.time())
         model_response.model = model
         ## CALCULATING USAGE
         if model in litellm.vertex_language_models and response_obj is not None:
-            model_response.choices[0].finish_reason = map_finish_reason(  # type: ignore[assignment]
-                response_obj.candidates[0].finish_reason.name
-            )
+            model_response.choices[0].finish_reason = map_finish_reason(response_obj.candidates[0].finish_reason.name)
             usage = Usage(
                 prompt_tokens=response_obj.usage_metadata.prompt_token_count,
                 completion_tokens=response_obj.usage_metadata.candidates_token_count,
@@ -484,7 +479,7 @@ async def async_completion(
             """
             Vertex AI Model Garden
             """
-            from google.cloud import aiplatform  # type: ignore
+            from google.cloud import aiplatform
 
             if vertex_project is None or vertex_location is None:
                 raise ValueError("Vertex project and location are required for custom endpoint")
@@ -531,18 +526,14 @@ async def async_completion(
 
         ## RESPONSE OBJECT
         if isinstance(completion_response, litellm.Message):
-            model_response.choices[0].message = completion_response  # type: ignore
+            model_response.choices[0].message = completion_response
         elif len(str(completion_response)) > 0:
-            model_response.choices[0].message.content = str(  # type: ignore
-                completion_response
-            )
+            model_response.choices[0].message.content = str(completion_response)
         model_response.created = int(time.time())
         model_response.model = model
         ## CALCULATING USAGE
         if model in litellm.vertex_language_models and response_obj is not None:
-            model_response.choices[0].finish_reason = map_finish_reason(  # type: ignore[assignment]
-                response_obj.candidates[0].finish_reason.name
-            )
+            model_response.choices[0].finish_reason = map_finish_reason(response_obj.candidates[0].finish_reason.name)
             usage = Usage(
                 prompt_tokens=response_obj.usage_metadata.prompt_token_count,
                 completion_tokens=response_obj.usage_metadata.candidates_token_count,
@@ -625,7 +616,7 @@ async def async_streaming(
         )
         response = llm_model.predict_streaming_async(prompt, **optional_params)
     elif mode == "custom":
-        from google.cloud import aiplatform  # type: ignore
+        from google.cloud import aiplatform
 
         if vertex_project is None or vertex_location is None:
             raise ValueError("Vertex project and location are required for custom endpoint")

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/llama3/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/llama3/transformation.py
@@ -123,7 +123,7 @@ class VertexAILlama3Config(OpenAIGPTConfig):
 
         ## RESPONSE OBJECT
         try:
-            completion_response: Final = OpenAIChatCompletionResponse(**raw_response.json())  # type: ignore
+            completion_response: Final = OpenAIChatCompletionResponse(**raw_response.json())
         except Exception as e:
             response_headers: Final = getattr(raw_response, "headers", None)
             raise VertexAIError(
@@ -136,7 +136,7 @@ class VertexAILlama3Config(OpenAIGPTConfig):
         model_response.created = completion_response.get("created", 0)
         setattr(model_response, "usage", Usage(**completion_response.get("usage", {})))
 
-        model_response.choices = self._transform_choices(  # type: ignore
+        model_response.choices = self._transform_choices(
             choices=completion_response["choices"],
             json_mode=json_mode,
         )
@@ -187,7 +187,7 @@ class VertexAILlama3StreamingHandler(OpenAIChatCompletionStreamingHandler):
                     ],
                 )
                 # Modify current chunk to be the first chunk with role but no finish_reason
-                result.choices[0].finish_reason = None  # type: ignore[assignment]
+                result.choices[0].finish_reason = None
                 delta.role = "assistant"
                 # Ensure content is empty string for first chunk, not None
                 if delta.content is None:

--- a/litellm/llms/vertex_ai/vertex_ai_partner_models/main.py
+++ b/litellm/llms/vertex_ai/vertex_ai_partner_models/main.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from enum import Enum
 from typing import Final
 
-import httpx  # type: ignore
+import httpx
 
 import litellm
 from litellm import LlmProviders

--- a/litellm/llms/vertex_ai/vertex_embeddings/embedding_handler.py
+++ b/litellm/llms/vertex_ai/vertex_embeddings/embedding_handler.py
@@ -47,7 +47,7 @@ class VertexEmbedding(VertexBase):
         litellm_params: dict | None = None,
     ) -> EmbeddingResponse:
         if aembedding is True:
-            return self.async_embedding(  # type: ignore
+            return self.async_embedding(
                 model=model,
                 input=input,
                 logging_obj=logging_obj,
@@ -105,7 +105,7 @@ class VertexEmbedding(VertexBase):
         if client is None or not isinstance(client, HTTPHandler):
             client = _get_httpx_client(params=_client_params)
         else:
-            client = client  # type: ignore
+            client = client
         ## LOGGING
         logging_obj.pre_call(
             input=vertex_request,
@@ -118,7 +118,7 @@ class VertexEmbedding(VertexBase):
         )
 
         try:
-            response: Final = client.post(url=api_base, headers=headers, json=vertex_request)  # type: ignore
+            response: Final = client.post(url=api_base, headers=headers, json=vertex_request)
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code
@@ -199,7 +199,7 @@ class VertexEmbedding(VertexBase):
         if client is None or not isinstance(client, AsyncHTTPHandler):
             client = get_async_httpx_client(params=_async_client_params, llm_provider=litellm.LlmProviders.VERTEX_AI)
         else:
-            client = client  # type: ignore
+            client = client
         ## LOGGING
         logging_obj.pre_call(
             input=vertex_request,
@@ -212,7 +212,7 @@ class VertexEmbedding(VertexBase):
         )
 
         try:
-            response: Final = await client.post(api_base, headers=headers, json=vertex_request)  # type: ignore
+            response: Final = await client.post(api_base, headers=headers, json=vertex_request)
             response.raise_for_status()
         except httpx.HTTPStatusError as err:
             error_code: Final = err.response.status_code

--- a/litellm/llms/vertex_ai/vertex_embeddings/transformation.py
+++ b/litellm/llms/vertex_ai/vertex_embeddings/transformation.py
@@ -185,7 +185,7 @@ class VertexAITextEmbeddingConfig(BaseModel):
         vertex_request["parameters"] = TextEmbeddingFineTunedParameters(**optional_params)
         # Remove 'shared_session' from parameters if present
         if vertex_request["parameters"] is not None and "shared_session" in vertex_request["parameters"]:
-            del vertex_request["parameters"]["shared_session"]  # type: ignore[typeddict-item]
+            del vertex_request["parameters"]["shared_session"]
 
         return vertex_request
 

--- a/litellm/llms/vertex_ai/vertex_gemma_models/main.py
+++ b/litellm/llms/vertex_ai/vertex_gemma_models/main.py
@@ -22,7 +22,7 @@ https://{ENDPOINT_NUMBER}.{location}-{REGION_NUMBER}.prediction.vertexai.goog/v1
 from collections.abc import Callable
 from typing import Final
 
-import httpx  # type: ignore
+import httpx
 
 from litellm.utils import ModelResponse
 

--- a/litellm/llms/vertex_ai/vertex_llm_base.py
+++ b/litellm/llms/vertex_ai/vertex_llm_base.py
@@ -342,7 +342,7 @@ class VertexBase:
     def refresh_auth(self, credentials: Any) -> None:
         try:
             from google.auth.transport.requests import (
-                Request,  # type: ignore[import-untyped]
+                Request,
             )
         except ImportError:
             raise ImportError(GOOGLE_IMPORT_ERROR_MESSAGE)
@@ -643,7 +643,7 @@ class VertexBase:
                         "Missing Gemini API key. Set the GEMINI_API_KEY or GOOGLE_API_KEY environment variable."
                     )
                 if gemini_api_key is not None:
-                    auth_header = {"x-goog-api-key": gemini_api_key}  # type: ignore[assignment]
+                    auth_header = {"x-goog-api-key": gemini_api_key}
             else:
                 # For Vertex AI
                 if use_psc_endpoint_format:
@@ -707,7 +707,7 @@ class VertexBase:
                 model=model,
                 stream=stream,
             )
-            auth_header = {"x-goog-api-key": gemini_api_key}  # type: ignore[assignment]
+            auth_header = {"x-goog-api-key": gemini_api_key}
         else:
             vertex_location = self.get_vertex_region(
                 vertex_region=vertex_location,

--- a/litellm/llms/vertex_ai/vertex_model_garden/main.py
+++ b/litellm/llms/vertex_ai/vertex_model_garden/main.py
@@ -19,7 +19,7 @@ Vertex Documentation for using the OpenAI /chat/completions endpoint: https://gi
 from collections.abc import Callable
 from typing import Final
 
-import httpx  # type: ignore
+import httpx
 
 from litellm.llms.vertex_ai.common_utils import get_vertex_base_url
 from litellm.utils import ModelResponse

--- a/litellm/llms/vllm/completion/handler.py
+++ b/litellm/llms/vllm/completion/handler.py
@@ -1,4 +1,4 @@
-import time  # type: ignore
+import time
 from collections.abc import Callable
 from typing import Final
 
@@ -26,7 +26,7 @@ class VLLMError(Exception):
 def validate_environment(model: str):
     global llm
     try:
-        from vllm import LLM, SamplingParams  # type: ignore
+        from vllm import LLM, SamplingParams
 
         if llm is None:
             llm = LLM(model=model)
@@ -90,7 +90,7 @@ def completion(
         )
         print_verbose(f"raw model_response: {outputs}")
         ## RESPONSE OBJECT
-        model_response.choices[0].message.content = outputs[0].outputs[0].text  # type: ignore
+        model_response.choices[0].message.content = outputs[0].outputs[0].text
 
         ## CALCULATING USAGE
         prompt_tokens: Final = len(outputs[0].prompt_token_ids)
@@ -165,7 +165,7 @@ def batch_completions(model: str, messages: list, optional_params=None, custom_p
     for output in outputs:
         model_response = ModelResponse()
         ## RESPONSE OBJECT
-        model_response.choices[0].message.content = output.outputs[0].text  # type: ignore
+        model_response.choices[0].message.content = output.outputs[0].text
 
         ## CALCULATING USAGE
         prompt_tokens = len(output.prompt_token_ids)

--- a/litellm/llms/voyage/rerank/transformation.py
+++ b/litellm/llms/voyage/rerank/transformation.py
@@ -127,7 +127,7 @@ class VoyageRerankConfig(BaseRerankConfig):
 
         return RerankResponse(
             id=_json_response.get("id", f"voyage-rerank-{model}"),
-            results=transformed_results,  # type: ignore
+            results=transformed_results,
             meta=rerank_meta,
         )
 

--- a/litellm/llms/watsonx/audio_transcription/transformation.py
+++ b/litellm/llms/watsonx/audio_transcription/transformation.py
@@ -112,7 +112,7 @@ class IBMWatsonXAudioTranscriptionConfig(IBMWatsonXMixin, OpenAIWhisperAudioTran
         supported_params: Final = self.get_supported_openai_params(model)
         for key, value in optional_params.items():
             if key in supported_params and value is not None:
-                form_data[key] = value  # type: ignore
+                form_data[key] = value
 
         # Prepare files dict with the audio file
         files: Final = {

--- a/litellm/llms/watsonx/chat/transformation.py
+++ b/litellm/llms/watsonx/chat/transformation.py
@@ -74,7 +74,7 @@ class IBMWatsonXChatConfig(IBMWatsonXMixin, OpenAIGPTConfig):
     def _get_openai_compatible_provider_info(
         self, api_base: str | None, api_key: str | None
     ) -> tuple[str | None, str | None]:
-        api_base = api_base or get_secret_str("HOSTED_VLLM_API_BASE")  # type: ignore
+        api_base = api_base or get_secret_str("HOSTED_VLLM_API_BASE")
         dynamic_api_key = api_key or get_secret_str("HOSTED_VLLM_API_KEY") or ""  # vllm does not require an api key
         return api_base, dynamic_api_key
 

--- a/litellm/llms/watsonx/common_utils.py
+++ b/litellm/llms/watsonx/common_utils.py
@@ -30,7 +30,7 @@ def get_watsonx_iam_url():
 
 
 def generate_iam_token(api_key=None, **params) -> str:
-    result: str | None = iam_token_cache.get_cache(api_key)  # type: ignore
+    result: str | None = iam_token_cache.get_cache(api_key)
 
     if result is None:
         headers: Final = {}
@@ -149,7 +149,7 @@ async def _aconvert_watsonx_messages_core(
         if result:
             return result
         # Fallback to default
-        return ptf.prompt_factory(model=model, messages=messages, custom_llm_provider="watsonx")  # type: ignore
+        return ptf.prompt_factory(model=model, messages=messages, custom_llm_provider="watsonx")
 
 
 def _convert_watsonx_messages_core(
@@ -181,7 +181,7 @@ def _convert_watsonx_messages_core(
         if result:
             return result
         # Fallback to default
-        return ptf.prompt_factory(model=model, messages=messages, custom_llm_provider="watsonx")  # type: ignore
+        return ptf.prompt_factory(model=model, messages=messages, custom_llm_provider="watsonx")
 
 
 async def aconvert_watsonx_messages_to_prompt(

--- a/litellm/llms/watsonx/completion/transformation.py
+++ b/litellm/llms/watsonx/completion/transformation.py
@@ -301,7 +301,7 @@ class IBMWatsonXAIConfig(IBMWatsonXMixin, BaseConfig):
         generated_text: Final = json_resp["results"][0]["generated_text"]
         prompt_tokens: Final = json_resp["results"][0]["input_token_count"]
         completion_tokens: Final = json_resp["results"][0]["generated_token_count"]
-        model_response.choices[0].message.content = generated_text  # type: ignore
+        model_response.choices[0].message.content = generated_text
         model_response.choices[0].finish_reason = map_finish_reason(json_resp["results"][0]["stop_reason"])
         if json_resp.get("created_at"):
             try:

--- a/litellm/llms/watsonx/rerank/transformation.py
+++ b/litellm/llms/watsonx/rerank/transformation.py
@@ -54,7 +54,7 @@ class IBMWatsonXRerankConfig(IBMWatsonXMixin, BaseRerankConfig):
             "max_tokens_per_doc",
         ]
 
-    def validate_environment(  # type: ignore[override]
+    def validate_environment(
         self,
         headers: dict,
         model: str,
@@ -199,6 +199,6 @@ class IBMWatsonXRerankConfig(IBMWatsonXMixin, BaseRerankConfig):
 
         return RerankResponse(
             id=response_id,
-            results=transformed_results,  # type: ignore
+            results=transformed_results,
             meta=rerank_meta,
         )

--- a/litellm/llms/xai/chat/transformation.py
+++ b/litellm/llms/xai/chat/transformation.py
@@ -36,7 +36,7 @@ class XAIChatConfig(OpenAIGPTConfig):
     def _get_openai_compatible_provider_info(
         self, api_base: str | None, api_key: str | None
     ) -> tuple[str | None, str | None]:
-        api_base = api_base or get_secret_str("XAI_API_BASE") or XAI_API_BASE  # type: ignore
+        api_base = api_base or get_secret_str("XAI_API_BASE") or XAI_API_BASE
         dynamic_api_key: Final = XAIModelInfo.get_api_key(api_key)
         return api_base, dynamic_api_key
 

--- a/litellm/main.py
+++ b/litellm/main.py
@@ -638,7 +638,7 @@ async def acompletion(
         elif asyncio.iscoroutine(init_response):
             response = await init_response
         else:
-            response = init_response  # type: ignore
+            response = init_response
 
         if (
             custom_llm_provider == "text-completion-openai"
@@ -724,28 +724,28 @@ def _handle_mock_potential_exceptions(
         if isinstance(mock_response, openai.APIError):
             raise mock_response
         raise litellm.MockException(
-            status_code=getattr(mock_response, "status_code", 500),  # type: ignore
+            status_code=getattr(mock_response, "status_code", 500),
             message=getattr(mock_response, "text", str(mock_response)),
-            llm_provider=getattr(mock_response, "llm_provider", custom_llm_provider or "openai"),  # type: ignore
-            model=model,  # type: ignore
+            llm_provider=getattr(mock_response, "llm_provider", custom_llm_provider or "openai"),
+            model=model,
             request=httpx.Request(method="POST", url="https://api.openai.com/v1/"),
         )
     elif isinstance(mock_response, str) and mock_response == "litellm.RateLimitError":
         raise litellm.RateLimitError(
             message="this is a mock rate limit error",
-            llm_provider=getattr(mock_response, "llm_provider", custom_llm_provider or "openai"),  # type: ignore
+            llm_provider=getattr(mock_response, "llm_provider", custom_llm_provider or "openai"),
             model=model,
         )
     elif isinstance(mock_response, str) and mock_response == "litellm.ContextWindowExceededError":
         raise litellm.ContextWindowExceededError(
             message="this is a mock context window exceeded error",
-            llm_provider=getattr(mock_response, "llm_provider", custom_llm_provider or "openai"),  # type: ignore
+            llm_provider=getattr(mock_response, "llm_provider", custom_llm_provider or "openai"),
             model=model,
         )
     elif isinstance(mock_response, str) and mock_response == "litellm.InternalServerError":
         raise litellm.InternalServerError(
             message="this is a mock internal server error",
-            llm_provider=getattr(mock_response, "llm_provider", custom_llm_provider or "openai"),  # type: ignore
+            llm_provider=getattr(mock_response, "llm_provider", custom_llm_provider or "openai"),
             model=model,
         )
     elif isinstance(mock_response, str) and mock_response.startswith("Exception: content_filter_policy"):
@@ -753,7 +753,7 @@ def _handle_mock_potential_exceptions(
             status_code=400,
             message=mock_response,
             llm_provider="azure",
-            model=model,  # type: ignore
+            model=model,
             request=httpx.Request(method="POST", url="https://api.openai.com/v1/"),
         )
 
@@ -882,7 +882,7 @@ def mock_completion(
             if not stream:
                 return mock_response
             # convert to ModelResponseStream
-            mock_response = convert_model_response_to_streaming(mock_response)  # type: ignore
+            mock_response = convert_model_response_to_streaming(mock_response)
 
         model_response: ModelResponse | ModelResponseStream = ModelResponse()
 
@@ -912,7 +912,7 @@ def mock_completion(
         mock_response = cast(str, mock_response)
 
         if n is None:
-            model_response.choices[0].message.content = mock_response  # type: ignore
+            model_response.choices[0].message.content = mock_response
         else:
             _all_choices: Final = []
             for i in range(n):
@@ -921,12 +921,12 @@ def mock_completion(
                     message=litellm.utils.Message(content=mock_response, role="assistant"),
                 )
                 _all_choices.append(_choice)
-            model_response.choices = _all_choices  # type: ignore
+            model_response.choices = _all_choices
         model_response.created = int(time.time())
         model_response.model = model
 
         if mock_tool_calls:
-            model_response.choices[0].message.tool_calls = [  # type: ignore
+            model_response.choices[0].message.tool_calls = [
                 ChatCompletionMessageToolCall(**tool_call) for tool_call in mock_tool_calls
             ]
 
@@ -1265,7 +1265,7 @@ def _complete_azure(ctx: _CompletionDispatchContext) -> _CompletionDispatchResul
             logger_fn=logger_fn,
             logging_obj=logging,
             acompletion=acompletion,
-            timeout=timeout,  # type: ignore
+            timeout=timeout,
             client=client,  # pass AsyncAzureOpenAI, AzureOpenAI client
             custom_llm_provider=custom_llm_provider,
         )
@@ -1297,7 +1297,7 @@ def _complete_azure(ctx: _CompletionDispatchContext) -> _CompletionDispatchResul
             logger_fn=logger_fn,
             logging_obj=logging,
             acompletion=acompletion,
-            timeout=timeout,  # type: ignore
+            timeout=timeout,
             client=client,  # pass AsyncAzureOpenAI, AzureOpenAI client
         )
 
@@ -1441,7 +1441,7 @@ def _complete_deepseek(ctx: _CompletionDispatchContext) -> _CompletionDispatchRe
             optional_params=optional_params,
             litellm_params=litellm_params,
             shared_session=shared_session,
-            timeout=timeout,  # type: ignore
+            timeout=timeout,
             client=client,
             custom_llm_provider=custom_llm_provider,
             encoding=_get_encoding(),
@@ -1587,7 +1587,7 @@ def _complete_azure_ai(ctx: _CompletionDispatchContext) -> _CompletionDispatchRe
                 optional_params=optional_params,
                 litellm_params=litellm_params,
                 shared_session=shared_session,
-                timeout=timeout,  # type: ignore
+                timeout=timeout,
                 client=client,  # pass AsyncOpenAI, OpenAI client
                 custom_llm_provider=custom_llm_provider,
                 encoding=_get_encoding(),
@@ -1677,7 +1677,7 @@ def _complete_text_completion_openai(
         optional_params=optional_params,
         litellm_params=litellm_params,
         logger_fn=logger_fn,
-        timeout=timeout,  # type: ignore
+        timeout=timeout,
     )
 
     if optional_params.get("stream", False) is False and acompletion is False and text_completion is False:
@@ -1730,7 +1730,7 @@ def _complete_fireworks_ai(
             optional_params=optional_params,
             litellm_params=litellm_params,
             shared_session=shared_session,
-            timeout=timeout,  # type: ignore
+            timeout=timeout,
             client=client,
             custom_llm_provider=custom_llm_provider,
             encoding=_get_encoding(),
@@ -1881,7 +1881,7 @@ def _complete_xai(ctx: _CompletionDispatchContext) -> _CompletionDispatchResult:
             optional_params=optional_params,
             litellm_params=litellm_params,
             shared_session=shared_session,
-            timeout=timeout,  # type: ignore
+            timeout=timeout,
             client=client,
             custom_llm_provider=custom_llm_provider,
             encoding=_get_encoding(),
@@ -2169,7 +2169,7 @@ def _complete_sap(ctx: _CompletionDispatchContext) -> _CompletionDispatchResult:
         logging_obj=logging,
         optional_params=optional_params,
         litellm_params=litellm_params,
-        timeout=timeout,  # type: ignore
+        timeout=timeout,
         shared_session=shared_session,
         client=client,
         custom_llm_provider=custom_llm_provider,
@@ -2488,7 +2488,7 @@ def _complete_custom_openai(
                 optional_params=optional_params,
                 litellm_params=litellm_params,
                 logger_fn=logger_fn,
-                timeout=timeout,  # type: ignore
+                timeout=timeout,
                 custom_prompt_dict=custom_prompt_dict,
                 client=client,  # pass AsyncOpenAI, OpenAI client
                 organization=organization,
@@ -2585,7 +2585,7 @@ def _complete_replicate(ctx: _CompletionDispatchContext) -> _CompletionDispatchR
 
     custom_prompt_dict = custom_prompt_dict or litellm.custom_prompt_dict
 
-    model_response = replicate_chat_completion(  # type: ignore
+    model_response = replicate_chat_completion(
         model=model,
         messages=messages,
         api_base=api_base,
@@ -3002,7 +3002,7 @@ def _complete_huggingface(ctx: _CompletionDispatchContext) -> _CompletionDispatc
         logging_obj=logging,
         optional_params=optional_params,
         litellm_params=litellm_params,
-        timeout=timeout,  # type: ignore
+        timeout=timeout,
         client=client,
         custom_llm_provider=custom_llm_provider,
         encoding=_get_encoding(),
@@ -3037,7 +3037,7 @@ def _complete_oci(ctx: _CompletionDispatchContext) -> _CompletionDispatchResult:
         logging_obj=logging,
         optional_params=optional_params,
         litellm_params=litellm_params,
-        timeout=timeout,  # type: ignore
+        timeout=timeout,
         client=client,
         custom_llm_provider=custom_llm_provider,
         encoding=_get_encoding(),
@@ -3101,7 +3101,7 @@ def _complete_oobabooga(ctx: _CompletionDispatchContext) -> _CompletionDispatchR
         model=model,
         messages=messages,
         model_response=model_response,
-        api_base=api_base,  # type: ignore
+        api_base=api_base,
         print_verbose=print_verbose,
         optional_params=optional_params,
         litellm_params=litellm_params,
@@ -3221,7 +3221,7 @@ def _complete_datarobot(ctx: _CompletionDispatchContext) -> _CompletionDispatchR
         logging_obj=logging,
         optional_params=optional_params,
         litellm_params=litellm_params,
-        timeout=timeout,  # type: ignore
+        timeout=timeout,
         client=client,
         custom_llm_provider=custom_llm_provider,
         encoding=_get_encoding(),
@@ -3430,13 +3430,13 @@ def _complete_vertex_ai_beta(
 
     api_base = api_base or litellm.api_base or get_secret("GEMINI_API_BASE")
     new_params: Final = safe_deep_copy(optional_params or {})
-    return vertex_chat_completion.completion(  # type: ignore
+    return vertex_chat_completion.completion(
         model=model,
         messages=messages,
         model_response=model_response,
         print_verbose=print_verbose,
         optional_params=new_params,
-        litellm_params=litellm_params,  # type: ignore
+        litellm_params=litellm_params,
         logger_fn=logger_fn,
         encoding=_get_encoding(),
         vertex_location=vertex_ai_location,
@@ -3446,7 +3446,7 @@ def _complete_vertex_ai_beta(
         logging_obj=logging,
         acompletion=acompletion,
         timeout=timeout,
-        custom_llm_provider=custom_llm_provider,  # type: ignore
+        custom_llm_provider=custom_llm_provider,
         client=client,
         api_base=api_base,
         extra_headers=headers,
@@ -3500,7 +3500,7 @@ def _complete_vertex_ai(ctx: _CompletionDispatchContext) -> _CompletionDispatchR
             model_response=model_response,
             print_verbose=print_verbose,
             optional_params=new_params,
-            litellm_params=litellm_params,  # type: ignore
+            litellm_params=litellm_params,
             logger_fn=logger_fn,
             encoding=_get_encoding(),
             api_base=api_base,
@@ -3515,13 +3515,13 @@ def _complete_vertex_ai(ctx: _CompletionDispatchContext) -> _CompletionDispatchR
             client=client,
         )
     elif model_route == VertexAIModelRoute.GEMINI:
-        model_response = vertex_chat_completion.completion(  # type: ignore
+        model_response = vertex_chat_completion.completion(
             model=model,
             messages=messages,
             model_response=model_response,
             print_verbose=print_verbose,
             optional_params=new_params,
-            litellm_params=litellm_params,  # type: ignore
+            litellm_params=litellm_params,
             logger_fn=logger_fn,
             encoding=_get_encoding(),
             vertex_location=vertex_ai_location,
@@ -3531,7 +3531,7 @@ def _complete_vertex_ai(ctx: _CompletionDispatchContext) -> _CompletionDispatchR
             logging_obj=logging,
             acompletion=acompletion,
             timeout=timeout,
-            custom_llm_provider=custom_llm_provider,  # type: ignore
+            custom_llm_provider=custom_llm_provider,
             client=client,
             api_base=api_base,
             extra_headers=headers,
@@ -3544,7 +3544,7 @@ def _complete_vertex_ai(ctx: _CompletionDispatchContext) -> _CompletionDispatchR
             model_response=model_response,
             print_verbose=print_verbose,
             optional_params=new_params,
-            litellm_params=litellm_params,  # type: ignore
+            litellm_params=litellm_params,
             logger_fn=logger_fn,
             encoding=_get_encoding(),
             api_base=api_base,
@@ -3566,7 +3566,7 @@ def _complete_vertex_ai(ctx: _CompletionDispatchContext) -> _CompletionDispatchR
             model_response=model_response,
             print_verbose=print_verbose,
             optional_params=new_params,
-            litellm_params=litellm_params,  # type: ignore
+            litellm_params=litellm_params,
             logger_fn=logger_fn,
             encoding=_get_encoding(),
             api_base=api_base,
@@ -3599,7 +3599,7 @@ def _complete_vertex_ai(ctx: _CompletionDispatchContext) -> _CompletionDispatchR
             messages=messages,
             model_response=model_response,
             optional_params=new_params,
-            litellm_params=litellm_params,  # type: ignore
+            litellm_params=litellm_params,
             encoding=_get_encoding(),
             api_key=None,
             api_base=api_base,
@@ -3725,7 +3725,7 @@ def _complete_text_completion_codestral(
 
     text_completion_model_response: Final = litellm.TextCompletionResponse(stream=stream)
 
-    _model_response: Final = codestral_text_completions.completion(  # type: ignore
+    _model_response: Final = codestral_text_completions.completion(
         model=model,
         messages=messages,
         model_response=text_completion_model_response,
@@ -3784,7 +3784,7 @@ def _complete_text_completion_inception(
         messages=messages,
         model_response=model_response,
         print_verbose=print_verbose,
-        api_key=api_key,  # type: ignore[arg-type]
+        api_key=api_key,
         custom_llm_provider="text-completion-inception",
         api_base=api_base,
         acompletion=acompletion,
@@ -3793,7 +3793,7 @@ def _complete_text_completion_inception(
         optional_params=optional_params,
         litellm_params=litellm_params,
         logger_fn=logger_fn,
-        timeout=timeout,  # type: ignore
+        timeout=timeout,
     )
 
     if optional_params.get("stream", False) is False and acompletion is False and text_completion is False:
@@ -3948,7 +3948,7 @@ def _complete_bedrock(ctx: _CompletionDispatchContext) -> _CompletionDispatchRes
             custom_prompt_dict=custom_prompt_dict,
             model_response=model_response,
             optional_params=optional_params,
-            litellm_params=litellm_params,  # type: ignore
+            litellm_params=litellm_params,
             logger_fn=logger_fn,
             encoding=_get_encoding(),
             logging_obj=logging,
@@ -4029,7 +4029,7 @@ def _complete_watsonx(ctx: _CompletionDispatchContext) -> _CompletionDispatchRes
         optional_params=optional_params,
         litellm_params=litellm_params,
         logger_fn=logger_fn,
-        timeout=timeout,  # type: ignore
+        timeout=timeout,
         custom_prompt_dict=custom_prompt_dict,
         client=client,  # pass AsyncOpenAI, OpenAI client
         encoding=_get_encoding(),
@@ -4381,7 +4381,7 @@ def _complete_snowflake(ctx: _CompletionDispatchContext) -> _CompletionDispatchR
             optional_params=optional_params,
             litellm_params=litellm_params,
             shared_session=shared_session,
-            timeout=timeout,  # type: ignore
+            timeout=timeout,
             client=client,
             custom_llm_provider=custom_llm_provider,
             encoding=_get_encoding(),
@@ -4466,7 +4466,7 @@ def _complete_gdc(ctx: _CompletionDispatchContext) -> _CompletionDispatchResult:
         logging_obj=logging,
         optional_params=optional_params,
         litellm_params=litellm_params,
-        timeout=timeout,  # type: ignore
+        timeout=timeout,
         client=client,
         custom_llm_provider=custom_llm_provider,
         encoding=_get_encoding(),
@@ -4504,7 +4504,7 @@ def _complete_bytez(ctx: _CompletionDispatchContext) -> _CompletionDispatchResul
         logging_obj=logging,
         optional_params=optional_params,
         litellm_params=litellm_params,
-        timeout=timeout,  # type: ignore
+        timeout=timeout,
         client=client,
         custom_llm_provider=custom_llm_provider,
         encoding=_get_encoding(),
@@ -4544,7 +4544,7 @@ def _complete_lemonade(ctx: _CompletionDispatchContext) -> _CompletionDispatchRe
         logging_obj=logging,
         optional_params=optional_params,
         litellm_params=litellm_params,
-        timeout=timeout,  # type: ignore
+        timeout=timeout,
         client=client,
         custom_llm_provider=custom_llm_provider,
         encoding=_get_encoding(),
@@ -4591,7 +4591,7 @@ def _complete_ovhcloud(ctx: _CompletionDispatchContext) -> _CompletionDispatchRe
         logging_obj=logging,
         optional_params=optional_params,
         litellm_params=litellm_params,
-        timeout=timeout,  # type: ignore
+        timeout=timeout,
         client=client,
         custom_llm_provider=custom_llm_provider,
         encoding=_get_encoding(),
@@ -4634,7 +4634,7 @@ def _complete_custom(ctx: _CompletionDispatchContext) -> _CompletionDispatchResu
     )
 
     """
-    prompt: Final = " ".join([message["content"] for message in messages])  # type: ignore
+    prompt: Final = " ".join([message["content"] for message in messages])
     resp: Final = litellm.module_level_client.post(
         url,
         headers=headers,
@@ -4666,7 +4666,7 @@ def _complete_custom(ctx: _CompletionDispatchContext) -> _CompletionDispatchResu
     """
     string_response: Final = response_json["data"][0]["output"][0]
     ## RESPONSE OBJECT
-    model_response.choices[0].message.content = string_response  # type: ignore
+    model_response.choices[0].message.content = string_response
     model_response.created = int(time.time())
     model_response.model = model
     return model_response
@@ -4719,7 +4719,7 @@ def _complete_custom_providers(
         optional_params=optional_params,
         litellm_params=litellm_params,
         logger_fn=logger_fn,
-        timeout=timeout,  # type: ignore
+        timeout=timeout,
         custom_prompt_dict=custom_prompt_dict,
         client=client,  # pass AsyncOpenAI, OpenAI client
         encoding=_get_encoding(),
@@ -4835,7 +4835,7 @@ def _complete_langflow(ctx: _CompletionDispatchContext) -> _CompletionDispatchRe
 
 @tracer.wrap()
 @client
-def completion(  # type: ignore
+def completion(
     model: str,
     # Optional OpenAI params: see https://platform.openai.com/docs/api-reference/chat/create
     messages: list = [],
@@ -5221,7 +5221,7 @@ def completion(  # type: ignore
                 model_info=model_info,
             )
         ### BUILD CUSTOM PROMPT TEMPLATE -- IF GIVEN ###
-        custom_prompt_dict = {}  # type: ignore
+        custom_prompt_dict = {}
         if initial_prompt_value or roles or final_prompt_value or bos_token or eos_token:
             custom_prompt_dict = {model: {}}
             if initial_prompt_value:
@@ -5458,7 +5458,7 @@ def completion(  # type: ignore
                 logging_obj=logging,
                 optional_params=optional_params,
                 litellm_params=litellm_params,
-                timeout=timeout,  # type: ignore
+                timeout=timeout,
                 client=client,  # pass AsyncOpenAI, OpenAI client
                 custom_llm_provider=custom_llm_provider,
                 encoding=_get_encoding(),
@@ -5733,7 +5733,7 @@ def completion_with_retries(*args, **kwargs):
     kwargs["num_retries"] = 0
     retry_strategy: Final[Literal["exponential_backoff_retry", "constant_retry"]] = kwargs.pop(
         "retry_strategy", "constant_retry"
-    )  # type: ignore
+    )
     original_function: Final = kwargs.pop("original_function", completion)
     if retry_strategy == "exponential_backoff_retry":
         retryer = tenacity.Retrying(
@@ -5789,7 +5789,7 @@ def responses_with_retries(*args, **kwargs):
     kwargs["num_retries"] = 0
     retry_strategy: Final[Literal["exponential_backoff_retry", "constant_retry"]] = kwargs.pop(
         "retry_strategy", "constant_retry"
-    )  # type: ignore
+    )
     original_function: Final = kwargs.pop("original_function", responses)
     if retry_strategy == "exponential_backoff_retry":
         retryer = tenacity.Retrying(
@@ -5870,7 +5870,7 @@ async def aembedding(*args, **kwargs) -> EmbeddingResponse:
         elif isinstance(init_response, EmbeddingResponse):  ## CACHING SCENARIO
             response = init_response
         elif asyncio.iscoroutine(init_response):
-            response = await init_response  # type: ignore
+            response = await init_response
         if response is not None and isinstance(response, EmbeddingResponse) and hasattr(response, "_hidden_params"):
             response._hidden_params["custom_llm_provider"] = custom_llm_provider
 
@@ -5993,8 +5993,8 @@ def embedding(
     client: Final = kwargs.pop("client", None)
     shared_session: Final = kwargs.get("shared_session", None)
     max_retries: Final = kwargs.get("max_retries", None)
-    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
-    mock_response: Final[list[float] | None] = kwargs.get("mock_response", None)  # type: ignore
+    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
+    mock_response: Final[list[float] | None] = kwargs.get("mock_response", None)
     azure_ad_token_provider: Final = kwargs.get("azure_ad_token_provider", None)
     aembedding: Final[bool | None] = kwargs.get("aembedding", None)
     extra_headers: Final = kwargs.get("extra_headers", None)
@@ -6071,7 +6071,7 @@ def embedding(
 
     litellm_params_dict: Final = get_litellm_params(**kwargs)
 
-    logging: Final[LiteLLMLoggingObj] = litellm_logging_obj  # type: ignore
+    logging: Final[LiteLLMLoggingObj] = litellm_logging_obj
     logging.update_environment_variables(
         model=model,
         user=user,
@@ -6195,10 +6195,10 @@ def embedding(
                 shared_session=shared_session,
             )
         elif custom_llm_provider == "databricks":
-            api_base = api_base or litellm.api_base or get_secret("DATABRICKS_API_BASE")  # type: ignore
+            api_base = api_base or litellm.api_base or get_secret("DATABRICKS_API_BASE")
 
             # set API KEY
-            api_key = api_key or litellm.api_key or litellm.databricks_key or get_secret("DATABRICKS_API_KEY")  # type: ignore
+            api_key = api_key or litellm.api_key or litellm.databricks_key or get_secret("DATABRICKS_API_KEY")
 
             ## EMBEDDING CALL
             response = databricks_embedding.embedding(
@@ -6382,11 +6382,11 @@ def embedding(
                 headers=headers,
             )
         elif custom_llm_provider == "huggingface":
-            api_key = api_key or litellm.huggingface_key or get_secret("HUGGINGFACE_API_KEY") or litellm.api_key  # type: ignore
+            api_key = api_key or litellm.huggingface_key or get_secret("HUGGINGFACE_API_KEY") or litellm.api_key
             response = huggingface_embed.embedding(
                 model=model,
                 input=input,
-                encoding=_get_encoding(),  # type: ignore
+                encoding=_get_encoding(),
                 api_key=api_key,
                 api_base=api_base,
                 logging_obj=logging,
@@ -6440,7 +6440,7 @@ def embedding(
 
             api_base = api_base or litellm.api_base or get_secret_str("GEMINI_API_BASE")
 
-            response = google_batch_embeddings.batch_embeddings(  # type: ignore
+            response = google_batch_embeddings.batch_embeddings(
                 model=model,
                 input=input,
                 encoding=_get_encoding(),
@@ -6492,7 +6492,7 @@ def embedding(
                 uses_embed_content = False
 
             if uses_embed_content:
-                response = google_batch_embeddings.batch_embeddings(  # type: ignore
+                response = google_batch_embeddings.batch_embeddings(
                     model=model,
                     input=input,
                     encoding=_get_encoding(),
@@ -6564,18 +6564,18 @@ def embedding(
                 api_key=api_key,
             )
         elif custom_llm_provider == "ollama":
-            api_base = litellm.api_base or api_base or get_secret_str("OLLAMA_API_BASE") or "http://localhost:11434"  # type: ignore
+            api_base = litellm.api_base or api_base or get_secret_str("OLLAMA_API_BASE") or "http://localhost:11434"
 
             if isinstance(input, str):
                 input = [input]
             if not all(isinstance(item, str) for item in input):
                 raise litellm.BadRequestError(
                     message=f"Invalid input for ollama embeddings. input={input}",
-                    model=model,  # type: ignore
-                    llm_provider="ollama",  # type: ignore
+                    model=model,
+                    llm_provider="ollama",
                 )
             ollama_embeddings_fn: Final = ollama.ollama_aembeddings if aembedding is True else ollama.ollama_embeddings
-            response = ollama_embeddings_fn(  # type: ignore
+            response = ollama_embeddings_fn(
                 api_base=api_base,
                 model=model,
                 prompts=input,
@@ -7016,7 +7016,7 @@ async def atext_completion(*args, **kwargs) -> TextCompletionResponse | TextComp
         elif asyncio.iscoroutine(init_response):
             response = await init_response
         else:
-            response = init_response  # type: ignore
+            response = init_response
 
         if (
             kwargs.get("stream", False) is True
@@ -7169,7 +7169,7 @@ def text_completion(
 
     # get custom_llm_provider
     _model, custom_llm_provider, dynamic_api_key, api_base = get_llm_provider(
-        model=model,  # type: ignore
+        model=model,
         custom_llm_provider=custom_llm_provider,
         api_base=api_base,
     )
@@ -7193,7 +7193,7 @@ def text_completion(
                 def process_prompt(i, individual_prompt):
                     decoded_prompt: Final = tokenizer.decode(individual_prompt)
                     all_params: Final = {**kwargs, **optional_params}
-                    response: Final[TextCompletionResponse] = text_completion(  # type: ignore
+                    response: Final[TextCompletionResponse] = text_completion(
                         model=model,
                         prompt=decoded_prompt,
                         num_retries=3,  # ensure this does not fail for the batch
@@ -7214,7 +7214,7 @@ def text_completion(
                     ]
                     for i, future in enumerate(concurrent.futures.as_completed(completed_futures)):
                         responses[i] = future.result()
-                    text_completion_response.choices = responses  # type: ignore
+                    text_completion_response.choices = responses
 
                 return text_completion_response
     # else:
@@ -7243,7 +7243,7 @@ def text_completion(
         and (isinstance(prompt[0], list) or isinstance(prompt[0], int))
     ):
         # Support for token IDs as prompt (list of integers or list of lists of integers)
-        messages = [{"role": "user", "content": prompt}]  # type: ignore
+        messages = [{"role": "user", "content": prompt}]
     else:
         raise Exception(
             f"Unmapped prompt format. Your prompt is neither a list of strings nor a string. prompt={prompt}. File an issue - https://github.com/BerriAI/litellm/issues"
@@ -7313,7 +7313,7 @@ async def aadapter_completion(*, adapter_id: str, **kwargs) -> BaseModel | Adapt
 
         new_kwargs: Final = translation_obj.translate_completion_input_params(kwargs=kwargs)
 
-        response: Final[ModelResponse | CustomStreamWrapper] = await acompletion(**new_kwargs)  # type: ignore
+        response: Final[ModelResponse | CustomStreamWrapper] = await acompletion(**new_kwargs)
         translated_response: BaseModel | AdapterCompletionStreamWrapper | None = None
         if isinstance(response, ModelResponse):
             translated_response = translation_obj.translate_completion_output_params(response=response)
@@ -7352,7 +7352,7 @@ def adapter_completion(*, adapter_id: str, **kwargs) -> BaseModel | AdapterCompl
 
     new_kwargs: Final = translation_obj.translate_completion_input_params(kwargs=kwargs)
 
-    response: Final[ModelResponse | CustomStreamWrapper] = completion(**new_kwargs)  # type: ignore
+    response: Final[ModelResponse | CustomStreamWrapper] = completion(**new_kwargs)
     translated_response: BaseModel | AdapterCompletionStreamWrapper | None = None
     if isinstance(response, ModelResponse):
         translated_response = translation_obj.translate_completion_output_params(response=response)
@@ -7425,7 +7425,7 @@ async def amoderation(
     if openai_client is None or not isinstance(openai_client, AsyncOpenAI):
         # call helper to get OpenAI client
         # _get_openai_client maintains in-memory caching logic for OpenAI clients
-        _openai_client: AsyncOpenAI = openai_chat_completions._get_openai_client(  # type: ignore
+        _openai_client: AsyncOpenAI = openai_chat_completions._get_openai_client(
             is_async=True,
             api_key=api_key,
             api_base=optional_params.api_base or _dynamic_api_base,
@@ -7489,7 +7489,7 @@ async def atranscription(*args, **kwargs) -> TranscriptionResponse:
         elif isinstance(init_response, TranscriptionResponse):  ## CACHING SCENARIO
             response = init_response
         elif asyncio.iscoroutine(init_response):
-            response = await init_response  # type: ignore
+            response = await init_response
         else:
             # Call the synchronous function using run_in_executor
             response = await loop.run_in_executor(None, func_with_context)
@@ -7551,7 +7551,7 @@ def transcription(
     model_info: Final = kwargs.get("model_info", None)
     metadata: Final = kwargs.get("metadata", None)
     atranscription: Final = kwargs.pop("atranscription", False)
-    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
     extra_headers: Final = kwargs.get("extra_headers", None)
     shared_session: Final = kwargs.get("shared_session", None)
     kwargs.pop("tags", [])
@@ -7574,7 +7574,7 @@ def transcription(
         custom_llm_provider=custom_llm_provider,
         api_base=api_base,
         api_key=api_key,
-    )  # type: ignore
+    )
 
     api_key = dynamic_api_key if dynamic_api_key is not None else api_key
 
@@ -7649,7 +7649,7 @@ def transcription(
             or get_secret("OPENAI_BASE_URL")
             or get_secret("OPENAI_API_BASE")
             or "https://api.openai.com/v1"
-        )  # type: ignore
+        )
         openai.organization = (
             litellm.organization
             or get_secret("OPENAI_ORGANIZATION")
@@ -7657,7 +7657,7 @@ def transcription(
         )
         # set API KEY
 
-        api_key = api_key or litellm.api_key or litellm.openai_key or get_secret("OPENAI_API_KEY")  # type: ignore
+        api_key = api_key or litellm.api_key or litellm.openai_key or get_secret("OPENAI_API_KEY")
         response = openai_audio_transcriptions.audio_transcriptions(
             model=model,
             audio_file=file,
@@ -7715,7 +7715,7 @@ def transcription(
             api_base=api_base,
             api_key=api_key,
             headers=extra_headers,
-            provider_config=provider_config,  # type: ignore[arg-type]
+            provider_config=provider_config,
         )
     elif custom_llm_provider == "bedrock":
         from litellm.llms.bedrock.audio_transcription import BedrockAudioTranscriptionRustDispatch
@@ -7808,7 +7808,7 @@ async def aspeech(*args, **kwargs) -> HttpxBinaryResponseContent:
         else:
             # Call the synchronous function using run_in_executor
             response = await loop.run_in_executor(None, func_with_context)
-        return response  # type: ignore
+        return response
     except Exception as e:
         custom_llm_provider = custom_llm_provider or "openai"
         raise exception_type(
@@ -7850,14 +7850,14 @@ def speech(
     shared_session: Final = kwargs.get("shared_session", None)
     model, custom_llm_provider, dynamic_api_key, api_base = get_llm_provider(
         model=model, custom_llm_provider=custom_llm_provider, api_base=api_base
-    )  # type: ignore
+    )
     kwargs.pop("tags", [])
 
     optional_params = {}
     if response_format is not None:
         optional_params["response_format"] = response_format
     if speed is not None:
-        optional_params["speed"] = speed  # type: ignore
+        optional_params["speed"] = speed
     if instructions is not None:
         optional_params["instructions"] = instructions
 
@@ -7914,28 +7914,28 @@ def speech(
             or get_secret("OPENAI_BASE_URL")
             or get_secret("OPENAI_API_BASE")
             or "https://api.openai.com/v1"
-        )  # type: ignore
+        )
         # set API KEY
         api_key = (
             api_key
             or litellm.api_key  # for deepinfra/perplexity/anyscale we check in get_llm_provider and pass in the api key from there
             or litellm.openai_key
             or get_secret("OPENAI_API_KEY")
-        )  # type: ignore
+        )
 
         organization = (
             organization
             or litellm.organization
             or get_secret("OPENAI_ORGANIZATION")
             or None  # default - https://github.com/openai/openai-python/blob/284c1799070c723c6a553337134148a7ab088dd8/openai/util.py#L105
-        )  # type: ignore
+        )
 
         project = (
             project
             or litellm.project
             or get_secret("OPENAI_PROJECT")
             or None  # default - https://github.com/openai/openai-python/blob/284c1799070c723c6a553337134148a7ab088dd8/openai/util.py#L105
-        )  # type: ignore
+        )
 
         headers = headers or litellm.headers
 
@@ -7972,7 +7972,7 @@ def speech(
             # Cast to specific Azure config type to access dispatch method
             azure_config: Final = cast(AzureAVATextToSpeechConfig, text_to_speech_provider_config)
 
-            response = azure_config.dispatch_text_to_speech(  # type: ignore
+            response = azure_config.dispatch_text_to_speech(
                 model=model,
                 input=input,
                 voice=voice,
@@ -7995,9 +7995,9 @@ def speech(
                     model=model,
                     llm_provider=custom_llm_provider,
                 )
-            api_base = api_base or litellm.api_base or get_secret("AZURE_API_BASE")  # type: ignore
+            api_base = api_base or litellm.api_base or get_secret("AZURE_API_BASE")
 
-            api_version = api_version or litellm.api_version or get_secret("AZURE_API_VERSION")  # type: ignore
+            api_version = api_version or litellm.api_version or get_secret("AZURE_API_VERSION")
 
             api_key = (
                 api_key
@@ -8005,9 +8005,9 @@ def speech(
                 or litellm.azure_key
                 or get_secret("AZURE_OPENAI_API_KEY")
                 or get_secret("AZURE_API_KEY")
-            )  # type: ignore
+            )
 
-            azure_ad_token: Final[str | None] = optional_params.get("extra_body", {}).pop(  # type: ignore
+            azure_ad_token: Final[str | None] = optional_params.get("extra_body", {}).pop(
                 "azure_ad_token", None
             ) or get_secret("AZURE_AD_TOKEN")
             azure_ad_token_provider: Final = kwargs.get("azure_ad_token_provider", None)
@@ -8162,7 +8162,7 @@ def speech(
         # Cast to specific RunwayML config type to access dispatch method
         runwayml_config: Final = cast(RunwayMLTextToSpeechConfig, text_to_speech_provider_config)
 
-        response = runwayml_config.dispatch_text_to_speech(  # type: ignore
+        response = runwayml_config.dispatch_text_to_speech(
             model=model,
             input=input,
             voice=voice,
@@ -8812,7 +8812,7 @@ async def acount_tokens(
     local_count: Final = litellm.token_counter(
         model=model,
         messages=fallback_messages,
-        tools=tools,  # type: ignore[arg-type]
+        tools=tools,
     )
 
     return TokenCountResponse(

--- a/litellm/models/team.py
+++ b/litellm/models/team.py
@@ -83,7 +83,7 @@ class TeamBase(LiteLLMPydanticObjectBase):
 
 
 class LiteLLM_TeamTable(TeamBase):
-    team_id: str  # type: ignore
+    team_id: str
     spend: float | None = None
     max_parallel_requests: int | None = None
     budget_duration: str | None = None

--- a/litellm/passthrough/main.py
+++ b/litellm/passthrough/main.py
@@ -333,7 +333,7 @@ def llm_passthrough_route(
             )
         else:
             # Sync path - client.client.send returns Response directly
-            response: httpx.Response = client.client.send(request=request, stream=is_streaming_request)  # type: ignore
+            response: httpx.Response = client.client.send(request=request, stream=is_streaming_request)
             response.raise_for_status()
 
             if (
@@ -395,7 +395,7 @@ def _sync_streaming(
     raw_bytes: Final[list[bytes]] = []
     flush_scheduled = False
     try:
-        for chunk in response.iter_bytes():  # type: ignore
+        for chunk in response.iter_bytes():
             raw_bytes.append(chunk)
             yield chunk
     finally:
@@ -435,7 +435,7 @@ async def _async_streaming(
     raw_bytes: Final[list[bytes]] = []
     flush_scheduled = False
     try:
-        async for chunk in iter_response.aiter_bytes():  # type: ignore
+        async for chunk in iter_response.aiter_bytes():
             raw_bytes.append(chunk)
             yield chunk
     except Exception:

--- a/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
+++ b/litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py
@@ -401,7 +401,7 @@ class MCPRequestHandler:
         async def mock_body():
             return b"{}"
 
-        request.body = mock_body  # type: ignore
+        request.body = mock_body
         # Inline import — auth_utils participates in a proxy import cycle.
         from litellm.proxy.auth.auth_utils import (  # noqa: PLC0415
             get_request_route,

--- a/litellm/proxy/_experimental/mcp_server/db.py
+++ b/litellm/proxy/_experimental/mcp_server/db.py
@@ -535,9 +535,9 @@ def decrypt_credentials(
         "aws_session_token",
     ]
     for field in secret_fields:
-        value = credentials.get(field)  # type: ignore[literal-required]
+        value = credentials.get(field)
         if value is not None and isinstance(value, str):
-            credentials[field] = decrypt_value_helper(  # type: ignore[literal-required]
+            credentials[field] = decrypt_value_helper(
                 value=value,
                 key=field,
                 exception_type="debug",
@@ -807,7 +807,7 @@ async def create_mcp_server(
     data_dict["updated_by"] = touched_by
 
     new_mcp_server: Final[LiteLLM_MCPServerTable] = await MCPServerRepository(prisma_client).table.create(
-        data=data_dict  # type: ignore
+        data=data_dict
     )
 
     _decrypt_env_vars_on_returned_row(new_mcp_server)
@@ -932,7 +932,7 @@ async def update_mcp_server(
 
     updated_mcp_server: Final[LiteLLM_MCPServerTable] = await MCPServerRepository(prisma_client).table.update(
         where={"server_id": data.server_id},
-        data=data_dict,  # type: ignore
+        data=data_dict,
     )
 
     _decrypt_env_vars_on_returned_row(updated_mcp_server)

--- a/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
+++ b/litellm/proxy/_experimental/mcp_server/mcp_server_manager.py
@@ -177,7 +177,7 @@ except ImportError:
         is_valid: bool = True
         warnings: list = []
 
-    def validate_tool_name(name: str) -> _ToolNameValidationResult:  # type: ignore[misc]
+    def validate_tool_name(name: str) -> _ToolNameValidationResult:
         return _ToolNameValidationResult()
 
 
@@ -2045,7 +2045,7 @@ class MCPServerManager:
             mcp_oauth_metadata = await self._fetch_issuer_anchored_oauth_metadata(manual_issuer, server_url)
         else:
             mcp_oauth_metadata = await self._descovery_metadata(
-                server_url=server_url,  # type: ignore[arg-type]
+                server_url=server_url,
                 allow_origin_fallback=is_discovery_auth_type,
                 warn_when_no_metadata=warn_on_empty_discovery,
             )
@@ -4614,7 +4614,7 @@ class MCPServerManager:
         try:
             # Use standard pre_call_hook
             modified_data: Final = await proxy_logging_obj.pre_call_hook(
-                user_api_key_dict=user_api_key_auth,  # type: ignore
+                user_api_key_dict=user_api_key_auth,
                 data=synthetic_llm_data,
                 call_type=CallTypes.call_mcp_tool.value,
             )

--- a/litellm/proxy/_experimental/mcp_server/sampling_handler.py
+++ b/litellm/proxy/_experimental/mcp_server/sampling_handler.py
@@ -762,8 +762,8 @@ async def _check_model_access(model: str, user_api_key_auth: "UserAPIKeyAuth | N
             )
         except ImportError:
             _prisma_client = None
-            _user_api_key_cache = None  # type: ignore[assignment]
-            _proxy_logging_obj = None  # type: ignore[assignment]
+            _user_api_key_cache = None
+            _proxy_logging_obj = None
 
         if _team_id and _prisma_client and _user_api_key_cache:
             try:

--- a/litellm/proxy/_experimental/mcp_server/server.py
+++ b/litellm/proxy/_experimental/mcp_server/server.py
@@ -154,14 +154,14 @@ except ImportError as e:
     # When MCP is not available, we set these to None at module level
     # All code using these types is inside `if MCP_AVAILABLE:` blocks
     # so they will never be accessed at runtime
-    BlobResourceContents = None  # type: ignore
-    GetPromptResult = None  # type: ignore
-    ReadResourceContents = None  # type: ignore
-    ReadResourceResult = None  # type: ignore
-    Resource = None  # type: ignore
-    ResourceTemplate = None  # type: ignore
-    Server = None  # type: ignore
-    TextResourceContents = None  # type: ignore
+    BlobResourceContents = None
+    GetPromptResult = None
+    ReadResourceContents = None
+    ReadResourceResult = None
+    Resource = None
+    ResourceTemplate = None
+    Server = None
+    TextResourceContents = None
 
 
 # Global variables to track initialization
@@ -400,7 +400,7 @@ if MCP_AVAILABLE:
     try:
         from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
     except ImportError:
-        StreamableHTTPSessionManager = None  # type: ignore
+        StreamableHTTPSessionManager = None
     from mcp.types import (
         CallToolResult,
         EmbeddedResource,
@@ -514,9 +514,7 @@ if MCP_AVAILABLE:
         name=LITELLM_MCP_SERVER_NAME,
         version=LITELLM_MCP_SERVER_VERSION,
     )
-    server.create_initialization_options = types.MethodType(  # type: ignore[method-assign]
-        _gateway_create_initialization_options, server
-    )
+    server.create_initialization_options = types.MethodType(_gateway_create_initialization_options, server)
     sse: Final[SseServerTransport] = SseServerTransport("/mcp/sse/messages")
 
     # Create session managers
@@ -2810,7 +2808,7 @@ if MCP_AVAILABLE:
                 arguments=arguments or {},
                 server_name=server_name or mcp_server.name,
                 user_api_key_auth=user_api_key_auth,
-                proxy_logging_obj=proxy_logging_obj,  # type: ignore[arg-type]
+                proxy_logging_obj=proxy_logging_obj,
                 server=mcp_server,
                 raw_headers=raw_headers,
             )

--- a/litellm/proxy/_experimental/mcp_server/tool_registry.py
+++ b/litellm/proxy/_experimental/mcp_server/tool_registry.py
@@ -12,7 +12,7 @@ else:
     try:
         from mcp.types import Tool as MCPToolSDKTool
     except ImportError:
-        MCPToolSDKTool = None  # type: ignore
+        MCPToolSDKTool = None
 
 
 class MCPToolRegistry:

--- a/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
+++ b/litellm/proxy/_experimental/mcp_server/ui_session_utils.py
@@ -20,7 +20,7 @@ def clone_user_api_key_auth_with_team(
     try:
         cloned_auth = user_api_key_auth.model_copy()
     except AttributeError:
-        cloned_auth = user_api_key_auth.copy()  # type: ignore[attr-defined]
+        cloned_auth = user_api_key_auth.copy()
     cloned_auth.team_id = team_id
     return cloned_auth
 

--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -1144,7 +1144,7 @@ class GenerateKeyRequest(KeyRequestBase):
 
 
 class GenerateKeyResponse(KeyRequestBase):
-    key: str  # type: ignore
+    key: str
     key_name: str | None = None
     key_type: str | None = None
     expires: datetime | None = None
@@ -2869,7 +2869,7 @@ class LiteLLM_OrganizationTableWithMembers(LiteLLM_OrganizationTable):
 
 
 class NewOrganizationResponse(LiteLLM_OrganizationTable):
-    organization_id: str  # type: ignore
+    organization_id: str
     created_at: datetime
     updated_at: datetime
 

--- a/litellm/proxy/agent_endpoints/a2a_endpoints.py
+++ b/litellm/proxy/agent_endpoints/a2a_endpoints.py
@@ -804,7 +804,7 @@ async def invoke_agent_a2a(
             )
             # Defer spend-log until after post_call_success_hook so guardrail
             # results written by the unified_guardrail hook are captured.
-            logging_obj._defer_async_logging = True  # type: ignore[union-attr]
+            logging_obj._defer_async_logging = True
             response = await asend_message(
                 request=a2a_request,
                 api_base=agent_url,
@@ -825,11 +825,11 @@ async def invoke_agent_a2a(
             finally:
                 _enqueue_fn: Final = getattr(logging_obj, "_enqueue_deferred_logging", None)
                 if _enqueue_fn is not None:
-                    logging_obj._enqueue_deferred_logging = None  # type: ignore[union-attr]
+                    logging_obj._enqueue_deferred_logging = None
                     _enqueue_fn()
 
             response_dict: Final[dict[str, Any]] = (
-                response.model_dump(mode="json", exclude_none=True)  # type: ignore
+                response.model_dump(mode="json", exclude_none=True)
                 if hasattr(response, "model_dump")
                 else response
                 if isinstance(response, dict)

--- a/litellm/proxy/agent_endpoints/agent_registry.py
+++ b/litellm/proxy/agent_endpoints/agent_registry.py
@@ -148,7 +148,7 @@ class AgentRegistry:
             # create a stable hash id for config item
             config_hash = self._create_agent_id(agent_config_item)
 
-            self.register_agent(agent_config=AgentResponse(agent_id=config_hash, **agent_config_item))  # type: ignore
+            self.register_agent(agent_config=AgentResponse(agent_id=config_hash, **agent_config_item))
 
     def load_agents_from_db_and_config(
         self,
@@ -175,7 +175,7 @@ class AgentRegistry:
                 if not isinstance(db_agent, dict):
                     raise ValueError("db_agents must be a list of dictionaries")
 
-                self.register_agent(agent_config=AgentResponse(**db_agent))  # type: ignore
+                self.register_agent(agent_config=AgentResponse(**db_agent))
 
         self.load_agents_from_config(agent_config if agent_config is not None else self.config_agents)
         return self.agent_list
@@ -269,7 +269,7 @@ class AgentRegistry:
                     created_agent_dict["object_permission"] = created_agent.object_permission.model_dump()
                 except Exception:
                     created_agent_dict["object_permission"] = created_agent.object_permission.dict()
-            return AgentResponse(**created_agent_dict)  # type: ignore
+            return AgentResponse(**created_agent_dict)
         except Exception as e:
             raise Exception(f"Error adding agent to DB: {e}")
 
@@ -361,7 +361,7 @@ class AgentRegistry:
                     patched_agent_dict["object_permission"] = patched_agent.object_permission.model_dump()
                 except Exception:
                     patched_agent_dict["object_permission"] = patched_agent.object_permission.dict()
-            return AgentResponse(**patched_agent_dict)  # type: ignore
+            return AgentResponse(**patched_agent_dict)
         except Exception as e:
             raise Exception(f"Error patching agent in DB: {e}")
 
@@ -448,7 +448,7 @@ class AgentRegistry:
                     updated_agent_dict["object_permission"] = updated_agent.object_permission.model_dump()
                 except Exception:
                     updated_agent_dict["object_permission"] = updated_agent.object_permission.dict()
-            return AgentResponse(**updated_agent_dict)  # type: ignore
+            return AgentResponse(**updated_agent_dict)
         except Exception as e:
             raise Exception(f"Error updating agent in DB: {e}")
 

--- a/litellm/proxy/agent_endpoints/databricks_oauth.py
+++ b/litellm/proxy/agent_endpoints/databricks_oauth.py
@@ -111,9 +111,9 @@ def parse_databricks_oauth_config(
     scope: Final = _resolve_secret(raw.get("scope")) or _DEFAULT_SCOPE
 
     return DatabricksAppOAuthConfig(
-        client_id=client_id,  # type: ignore[arg-type]
-        client_secret=client_secret,  # type: ignore[arg-type]
-        token_url=_token_url_from_workspace(workspace_url),  # type: ignore[arg-type]
+        client_id=client_id,
+        client_secret=client_secret,
+        token_url=_token_url_from_workspace(workspace_url),
         scope=scope,
     )
 

--- a/litellm/proxy/agent_endpoints/endpoints.py
+++ b/litellm/proxy/agent_endpoints/endpoints.py
@@ -392,9 +392,7 @@ async def create_agent(
         created_by: Final = user_api_key_dict.user_id or "unknown"
 
         # check for naming conflicts
-        existing_agent: Final = AGENT_REGISTRY.get_agent_by_name(
-            agent_name=request.get("agent_name")  # type: ignore
-        )
+        existing_agent: Final = AGENT_REGISTRY.get_agent_by_name(agent_name=request.get("agent_name"))
         if existing_agent is not None:
             raise HTTPException(
                 status_code=400,
@@ -419,7 +417,7 @@ async def create_agent(
                 http_request=http_request,
                 agent_name=request.get("agent_name"),
             )
-            agent_to_create = {**request, "agent_card_params": merged_card}  # type: ignore[typeddict-item]
+            agent_to_create = {**request, "agent_card_params": merged_card}
 
         result: Final = await AGENT_REGISTRY.add_agent_to_db(
             agent=agent_to_create,
@@ -505,7 +503,7 @@ async def get_agent_by_id(
                         agent_dict["object_permission"] = agent_row.object_permission.model_dump()
                     except Exception:
                         agent_dict["object_permission"] = agent_row.object_permission.dict()
-                agent = AgentResponse(**agent_dict)  # type: ignore
+                agent = AgentResponse(**agent_dict)
         else:
             # Agent found in memory — refresh spend from DB
             db_row: Final = await agents_table(prisma_client).find_unique(where={"agent_id": agent_id})
@@ -609,7 +607,7 @@ async def update_agent(
                 http_request=http_request,
                 agent_name=request.get("agent_name"),
             )
-            agent_to_update = {**request, "agent_card_params": merged_card}  # type: ignore[typeddict-item]
+            agent_to_update = {**request, "agent_card_params": merged_card}
 
         result: Final = await AGENT_REGISTRY.update_agent_in_db(
             agent_id=agent_id,
@@ -619,7 +617,7 @@ async def update_agent(
         )
 
         # deregister in memory
-        AGENT_REGISTRY.deregister_agent(agent_name=existing_agent.get("agent_name"))  # type: ignore
+        AGENT_REGISTRY.deregister_agent(agent_name=existing_agent.get("agent_name"))
         # register in memory
         AGENT_REGISTRY.register_agent(agent_config=result)
 
@@ -712,7 +710,7 @@ async def patch_agent(
                 http_request=http_request,
                 agent_name=request.get("agent_name"),
             )
-            patch_payload = {**request, "agent_card_params": merged_card}  # type: ignore[typeddict-item]
+            patch_payload = {**request, "agent_card_params": merged_card}
 
         result: Final = await AGENT_REGISTRY.patch_agent_in_db(
             agent_id=agent_id,
@@ -722,7 +720,7 @@ async def patch_agent(
         )
 
         # deregister in memory
-        AGENT_REGISTRY.deregister_agent(agent_name=existing_agent.get("agent_name"))  # type: ignore
+        AGENT_REGISTRY.deregister_agent(agent_name=existing_agent.get("agent_name"))
         # register in memory
         AGENT_REGISTRY.register_agent(agent_config=result)
 
@@ -783,7 +781,7 @@ async def delete_agent(
 
         await AGENT_REGISTRY.delete_agent_from_db(agent_id=agent_id, prisma_client=prisma_client)
 
-        AGENT_REGISTRY.deregister_agent(agent_name=existing_agent.get("agent_name"))  # type: ignore
+        AGENT_REGISTRY.deregister_agent(agent_name=existing_agent.get("agent_name"))
 
         return {"message": f"Agent {agent_id} deleted successfully"}
     except HTTPException:
@@ -856,7 +854,7 @@ async def make_agent_public(
             # check if agent exists in DB
             agent = await agents_table(prisma_client).find_unique(where={"agent_id": agent_id})
             if agent is not None:
-                agent = AgentResponse(**agent.model_dump())  # type: ignore
+                agent = AgentResponse(**agent.model_dump())
 
             if agent is None:
                 raise HTTPException(status_code=404, detail=f"Agent with ID {agent_id} not found")
@@ -971,7 +969,7 @@ async def make_agents_public(
                 # check if agent exists in DB
                 agent = await agents_table(prisma_client).find_unique(where={"agent_id": agent_id})
                 if agent is not None:
-                    agent = AgentResponse(**agent.model_dump())  # type: ignore
+                    agent = AgentResponse(**agent.model_dump())
 
                 if agent is None:
                     raise HTTPException(status_code=404, detail=f"Agent with ID {agent_id} not found")

--- a/litellm/proxy/auth/auth_checks_organization.py
+++ b/litellm/proxy/auth/auth_checks_organization.py
@@ -128,7 +128,7 @@ def get_user_organization_info(
         for _membership in user_object.organization_memberships:
             if _membership.organization_id is not None:
                 _user_organizations.append(_membership.organization_id)
-                _user_organization_role_mapping[_membership.organization_id] = _membership.user_role  # type: ignore
+                _user_organization_role_mapping[_membership.organization_id] = _membership.user_role
 
     return _user_organizations, _user_organization_role_mapping
 

--- a/litellm/proxy/auth/handle_jwt.py
+++ b/litellm/proxy/auth/handle_jwt.py
@@ -385,7 +385,7 @@ class JWTHandler:
                         team_id[0],
                     )
                     team_id = team_id[0]
-                return team_id  # type: ignore[return-value]
+                return team_id
             elif self.litellm_jwtauth.team_id_default is not None:
                 team_id = self.litellm_jwtauth.team_id_default
             else:
@@ -945,9 +945,9 @@ class JWTHandler:
             public_key_obj: Final = PyJWK.from_dict(self._get_jwk_from_public_key(public_key=public_key)).key
             return jwt.decode(
                 token,
-                public_key_obj,  # type: ignore
+                public_key_obj,
                 algorithms=self.SUPPORTED_JWT_ALGORITHMS,
-                options=decode_options,  # type: ignore[arg-type]
+                options=decode_options,
                 audience=audience,
                 issuer=issuer,
                 leeway=self.leeway,
@@ -964,7 +964,7 @@ class JWTHandler:
             algorithms=self.SUPPORTED_JWT_ALGORITHMS,
             audience=audience,
             issuer=issuer,
-            options=decode_options,  # type: ignore[arg-type]
+            options=decode_options,
             leeway=self.leeway,
         )
 

--- a/litellm/proxy/auth/login_utils.py
+++ b/litellm/proxy/auth/login_utils.py
@@ -207,7 +207,7 @@ async def authenticate_user(
                     "spend": 0,
                     "user_id": key_user_id,
                     "team_id": "litellm-dashboard",
-                },  # type: ignore
+                },
             )
         else:
             raise ProxyException(
@@ -217,7 +217,7 @@ async def authenticate_user(
                 code=500,
             )
 
-        key = response["token"]  # type: ignore
+        key = response["token"]
 
         if get_secret_bool("EXPERIMENTAL_UI_LOGIN"):
             from litellm.proxy.auth.auth_checks import ExperimentalUIJWTToken
@@ -272,7 +272,7 @@ async def authenticate_user(
             if os.getenv("DATABASE_URL") is not None:
                 response = await generate_key_helper_fn(
                     request_type="key",
-                    **{  # type: ignore
+                    **{
                         "user_role": user_role,
                         "duration": LITELLM_UI_SESSION_DURATION,
                         "key_max_budget": litellm.max_ui_session_budget,
@@ -292,7 +292,7 @@ async def authenticate_user(
                     code=500,
                 )
 
-            key = response["token"]  # type: ignore
+            key = response["token"]
 
             return LoginResult(
                 user_id=user_id,

--- a/litellm/proxy/auth/model_checks.py
+++ b/litellm/proxy/auth/model_checks.py
@@ -394,9 +394,7 @@ def _get_wildcard_models(
                     for router_model in model_list:
                         wildcard_models = get_known_models_from_wildcard(
                             wildcard_model=model,
-                            litellm_params=LiteLLM_Params(
-                                **router_model["litellm_params"]  # type: ignore
-                            ),
+                            litellm_params=LiteLLM_Params(**router_model["litellm_params"]),
                         )
                         all_wildcard_models.extend(wildcard_models)
                 else:

--- a/litellm/proxy/auth/rds_iam_token.py
+++ b/litellm/proxy/auth/rds_iam_token.py
@@ -34,7 +34,7 @@ def init_rds_client(
     # Iterate over parameters and update if needed
     for i, param in enumerate(params_to_check):
         if param and param.startswith("os.environ/"):
-            params_to_check[i] = get_secret(param)  # type: ignore
+            params_to_check[i] = get_secret(param)
     # Assign updated values back to parameters
     (
         aws_access_key_id,
@@ -62,13 +62,11 @@ def init_rds_client(
     import boto3
 
     if isinstance(timeout, float):
-        config = boto3.session.Config(connect_timeout=timeout, read_timeout=timeout)  # type: ignore
+        config = boto3.session.Config(connect_timeout=timeout, read_timeout=timeout)
     elif isinstance(timeout, httpx.Timeout):
-        config = boto3.session.Config(  # type: ignore
-            connect_timeout=timeout.connect, read_timeout=timeout.read
-        )
+        config = boto3.session.Config(connect_timeout=timeout.connect, read_timeout=timeout.read)
     else:
-        config = boto3.session.Config()  # type: ignore
+        config = boto3.session.Config()
 
     ### CHECK STS ###
     if aws_web_identity_token is not None and aws_role_name is not None and aws_session_name is not None:

--- a/litellm/proxy/auth/user_api_key_auth.py
+++ b/litellm/proxy/auth/user_api_key_auth.py
@@ -252,8 +252,8 @@ async def _check_key_model_budget_with_fallback(
             raise e
         request_data["model"] = fallback_model
         _safe_set_request_parsed_body(request=request, parsed_body=request_data)
-        request._json = request_data  # type: ignore[attr-defined]
-        request._body = orjson.dumps(request_data)  # type: ignore[attr-defined]
+        request._json = request_data
+        request._body = orjson.dumps(request_data)
         path_params: Final = request.scope.get("path_params")
         if isinstance(path_params, dict) and "model" in path_params:
             path_params["model"] = fallback_model
@@ -438,7 +438,7 @@ async def user_api_key_auth_websocket(websocket: WebSocket):
     async def return_body():
         return _realtime_request_body(model)
 
-    request.body = return_body  # type: ignore
+    request.body = return_body
 
     authorization: Final = websocket.headers.get("authorization")
     # If no Authorization header, try the api-key header
@@ -629,7 +629,7 @@ async def check_api_key_for_custom_headers_or_pass_through_endpoints(
     is_mapped_pass_through_route: bool = False
     normalized_route: Final = normalize_route_for_root_path(route)
     if normalized_route is not None:
-        for mapped_route in LiteLLMRoutes.mapped_pass_through_routes.value:  # type: ignore
+        for mapped_route in LiteLLMRoutes.mapped_pass_through_routes.value:
             if normalized_route.startswith(mapped_route):
                 is_mapped_pass_through_route = True
                 break
@@ -662,10 +662,8 @@ async def check_api_key_for_custom_headers_or_pass_through_endpoints(
                     headers = endpoint.get("headers", None)
                     if headers is not None:
                         header_key = headers.get("litellm_user_api_key", "")
-                        if (
-                            isinstance(request.headers, dict) and request.headers.get(key=header_key) is not None  # type: ignore
-                        ):
-                            api_key = request.headers.get(key=header_key)  # type: ignore
+                        if isinstance(request.headers, dict) and request.headers.get(key=header_key) is not None:
+                            api_key = request.headers.get(key=header_key)
     return api_key
 
 
@@ -1140,7 +1138,7 @@ async def _user_api_key_auth_builder(
                 api_key = response
                 custom_auth_api_key = True
         elif user_custom_auth is not None:
-            response = await user_custom_auth(request=request, api_key=api_key)  # type: ignore
+            response = await user_custom_auth(request=request, api_key=api_key)
             validated = UserAPIKeyAuth.model_validate(response)
             if getattr(litellm, "enable_post_custom_auth_checks", False):
                 validated = await _run_post_custom_auth_checks(
@@ -1166,8 +1164,7 @@ async def _user_api_key_auth_builder(
 
         ######## Route Checks Before Reading DB / Cache for "token" ################
         if not _route_requires_auth_despite_public(route=route, general_settings=general_settings) and (
-            route in LiteLLMRoutes.public_routes.value  # type: ignore
-            or route_in_additonal_public_routes(current_route=route)
+            route in LiteLLMRoutes.public_routes.value or route_in_additonal_public_routes(current_route=route)
         ):
             # check if public endpoint
             return UserAPIKeyAuth(user_role=LitellmUserRoles.INTERNAL_USER_VIEW_ONLY)
@@ -1616,7 +1613,7 @@ async def _user_api_key_auth_builder(
                 verbose_logger.debug(e)  # moving from .warning to .debug as it spams logs when team missing from cache.
 
         try:
-            is_master_key_valid = secrets.compare_digest(api_key, master_key)  # type: ignore
+            is_master_key_valid = secrets.compare_digest(api_key, master_key)
         except Exception:
             is_master_key_valid = False
 
@@ -1662,7 +1659,7 @@ async def _user_api_key_auth_builder(
 
         ## IF it's not a master key
         ## Route should not be in master_key_only_routes
-        if route in LiteLLMRoutes.master_key_only_routes.value:  # type: ignore
+        if route in LiteLLMRoutes.master_key_only_routes.value:
             raise Exception(f"Tried to access route={route}, which is only for MASTER KEY")
 
         ## Check DB
@@ -1813,7 +1810,7 @@ async def _user_api_key_auth_builder(
                                 where={
                                     "user_id": _user_id,
                                     "team_id": _team_id,
-                                },  # type: ignore
+                                },
                                 include={"litellm_budget_table": True},
                             )
                             if _db_member is not None:
@@ -2158,10 +2155,7 @@ async def _run_centralized_common_checks(
     # auth in the builder — the wrapper must not retroactively apply
     # authz on top, or k8s readiness probes and other unauthenticated
     # callers get 401.
-    if (
-        route in LiteLLMRoutes.public_routes.value  # type: ignore[attr-defined]
-        or route_in_additonal_public_routes(current_route=route)
-    ):
+    if route in LiteLLMRoutes.public_routes.value or route_in_additonal_public_routes(current_route=route):
         return
 
     # User-configured pass-through endpoints with ``auth: false`` are

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -195,14 +195,14 @@ async def create_batch(
             original_file_id: Final = get_original_file_id(input_file_id)
             _create_batch_data["input_file_id"] = original_file_id
             prepare_data_with_credentials(
-                data=_create_batch_data,  # type: ignore
+                data=_create_batch_data,
                 credentials=credentials,
             )
 
             # Create batch using model credentials
             response = await litellm.acreate_batch(
                 custom_llm_provider=credentials["custom_llm_provider"],
-                **_create_batch_data,  # type: ignore
+                **_create_batch_data,
             )
 
             # Encode the batch ID and related file IDs with model information
@@ -241,7 +241,7 @@ async def create_batch(
                     detail={"error": "LLM Router not initialized. Ensure models added to proxy."},
                 )
 
-            response = await llm_router.acreate_batch(**_create_batch_data)  # type: ignore
+            response = await llm_router.acreate_batch(**_create_batch_data)
         elif (
             unified_file_id and input_file_id
         ):  # litellm_proxy:application/octet-stream;unified_id,c4843482-b176-4901-8292-7523fd0f2c6e;target_model_names,gpt-4o-mini
@@ -284,14 +284,14 @@ async def create_batch(
                 )
 
                 prepare_data_with_credentials(
-                    data=_create_batch_data,  # type: ignore
+                    data=_create_batch_data,
                     credentials=credentials,
                 )
 
                 # Create batch using model credentials
                 response = await litellm.acreate_batch(
                     custom_llm_provider=credentials["custom_llm_provider"],
-                    **_create_batch_data,  # type: ignore
+                    **_create_batch_data,
                 )
 
                 encode_batch_response_ids(response, model=model_param)
@@ -307,7 +307,7 @@ async def create_batch(
                 )
                 response = await litellm.acreate_batch(
                     custom_llm_provider=custom_llm_provider,
-                    **_create_batch_data,  # type: ignore
+                    **_create_batch_data,
                 )
 
         ### CALL HOOKS ### - modify outgoing data
@@ -502,7 +502,7 @@ async def retrieve_batch(
             # Retrieve batch using model credentials
             response = await litellm.aretrieve_batch(
                 custom_llm_provider=credentials["custom_llm_provider"],
-                **data,  # type: ignore
+                **data,
             )
 
             encode_batch_response_ids(response, model=model_from_id)
@@ -518,7 +518,7 @@ async def retrieve_batch(
                     detail={"error": "LLM Router not initialized. Ensure models added to proxy."},
                 )
 
-            response = await llm_router.aretrieve_batch(**data)  # type: ignore
+            response = await llm_router.aretrieve_batch(**data)
             response._hidden_params["unified_batch_id"] = unified_batch_id
             if unified_batch_id:
                 model_id_from_batch: Final = get_model_id_from_unified_batch_id(unified_batch_id)
@@ -541,7 +541,7 @@ async def retrieve_batch(
             )
             response = await litellm.aretrieve_batch(
                 custom_llm_provider=custom_llm_provider,
-                **data,  # type: ignore
+                **data,
             )
 
         # FIX: Update the database with the latest state from provider
@@ -696,7 +696,7 @@ async def list_batches(
                 custom_llm_provider=credentials["custom_llm_provider"],
                 after=after,
                 limit=limit,
-                **data,  # type: ignore
+                **data,
             )
 
             # Encode batch IDs in the list response so clients can use
@@ -737,7 +737,7 @@ async def list_batches(
                 custom_llm_provider=custom_llm_provider,
             )
             response = await litellm.alist_batches(
-                custom_llm_provider=custom_llm_provider,  # type: ignore
+                custom_llm_provider=custom_llm_provider,
                 after=after,
                 limit=limit,
                 **data,
@@ -747,7 +747,7 @@ async def list_batches(
         _response: Final = await proxy_logging_obj.post_call_success_hook(
             data=data,
             user_api_key_dict=user_api_key_dict,
-            response=response,  # type: ignore
+            response=response,
         )
         if _response is not None and type(response) is type(_response):
             response = _response
@@ -883,7 +883,7 @@ async def cancel_batch(
             # Cancel batch using model credentials
             response = await litellm.acancel_batch(
                 custom_llm_provider=credentials["custom_llm_provider"],
-                **data,  # type: ignore
+                **data,
             )
 
             encode_batch_response_ids(response, model=model_from_id)
@@ -908,7 +908,7 @@ async def cancel_batch(
                 )
             data["model"] = model_id_from_batch
             data["batch_id"] = get_batch_id_from_unified_batch_id(unified_batch_id)
-            response = await llm_router.acancel_batch(**data)  # type: ignore
+            response = await llm_router.acancel_batch(**data)
             response._hidden_params["unified_batch_id"] = unified_batch_id
 
             if not response._hidden_params.get("model_id") and data.get("model"):
@@ -934,7 +934,7 @@ async def cancel_batch(
             )
             _cancel_batch_data: Final = CancelBatchRequest(batch_id=batch_id, **data)
             response = await litellm.acancel_batch(
-                custom_llm_provider=custom_llm_provider,  # type: ignore
+                custom_llm_provider=custom_llm_provider,
                 **_cancel_batch_data,
             )
 

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -682,7 +682,7 @@ async def create_response(
         # Generator was empty. Default status
         async def empty_gen() -> AsyncGenerator[str, None]:
             if False:
-                yield  # type: ignore
+                yield
 
         return StreamingResponse(
             empty_gen(),
@@ -1395,10 +1395,10 @@ class ProxyBaseLLMRequestProcessing:
             trust_client_model_info=False,
         )
 
-        self.data = await proxy_logging_obj.pre_call_hook(  # type: ignore
+        self.data = await proxy_logging_obj.pre_call_hook(
             user_api_key_dict=user_api_key_dict,
             data=self.data,
-            call_type=route_type,  # type: ignore
+            call_type=route_type,
         )
 
         if "messages" in self.data and self.data["messages"]:
@@ -1751,7 +1751,7 @@ class ProxyBaseLLMRequestProcessing:
         if _post_call_guardrails_active and not self._is_streaming_request(
             data=self.data, is_streaming_request=is_streaming_request
         ):
-            logging_obj._defer_async_logging = True  # type: ignore
+            logging_obj._defer_async_logging = True
 
         tasks: Final = []
         # Start the moderation check (during_call_hook) as early as possible
@@ -1761,7 +1761,7 @@ class ProxyBaseLLMRequestProcessing:
                 proxy_logging_obj.during_call_hook(
                     data=self.data,
                     user_api_key_dict=user_api_key_dict,
-                    call_type=route_type,  # type: ignore
+                    call_type=route_type,
                 )
             )
         )
@@ -1884,7 +1884,7 @@ class ProxyBaseLLMRequestProcessing:
                             cache_hit=cache_hit,
                         )
 
-                    logging_obj._on_deferred_stream_complete = _on_deferred_stream_complete  # type: ignore[union-attr]
+                    logging_obj._on_deferred_stream_complete = _on_deferred_stream_complete
 
                 if route_type == "allm_passthrough_route":
                     # Check if response is an async generator
@@ -1898,9 +1898,7 @@ class ProxyBaseLLMRequestProcessing:
                             self._has_post_call_guardrails_for_passthrough()
                             and self._passthrough_endpoint_has_stream_guardrail_handler()
                         ):
-                            body_bytes: Final = b"".join(
-                                [chunk async for chunk in generator]  # type: ignore[union-attr]
-                            )
+                            body_bytes: Final = b"".join([chunk async for chunk in generator])
                             modified_bytes: Final = await self._handle_event_stream_allm_passthrough_route(
                                 body_bytes=body_bytes,
                                 proxy_logging_obj=proxy_logging_obj,
@@ -1919,7 +1917,7 @@ class ProxyBaseLLMRequestProcessing:
                         # For passthrough routes, stream directly without error parsing
                         # since we're dealing with raw binary data (e.g., AWS event streams)
                         return StreamingResponse(
-                            content=generator,  # type: ignore[arg-type]
+                            content=generator,
                             status_code=status.HTTP_200_OK,
                             headers=custom_headers,
                         )
@@ -1934,8 +1932,8 @@ class ProxyBaseLLMRequestProcessing:
                         if _early is not None:
                             return _early
                         return StreamingResponse(
-                            content=response.aiter_bytes(),  # type: ignore[union-attr]
-                            status_code=response.status_code,  # type: ignore[union-attr]
+                            content=response.aiter_bytes(),
+                            status_code=response.status_code,
                             headers=custom_headers,
                         )
                 elif route_type == "anthropic_messages":
@@ -1995,7 +1993,7 @@ class ProxyBaseLLMRequestProcessing:
             # Clear the closure so guardrails run inline as before — this
             # preserves blocking behavior and avoids double invocation.
             if getattr(logging_obj, "_on_deferred_stream_complete", None):
-                logging_obj._on_deferred_stream_complete = None  # type: ignore[union-attr]
+                logging_obj._on_deferred_stream_complete = None
 
             if route_type == "allm_passthrough_route":
                 _non_streaming_custom_headers: Final = ProxyBaseLLMRequestProcessing.get_custom_headers(
@@ -2026,7 +2024,7 @@ class ProxyBaseLLMRequestProcessing:
             response = await proxy_logging_obj.post_call_success_hook(
                 data=self.data,
                 user_api_key_dict=user_api_key_dict,
-                response=response,  # type: ignore[arg-type]
+                response=response,
             )
         except Exception:
             _exception_raised = True
@@ -2048,7 +2046,7 @@ class ProxyBaseLLMRequestProcessing:
             if _exception_raised:
                 _deferred_fn: Final = getattr(logging_obj, "_on_deferred_stream_complete", None)
                 if _deferred_fn is not None:
-                    logging_obj._on_deferred_stream_complete = None  # type: ignore[union-attr]
+                    logging_obj._on_deferred_stream_complete = None
                     try:
                         asyncio.create_task(
                             logging_obj.dispatch_success_handlers(
@@ -2404,8 +2402,8 @@ class ProxyBaseLLMRequestProcessing:
         )
 
         try:
-            response_status: Final[int] = response.status_code  # type: ignore[union-attr]
-            content_type: Final[str] = response.headers.get("content-type", "")  # type: ignore[union-attr]
+            response_status: Final[int] = response.status_code
+            content_type: Final[str] = response.headers.get("content-type", "")
         except AttributeError:
             return None
 
@@ -2419,7 +2417,7 @@ class ProxyBaseLLMRequestProcessing:
             return None
 
         response_headers: Final = HttpPassThroughEndpointHelpers.get_response_headers(
-            headers=response.headers,  # type: ignore[union-attr]
+            headers=response.headers,
             custom_headers=custom_headers,
         )
         callback_headers: Final = await proxy_logging_obj.post_call_response_headers_hook(
@@ -2432,7 +2430,7 @@ class ProxyBaseLLMRequestProcessing:
             response_headers.update(callback_headers)
 
         if is_event_stream:
-            body_bytes = await response.aread()  # type: ignore[union-attr]
+            body_bytes = await response.aread()
             modified_bytes: Final = await self._handle_event_stream_allm_passthrough_route(
                 body_bytes=body_bytes,
                 proxy_logging_obj=proxy_logging_obj,
@@ -2445,7 +2443,7 @@ class ProxyBaseLLMRequestProcessing:
                 headers=response_headers,
             )
 
-        body_bytes = await response.aread()  # type: ignore[union-attr]
+        body_bytes = await response.aread()
         try:
             parsed: Final = _json.loads(body_bytes)
         except (_json.JSONDecodeError, UnicodeDecodeError):
@@ -2522,7 +2520,7 @@ class ProxyBaseLLMRequestProcessing:
         _enqueue_fn: Final = getattr(logging_obj, "_enqueue_deferred_logging", None)
         if _enqueue_fn is None:
             return
-        logging_obj._enqueue_deferred_logging = None  # type: ignore[union-attr]
+        logging_obj._enqueue_deferred_logging = None
         if exception_raised:
             return
         try:

--- a/litellm/proxy/common_utils/callback_utils.py
+++ b/litellm/proxy/common_utils/callback_utils.py
@@ -309,7 +309,7 @@ def initialize_callbacks_on_proxy(
         if isinstance(litellm.callbacks, list):
             litellm.callbacks.extend(imported_list)
         else:
-            litellm.callbacks = imported_list  # type: ignore
+            litellm.callbacks = imported_list
 
         if "prometheus" in value:
             from litellm.integrations.prometheus import PrometheusLogger

--- a/litellm/proxy/common_utils/custom_openapi_spec.py
+++ b/litellm/proxy/common_utils/custom_openapi_spec.py
@@ -38,11 +38,11 @@ class CustomOpenAPISpec:
         """
         try:
             # Try Pydantic v2 method first
-            return model_class.model_json_schema()  # type: ignore
+            return model_class.model_json_schema()
         except AttributeError:
             try:
                 # Fallback to Pydantic v1 method
-                return model_class.schema()  # type: ignore
+                return model_class.schema()
             except AttributeError:
                 # If both methods fail, return None
                 return None

--- a/litellm/proxy/common_utils/debug_utils.py
+++ b/litellm/proxy/common_utils/debug_utils.py
@@ -87,7 +87,7 @@ async def get_active_tasks_stats():
 
 if os.environ.get("LITELLM_PROFILE", "false").lower() == "true":
     try:
-        import objgraph  # type: ignore
+        import objgraph
 
         print("growth of objects")  # noqa: T201
         objgraph.show_growth()
@@ -418,7 +418,7 @@ def _get_cache_memory_stats(user_api_key_cache, llm_router, proxy_logging_obj, r
             try:
                 if hasattr(redis_usage_cache, "redis_client") and redis_usage_cache.redis_client:
                     if hasattr(redis_usage_cache.redis_client, "connection_pool"):
-                        pool_info: Final = redis_usage_cache.redis_client.connection_pool  # type: ignore
+                        pool_info: Final = redis_usage_cache.redis_client.connection_pool
                         cache_stats["redis_usage_cache"]["connection_pool"] = {
                             "max_connections": (
                                 pool_info.max_connections if hasattr(pool_info, "max_connections") else None
@@ -687,7 +687,7 @@ async def get_otel_spans():
 
     otel_exporter: Final = open_telemetry_logger.OTEL_EXPORTER
     if hasattr(otel_exporter, "get_finished_spans"):
-        recorded_spans = otel_exporter.get_finished_spans()  # type: ignore
+        recorded_spans = otel_exporter.get_finished_spans()
     else:
         recorded_spans = []
 

--- a/litellm/proxy/common_utils/encrypt_decrypt_utils.py
+++ b/litellm/proxy/common_utils/encrypt_decrypt_utils.py
@@ -101,7 +101,7 @@ def encrypt_value_helper(value: str, new_encryption_key: str | None = None):
                 # is returned directly with no extra base64 wrapper.
                 return _encrypt_aes_gcm(value=value, signing_key=cast(str, signing_key))
 
-            encrypted_value = encrypt_value(value=value, signing_key=signing_key)  # type: ignore
+            encrypted_value = encrypt_value(value=value, signing_key=signing_key)
             # Use urlsafe_b64encode for URL-safe base64 encoding (replaces + with - and / with _)
             encrypted_value = base64.urlsafe_b64encode(encrypted_value).decode("utf-8")
 
@@ -139,7 +139,7 @@ def decrypt_value_helper(
                 # If URL-safe decoding fails, try standard base64 decoding for backwards compatibility
                 decoded_b64 = base64.b64decode(value)
 
-            value = decrypt_value(value=decoded_b64, signing_key=signing_key)  # type: ignore
+            value = decrypt_value(value=decoded_b64, signing_key=signing_key)
             return value
 
         # if it's not str - do not decrypt it, return the value
@@ -199,7 +199,7 @@ def decrypt_value(value: bytes, signing_key: str) -> str:
             return ""
 
         plaintext = box.decrypt(value)
-        plaintext = plaintext.decode("utf-8")  # type: ignore
-        return plaintext  # type: ignore
+        plaintext = plaintext.decode("utf-8")
+        return plaintext
     except Exception as e:
         raise e

--- a/litellm/proxy/common_utils/proxy_rate_limit_error.py
+++ b/litellm/proxy/common_utils/proxy_rate_limit_error.py
@@ -98,7 +98,7 @@ def _coerce_message(detail: Any) -> str:
 # Both narrowings are intentional and handled at construction time — every
 # instance always has status_code == 429 and a Dict-typed headers — so we
 # silence the ATTR-overlap check rather than relax the annotations.
-class ProxyRateLimitError(HTTPException, RateLimitError):  # type: ignore[misc]
+class ProxyRateLimitError(HTTPException, RateLimitError):
     """
     A 429 raised by litellm's proxy-side rate limiting hooks.
 

--- a/litellm/proxy/common_utils/reset_budget_job.py
+++ b/litellm/proxy/common_utils/reset_budget_job.py
@@ -792,7 +792,7 @@ class ResetBudgetJob:
                 if changed:
                     await VerificationTokenRepository(self.prisma_client).table.update(
                         where={"token": row["token"]},
-                        data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
+                        data={"budget_limits": json.dumps(windows)},
                     )
         except Exception as e:
             verbose_proxy_logger.exception("Failed to reset budget windows for keys: %s", e)
@@ -821,7 +821,7 @@ class ResetBudgetJob:
                 if changed:
                     await TeamRepository(self.prisma_client).table.update(
                         where={"team_id": row["team_id"]},
-                        data={"budget_limits": json.dumps(windows)},  # type: ignore[arg-type]
+                        data={"budget_limits": json.dumps(windows)},
                     )
         except Exception as e:
             verbose_proxy_logger.exception("Failed to reset budget windows for teams: %s", e)

--- a/litellm/proxy/common_utils/swagger_utils.py
+++ b/litellm/proxy/common_utils/swagger_utils.py
@@ -8,7 +8,7 @@ from litellm.exceptions import LITELLM_EXCEPTION_TYPES
 class ErrorResponse(BaseModel):
     detail: dict[str, Any] = Field(
         ...,
-        example={  # type: ignore
+        example={
             "error": {
                 "message": "Error message",
                 "type": "error_type",

--- a/litellm/proxy/common_utils/user_api_key_cache.py
+++ b/litellm/proxy/common_utils/user_api_key_cache.py
@@ -57,7 +57,7 @@ class UserApiKeyCache(DualCache):
         **kwargs: Any,
     ) -> Any: ...
 
-    def get_cache(  # type: ignore[override]
+    def get_cache(
         self,
         key,
         parent_otel_span=None,
@@ -102,7 +102,7 @@ class UserApiKeyCache(DualCache):
         **kwargs: Any,
     ) -> Any: ...
 
-    async def async_get_cache(  # type: ignore[override]
+    async def async_get_cache(
         self,
         key,
         parent_otel_span=None,
@@ -129,19 +129,17 @@ class UserApiKeyCache(DualCache):
             return None
         return decoded
 
-    def set_cache(self, key, value, local_only: bool = False, **kwargs):  # type: ignore[override]
+    def set_cache(self, key, value, local_only: bool = False, **kwargs):
         model_type: Final = cast(type[BaseModel] | None, kwargs.pop("model_type", None))
         payload: Final = CacheCodec.serialize(value, model_type=model_type)
         return super().set_cache(key=key, value=payload, local_only=local_only, **kwargs)
 
-    async def async_set_cache(self, key, value, local_only: bool = False, **kwargs):  # type: ignore[override]
+    async def async_set_cache(self, key, value, local_only: bool = False, **kwargs):
         model_type: Final = cast(type[BaseModel] | None, kwargs.pop("model_type", None))
         payload: Final = CacheCodec.serialize(value, model_type=model_type)
         return await super().async_set_cache(key=key, value=payload, local_only=local_only, **kwargs)
 
-    async def async_set_cache_pipeline(  # type: ignore[override]
-        self, cache_list: list, local_only: bool = False, **kwargs
-    ) -> None:
+    async def async_set_cache_pipeline(self, cache_list: list, local_only: bool = False, **kwargs) -> None:
         """
         Batch writes with the same Codec boundary as ``async_set_cache`` without
         ``model_type``: ``BaseModel`` values become JSON-safe dicts; dicts/scalars unchanged.

--- a/litellm/proxy/container_endpoints/handler_factory.py
+++ b/litellm/proxy/container_endpoints/handler_factory.py
@@ -328,7 +328,7 @@ async def _process_multipart_upload_request(
             request=request,
             fastapi_response=fastapi_response,
             user_api_key_dict=user_api_key_dict,
-            route_type=route_type,  # type: ignore[arg-type]
+            route_type=route_type,
             proxy_logging_obj=proxy_logging_obj,
             llm_router=llm_router,
             general_settings=general_settings,
@@ -411,7 +411,7 @@ async def _process_request(
             request=request,
             fastapi_response=fastapi_response,
             user_api_key_dict=user_api_key_dict,
-            route_type=route_type,  # type: ignore[arg-type]
+            route_type=route_type,
             proxy_logging_obj=proxy_logging_obj,
             llm_router=llm_router,
             general_settings=general_settings,

--- a/litellm/proxy/db/db_spend_update_writer.py
+++ b/litellm/proxy/db/db_spend_update_writer.py
@@ -1688,7 +1688,7 @@ class DBSpendUpdateWriter:
 
         except Exception as e:
             if "transactions_to_process" in locals():
-                for key in transactions_to_process:  # type: ignore
+                for key in transactions_to_process:
                     daily_spend_transactions.pop(key, None)
             _raise_failed_update_spend_exception(e=e, start_time=start_time, proxy_logging_obj=proxy_logging_obj)
 

--- a/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
+++ b/litellm/proxy/db/db_transaction_queue/pod_lock_manager.py
@@ -177,12 +177,12 @@ end
                     lock_key,
                 )
 
-        current_value = await self.redis_cache.async_get_cache(lock_key)  # type: ignore
+        current_value = await self.redis_cache.async_get_cache(lock_key)
         if isinstance(current_value, bytes):
             current_value = current_value.decode("utf-8")
         if current_value != self.pod_id:
             return 0
-        result = await self.redis_cache.async_delete_cache(lock_key)  # type: ignore
+        result = await self.redis_cache.async_delete_cache(lock_key)
         return int(result or 0)
 
     @staticmethod

--- a/litellm/proxy/db/db_transaction_queue/redis_update_buffer.py
+++ b/litellm/proxy/db/db_transaction_queue/redis_update_buffer.py
@@ -736,10 +736,8 @@ class RedisUpdateBuffer:
             # Process each field type
             for field in transaction_fields:
                 if transaction.get(field):
-                    for entity_id, amount in transaction[field].items():  # type: ignore
-                        combined_transaction[field][entity_id] = (  # type: ignore
-                            combined_transaction[field].get(entity_id, 0) + amount  # type: ignore
-                        )
+                    for entity_id, amount in transaction[field].items():
+                        combined_transaction[field][entity_id] = combined_transaction[field].get(entity_id, 0) + amount
 
         return combined_transaction
 

--- a/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
+++ b/litellm/proxy/db/db_transaction_queue/spend_update_queue.py
@@ -197,7 +197,7 @@ class SpendUpdateQueue(BaseUpdateQueue):
                 transactions_dict = {}
 
                 # type ignore: dict_key is guaranteed to be one of "one of ("user_list_transactions", "end_user_list_transactions", "key_list_transactions", "team_list_transactions", "team_member_list_transactions", "org_list_transactions")"
-                db_spend_update_transactions[dict_key] = transactions_dict  # type: ignore
+                db_spend_update_transactions[dict_key] = transactions_dict
 
             if entity_id not in transactions_dict:
                 transactions_dict[entity_id] = 0

--- a/litellm/proxy/db/dynamo_db.py
+++ b/litellm/proxy/db/dynamo_db.py
@@ -30,7 +30,7 @@ class DynamoDBWrapper(CustomDB):
                 self.throughput_type = Throughput(
                     read=database_arguments.read_capacity_units,
                     write=database_arguments.write_capacity_units,
-                )  # type: ignore
+                )
             else:
                 raise Exception(
                     f"Invalid args passed in. Need to set both read_capacity_units and write_capacity_units. Args passed in - {database_arguments}"

--- a/litellm/proxy/db/prisma_client.py
+++ b/litellm/proxy/db/prisma_client.py
@@ -537,7 +537,7 @@ class PrismaWrapper:
         `_safe_refresh_token`, which double-checks token freshness under the
         lock) don't re-acquire it — `asyncio.Lock` is not reentrant.
         """
-        from prisma import Prisma  # type: ignore
+        from prisma import Prisma
 
         if expected_generation is not None and expected_generation != self._engine_generation:
             verbose_proxy_logger.info(

--- a/litellm/proxy/db/spend_counter_reseed.py
+++ b/litellm/proxy/db/spend_counter_reseed.py
@@ -233,7 +233,7 @@ class SpendCounterReseed:
         try:
             response: Final = await SpendLogsRepository(prisma_client).table.group_by(
                 by=[group_field],
-                where=where,  # type: ignore[arg-type]
+                where=where,
                 sum={"spend": True},
             )
         except Exception:

--- a/litellm/proxy/example_config_yaml/custom_auth.py
+++ b/litellm/proxy/example_config_yaml/custom_auth.py
@@ -27,7 +27,7 @@ async def generate_key_fn(data: GenerateKeyRequest):
         bool: True if a key should be generated, False otherwise.
     """
     # decide if a key should be generated or not
-    data_json: Final = data.json()  # type: ignore
+    data_json: Final = data.json()
 
     # Unpacking variables
     team_id: Final = data_json.get("team_id")

--- a/litellm/proxy/example_config_yaml/custom_handler.py
+++ b/litellm/proxy/example_config_yaml/custom_handler.py
@@ -13,14 +13,14 @@ class MyCustomLLM(CustomLLM):
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": "Hello world"}],
             mock_response="Hi!",
-        )  # type: ignore
+        )
 
     async def acompletion(self, *args, **kwargs) -> litellm.ModelResponse:
         return litellm.completion(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": "Hello world"}],
             mock_response="Hi!",
-        )  # type: ignore
+        )
 
 
 my_custom_llm: Final = MyCustomLLM()

--- a/litellm/proxy/guardrails/guardrail_hooks/azure/text_moderation.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/azure/text_moderation.py
@@ -123,7 +123,7 @@ class AzureContentSafetyTextModerationGuardrail(AzureGuardrailBase, CustomGuardr
         for chunk in chunks:
             request_body = AzureTextModerationGuardrailRequestBody(
                 text=chunk,
-                **self.optional_params_request_body,  # type: ignore[misc]
+                **self.optional_params_request_body,
             )
             response_json = await self._post_to_content_safety("text:analyze", cast(dict, request_body))
 

--- a/litellm/proxy/guardrails/guardrail_hooks/block_code_execution/block_code_execution.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/block_code_execution/block_code_execution.py
@@ -576,5 +576,5 @@ class BlockCodeExecutionGuardrail(CustomGuardrail):
                 end_time=datetime.now().timestamp(),
                 duration=(datetime.now() - start_time).total_seconds(),
                 event_type=event_type,
-                tracing_detail=GuardrailTracingDetail(**tracing_kw),  # type: ignore[typeddict-item]
+                tracing_detail=GuardrailTracingDetail(**tracing_kw),
             )

--- a/litellm/proxy/guardrails/guardrail_hooks/cisco_ai_defense/cisco_ai_defense.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/cisco_ai_defense/cisco_ai_defense.py
@@ -1209,14 +1209,14 @@ class CiscoAIDefenseGuardrail(_CiscoAIDefenseMcpMixin, CustomGuardrail):
         for key in ("result", "data", "inspection", "ai_defense", "aiDefense"):
             value = inspect_response.get(key)
             if cls._has_decision_fields(value):
-                return value  # type: ignore[return-value]
+                return value
 
         result: Final = inspect_response.get("result")
         if isinstance(result, dict):
             for key in ("data", "inspection", "ai_defense", "aiDefense"):
                 value = result.get(key)
                 if cls._has_decision_fields(value):
-                    return value  # type: ignore[return-value]
+                    return value
 
         return inspect_response
 

--- a/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/generic_guardrail_api/generic_guardrail_api.py
@@ -268,7 +268,7 @@ class GenericGuardrailAPI(CustomGuardrail):
         for field_name in GenericGuardrailAPIMetadata.__annotations__.keys():
             value = metadata_dict.get(field_name)
             if value is not None:
-                result_metadata[field_name] = value  # type: ignore[literal-required]
+                result_metadata[field_name] = value
 
         # handle user_api_key_token = user_api_key_hash
         if metadata_dict.get("user_api_key_token") is not None:

--- a/litellm/proxy/guardrails/guardrail_hooks/guardrails_ai/guardrails_ai.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/guardrails_ai/guardrails_ai.py
@@ -82,7 +82,7 @@ class GuardrailsAI(CustomGuardrail):
             },
         )
         verbose_proxy_logger.debug("guardrails_ai response: %s", response)
-        _json_response: Final = GuardrailsAIResponse(**response.json())  # type: ignore
+        _json_response: Final = GuardrailsAIResponse(**response.json())
         if _json_response.get("validationPassed") is False:
             raise HTTPException(
                 status_code=400,
@@ -128,7 +128,7 @@ class GuardrailsAI(CustomGuardrail):
                 },
             )
 
-        _json_response: Final = GuardrailsAIResponsePreCall(**response.json())  # type: ignore
+        _json_response: Final = GuardrailsAIResponsePreCall(**response.json())
         response = _json_response.get("outputs", [])[0].get("data", [])[0]
         return response
 

--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -722,7 +722,7 @@ class HeadroomGuardrail(CustomGuardrail):
         stream: bool,
         kwargs: dict,
     ) -> AgenticLoopPlan:
-        tool_calls: Final[list[dict[str, object]]] = tools.get("tool_calls", [])  # type: ignore[assignment]
+        tool_calls: Final[list[dict[str, object]]] = tools.get("tool_calls", [])
 
         self._prune_expired_hashes()
         call_id: Final = _resolve_call_id(logging_obj, kwargs)

--- a/litellm/proxy/guardrails/guardrail_hooks/lakera_ai_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/lakera_ai_v2.py
@@ -235,7 +235,7 @@ class LakeraAIGuardrail(CustomGuardrail):
         ########## 1. Make the Lakera AI v2 guard API request ##########
         #########################################################
         lakera_guardrail_response, masked_entity_count = await self.call_v2_guard(
-            messages=new_messages,  # type: ignore[arg-type]
+            messages=new_messages,
             request_data=data,
             event_type=GuardrailEventHooks.pre_call,
         )
@@ -247,14 +247,14 @@ class LakeraAIGuardrail(CustomGuardrail):
             # If only PII violations exist, mask the PII (string input only).
             if self._is_only_pii_violation(lakera_guardrail_response) and not is_multimodal_input:
                 redacted_messages: Final = self._mask_pii_in_messages(
-                    messages=new_messages,  # type: ignore[arg-type]
+                    messages=new_messages,
                     lakera_response=lakera_guardrail_response,
                     masked_entity_count=masked_entity_count,
                 )
                 # Write back to ``messages`` AND ``input``. The Responses-API
                 # backend reads ``input``; writing only to ``messages``
                 # would let unredacted PII reach the LLM for /v1/responses.
-                apply_redacted_messages_back(data, list(redacted_messages))  # type: ignore[arg-type]
+                apply_redacted_messages_back(data, list(redacted_messages))
                 verbose_proxy_logger.debug("Lakera AI: Masked PII in messages instead of blocking request")
             else:
                 # Check on_flagged setting
@@ -303,7 +303,7 @@ class LakeraAIGuardrail(CustomGuardrail):
         ########## 1. Make the Lakera AI v2 guard API request ##########
         #########################################################
         lakera_guardrail_response, masked_entity_count = await self.call_v2_guard(
-            messages=new_messages,  # type: ignore[arg-type]
+            messages=new_messages,
             request_data=data,
             event_type=GuardrailEventHooks.during_call,
         )
@@ -314,14 +314,14 @@ class LakeraAIGuardrail(CustomGuardrail):
         if lakera_guardrail_response.get("flagged") is True:
             if self._is_only_pii_violation(lakera_guardrail_response) and not is_multimodal_input:
                 redacted_messages: Final = self._mask_pii_in_messages(
-                    messages=new_messages,  # type: ignore[arg-type]
+                    messages=new_messages,
                     lakera_response=lakera_guardrail_response,
                     masked_entity_count=masked_entity_count,
                 )
                 # Write back to ``messages`` AND ``input``. The Responses-API
                 # backend reads ``input``; writing only to ``messages``
                 # would let unredacted PII reach the LLM for /v1/responses.
-                apply_redacted_messages_back(data, list(redacted_messages))  # type: ignore[arg-type]
+                apply_redacted_messages_back(data, list(redacted_messages))
                 verbose_proxy_logger.debug("Lakera AI: Masked PII in messages instead of blocking request")
             else:
                 if self.on_flagged == "monitor":

--- a/litellm/proxy/guardrails/guardrail_hooks/lasso/lasso.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/lasso/lasso.py
@@ -15,7 +15,7 @@ try:
 
     ULID_AVAILABLE = True
 except ImportError:
-    ulid = None  # type: ignore
+    ulid = None
     ULID_AVAILABLE = False
 
 try:
@@ -23,7 +23,7 @@ try:
 
     HTTPX_AVAILABLE = True
 except ImportError:
-    httpx = None  # type: ignore
+    httpx = None
     HTTPX_AVAILABLE = False
 
 from fastapi import HTTPException
@@ -163,7 +163,7 @@ class LassoGuardrail(CustomGuardrail):
         Falls back to UUID if ULID library is not available.
         """
         if ULID_AVAILABLE and ulid is not None:
-            return str(ulid.ULID())  # type: ignore
+            return str(ulid.ULID())
         else:
             verbose_proxy_logger.debug("ULID library not available, using UUID")
             return str(uuid.uuid4())

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/__init__.py
@@ -38,7 +38,7 @@ def initialize_guardrail(
         patterns=litellm_params.patterns,
         blocked_words=litellm_params.blocked_words,
         blocked_words_file=litellm_params.blocked_words_file,
-        event_hook=litellm_params.mode,  # type: ignore
+        event_hook=litellm_params.mode,
         default_on=litellm_params.default_on or False,
         categories=getattr(litellm_params, "categories", None),
         severity_threshold=getattr(litellm_params, "severity_threshold", "medium"),

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/content_filter.py
@@ -1681,7 +1681,7 @@ class ContentFilterGuardrail(CustomGuardrail):
             end_time=datetime.now().timestamp(),
             duration=(datetime.now() - start_time).total_seconds(),
             masked_entity_count=masked_entity_count,
-            tracing_detail=GuardrailTracingDetail(**tracing_kw),  # type: ignore[typeddict-item]
+            tracing_detail=GuardrailTracingDetail(**tracing_kw),
         )
 
     @staticmethod

--- a/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/guardrail_benchmarks/test_eval.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/litellm_content_filter/guardrail_benchmarks/test_eval.py
@@ -249,7 +249,7 @@ def _content_filter(category: str):
     guardrail: Final = ContentFilterGuardrail(
         guardrail_name=f"{category}_eval",
         categories=[
-            {  # type: ignore[list-item]
+            {
                 "category": category,
                 "enabled": True,
                 "action": "BLOCK",
@@ -532,7 +532,7 @@ class _LlmJudgeChecker:
             temperature=0,
             max_tokens=5,
         )
-        decision: Final = (response.choices[0].message.content or "").strip().upper()  # type: ignore[union-attr]
+        decision: Final = (response.choices[0].message.content or "").strip().upper()
 
         if "BLOCK" in decision:
             raise HTTPException(

--- a/litellm/proxy/guardrails/guardrail_hooks/llm_as_a_judge/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/llm_as_a_judge/__init__.py
@@ -187,7 +187,7 @@ class LLMAsAJudgeGuardrail(CustomGuardrail):
                 response_format={"type": "json_object"},
                 temperature=0,
             )
-        raw: Final = response.choices[0].message.content or "{}"  # type: ignore[union-attr]
+        raw: Final = response.choices[0].message.content or "{}"
         return _parse_judge_verdict(raw)
 
     async def apply_guardrail(

--- a/litellm/proxy/guardrails/guardrail_hooks/mcp_end_user_permission/mcp_end_user_permission.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/mcp_end_user_permission/mcp_end_user_permission.py
@@ -138,7 +138,7 @@ class MCPEndUserPermissionGuardrail(CustomGuardrail):
         )
 
     @staticmethod
-    async def _fetch_end_user_object(end_user_id: str):  # type: ignore[return]
+    async def _fetch_end_user_object(end_user_id: str):
         """
         Fetch end user object via the same cached path used during auth.
         No extra DB round-trip when the cache is warm.

--- a/litellm/proxy/guardrails/guardrail_hooks/mcp_jwt_signer/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/mcp_jwt_signer/__init__.py
@@ -26,7 +26,7 @@ def initialize_guardrail(litellm_params: "LitellmParams", guardrail: "Guardrail"
 
     optional_params: Final = getattr(litellm_params, "optional_params", None)
 
-    def _get(key):  # type: ignore[no-untyped-def]
+    def _get(key):
         if optional_params is not None:
             v: Final = getattr(optional_params, key, None)
             if v is not None:

--- a/litellm/proxy/guardrails/guardrail_hooks/mcp_jwt_signer/mcp_jwt_signer.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/mcp_jwt_signer/mcp_jwt_signer.py
@@ -116,7 +116,7 @@ def _load_private_key_from_env(env_var: str) -> RSAPrivateKey:
             key_bytes = f.read()
     else:
         key_bytes = key_material.encode("utf-8")
-    return serialization.load_pem_private_key(key_bytes, password=None)  # type: ignore[return-value]
+    return serialization.load_pem_private_key(key_bytes, password=None)
 
 
 def _generate_rsa_key_pair() -> RSAPrivateKey:
@@ -153,7 +153,7 @@ async def _fetch_jwks(jwks_uri: str) -> list[dict[str, Any]]:
     if cached is not None:
         keys, fetched_at = cached
         if now - fetched_at < _JWKS_CACHE_TTL:
-            return keys  # type: ignore[return-value]
+            return keys
 
     from litellm.llms.custom_httpx.http_handler import (
         get_async_httpx_client,
@@ -165,7 +165,7 @@ async def _fetch_jwks(jwks_uri: str) -> list[dict[str, Any]]:
     resp.raise_for_status()
     keys = resp.json().get("keys", [])
     _jwks_cache[jwks_uri] = (keys, now)
-    return keys  # type: ignore[return-value]
+    return keys
 
 
 async def _fetch_oidc_discovery(discovery_uri: str) -> dict[str, Any]:
@@ -178,7 +178,7 @@ async def _fetch_oidc_discovery(discovery_uri: str) -> dict[str, Any]:
     client: Final = get_async_httpx_client(llm_provider=httpxSpecialProvider.Oauth2Check)
     resp: Final = await client.get(discovery_uri, headers={"Accept": "application/json"})
     resp.raise_for_status()
-    return resp.json()  # type: ignore[return-value]
+    return resp.json()
 
 
 class MCPJWTSigner(CustomGuardrail):
@@ -422,9 +422,7 @@ class MCPJWTSigner(CustomGuardrail):
         try:
             jwks_set: Final = PyJWKSet.from_dict({"keys": jwks_keys})
         except Exception as exc:
-            raise jwt.exceptions.PyJWKSetError(  # type: ignore[attr-defined]
-                f"Failed to parse JWKS from {jwks_uri!r}: {exc}"
-            ) from exc
+            raise jwt.exceptions.PyJWKSetError(f"Failed to parse JWKS from {jwks_uri!r}: {exc}") from exc
 
         signing_jwk = None
         for jwk_obj in jwks_set.keys:
@@ -433,9 +431,7 @@ class MCPJWTSigner(CustomGuardrail):
                 break
 
         if signing_jwk is None:
-            raise jwt.exceptions.PyJWKSetError(  # type: ignore[attr-defined]
-                f"No JWKS key matching kid={kid!r} at {jwks_uri!r}"
-            )
+            raise jwt.exceptions.PyJWKSetError(f"No JWKS key matching kid={kid!r} at {jwks_uri!r}")
 
         # Use the algorithm declared by the JWKS key entry, not the token header.
         # PyJWT populates algorithm_name from the key's `alg` field; when absent
@@ -485,7 +481,7 @@ class MCPJWTSigner(CustomGuardrail):
         resp.raise_for_status()
         result: Final[dict[str, Any]] = resp.json()
         if not result.get("active", False):
-            raise jwt.exceptions.ExpiredSignatureError(  # type: ignore[attr-defined]
+            raise jwt.exceptions.ExpiredSignatureError(
                 "MCPJWTSigner: incoming token is inactive (introspection returned active=false)"
             )
         return result

--- a/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/model_armor/model_armor.py
@@ -434,7 +434,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
         guardrail_response: Final = metadata.get("_model_armor_response", {})
 
         # Determine status – default to "success" but prefer the explicit value if present.
-        guardrail_status: Final[GuardrailStatus] = metadata.get("_model_armor_status", "success")  # type: ignore
+        guardrail_status: Final[GuardrailStatus] = metadata.get("_model_armor_status", "success")
 
         self.add_standard_logging_guardrail_information_to_request_data(
             guardrail_json_response=guardrail_response,
@@ -923,7 +923,7 @@ class ModelArmorGuardrail(CustomGuardrail, VertexBase):
                     else:
                         error_obj = {"message": str(error_value)}
                     error_obj["code"] = str(e.status_code)
-                    yield f"data: {json.dumps({'error': error_obj})}\n\n"  # type: ignore[misc]
+                    yield f"data: {json.dumps({'error': error_obj})}\n\n"
                     return
                 except Exception as e:
                     verbose_proxy_logger.error("Model Armor streaming error: %s", str(e), exc_info=True)

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma.py
@@ -179,7 +179,7 @@ class NomaGuardrail(CustomGuardrail):
         if not messages:
             return None
 
-        input_items, instructions = self._responses_transform_handler.convert_chat_completion_messages_to_responses_api(  # type: ignore[arg-type]
+        input_items, instructions = self._responses_transform_handler.convert_chat_completion_messages_to_responses_api(
             messages
         )
 

--- a/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/noma/noma_v2.py
@@ -237,7 +237,7 @@ class NomaV2Guardrail(CustomGuardrail):
             for field in _INTERVENED_INPUT_FIELDS:
                 value = response_json.get(field)
                 if isinstance(value, list):
-                    updated_inputs[field] = value  # type: ignore[literal-required]
+                    updated_inputs[field] = value
             return updated_inputs
 
         return inputs

--- a/litellm/proxy/guardrails/guardrail_hooks/pangea/pangea.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/pangea/pangea.py
@@ -168,7 +168,7 @@ class PangeaHandler(CustomGuardrail):
 
         ai_guard_payload: Final = {
             "debug": False,
-            "input": {"messages": messages, "tools": data.get("tools")},  # type: ignore
+            "input": {"messages": messages, "tools": data.get("tools")},
             "event_type": "input",
         }
         if self.pangea_input_recipe:
@@ -182,7 +182,7 @@ class PangeaHandler(CustomGuardrail):
 
         output: Final = ai_guard_response.get("result", {}).get("output", {})
         if call_type == "text_completion" or call_type == "atext_completion":
-            data = transformer.update_original_body(output["messages"])  # type: ignore
+            data = transformer.update_original_body(output["messages"])
         else:
             data["messages"] = output["messages"]
         return data

--- a/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/panw_prisma_airs/panw_prisma_airs.py
@@ -330,7 +330,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
             payload["ai_profile"] = ai_profile
 
         if is_response and tool_event is None:
-            payload["metadata"]["is_response"] = True  # type: ignore[call-overload, index]
+            payload["metadata"]["is_response"] = True
 
         headers: Final = {
             "Content-Type": "application/json",
@@ -343,7 +343,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
             async_client: Final = get_async_httpx_client(llm_provider=httpxSpecialProvider.GuardrailCallback)
 
             # Bypass wrapper to access follow_redirects parameter
-            response: Final = await async_client.client.post(  # type: ignore[attr-defined]
+            response: Final = await async_client.client.post(
                 f"{self.api_base}/v1/scan/sync/request",
                 headers=headers,
                 json=payload,
@@ -606,9 +606,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
                     if isinstance(content, str):
                         choice.message.content = masked_text
                     elif isinstance(content, list):
-                        choice.message.content = self._mask_content_list(  # type: ignore
-                            content, masked_text
-                        )
+                        choice.message.content = self._mask_content_list(content, masked_text)
 
                 # Mask tool call arguments
                 if hasattr(choice.message, "tool_calls") and choice.message.tool_calls:
@@ -1366,7 +1364,7 @@ class PanwPrismaAirsHandler(CustomGuardrail):
             # returns a proper JSON error response with the correct status code.
             # (Raising from a generator hits create_response's generic except → 500.)
             detail: Final = e.detail if isinstance(e.detail, dict) else {"message": str(e.detail)}
-            error_obj: Final[dict[str, Any]] = dict(detail.get("error", detail))  # type: ignore[arg-type]
+            error_obj: Final[dict[str, Any]] = dict(detail.get("error", detail))
             error_obj["code"] = e.status_code
             yield f"data: {json.dumps({'error': error_obj})}\n\n"
         except Exception as e:

--- a/litellm/proxy/guardrails/guardrail_hooks/pillar/pillar.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/pillar/pillar.py
@@ -395,7 +395,7 @@ class PillarGuardrail(CustomGuardrail):
         verbose_proxy_logger.debug("Pillar Guardrail: Post-call hook")
 
         # Extract response messages in the format Pillar expects
-        response_dict = response.model_dump() if hasattr(response, "model_dump") else {}  # type: ignore[union-attr]
+        response_dict = response.model_dump() if hasattr(response, "model_dump") else {}
         response_messages: Final = [
             choice.get("message") for choice in response_dict.get("choices", []) if choice.get("message")
         ]

--- a/litellm/proxy/guardrails/guardrail_hooks/presidio.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/presidio.py
@@ -148,10 +148,10 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
     ):
         self.presidio_analyzer_api_base: str | None = presidio_analyzer_api_base or get_secret(
             "PRESIDIO_ANALYZER_API_BASE", None
-        )  # type: ignore
+        )
         self.presidio_anonymizer_api_base: str | None = presidio_anonymizer_api_base or litellm.get_secret(
             "PRESIDIO_ANONYMIZER_API_BASE", None
-        )  # type: ignore
+        )
 
         if self.presidio_analyzer_api_base is None:
             raise Exception("Missing `PRESIDIO_ANALYZER_API_BASE` from environment")
@@ -831,7 +831,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
 
         return kwargs, result
 
-    async def async_post_call_success_hook(  # type: ignore
+    async def async_post_call_success_hook(
         self,
         data: dict,
         user_api_key_dict: UserAPIKeyAuth,
@@ -1069,7 +1069,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                     else:
                         all_chunks.append(chunk)
                 elif isinstance(chunk, bytes):
-                    yield chunk  # type: ignore[misc]
+                    yield chunk
                     continue
                 else:
                     if all_chunks:
@@ -1202,9 +1202,9 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
                         remaining_chunks.append(chunk)
                 elif isinstance(chunk, bytes):
                     if pii_tokens:
-                        yield self._unmask_sse_bytes_chunk(chunk, pii_tokens)  # type: ignore[misc]
+                        yield self._unmask_sse_bytes_chunk(chunk, pii_tokens)
                     else:
-                        yield chunk  # type: ignore[misc]
+                        yield chunk
                     continue
                 else:
                     # /v1/responses events: unmask response.completed text in-place.
@@ -1251,7 +1251,7 @@ class _OPTIONAL_PresidioPIIMasking(CustomGuardrail):
             for chunk in remaining_chunks:
                 yield chunk
 
-    async def async_post_call_streaming_iterator_hook(  # type: ignore[override]
+    async def async_post_call_streaming_iterator_hook(
         self,
         user_api_key_dict: UserAPIKeyAuth,
         response: Any,

--- a/litellm/proxy/guardrails/guardrail_hooks/qualifire/qualifire.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/qualifire/qualifire.py
@@ -442,12 +442,12 @@ class QualifireGuardrail(CustomGuardrail):
             # If no structured messages available, construct from texts
             if not messages and texts:
                 # Create a simple message structure for the output
-                messages = [{"role": "assistant", "content": output or ""}]  # type: ignore
+                messages = [{"role": "assistant", "content": output or ""}]
 
         if not messages:
             # For pre_call with no messages, try to construct from texts
             if texts:
-                messages = [{"role": "user", "content": texts[-1] if texts else ""}]  # type: ignore
+                messages = [{"role": "user", "content": texts[-1] if texts else ""}]
             else:
                 verbose_proxy_logger.debug("Qualifire Guardrail: No messages or texts found, skipping")
                 return inputs
@@ -465,7 +465,7 @@ class QualifireGuardrail(CustomGuardrail):
         return inputs
 
     @staticmethod
-    def get_config_model() -> type["GuardrailConfigModel"] | None:  # type: ignore
+    def get_config_model() -> type["GuardrailConfigModel"] | None:
         from litellm.types.proxy.guardrails.guardrail_hooks.qualifire import (
             QualifireGuardrailConfigModel,
         )

--- a/litellm/proxy/guardrails/guardrail_hooks/repelloai/repelloai.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/repelloai/repelloai.py
@@ -223,7 +223,7 @@ class RepelloAIGuardrail(CustomGuardrail):
             return repelloai_response
         except HTTPException as e:
             status = "guardrail_failed_to_respond"
-            guardrail_json_response = str(e.detail) if not isinstance(e.detail, (dict, list)) else e.detail  # type: ignore[assignment]
+            guardrail_json_response = str(e.detail) if not isinstance(e.detail, (dict, list)) else e.detail
             raise
         except HTTPError as e:
             status = "guardrail_failed_to_respond"

--- a/litellm/proxy/guardrails/guardrail_hooks/semantic_guard/__init__.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/semantic_guard/__init__.py
@@ -56,7 +56,7 @@ def initialize_guardrail(
         custom_routes_file=getattr(litellm_params, "custom_routes_file", None),
         custom_routes=getattr(litellm_params, "custom_routes", None),
         on_flagged_action=getattr(litellm_params, "on_flagged_action", "block"),
-        event_hook=litellm_params.mode,  # type: ignore
+        event_hook=litellm_params.mode,
         default_on=litellm_params.default_on or False,
     )
 

--- a/litellm/proxy/guardrails/guardrail_hooks/semantic_guard/semantic_guard.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/semantic_guard/semantic_guard.py
@@ -22,7 +22,7 @@ from litellm.types.utils import CallTypes
 try:
     from fastapi.exceptions import HTTPException
 except ImportError:
-    HTTPException = None  # type: ignore
+    HTTPException = None
 
 if TYPE_CHECKING:
     from semantic_router.routers import SemanticRouter

--- a/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/unified_guardrail/unified_guardrail.py
@@ -232,10 +232,10 @@ class UnifiedLLMGuardrails(CustomLogger):
         call_type: CallTypesLiteral | None = None
         if user_api_key_dict.request_route is not None:
             call_types: Final = get_call_types_for_route(user_api_key_dict.request_route)
-            if call_types is not None and len(call_types) > 0:  # type: ignore
-                call_type = call_types[0]  # type: ignore
+            if call_types is not None and len(call_types) > 0:
+                call_type = call_types[0]
         if call_type is None:
-            call_type = _infer_call_type(call_type=None, completion_response=response)  # type: ignore
+            call_type = _infer_call_type(call_type=None, completion_response=response)
 
         # Fallback: resolve call_type from logging_obj for pass-through endpoints
         if call_type is None:
@@ -275,7 +275,7 @@ class UnifiedLLMGuardrails(CustomLogger):
 
         try:
             response = await endpoint_translation.process_output_response(
-                response=response,  # type: ignore
+                response=response,
                 guardrail_to_apply=guardrail_to_apply,
                 litellm_logging_obj=data.get("litellm_logging_obj"),
                 user_api_key_dict=user_api_key_dict,
@@ -958,7 +958,7 @@ class UnifiedLLMGuardrails(CustomLogger):
                     call_type = call_types[0].value
 
             if call_type is None:
-                call_type = _infer_call_type(call_type=None, completion_response=item)  # type: ignore
+                call_type = _infer_call_type(call_type=None, completion_response=item)
 
             # If call type not supported, just pass through all chunks
             if call_type is None or CallTypes(call_type) not in endpoint_guardrail_translation_mappings:

--- a/litellm/proxy/guardrails/guardrail_registry.py
+++ b/litellm/proxy/guardrails/guardrail_registry.py
@@ -348,7 +348,7 @@ class GuardrailRegistry:
 
             guardrails: Final[list[Guardrail]] = []
             for guardrail in guardrails_from_db:
-                guardrails.append(Guardrail(**(dict(guardrail))))  # type: ignore
+                guardrails.append(Guardrail(**(dict(guardrail))))
 
             return guardrails
         except Exception as e:
@@ -366,7 +366,7 @@ class GuardrailRegistry:
             if not guardrail:
                 return None
 
-            return Guardrail(**(dict(guardrail)))  # type: ignore
+            return Guardrail(**(dict(guardrail)))
         except Exception as e:
             raise Exception(f"Error getting guardrail from DB: {e}")
 
@@ -382,7 +382,7 @@ class GuardrailRegistry:
             if not guardrail:
                 return None
 
-            return Guardrail(**(dict(guardrail)))  # type: ignore
+            return Guardrail(**(dict(guardrail)))
         except Exception as e:
             raise Exception(f"Error getting guardrail from DB: {e}")
 
@@ -472,7 +472,7 @@ class InMemoryGuardrailHandler:
                 custom_guardrail_callback = initializer(
                     litellm_params,
                     guardrail,
-                    llm_router,  # type: ignore
+                    llm_router,
                 )
             else:
                 custom_guardrail_callback = initializer(litellm_params, guardrail)
@@ -563,7 +563,7 @@ class InMemoryGuardrailHandler:
             default_on=default_on,
             **extra_params,
         )
-        litellm.logging_callback_manager.add_litellm_callback(_guardrail_callback)  # type: ignore
+        litellm.logging_callback_manager.add_litellm_callback(_guardrail_callback)
 
         return _guardrail_callback
 

--- a/litellm/proxy/guardrails/init_guardrails.py
+++ b/litellm/proxy/guardrails/init_guardrails.py
@@ -127,7 +127,7 @@ def initialize_guardrails(
 
                     if guardrail.logging_only is True:
                         if callback == "presidio":
-                            callback_specific_params["presidio"] = {"logging_only": True}  # type: ignore
+                            callback_specific_params["presidio"] = {"logging_only": True}
 
         default_on_callbacks_list: Final = list(default_on_callbacks)
         if len(default_on_callbacks_list) > 0:

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -1435,8 +1435,8 @@ async def _get_health_readiness_details(
                 try:
                     index_info = await litellm.cache.cache._index_info()
                 except Exception as e:
-                    index_info = "index does not exist - error: " + str(e)  # type: ignore[assignment]
-                cache_type = {"type": cache_type, "index_info": index_info}  # type: ignore[assignment]
+                    index_info = "index does not exist - error: " + str(e)
+                cache_type = {"type": cache_type, "index_info": index_info}
 
         # check log level
         log_level_name: Final = logging.getLevelName(verbose_logger.getEffectiveLevel())

--- a/litellm/proxy/hooks/dynamic_rate_limiter.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter.py
@@ -228,7 +228,7 @@ class _PROXY_DynamicRateLimitHandler(CustomLogger):
                 ## UPDATE CACHE WITH ACTIVE PROJECT
                 asyncio.create_task(
                     self.internal_usage_cache.async_set_cache_sadd(  # this is a set
-                        model=data["model"],  # type: ignore
+                        model=data["model"],
                         value=[user_api_key_dict.token or "default_key"],
                     )
                 )

--- a/litellm/proxy/hooks/litellm_skills/main.py
+++ b/litellm/proxy/hooks/litellm_skills/main.py
@@ -422,8 +422,8 @@ class SkillsInjectionHook(CustomLogger):
                     )
 
         # OpenAI format: response has choices[0].message.tool_calls
-        if not tool_calls and hasattr(response, "choices") and response.choices:  # type: ignore[union-attr]
-            msg: Final = response.choices[0].message  # type: ignore[union-attr]
+        if not tool_calls and hasattr(response, "choices") and response.choices:
+            msg: Final = response.choices[0].message
             if hasattr(msg, "tool_calls") and msg.tool_calls:
                 for tc in msg.tool_calls:
                     tool_calls.append(
@@ -709,8 +709,8 @@ print('No executable skill module found')
 
         for iteration in range(self.max_iterations):
             # OpenAI format response has choices[0].message
-            assistant_message = current_response.choices[0].message  # type: ignore[union-attr]
-            stop_reason = current_response.choices[0].finish_reason  # type: ignore[union-attr]
+            assistant_message = current_response.choices[0].message
+            stop_reason = current_response.choices[0].finish_reason
 
             # Build assistant message for conversation history
             assistant_msg_dict: dict[str, Any] = {

--- a/litellm/proxy/hooks/mcp_semantic_filter/hook.py
+++ b/litellm/proxy/hooks/mcp_semantic_filter/hook.py
@@ -376,7 +376,7 @@ class SemanticToolFilterHook(CustomLogger):
             if mcp_tools:
                 filtered_mcp_tools = await self.filter.filter_tools(
                     query=user_query,
-                    available_tools=mcp_tools,  # type: ignore
+                    available_tools=mcp_tools,
                 )
             else:
                 filtered_mcp_tools = []

--- a/litellm/proxy/hooks/model_max_budget_limiter.py
+++ b/litellm/proxy/hooks/model_max_budget_limiter.py
@@ -225,7 +225,7 @@ class _PROXY_VirtualKeyModelMaxBudgetLimiter(RouterBudgetLimiting):
         healthy_deployments: list,
         messages: list[AllMessageValues] | None,
         request_kwargs: dict | None = None,
-        parent_otel_span: Span | None = None,  # type: ignore
+        parent_otel_span: Span | None = None,
     ) -> list[dict]:
         return healthy_deployments
 

--- a/litellm/proxy/hooks/parallel_request_limiter.py
+++ b/litellm/proxy/hooks/parallel_request_limiter.py
@@ -532,7 +532,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
             total_tokens = 0
 
             if isinstance(response_obj, (ModelResponse, EmbeddingResponse, TextCompletionResponse)):
-                total_tokens = response_obj.usage.total_tokens  # type: ignore
+                total_tokens = response_obj.usage.total_tokens
 
             # ------------
             # Update usage - API Key
@@ -612,7 +612,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                     response_obj,
                     (ModelResponse, EmbeddingResponse, TextCompletionResponse),
                 ):
-                    total_tokens = response_obj.usage.total_tokens  # type: ignore
+                    total_tokens = response_obj.usage.total_tokens
 
                 request_count_api_key = f"{user_api_key_user_id}::{precise_minute}::request_count"
 
@@ -644,7 +644,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                     response_obj,
                     (ModelResponse, EmbeddingResponse, TextCompletionResponse),
                 ):
-                    total_tokens = response_obj.usage.total_tokens  # type: ignore
+                    total_tokens = response_obj.usage.total_tokens
 
                 request_count_api_key = f"{user_api_key_team_id}::{precise_minute}::request_count"
 
@@ -676,7 +676,7 @@ class _PROXY_MaxParallelRequestsHandler(CustomLogger):
                     response_obj,
                     (ModelResponse, EmbeddingResponse, TextCompletionResponse),
                 ):
-                    total_tokens = response_obj.usage.total_tokens  # type: ignore
+                    total_tokens = response_obj.usage.total_tokens
 
                 request_count_api_key = f"{user_api_key_end_user_id}::{precise_minute}::request_count"
 

--- a/litellm/proxy/hooks/prompt_injection_detection.py
+++ b/litellm/proxy/hooks/prompt_injection_detection.py
@@ -158,7 +158,7 @@ class _OPTIONAL_PromptInjectionDetection(CustomLogger):
                     f"Call Type - {call_type}, not in accepted list - ['completion','embeddings','image_generation','moderation','audio_transcription']"
                 )
                 return data
-            formatted_prompt: Final = get_formatted_prompt(data=data, call_type=call_type)  # type: ignore
+            formatted_prompt: Final = get_formatted_prompt(data=data, call_type=call_type)
 
             is_prompt_attack = False
 
@@ -189,7 +189,7 @@ class _OPTIONAL_PromptInjectionDetection(CustomLogger):
             if (
                 e.status_code == 400
                 and isinstance(e.detail, dict)
-                and "error" in e.detail  # type: ignore
+                and "error" in e.detail
                 and self.prompt_injection_params is not None
                 and self.prompt_injection_params.reject_as_response
             ):
@@ -200,7 +200,7 @@ class _OPTIONAL_PromptInjectionDetection(CustomLogger):
                 "litellm.proxy.hooks.prompt_injection_detection.py::async_pre_call_hook(): Exception occured - %s", e
             )
 
-    async def async_moderation_hook(  # type: ignore
+    async def async_moderation_hook(
         self,
         data: dict,
         user_api_key_dict: UserAPIKeyAuth,
@@ -218,7 +218,7 @@ class _OPTIONAL_PromptInjectionDetection(CustomLogger):
         if self.prompt_injection_params is None:
             return None
 
-        formatted_prompt: Final = get_formatted_prompt(data=data, call_type=call_type)  # type: ignore
+        formatted_prompt: Final = get_formatted_prompt(data=data, call_type=call_type)
         is_prompt_attack = False
 
         prompt_injection_system_prompt: Final = getattr(

--- a/litellm/proxy/hooks/proxy_track_cost_callback.py
+++ b/litellm/proxy/hooks/proxy_track_cost_callback.py
@@ -304,7 +304,7 @@ class _ProxyDBLogger(CustomLogger):
                 ):
                     if sl_object is not None:
                         cost_tracking_failure_debug_info: dict | str = (
-                            sl_object["response_cost_failure_debug_info"]  # type: ignore
+                            sl_object["response_cost_failure_debug_info"]
                             or "response_cost_failure_debug_info is None in standard_logging_object"
                         )
                     else:

--- a/litellm/proxy/hooks/responses_id_security.py
+++ b/litellm/proxy/hooks/responses_id_security.py
@@ -256,7 +256,7 @@ class ResponsesIDSecurity(CustomLogger):
             )
         return response
 
-    async def async_post_call_streaming_iterator_hook(  # type: ignore
+    async def async_post_call_streaming_iterator_hook(
         self, user_api_key_dict: "UserAPIKeyAuth", response: Any, request_data: dict
     ) -> AsyncGenerator[BaseLiteLLMOpenAIResponseObject, None]:
         from litellm.proxy.proxy_server import general_settings

--- a/litellm/proxy/hooks/user_management_event_hooks.py
+++ b/litellm/proxy/hooks/user_management_event_hooks.py
@@ -113,12 +113,12 @@ class UserManagementEventHooks:
 
         if use_enterprise_email_hooks and (data.send_invite_email is True):
             initialized_email_loggers: Final = litellm.logging_callback_manager.get_custom_loggers_for_type(
-                callback_type=BaseEmailLogger  # type: ignore
+                callback_type=BaseEmailLogger
             )
             if len(initialized_email_loggers) > 0:
                 for email_logger in initialized_email_loggers:
-                    if isinstance(email_logger, BaseEmailLogger):  # type: ignore
-                        await email_logger.send_user_invitation_email(  # type: ignore
+                    if isinstance(email_logger, BaseEmailLogger):
+                        await email_logger.send_user_invitation_email(
                             event=event,
                         )
 

--- a/litellm/proxy/management_endpoints/budget_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/budget_management_endpoints.py
@@ -92,10 +92,10 @@ async def new_budget(
     try:
         response: Final = await BudgetRepository(prisma_client).table.create(
             data={
-                **budget_obj_jsonified,  # type: ignore
+                **budget_obj_jsonified,
                 "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
                 "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-            }  # type: ignore
+            }
         )
     except Exception as e:
         if not isinstance(e, UniqueViolationError):
@@ -174,10 +174,10 @@ async def update_budget(
     response: Final = await BudgetRepository(prisma_client).table.update(
         where={"budget_id": budget_obj.budget_id},
         data={
-            **budget_obj.model_dump(exclude_unset=True),  # type: ignore
+            **budget_obj.model_dump(exclude_unset=True),
             **recomputed_reset_at,
             "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-        },  # type: ignore
+        },
     )
 
     return response

--- a/litellm/proxy/management_endpoints/config_override_endpoints.py
+++ b/litellm/proxy/management_endpoints/config_override_endpoints.py
@@ -15,7 +15,7 @@ from litellm.litellm_core_utils.safe_json_loads import safe_json_loads
 try:
     from prisma.errors import RecordNotFoundError
 except ImportError:
-    RecordNotFoundError = Exception  # type: ignore
+    RecordNotFoundError = Exception
 
 import litellm
 from litellm._logging import verbose_proxy_logger

--- a/litellm/proxy/management_endpoints/customer_endpoints.py
+++ b/litellm/proxy/management_endpoints/customer_endpoints.py
@@ -89,9 +89,9 @@ async def block_user(data: BlockUsers):
         if prisma_client is not None:
             for id in data.user_ids:
                 record = await EndUserRepository(prisma_client).table.upsert(
-                    where={"user_id": id},  # type: ignore
+                    where={"user_id": id},
                     data={
-                        "create": {"user_id": id, "blocked": True},  # type: ignore
+                        "create": {"user_id": id, "blocked": True},
                         "update": {"blocked": True},
                     },
                 )
@@ -351,7 +351,7 @@ async def new_end_user(
                 budget_record: Final = await BudgetRepository(prisma_client).table.create(
                     data={
                         **_new_budget.model_dump(exclude_unset=True),
-                        "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,  # type: ignore
+                        "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
                         "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
                     }
                 )
@@ -385,7 +385,7 @@ async def new_end_user(
 
         ## WRITE TO DB ##
         end_user_record: Final = await EndUserRepository(prisma_client).table.create(
-            data=new_end_user_obj,  # type: ignore
+            data=new_end_user_obj,
             include={"litellm_budget_table": True, "object_permission": True},
         )
 
@@ -621,12 +621,12 @@ async def update_end_user(
             update_end_user_table_data.pop("object_permission", None)
 
         if data.user_id is not None and len(data.user_id) > 0:
-            update_end_user_table_data["user_id"] = data.user_id  # type: ignore
+            update_end_user_table_data["user_id"] = data.user_id
             verbose_proxy_logger.debug("In update customer, user_id condition block.")
             response: Final = await EndUserRepository(prisma_client).table.update(
                 where={"user_id": data.user_id},
                 data=update_end_user_table_data,
-                include={"litellm_budget_table": True, "object_permission": True},  # type: ignore
+                include={"litellm_budget_table": True, "object_permission": True},
             )
             if response is None:
                 raise ValueError(f"Failed updating customer data. User ID does not exist passed user_id={data.user_id}")

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -536,7 +536,7 @@ async def new_user(
             user_api_key_dict=user_api_key_dict,
         )
 
-        data_json = data.json()  # type: ignore
+        data_json = data.json()
         data_json = _update_internal_new_user_params(data_json, data)
         # Persist the requested grants as their own row and link it, mirroring key/team creation.
         # generate_key_helper_fn only forwards object_permission_id, so without this the entitlement
@@ -1816,7 +1816,7 @@ async def bulk_user_update(
             for user in all_users_in_db:
                 user_update_request = data.user_updates.model_copy()
                 user_update_request.user_id = user.user_id
-                users_to_update.append(user_update_request)  # type: ignore
+                users_to_update.append(user_update_request)
 
         if successful_updates > 0:
             return BulkUpdateUserResponse(

--- a/litellm/proxy/management_endpoints/key_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/key_management_endpoints.py
@@ -441,7 +441,7 @@ def _personal_key_generation_check(user_api_key_dict: UserAPIKeyAuth, data: Gene
     ):
         return True
 
-    _personal_key_generation: Final = litellm.key_generation_settings["personal_key_generation"]  # type: ignore
+    _personal_key_generation: Final = litellm.key_generation_settings["personal_key_generation"]
 
     _personal_key_membership_check(
         user_api_key_dict,
@@ -955,7 +955,7 @@ async def _common_key_generation_helper(
 
         _budget: Final = await BudgetRepository(prisma_client).table.create(
             data={
-                **new_budget,  # type: ignore
+                **new_budget,
                 "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
                 "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
             }
@@ -982,7 +982,7 @@ async def _common_key_generation_helper(
             )
             delattr(data, field)
 
-    data_json = data.model_dump(exclude_unset=True, exclude_none=True)  # type: ignore
+    data_json = data.model_dump(exclude_unset=True, exclude_none=True)
 
     data_json = handle_key_type(data, data_json)
 
@@ -1651,7 +1651,7 @@ async def generate_key_fn(
 
         if user_custom_key_generate is not None:
             if inspect.iscoroutinefunction(user_custom_key_generate):
-                result: Final = await user_custom_key_generate(data)  # type: ignore
+                result: Final = await user_custom_key_generate(data)
             else:
                 raise ValueError("user_custom_key_generate must be a coroutine")
             decision: Final = result.get("decision", True)
@@ -1848,7 +1848,7 @@ async def generate_service_account_key_fn(
 
     if user_custom_key_generate is not None:
         if inspect.iscoroutinefunction(user_custom_key_generate):
-            result: Final = await user_custom_key_generate(data)  # type: ignore
+            result: Final = await user_custom_key_generate(data)
         else:
             raise ValueError("user_custom_key_generate must be a coroutine")
         decision: Final = result.get("decision", True)
@@ -3559,7 +3559,7 @@ async def info_key_fn(
         if key is not None:
             hashed_key = _hash_token_if_needed(token=key)
         key_info = await VerificationTokenRepository(prisma_client).table.find_unique(
-            where={"token": hashed_key},  # type: ignore
+            where={"token": hashed_key},
             include={"litellm_budget_table": True},
         )
         if key_info is None:
@@ -3873,8 +3873,8 @@ async def generate_key_helper_fn(
                     if user_row is None:
                         raise Exception("Failed to create user")
                     ## use default user model list if no key-specific model list provided
-                    if len(user_row.models) > 0 and len(key_data["models"]) == 0:  # type: ignore
-                        key_data["models"] = user_row.models  # type: ignore
+                    if len(user_row.models) > 0 and len(key_data["models"]) == 0:
+                        key_data["models"] = user_row.models
                 elif query_type == "update_data":
                     user_row = await prisma_client.update_data(
                         data=user_data,
@@ -4278,8 +4278,8 @@ async def _rotate_master_key(
             )
             if new_model:
                 _dumped = new_model.model_dump(exclude_none=True)
-                _dumped["litellm_params"] = prisma.Json(_dumped["litellm_params"])  # type: ignore[attr-defined]
-                _dumped["model_info"] = prisma.Json(_dumped["model_info"])  # type: ignore[attr-defined]
+                _dumped["litellm_params"] = prisma.Json(_dumped["litellm_params"])
+                _dumped["model_info"] = prisma.Json(_dumped["model_info"])
                 new_models.append(_dumped)
         verbose_proxy_logger.debug("Resetting proxy model table")
         async with prisma_client.db.tx() as tx:
@@ -4314,7 +4314,7 @@ async def _rotate_master_key(
             if encrypted_env_vars:
                 await _config_table(prisma_client).update(
                     where={"param_name": "environment_variables"},
-                    data={"param_value": prisma.Json(encrypted_env_vars)},  # type: ignore[attr-defined]
+                    data={"param_value": prisma.Json(encrypted_env_vars)},
                 )
 
     # 4. process MCP server table
@@ -4372,13 +4372,9 @@ async def _rotate_master_key(
                 )
                 _cred_data = encrypted_cred.model_dump(exclude_none=True)
                 if "credential_values" in _cred_data:
-                    _cred_data["credential_values"] = prisma.Json(  # type: ignore[attr-defined]
-                        _cred_data["credential_values"]
-                    )
+                    _cred_data["credential_values"] = prisma.Json(_cred_data["credential_values"])
                 if "credential_info" in _cred_data:
-                    _cred_data["credential_info"] = prisma.Json(  # type: ignore[attr-defined]
-                        _cred_data["credential_info"]
-                    )
+                    _cred_data["credential_info"] = prisma.Json(_cred_data["credential_info"])
                 await _credentials_table(prisma_client).update(
                     where={"credential_name": cred.credential_name},
                     data={
@@ -4622,7 +4618,7 @@ async def _execute_virtual_key_regeneration(
 
     updated_token: Final = await VerificationTokenRepository(prisma_client).table.update(
         where={"token": hashed_api_key},
-        data=update_data,  # type: ignore
+        data=update_data,
     )
     updated_token_dict: Final = dict(updated_token) if updated_token is not None else {}
     updated_token_dict["key"] = new_token
@@ -5869,9 +5865,9 @@ async def _list_key_helper(
     # Fetch keys with pagination
     if use_deleted_table:
         keys = await DeletedVerificationTokenRepository(prisma_client).table.find_many(
-            where=where,  # type: ignore
-            skip=skip,  # type: ignore
-            take=size,  # type: ignore
+            where=where,
+            skip=skip,
+            take=size,
             order=(
                 order_by
                 if order_by
@@ -5883,9 +5879,9 @@ async def _list_key_helper(
         )
     else:
         keys = await VerificationTokenRepository(prisma_client).table.find_many(
-            where=where,  # type: ignore
-            skip=skip,  # type: ignore
-            take=size,  # type: ignore
+            where=where,
+            skip=skip,
+            take=size,
             order=(
                 order_by
                 if order_by
@@ -5901,13 +5897,9 @@ async def _list_key_helper(
 
     # Get total count of keys
     if use_deleted_table:
-        total_count = await _deleted_verification_token_table(prisma_client).count(
-            where=where  # type: ignore
-        )
+        total_count = await _deleted_verification_token_table(prisma_client).count(where=where)
     else:
-        total_count = await _prisma_table(VerificationTokenRepository(prisma_client)).count(
-            where=where  # type: ignore
-        )
+        total_count = await _prisma_table(VerificationTokenRepository(prisma_client)).count(where=where)
 
     verbose_proxy_logger.debug("Total count of keys: %s", total_count)
 
@@ -6136,7 +6128,7 @@ async def block_key(
 
     record: Final = await _prisma_table(VerificationTokenRepository(prisma_client)).update(
         where={"token": hashed_token},
-        data={"blocked": True},  # type: ignore
+        data={"blocked": True},
     )
 
     ## UPDATE KEY CACHE - invalidate so next read re-fetches from DB
@@ -6249,7 +6241,7 @@ async def unblock_key(
 
     record: Final = await _prisma_table(VerificationTokenRepository(prisma_client)).update(
         where={"token": hashed_token},
-        data={"blocked": False},  # type: ignore
+        data={"blocked": False},
     )
 
     ## UPDATE KEY CACHE - invalidate so next read re-fetches from DB

--- a/litellm/proxy/management_endpoints/mcp_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/mcp_management_endpoints.py
@@ -40,8 +40,8 @@ from fastapi.responses import JSONResponse
 try:
     from prisma.errors import RecordNotFoundError, UniqueViolationError
 except ImportError:
-    RecordNotFoundError = Exception  # type: ignore
-    UniqueViolationError = Exception  # type: ignore
+    RecordNotFoundError = Exception
+    UniqueViolationError = Exception
 
 import litellm
 from litellm._logging import verbose_logger, verbose_proxy_logger
@@ -109,7 +109,7 @@ if MCP_AVAILABLE:
             is_valid: bool = True
             warnings: list = []
 
-        def validate_tool_name(name: str) -> _ToolNameValidationResult:  # type: ignore[misc]
+        def validate_tool_name(name: str) -> _ToolNameValidationResult:
             return _ToolNameValidationResult()
 
     from litellm.proxy._experimental.mcp_server.db import (
@@ -489,7 +489,7 @@ if MCP_AVAILABLE:
         try:
             redacted_server = mcp_server.model_copy(deep=True)
         except AttributeError:
-            redacted_server = mcp_server.copy(deep=True)  # type: ignore[attr-defined]
+            redacted_server = mcp_server.copy(deep=True)
 
         if hasattr(redacted_server, "credentials"):
             setattr(redacted_server, "credentials", _preserved_admin_config_credentials(redacted_server.credentials))
@@ -702,9 +702,9 @@ if MCP_AVAILABLE:
 
         payload_dict: dict[str, Any]
         try:
-            payload_dict = payload.model_dump()  # type: ignore[attr-defined]
+            payload_dict = payload.model_dump()
         except AttributeError:
-            payload_dict = payload.dict()  # type: ignore[attr-defined]
+            payload_dict = payload.dict()
         payload_dict["credentials"] = inherited_credentials
         return NewMCPServerRequest.model_validate(payload_dict)
 

--- a/litellm/proxy/management_endpoints/model_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/model_management_endpoints.py
@@ -160,9 +160,7 @@ def _raise_on_strategy_router_write_violation(
 def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> PrismaCompatibleUpdateDBModel:
     merged_deployment_dict: Final = DeploymentTypedDict(
         model_name=db_model.model_name,
-        litellm_params=LiteLLMParamsTypedDict(
-            **db_model.litellm_params.model_dump(exclude_none=True)  # type: ignore
-        ),
+        litellm_params=LiteLLMParamsTypedDict(**db_model.litellm_params.model_dump(exclude_none=True)),
         model_info=db_model.model_info.model_dump(exclude_none=True),
     )
     # update model name
@@ -176,7 +174,7 @@ def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> Pr
             k: encrypt_value_helper(v) for k, v in updated_patch.litellm_params.model_dump(exclude_none=True).items()
         }
 
-        merged_deployment_dict["litellm_params"].update(encrypted_params)  # type: ignore
+        merged_deployment_dict["litellm_params"].update(encrypted_params)
 
     # update model info
     if updated_patch.model_info:
@@ -196,13 +194,13 @@ def update_db_model(db_model: Deployment, updated_patch: updateDeployment) -> Pr
     if updated_patch.litellm_params:
         for field in updated_patch.litellm_params.model_fields_set:
             if field in SPECIAL_MODEL_INFO_PARAMS and getattr(updated_patch.litellm_params, field) is None:
-                merged_deployment_dict["litellm_params"].pop(field, None)  # type: ignore
+                merged_deployment_dict["litellm_params"].pop(field, None)
                 merged_deployment_dict.get("model_info", {}).pop(field, None)
     if updated_patch.model_info:
         for field in updated_patch.model_info.model_fields_set:
             if field in SPECIAL_MODEL_INFO_PARAMS and getattr(updated_patch.model_info, field) is None:
-                merged_deployment_dict["model_info"].pop(field, None)  # type: ignore
-                merged_deployment_dict.get("litellm_params", {}).pop(field, None)  # type: ignore
+                merged_deployment_dict["model_info"].pop(field, None)
+                merged_deployment_dict.get("litellm_params", {}).pop(field, None)
 
     # convert to prisma compatible format
 
@@ -565,19 +563,15 @@ async def _add_model_to_db(
     _data: Final[dict] = {
         "model_id": model_params.model_info.id,
         "model_name": model_params.model_name,
-        "litellm_params": model_params.litellm_params.model_dump_json(exclude_none=True),  # type: ignore
-        "model_info": model_params.model_info.model_dump_json(  # type: ignore
-            exclude_none=True
-        ),
+        "litellm_params": model_params.litellm_params.model_dump_json(exclude_none=True),
+        "model_info": model_params.model_info.model_dump_json(exclude_none=True),
         "created_by": user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
         "updated_by": user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
     }
     if model_params.model_info.id is not None:
         _data["model_id"] = model_params.model_info.id
     if should_create_model_in_db:
-        model_response = await ModelRepository(prisma_client).table.create(
-            data=_data  # type: ignore
-        )
+        model_response = await ModelRepository(prisma_client).table.create(data=_data)
     else:
         model_response = LiteLLM_ProxyModelTable(**_data)
     return model_response
@@ -925,7 +919,7 @@ async def _remove_unbacked_team_models(
     updated_team_row: Final[LiteLLM_TeamTable] = await prisma_client.db.litellm_teamtable.update(
         where={"team_id": team_id},
         data={"models": [model for model in existing_team_row.models if model not in names_to_remove]},
-        include={"object_permission": True},  # type: ignore
+        include={"object_permission": True},
     )
     await _refresh_cached_team(
         team_row=updated_team_row,
@@ -1550,12 +1544,12 @@ async def update_model(
                     pass
 
             _data: Final[dict] = {
-                "litellm_params": json.dumps(merged_dictionary),  # type: ignore
+                "litellm_params": json.dumps(merged_dictionary),
                 "updated_by": user_api_key_dict.user_id or LITELLM_PROXY_ADMIN_NAME,
             }
             model_response: Final = await ModelRepository(prisma_client).table.update(
                 where={"model_id": _model_id},
-                data=_data,  # type: ignore
+                data=_data,
             )
 
             # Clear cache and reload models (uses config setting or defaults to preserving config models for DB updates)

--- a/litellm/proxy/management_endpoints/organization_endpoints.py
+++ b/litellm/proxy/management_endpoints/organization_endpoints.py
@@ -1534,7 +1534,7 @@ async def add_member_to_organization(
                 user_email=member.user_email,
             )
 
-            _returned_user = await prisma_client.insert_data(data=new_user_defaults, table_name="user")  # type: ignore
+            _returned_user = await prisma_client.insert_data(data=new_user_defaults, table_name="user")
             if _returned_user is not None:
                 user_object = LiteLLM_UserTable.model_validate(_returned_user.model_dump())
         elif existing_user_email_row is not None and len(existing_user_email_row) > 1:

--- a/litellm/proxy/management_endpoints/policy_endpoints/ai_policy_suggester.py
+++ b/litellm/proxy/management_endpoints/policy_endpoints/ai_policy_suggester.py
@@ -76,7 +76,7 @@ class AiPolicySuggester:
                 temperature=0.2,
             )
 
-            tool_calls: Final = response.choices[0].message.tool_calls  # type: ignore
+            tool_calls: Final = response.choices[0].message.tool_calls
             if not tool_calls:
                 return {
                     "selected_templates": [],

--- a/litellm/proxy/management_endpoints/policy_endpoints/endpoints.py
+++ b/litellm/proxy/management_endpoints/policy_endpoints/endpoints.py
@@ -212,7 +212,7 @@ def _chat_body_from_inputs(inputs: GenericGuardrailAPIInputs, agent_id: str, req
     structured: Final = inputs.get("structured_messages")
     texts: Final = inputs.get("texts")
     if structured:
-        messages = list(structured)  # type: ignore[arg-type]
+        messages = list(structured)
     elif texts:
         if len(texts) == 1:
             messages = [{"role": "user", "content": texts[0]}]
@@ -789,7 +789,7 @@ async def _stream_llm_competitor_names(
     )
     buffer = ""
     count = len(existing)
-    async for chunk in response:  # type: ignore[union-attr]
+    async for chunk in response:
         delta = chunk.choices[0].delta.content or ""
         buffer += delta
         while "\n" in buffer:
@@ -923,7 +923,7 @@ async def _generate_competitor_variations(competitors: list, model: str = DEFAUL
             messages=[{"role": "user", "content": prompt}],
             temperature=COMPETITOR_LLM_TEMPERATURE,
         )
-        raw: Final = response.choices[0].message.content or ""  # type: ignore
+        raw: Final = response.choices[0].message.content or ""
         return _parse_variations_response(raw, capped)
     except Exception as e:
         verbose_proxy_logger.error("LLM competitor variation generation failed: %s", e)
@@ -963,7 +963,7 @@ async def _discover_competitors_via_llm(prompt: str, model: str = DEFAULT_COMPET
             messages=[{"role": "user", "content": prompt}],
             temperature=COMPETITOR_LLM_TEMPERATURE,
         )
-        raw: Final = response.choices[0].message.content or ""  # type: ignore
+        raw: Final = response.choices[0].message.content or ""
         competitors = [name for line in raw.strip().split("\n") if (name := _clean_competitor_line(line)) is not None]
         return competitors[:MAX_COMPETITOR_NAMES]
     except Exception as e:

--- a/litellm/proxy/management_endpoints/tag_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/tag_management_endpoints.py
@@ -218,7 +218,7 @@ async def get_deployments_by_model(model: str, llm_router: "Router") -> list["De
     return [
         Deployment(
             model_name=deployment["model_name"],
-            litellm_params=LiteLLM_Params(**deployment["litellm_params"]),  # type: ignore
+            litellm_params=LiteLLM_Params(**deployment["litellm_params"]),
             model_info=ModelInfo(**deployment.get("model_info") or {}),
         )
         for deployment in deployments
@@ -536,7 +536,7 @@ def _validate_tag_list_date_range(start_date: str | None, end_date: str | None) 
         return
     try:
         start: Final = datetime.strptime(start_date, "%Y-%m-%d")
-        end: Final = datetime.strptime(end_date, "%Y-%m-%d")  # type: ignore[arg-type]
+        end: Final = datetime.strptime(end_date, "%Y-%m-%d")
     except ValueError as e:
         raise HTTPException(
             status_code=400,

--- a/litellm/proxy/management_endpoints/team_callback_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_callback_endpoints.py
@@ -322,7 +322,7 @@ async def add_team_callbacks(
 
         new_team_row: Final = await TeamRepository(prisma_client).table.update(
             where={"team_id": team_id},
-            data={"metadata": team_metadata_json},  # type: ignore
+            data={"metadata": team_metadata_json},
             # `object_permission` is included so `_refresh_cached_team` doesn't
             # write a cached team with the relation nulled out — see
             # team_model_add for the full rationale.
@@ -442,7 +442,7 @@ async def disable_team_logging(
         # Update team in database
         updated_team: Final = await TeamRepository(prisma_client).table.update(
             where={"team_id": team_id},
-            data={"metadata": team_metadata_json},  # type: ignore
+            data={"metadata": team_metadata_json},
             # `object_permission` is included so `_refresh_cached_team` doesn't
             # write a cached team with the relation nulled out — see
             # team_model_add for the full rationale.

--- a/litellm/proxy/management_endpoints/team_endpoints.py
+++ b/litellm/proxy/management_endpoints/team_endpoints.py
@@ -1311,9 +1311,7 @@ async def new_team(
                 created_by=user_api_key_dict.user_id or litellm_proxy_admin_name,
                 updated_by=user_api_key_dict.user_id or litellm_proxy_admin_name,
             )
-            model_dict: Final = await _model_db(prisma_client).create(
-                {**litellm_modeltable.json(exclude_none=True)}  # type: ignore
-            )  # type: ignore
+            model_dict: Final = await _model_db(prisma_client).create({**litellm_modeltable.json(exclude_none=True)})
 
             _model_id = model_dict.id
 
@@ -1387,7 +1385,7 @@ async def new_team(
                 w = window if isinstance(window, dict) else window.model_dump()
                 w["reset_at"] = get_budget_reset_time(budget_duration=w["budget_duration"]).isoformat()
                 initialized_windows.append(w)
-            complete_team_data.budget_limits = initialized_windows  # type: ignore[assignment]
+            complete_team_data.budget_limits = initialized_windows
 
         ## Add Team Member Budget Table
         members_with_roles: list[Member] = []
@@ -1411,7 +1409,7 @@ async def new_team(
 
         team_row: Final[LiteLLM_TeamTable] = await TeamRepository(prisma_client).table.create(
             data=complete_team_data_dict,
-            include={"litellm_model_table": True},  # type: ignore
+            include={"litellm_model_table": True},
         )
 
         ## ADD TEAM ID TO USER TABLE ##
@@ -1529,17 +1527,15 @@ async def _update_model_table(
             updated_by=user_api_key_dict.user_id or litellm_proxy_admin_name,
         )
         if model_id is None:
-            model_dict = await _model_db(prisma_client).create(
-                data={**litellm_modeltable.json(exclude_none=True)}  # type: ignore
-            )
+            model_dict = await _model_db(prisma_client).create(data={**litellm_modeltable.json(exclude_none=True)})
         else:
             model_dict = await _model_db(prisma_client).upsert(
                 where={"id": model_id},
                 data={
-                    "update": {**litellm_modeltable.json(exclude_none=True)},  # type: ignore
-                    "create": {**litellm_modeltable.json(exclude_none=True)},  # type: ignore
+                    "update": {**litellm_modeltable.json(exclude_none=True)},
+                    "create": {**litellm_modeltable.json(exclude_none=True)},
                 },
-            )  # type: ignore
+            )
 
         _model_id = model_dict.id
 
@@ -2091,7 +2087,7 @@ async def update_team(
             include={
                 "litellm_model_table": True,
                 "object_permission": True,
-            },  # type: ignore
+            },
         )
 
         if team_row is None or team_row.team_id is None:
@@ -3089,7 +3085,7 @@ async def team_member_delete(
         where={
             "team_id": data.team_id,
         },
-        data={"members_with_roles": json.dumps(_db_new_team_members)},  # type: ignore
+        data={"members_with_roles": json.dumps(_db_new_team_members)},
     )
 
     _emit_team_members_metric(existing_team_row)
@@ -3101,9 +3097,7 @@ async def team_member_delete(
         key_val["user_id"] = data.user_id
     elif data.user_email is not None:
         key_val["user_email"] = data.user_email
-    existing_user_rows: Final = await UserRepository(prisma_client).table.find_many(
-        where=key_val  # type: ignore
-    )
+    existing_user_rows: Final = await UserRepository(prisma_client).table.find_many(where=key_val)
 
     if existing_user_rows is not None and (isinstance(existing_user_rows, list) and len(existing_user_rows) > 0):
         for existing_user in existing_user_rows:
@@ -3347,7 +3341,7 @@ async def team_member_update(
         _db_team_members: Final[list[dict]] = [m.model_dump() for m in team_members]
         await _team_db(prisma_client).update(
             where={"team_id": data.team_id},
-            data={"members_with_roles": json.dumps(_db_team_members)},  # type: ignore
+            data={"members_with_roles": json.dumps(_db_team_members)},
         )
 
     return TeamMemberUpdateResponse(
@@ -3622,7 +3616,7 @@ async def delete_team(
     if litellm.store_audit_logs is True:
         # make an audit log for each team deleted
         for team_id in data.team_ids:
-            team_row: LiteLLM_TeamTable | None = await prisma_client.get_data(  # type: ignore
+            team_row: LiteLLM_TeamTable | None = await prisma_client.get_data(
                 team_id=team_id, table_name="team", query_type="find_unique"
             )
 
@@ -4160,7 +4154,7 @@ async def block_team(
 
     record: Final = await _team_db(prisma_client).update(
         where={"team_id": data.team_id},
-        data={"blocked": True},  # type: ignore
+        data={"blocked": True},
     )
 
     return record
@@ -4209,7 +4203,7 @@ async def unblock_team(
 
     record: Final = await _team_db(prisma_client).update(
         where={"team_id": data.team_id},
-        data={"blocked": False},  # type: ignore
+        data={"blocked": False},
     )
 
     return record
@@ -4357,7 +4351,7 @@ async def _build_team_list_where_conditions(
             user_object_correct_type: Final = await get_user_object(
                 user_id=user_id,
                 prisma_client=prisma_client,
-                user_api_key_cache=user_api_key_cache,  # type: ignore[arg-type]
+                user_api_key_cache=user_api_key_cache,
                 user_id_upsert=False,
                 proxy_logging_obj=proxy_logging_obj,
             )
@@ -5093,7 +5087,7 @@ async def team_model_add(
     updated_team: Final = await _team_db(prisma_client).update(
         where={"team_id": data.team_id},
         data={"updated_at": datetime.now(timezone.utc)},
-        include={"object_permission": True},  # type: ignore
+        include={"object_permission": True},
     )
 
     await _refresh_cached_team(
@@ -5175,7 +5169,7 @@ async def team_model_delete(
     updated_team: Final = await TeamRepository(prisma_client).table.update(
         where={"team_id": data.team_id},
         data={"models": updated_models},
-        include={"object_permission": True},  # type: ignore
+        include={"object_permission": True},
     )
 
     await _refresh_cached_team(

--- a/litellm/proxy/management_endpoints/ui_sso.py
+++ b/litellm/proxy/management_endpoints/ui_sso.py
@@ -937,7 +937,7 @@ async def google_login(
     # check if user defined a custom auth sso sign in handler, if yes, use it
     if user_custom_ui_sso_sign_in_handler is not None:
         try:
-            from litellm_enterprise.proxy.auth.custom_sso_handler import (  # type: ignore[import-untyped]
+            from litellm_enterprise.proxy.auth.custom_sso_handler import (
                 EnterpriseCustomSSOHandler,
             )
 
@@ -2019,7 +2019,7 @@ async def _build_cli_sso_user_defined_values(
     user_id: Final = parsed_openid_result.get("user_id")
     if user_custom_sso is not None:
         if inspect.iscoroutinefunction(user_custom_sso):
-            return await user_custom_sso(result)  # type: ignore
+            return await user_custom_sso(result)
         raise ValueError("user_custom_sso must be a coroutine function")
     if user_id is None:
         return None
@@ -2365,12 +2365,12 @@ async def insert_sso_user(
         if _should_use_role_from_sso_response(sso_role):
             # Preserve the SSO-extracted role, but apply other defaults
             preserved_role: Final = sso_role
-            user_defined_values.update(litellm.default_internal_user_params)  # type: ignore
+            user_defined_values.update(litellm.default_internal_user_params)
             user_defined_values["user_role"] = preserved_role  # Restore preserved role
             verbose_proxy_logger.debug("Preserved SSO-extracted role '%s'", preserved_role)
         else:
             # SSO didn't provide a valid role, apply all defaults including role
-            user_defined_values.update(litellm.default_internal_user_params)  # type: ignore
+            user_defined_values.update(litellm.default_internal_user_params)
 
     # Set budget for internal users
     if user_defined_values.get("user_role") == LitellmUserRoles.INTERNAL_USER.value:
@@ -2385,7 +2385,7 @@ async def insert_sso_user(
     new_user_request: Final = NewUserRequest(
         user_id=user_defined_values["user_id"],
         user_email=normalize_email(user_defined_values["user_email"]),
-        user_role=user_defined_values["user_role"],  # type: ignore
+        user_role=user_defined_values["user_role"],
         max_budget=user_defined_values["max_budget"],
         budget_duration=user_defined_values["budget_duration"],
         sso_user_id=user_defined_values["user_id"],
@@ -2816,7 +2816,7 @@ class SSOAuthenticationHandler:
                     state_only_params[key] = value
 
             # Get the redirect response from fastapi-sso with only state param
-            redirect_response: Final = await generic_sso.get_login_redirect(**state_only_params)  # type: ignore
+            redirect_response: Final = await generic_sso.get_login_redirect(**state_only_params)
 
             # If PKCE is enabled, add PKCE parameters to the redirect URL
             if code_verifier and "state" in redirect_params:
@@ -3188,7 +3188,7 @@ class SSOAuthenticationHandler:
 
         if user_email is not None and os.getenv("ALLOWED_EMAIL_DOMAINS") is not None:
             email_domain: Final = user_email.split("@")[1]
-            allowed_domains: Final = os.getenv("ALLOWED_EMAIL_DOMAINS").split(",")  # type: ignore
+            allowed_domains: Final = os.getenv("ALLOWED_EMAIL_DOMAINS").split(",")
             if email_domain not in allowed_domains:
                 raise HTTPException(
                     status_code=401,
@@ -3211,7 +3211,7 @@ class SSOAuthenticationHandler:
             user_id = getattr(result, "id", None)
             user_email = normalize_email(getattr(result, "email", None))
             if user_role is None:
-                _role_from_attr: Final = getattr(result, generic_user_role_attribute_name, None)  # type: ignore
+                _role_from_attr: Final = getattr(result, generic_user_role_attribute_name, None)
                 if _role_from_attr is not None:
                     # Convert enum to string if needed
                     user_role = (
@@ -3280,7 +3280,7 @@ class SSOAuthenticationHandler:
 
         if user_custom_sso is not None:
             if inspect.iscoroutinefunction(user_custom_sso):
-                user_defined_values = await user_custom_sso(result)  # type: ignore
+                user_defined_values = await user_custom_sso(result)
             else:
                 raise ValueError("user_custom_sso must be a coroutine function")
         elif user_id is not None:
@@ -3352,8 +3352,8 @@ class SSOAuthenticationHandler:
             table_name="key",
         )
 
-        key = response["token"]  # type: ignore
-        user_id = response["user_id"]  # type: ignore
+        key = response["token"]
+        user_id = response["user_id"]
 
         user_role = user_defined_values["user_role"] or LitellmUserRoles.INTERNAL_USER_VIEW_ONLY.value
         if user_id and isinstance(user_id, str):
@@ -4016,7 +4016,7 @@ class MicrosoftSSOHandler:
         original_msft_result: Final = (
             await microsoft_sso.verify_and_process(
                 request=request,
-                convert_response=False,  # type: ignore
+                convert_response=False,
             )
             or {}
         )
@@ -4343,7 +4343,7 @@ class GoogleSSOHandler:
             return (
                 await google_sso.verify_and_process(
                     request=request,
-                    convert_response=False,  # type: ignore
+                    convert_response=False,
                 )
                 or {}
             )

--- a/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
+++ b/litellm/proxy/management_endpoints/usage_endpoints/ai_usage_chat.py
@@ -534,7 +534,7 @@ async def stream_usage_ai_chat(
             tools=tools,
             temperature=USAGE_AI_TEMPERATURE,
         )
-        choice: Final = response.choices[0]  # type: ignore
+        choice: Final = response.choices[0]
 
         if not choice.message.tool_calls:
             if choice.message.content:

--- a/litellm/proxy/management_endpoints/workflow_management_endpoints.py
+++ b/litellm/proxy/management_endpoints/workflow_management_endpoints.py
@@ -21,7 +21,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 try:
     from prisma.errors import UniqueViolationError
 except ImportError:
-    UniqueViolationError = None  # type: ignore
+    UniqueViolationError = None
 from pydantic import BaseModel
 
 from litellm._logging import verbose_proxy_logger

--- a/litellm/proxy/management_helpers/audit_logs.py
+++ b/litellm/proxy/management_helpers/audit_logs.py
@@ -66,7 +66,7 @@ def _resolve_audit_log_callback(name: str) -> CustomLogger | None:
         )
 
         instance = _init_custom_logger_compatible_class(
-            logging_integration=name,  # type: ignore
+            logging_integration=name,
             internal_usage_cache=None,
             llm_router=None,
         )
@@ -227,7 +227,7 @@ async def create_audit_log_for_update(request_data: LiteLLM_AuditLogs):
     try:
         await AuditLogRepository(prisma_client).table.create(
             data={
-                **_request_data,  # type: ignore
+                **_request_data,
             }
         )
     except Exception as e:

--- a/litellm/proxy/management_helpers/user_invitation.py
+++ b/litellm/proxy/management_helpers/user_invitation.py
@@ -35,7 +35,7 @@ async def create_invitation_for_user(
                 "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
                 "updated_at": current_time,
                 "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
-            }  # type: ignore
+            }
         )
         return response
     except Exception as e:

--- a/litellm/proxy/management_helpers/utils.py
+++ b/litellm/proxy/management_helpers/utils.py
@@ -109,11 +109,11 @@ async def handle_budget_for_entity(
 
             _budget: Final = await BudgetRepository(prisma_client).table.create(
                 data={
-                    **new_budget_data,  # type: ignore
+                    **new_budget_data,
                     "created_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
                     "updated_by": user_api_key_dict.user_id or litellm_proxy_admin_name,
                 }
-            )  # type: ignore
+            )
 
             return _budget.budget_id
         else:
@@ -321,7 +321,7 @@ async def add_new_member(
         )
         if existing_user_row is None or (isinstance(existing_user_row, list) and len(existing_user_row) == 0):
             new_user_defaults["teams"] = [team_id]
-            _returned_user = await prisma_client.insert_data(data=new_user_defaults, table_name="user")  # type: ignore
+            _returned_user = await prisma_client.insert_data(data=new_user_defaults, table_name="user")
 
             if _returned_user is not None:
                 returned_user = LiteLLM_UserTable.model_validate(_returned_user.model_dump())

--- a/litellm/proxy/middleware/in_flight_requests_middleware.py
+++ b/litellm/proxy/middleware/in_flight_requests_middleware.py
@@ -41,13 +41,13 @@ class InFlightRequestsMiddleware:
         InFlightRequestsMiddleware._in_flight += 1
         gauge: Final = InFlightRequestsMiddleware._get_gauge()
         if gauge is not None:
-            gauge.inc()  # type: ignore
+            gauge.inc()
         try:
             await self.app(scope, receive, send)
         finally:
             InFlightRequestsMiddleware._in_flight -= 1
             if gauge is not None:
-                gauge.dec()  # type: ignore
+                gauge.dec()
 
     @staticmethod
     def get_count() -> int:

--- a/litellm/proxy/openai_files_endpoints/file_content_streaming_handler.py
+++ b/litellm/proxy/openai_files_endpoints/file_content_streaming_handler.py
@@ -88,7 +88,7 @@ class FileContentStreamingHandler:
             raise
         finally:
             if hasattr(stream_iterator, "aclose"):
-                await stream_iterator.aclose()  # type: ignore[attr-defined]
+                await stream_iterator.aclose()
 
     @staticmethod
     async def get_streaming_file_content_response(
@@ -112,7 +112,7 @@ class FileContentStreamingHandler:
                     "file_id": file_id,
                     "stream": True,
                     **data,
-                }  # type: ignore
+                }
             ),
         )
 

--- a/litellm/proxy/openai_files_endpoints/files_endpoints.py
+++ b/litellm/proxy/openai_files_endpoints/files_endpoints.py
@@ -193,7 +193,7 @@ async def route_create_file(
 
         # Merge credentials into the request
         prepare_data_with_credentials(
-            data=_create_file_request,  # type: ignore
+            data=_create_file_request,
             credentials=credentials,
         )
 
@@ -201,7 +201,7 @@ async def route_create_file(
         response = await litellm.acreate_file(
             **_create_file_request,
             custom_llm_provider=credentials["custom_llm_provider"],
-        )  # type: ignore
+        )
 
         # Encode the file ID with model information
         if response and hasattr(response, "id") and response.id:
@@ -264,9 +264,9 @@ async def route_create_file(
         if llm_provider_config is not None:
             # add llm_provider_config to data
             _create_file_request.update(llm_provider_config)
-        _create_file_request.pop("custom_llm_provider", None)  # type: ignore
+        _create_file_request.pop("custom_llm_provider", None)
         # for now use custom_llm_provider=="openai" -> this will change as LiteLLM adds more providers for acreate_batch
-        response = await litellm.acreate_file(**_create_file_request, custom_llm_provider=custom_llm_provider)  # type: ignore
+        response = await litellm.acreate_file(**_create_file_request, custom_llm_provider=custom_llm_provider)
 
     return response
 
@@ -704,7 +704,7 @@ async def get_file_content(
                         "file_id": file_id,
                         **data,
                     }
-                )  # type: ignore
+                )
 
             else:
                 response = await managed_files_obj.afile_content(
@@ -787,14 +787,14 @@ async def get_file_content(
                 # Use model-based routing with credentials from config
                 prepare_data_with_credentials(
                     data=data,
-                    credentials=credentials,  # type: ignore
+                    credentials=credentials,
                     file_id=original_file_id,  # Use decoded file ID if from encoded ID
                     include_internal_credentials=True,
                 )
                 response = await litellm.afile_content(
-                    custom_llm_provider=credentials["custom_llm_provider"],  # type: ignore
+                    custom_llm_provider=credentials["custom_llm_provider"],
                     **data,
-                )  # type: ignore
+                )
 
                 verbose_proxy_logger.debug(
                     f"Retrieved file content using model: {model_used}"
@@ -807,7 +807,7 @@ async def get_file_content(
                         "custom_llm_provider": custom_llm_provider,
                         "file_id": file_id,
                         **data,
-                    }  # type: ignore
+                    }
                 )
 
         ### ALERTING ###
@@ -951,12 +951,12 @@ async def get_file(
             # Use model-based routing with credentials from config
             prepare_data_with_credentials(
                 data=data,
-                credentials=credentials,  # type: ignore
+                credentials=credentials,
                 file_id=original_file_id,
                 include_internal_credentials=True,
             )
 
-            response = await litellm.afile_retrieve(**data)  # type: ignore
+            response = await litellm.afile_retrieve(**data)
 
             # Keep the encoded ID in response if it was originally encoded
             if original_file_id and response and hasattr(response, "id") and response.id:
@@ -1002,7 +1002,7 @@ async def get_file(
             response = await litellm.afile_retrieve(
                 custom_llm_provider=custom_llm_provider,
                 file_id=file_id,
-                **data,  # type: ignore
+                **data,
             )
 
         ### ALERTING ###
@@ -1149,15 +1149,15 @@ async def delete_file(
             # Use model-based routing with credentials from config
             prepare_data_with_credentials(
                 data=data,
-                credentials=credentials,  # type: ignore
+                credentials=credentials,
                 file_id=original_file_id,
                 include_internal_credentials=True,
             )
 
             response = await litellm.afile_delete(
-                custom_llm_provider=credentials["custom_llm_provider"],  # type: ignore
+                custom_llm_provider=credentials["custom_llm_provider"],
                 **data,
-            )  # type: ignore
+            )
 
             verbose_proxy_logger.debug(
                 f"Deleted file using model: {model_used}"
@@ -1208,7 +1208,7 @@ async def delete_file(
             response = await litellm.afile_delete(
                 custom_llm_provider=custom_llm_provider,
                 file_id=file_id,
-                **data,  # type: ignore
+                **data,
             )
 
         ### ALERTING ###
@@ -1330,11 +1330,11 @@ async def list_files(
 
         if should_route and credentials is not None:
             # Use model-based routing with credentials from config
-            data.update(credentials)  # type: ignore
+            data.update(credentials)
             response = await litellm.afile_list(
-                custom_llm_provider=credentials["custom_llm_provider"],  # type: ignore
+                custom_llm_provider=credentials["custom_llm_provider"],
                 purpose=purpose,
-                **data,  # type: ignore
+                **data,
             )
 
             verbose_proxy_logger.debug("Listed files using model: %s", model_used)
@@ -1384,7 +1384,7 @@ async def list_files(
             response = await litellm.afile_list(
                 custom_llm_provider=custom_llm_provider,
                 purpose=purpose,
-                **data,  # type: ignore
+                **data,
             )
 
         if response is None:

--- a/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/llm_passthrough_endpoints.py
@@ -841,7 +841,7 @@ async def handle_bedrock_count_tokens(
                 # Copy all litellm_params - BaseAWSLLM will handle AWS credential discovery
                 for key, value in model_litellm_params.items():
                     if key != "user_api_key_dict":  # Don't overwrite user_api_key_dict
-                        litellm_params[key] = value  # type: ignore
+                        litellm_params[key] = value
 
         verbose_proxy_logger.debug("Count tokens litellm_params: %s", litellm_params)
         verbose_proxy_logger.debug("Resolved model: %s", resolved_model)
@@ -1039,7 +1039,7 @@ async def bedrock_proxy_route(
     from litellm.llms.bedrock.chat import BedrockConverseLLM
 
     bedrock_llm: Final = BedrockConverseLLM()
-    credentials: Final[Credentials] = bedrock_llm.get_credentials()  # type: ignore
+    credentials: Final[Credentials] = bedrock_llm.get_credentials()
     sigv4: Final = SigV4Auth(credentials, "bedrock", aws_region_name)
     headers: Final = {"Content-Type": "application/json"}
     # Assuming the body contains JSON data, parse it
@@ -1060,7 +1060,7 @@ async def bedrock_proxy_route(
     endpoint_func: Final = create_pass_through_route(
         endpoint=endpoint,
         target=str(prepped.url),
-        custom_headers=prepped.headers,  # type: ignore
+        custom_headers=prepped.headers,
         is_streaming_request=is_streaming_request,
         _forward_headers=True,
     )  # dynamically construct pass-through endpoint based on incoming path
@@ -1729,7 +1729,7 @@ async def _base_vertex_proxy_route(
         headers_passed_through,
         vertex_project,
         vertex_location,
-    ) = await _prepare_vertex_auth_headers(  # type: ignore
+    ) = await _prepare_vertex_auth_headers(
         request=request,
         vertex_credentials=vertex_credentials,
         router_credentials=router_credentials,
@@ -1971,7 +1971,7 @@ class BaseOpenAIPassThroughHandler:
             custom_headers=BaseOpenAIPassThroughHandler._assemble_headers(
                 api_key=api_key, request=request, extra_headers=extra_headers
             ),
-            is_streaming_request=is_streaming_request,  # type: ignore
+            is_streaming_request=is_streaming_request,
             custom_llm_provider=(
                 custom_llm_provider.value
                 if hasattr(custom_llm_provider, "value")

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/anthropic_passthrough_logging_handler.py
@@ -269,8 +269,8 @@ class AnthropicPassthroughLoggingHandler:
             # the pass-through success path reads spend from
             # model_call_details["response_cost"], not from kwargs
             logging_obj.model_call_details["response_cost"] = response_cost
-            passthrough_logging_payload: Final[PassthroughStandardLoggingPayload | None] = (  # type: ignore
-                kwargs.get("passthrough_logging_payload")
+            passthrough_logging_payload: Final[PassthroughStandardLoggingPayload | None] = kwargs.get(
+                "passthrough_logging_payload"
             )
             if passthrough_logging_payload:
                 user: Final = AnthropicPassthroughLoggingHandler._get_user_from_metadata(
@@ -1006,7 +1006,7 @@ class AnthropicPassthroughLoggingHandler:
                 import asyncio
 
                 asyncio.create_task(
-                    managed_files_hook.store_unified_object_id(  # type: ignore
+                    managed_files_hook.store_unified_object_id(
                         unified_object_id=unified_object_id,
                         file_object=batch_object,
                         litellm_parent_otel_span=None,

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/assembly_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/assembly_passthrough_logging_handler.py
@@ -131,8 +131,8 @@ class AssemblyAIPassthroughLoggingHandler:
             status="success",
         )
 
-        passthrough_logging_payload: Final[PassthroughStandardLoggingPayload | None] = (  # type: ignore
-            kwargs.get("passthrough_logging_payload")
+        passthrough_logging_payload: Final[PassthroughStandardLoggingPayload | None] = kwargs.get(
+            "passthrough_logging_payload"
         )
 
         verbose_proxy_logger.debug(

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/base_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/base_passthrough_logging_handler.py
@@ -119,8 +119,8 @@ class BasePassthroughLoggingHandler(ABC):
             # the pass-through success path reads spend from
             # model_call_details["response_cost"], not from kwargs
             logging_obj.model_call_details["response_cost"] = response_cost
-            passthrough_logging_payload: Final[PassthroughStandardLoggingPayload | None] = (  # type: ignore
-                kwargs.get("passthrough_logging_payload")
+            passthrough_logging_payload: Final[PassthroughStandardLoggingPayload | None] = kwargs.get(
+                "passthrough_logging_payload"
             )
             if passthrough_logging_payload:
                 user: Final = self._get_user_from_metadata(

--- a/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
+++ b/litellm/proxy/pass_through_endpoints/llm_provider_handlers/vertex_passthrough_logging_handler.py
@@ -830,7 +830,7 @@ class VertexPassthroughLoggingHandler:
                 import asyncio
 
                 asyncio.create_task(
-                    managed_files_hook.store_unified_object_id(  # type: ignore
+                    managed_files_hook.store_unified_object_id(
                         unified_object_id=unified_object_id,
                         file_object=batch_object,
                         litellm_parent_otel_span=None,

--- a/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
+++ b/litellm/proxy/pass_through_endpoints/pass_through_endpoints.py
@@ -190,7 +190,7 @@ async def chat_completion_pass_through_endpoint(
             data["model"] = user_model
 
         data = await add_litellm_data_to_request(
-            data=data,  # type: ignore
+            data=data,
             request=request,
             general_settings=general_settings,
             user_api_key_dict=user_api_key_dict,
@@ -224,7 +224,7 @@ async def chat_completion_pass_through_endpoint(
             data["model"] = user_api_key_dict.aliases[data["model"]]
 
         ### CALL HOOKS ### - modify incoming data before calling the model
-        data = await proxy_logging_obj.pre_call_hook(  # type: ignore
+        data = await proxy_logging_obj.pre_call_hook(
             user_api_key_dict=user_api_key_dict, data=data, call_type="text_completion"
         )
 
@@ -568,7 +568,7 @@ class HttpPassThroughEndpointHelpers(BasePassthroughUtils):
 
         kwargs: Final = {
             "litellm_params": {
-                **litellm_params_in_body,  # type: ignore
+                **litellm_params_in_body,
                 "metadata": _metadata,
                 "proxy_server_request": {
                     "url": str(request.url),
@@ -1329,7 +1329,7 @@ async def pass_through_request(
             response_body = await proxy_logging_obj.post_call_success_hook(
                 data=hook_data,
                 user_api_key_dict=user_api_key_dict,
-                response=response_body,  # type: ignore[arg-type]
+                response=response_body,
             )
             if isinstance(response_body, dict):
                 content = json.dumps(response_body).encode("utf-8")
@@ -1669,7 +1669,7 @@ def create_pass_through_route(
         adapter_id: Final = str(uuid.uuid4())
         litellm.adapters = [{"id": adapter_id, "adapter": adapter}]
 
-        async def endpoint_func(  # type: ignore
+        async def endpoint_func(
             request: Request,
             fastapi_response: Response,
             user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
@@ -1685,7 +1685,7 @@ def create_pass_through_route(
     except Exception:
         verbose_proxy_logger.debug("Defaulting to target being a url.")
 
-        async def endpoint_func(  # type: ignore
+        async def endpoint_func(
             request: Request,
             fastapi_response: Response,
             user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
@@ -1777,7 +1777,7 @@ def create_pass_through_route(
                 final_custom_body = custom_body_data
 
             try:
-                return await pass_through_request(  # type: ignore
+                return await pass_through_request(
                     request=request,
                     target=full_target,
                     custom_headers=headers_dict,
@@ -1951,7 +1951,7 @@ async def websocket_passthrough_request(
         _parsed_body={},  # WebSocket doesn't have a traditional request body
         passthrough_logging_payload=passthrough_logging_payload,
         litellm_call_id=litellm_call_id,
-        request=dummy_request,  # type: ignore
+        request=dummy_request,
         logging_obj=logging_obj,
     )
 
@@ -2176,8 +2176,8 @@ async def websocket_passthrough_request(
             end_time: Final = datetime.now()
 
             # Update passthrough logging payload with response data
-            passthrough_logging_payload["response_body"] = websocket_messages  # type: ignore
-            passthrough_logging_payload["end_time"] = end_time  # type: ignore
+            passthrough_logging_payload["response_body"] = websocket_messages
+            passthrough_logging_payload["end_time"] = end_time
 
             # Remove logging_obj from kwargs to avoid duplicate keyword argument
             success_kwargs: Final = kwargs.copy()
@@ -2216,8 +2216,8 @@ async def websocket_passthrough_request(
             # Use the same success handler as HTTP passthrough endpoints
             GLOBAL_LOGGING_WORKER.ensure_initialized_and_enqueue(
                 async_coroutine=pass_through_endpoint_logging.pass_through_async_success_handler(
-                    httpx_response=mock_response,  # type: ignore
-                    response_body=websocket_messages,  # type: ignore
+                    httpx_response=mock_response,
+                    response_body=websocket_messages,
                     url_route=endpoint or "",
                     result="websocket_connection_successful",
                     start_time=start_time,
@@ -2234,7 +2234,7 @@ async def websocket_passthrough_request(
                 await proxy_logging_obj.post_call_success_hook(
                     data={},
                     user_api_key_dict=user_api_key_dict,
-                    response={"status": "websocket_connection_successful"},  # type: ignore
+                    response={"status": "websocket_connection_successful"},
                 )
 
     except InvalidStatus as exc:
@@ -2517,7 +2517,7 @@ class InitPassThroughEndpointHelpers:
         SafeRouteAdder.add_api_route_if_not_exists(
             app=app,
             path=path,
-            endpoint=create_pass_through_route(  # type: ignore
+            endpoint=create_pass_through_route(
                 path,
                 target,
                 custom_headers,
@@ -2600,7 +2600,7 @@ class InitPassThroughEndpointHelpers:
         SafeRouteAdder.add_api_route_if_not_exists(
             app=app,
             path=wildcard_path,
-            endpoint=create_pass_through_route(  # type: ignore
+            endpoint=create_pass_through_route(
                 path,
                 target,
                 custom_headers,
@@ -2894,11 +2894,11 @@ async def initialize_pass_through_endpoints(
     combined_pass_through_endpoints: list[dict | PassThroughGenericEndpoint]
 
     if config_passthrough_endpoints is not None:
-        combined_pass_through_endpoints = _get_combined_pass_through_endpoints(  # type: ignore
+        combined_pass_through_endpoints = _get_combined_pass_through_endpoints(
             pass_through_endpoints, config_passthrough_endpoints
         )
     else:
-        combined_pass_through_endpoints = pass_through_endpoints  # type: ignore
+        combined_pass_through_endpoints = pass_through_endpoints
 
     ## clear all existing pass-through endpoints from the FastAPI app routes
     # InitPassThroughEndpointHelpers.clear_all_pass_through_routes()

--- a/litellm/proxy/policy_engine/pipeline_executor.py
+++ b/litellm/proxy/policy_engine/pipeline_executor.py
@@ -27,7 +27,7 @@ from litellm.types.proxy.policy_engine.pipeline_types import (
 try:
     from fastapi.exceptions import HTTPException
 except ImportError:
-    HTTPException = None  # type: ignore
+    HTTPException = None
 
 
 class PipelineExecutor:
@@ -182,9 +182,9 @@ class PipelineExecutor:
             if mode == "pre_call":
                 response = await target.async_pre_call_hook(
                     user_api_key_dict=user_api_key_dict,
-                    cache=None,  # type: ignore
+                    cache=None,
                     data=data,
-                    call_type=call_type,  # type: ignore
+                    call_type=call_type,
                 )
                 if isinstance(callback, CustomGuardrail):
                     callback.mark_pre_call_hook_ran(data)
@@ -194,7 +194,7 @@ class PipelineExecutor:
                 response = await target.async_post_call_success_hook(
                     user_api_key_dict=user_api_key_dict,
                     data=data,
-                    response=data.get("response"),  # type: ignore
+                    response=data.get("response"),
                 )
             else:
                 return ("error", None, f"Unsupported pipeline mode: {mode}", None)

--- a/litellm/proxy/policy_engine/policy_resolve_endpoints.py
+++ b/litellm/proxy/policy_engine/policy_resolve_endpoints.py
@@ -81,7 +81,7 @@ def _get_tags_from_metadata(metadata: object, json_metadata: object = None) -> l
 
 async def _fetch_all_teams(prisma_client: object) -> list:
     """Fetch teams from DB once. Reuse the result across tag and alias lookups."""
-    return await TeamRepository(prisma_client).table.find_many(  # type: ignore
+    return await TeamRepository(prisma_client).table.find_many(
         where={},
         order={"created_at": "desc"},
         take=MAX_POLICY_ESTIMATE_IMPACT_ROWS,
@@ -161,7 +161,7 @@ async def _find_affected_by_team_patterns(
     new_keys: Final[list] = []
     unnamed_keys_count = 0
     if matched_team_ids:
-        keys: Final = await VerificationTokenRepository(prisma_client).table.find_many(  # type: ignore
+        keys: Final = await VerificationTokenRepository(prisma_client).table.find_many(
             where={"team_id": {"in": matched_team_ids}},
             order={"created_at": "desc"},
             take=MAX_POLICY_ESTIMATE_IMPACT_ROWS,
@@ -182,7 +182,7 @@ async def _find_affected_keys_by_alias(prisma_client: object, key_patterns: list
 
     affected: Final[list] = []
 
-    keys: Final = await VerificationTokenRepository(prisma_client).table.find_many(  # type: ignore
+    keys: Final = await VerificationTokenRepository(prisma_client).table.find_many(
         where=_build_alias_where("key_alias", key_patterns),
         order={"created_at": "desc"},
         take=MAX_POLICY_ESTIMATE_IMPACT_ROWS,
@@ -364,7 +364,7 @@ async def estimate_attachment_impact(
 
         # Tag-based impact
         if tag_patterns:
-            keys: Final = await VerificationTokenRepository(prisma_client).table.find_many(  # type: ignore
+            keys: Final = await VerificationTokenRepository(prisma_client).table.find_many(
                 where={},
                 order={"created_at": "desc"},
                 take=MAX_POLICY_ESTIMATE_IMPACT_ROWS,

--- a/litellm/proxy/prompts/prompt_endpoints.py
+++ b/litellm/proxy/prompts/prompt_endpoints.py
@@ -1199,7 +1199,7 @@ async def test_prompt(
             # Use conversation history for user/assistant messages
             messages = system_messages + request.conversation_history
         else:
-            messages = rendered_messages  # type: ignore[assignment]
+            messages = rendered_messages
 
         # Use PromptTemplate's optional_params which already extracts all parameters
         optional_params: Final = template.optional_params.copy()

--- a/litellm/proxy/prompts/prompt_registry.py
+++ b/litellm/proxy/prompts/prompt_registry.py
@@ -137,7 +137,7 @@ class InMemoryPromptRegistry:
             custom_prompt_callback = initializer(litellm_params, prompt)
             if not isinstance(custom_prompt_callback, CustomPromptManagement):
                 raise ValueError(f"CustomPromptManagement is required, got {type(custom_prompt_callback)}")
-            litellm.logging_callback_manager.add_litellm_callback(custom_prompt_callback)  # type: ignore
+            litellm.logging_callback_manager.add_litellm_callback(custom_prompt_callback)
         else:
             raise ValueError(f"Unsupported prompt: {prompt_integration}")
 

--- a/litellm/proxy/proxy_cli.py
+++ b/litellm/proxy/proxy_cli.py
@@ -175,13 +175,13 @@ def append_query_params(url: str | None, params: dict) -> str:
     parsed_query.update(params)
     encoded_query: Final = urlparse.urlencode(parsed_query, doseq=True)
     modified_url: Final = urlparse.urlunparse(parsed_url._replace(query=encoded_query))
-    return modified_url  # type: ignore
+    return modified_url
 
 
 class ProxyInitializationHelpers:
     @staticmethod
     def _echo_litellm_version():
-        pkg_version: Final = importlib.metadata.version("litellm")  # type: ignore
+        pkg_version: Final = importlib.metadata.version("litellm")
         click.echo(f"\nLiteLLM: Current Version = {pkg_version}\n")
 
     @staticmethod
@@ -360,14 +360,14 @@ class ProxyInitializationHelpers:
             original_iter: Final = StatReload.iter_py_files
             patched_paths = set()
 
-            def _iter_with_extra(self):  # type: ignore[no-untyped-def]
+            def _iter_with_extra(self):
                 yield from original_iter(self)
                 for path in StatReload._litellm_patched_config_paths:
                     if path.exists():
                         yield path
 
-            StatReload.iter_py_files = _iter_with_extra  # type: ignore[assignment]
-            StatReload._litellm_patched_config_paths = patched_paths  # type: ignore[attr-defined]
+            StatReload.iter_py_files = _iter_with_extra
+            StatReload._litellm_patched_config_paths = patched_paths
 
         patched_paths.update(resolved)
         return True
@@ -421,7 +421,7 @@ class ProxyInitializationHelpers:
                 config.ciphers = ciphers
 
         # hypercorn serve raises a type warning when passing a fast api app - even though fast API is a valid type
-        asyncio.run(serve(app, config))  # type: ignore
+        asyncio.run(serve(app, config))
 
     @staticmethod
     def _init_granian_server(
@@ -1338,7 +1338,7 @@ def run_server(
         # Auto-create PROMETHEUS_MULTIPROC_DIR for multi-worker setups
         ProxyInitializationHelpers._maybe_setup_prometheus_multiproc_dir(
             num_workers=num_workers,
-            litellm_settings=litellm_settings if config else None,  # type: ignore[possibly-unbound]
+            litellm_settings=litellm_settings if config else None,
         )
 
         # Skip server startup if requested (after all setup is done)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -163,7 +163,7 @@ try:
     import backoff
     import fastapi
     import orjson
-    import yaml  # type: ignore
+    import yaml
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
 except ImportError as e:
     raise ImportError(f"Missing dependency {e}. Run `pip install 'litellm[proxy]'`")
@@ -684,7 +684,7 @@ try:
 except Exception:
     # when using litellm docker image
     try:
-        import enterprise  # type: ignore
+        import enterprise
     except Exception:
         pass
 
@@ -830,7 +830,7 @@ async def proxy_shutdown_event():
     await jwt_handler.close()
 
     if db_writer_client is not None:
-        await db_writer_client.close()  # type: ignore[reportGeneralTypeIssues]
+        await db_writer_client.close()
 
     # final flush of billable-request counts: without it, up to one export
     # interval of enterprise billing data is dropped on every restart
@@ -947,7 +947,7 @@ async def proxy_startup_event(app: FastAPI):
     ## CHECK MASTER KEY IN ENVIRONMENT ##
     master_key = get_secret_str("LITELLM_MASTER_KEY")
     ### LOAD CONFIG ###
-    worker_config: str | dict | None = get_secret("WORKER_CONFIG")  # type: ignore
+    worker_config: str | dict | None = get_secret("WORKER_CONFIG")
     env_config_yaml: Final[str | None] = get_secret_str("CONFIG_FILE_PATH")
     verbose_proxy_logger.debug("worker_config: %s", _redact_worker_config_for_logging(worker_config))
     # check if it's a valid file path
@@ -983,7 +983,7 @@ async def proxy_startup_event(app: FastAPI):
 
     # check if DATABASE_URL in environment - load from there
     if prisma_client is None:
-        _db_url: Final[str | None] = get_secret("DATABASE_URL", None)  # type: ignore
+        _db_url: Final[str | None] = get_secret("DATABASE_URL", None)
         prisma_client = await ProxyStartupEvent._setup_prisma_client(
             database_url=_db_url,
             proxy_logging_obj=proxy_logging_obj,
@@ -1177,7 +1177,7 @@ async def proxy_startup_event(app: FastAPI):
 
     await proxy_config.stop_config_sync_subscriber()
 
-    await proxy_shutdown_event()  # type: ignore[reportGeneralTypeIssues]
+    await proxy_shutdown_event()
 
 
 def _generate_stable_operation_id(route: Any) -> str:
@@ -1271,7 +1271,7 @@ app = FastAPI(
     description=_description,
     version=version,
     root_path=server_root_path,
-    lifespan=proxy_startup_event,  # type: ignore[reportGeneralTypeIssues]
+    lifespan=proxy_startup_event,
     generate_unique_id_function=_generate_stable_operation_id,
     strict_content_type=False,
 )
@@ -1414,10 +1414,10 @@ def custom_openapi():
 
 
 if os.getenv("DOCS_FILTERED", "False") == "True" and premium_user:
-    app.openapi = custom_openapi  # type: ignore
+    app.openapi = custom_openapi
 else:
     # For regular users, use get_openapi_schema to include LLM API schemas
-    app.openapi = get_openapi_schema  # type: ignore
+    app.openapi = get_openapi_schema
 
 
 class UserAPIKeyCacheTTLEnum(enum.Enum):
@@ -1999,7 +1999,7 @@ if docs_url != "/" and root_redirect_url is not None:
 
     @app.get("/", include_in_schema=False)
     async def root_redirect():
-        return RedirectResponse(url=root_redirect_url)  # type: ignore[arg-type]
+        return RedirectResponse(url=root_redirect_url)
 
 
 user_api_base = None
@@ -2089,7 +2089,7 @@ db_writer_client: AsyncHTTPHandler | None = None
 
 def _resolve_typed_dict_type(typ):
     """Resolve the actual TypedDict class from a potentially wrapped type."""
-    from typing_extensions import _TypedDictMeta  # type: ignore
+    from typing_extensions import _TypedDictMeta
 
     origin: Final = get_origin(typ)
     if origin is Union or origin is UnionType:  # Check if it's a Union (like Optional)
@@ -2824,7 +2824,7 @@ async def update_cache(
     end_user_id: str | None,
     team_id: str | None,
     response_cost: float | None,
-    parent_otel_span: Span | None,  # type: ignore
+    parent_otel_span: Span | None,
     tags: list[str] | None = None,
 ):
     """
@@ -2867,7 +2867,7 @@ async def update_cache(
             projected_spend, projected_exceeded_date = _get_projected_spend_over_limit(
                 current_spend=new_spend,
                 soft_budget_limit=existing_spend_obj.soft_budget,
-            )  # type: ignore
+            )
             soft_limit: Final = existing_spend_obj.soft_budget
             call_info: Final = CallInfo(
                 token=existing_spend_obj.token or "",
@@ -4335,7 +4335,7 @@ class ProxyConfig:
 
             # Cast to SearchToolTypedDict for type safety
             try:
-                search_tool_typed: SearchToolTypedDict = SearchToolTypedDict(**search_tool)  # type: ignore
+                search_tool_typed: SearchToolTypedDict = SearchToolTypedDict(**search_tool)
                 search_tools_parsed.append(search_tool_typed)
             except Exception as e:
                 verbose_proxy_logger.error("Error parsing search tool %s: %s", search_tool_name, e)
@@ -4605,7 +4605,7 @@ class ProxyConfig:
                 elif key == "max_budget":
                     litellm.max_budget = float(value)
                 elif key == "max_internal_user_budget":
-                    litellm.max_internal_user_budget = float(value)  # type: ignore
+                    litellm.max_internal_user_budget = float(value)
                 elif key == "default_max_internal_user_budget":
                     litellm.default_max_internal_user_budget = float(value)
                     if litellm.max_internal_user_budget is None:
@@ -4843,7 +4843,7 @@ class ProxyConfig:
             master_key = general_settings.get("master_key", get_secret("LITELLM_MASTER_KEY", None))
 
             if master_key and master_key.startswith("os.environ/"):
-                master_key = get_secret(master_key)  # type: ignore
+                master_key = get_secret(master_key)
 
             if master_key is not None and isinstance(master_key, str):
                 litellm_master_key_hash = hash_token(master_key)
@@ -5067,7 +5067,7 @@ class ProxyConfig:
                     _v = v.replace("os.environ/", "")
                     v = os.getenv(_v)
                     assistant_settings["litellm_params"][k] = v
-            assistants_config = AssistantsTypedDict(**assistant_settings)  # type: ignore
+            assistants_config = AssistantsTypedDict(**assistant_settings)
 
         ## SEARCH TOOLS SETTINGS
         search_tools: Final[list[SearchToolTypedDict] | None] = self.parse_search_tools(config)
@@ -5126,7 +5126,7 @@ class ProxyConfig:
                 async_only_mode=True  # only init async clients
             ),
             ignore_invalid_deployments=True,  # don't raise an error if a deployment is invalid
-        )  # type: ignore
+        )
 
         if redis_usage_cache is not None and router.cache.redis_cache is None:
             router._update_redis_cache(cache=redis_usage_cache)
@@ -5188,7 +5188,7 @@ class ProxyConfig:
                 global_agent_registry,
             )
 
-            global_agent_registry.load_agents_from_config(agent_config)  # type: ignore
+            global_agent_registry.load_agents_from_config(agent_config)
 
         mcp_servers_config: Final = config.get("mcp_servers", None)
         if mcp_servers_config:
@@ -7185,7 +7185,7 @@ async def async_assistants_data_generator(response, user_api_key_dict: UserAPIKe
             )
 
             # chunk = chunk.model_dump_json(exclude_none=True)
-            async for c in chunk:  # type: ignore
+            async for c in chunk:
                 c = c.model_dump_json(exclude_none=True)
                 try:
                     yield f"data: {c}\n\n"
@@ -7995,7 +7995,7 @@ class ProxyStartupEvent:
         never on a reset schedule holds lifetime accrual, which must not
         gate the first duration window.
         """
-        await generate_key_helper_fn(  # type: ignore
+        await generate_key_helper_fn(
             request_type="user",
             table_name="user",
             user_id=LITELLM_PROXY_BUDGET_NAME,
@@ -8064,7 +8064,7 @@ class ProxyStartupEvent:
             teams_pydantic_obj: Final = [NewUserRequestTeam(**team) for team in _teams]
             await update_default_team_member_budget(
                 teams=teams_pydantic_obj,
-                user_api_key_dict=UserAPIKeyAuth(token=hash_token(master_key)),  # type: ignore
+                user_api_key_dict=UserAPIKeyAuth(token=hash_token(master_key)),
             )
 
     @classmethod
@@ -9213,12 +9213,12 @@ async def chat_completion(
             request_data=_data,
         )
         _chat_response = litellm.ModelResponse()
-        _chat_response.model = e.model  # type: ignore
-        _chat_response.choices[0].message.content = e.message  # type: ignore
-        _chat_response.choices[0].finish_reason = "content_filter"  # type: ignore
+        _chat_response.model = e.model
+        _chat_response.choices[0].message.content = e.message
+        _chat_response.choices[0].finish_reason = "content_filter"
         # Report the blocked LLM response's real usage (set before the stream
         # branch so both paths carry it); zero for pre-call blocks.
-        _chat_response.usage = _blocked_response_usage(e.original_response)  # type: ignore
+        _chat_response.usage = _blocked_response_usage(e.original_response)
 
         if data.get("stream", None) is not None and data["stream"] is True:
             _iterator = litellm.utils.ModelResponseIterator(model_response=_chat_response, convert_to_delta=True)
@@ -9249,7 +9249,7 @@ async def chat_completion(
             request_data=_data,
         )
         _chat_response = litellm.ModelResponse()
-        _chat_response.choices[0].message.content = e.message  # type: ignore
+        _chat_response.choices[0].message.content = e.message
 
         if data.get("stream", None) is not None and data["stream"] is True:
             _iterator = litellm.utils.ModelResponseIterator(model_response=_chat_response, convert_to_delta=True)
@@ -9272,7 +9272,7 @@ async def chat_completion(
                 status_code=(e.status_code if hasattr(e, "status_code") else status.HTTP_400_BAD_REQUEST),
             )
         _usage: Final = litellm.Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)
-        _chat_response.usage = _usage  # type: ignore
+        _chat_response.usage = _usage
         return _chat_response
     except Exception as e:
         raise await base_llm_response_processor._handle_llm_api_exception(
@@ -9367,7 +9367,7 @@ async def completion(
             _text_response: Final = litellm.ModelResponse()
             # Set text attribute dynamically for text completion format
             setattr(_text_response.choices[0], "text", e.message)
-            _text_response.model = e.model  # type: ignore[assignment]
+            _text_response.model = e.model
             _usage = _blocked_response_usage(e.original_response)
             # Set usage attribute dynamically (ModelResponse accepts usage in __init__ but it's not in type definition)
             setattr(_text_response, "usage", _usage)
@@ -9392,9 +9392,9 @@ async def completion(
         else:
             _response = litellm.TextCompletionResponse()
             _response.choices[0].text = e.message
-            _response.model = e.model  # type: ignore
+            _response.model = e.model
             _usage = _blocked_response_usage(e.original_response)
-            _response.usage = _usage  # type: ignore
+            _response.usage = _usage
             return _response
     except RejectedRequestError as e:
         _data = e.request_data
@@ -9410,8 +9410,8 @@ async def completion(
                 completion_tokens=0,
                 total_tokens=0,
             )
-            _chat_response.usage = _usage  # type: ignore
-            _chat_response.choices[0].message.content = e.message  # type: ignore
+            _chat_response.usage = _usage
+            _chat_response.choices[0].message.content = e.message
             _iterator = litellm.utils.ModelResponseIterator(model_response=_chat_response, convert_to_delta=True)
             _streaming_response = litellm.TextCompletionStreamWrapper(
                 completion_stream=_iterator,
@@ -9813,9 +9813,9 @@ async def audio_speech(
                 media_type = "audio/wav"  # Gemini TTS returns WAV format after conversion
 
         return StreamingResponse(
-            _audio_speech_chunk_generator(response),  # type: ignore[arg-type]
+            _audio_speech_chunk_generator(response),
             media_type=media_type,
-            headers=custom_headers,  # type: ignore
+            headers=custom_headers,
         )
 
     except Exception as e:
@@ -10110,7 +10110,7 @@ async def realtime_websocket_endpoint(
     async def return_body():
         return _realtime_request_body(route_model)
 
-    request.body = return_body  # type: ignore
+    request.body = return_body
 
     ### ROUTE THE REQUEST ###
     base_llm_response_processor: Final = ProxyBaseLLMRequestProcessing(data=data)
@@ -10166,7 +10166,7 @@ async def realtime_websocket_endpoint(
             user_model=user_model,
         )
         await llm_call
-    except websockets.exceptions.InvalidStatusCode as e:  # type: ignore
+    except websockets.exceptions.InvalidStatusCode as e:
         verbose_proxy_logger.exception("Invalid status code")
         await websocket.close(code=e.status_code, reason="Invalid status code")
     except Exception:
@@ -11001,7 +11001,7 @@ async def _try_provider_token_count(
     try:
         result: Final = await provider_counter.count_tokens(
             model_to_use=model_to_use or "",
-            messages=messages,  # type: ignore
+            messages=messages,
             contents=contents,
             deployment=deployment,
             request_model=request_model,
@@ -11138,7 +11138,7 @@ async def token_counter(request: TokenCountRequest, call_endpoint: bool = False)
         model=model_to_use,
         text=prompt,
         messages=messages,
-        custom_tokenizer=_tokenizer_used,  # type: ignore
+        custom_tokenizer=_tokenizer_used,
     )
     return TokenCountResponse(
         total_tokens=total_tokens,
@@ -13522,8 +13522,8 @@ async def alerting_settings(
 
     if db_general_settings is not None and db_general_settings.param_value is not None:
         db_general_settings_dict: Final = dict(db_general_settings.param_value)
-        alerting_args_dict: dict = db_general_settings_dict.get("alerting_args", {})  # type: ignore
-        alerting_values: list | None = db_general_settings_dict.get("alerting")  # type: ignore
+        alerting_args_dict: dict = db_general_settings_dict.get("alerting_args", {})
+        alerting_values: list | None = db_general_settings_dict.get("alerting")
     else:
         alerting_args_dict = {}
         alerting_values = None
@@ -13606,7 +13606,7 @@ async def async_queue_request(
     """
     data = {}
     try:
-        data = await request.json()  # type: ignore
+        data = await request.json()
         data.pop("_litellm_strip_stream_usage", None)
 
         # Include original request and headers in the data
@@ -14065,7 +14065,7 @@ async def onboarding(invite_link: str, request: Request):
     import jwt
 
     user_email: Final = user_obj.user_email
-    onboarding_token: Final = jwt.encode(  # type: ignore
+    onboarding_token: Final = jwt.encode(
         {
             "token_type": "litellm_onboarding",
             "invitation_link": invite_link,
@@ -14088,7 +14088,7 @@ async def onboarding(invite_link: str, request: Request):
         disabled_non_admin_personal_key_creation=disabled_non_admin_personal_key_creation,
         server_root_path=get_server_root_path(),
     )
-    jwt_token: Final = jwt.encode(  # type: ignore
+    jwt_token: Final = jwt.encode(
         cast(dict, returned_ui_token_object),
         master_key,
         algorithm="HS256",
@@ -14177,9 +14177,9 @@ async def _generate_onboarding_ui_session_token(user_obj: Any) -> str:
             "spend": 0,
             "user_id": user_obj.user_id,
             "team_id": UI_TEAM_ID,
-        },  # type: ignore
+        },
     )
-    key: Final = response["token"]  # type: ignore
+    key: Final = response["token"]
 
     import jwt
 
@@ -14198,7 +14198,7 @@ async def _generate_onboarding_ui_session_token(user_obj: Any) -> str:
         server_root_path=get_server_root_path(),
     )
     assert master_key is not None
-    return jwt.encode(  # type: ignore
+    return jwt.encode(
         cast(dict, returned_ui_token_object),
         master_key,
         algorithm="HS256",
@@ -14271,7 +14271,7 @@ async def claim_onboarding_link(data: InvitationClaim, request: Request):
             data={
                 "is_accepted": True,
                 "updated_at": current_time,
-                "updated_by": invite_obj.user_id,  # type: ignore
+                "updated_by": invite_obj.user_id,
             },
         )
         if updated_count == 0:
@@ -14295,7 +14295,7 @@ async def claim_onboarding_link(data: InvitationClaim, request: Request):
             data={
                 "accepted_at": current_time,
                 "updated_at": current_time,
-                "updated_by": invite_obj.user_id,  # type: ignore
+                "updated_by": invite_obj.user_id,
             },
         )
 
@@ -14607,7 +14607,7 @@ async def invitation_update(
             "is_accepted": data.is_accepted,
             "accepted_at": current_time,
             "updated_at": current_time,
-            "updated_by": user_api_key_dict.user_id,  # type: ignore
+            "updated_by": user_api_key_dict.user_id,
         },
     )
 
@@ -14968,8 +14968,8 @@ async def update_config_general_settings(
             "create": {
                 "param_name": "general_settings",
                 "param_value": json.dumps(general_settings),
-            },  # type: ignore
-            "update": {"param_value": json.dumps(general_settings)},  # type: ignore
+            },
+            "update": {"param_value": json.dumps(general_settings)},
         },
     )
     await invalidate_config_param("general_settings")
@@ -15561,8 +15561,8 @@ async def delete_config_general_settings(
             "create": {
                 "param_name": "general_settings",
                 "param_value": json.dumps(general_settings),
-            },  # type: ignore
-            "update": {"param_value": json.dumps(general_settings)},  # type: ignore
+            },
+            "update": {"param_value": json.dumps(general_settings)},
         },
     )
     await invalidate_config_param("general_settings")

--- a/litellm/proxy/public_endpoints/public_endpoints.py
+++ b/litellm/proxy/public_endpoints/public_endpoints.py
@@ -404,7 +404,7 @@ async def get_supported_endpoints() -> SupportedEndpointsResponse:
     """
     global _cached_endpoints
     if _cached_endpoints is None:
-        _cached_endpoints = SupportedEndpointsResponse(endpoints=_load_endpoints())  # type: ignore[arg-type]
+        _cached_endpoints = SupportedEndpointsResponse(endpoints=_load_endpoints())
     return _cached_endpoints
 
 

--- a/litellm/proxy/realtime_endpoints/endpoints.py
+++ b/litellm/proxy/realtime_endpoints/endpoints.py
@@ -284,7 +284,7 @@ async def create_realtime_client_secret(
             llm_router=llm_router,
             user_model=user_model,
         )
-        upstream_resp: Final[httpx.Response] = await llm_call  # type: ignore
+        upstream_resp: Final[httpx.Response] = await llm_call
 
     except Exception as e:
         await proxy_logging_obj.post_call_failure_hook(
@@ -318,7 +318,7 @@ async def create_realtime_client_secret(
             upstream_resp.status_code,
             upstream_resp.text,
         )
-        return Response(  # type: ignore[return-value]
+        return Response(
             content=upstream_resp.content,
             status_code=upstream_resp.status_code,
             media_type="application/json",
@@ -477,7 +477,7 @@ async def proxy_realtime_calls(
             llm_router=llm_router,
             user_model=user_model,
         )
-        upstream_resp: Final[httpx.Response] = await llm_call  # type: ignore
+        upstream_resp: Final[httpx.Response] = await llm_call
 
     except Exception as e:
         await proxy_logging_obj.post_call_failure_hook(
@@ -588,7 +588,7 @@ async def create_realtime_transcription_session(
             llm_router=llm_router,
             user_model=user_model,
         )
-        upstream_resp: Final[httpx.Response] = await llm_call  # type: ignore
+        upstream_resp: Final[httpx.Response] = await llm_call
 
     except Exception as e:
         await proxy_logging_obj.post_call_failure_hook(
@@ -622,7 +622,7 @@ async def create_realtime_transcription_session(
             upstream_resp.status_code,
             upstream_resp.text,
         )
-        return Response(  # type: ignore[return-value]
+        return Response(
             content=upstream_resp.content,
             status_code=upstream_resp.status_code,
             media_type="application/json",

--- a/litellm/proxy/response_api_endpoints/endpoints.py
+++ b/litellm/proxy/response_api_endpoints/endpoints.py
@@ -356,7 +356,7 @@ async def responses_api(
         # Store in managed objects table if background mode is enabled
         if data.get("background") and isinstance(response, ResponsesAPIResponse):
             if response.status in ["queued", "in_progress"]:
-                from litellm_enterprise.proxy.hooks.managed_files import (  # type: ignore
+                from litellm_enterprise.proxy.hooks.managed_files import (
                     _PROXY_LiteLLMManagedFiles,
                 )
 
@@ -1327,7 +1327,7 @@ async def responses_websocket_endpoint(
     async def return_body():
         return _body_bytes
 
-    request.body = return_body  # type: ignore
+    request.body = return_body
 
     # Phase 1: pre-call processing (auth, guardrails, rate limits)
     base_llm_response_processor: Final = ProxyBaseLLMRequestProcessing(data=data)

--- a/litellm/proxy/search_endpoints/search_tool_registry.py
+++ b/litellm/proxy/search_endpoints/search_tool_registry.py
@@ -173,7 +173,7 @@ class SearchToolRegistry:
             for search_tool in search_tools_from_db:
                 # Convert Prisma result to dict with ISO formatted datetimes
                 search_tool_dict = SearchToolRegistry._convert_prisma_to_dict(search_tool)
-                search_tools.append(SearchTool(**search_tool_dict))  # type: ignore
+                search_tools.append(SearchTool(**search_tool_dict))
 
             return search_tools
         except Exception as e:
@@ -203,7 +203,7 @@ class SearchToolRegistry:
 
             # Convert Prisma result to dict with ISO formatted datetimes
             search_tool_dict: Final = self._convert_prisma_to_dict(search_tool)
-            return SearchTool(**search_tool_dict)  # type: ignore
+            return SearchTool(**search_tool_dict)
         except Exception as e:
             verbose_proxy_logger.exception("Error getting search tool from DB: %s", e)
             raise Exception(f"Error getting search tool from DB: {e}")
@@ -231,7 +231,7 @@ class SearchToolRegistry:
 
             # Convert Prisma result to dict with ISO formatted datetimes
             search_tool_dict: Final = self._convert_prisma_to_dict(search_tool)
-            return SearchTool(**search_tool_dict)  # type: ignore
+            return SearchTool(**search_tool_dict)
         except Exception as e:
             verbose_proxy_logger.exception("Error getting search tool from DB: %s", e)
             raise Exception(f"Error getting search tool from DB: {e}")

--- a/litellm/proxy/spend_tracking/spend_management_endpoints.py
+++ b/litellm/proxy/spend_tracking/spend_management_endpoints.py
@@ -2928,13 +2928,13 @@ async def view_spend_logs(
 
             if api_key is not None and isinstance(api_key, str):
                 if api_key.startswith("sk-"):
-                    filter_query["api_key"] = prisma_client.hash_token(token=api_key)  # type: ignore
+                    filter_query["api_key"] = prisma_client.hash_token(token=api_key)
                 else:
-                    filter_query["api_key"] = api_key  # type: ignore
+                    filter_query["api_key"] = api_key
             if request_id is not None and isinstance(request_id, str):
-                filter_query["request_id"] = request_id  # type: ignore
+                filter_query["request_id"] = request_id
             if user_id is not None and isinstance(user_id, str):
-                filter_query["user"] = user_id  # type: ignore
+                filter_query["user"] = user_id
 
             # Check if user wants unsummarized data
             if not summarize:
@@ -2950,7 +2950,7 @@ async def view_spend_logs(
             # SQL query
             response: Final = await SpendLogsRepository(prisma_client).table.group_by(
                 by=["api_key", "user", "model", "startTime"],
-                where=filter_query,  # type: ignore
+                where=filter_query,
                 sum={
                     "spend": True,
                 },
@@ -2959,13 +2959,13 @@ async def view_spend_logs(
             if isinstance(response, list) and len(response) > 0 and isinstance(response[0], dict):
                 result: Final[dict] = {}
                 for record in response:
-                    dt_object = datetime.strptime(str(record["startTime"]), "%Y-%m-%dT%H:%M:%S.%fZ")  # type: ignore
+                    dt_object = datetime.strptime(str(record["startTime"]), "%Y-%m-%dT%H:%M:%S.%fZ")
                     date = dt_object.date()
                     if date not in result:
                         result[date] = {"users": {}, "models": {}}
-                    api_key = record["api_key"]  # type: ignore
-                    user_id = record["user"]  # type: ignore
-                    model = record["model"]  # type: ignore
+                    api_key = record["api_key"]
+                    user_id = record["user"]
+                    model = record["model"]
                     result[date]["spend"] = result[date].get("spend", 0) + record.get("_sum", {}).get("spend", 0)
                     result[date][api_key] = result[date].get(api_key, 0) + record.get("_sum", {}).get("spend", 0)
                     result[date]["users"][user_id] = result[date]["users"].get(user_id, 0) + record.get("_sum", {}).get(
@@ -4107,7 +4107,7 @@ async def _build_ui_spend_logs_response(
         # v2 path: return raw Prisma model instances so FastAPI applies its
         # own Pydantic-aware serialisation (preserves alias handling, custom
         # serializers, etc.).
-        response_data = data  # type: ignore[assignment]
+        response_data = data
 
     return {
         "data": response_data,

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -124,9 +124,7 @@ def _get_spend_logs_metadata(
 
     # Filter the metadata dictionary to include only the specified keys
     clean_metadata: Final = SpendLogsMetadata(
-        **{  # type: ignore
-            key: metadata.get(key) for key in SpendLogsMetadata.__annotations__.keys()
-        }
+        **{key: metadata.get(key) for key in SpendLogsMetadata.__annotations__.keys()}
     )
     raw_user_api_key: Final = clean_metadata.get("user_api_key")
     if raw_user_api_key is not None and isinstance(raw_user_api_key, str):

--- a/litellm/proxy/types_utils/utils.py
+++ b/litellm/proxy/types_utils/utils.py
@@ -41,13 +41,13 @@ def get_instance_fn(value: str, config_file_path: str | None = None) -> Any:
             module_file_path = os.path.join(directory, *module_name.split(".")) + ".py"
 
         if module_file_path is not None and os.path.exists(module_file_path):
-            spec: Final = importlib.util.spec_from_file_location(module_name, module_file_path)  # type: ignore
+            spec: Final = importlib.util.spec_from_file_location(module_name, module_file_path)
             if spec is None:
                 raise ImportError(f"Could not find a module specification for {module_file_path}")
-            module = importlib.util.module_from_spec(spec)  # type: ignore
+            module = importlib.util.module_from_spec(spec)
             if spec.loader is None:
                 raise ImportError(f"Could not find a module loader for {module_file_path}")
-            spec.loader.exec_module(module)  # type: ignore
+            spec.loader.exec_module(module)
         else:
             module = importlib.import_module(module_name)
 

--- a/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
+++ b/litellm/proxy/ui_crud_endpoints/proxy_setting_endpoints.py
@@ -300,7 +300,7 @@ def _get_effective_ui_settings_class() -> type[UISettings]:
         return _EFFECTIVE_UI_SETTINGS_CLASS
     if not _EXTRA_UI_SETTINGS_FIELDS:
         return UISettings
-    _EFFECTIVE_UI_SETTINGS_CLASS = create_model(  # type: ignore[call-overload]
+    _EFFECTIVE_UI_SETTINGS_CLASS = create_model(
         "EffectiveUISettings",
         __base__=UISettings,
         __doc__=UISettings.__doc__,
@@ -784,7 +784,7 @@ async def update_internal_user_settings(
     if settings.teams is not None and all(isinstance(team, NewUserRequestTeam) for team in settings.teams):
         await update_default_team_member_budget(
             settings.teams,
-            user_api_key_dict=user_api_key_dict,  # type: ignore
+            user_api_key_dict=user_api_key_dict,
         )
 
     return await _update_litellm_setting(

--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -52,10 +52,10 @@ try:
         SMTPEmailLogger,
     )
 except ImportError:
-    BaseEmailLogger = None  # type: ignore
-    SendGridEmailLogger = None  # type: ignore
-    SMTPEmailLogger = None  # type: ignore
-    ResendEmailLogger = None  # type: ignore
+    BaseEmailLogger = None
+    SendGridEmailLogger = None
+    SMTPEmailLogger = None
+    ResendEmailLogger = None
 
 try:
     import backoff
@@ -430,7 +430,7 @@ class ProxyLogging:
             if email_logger_class is not None:
                 # All email logger classes now accept internal_usage_cache
                 self.email_logging_instance = email_logger_class(
-                    internal_usage_cache=self.internal_usage_cache.dual_cache,  # type: ignore[call-arg]
+                    internal_usage_cache=self.internal_usage_cache.dual_cache,
                 )
         self.premium_user = premium_user
         self.service_logging_obj = ServiceLogging()
@@ -523,7 +523,7 @@ class ProxyLogging:
                     or "outage_alerts" in self.alert_types
                     or "region_outage_alerts" in self.alert_types
                 ):
-                    litellm.logging_callback_manager.add_litellm_callback(self.slack_alerting_instance)  # type: ignore
+                    litellm.logging_callback_manager.add_litellm_callback(self.slack_alerting_instance)
                 litellm.logging_callback_manager.add_litellm_success_callback(
                     self.slack_alerting_instance.response_taking_too_long_callback
                 )
@@ -560,7 +560,7 @@ class ProxyLogging:
 
     def _init_litellm_callbacks(self, llm_router: Router | None = None):
         self._add_proxy_hooks(llm_router)
-        litellm.logging_callback_manager.add_litellm_callback(self.service_logging_obj)  # type: ignore
+        litellm.logging_callback_manager.add_litellm_callback(self.service_logging_obj)
 
         # Track string callbacks and their initialized instances so we can
         # replace them in-place, preventing duplicates (string + instance) in
@@ -970,7 +970,7 @@ class ProxyLogging:
 
         if hook_type == "pre_call":
             return await target.async_pre_call_hook(
-                user_api_key_dict=user_api_key_dict,  # type: ignore
+                user_api_key_dict=user_api_key_dict,
                 cache=self.call_details["user_api_key_cache"],
                 data=data,
                 call_type=call_type,
@@ -978,14 +978,14 @@ class ProxyLogging:
         elif hook_type == "during_call":
             return await target.async_moderation_hook(
                 data=data,
-                user_api_key_dict=user_api_key_dict,  # type: ignore
+                user_api_key_dict=user_api_key_dict,
                 call_type=call_type,
             )
         elif hook_type == "post_call":
             return await target.async_post_call_success_hook(
-                user_api_key_dict=user_api_key_dict,  # type: ignore
+                user_api_key_dict=user_api_key_dict,
                 data=data,
-                response=response,  # type: ignore
+                response=response,
             )
         else:
             raise ValueError(f"Unknown hook_type: {hook_type}")
@@ -1419,7 +1419,7 @@ class ProxyLogging:
 
                         result = await self._process_guardrail_callback(
                             callback=_callback,
-                            data=data,  # type: ignore
+                            data=data,
                             user_api_key_dict=user_api_key_dict,
                             call_type=call_type,
                             event_type=GuardrailEventHooks.pre_call,
@@ -1440,8 +1440,8 @@ class ProxyLogging:
                         response = await _callback.async_pre_call_hook(
                             user_api_key_dict=user_api_key_dict,
                             cache=self.call_details["user_api_key_cache"],
-                            data=data,  # type: ignore
-                            call_type=call_type,  # type: ignore
+                            data=data,
+                            call_type=call_type,
                         )
                         if response is not None:
                             data = await self.process_pre_call_hook_response(
@@ -1826,7 +1826,7 @@ class ProxyLogging:
 
                 # V1 implementation - backwards compatibility
                 if callback.event_hook is None and hasattr(callback, "moderation_check"):
-                    if callback.moderation_check == "pre_call":  # type: ignore
+                    if callback.moderation_check == "pre_call":
                         return
                 else:
                     # Main - V2 Guardrails implementation
@@ -1864,8 +1864,8 @@ class ProxyLogging:
                         callback,
                         callback.async_moderation_hook(
                             data=data,
-                            user_api_key_dict=user_api_key_auth_dict,  # type: ignore
-                            call_type=call_type,  # type: ignore
+                            user_api_key_dict=user_api_key_auth_dict,
+                            call_type=call_type,
                         ),
                         "during_call",
                     )
@@ -2146,7 +2146,7 @@ class ProxyLogging:
                         cast(_custom_logger_compatible_callbacks_literal, callback)
                     )
                 else:
-                    _callback = callback  # type: ignore
+                    _callback = callback
                 if _callback is not None and isinstance(_callback, CustomLogger):
                     try:
                         hook_result = await _callback.async_post_call_failure_hook(
@@ -2335,7 +2335,7 @@ class ProxyLogging:
                         cast(_custom_logger_compatible_callbacks_literal, callback)
                     )
                 else:
-                    _callback = callback  # type: ignore
+                    _callback = callback
 
                 if _callback is not None:
                     if isinstance(_callback, CustomGuardrail):
@@ -2562,7 +2562,7 @@ class ProxyLogging:
                         cast(_custom_logger_compatible_callbacks_literal, callback)
                     )
                 else:
-                    _callback = callback  # type: ignore
+                    _callback = callback
 
                 if _callback is not None and isinstance(_callback, CustomLogger):
                     if _accepts_litellm_call_info(_callback):
@@ -2679,7 +2679,7 @@ class ProxyLogging:
                             cast(_custom_logger_compatible_callbacks_literal, callback)
                         )
                     else:
-                        _callback = callback  # type: ignore
+                        _callback = callback
                     if _callback is not None and isinstance(_callback, CustomLogger):
                         if str_so_far is not None:
                             complete_response = str_so_far + response_str
@@ -2973,9 +2973,7 @@ async def prefetch_config_params(prisma_client: Any, param_names: list[str]) -> 
     if not param_names:
         return
     try:
-        rows: Final = await ConfigRepository(prisma_client).table.find_many(
-            where={"param_name": {"in": param_names}}  # type: ignore
-        )
+        rows: Final = await ConfigRepository(prisma_client).table.find_many(where={"param_name": {"in": param_names}})
     except Exception as e:
         verbose_proxy_logger.debug(
             "prefetch_config_params failed, falling through to per-param queries: %s",
@@ -3008,7 +3006,7 @@ class PrismaClient:
         self.iam_token_db_auth: bool | None = str_to_bool(os.getenv("IAM_TOKEN_DB_AUTH"))
         verbose_proxy_logger.debug("Creating Prisma Client..")
         try:
-            from prisma import Prisma  # type: ignore
+            from prisma import Prisma
         except Exception as e:
             verbose_proxy_logger.error("Failed to import Prisma client: %s", e)
             verbose_proxy_logger.error("This usually means 'prisma generate' hasn't been run yet.")
@@ -3309,21 +3307,13 @@ class PrismaClient:
 
         async def _do_query():
             if table_name == "users":
-                return await UserRepository(self).table.find_first(
-                    where={key: value}  # type: ignore
-                )
+                return await UserRepository(self).table.find_first(where={key: value})
             elif table_name == "keys":
-                return await VerificationTokenRepository(self).table.find_first(  # type: ignore
-                    where={key: value}  # type: ignore
-                )
+                return await VerificationTokenRepository(self).table.find_first(where={key: value})
             elif table_name == "config":
-                return await ConfigRepository(self).table.find_first(  # type: ignore
-                    where={key: value}  # type: ignore
-                )
+                return await ConfigRepository(self).table.find_first(where={key: value})
             elif table_name == "spend":
-                return await self.db.l.find_first(  # type: ignore
-                    where={key: value}  # type: ignore
-                )
+                return await self.db.l.find_first(where={key: value})
             return None
 
         try:
@@ -3444,7 +3434,7 @@ class PrismaClient:
                             detail={"error": f"No token passed in. Token={token}"},
                         )
                     response = await VerificationTokenRepository(self).table.find_unique(
-                        where={"token": hashed_token},  # type: ignore
+                        where={"token": hashed_token},
                         include={"litellm_budget_table": True},
                     )
                     if response is not None:
@@ -3478,7 +3468,7 @@ class PrismaClient:
                                 r.expires = r.expires.isoformat()
                 elif query_type == "find_all" and expires is not None and reset_at is not None:
                     response = await VerificationTokenRepository(self).table.find_many(
-                        where={  # type: ignore
+                        where={
                             "OR": [
                                 {"expires": None},
                                 {"expires": {"gt": expires}},
@@ -3509,7 +3499,7 @@ class PrismaClient:
                             where_filter["token"]["in"] = hashed_tokens
                     response = await VerificationTokenRepository(self).table.find_many(
                         order={"spend": "desc"},
-                        where=where_filter,  # type: ignore
+                        where=where_filter,
                         include={"litellm_budget_table": True},
                     )
                 if response is not None:
@@ -3525,18 +3515,16 @@ class PrismaClient:
                     if key_val is None:
                         key_val = {"user_id": user_id}
 
-                    response = await UserRepository(self).table.find_unique(  # type: ignore
-                        where=key_val,  # type: ignore
+                    response = await UserRepository(self).table.find_unique(
+                        where=key_val,
                         include={"organization_memberships": True},
                     )
 
                 elif query_type == "find_all" and key_val is not None:
-                    response = await UserRepository(self).table.find_many(
-                        where=key_val  # type: ignore
-                    )  # type: ignore
+                    response = await UserRepository(self).table.find_many(where=key_val)
                 elif query_type == "find_all" and reset_at is not None:
                     response = await UserRepository(self).table.find_many(
-                        where={  # type: ignore
+                        where={
                             # A user seeded from default_internal_user_params
                             # (or created via /user/new without an explicit
                             # budget_reset_at) has budget_duration set but
@@ -3561,12 +3549,12 @@ class PrismaClient:
                     response = await UserRepository(self).table.find_many(where={"user_id": {"in": user_id_list}})
                 elif query_type == "find_all":
                     if expires is not None:
-                        response = await UserRepository(self).table.find_many(  # type: ignore
+                        response = await UserRepository(self).table.find_many(
                             order={"spend": "desc"},
-                            where={  # type: ignore
+                            where={
                                 "OR": [
-                                    {"expires": None},  # type: ignore
-                                    {"expires": {"gt": expires}},  # type: ignore
+                                    {"expires": None},
+                                    {"expires": {"gt": expires}},
                                 ],
                             },
                         )
@@ -3591,27 +3579,27 @@ class PrismaClient:
                 verbose_proxy_logger.debug("PrismaClient: get_data: table_name == 'spend'")
                 if key_val is not None:
                     if query_type == "find_unique":
-                        response = await SpendLogsRepository(self).table.find_unique(  # type: ignore
-                            where={  # type: ignore
-                                key_val["key"]: key_val["value"],  # type: ignore
+                        response = await SpendLogsRepository(self).table.find_unique(
+                            where={
+                                key_val["key"]: key_val["value"],
                             }
                         )
                     elif query_type == "find_all":
-                        response = await SpendLogsRepository(self).table.find_many(  # type: ignore
+                        response = await SpendLogsRepository(self).table.find_many(
                             where={
-                                key_val["key"]: key_val["value"],  # type: ignore
+                                key_val["key"]: key_val["value"],
                             }
                         )
                     return response
                 else:
-                    response = await SpendLogsRepository(self).table.find_many(  # type: ignore
+                    response = await SpendLogsRepository(self).table.find_many(
                         order={"startTime": "desc"},
                     )
                     return response
             elif table_name == "budget" and reset_at is not None:
                 if query_type == "find_all":
                     response = await BudgetRepository(self).table.find_many(
-                        where={  # type: ignore
+                        where={
                             "OR": [
                                 {
                                     "AND": [
@@ -3634,12 +3622,12 @@ class PrismaClient:
             elif table_name == "team":
                 if query_type == "find_unique":
                     response = await TeamRepository(self).table.find_unique(
-                        where={"team_id": team_id},  # type: ignore
-                        include={"litellm_model_table": True},  # type: ignore
+                        where={"team_id": team_id},
+                        include={"litellm_model_table": True},
                     )
                 elif query_type == "find_all" and reset_at is not None:
                     response = await TeamRepository(self).table.find_many(
-                        where={  # type: ignore
+                        where={
                             # Same NULL budget_reset_at gap as the user query
                             # above: a team with a budget_duration but no
                             # initialized budget_reset_at would never be reset.
@@ -3668,11 +3656,9 @@ class PrismaClient:
                 return response
             elif table_name == "user_notification":
                 if query_type == "find_unique":
-                    response = await UserNotificationsRepository(self).table.find_unique(  # type: ignore
-                        where={"user_id": user_id}  # type: ignore
-                    )
+                    response = await UserNotificationsRepository(self).table.find_unique(where={"user_id": user_id})
                 elif query_type == "find_all":
-                    response = await UserNotificationsRepository(self).table.find_many()  # type: ignore
+                    response = await UserNotificationsRepository(self).table.find_many()
                 return response
             elif table_name == "combined_view":
                 # check if plain text or hash
@@ -3848,12 +3834,12 @@ class PrismaClient:
                 if db_data.get("budget_limits") is None:
                     db_data.pop("budget_limits", None)
                 print_verbose("PrismaClient: Before upsert into litellm_verificationtoken")
-                new_verification_token: Final = await VerificationTokenRepository(self).table.upsert(  # type: ignore
+                new_verification_token: Final = await VerificationTokenRepository(self).table.upsert(
                     where={
                         "token": hashed_token,
                     },
                     data={
-                        "create": {**db_data},  # type: ignore
+                        "create": {**db_data},
                         "update": {},  # don't do anything if it already exists
                     },
                     include={"litellm_budget_table": True},
@@ -3866,7 +3852,7 @@ class PrismaClient:
                     new_user_row: Final = await UserRepository(self).table.upsert(
                         where={"user_id": data["user_id"]},
                         data={
-                            "create": {**db_data},  # type: ignore
+                            "create": {**db_data},
                             "update": {},  # don't do anything if it already exists
                         },
                     )
@@ -3889,7 +3875,7 @@ class PrismaClient:
                 new_team_row: Final = await TeamRepository(self).table.upsert(
                     where={"team_id": data["team_id"]},
                     data={
-                        "create": {**db_data},  # type: ignore
+                        "create": {**db_data},
                         "update": {},  # don't do anything if it already exists
                     },
                 )
@@ -3909,9 +3895,9 @@ class PrismaClient:
                     updated_data = v
                     updated_data = json.dumps(updated_data)
                     updated_table_row = ConfigRepository(self).table.upsert(
-                        where={"param_name": k},  # type: ignore
+                        where={"param_name": k},
                         data={
-                            "create": {"param_name": k, "param_value": updated_data},  # type: ignore
+                            "create": {"param_name": k, "param_value": updated_data},
                             "update": {"param_value": updated_data},
                         },
                     )
@@ -3927,7 +3913,7 @@ class PrismaClient:
                 new_spend_row: Final = await SpendLogsRepository(self).table.upsert(
                     where={"request_id": data["request_id"]},
                     data={
-                        "create": {**db_data},  # type: ignore
+                        "create": {**db_data},
                         "update": {},  # don't do anything if it already exists
                     },
                 )
@@ -3935,10 +3921,10 @@ class PrismaClient:
                 return new_spend_row
             elif table_name == "user_notification":
                 db_data = self.jsonify_object(data=data)
-                new_user_notification_row: Final = await UserNotificationsRepository(self).table.upsert(  # type: ignore
+                new_user_notification_row: Final = await UserNotificationsRepository(self).table.upsert(
                     where={"request_id": data["request_id"]},
                     data={
-                        "create": {**db_data},  # type: ignore
+                        "create": {**db_data},
                         "update": {},  # don't do anything if it already exists
                     },
                 )
@@ -3998,14 +3984,14 @@ class PrismaClient:
                 token = _hash_token_if_needed(token=token)
                 db_data["token"] = token
                 response: Final = await VerificationTokenRepository(self).table.update(
-                    where={"token": token},  # type: ignore
-                    data={**db_data},  # type: ignore
+                    where={"token": token},
+                    data={**db_data},
                 )
                 verbose_proxy_logger.debug("\033[91m" + f"DB Token Table update succeeded {response}" + "\033[0m")
                 _data: dict = {}
                 if response is not None:
                     try:
-                        _data = response.model_dump()  # type: ignore
+                        _data = response.model_dump()
                     except Exception:
                         _data = response.dict()
                 return {"token": token, "data": _data}
@@ -4021,12 +4007,10 @@ class PrismaClient:
                     else:
                         update_key_values = db_data
                 update_user_row: Final = await UserRepository(self).table.upsert(
-                    where={"user_id": user_id},  # type: ignore
+                    where={"user_id": user_id},
                     data={
-                        "create": {**db_data},  # type: ignore
-                        "update": {
-                            **update_key_values  # type: ignore
-                        },  # just update user-specified values, if it already exists
+                        "create": {**db_data},
+                        "update": {**update_key_values},  # just update user-specified values, if it already exists
                     },
                 )
                 verbose_proxy_logger.info(
@@ -4050,12 +4034,10 @@ class PrismaClient:
                 ):
                     update_key_values["members_with_roles"] = json.dumps(update_key_values["members_with_roles"])
                 update_team_row: Final = await TeamRepository(self).table.upsert(
-                    where={"team_id": team_id},  # type: ignore
+                    where={"team_id": team_id},
                     data={
-                        "create": {**db_data},  # type: ignore
-                        "update": {
-                            **update_key_values  # type: ignore
-                        },  # just update user-specified values, if it already exists
+                        "create": {**db_data},
+                        "update": {**update_key_values},  # just update user-specified values, if it already exists
                     },
                 )
                 verbose_proxy_logger.info(
@@ -4075,15 +4057,15 @@ class PrismaClient:
                 batcher = self.db.batch_()
                 for idx, t in enumerate(data_list):
                     # check if plain text or hash
-                    if t.token.startswith("sk-"):  # type: ignore
-                        t.token = self.hash_token(token=t.token)  # type: ignore
+                    if t.token.startswith("sk-"):
+                        t.token = self.hash_token(token=t.token)
                     try:
                         data_json = self.jsonify_object(data=t.model_dump(exclude_none=True))
                     except Exception:
                         data_json = self.jsonify_object(data=t.dict(exclude_none=True))
                     batcher.litellm_verificationtoken.update(
-                        where={"token": t.token},  # type: ignore
-                        data={**data_json},  # type: ignore
+                        where={"token": t.token},
+                        data={**data_json},
                     )
                 await batcher.commit()
                 print_verbose("\033[91m" + "DB Token Table update succeeded" + "\033[0m")
@@ -4104,12 +4086,10 @@ class PrismaClient:
                     except Exception:
                         data_json = self.jsonify_object(data=user.dict())
                     batcher.litellm_usertable.upsert(
-                        where={"user_id": user.user_id},  # type: ignore
+                        where={"user_id": user.user_id},
                         data={
-                            "create": {**data_json},  # type: ignore
-                            "update": {
-                                **data_json  # type: ignore
-                            },  # just update user-specified values, if it already exists
+                            "create": {**data_json},
+                            "update": {**data_json},  # just update user-specified values, if it already exists
                         },
                     )
                 await batcher.commit()
@@ -4131,12 +4111,10 @@ class PrismaClient:
                     except Exception:
                         data_json = self.jsonify_object(data=enduser.dict())
                     batcher.litellm_endusertable.upsert(
-                        where={"user_id": enduser.user_id},  # type: ignore
+                        where={"user_id": enduser.user_id},
                         data={
-                            "create": {**data_json},  # type: ignore
-                            "update": {
-                                **data_json  # type: ignore
-                            },  # just update end-user-specified values, if it already exists
+                            "create": {**data_json},
+                            "update": {**data_json},  # just update end-user-specified values, if it already exists
                         },
                     )
                 await batcher.commit()
@@ -4158,12 +4136,10 @@ class PrismaClient:
                     except Exception:
                         data_json = self.jsonify_object(data=budget.dict())
                     batcher.litellm_budgettable.upsert(
-                        where={"budget_id": budget.budget_id},  # type: ignore
+                        where={"budget_id": budget.budget_id},
                         data={
-                            "create": {**data_json},  # type: ignore
-                            "update": {
-                                **data_json  # type: ignore
-                            },  # just update end-user-specified values, if it already exists
+                            "create": {**data_json},
+                            "update": {**data_json},  # just update end-user-specified values, if it already exists
                         },
                     )
                 await batcher.commit()
@@ -4183,12 +4159,10 @@ class PrismaClient:
                     except Exception:
                         data_json = self.jsonify_object(data=team.dict(exclude_none=True))
                     batcher.litellm_teamtable.upsert(
-                        where={"team_id": team.team_id},  # type: ignore
+                        where={"team_id": team.team_id},
                         data={
-                            "create": {**data_json},  # type: ignore
-                            "update": {
-                                **data_json  # type: ignore
-                            },  # just update user-specified values, if it already exists
+                            "create": {**data_json},
+                            "update": {**data_json},  # just update user-specified values, if it already exists
                         },
                     )
                 await batcher.commit()
@@ -4248,9 +4222,7 @@ class PrismaClient:
                 else:
                     filter_query = {"token": {"in": hashed_tokens}}
 
-                deleted_tokens: Final = await VerificationTokenRepository(self).table.delete_many(
-                    where=filter_query  # type: ignore
-                )
+                deleted_tokens: Final = await VerificationTokenRepository(self).table.delete_many(where=filter_query)
                 verbose_proxy_logger.debug("deleted_tokens: %s", deleted_tokens)
                 return {"deleted_keys": deleted_tokens}
             elif table_name == "team" and team_id_list is not None and isinstance(team_id_list, list):
@@ -4533,7 +4505,7 @@ class PrismaClient:
             return False
         fd = -1
         try:
-            fd = os.pidfd_open(pid, 0)  # type: ignore[attr-defined]
+            fd = os.pidfd_open(pid, 0)
             asyncio.get_running_loop().add_reader(fd, self._on_pidfd_readable)
             self._engine_pidfd = fd
             return True

--- a/litellm/proxy/vector_store_files_endpoints/endpoints.py
+++ b/litellm/proxy/vector_store_files_endpoints/endpoints.py
@@ -143,7 +143,7 @@ def _update_request_data_with_managed_file_id(
         # Use model-based routing with credentials from config
         prepare_data_with_credentials(
             data=data,
-            credentials=credentials,  # type: ignore
+            credentials=credentials,
             file_id=original_file_id,  # Use decoded file ID if from encoded ID
         )
 

--- a/litellm/proxy/vertex_ai_endpoints/langfuse_endpoints.py
+++ b/litellm/proxy/vertex_ai_endpoints/langfuse_endpoints.py
@@ -216,7 +216,7 @@ async def langfuse_proxy_route(
         endpoint=endpoint,
         target=target_url,
         custom_headers=target_headers,
-        query_params=dict(request.query_params),  # type: ignore
+        query_params=dict(request.query_params),
     )  # dynamically construct pass-through endpoint based on incoming path
     received_value: Final = await endpoint_func(
         request,

--- a/litellm/rag/ingestion/base_ingestion.py
+++ b/litellm/rag/ingestion/base_ingestion.py
@@ -176,12 +176,8 @@ class BaseRAGIngestion(ABC):
             )
 
         # Extract text from pages
-        if hasattr(ocr_response, "pages") and ocr_response.pages:  # type: ignore
-            return "\n\n".join(
-                page.markdown
-                for page in ocr_response.pages
-                if hasattr(page, "markdown")  # type: ignore
-            )
+        if hasattr(ocr_response, "pages") and ocr_response.pages:
+            return "\n\n".join(page.markdown for page in ocr_response.pages if hasattr(page, "markdown"))
 
         return None
 

--- a/litellm/rag/main.py
+++ b/litellm/rag/main.py
@@ -305,7 +305,7 @@ async def _execute_query_pipeline(
         if isinstance(logging_obj, LiteLLMLoggingObj):
             logging_obj.model_call_details["additional_response_cost"] = sub_call_cost
 
-    return response  # type: ignore[return-value]
+    return response
 
 
 @client
@@ -451,7 +451,7 @@ def ingest(
 
         if _is_async:
             return _execute_ingest_pipeline(
-                ingest_options=ingest_options,  # type: ignore
+                ingest_options=ingest_options,
                 file_data=file_data,
                 file_url=file_url,
                 file_id=file_id,
@@ -460,7 +460,7 @@ def ingest(
         else:
             return asyncio.get_event_loop().run_until_complete(
                 _execute_ingest_pipeline(
-                    ingest_options=ingest_options,  # type: ignore
+                    ingest_options=ingest_options,
                     file_data=file_data,
                     file_url=file_url,
                     file_id=file_id,

--- a/litellm/realtime_api/main.py
+++ b/litellm/realtime_api/main.py
@@ -109,7 +109,7 @@ async def acreate_realtime_client_secret(
         expires_after=RealtimeExpiresAfter(**expires_after) if expires_after else None,
     )
     model_name = (req.session.model if req.session is not None else None) or req.model or "gpt-4o-realtime-preview"
-    litellm_logging_obj: Final[LiteLLMLogging] = kwargs.get("litellm_logging_obj")  # type: ignore
+    litellm_logging_obj: Final[LiteLLMLogging] = kwargs.get("litellm_logging_obj")
     litellm_params: Final = GenericLiteLLMParams(**kwargs)
 
     (
@@ -177,7 +177,7 @@ async def acreate_realtime_transcription_session(
         **(transcription_session or {}),
     )
     model_name = req.resolved_model() or "gpt-realtime-whisper"
-    litellm_logging_obj: Final[LiteLLMLogging] = kwargs.get("litellm_logging_obj")  # type: ignore
+    litellm_logging_obj: Final[LiteLLMLogging] = kwargs.get("litellm_logging_obj")
     litellm_params: Final = GenericLiteLLMParams(**kwargs)
 
     (
@@ -238,7 +238,7 @@ async def arealtime_calls(
     **kwargs,
 ):
     model_name = model or "gpt-4o-realtime-preview"
-    litellm_logging_obj: Final[LiteLLMLogging] = kwargs.get("litellm_logging_obj")  # type: ignore
+    litellm_logging_obj: Final[LiteLLMLogging] = kwargs.get("litellm_logging_obj")
     litellm_params: Final = GenericLiteLLMParams(**kwargs)
 
     (
@@ -305,7 +305,7 @@ async def _arealtime(
         headers = {}
     if extra_headers is not None:
         headers.update(extra_headers)
-    litellm_logging_obj: Final[LiteLLMLogging] = kwargs.get("litellm_logging_obj")  # type: ignore
+    litellm_logging_obj: Final[LiteLLMLogging] = kwargs.get("litellm_logging_obj")
     user: Final = kwargs.get("user", None)
     litellm_params: Final = GenericLiteLLMParams(**kwargs)
 
@@ -572,7 +572,7 @@ async def _realtime_health_check(
         url = vertex_realtime_config.get_complete_url(api_base=api_base, model=model)
         ssl_context = get_shared_realtime_ssl_context()
         headers: Final = vertex_realtime_config.validate_environment(headers={}, model=model, api_key=None)
-        async with websockets.connect(  # type: ignore
+        async with websockets.connect(
             url,
             additional_headers=headers,
             max_size=REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
@@ -582,10 +582,10 @@ async def _realtime_health_check(
     else:
         raise ValueError(f"Unsupported model: {model}")
     ssl_context = get_shared_realtime_ssl_context()
-    async with websockets.connect(  # type: ignore
+    async with websockets.connect(
         url,
         additional_headers={
-            "api-key": api_key,  # type: ignore
+            "api-key": api_key,
         },
         max_size=REALTIME_WEBSOCKET_MAX_MESSAGE_SIZE_BYTES,
         ssl=ssl_context,

--- a/litellm/rerank_api/main.py
+++ b/litellm/rerank_api/main.py
@@ -108,8 +108,8 @@ def rerank(
     # typed named param there would trip the basedpyright budget gate without
     # adding real safety; it stays typed downstream via get_optional_rerank_params.
     instruction: Final[str | None] = kwargs.get("instruction", None)
-    headers: Final[dict | None] = kwargs.get("headers")  # type: ignore
-    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+    headers: Final[dict | None] = kwargs.get("headers")
+    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
     litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
     proxy_server_request: Final = kwargs.get("proxy_server_request", None)
     model_info: Final = kwargs.get("model_info", None)
@@ -195,7 +195,7 @@ def rerank(
                 dynamic_api_base
                 or optional_params.api_base
                 or litellm.api_base
-                or get_secret("COHERE_API_BASE")  # type: ignore
+                or get_secret("COHERE_API_BASE")
                 or "https://api.cohere.com"
             )
 
@@ -221,7 +221,7 @@ def rerank(
                 dynamic_api_base  # for deepinfra/perplexity/anyscale/groq/friendliai we check in get_llm_provider and pass in the api base from there
                 or optional_params.api_base
                 or litellm.api_base
-                or get_secret("AZURE_AI_API_BASE")  # type: ignore
+                or get_secret("AZURE_AI_API_BASE")
             )
             response = base_llm_http_handler.rerank(
                 model=model,
@@ -270,7 +270,7 @@ def rerank(
                 dynamic_api_key
                 or optional_params.api_key
                 or litellm.togetherai_api_key
-                or get_secret("TOGETHERAI_API_KEY")  # type: ignore
+                or get_secret("TOGETHERAI_API_KEY")
                 or litellm.api_key
             )
 
@@ -293,7 +293,7 @@ def rerank(
                 raise ValueError("Jina AI API key is required, please set 'JINA_AI_API_KEY' in your environment")
 
             api_base = (
-                dynamic_api_base or optional_params.api_base or litellm.api_base or get_secret("BEDROCK_API_BASE")  # type: ignore
+                dynamic_api_base or optional_params.api_base or litellm.api_base or get_secret("BEDROCK_API_BASE")
             )
 
             response = base_llm_http_handler.rerank(
@@ -319,7 +319,7 @@ def rerank(
             # Rerank uses ai.api.nvidia.com instead of integrate.api.nvidia.com
             api_base = (
                 optional_params.api_base
-                or get_secret("NVIDIA_NIM_API_BASE")  # type: ignore
+                or get_secret("NVIDIA_NIM_API_BASE")
                 or "https://ai.api.nvidia.com"  # Default for rerank
             )
 
@@ -340,7 +340,7 @@ def rerank(
             )
         elif _custom_llm_provider == litellm.LlmProviders.BEDROCK:
             api_base = (
-                dynamic_api_base or optional_params.api_base or litellm.api_base or get_secret("BEDROCK_API_BASE")  # type: ignore
+                dynamic_api_base or optional_params.api_base or litellm.api_base or get_secret("BEDROCK_API_BASE")
             )
 
             # Merge headers and extra_headers if both are provided

--- a/litellm/responses/file_search/emulated_handler.py
+++ b/litellm/responses/file_search/emulated_handler.py
@@ -483,7 +483,7 @@ def _build_follow_up_input(
         if isinstance(_item, dict):
             first_response_output_items.append(_item)
         elif hasattr(_item, "model_dump"):
-            first_response_output_items.append(_item.model_dump(exclude_none=True))  # type: ignore[union-attr]
+            first_response_output_items.append(_item.model_dump(exclude_none=True))
         else:
             first_response_output_items.append(_item)
 

--- a/litellm/responses/litellm_completion_transformation/streaming_iterator.py
+++ b/litellm/responses/litellm_completion_transformation/streaming_iterator.py
@@ -225,7 +225,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         self._final_tool_events_queued = True
 
         try:
-            message: Final = litellm_complete_object.choices[0].message  # type: ignore
+            message: Final = litellm_complete_object.choices[0].message
             tool_calls = getattr(message, "tool_calls", None)
         except Exception:
             tool_calls = None
@@ -535,17 +535,16 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             item_id=self._cached_item_id,
             output_index=0,
             content_index=0,
-            text=getattr(litellm_complete_object.choices[0].message, "content", "")  # type: ignore
-            or "",
+            text=getattr(litellm_complete_object.choices[0].message, "content", "") or "",
         )
 
     def create_output_content_part_done_event(self, litellm_complete_object: ModelResponse) -> ContentPartDoneEvent:
         if self._cached_item_id is None:
             self._cached_item_id = f"msg_{uuid.uuid4()}"
 
-        text: Final = getattr(litellm_complete_object.choices[0].message, "content", "") or ""  # type: ignore
-        reasoning_content = getattr(litellm_complete_object.choices[0].message, "reasoning_content", "") or ""  # type: ignore
-        annotations: Final = getattr(litellm_complete_object.choices[0].message, "annotations", None)  # type: ignore
+        text: Final = getattr(litellm_complete_object.choices[0].message, "content", "") or ""
+        reasoning_content = getattr(litellm_complete_object.choices[0].message, "reasoning_content", "") or ""
+        annotations: Final = getattr(litellm_complete_object.choices[0].message, "annotations", None)
 
         part: PART_UNION_TYPES | None = None
         if reasoning_content:
@@ -563,7 +562,7 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
             part = ContentPartDonePartOutputText(
                 type="output_text",
                 text=text,
-                annotations=response_annotations,  # type: ignore
+                annotations=response_annotations,
                 logprobs=None,
             )
 
@@ -579,8 +578,8 @@ class LiteLLMCompletionStreamingIterator(ResponsesAPIStreamingIterator):
         if self._cached_item_id is None:
             self._cached_item_id = f"msg_{uuid.uuid4()}"
 
-        text: Final = self.litellm_model_response.choices[0].message.content or ""  # type: ignore
-        annotations = getattr(self.litellm_model_response.choices[0].message, "annotations", None)  # type: ignore
+        text: Final = self.litellm_model_response.choices[0].message.content or ""
+        annotations = getattr(self.litellm_model_response.choices[0].message, "annotations", None)
 
         response_annotations: Final = (
             LiteLLMCompletionResponsesConfig._transform_chat_completion_annotations_to_response_output_annotations(

--- a/litellm/responses/litellm_completion_transformation/transformation.py
+++ b/litellm/responses/litellm_completion_transformation/transformation.py
@@ -215,7 +215,7 @@ class LiteLLMCompletionResponsesConfig:
             tools,
             web_search_options,
         ) = LiteLLMCompletionResponsesConfig.transform_responses_api_tools_to_chat_completion_tools(
-            responses_api_request.get("tools") or []  # type: ignore
+            responses_api_request.get("tools") or []
         )
 
         if web_search_options is not None and LiteLLMCompletionResponsesConfig._should_drop_derived_web_search_options(
@@ -1239,7 +1239,7 @@ class LiteLLMCompletionResponsesConfig:
             stripped: Final = content_type[len("input_") :]
             # Validate stripped type is valid, otherwise default to "text"
             if stripped in ValidChatCompletionMessageContentTypes:
-                return stripped  # type: ignore
+                return stripped
             # Handle input_audio -> input_audio (it's already valid)
             if stripped == "audio":
                 return "input_audio"
@@ -1251,7 +1251,7 @@ class LiteLLMCompletionResponsesConfig:
 
         # Return as-is if it's a valid type, otherwise default to "text"
         if content_type in ValidChatCompletionMessageContentTypes:
-            return content_type  # type: ignore
+            return content_type
 
         return "text"
 
@@ -1309,13 +1309,13 @@ class LiteLLMCompletionResponsesConfig:
                     },
                 }
                 if tool.get("cache_control"):
-                    chat_completion_tool["cache_control"] = tool.get("cache_control")  # type: ignore
+                    chat_completion_tool["cache_control"] = tool.get("cache_control")
                 if tool.get("defer_loading"):
-                    chat_completion_tool["defer_loading"] = tool.get("defer_loading")  # type: ignore
+                    chat_completion_tool["defer_loading"] = tool.get("defer_loading")
                 if tool.get("allowed_callers"):
-                    chat_completion_tool["allowed_callers"] = tool.get("allowed_callers")  # type: ignore
+                    chat_completion_tool["allowed_callers"] = tool.get("allowed_callers")
                 if tool.get("input_examples"):
-                    chat_completion_tool["input_examples"] = tool.get("input_examples")  # type: ignore
+                    chat_completion_tool["input_examples"] = tool.get("input_examples")
                 chat_completion_tools.append(cast(ChatCompletionToolParam, chat_completion_tool))
             elif tool.get("type") == "custom":
                 converted = convert_custom_tool_to_function_tool(tool)
@@ -1351,7 +1351,7 @@ class LiteLLMCompletionResponsesConfig:
         result: Final[list[dict[str, Any]]] = []
         for tool in chat_completion_tools:
             if not isinstance(tool, dict):
-                result.append(tool)  # type: ignore
+                result.append(tool)
                 continue
             if tool.get("type") == "function":
                 fn = cast(dict[str, Any], tool.get("function") or {})
@@ -1435,9 +1435,7 @@ class LiteLLMCompletionResponsesConfig:
                         provider_specific_fields = getattr(tool, "provider_specific_fields")
                         if not isinstance(provider_specific_fields, dict):
                             provider_specific_fields = (
-                                dict(provider_specific_fields)  # type: ignore
-                                if hasattr(provider_specific_fields, "__dict__")
-                                else {}
+                                dict(provider_specific_fields) if hasattr(provider_specific_fields, "__dict__") else {}
                             )
                     elif hasattr(function_definition, "provider_specific_fields") and getattr(
                         function_definition, "provider_specific_fields", None
@@ -1445,9 +1443,7 @@ class LiteLLMCompletionResponsesConfig:
                         provider_specific_fields = getattr(function_definition, "provider_specific_fields")
                         if not isinstance(provider_specific_fields, dict):
                             provider_specific_fields = (
-                                dict(provider_specific_fields)  # type: ignore
-                                if hasattr(provider_specific_fields, "__dict__")
-                                else {}
+                                dict(provider_specific_fields) if hasattr(provider_specific_fields, "__dict__") else {}
                             )
 
                     output_tool_call: ResponseFunctionToolCall = ResponseFunctionToolCall(
@@ -1465,7 +1461,7 @@ class LiteLLMCompletionResponsesConfig:
                             output_tool_call,
                             "provider_specific_fields",
                             provider_specific_fields,
-                        )  # type: ignore
+                        )
 
                     responses_tools.append(output_tool_call)
         return responses_tools
@@ -1531,17 +1527,13 @@ class LiteLLMCompletionResponsesConfig:
             provider_specific_fields = (
                 dict(provider_specific_fields) if hasattr(provider_specific_fields, "__dict__") else {}
             )
-        elif hasattr(tool_call_item, "get") and callable(tool_call_item.get):  # type: ignore
-            provider_fields: Final = tool_call_item.get("provider_specific_fields")  # type: ignore
+        elif hasattr(tool_call_item, "get") and callable(tool_call_item.get):
+            provider_fields: Final = tool_call_item.get("provider_specific_fields")
             if provider_fields:
                 provider_specific_fields = (
                     provider_fields
                     if isinstance(provider_fields, dict)
-                    else (
-                        dict(provider_fields)  # type: ignore
-                        if hasattr(provider_fields, "__dict__")
-                        else {}
-                    )
+                    else (dict(provider_fields) if hasattr(provider_fields, "__dict__") else {})
                 )
 
         function_dict: Final[dict[str, Any]] = {

--- a/litellm/responses/main.py
+++ b/litellm/responses/main.py
@@ -39,7 +39,7 @@ from litellm.types.llms.openai import (
 
 # Handle ResponseText import with fallback
 if TYPE_CHECKING:
-    from litellm.types.llms.openai import ResponseText  # type: ignore
+    from litellm.types.llms.openai import ResponseText
 else:
     ResponseText = str  # Fallback for ResponseText import
 from litellm.litellm_core_utils.get_litellm_params import get_litellm_params
@@ -77,7 +77,7 @@ def mock_responses_api_response(
     mock_response: str = "In a peaceful grove beneath a silver moon, a unicorn named Lumina discovered a hidden pool that reflected the stars. As she dipped her horn into the water, the pool began to shimmer, revealing a pathway to a magical realm of endless night skies. Filled with wonder, Lumina whispered a wish for all who dream to find their own hidden magic, and as she glanced back, her hoofprints sparkled like stardust.",
 ):
     return ResponsesAPIResponse(
-        **{  # type: ignore
+        **{
             "id": "resp_67ccd2bed1ec8190b14f964abc0542670bb6a6b452d3795b",
             "object": "response",
             "created_at": 1741476542,
@@ -293,7 +293,7 @@ async def aresponses_api_with_mcp(
     # Auto-Execute Tools Handling
     # If auto-execute tools is True, then we need to execute the tool calls
     #########################################################
-    if should_auto_execute and isinstance(response, ResponsesAPIResponse):  # type: ignore
+    if should_auto_execute and isinstance(response, ResponsesAPIResponse):
         tool_calls: Final = LiteLLM_Proxy_MCP_Handler._extract_tool_calls_from_response(response=response)
 
         if tool_calls:
@@ -465,11 +465,7 @@ async def aresponses(
             if isinstance(input, str):
                 client_input: list[AllMessageValues] = [{"role": "user", "content": input}]
             else:
-                client_input = [
-                    item  # type: ignore[misc]
-                    for item in input
-                    if isinstance(item, dict) and "role" in item
-                ]
+                client_input = [item for item in input if isinstance(item, dict) and "role" in item]
             (
                 model,
                 merged_input,
@@ -583,11 +579,7 @@ def _apply_prompt_management_to_responses_call(
     if isinstance(input, str):
         client_input: list[AllMessageValues] = [{"role": "user", "content": input}]
     else:
-        client_input = [
-            item  # type: ignore[misc]
-            for item in input
-            if isinstance(item, dict) and "role" in item
-        ]
+        client_input = [item for item in input if isinstance(item, dict) and "role" in item]
 
     if isinstance(litellm_logging_obj, LiteLLMLoggingObj) and litellm_logging_obj.should_run_prompt_management_hooks(
         prompt_id=prompt_id, non_default_params=kwargs
@@ -907,7 +899,7 @@ def responses(
     local_vars: Final = locals()
 
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("aresponses", False) is True
         use_chat_completions_api = _pop_use_chat_completions_api_kw(kwargs)
@@ -1232,7 +1224,7 @@ def delete_responses(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("adelete_responses", False) is True
 
@@ -1403,7 +1395,7 @@ def get_responses(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("aget_responses", False) is True
 
@@ -1552,7 +1544,7 @@ def list_input_items(
     """List input items for a response"""
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("alist_input_items", False) is True
 
@@ -1696,7 +1688,7 @@ def cancel_responses(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("acancel_responses", False) is True
 
@@ -1868,7 +1860,7 @@ def compact_responses(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("acompact_responses", False) is True
 
@@ -1997,7 +1989,7 @@ async def _aresponses_websocket(
     ``BaseResponsesAPIConfig``, and hands off to
     ``BaseLLMHTTPHandler.async_responses_websocket``.
     """
-    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+    litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
     user: Final = kwargs.get("user", None)
     litellm_params: Final = GenericLiteLLMParams(**kwargs)
     litellm_params_dict: Final = get_litellm_params(**kwargs)

--- a/litellm/responses/mcp/litellm_proxy_mcp_handler.py
+++ b/litellm/responses/mcp/litellm_proxy_mcp_handler.py
@@ -272,9 +272,7 @@ class LiteLLM_Proxy_MCP_Handler:
         tools: Final = listing.tools
 
         allowed_mcp_server_ids: Final = await global_mcp_server_manager.get_allowed_mcp_servers(user_api_key_auth)
-        allowed_mcp_servers = global_mcp_server_manager.get_mcp_servers_from_ids(  # type: ignore[attr-defined]
-            allowed_mcp_server_ids
-        )
+        allowed_mcp_servers = global_mcp_server_manager.get_mcp_servers_from_ids(allowed_mcp_server_ids)
 
         allowed_mcp_servers = await _get_allowed_mcp_servers_from_mcp_server_names(
             mcp_servers=effective_server_filter,
@@ -1274,7 +1272,7 @@ class LiteLLM_Proxy_MCP_Handler:
         )
 
         # Add the new output elements to the response
-        response.output.append(mcp_tools_output.model_dump())  # type: ignore
-        response.output.append(tool_results_output.model_dump())  # type: ignore
+        response.output.append(mcp_tools_output.model_dump())
+        response.output.append(tool_results_output.model_dump())
 
         return response

--- a/litellm/responses/mcp/mcp_streaming_iterator.py
+++ b/litellm/responses/mcp/mcp_streaming_iterator.py
@@ -506,7 +506,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         if self.base_iterator:
             if hasattr(self.base_iterator, "__anext__"):
                 try:
-                    chunk: Final = await cast(Any, self.base_iterator).__anext__()  # type: ignore[attr-defined]
+                    chunk: Final = await cast(Any, self.base_iterator).__anext__()
 
                     # Capture the response ID from the first event to ensure consistency
                     if self._cached_response_id is None and hasattr(chunk, "response"):
@@ -563,7 +563,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         if not self.base_iterator or not hasattr(self.base_iterator, "__anext__"):
             raise StopAsyncIteration
 
-        chunk: Final = await cast(Any, self.base_iterator).__anext__()  # type: ignore[attr-defined]
+        chunk: Final = await cast(Any, self.base_iterator).__anext__()
 
         if self._cached_response_id is None and hasattr(chunk, "response"):
             new_response: Final = getattr(chunk, "response", None)
@@ -648,7 +648,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
         try:
             # Extract tool calls from the response
             if self.collected_response is not None:
-                tool_calls = LiteLLM_Proxy_MCP_Handler._extract_tool_calls_from_response(self.collected_response)  # type: ignore[arg-type]
+                tool_calls = LiteLLM_Proxy_MCP_Handler._extract_tool_calls_from_response(self.collected_response)
             else:
                 tool_calls = []
             if not tool_calls:
@@ -770,7 +770,7 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
             # Create follow-up input
             if self.collected_response is not None:
                 follow_up_input: Final = LiteLLM_Proxy_MCP_Handler._create_follow_up_input(
-                    response=self.collected_response,  # type: ignore[arg-type]
+                    response=self.collected_response,
                     tool_results=self.tool_results,
                     original_input=self.original_request_params.get("input"),
                 )
@@ -821,14 +821,14 @@ class MCPEnhancedStreamingIterator(BaseResponsesAPIStreamingIterator):
 
     def __next__(self) -> ResponsesAPIStreamingResponse:
         # First, emit any queued MCP events
-        if self.mcp_events:  # type: ignore[attr-defined]
-            return self.mcp_events.pop(0)  # type: ignore[attr-defined]
+        if self.mcp_events:
+            return self.mcp_events.pop(0)
 
         # Then delegate to the base iterator
         if not self.is_async:
             try:
                 if self.base_iterator and hasattr(self.base_iterator, "__next__"):
-                    return next(cast(Any, self.base_iterator))  # type: ignore[arg-type]
+                    return next(cast(Any, self.base_iterator))
                 else:
                     raise StopIteration
             except StopIteration:

--- a/litellm/responses/streaming_iterator.py
+++ b/litellm/responses/streaming_iterator.py
@@ -1388,9 +1388,9 @@ class ResponsesWebSocketStreaming:
         try:
             while True:
                 try:
-                    raw_response = await self.backend_ws.recv(decode=False)  # type: ignore[union-attr]
+                    raw_response = await self.backend_ws.recv(decode=False)
                 except TypeError:
-                    raw_response = await self.backend_ws.recv()  # type: ignore[union-attr, assignment]
+                    raw_response = await self.backend_ws.recv()
 
                 if isinstance(raw_response, bytes):
                     response_str = raw_response.decode("utf-8")
@@ -1422,7 +1422,7 @@ class ResponsesWebSocketStreaming:
 
                 await self.websocket.send_text(output_masked_str)
 
-        except websockets.exceptions.ConnectionClosed as e:  # type: ignore
+        except websockets.exceptions.ConnectionClosed as e:
             verbose_logger.debug("Responses WS backend connection closed: %s", e)
         except Exception as e:
             verbose_logger.exception("Error in responses WS backend_to_client: %s", e)
@@ -1720,14 +1720,14 @@ class ResponsesWebSocketStreaming:
                 masked_first: Final = await self._mask_response_create(self.first_message)
                 self._store_input(masked_first)
                 self._store_event(masked_first)
-                await self.backend_ws.send(masked_first)  # type: ignore[union-attr]
+                await self.backend_ws.send(masked_first)
 
             while True:
                 message = await self.websocket.receive_text()
                 masked = await self._mask_response_create(message)
                 self._store_input(masked)
                 self._store_event(masked)
-                await self.backend_ws.send(masked)  # type: ignore[union-attr]
+                await self.backend_ws.send(masked)
 
         except Exception as e:
             verbose_logger.debug("Responses WS client_to_backend ended: %s", e)
@@ -2141,7 +2141,7 @@ class ManagedResponsesWebSocketHandler:
         """
         completed_event: dict[str, Any] | None = None
         stream_response: Final = await litellm.aresponses(model=model, **call_kwargs)
-        async for chunk in stream_response:  # type: ignore[union-attr]
+        async for chunk in stream_response:
             if chunk is None:
                 continue
             # Read type from the object before serializing to avoid double JSON parse

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -513,7 +513,7 @@ class Router:
                 cache_config["host"] = redis_host
 
             if redis_port is not None:
-                cache_config["port"] = str(redis_port)  # type: ignore
+                cache_config["port"] = str(redis_port)
 
             if redis_password is not None:
                 cache_config["password"] = redis_password
@@ -531,7 +531,7 @@ class Router:
         if cache_responses:
             if litellm.cache is None:
                 # the cache can be initialized on the proxy server. We should not overwrite it
-                litellm.cache = litellm.Cache(type=cache_type, **cache_config)  # type: ignore
+                litellm.cache = litellm.Cache(type=cache_type, **cache_config)
             self.cache_responses = cache_responses
         self.cache = DualCache(
             redis_cache=redis_cache, in_memory_cache=InMemoryCache()
@@ -581,7 +581,7 @@ class Router:
         if model_list is not None:
             # set_model_list will build indices automatically
             self.set_model_list(model_list)
-            self.healthy_deployments: list = self.model_list  # type: ignore
+            self.healthy_deployments: list = self.model_list
             for m in model_list:
                 if "model" in m["litellm_params"]:
                     self.deployment_latency_map[m["litellm_params"]["model"]] = 0
@@ -908,9 +908,9 @@ class Router:
                 selector = LeastBusyLoggingHandler(router_cache=self.cache)
                 if register_callbacks:
                     if isinstance(litellm.input_callback, list):
-                        litellm.input_callback.append(selector)  # type: ignore
+                        litellm.input_callback.append(selector)
                     else:
-                        litellm.input_callback = [selector]  # type: ignore
+                        litellm.input_callback = [selector]
             case RoutingStrategy.USAGE_BASED_ROUTING.value:
                 selector = LowestTPMLoggingHandler(
                     router_cache=self.cache,
@@ -935,7 +935,7 @@ class Router:
                 pass
 
         if selector is not None and register_callbacks and isinstance(litellm.callbacks, list):
-            litellm.logging_callback_manager.add_litellm_callback(selector)  # type: ignore
+            litellm.logging_callback_manager.add_litellm_callback(selector)
 
         return selector
 
@@ -1497,7 +1497,7 @@ class Router:
 
         # Auto-register JSON-generated container file endpoints
         for name, func in container_file_endpoints.items():
-            setattr(self, name, self.factory_function(func, call_type=name))  # type: ignore[arg-type]
+            setattr(self, name, self.factory_function(func, call_type=name))
 
     def _initialize_skills_endpoints(self):
         """Initialize Anthropic Skills API endpoints."""
@@ -2029,7 +2029,7 @@ class Router:
         if (
             complete_response_object_usage is not None
             and hasattr(complete_response_object_usage, "usage")
-            and complete_response_object_usage.usage is not None  # type: ignore
+            and complete_response_object_usage.usage is not None
         ):
             usage_objects.append(complete_response_object_usage)
         combined_usage: Final = BaseTokenUsageProcessor.combine_usage_objects(usage_objects=usage_objects)
@@ -2149,7 +2149,7 @@ class Router:
                     # If fallback returns a streaming response, iterate over it
                     if hasattr(fallback_response, "__aiter__"):
                         prepared_fallback_hidden_params = Router._prepare_fallback_hidden_params(fallback_response)
-                        async for fallback_item in fallback_response:  # type: ignore
+                        async for fallback_item in fallback_response:
                             Router._apply_fallback_hidden_params_to_item(fallback_item, prepared_fallback_hidden_params)
                             if (
                                 fallback_item
@@ -2456,9 +2456,9 @@ class Router:
                 # because the surrounding function body wasn't fully
                 # type-narrowed; the new typed terminal-event tuple above
                 # is what made these surface.
-                self.response = getattr(source_iterator, "response", None)  # type: ignore[assignment]
-                self.model = getattr(source_iterator, "model", None)  # type: ignore[assignment]
-                self.logging_obj = getattr(  # type: ignore[assignment]
+                self.response = getattr(source_iterator, "response", None)
+                self.model = getattr(source_iterator, "model", None)
+                self.logging_obj = getattr(
                     source_iterator,
                     "logging_obj",
                     getattr(source_iterator, "litellm_logging_obj", None),
@@ -2575,7 +2575,7 @@ class Router:
 
                     if hasattr(fallback_response, "__aiter__"):
                         prepared_fallback_hidden_params = Router._prepare_fallback_hidden_params(fallback_response)
-                        async for fallback_item in fallback_response:  # type: ignore
+                        async for fallback_item in fallback_response:
                             Router._apply_fallback_hidden_params_to_item(fallback_item, prepared_fallback_hidden_params)
                             if partial_usage is not None:
                                 Router._combine_responses_fallback_usage(fallback_item, partial_usage)
@@ -2594,7 +2594,7 @@ class Router:
                 with anyio.CancelScope(shield=True):
                     if hasattr(source_iterator, "aclose"):
                         try:
-                            await source_iterator.aclose()  # type: ignore[func-returns-value]
+                            await source_iterator.aclose()
                         except BaseException as exc:
                             verbose_router_logger.debug(
                                 "stream_with_fallbacks(aresponses): error closing source: %s",
@@ -2712,7 +2712,7 @@ class Router:
             finally:
                 if hasattr(model_response, "close"):
                     try:
-                        model_response.close()  # type: ignore[reportAttributeAccessIssue]
+                        model_response.close()
                     except BaseException as close_err:
                         verbose_router_logger.debug(
                             "stream_with_fallbacks: error closing model_response: %s",
@@ -2954,14 +2954,14 @@ class Router:
         per-deployment retry settings instead of the global setting.
         """
         # Only set if exception doesn't already have num_retries
-        if hasattr(exception, "num_retries") and exception.num_retries is not None:  # type: ignore
+        if hasattr(exception, "num_retries") and exception.num_retries is not None:
             return
 
         litellm_params: Final = deployment.get("litellm_params", {})
         dep_num_retries: Final = litellm_params.get("num_retries")
         if dep_num_retries is not None:
             try:
-                exception.num_retries = int(dep_num_retries)  # type: ignore  # Handle both int and str
+                exception.num_retries = int(dep_num_retries)  # Handle both int and str
             except (ValueError, TypeError):
                 pass  # Skip if value can't be converted to int
 
@@ -2980,7 +2980,7 @@ class Router:
         deployment_id: Final = (deployment.get("model_info") or {}).get("id")
         if deployment_id:
             try:
-                exception.failed_deployment_id = deployment_id  # type: ignore[attr-defined]
+                exception.failed_deployment_id = deployment_id
             except Exception:
                 pass
 
@@ -3262,7 +3262,7 @@ class Router:
             _tasks = []
             for model in models:
                 # add each task but if the task fails
-                _tasks.append(_async_completion_no_exceptions(model=model, messages=messages, **kwargs))  # type: ignore
+                _tasks.append(_async_completion_no_exceptions(model=model, messages=messages, **kwargs))
             response = await asyncio.gather(*_tasks)
             return response
         elif isinstance(messages, list) and all(isinstance(m, list) for m in messages):
@@ -3274,7 +3274,7 @@ class Router:
                         _async_completion_no_exceptions_return_idx(
                             model=model,
                             idx=idx,
-                            messages=message,  # type: ignore[arg-type]
+                            messages=message,
                             **kwargs,
                         )
                     )
@@ -3365,7 +3365,7 @@ class Router:
             Wrapper around self.acompletion that catches exceptions and returns them as a result
             """
             try:
-                result = await self.acompletion(model=model, messages=messages, stream=stream, **kwargs)  # type: ignore
+                result = await self.acompletion(model=model, messages=messages, stream=stream, **kwargs)
                 return result
             except asyncio.CancelledError:
                 verbose_router_logger.debug("Received 'task.cancel'. Cancelling call w/ model=%s.", model)
@@ -3373,7 +3373,7 @@ class Router:
             except Exception as e:
                 return e
 
-        pending_tasks = []  # type: ignore
+        pending_tasks = []
 
         async def check_response(task: asyncio.Task):
             nonlocal pending_tasks
@@ -3403,7 +3403,7 @@ class Router:
 
         # Await the first task to complete successfully
         while pending_tasks:
-            done, pending_tasks = await asyncio.wait(  # type: ignore
+            done, pending_tasks = await asyncio.wait(
                 pending_tasks, return_when=asyncio.FIRST_COMPLETED
             )
             for completed_task in done:
@@ -4098,7 +4098,7 @@ class Router:
                     kwargs[k].update(v)
 
             # call via litellm.completion()
-            return litellm.text_completion(**{**data, "prompt": prompt, "caching": self.cache_responses, **kwargs})  # type: ignore
+            return litellm.text_completion(**{**data, "prompt": prompt, "caching": self.cache_responses, **kwargs})
         except Exception as e:
             raise e
 
@@ -4275,12 +4275,12 @@ class Router:
                     await self.async_routing_strategy_pre_call_checks(
                         deployment=deployment, parent_otel_span=parent_otel_span
                     )
-                    response = await response  # type: ignore
+                    response = await response
             else:
                 await self.async_routing_strategy_pre_call_checks(
                     deployment=deployment, parent_otel_span=parent_otel_span
                 )
-                response = await response  # type: ignore
+                response = await response
 
             self.success_calls[model_name] += 1
             verbose_router_logger.info("litellm.aadapter_completion(model=%s)\x1b[32m 200 OK\x1b[0m", model_name)
@@ -4535,12 +4535,12 @@ class Router:
                     await self.async_routing_strategy_pre_call_checks(
                         deployment=deployment, parent_otel_span=parent_otel_span
                     )
-                    response = await response  # type: ignore
+                    response = await response
             else:
                 await self.async_routing_strategy_pre_call_checks(
                     deployment=deployment, parent_otel_span=parent_otel_span
                 )
-                response = await response  # type: ignore
+                response = await response
 
             self.success_calls[model_name] += 1
             verbose_router_logger.info("ageneric_api_call_with_fallbacks(model=%s)\x1b[32m 200 OK\x1b[0m", model_name)
@@ -4941,12 +4941,12 @@ class Router:
                         await self.async_routing_strategy_pre_call_checks(
                             deployment=deployment, parent_otel_span=parent_otel_span
                         )
-                        response = await response  # type: ignore
+                        response = await response
                 else:
                     await self.async_routing_strategy_pre_call_checks(
                         deployment=deployment, parent_otel_span=parent_otel_span
                     )
-                    response = await response  # type: ignore
+                    response = await response
 
                 self.success_calls[model_name] += 1
                 verbose_router_logger.info("litellm.acreate_file(model=%s)\x1b[32m 200 OK\x1b[0m", model_name)
@@ -5173,17 +5173,17 @@ class Router:
                     await self.async_routing_strategy_pre_call_checks(
                         deployment=deployment, parent_otel_span=parent_otel_span
                     )
-                    response = await response  # type: ignore
+                    response = await response
             else:
                 await self.async_routing_strategy_pre_call_checks(
                     deployment=deployment, parent_otel_span=parent_otel_span
                 )
-                response = await response  # type: ignore
+                response = await response
 
             self.success_calls[model_name] += 1
             verbose_router_logger.info("litellm.acreate_batch(model=%s)\x1b[32m 200 OK\x1b[0m", model_name)
 
-            return response  # type: ignore
+            return response
         except Exception as e:
             verbose_router_logger.exception(
                 "litellm._acreate_batch(model=%s, %s)\x1b[31m Exception %s\x1b[0m", model, kwargs, e
@@ -5233,7 +5233,7 @@ class Router:
                     # Update kwargs with the current model name or any other model-specific adjustments
                     ## SET CUSTOM PROVIDER TO SELECTED DEPLOYMENT ##
                     if not custom_llm_provider:
-                        _, custom_llm_provider, _, _ = get_llm_provider(  # type: ignore
+                        _, custom_llm_provider, _, _ = get_llm_provider(
                             model=model
                         )
                     new_kwargs: Final = safe_deep_copy(kwargs)
@@ -5248,7 +5248,7 @@ class Router:
                         **{
                             **data,
                             "custom_llm_provider": custom_llm_provider,
-                            **new_kwargs,  # type: ignore
+                            **new_kwargs,
                         },
                     )
                 except Exception as e:
@@ -5395,17 +5395,17 @@ class Router:
                     await self.async_routing_strategy_pre_call_checks(
                         deployment=deployment, parent_otel_span=parent_otel_span
                     )
-                    response = await response  # type: ignore
+                    response = await response
             else:
                 await self.async_routing_strategy_pre_call_checks(
                     deployment=deployment, parent_otel_span=parent_otel_span
                 )
-                response = await response  # type: ignore
+                response = await response
 
             self.success_calls[model_name] += 1
             verbose_router_logger.info("litellm.acancel_batch(model=%s)\x1b[32m 200 OK\x1b[0m", model_name)
 
-            return response  # type: ignore
+            return response
         except Exception as e:
             verbose_router_logger.exception(
                 "litellm._acancel_batch(model=%s, %s)\x1b[31m Exception %s\x1b[0m", model, kwargs, e
@@ -5451,7 +5451,7 @@ class Router:
                 if final_results["first_id"] is None and hasattr(result, "first_id"):
                     final_results["first_id"] = getattr(result, "first_id")
                 final_results["last_id"] = getattr(result, "last_id")
-                final_results["data"].extend(result.data)  # type: ignore
+                final_results["data"].extend(result.data)
 
                 ## check 'has_more'
                 if getattr(result, "has_more", False) is True:
@@ -6022,7 +6022,7 @@ class Router:
                 raise Exception(
                     "'custom_llm_provider' must be set. Either via:\n `Router(assistants_config={'custom_llm_provider': ..})` \nor\n `router.arun_thread(custom_llm_provider=..)`"
                 )
-        return await original_function(  # type: ignore
+        return await original_function(
             custom_llm_provider=custom_llm_provider, client=client, **kwargs
         )
 
@@ -6123,7 +6123,7 @@ class Router:
         verbose_router_logger.debug("Traceback", exc_info=True)
         original_exception: Final = e
         fallback_model_group = None
-        original_model_group: Final[str | None] = kwargs.get("model")  # type: ignore
+        original_model_group: Final[str | None] = kwargs.get("model")
         fallback_failure_exception_str = ""
 
         if disable_fallbacks is True or original_model_group is None:
@@ -6317,7 +6317,7 @@ class Router:
                         masked_fallbacks,
                     )
                     if hasattr(original_exception, "message") and litellm.expose_router_debug_in_errors:
-                        original_exception.message += f"No fallback model group found for original model_group={model_group}. Fallbacks={masked_fallbacks}"  # type: ignore
+                        original_exception.message += f"No fallback model group found for original model_group={model_group}. Fallbacks={masked_fallbacks}"
                     raise original_exception
 
                 input_kwargs.update(
@@ -6351,12 +6351,12 @@ class Router:
 
         if hasattr(original_exception, "message") and litellm.expose_router_debug_in_errors:
             # add the available fallbacks to the exception
-            original_exception.message += ". Received Model Group={}\nAvailable Model Group Fallbacks={}".format(  # type: ignore
+            original_exception.message += ". Received Model Group={}\nAvailable Model Group Fallbacks={}".format(
                 model_group,
                 mask_sensitive_structure(fallback_model_group),
             )
             if len(fallback_failure_exception_str) > 0:
-                original_exception.message += (  # type: ignore
+                original_exception.message += (
                     f"\nError doing the fallback: {fallback_failure_exception_str}"
                 )
 
@@ -6592,7 +6592,7 @@ class Router:
                     ## LOGGING
                     kwargs = self.log_retry(kwargs=kwargs, e=e)
                     remaining_retries = num_retries - current_attempt - 1
-                    _model: str | None = kwargs.get("model")  # type: ignore
+                    _model: str | None = kwargs.get("model")
                     if _model is not None:
                         (
                             _healthy_deployments,
@@ -6814,10 +6814,10 @@ class Router:
             return 0
 
         response_headers: httpx.Headers | None = None
-        if hasattr(e, "response") and hasattr(e.response, "headers"):  # type: ignore
-            response_headers = e.response.headers  # type: ignore
+        if hasattr(e, "response") and hasattr(e.response, "headers"):
+            response_headers = e.response.headers
         if hasattr(e, "litellm_response_headers"):
-            response_headers = e.litellm_response_headers  # type: ignore
+            response_headers = e.litellm_response_headers
 
         if response_headers is not None:
             timeout = litellm._calculate_retry_after(
@@ -7144,10 +7144,10 @@ class Router:
                 if k not in [_metadata_var, "messages", "original_function"]:
                     previous_model[k] = v
                 elif k == _metadata_var and isinstance(v, dict):
-                    previous_model[_metadata_var] = {}  # type: ignore
+                    previous_model[_metadata_var] = {}
                     for metadata_k, metadata_v in kwargs[_metadata_var].items():
                         if metadata_k != "previous_models":
-                            previous_model[k][metadata_k] = metadata_v  # type: ignore
+                            previous_model[k][metadata_k] = metadata_v
 
             # check current size of self.previous_models, if it's larger than 3, remove the first element
             if len(self.previous_models) > 3:
@@ -7224,7 +7224,7 @@ class Router:
     def _get_healthy_deployments(self, model: str, parent_otel_span: Span | None):
         _all_deployments: list = []
         try:
-            _, _all_deployments = self._common_checks_available_deployment(  # type: ignore
+            _, _all_deployments = self._common_checks_available_deployment(
                 model=model,
             )
             if isinstance(_all_deployments, dict):
@@ -7252,7 +7252,7 @@ class Router:
         """
         _all_deployments: list = []
         try:
-            _, _all_deployments = self._common_checks_available_deployment(  # type: ignore
+            _, _all_deployments = self._common_checks_available_deployment(
                 model=model,
             )
             if isinstance(_all_deployments, dict):
@@ -8979,7 +8979,7 @@ class Router:
             if not is_match:
                 continue
             # model in model group found #
-            litellm_params = LiteLLM_Params(**model["litellm_params"])  # type: ignore
+            litellm_params = LiteLLM_Params(**model["litellm_params"])
             # get configurable clientside auth params
             configurable_clientside_auth_params = litellm_params.configurable_clientside_auth_params
 
@@ -8990,32 +8990,32 @@ class Router:
             # get model tpm
             _deployment_tpm: int | None = None
             if _deployment_tpm is None:
-                _deployment_tpm = model.get("tpm", None)  # type: ignore
+                _deployment_tpm = model.get("tpm", None)
             if _deployment_tpm is None:
-                _deployment_tpm = model_litellm_params.get("tpm", None)  # type: ignore
+                _deployment_tpm = model_litellm_params.get("tpm", None)
             if _deployment_tpm is None:
-                _deployment_tpm = model_info_dict.get("tpm", None)  # type: ignore
+                _deployment_tpm = model_info_dict.get("tpm", None)
 
             # get model rpm
             _deployment_rpm: int | None = None
             if _deployment_rpm is None:
-                _deployment_rpm = model.get("rpm", None)  # type: ignore
+                _deployment_rpm = model.get("rpm", None)
             if _deployment_rpm is None:
-                _deployment_rpm = model_litellm_params.get("rpm", None)  # type: ignore
+                _deployment_rpm = model_litellm_params.get("rpm", None)
             if _deployment_rpm is None:
-                _deployment_rpm = model_info_dict.get("rpm", None)  # type: ignore
+                _deployment_rpm = model_info_dict.get("rpm", None)
 
-            _deployment_itpm: int | None = model.get("itpm")  # type: ignore
+            _deployment_itpm: int | None = model.get("itpm")
             if _deployment_itpm is None:
-                _deployment_itpm = model_litellm_params.get("itpm", None)  # type: ignore
+                _deployment_itpm = model_litellm_params.get("itpm", None)
             if _deployment_itpm is None:
-                _deployment_itpm = model_info_dict.get("itpm", None)  # type: ignore
+                _deployment_itpm = model_info_dict.get("itpm", None)
 
-            _deployment_otpm: int | None = model.get("otpm")  # type: ignore
+            _deployment_otpm: int | None = model.get("otpm")
             if _deployment_otpm is None:
-                _deployment_otpm = model_litellm_params.get("otpm", None)  # type: ignore
+                _deployment_otpm = model_litellm_params.get("otpm", None)
             if _deployment_otpm is None:
-                _deployment_otpm = model_info_dict.get("otpm", None)  # type: ignore
+                _deployment_otpm = model_info_dict.get("otpm", None)
 
             # get model info
             try:
@@ -9064,7 +9064,7 @@ class Router:
                 )
 
             if model_group_info is None:
-                model_group_info = ModelGroupInfo(  # type: ignore
+                model_group_info = ModelGroupInfo(
                     **{
                         "model_group": user_facing_model_group_name,
                         "providers": [llm_provider],
@@ -9113,31 +9113,31 @@ class Router:
                     model_group_info.output_cost_per_token = _output_cost_per_token
                 if (
                     model_info.get("supports_parallel_function_calling", None) is not None
-                    and model_info["supports_parallel_function_calling"] is True  # type: ignore
+                    and model_info["supports_parallel_function_calling"] is True
                 ):
                     model_group_info.supports_parallel_function_calling = True
                 if (
-                    model_info.get("supports_vision", None) is not None and model_info["supports_vision"] is True  # type: ignore
+                    model_info.get("supports_vision", None) is not None and model_info["supports_vision"] is True
                 ):
                     model_group_info.supports_vision = True
                 if (
                     model_info.get("supports_function_calling", None) is not None
-                    and model_info["supports_function_calling"] is True  # type: ignore
+                    and model_info["supports_function_calling"] is True
                 ):
                     model_group_info.supports_function_calling = True
                 if (
                     model_info.get("supports_web_search", None) is not None
-                    and model_info["supports_web_search"] is True  # type: ignore
+                    and model_info["supports_web_search"] is True
                 ):
                     model_group_info.supports_web_search = True
                 if (
                     model_info.get("supports_url_context", None) is not None
-                    and model_info["supports_url_context"] is True  # type: ignore
+                    and model_info["supports_url_context"] is True
                 ):
                     model_group_info.supports_url_context = True
 
                 if (
-                    model_info.get("supports_reasoning", None) is not None and model_info["supports_reasoning"] is True  # type: ignore
+                    model_info.get("supports_reasoning", None) is not None and model_info["supports_reasoning"] is True
                 ):
                     model_group_info.supports_reasoning = True
                 if (
@@ -9153,22 +9153,22 @@ class Router:
             if _deployment_tpm is not None:
                 if total_tpm is None:
                     total_tpm = 0
-                total_tpm += _deployment_tpm  # type: ignore
+                total_tpm += _deployment_tpm
 
             if _deployment_rpm is not None:
                 if total_rpm is None:
                     total_rpm = 0
-                total_rpm += _deployment_rpm  # type: ignore
+                total_rpm += _deployment_rpm
 
             if _deployment_itpm is not None:
                 if total_itpm is None:
                     total_itpm = 0
-                total_itpm += _deployment_itpm  # type: ignore
+                total_itpm += _deployment_itpm
 
             if _deployment_otpm is not None:
                 if total_otpm is None:
                     total_otpm = 0
-                total_otpm += _deployment_otpm  # type: ignore
+                total_otpm += _deployment_otpm
         if model_group_info is not None:
             ## UPDATE WITH TOTAL TPM/RPM FOR MODEL GROUP
             if total_tpm is not None:
@@ -9238,7 +9238,7 @@ class Router:
             return None, None
 
         for model in model_list:
-            id: str | None = model.get("model_info", {}).get("id")  # type: ignore
+            id: str | None = model.get("model_info", {}).get("id")
             litellm_model: str | None = model["litellm_params"].get(
                 "model"
             )  # USE THE MODEL SENT TO litellm.completion() - consistent with how global_router cache is written.
@@ -9299,7 +9299,7 @@ class Router:
             return None, None
 
         for model in model_list:
-            model_id: str | None = model.get("model_info", {}).get("id")  # type: ignore
+            model_id: str | None = model.get("model_info", {}).get("id")
             litellm_model: str | None = model["litellm_params"].get("model")
             if model_id is None or litellm_model is None:
                 continue
@@ -9853,7 +9853,7 @@ class Router:
             if isinstance(model_value, str):
                 _router_model_name: str = model_value
             elif isinstance(model_value, dict):
-                _model_value = RouterModelGroupAliasItem(**model_value)  # type: ignore
+                _model_value = RouterModelGroupAliasItem(**model_value)
                 if _model_value["hidden"] is True:
                     continue
                 else:
@@ -9892,7 +9892,7 @@ class Router:
 
             if model_name is not None and potential_wildcard_models is not None:
                 for m in potential_wildcard_models:
-                    deployment_typed_dict = DeploymentTypedDict(**m)  # type: ignore
+                    deployment_typed_dict = DeploymentTypedDict(**m)
                     deployment_typed_dict["model_name"] = model_name
                     returned_models.append(deployment_typed_dict)
 
@@ -10633,7 +10633,7 @@ class Router:
             input=input,
             specific_deployment=specific_deployment,
             request_kwargs=request_kwargs,
-        )  # type: ignore
+        )
 
         # IF TEAM ID SPECIFIED ON MODEL, AND REQUEST CONTAINS USER_API_KEY_TEAM_ID, FILTER OUT MODELS THAT ARE NOT IN THE TEAM
         ## THIS PREVENTS WRITING FILES OF OTHER TEAMS TO MODELS THAT ARE TEAM-ONLY MODELS
@@ -10706,7 +10706,7 @@ class Router:
                 request_kwargs=request_kwargs,
             )
         # check if user wants to do tag based routing
-        healthy_deployments = await get_deployments_for_tag(  # type: ignore
+        healthy_deployments = await get_deployments_for_tag(
             llm_router_instance=self,
             model=model,
             request_kwargs=request_kwargs,
@@ -10822,7 +10822,7 @@ class Router:
                 strategy=strategy,
                 selector=strategy_selector,
                 model=model,
-                healthy_deployments=healthy_deployments,  # type: ignore
+                healthy_deployments=healthy_deployments,
                 messages=messages,
                 input=input,
                 request_kwargs=request_kwargs,
@@ -10869,7 +10869,7 @@ class Router:
                     ).start()  # log response
                     # Handle any exceptions that might occur during streaming
                     asyncio.create_task(
-                        logging_obj.async_failure_handler(e, traceback_exception)  # type: ignore
+                        logging_obj.async_failure_handler(e, traceback_exception)
                     )
             raise e
 
@@ -10952,7 +10952,7 @@ class Router:
                 strategy=strategy,
                 selector=strategy_selector,
                 model=model,
-                healthy_deployments=pass_through_deployments,  # type: ignore
+                healthy_deployments=pass_through_deployments,
                 messages=messages,
                 input=input,
                 request_kwargs=request_kwargs,
@@ -10996,7 +10996,7 @@ class Router:
                         args=(e, traceback_exception),
                     ).start()
                     asyncio.create_task(
-                        logging_obj.async_failure_handler(e, traceback_exception)  # type: ignore
+                        logging_obj.async_failure_handler(e, traceback_exception)
                     )
             raise e
 
@@ -11335,7 +11335,7 @@ class Router:
             strategy=strategy,
             selector=strategy_selector,
             model=model,
-            healthy_deployments=healthy_deployments,  # type: ignore
+            healthy_deployments=healthy_deployments,
             messages=messages,
             input=input,
             request_kwargs=request_kwargs,
@@ -11477,7 +11477,7 @@ class Router:
             strategy=strategy,
             selector=strategy_selector,
             model=model,
-            healthy_deployments=pass_through_deployments,  # type: ignore
+            healthy_deployments=pass_through_deployments,
             messages=messages,
             input=input,
             request_kwargs=request_kwargs,
@@ -11709,7 +11709,7 @@ class Router:
 
         self.slack_alerting_logger = _slack_alerting_logger
 
-        litellm.logging_callback_manager.add_litellm_callback(_slack_alerting_logger)  # type: ignore
+        litellm.logging_callback_manager.add_litellm_callback(_slack_alerting_logger)
         litellm.logging_callback_manager.add_litellm_success_callback(
             _slack_alerting_logger.response_taking_too_long_callback
         )

--- a/litellm/router_strategy/budget_limiter.py
+++ b/litellm/router_strategy/budget_limiter.py
@@ -110,7 +110,7 @@ class RouterBudgetLimiting(CustomLogger):
 
         # Add self to litellm callbacks if it's a list
         if isinstance(litellm.callbacks, list):
-            litellm.logging_callback_manager.add_litellm_callback(self)  # type: ignore
+            litellm.logging_callback_manager.add_litellm_callback(self)
 
     async def async_filter_deployments(
         self,
@@ -118,7 +118,7 @@ class RouterBudgetLimiting(CustomLogger):
         healthy_deployments: list,
         messages: list[AllMessageValues] | None,
         request_kwargs: dict | None = None,
-        parent_otel_span: Span | None = None,  # type: ignore
+        parent_otel_span: Span | None = None,
     ) -> list[dict]:
         """
         Filter out deployments that have exceeded their provider budget limit.

--- a/litellm/router_strategy/lowest_tpm_rpm_v2.py
+++ b/litellm/router_strategy/lowest_tpm_rpm_v2.py
@@ -105,7 +105,7 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                         request=httpx.Request(
                             method="tpm_rpm_limits",
                             url="https://github.com/BerriAI/litellm",
-                        ),  # type: ignore
+                        ),
                     ),
                 )
             else:
@@ -123,7 +123,7 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                             request=httpx.Request(
                                 method="tpm_rpm_limits",
                                 url="https://github.com/BerriAI/litellm",
-                            ),  # type: ignore
+                            ),
                         ),
                     )
             return deployment
@@ -175,11 +175,11 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                     response=httpx.Response(
                         status_code=429,
                         content=f"{RouterErrors.user_defined_ratelimit_error.value} rpm limit={deployment_rpm}. current usage={local_result}",
-                        headers={"retry-after": str(60)},  # type: ignore
+                        headers={"retry-after": str(60)},
                         request=httpx.Request(
                             method="tpm_rpm_limits",
                             url="https://github.com/BerriAI/litellm",
-                        ),  # type: ignore
+                        ),
                     ),
                     num_retries=deployment.get("num_retries"),
                 )
@@ -194,11 +194,11 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                         response=httpx.Response(
                             status_code=429,
                             content=f"{RouterErrors.user_defined_ratelimit_error.value} rpm limit={deployment_rpm}. current usage={result}",
-                            headers={"retry-after": str(60)},  # type: ignore
+                            headers={"retry-after": str(60)},
                             request=httpx.Request(
                                 method="tpm_rpm_limits",
                                 url="https://github.com/BerriAI/litellm",
-                            ),  # type: ignore
+                            ),
                         ),
                         num_retries=deployment.get("num_retries"),
                     )
@@ -516,11 +516,11 @@ class LowestTPMLoggingHandler_v2(BaseRoutingStrategy, CustomLogger):
                 response=httpx.Response(
                     status_code=429,
                     content="",
-                    headers={"retry-after": str(60)},  # type: ignore
+                    headers={"retry-after": str(60)},
                     request=httpx.Request(
                         method="tpm_rpm_limits",
                         url="https://github.com/BerriAI/litellm",
-                    ),  # type: ignore
+                    ),
                 ),
             )
 

--- a/litellm/router_utils/batch_utils.py
+++ b/litellm/router_utils/batch_utils.py
@@ -85,7 +85,7 @@ def replace_model_in_jsonl(file_content: FileTypes, new_model_name: str) -> File
         if hasattr(source, "read"):
             if hasattr(source, "seek"):
                 try:
-                    source.seek(0)  # type: ignore[attr-defined]
+                    source.seek(0)
                 except (OSError, ValueError):
                     pass
             line_iter: object = source
@@ -108,7 +108,7 @@ def replace_model_in_jsonl(file_content: FileTypes, new_model_name: str) -> File
         output: Final = InMemoryFile(b"", name="modified_file.jsonl", content_type="application/jsonl")
         wrote_any = False
         buffer = ""
-        for raw_line in line_iter:  # type: ignore[attr-defined]
+        for raw_line in line_iter:
             buffer += raw_line.decode("utf-8") if isinstance(raw_line, (bytes, bytearray)) else raw_line
             stripped = buffer.strip()
             if not stripped:
@@ -132,7 +132,7 @@ def replace_model_in_jsonl(file_content: FileTypes, new_model_name: str) -> File
             verbose_logger.error("error parsing trailing batch content: %s...", buffer[:100])
             if hasattr(source, "seek"):
                 try:
-                    source.seek(0)  # type: ignore[attr-defined]
+                    source.seek(0)
                 except (OSError, ValueError):
                     pass
             return file_content
@@ -142,7 +142,7 @@ def replace_model_in_jsonl(file_content: FileTypes, new_model_name: str) -> File
             return file_content
 
         output.seek(0)
-        return output  # type: ignore
+        return output
 
     except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
         # return the original file content if there is an error replacing the model name

--- a/litellm/router_utils/cooldown_cache.py
+++ b/litellm/router_utils/cooldown_cache.py
@@ -120,7 +120,7 @@ class CooldownCache:
         # Process the results
         for model_id, result in zip(model_ids, results):
             if result and isinstance(result, dict):
-                cooldown_cache_value = CooldownCacheValue(**result)  # type: ignore
+                cooldown_cache_value = CooldownCacheValue(**result)
                 active_cooldowns.append((model_id, cooldown_cache_value))
 
         return active_cooldowns
@@ -137,7 +137,7 @@ class CooldownCache:
         # Process the results
         for model_id, result in zip(model_ids, results):
             if result and isinstance(result, dict):
-                cooldown_cache_value = CooldownCacheValue(**result)  # type: ignore
+                cooldown_cache_value = CooldownCacheValue(**result)
                 active_cooldowns.append((model_id, cooldown_cache_value))
 
         return active_cooldowns
@@ -155,7 +155,7 @@ class CooldownCache:
         # Process the results
         for model_id, result in zip(model_ids, results):
             if result and isinstance(result, dict):
-                cooldown_cache_value = CooldownCacheValue(**result)  # type: ignore
+                cooldown_cache_value = CooldownCacheValue(**result)
                 if min_cooldown_time is None or cooldown_cache_value["cooldown_time"] < min_cooldown_time:
                     min_cooldown_time = cooldown_cache_value["cooldown_time"]
 

--- a/litellm/router_utils/get_retry_from_policy.py
+++ b/litellm/router_utils/get_retry_from_policy.py
@@ -30,7 +30,7 @@ def get_num_retries_from_retry_policy(
     # if we can find the exception then in the retry policy -> return the number of retries
 
     if model_group_retry_policy is not None and model_group is not None and model_group in model_group_retry_policy:
-        retry_policy = model_group_retry_policy.get(model_group, None)  # type: ignore
+        retry_policy = model_group_retry_policy.get(model_group, None)
 
     if retry_policy is None:
         return None

--- a/litellm/router_utils/search_api_router.py
+++ b/litellm/router_utils/search_api_router.py
@@ -63,7 +63,7 @@ class SearchAPIRouter:
             router_search_tools: Final[list] = []
             for tool in search_tools:
                 # Create dict that matches SearchToolTypedDict structure
-                router_search_tool: SearchToolTypedDict = {  # type: ignore
+                router_search_tool: SearchToolTypedDict = {
                     "search_tool_id": tool.get("search_tool_id"),
                     "search_tool_name": tool.get("search_tool_name"),
                     "litellm_params": tool.get("litellm_params", {}),

--- a/litellm/search/main.py
+++ b/litellm/search/main.py
@@ -228,7 +228,7 @@ def search(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("asearch", False) is True
 

--- a/litellm/secret_managers/aws_secret_manager_v2.py
+++ b/litellm/secret_managers/aws_secret_manager_v2.py
@@ -281,7 +281,7 @@ class AWSSecretsManagerV2(BaseAWSLLM, BaseSecretManager):
                 tags_list = tags
             else:
                 raise ValueError("Tags must be a dict or list of {Key, Value} pairs")
-            data["Tags"] = tags_list  # type: ignore[assignment]
+            data["Tags"] = tags_list
 
         endpoint_url, headers, body = self._prepare_request(
             action="CreateSecret",

--- a/litellm/secret_managers/custom_secret_manager_loader.py
+++ b/litellm/secret_managers/custom_secret_manager_loader.py
@@ -58,12 +58,12 @@ def load_custom_secret_manager(config_file_path: str | None = None) -> None:
     directory: Final = os.path.dirname(config_file_path)
     module_file_path: Final = os.path.join(directory, _file_name) + ".py"
 
-    spec: Final = importlib.util.spec_from_file_location(_class_name, module_file_path)  # type: ignore
+    spec: Final = importlib.util.spec_from_file_location(_class_name, module_file_path)
     if not spec:
         raise ImportError(f"Could not find a module specification for {module_file_path}")
 
-    module: Final = importlib.util.module_from_spec(spec)  # type: ignore
-    spec.loader.exec_module(module)  # type: ignore
+    module: Final = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
     _secret_manager_class: Final = getattr(module, _class_name)
 
     # Validate that it's a CustomSecretManager subclass

--- a/litellm/secret_managers/google_kms.py
+++ b/litellm/secret_managers/google_kms.py
@@ -26,7 +26,7 @@ def load_google_kms(use_google_kms: bool | None):
     if use_google_kms is None or use_google_kms is False:
         return
     try:
-        from google.cloud import kms_v1  # type: ignore
+        from google.cloud import kms_v1
 
         validate_environment()
 

--- a/litellm/setup_wizard.py
+++ b/litellm/setup_wizard.py
@@ -22,8 +22,8 @@ try:
 
     _HAS_RAW_TERMINAL: bool = True
 except ImportError:
-    termios = None  # type: ignore[assignment]
-    tty = None  # type: ignore[assignment]
+    termios = None
+    tty = None
     _HAS_RAW_TERMINAL = False
 
 from typing import Final

--- a/litellm/skills/main.py
+++ b/litellm/skills/main.py
@@ -160,7 +160,7 @@ def create_skill(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("acreate_skill", False) is True
 
@@ -180,7 +180,7 @@ def create_skill(
 
         # Merge extra_body if provided
         if extra_body:
-            create_request.update(extra_body)  # type: ignore
+            create_request.update(extra_body)
 
         # Route to LiteLLM DB if custom_llm_provider="litellm_proxy"
         if custom_llm_provider == LlmProviders.LITELLM_PROXY.value:
@@ -349,7 +349,7 @@ def list_skills(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("alist_skills", False) is True
 
@@ -390,7 +390,7 @@ def list_skills(
 
         # Merge extra_query if provided
         if extra_query:
-            list_params.update(extra_query)  # type: ignore
+            list_params.update(extra_query)
 
         # Validate environment and get headers
         headers = extra_headers or {}
@@ -522,7 +522,7 @@ def get_skill(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("aget_skill", False) is True
 
@@ -686,7 +686,7 @@ def delete_skill(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("adelete_skill", False) is True
 

--- a/litellm/types/containers/main.py
+++ b/litellm/types/containers/main.py
@@ -35,7 +35,7 @@ class ContainerObject(BaseModel):
         # Allow dictionary-style access to attributes
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump(**kwargs)
         except Exception:
@@ -59,7 +59,7 @@ class DeleteContainerResult(BaseModel):
     def __getitem__(self, key):
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump(**kwargs)
         except Exception:
@@ -84,7 +84,7 @@ class ContainerListResponse(BaseModel):
     def __getitem__(self, key):
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump(**kwargs)
         except Exception:
@@ -149,7 +149,7 @@ class ContainerFileObject(BaseModel):
     def __getitem__(self, key):
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump(**kwargs)
         except Exception:
@@ -174,7 +174,7 @@ class ContainerFileListResponse(BaseModel):
     def __getitem__(self, key):
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump(**kwargs)
         except Exception:
@@ -198,7 +198,7 @@ class DeleteContainerFileResponse(BaseModel):
     def __getitem__(self, key):
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump(**kwargs)
         except Exception:

--- a/litellm/types/google_genai/main.py
+++ b/litellm/types/google_genai/main.py
@@ -8,7 +8,7 @@ from litellm.types.llms.openai import BaseLiteLLMOpenAIResponseObject
 
 # During static type-checking we can rely on the real google-genai types.
 if TYPE_CHECKING:
-    from google.genai import types as _genai_types  # type: ignore
+    from google.genai import types as _genai_types
 
     ContentListUnion = _genai_types.ContentListUnion
     ContentListUnionDict = _genai_types.ContentListUnionDict
@@ -19,11 +19,11 @@ if TYPE_CHECKING:
     GenerateContentRequestParametersDict = _genai_types._GenerateContentParametersDict
     ToolConfigDict = _genai_types.ToolConfigDict
 
-    class GenerateContentRequestDict(GenerateContentRequestParametersDict):  # type: ignore[misc, valid-type]
+    class GenerateContentRequestDict(GenerateContentRequestParametersDict):
         generationConfig: Optional[Any]
-        tools: Optional[ToolConfigDict]  # type: ignore[assignment, valid-type]
+        tools: Optional[ToolConfigDict]
 
-    class GenerateContentResponse(GoogleGenAIGenerateContentResponse, BaseLiteLLMOpenAIResponseObject):  # type: ignore[misc, valid-type]
+    class GenerateContentResponse(GoogleGenAIGenerateContentResponse, BaseLiteLLMOpenAIResponseObject):
         _hidden_params: dict = {}
         pass
 
@@ -36,24 +36,24 @@ else:
     GenerateContentContentListUnionDict = Dict[str, Any]
 
     # Create a proper fallback class that can be instantiated
-    class GenerateContentConfigDict(dict):  # type: ignore[misc]
-        def __init__(self, **kwargs):  # type: ignore
+    class GenerateContentConfigDict(dict):
+        def __init__(self, **kwargs):
             super().__init__(**kwargs)
 
-    class GenerateContentRequestParametersDict(dict):  # type: ignore[misc]
-        def __init__(self, **kwargs):  # type: ignore
+    class GenerateContentRequestParametersDict(dict):
+        def __init__(self, **kwargs):
             super().__init__(**kwargs)
 
     ToolConfigDict = Dict[str, Any]
 
-    class GenerateContentRequestDict(GenerateContentRequestParametersDict):  # type: ignore[misc]
-        def __init__(self, **kwargs):  # type: ignore
+    class GenerateContentRequestDict(GenerateContentRequestParametersDict):
+        def __init__(self, **kwargs):
             # Extract specific fields
             self.generationConfig = kwargs.get("generationConfig")
             self.tools = kwargs.get("tools")
             super().__init__(**kwargs)
 
-    class GenerateContentResponse(BaseLiteLLMOpenAIResponseObject):  # type: ignore[misc]
-        def __init__(self, **kwargs):  # type: ignore
+    class GenerateContentResponse(BaseLiteLLMOpenAIResponseObject):
+        def __init__(self, **kwargs):
             super().__init__(**kwargs)
             self._hidden_params = kwargs.get("_hidden_params", {})

--- a/litellm/types/llms/base.py
+++ b/litellm/types/llms/base.py
@@ -9,7 +9,7 @@ class LiteLLMPydanticObjectBase(BaseModel):
     Implements default functions, all pydantic objects should have.
     """
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump(**kwargs)  # noqa
         except Exception:
@@ -63,7 +63,7 @@ class HiddenParams(OpenAIObject):
         # Allow dictionary-style assignment of attributes
         setattr(self, key, value)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump()  # noqa
         except Exception:

--- a/litellm/types/llms/openai.py
+++ b/litellm/types/llms/openai.py
@@ -44,7 +44,7 @@ from openai.types.responses.response import (
 
 # Handle OpenAI SDK version compatibility for Text type
 try:
-    from openai.types.responses.response_create_params import Text as ResponseText  # type: ignore[attr-defined] # fmt: skip # isort: skip
+    from openai.types.responses.response_create_params import Text as ResponseText  # fmt: skip # isort: skip
 except (ImportError, AttributeError):
     # Fall back to the concrete config type available in all SDK versions
     from openai.types.responses.response_text_config_param import (
@@ -343,7 +343,7 @@ class OpenAIFileObject(BaseModel):
         # Allow dictionary-style access to attributes
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump()  # noqa
         except Exception:
@@ -2334,7 +2334,7 @@ class OpenAIVideoObject(BaseModel):
     def __getitem__(self, key):
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump(**kwargs)
         except Exception:

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -19,7 +19,7 @@ from typing import (
 
 from openai._models import BaseModel as OpenAIObject
 from openai.types.audio.transcription_create_params import (
-    FileTypes as FileTypes,  # type: ignore
+    FileTypes as FileTypes,
 )
 from openai.types.chat.chat_completion import ChatCompletion as ChatCompletion
 from openai.types.completion_usage import (
@@ -1293,7 +1293,7 @@ class Message(SafeAttributeModel, OpenAIObject):
             init_values["reasoning_content"] = reasoning_content
 
         super(Message, self).__init__(
-            **init_values,  # type: ignore
+            **init_values,
             **params,
         )
 
@@ -1342,7 +1342,7 @@ class Message(SafeAttributeModel, OpenAIObject):
         # Allow dictionary-style assignment of attributes
         setattr(self, key, value)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump()  # noqa
         except Exception:
@@ -1832,7 +1832,7 @@ class StreamingChoices(OpenAIObject):
         if finish_reason:
             self.finish_reason = map_finish_reason(finish_reason)
         else:
-            self.finish_reason = None  # type: ignore[assignment]
+            self.finish_reason = None
         self.index = index
         if delta is not None:
             if isinstance(delta, Delta):
@@ -1847,7 +1847,7 @@ class StreamingChoices(OpenAIObject):
         if logprobs is not None and isinstance(logprobs, dict):
             self.logprobs = ChoiceLogprobs(**logprobs)
         else:
-            self.logprobs = logprobs  # type: ignore
+            self.logprobs = logprobs
 
     def __contains__(self, key):
         # Define custom behavior for the 'in' operator
@@ -1978,7 +1978,7 @@ class ModelResponseStream(ModelResponseBase):
         # Allow dictionary-style access to attributes
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump()  # noqa
         except Exception:
@@ -2011,12 +2011,12 @@ class ModelResponse(ModelResponseBase):
             new_choices: Final = []
             for choice in choices:
                 if isinstance(choice, Choices):
-                    _new_choice = choice  # type: ignore
+                    _new_choice = choice
                 elif isinstance(choice, dict):
-                    _new_choice = Choices(**choice)  # type: ignore
+                    _new_choice = Choices(**choice)
                 elif isinstance(choice, BaseModel):
                     dump = choice.model_dump() if hasattr(choice, "model_dump") else choice.dict()
-                    _new_choice = Choices(**dump)  # type: ignore
+                    _new_choice = Choices(**dump)
                 else:
                     _new_choice = choice
                 new_choices.append(_new_choice)
@@ -2077,7 +2077,7 @@ class ModelResponse(ModelResponseBase):
         # Allow dictionary-style access to attributes
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump()  # noqa
         except Exception:
@@ -2149,7 +2149,7 @@ class EmbeddingResponse(OpenAIObject):
             self._response_headers = _response_headers
 
         model = model
-        super().__init__(model=model, object=object, data=data, usage=usage)  # type: ignore
+        super().__init__(model=model, object=object, data=data, usage=usage)
 
         if hidden_params:
             self._hidden_params = hidden_params
@@ -2170,7 +2170,7 @@ class EmbeddingResponse(OpenAIObject):
         # Allow dictionary-style assignment of attributes
         setattr(self, key, value)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump()  # noqa
         except Exception:
@@ -2221,7 +2221,7 @@ class TextChoices(OpenAIObject):
         # Allow dictionary-style assignment of attributes
         setattr(self, key, value)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump()  # noqa
         except Exception:
@@ -2304,12 +2304,12 @@ class TextCompletionResponse(OpenAIObject):
             usage = Usage()
 
         super(TextCompletionResponse, self).__init__(
-            id=id,  # type: ignore
-            object=object,  # type: ignore
-            created=created,  # type: ignore
-            model=model,  # type: ignore
-            choices=choices,  # type: ignore
-            usage=usage,  # type: ignore
+            id=id,
+            object=object,
+            created=created,
+            model=model,
+            choices=choices,
+            usage=usage,
             **params,
         )
 
@@ -2365,7 +2365,7 @@ class ImageObject(OpenAIImage):
         provider_specific_fields=None,
         **kwargs,
     ):
-        super().__init__(b64_json=b64_json, url=url, revised_prompt=revised_prompt)  # type: ignore
+        super().__init__(b64_json=b64_json, url=url, revised_prompt=revised_prompt)
         if provider_specific_fields:
             self.provider_specific_fields = provider_specific_fields
 
@@ -2385,7 +2385,7 @@ class ImageObject(OpenAIImage):
         # Allow dictionary-style assignment of attributes
         setattr(self, key, value)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump()  # noqa
         except Exception:
@@ -2421,7 +2421,7 @@ from openai.types.images_response import ImagesResponse as OpenAIImageResponse
 class ImageResponse(OpenAIImageResponse, BaseLiteLLMOpenAIResponseObject):
     _hidden_params: dict = {}
 
-    usage: Optional[ImageUsage] = None  # type: ignore
+    usage: Optional[ImageUsage] = None
     """
     Users might use litellm with older python versions, we don't want this to break for them.
     Happens when their OpenAIImageResponse has the old OpenAI usage class.
@@ -2468,7 +2468,7 @@ class ImageResponse(OpenAIImageResponse, BaseLiteLLMOpenAIResponseObject):
             output_tokens=0,
             total_tokens=0,
         )
-        super().__init__(created=created, data=_data, usage=_usage)  # type: ignore
+        super().__init__(created=created, data=_data, usage=_usage)
 
         self.quality = kwargs.get("quality", None)
         self.output_format = kwargs.get("output_format", None)
@@ -2491,7 +2491,7 @@ class ImageResponse(OpenAIImageResponse, BaseLiteLLMOpenAIResponseObject):
         # Allow dictionary-style assignment of attributes
         setattr(self, key, value)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump()  # noqa
         except Exception:
@@ -2525,7 +2525,7 @@ class TranscriptionResponse(OpenAIObject):
     _response_headers: Optional[dict] = None
 
     def __init__(self, text=None):
-        super().__init__(text=text)  # type: ignore
+        super().__init__(text=text)
 
     def __contains__(self, key):
         # Define custom behavior for the 'in' operator
@@ -2543,7 +2543,7 @@ class TranscriptionResponse(OpenAIObject):
         # Allow dictionary-style assignment of attributes
         setattr(self, key, value)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump()  # noqa
         except Exception:
@@ -3815,7 +3815,7 @@ class SelectTokenizerResponse(TypedDict):
 
 class LiteLLMFineTuningJob(FineTuningJob):
     _hidden_params: dict = {}
-    seed: Optional[int] = None  # type: ignore
+    seed: Optional[int] = None
 
     def __init__(self, **kwargs):
         if "error" in kwargs and kwargs["error"] is not None:
@@ -3828,7 +3828,7 @@ class LiteLLMFineTuningJob(FineTuningJob):
 
 class LiteLLMBatch(Batch):
     _hidden_params: dict = {}
-    usage: Optional[Usage] = None  # type: ignore[assignment]
+    usage: Optional[Usage] = None
 
     def __contains__(self, key):
         # Define custom behavior for the 'in' operator
@@ -3842,7 +3842,7 @@ class LiteLLMBatch(Batch):
         # Allow dictionary-style access to attributes
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump()  # noqa
         except Exception:
@@ -3875,7 +3875,7 @@ class LiteLLMRealtimeStreamLoggingObject(LiteLLMPydanticObjectBase):
         # Allow dictionary-style access to attributes
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump()  # noqa
         except Exception:

--- a/litellm/types/videos/main.py
+++ b/litellm/types/videos/main.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Literal, Optional
 
-from openai.types.audio.transcription_create_params import FileTypes  # type: ignore
+from openai.types.audio.transcription_create_params import FileTypes
 from pydantic import BaseModel
 from typing_extensions import TypedDict
 
@@ -35,7 +35,7 @@ class VideoObject(BaseModel):
         # Allow dictionary-style access to attributes
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump(**kwargs)
         except Exception:
@@ -58,7 +58,7 @@ class VideoResponse(BaseModel):
     def __getitem__(self, key):
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump(**kwargs)
         except Exception:
@@ -120,7 +120,7 @@ class CharacterObject(BaseModel):
     def __getitem__(self, key):
         return getattr(self, key)
 
-    def json(self, **kwargs):  # type: ignore
+    def json(self, **kwargs):
         try:
             return self.model_dump(**kwargs)
         except Exception:

--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -17,7 +17,7 @@ import itertools
 import json
 import logging
 import os
-import random  # type: ignore
+import random
 import re
 import struct
 import subprocess
@@ -182,7 +182,7 @@ from litellm.types.utils import (
     Delta,
     Embedding,
     EmbeddingResponse,
-    FileTypes,  # type: ignore
+    FileTypes,
     Function,
     ImageResponse,
     LlmProviders,
@@ -612,7 +612,7 @@ def get_dynamic_callbacks(
 ) -> list:
     returned_callbacks: Final = litellm.callbacks.copy()
     if dynamic_callbacks:
-        returned_callbacks.extend(dynamic_callbacks)  # type: ignore
+        returned_callbacks.extend(dynamic_callbacks)
     return returned_callbacks
 
 
@@ -743,35 +743,35 @@ def function_setup(
             for callback in all_callbacks:
                 # check if callback is a string - e.g. "lago", "openmeter"
                 if isinstance(callback, str):
-                    callback = litellm.litellm_core_utils.litellm_logging._init_custom_logger_compatible_class(  # type: ignore
+                    callback = litellm.litellm_core_utils.litellm_logging._init_custom_logger_compatible_class(
                         callback,
                         internal_usage_cache=None,
-                        llm_router=None,  # type: ignore
+                        llm_router=None,
                     )
                     if callback is None or any(
                         type(cb) is type(callback) for cb in litellm._async_success_callback
                     ):  # don't double add a callback
                         continue
                 if callback not in litellm.input_callback:
-                    litellm.input_callback.append(callback)  # type: ignore
+                    litellm.input_callback.append(callback)
                 if callback not in litellm.success_callback:
-                    litellm.logging_callback_manager.add_litellm_success_callback(callback)  # type: ignore
+                    litellm.logging_callback_manager.add_litellm_success_callback(callback)
                 if callback not in litellm.failure_callback:
-                    litellm.logging_callback_manager.add_litellm_failure_callback(callback)  # type: ignore
+                    litellm.logging_callback_manager.add_litellm_failure_callback(callback)
                 if callback not in litellm._async_success_callback:
-                    litellm.logging_callback_manager.add_litellm_async_success_callback(callback)  # type: ignore
+                    litellm.logging_callback_manager.add_litellm_async_success_callback(callback)
                 if callback not in litellm._async_failure_callback:
-                    litellm.logging_callback_manager.add_litellm_async_failure_callback(callback)  # type: ignore
+                    litellm.logging_callback_manager.add_litellm_async_failure_callback(callback)
             print_verbose(f"Initialized litellm callbacks, Async Success Callbacks: {litellm._async_success_callback}")
 
         if (
             len(litellm.input_callback) > 0 or len(litellm.success_callback) > 0 or len(litellm.failure_callback) > 0
         ) and len(
-            callback_list  # type: ignore
-        ) == 0:  # type: ignore
+            callback_list
+        ) == 0:
             callback_list = list(
                 set(
-                    litellm.input_callback  # type: ignore
+                    litellm.input_callback
                     + litellm.success_callback
                     + litellm.failure_callback
                 )
@@ -781,7 +781,7 @@ def function_setup(
         ## ASYNC CALLBACKS - safety net for callbacks added via direct append
         if len(litellm.input_callback) > 0:
             removed_async_items = []
-            for index, callback in enumerate(litellm.input_callback):  # type: ignore
+            for index, callback in enumerate(litellm.input_callback):
                 if coroutine_checker.is_async_callable(callback):
                     litellm._async_input_callback.append(callback)
                     removed_async_items.append(index)
@@ -791,7 +791,7 @@ def function_setup(
                 litellm.input_callback.pop(index)
         if len(litellm.success_callback) > 0:
             removed_async_items = []
-            for index, callback in enumerate(litellm.success_callback):  # type: ignore
+            for index, callback in enumerate(litellm.success_callback):
                 if coroutine_checker.is_async_callable(callback):
                     litellm.logging_callback_manager.add_litellm_async_success_callback(callback)
                     removed_async_items.append(index)
@@ -809,7 +809,7 @@ def function_setup(
 
         if len(litellm.failure_callback) > 0:
             removed_async_items = []
-            for index, callback in enumerate(litellm.failure_callback):  # type: ignore
+            for index, callback in enumerate(litellm.failure_callback):
                 if coroutine_checker.is_async_callable(callback):
                     litellm.logging_callback_manager.add_litellm_async_failure_callback(callback)
                     removed_async_items.append(index)
@@ -1010,7 +1010,7 @@ def function_setup(
             stream = True
         get_litellm_logging_class: Final = getattr(sys.modules[__name__], "get_litellm_logging_class")
         logging_obj: Final = get_litellm_logging_class()(  # Victim for object pool
-            model=model,  # type: ignore
+            model=model,
             messages=messages,
             stream=stream,
             litellm_call_id=kwargs["litellm_call_id"],
@@ -1187,7 +1187,7 @@ def post_call_processing(
                     pass
                 else:
                     if isinstance(original_response, ModelResponse) and len(original_response.choices) > 0:
-                        model_response: Final[str | None] = original_response.choices[0].message.content  # type: ignore
+                        model_response: Final[str | None] = original_response.choices[0].message.content
                         if model_response is not None:
                             ### POST-CALL RULES ###
                             rules_obj.post_call_rules(input=model_response, model=model)
@@ -1220,7 +1220,7 @@ def post_call_processing(
                                         ):
                                             json_response_format = optional_params["response_format"]
                                         elif _parsing._completions.is_basemodel_type(
-                                            optional_params["response_format"]  # type: ignore
+                                            optional_params["response_format"]
                                         ):
                                             json_response_format = type_to_response_format_param(
                                                 response_format=optional_params["response_format"]
@@ -1521,7 +1521,7 @@ def client(original_function):
                     and not _is_litellm_router_call
                 ):
                     if len(args) > 0:
-                        args[0] = context_window_fallback_dict[model]  # type: ignore
+                        args[0] = context_window_fallback_dict[model]
                     else:
                         kwargs["model"] = context_window_fallback_dict[model]
                     return original_function(*args, **kwargs)
@@ -1740,7 +1740,7 @@ def client(original_function):
                             )
                         )
 
-                    logging_obj._enqueue_deferred_logging = _enqueue_deferred_logging  # type: ignore
+                    logging_obj._enqueue_deferred_logging = _enqueue_deferred_logging
                 else:
                     asyncio.create_task(
                         _client_async_logging_helper(
@@ -1825,7 +1825,7 @@ def client(original_function):
                     and not _is_litellm_router_call
                 ):
                     if len(args) > 0:
-                        args[0] = context_window_fallback_dict[model]  # type: ignore
+                        args[0] = context_window_fallback_dict[model]
                     else:
                         kwargs["model"] = context_window_fallback_dict[model]
                     return await original_function(*args, **kwargs)
@@ -1996,7 +1996,7 @@ def encode(model="", text="", custom_tokenizer: dict | None = None):
     # Normalize: HuggingFace Tokenizer.encode() returns an Encoding object;
     # extract .ids so the return type is always List[int].
     if hasattr(enc, "ids"):
-        return enc.ids  # type: ignore
+        return enc.ids
     return enc
 
 
@@ -2055,7 +2055,7 @@ def create_pretrained_tokenizer(identifier: str, revision="main", auth_token: st
         tokenizer = Tokenizer.from_pretrained(
             identifier,
             revision=revision,
-            auth_token=auth_token,  # type: ignore
+            auth_token=auth_token,
         )
     except Exception as e:
         verbose_logger.error("Error creating pretrained tokenizer: %s. Defaulting to version without 'auth_token'.", e)
@@ -4313,7 +4313,7 @@ def get_optional_params(
                 non_default_params=non_default_params,
                 optional_params=optional_params,
                 model=_azure_detection_model,
-                api_version=api_version,  # type: ignore
+                api_version=api_version,
                 drop_params=(drop_params if drop_params is not None and isinstance(drop_params, bool) else False),
             )
     elif provider_config is not None:
@@ -4776,9 +4776,9 @@ def get_utc_datetime():
     from datetime import datetime
 
     if hasattr(dt, "UTC"):
-        return datetime.now(dt.UTC)  # type: ignore
+        return datetime.now(dt.UTC)
     else:
-        return datetime.utcnow()  # type: ignore
+        return datetime.utcnow()
 
 
 def get_max_tokens(model: str) -> int | None:
@@ -5283,7 +5283,7 @@ def _get_model_info_helper(
             max_tokens: Final = _get_max_position_embeddings(model_name=model)
             return ModelInfoBase(
                 key=model,
-                max_tokens=max_tokens,  # type: ignore
+                max_tokens=max_tokens,
                 max_input_tokens=None,
                 max_output_tokens=None,
                 input_cost_per_token=0,
@@ -5516,7 +5516,7 @@ def _get_model_info_helper(
                 citation_cost_per_token=_model_info.get("citation_cost_per_token", None),
                 tiered_pricing=_model_info.get("tiered_pricing", None),
                 litellm_provider=_model_info.get("litellm_provider", custom_llm_provider),
-                mode=_model_info.get("mode"),  # type: ignore
+                mode=_model_info.get("mode"),
                 supports_system_messages=_model_info.get("supports_system_messages", None),
                 supports_response_schema=_model_info.get("supports_response_schema", None),
                 supports_vision=_model_info.get("supports_vision", None),
@@ -5556,7 +5556,7 @@ def _get_model_info_helper(
             )
             for cost_key, cost_value in _model_info.items():
                 if cost_key not in returned_model_info and _ABOVE_THRESHOLD_COST_KEY.search(cost_key) is not None:
-                    returned_model_info[cost_key] = cost_value  # type: ignore[literal-required]
+                    returned_model_info[cost_key] = cost_value
             return returned_model_info
     except Exception as e:
         verbose_logger.debug("Error getting model info: %s", e)
@@ -5584,7 +5584,7 @@ def _build_model_info(
     if provider_info:
         for key, value in provider_info.items():
             if value is not None:
-                _model_info[key] = value  # type: ignore
+                _model_info[key] = value
 
     # if verbose_logger.isEnabledFor(logging.DEBUG):
     # verbose_logger.debug(f"model_info: {_model_info}")
@@ -5684,8 +5684,8 @@ def get_model_info(
     return _cached_get_model_info(model, custom_llm_provider, api_base)
 
 
-get_model_info.cache_clear = _cached_get_model_info.cache_clear  # type: ignore[attr-defined]
-get_model_info.cache_info = _cached_get_model_info.cache_info  # type: ignore[attr-defined]
+get_model_info.cache_clear = _cached_get_model_info.cache_clear
+get_model_info.cache_info = _cached_get_model_info.cache_info
 
 
 def json_schema_type(python_type_name: str):
@@ -6315,7 +6315,7 @@ def prompt_token_calculator(model, messages):
         from anthropic import AI_PROMPT, HUMAN_PROMPT, Anthropic
 
         anthropic_obj: Final = Anthropic()
-        num_tokens = anthropic_obj.count_tokens(text)  # type: ignore
+        num_tokens = anthropic_obj.count_tokens(text)
     else:
         num_tokens = len(_get_default_encoding().encode(text))
     return num_tokens
@@ -6402,11 +6402,11 @@ def _get_retry_after_from_exception_header(
             try:
                 retry_after = int(retry_header)
             except Exception:
-                retry_date_tuple: Final = email.utils.parsedate_tz(retry_header)  # type: ignore
+                retry_date_tuple: Final = email.utils.parsedate_tz(retry_header)
                 if retry_date_tuple is None:
                     retry_after = -1
                 else:
-                    retry_date: Final = email.utils.mktime_tz(retry_date_tuple)  # type: ignore
+                    retry_date: Final = email.utils.mktime_tz(retry_date_tuple)
                     retry_after = int(retry_date - time.time())
         else:
             retry_after = -1
@@ -7151,7 +7151,7 @@ class ModelResponseIterator:
     def __init__(self, model_response: ModelResponse, convert_to_delta: bool = False):
         if convert_to_delta is True:
             _stream_response: Final = ModelResponseStream()
-            _stream_response.choices[0].delta.content = model_response.choices[0].message.content  # type: ignore
+            _stream_response.choices[0].delta.content = model_response.choices[0].message.content
             self.model_response: ModelResponse | ModelResponseStream = _stream_response
         else:
             self.model_response = model_response
@@ -7400,7 +7400,7 @@ def convert_to_dict(message: BaseModel | dict) -> dict:
         dict: The converted message.
     """
     if isinstance(message, BaseModel):
-        return message.model_dump(exclude_none=True)  # type: ignore
+        return message.model_dump(exclude_none=True)
     elif isinstance(message, dict):
         return message
     else:
@@ -7879,9 +7879,9 @@ class ProviderConfigManager:
         if config_entry is not None:
             config_factory, needs_model = config_entry
             if needs_model:
-                return config_factory(model)  # type: ignore
+                return config_factory(model)
             else:
-                return config_factory()  # type: ignore
+                return config_factory()
 
         # Fall back to JSON providers (generic OpenAI-compatible)
         from litellm.llms.openai_like.dynamic_config import create_config_class

--- a/litellm/vector_store_files/main.py
+++ b/litellm/vector_store_files/main.py
@@ -119,7 +119,7 @@ def create(
 ) -> VectorStoreFileObject | Coroutine[Any, Any, VectorStoreFileObject]:
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id")
         _is_async: Final = kwargs.pop("acreate", False) is True
 
@@ -248,7 +248,7 @@ def list(
 ) -> VectorStoreFileListResponse | Coroutine[Any, Any, VectorStoreFileListResponse]:
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id")
         _is_async: Final = kwargs.pop("alist", False) is True
 
@@ -358,7 +358,7 @@ def retrieve(
 ) -> VectorStoreFileObject | Coroutine[Any, Any, VectorStoreFileObject]:
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id")
         _is_async: Final = kwargs.pop("aretrieve", False) is True
 
@@ -466,7 +466,7 @@ def retrieve_content(
 ) -> VectorStoreFileContentResponse | Coroutine[Any, Any, VectorStoreFileContentResponse]:
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id")
         _is_async: Final = kwargs.pop("aretrieve_content", False) is True
 
@@ -580,7 +580,7 @@ def update(
 ) -> VectorStoreFileObject | Coroutine[Any, Any, VectorStoreFileObject]:
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id")
         _is_async: Final = kwargs.pop("aupdate", False) is True
 
@@ -695,7 +695,7 @@ def delete(
 ) -> VectorStoreFileDeleteResponse | Coroutine[Any, Any, VectorStoreFileDeleteResponse]:
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id")
         _is_async: Final = kwargs.pop("adelete", False) is True
 

--- a/litellm/vector_stores/main.py
+++ b/litellm/vector_stores/main.py
@@ -183,7 +183,7 @@ def create(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("acreate", False) is True
 
@@ -365,7 +365,7 @@ def search(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("asearch", False) is True
 
@@ -384,7 +384,7 @@ def search(
         if litellm_params.mock_response and isinstance(litellm_params.mock_response, (str, builtins.list)):
             mock_results = None
             if isinstance(litellm_params.mock_response, builtins.list):
-                mock_results = litellm_params.mock_response  # type: ignore[assignment]
+                mock_results = litellm_params.mock_response
             return mock_vector_store_search_response(mock_results=mock_results)
 
         # Default to OpenAI for vector stores
@@ -536,7 +536,7 @@ def retrieve(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("aretrieve", False) is True
 
@@ -680,7 +680,7 @@ def list(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("alist", False) is True
 
@@ -832,7 +832,7 @@ def update(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("aupdate", False) is True
 
@@ -975,7 +975,7 @@ def delete(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("adelete", False) is True
 

--- a/litellm/videos/main.py
+++ b/litellm/videos/main.py
@@ -183,7 +183,7 @@ def video_generation(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("async_call", False) is True
 
@@ -311,7 +311,7 @@ def video_content(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("async_call", False) is True
 
@@ -571,7 +571,7 @@ def video_remix(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("async_call", False) is True
 
@@ -786,7 +786,7 @@ def video_list(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("async_call", False) is True
 
@@ -838,7 +838,7 @@ def video_list(
         litellm_logging_obj.call_type = CallTypes.video_list.value
 
         # Call the handler with _is_async flag instead of directly calling the async handler
-        return base_llm_http_handler.video_list_handler(  # type: ignore[return-value]
+        return base_llm_http_handler.video_list_handler(
             after=after,
             limit=limit,
             order=order,
@@ -1004,7 +1004,7 @@ def video_status(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.get("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("async_call", False) is True
 
@@ -1152,7 +1152,7 @@ def video_create_character(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("async_call", False) is True
 
@@ -1277,7 +1277,7 @@ def video_get_character(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("async_call", False) is True
 
@@ -1404,7 +1404,7 @@ def video_edit(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("async_call", False) is True
 
@@ -1537,7 +1537,7 @@ def video_extension(
     """
     local_vars: Final = locals()
     try:
-        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")  # type: ignore
+        litellm_logging_obj: Final[LiteLLMLoggingObj] = kwargs.pop("litellm_logging_obj")
         litellm_call_id: Final[str | None] = kwargs.get("litellm_call_id", None)
         _is_async: Final = kwargs.pop("async_call", False) is True
 

--- a/ruff-strict-budget.json
+++ b/ruff-strict-budget.json
@@ -1,117 +1,117 @@
 {
   "ANN001": {
-    "limit": 3097
+    "limit": 2849
   },
   "ANN002": {
-    "limit": 69
+    "limit": 65
   },
   "ANN003": {
-    "limit": 831
+    "limit": 776
   },
   "ANN201": {
-    "limit": 2137
+    "limit": 1961
   },
   "ANN202": {
-    "limit": 941
+    "limit": 868
   },
   "ANN204": {
-    "limit": 724
+    "limit": 669
   },
   "ANN205": {
-    "limit": 127
+    "limit": 115
   },
   "ANN206": {
-    "limit": 130
+    "limit": 121
   },
   "ANN401": {
     "limit": 1848
   },
   "ASYNC230": {
-    "limit": 14
+    "limit": 11
   },
   "B004": {
-    "limit": 4
+    "limit": 2
   },
   "B006": {
-    "limit": 188
+    "limit": 178
   },
   "B008": {
     "limit": 505
   },
   "B009": {
-    "limit": 84
+    "limit": 81
   },
   "B010": {
     "limit": 194
   },
   "B018": {
-    "limit": 5
+    "limit": 2
   },
   "B019": {
-    "limit": 4
+    "limit": 1
   },
   "B021": {
-    "limit": 4
+    "limit": 1
   },
   "B026": {
-    "limit": 6
+    "limit": 3
   },
   "B033": {
     "limit": 0
   },
   "BLE001": {
-    "limit": 2899
+    "limit": 2897
   },
   "C401": {
-    "limit": 11
+    "limit": 8
   },
   "C404": {
-    "limit": 4
+    "limit": 1
   },
   "C405": {
-    "limit": 21
+    "limit": 19
   },
   "C408": {
-    "limit": 14
+    "limit": 11
   },
   "C414": {
-    "limit": 7
+    "limit": 4
   },
   "C419": {
-    "limit": 4
+    "limit": 1
   },
   "C901": {
     "limit": 310
   },
   "D419": {
-    "limit": 9
+    "limit": 6
   },
   "DTZ001": {
-    "limit": 5
+    "limit": 2
   },
   "DTZ003": {
-    "limit": 33
+    "limit": 26
   },
   "DTZ005": {
-    "limit": 241
+    "limit": 233
   },
   "DTZ006": {
-    "limit": 13
+    "limit": 10
   },
   "DTZ007": {
-    "limit": 23
+    "limit": 19
   },
   "DTZ011": {
-    "limit": 6
+    "limit": 3
   },
   "EXE001": {
-    "limit": 7
+    "limit": 4
   },
   "EXE002": {
-    "limit": 6
+    "limit": 3
   },
   "F401": {
-    "limit": 23
+    "limit": 20
   },
   "FURB136": {
     "limit": 0
@@ -126,22 +126,22 @@
     "limit": 0
   },
   "LOG015": {
-    "limit": 8
+    "limit": 5
   },
   "N999": {
-    "limit": 4
+    "limit": 1
   },
   "PERF102": {
-    "limit": 30
+    "limit": 27
   },
   "PERF401": {
-    "limit": 142
+    "limit": 23
   },
   "PERF402": {
-    "limit": 9
+    "limit": 0
   },
   "PERF403": {
-    "limit": 74
+    "limit": 34
   },
   "PIE790": {
     "limit": 0
@@ -150,37 +150,37 @@
     "limit": 0
   },
   "PIE804": {
-    "limit": 24
+    "limit": 18
   },
   "PIE810": {
-    "limit": 44
+    "limit": 43
   },
   "PLC0206": {
-    "limit": 31
+    "limit": 26
   },
   "PLC0208": {
     "limit": 0
   },
   "PLC0414": {
-    "limit": 38
+    "limit": 35
   },
   "PLR0124": {
-    "limit": 4
+    "limit": 1
   },
   "PLR0206": {
-    "limit": 4
+    "limit": 1
   },
   "PLR0402": {
     "limit": 0
   },
   "PLR1704": {
-    "limit": 6
+    "limit": 3
   },
   "PLR1711": {
     "limit": 0
   },
   "PLR1714": {
-    "limit": 261
+    "limit": 257
   },
   "PLR1730": {
     "limit": 0
@@ -189,28 +189,28 @@
     "limit": 0
   },
   "PLW0127": {
-    "limit": 43
+    "limit": 38
   },
   "PLW0133": {
-    "limit": 4
+    "limit": 1
   },
   "PLW0602": {
-    "limit": 230
+    "limit": 215
   },
   "PLW0603": {
-    "limit": 193
+    "limit": 191
   },
   "PLW1508": {
-    "limit": 198
+    "limit": 190
   },
   "PLW1510": {
-    "limit": 5
+    "limit": 2
   },
   "PYI030": {
     "limit": 0
   },
   "PYI036": {
-    "limit": 5
+    "limit": 3
   },
   "PYI041": {
     "limit": 0
@@ -222,19 +222,19 @@
     "limit": 0
   },
   "RET504": {
-    "limit": 702
+    "limit": 180
   },
   "RUF010": {
     "limit": 0
   },
   "RUF012": {
-    "limit": 168
+    "limit": 164
   },
   "RUF015": {
-    "limit": 11
+    "limit": 8
   },
   "RUF019": {
-    "limit": 41
+    "limit": 38
   },
   "RUF022": {
     "limit": 0
@@ -243,64 +243,64 @@
     "limit": 0
   },
   "RUF046": {
-    "limit": 5
+    "limit": 4
   },
   "RUF051": {
     "limit": 0
   },
   "RUF059": {
-    "limit": 73
+    "limit": 67
   },
   "RUF100": {
-    "limit": 480
+    "limit": 100
   },
   "S110": {
-    "limit": 236
+    "limit": 220
   },
   "S112": {
-    "limit": 24
+    "limit": 22
   },
   "SIM101": {
-    "limit": 61
+    "limit": 58
   },
   "SIM102": {
-    "limit": 324
+    "limit": 314
   },
   "SIM103": {
-    "limit": 129
+    "limit": 119
   },
   "SIM113": {
-    "limit": 6
+    "limit": 3
   },
   "SIM114": {
     "limit": 0
   },
   "SIM115": {
-    "limit": 5
+    "limit": 2
   },
   "SIM117": {
-    "limit": 10
+    "limit": 7
   },
   "SIM118": {
     "limit": 0
   },
   "SIM201": {
-    "limit": 4
+    "limit": 1
   },
   "SIM210": {
-    "limit": 11
+    "limit": 8
   },
   "SIM211": {
-    "limit": 4
+    "limit": 1
   },
   "SIM222": {
-    "limit": 4
+    "limit": 1
   },
   "SIM401": {
-    "limit": 12
+    "limit": 11
   },
   "TC004": {
-    "limit": 8
+    "limit": 5
   },
   "TC005": {
     "limit": 0
@@ -309,19 +309,19 @@
     "limit": 0
   },
   "TRY002": {
-    "limit": 547
+    "limit": 526
   },
   "TRY004": {
-    "limit": 97
+    "limit": 96
   },
   "TRY201": {
-    "limit": 420
+    "limit": 407
   },
   "TRY203": {
-    "limit": 121
+    "limit": 113
   },
   "TRY300": {
-    "limit": 879
+    "limit": 860
   },
   "UP006": {
     "limit": 0
@@ -342,10 +342,10 @@
     "limit": 0
   },
   "UP028": {
-    "limit": 5
+    "limit": 2
   },
   "UP031": {
-    "limit": 5
+    "limit": 2
   },
   "UP032": {
     "limit": 0
@@ -357,7 +357,7 @@
     "limit": 0
   },
   "UP036": {
-    "limit": 4
+    "limit": 1
   },
   "UP037": {
     "limit": 0

--- a/type-discipline-budget.json
+++ b/type-discipline-budget.json
@@ -1,15 +1,15 @@
 {
   "LIT001": {
-    "limit": 23348
+    "limit": 23346
   },
   "LIT002": {
     "limit": 27227
   },
   "LIT003": {
-    "limit": 292
+    "limit": 286
   },
   "LIT004": {
-    "limit": 44
+    "limit": 43
   },
   "LIT005": {
     "limit": 0
@@ -21,7 +21,7 @@
     "limit": 0
   },
   "LIT008": {
-    "limit": 1004
+    "limit": 951
   },
   "LIT009": {
     "limit": 2460

--- a/type-discipline-budget.json
+++ b/type-discipline-budget.json
@@ -24,12 +24,12 @@
     "limit": 951
   },
   "LIT009": {
-    "limit": 2460
+    "limit": 0
   },
   "LIT010": {
-    "limit": 25327
+    "limit": 16828
   },
   "LIT011": {
-    "limit": 8406
+    "limit": 5603
   }
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Ruff strict and LIT budgets carry 15.8k stale headroom
- RET504 alone allows 522 net-new unnecessary assignments
- 2465 inert type: ignore comments litter the codebase
- Follow-up to #35828 and #35927 covering the other two gates

How it solves it:

- Set 83 ruff strict limits and 7 LIT limits to live counts
- Remove every type: ignore comment and set LIT009 to 0
- Contagious ANN401 keeps its headroom
- Any net-new violation in the tightened rules now reddens the gate

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs below were captured at 20d297a151 with latest staging merged in, except the sweep comparison, which is labeled with its own hash. This PR touches only the two budget files and comments that basedpyright never read, so there is no runtime behavior to exercise; the gates themselves are the end-to-end surface

Both gates green with the tightened limits:

```
$ python scripts/ruff_strict_gate.py --base origin/litellm_internal_staging
OK: every strict rule is within its codebase ceiling (base origin/litellm_internal_staging)

$ python scripts/type_discipline_gate.py --base origin/litellm_internal_staging
OK: every LIT rule is within its codebase ceiling (base origin/litellm_internal_staging)
```

A one-line unused import reddening the ruff gate (the file was deleted right after):

```
$ printf 'import os\n' > litellm/_demo_f401.py
$ python scripts/ruff_strict_gate.py --base origin/litellm_internal_staging
FAIL: strict-rule totals exceed their limit (base origin/litellm_internal_staging):
  F401: total 21 over limit 20 (this change added 1)
Reduce the new violations or remove an equal number elsewhere; the ceiling is the limit in ruff-strict-budget.json.
```

A `**kwargs` function reddening the LIT gate (also deleted right after):

```
$ printf 'def _demo(**kwargs: object) -> None:\n    pass\n' > litellm/_demo_kwargs.py
$ python scripts/type_discipline_gate.py --base origin/litellm_internal_staging
FAIL: LIT-rule totals exceed their limit (base origin/litellm_internal_staging):
  LIT008: total 952 over limit 951 (this change added 1)
Remove the new violations, give each a reason (`# noqa: XXX  # <reason>`, `# pyright: ignore[rule]  # <reason>`, `# mutable-ok: <reason>`, `# cast-ok: <reason>`, `# guard-ok: <reason>`, `# kwargs-ok: <reason>`, `# rebind-ok: <reason>`), or remove an equal number elsewhere; the ceiling is the limit in type-discipline-budget.json.
```

A type: ignore comment reddening the LIT gate through the new LIT009 zero (also deleted right after). This demo runs with `--base HEAD` because staging still carries the 2465 ignores this PR removes, so against that base the bystander guard covers any total below 2465 until this merges; HEAD as base models the post-merge state every future PR will face:

```
$ printf 'from typing import Final\n\nx: Final = 1  # type: ignore\n' > litellm/_demo_ignore.py
$ python scripts/type_discipline_gate.py --base HEAD
FAIL: LIT-rule totals exceed their limit (base HEAD):
  LIT009: total 1 over limit 0 (this change added 1)
Remove the new violations, give each a reason (`# noqa: XXX  # <reason>`, `# pyright: ignore[rule]  # <reason>`, `# mutable-ok: <reason>`, `# cast-ok: <reason>`, `# guard-ok: <reason>`, `# kwargs-ok: <reason>`, `# rebind-ok: <reason>`), or remove an equal number elsewhere; the ceiling is the limit in type-discipline-budget.json.
```

The comment sweep proven inert, captured at 338e411103 before the staging merge shifted the tree total: the basedpyright gate reports the identical error total on the tree with all 2465 comments (checked out from cdfefd7f41) and on the swept tree

```
$ python scripts/type_check_gate.py --base origin/litellm_internal_staging   # before the sweep
OK: every rule is within its basedpyright limit or no higher than base (149782 errors total)
$ python scripts/type_check_gate.py --base origin/litellm_internal_staging   # after the sweep
OK: every rule is within its basedpyright limit or no higher than base (149782 errors total)
```

## Type

🚄 Infrastructure

## Changes

Same rationale as #35828 and #35927, applied to the two non-basedpyright gates: every rule tightened here is purely local, meaning the violation is caused entirely by the lines the change itself writes, never forced by upstream untyped code, so the fix never extends beyond the change and the rare deliberate case takes a suppression with a reason. An unnecessary assignment before return, a leftover noqa, a naive datetime, a bare loop that should be a comprehension, or a swallowed exception is always the new code's own doing

`ruff-strict-budget.json` drops 83 limits to the live count measured on this branch point, freeing 2020 violations of headroom. The rules that shed ten or more:

| Rule | Old | New |
|---|---|---|
| RET504 | 702 | 180 |
| RUF100 | 480 | 100 |
| ANN001 | 3097 | 2849 |
| ANN201 | 2137 | 1961 |
| PERF401 | 142 | 23 |
| ANN202 | 941 | 868 |
| ANN003 | 831 | 776 |
| ANN204 | 724 | 669 |
| PERF403 | 74 | 34 |
| TRY002 | 547 | 526 |
| TRY300 | 879 | 860 |
| S110 | 236 | 220 |
| PLW0602 | 230 | 215 |
| TRY201 | 420 | 407 |
| ANN205 | 127 | 115 |
| B006 | 188 | 178 |
| SIM102 | 324 | 314 |
| SIM103 | 129 | 119 |

The other 65 rules each shed under ten, mostly the uniform pad that left single-digit rules sitting at a limit of 4 or 5 over a live count of 1 or 2; the diff is the full list. The huge RET504, RUF100, and PERF401 drops are real fixes from the Final-annotation sweep in #35807 whose ratchet never captured them, since ruff stops flagging an assignment once it carries an annotation

The ANN annotation rules count as local because they fire on the signature you are writing, not on what you call: an untyped upstream value can force an `Any` annotation (which is why the contagious ANN401 keeps its 1848 headroom untouched) but never a missing one. Rules currently sitting above their limit and riding the merge-base guard (TID251, UP007, SIM118, C901, and friends) are also untouched, since lowering an already-breached limit changes nothing

`type-discipline-budget.json` drops all seven LIT rules with stale headroom to their live counts: LIT008 (`**kwargs` parameters) 1004 to 951, LIT003 (noqa without reason) 292 to 286, LIT004 (pyright-ignore without codes or reason) 44 to 43, LIT001 (mutable collection annotations) 23348 to 23346, LIT010 (unannotated assignments) 25327 to 16828, LIT011 (parameter rebinds) 8406 to 5603, and LIT009 (type: ignore comments) 2460 to 0. LIT010 and LIT011 had kept a deliberate 1.5x grandfather from #35807, but both are as local as the rest and each has a trivial escape: LIT010 wants a `: Final` annotation (unpacking and walrus targets are exempt) and LIT011 takes `# rebind-ok: <reason>`, so new code has no claim on shared headroom

The LIT009 zero is earned rather than ratcheted: this PR deletes every `# type: ignore` comment in litellm/, 2465 of them across 442 files. pyrightconfig.json sets `enableTypeIgnoreComments` to false, so basedpyright never honored a single one, and no other type checker runs in CI; the identical 149782 error total before and after the sweep (shown above) proves the comments were pure noise. Dropping a trailing comment sometimes lets ruff format rejoin a previously split line, which reformatted 66 of the touched files; the budgets were re-measured on the formatted tree and no count moved

The gates fail a rule only when its count is both over the limit and above the merge-base count, so pre-existing drift keeps merging fine while any net-new violation in these categories now fails pre-commit and CI, as the demos above show

No tests are added because no code changes; the gate logic enforcing these limits is already covered by `tests/test_litellm/test_ruff_strict_gate.py` and `tests/test_litellm/test_type_discipline_gate.py`

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 20d297a151e410160ba55e3efe6e0d1db360bc35. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->