### PR TITLE
chore(ui): zero stale headroom on local dashboard eslint budgets

### DIFF
--- a/ui/litellm-dashboard/eslint-budgets.json
+++ b/ui/litellm-dashboard/eslint-budgets.json
@@ -1,8 +1,8 @@
 {
   "@typescript-eslint/no-explicit-any": { "max": 2040, "target": 1500 },
-  "no-console": { "max": 484, "target": 0 },
-  "complexity": { "max": 140, "target": 80 },
-  "max-depth": { "max": 70, "target": 30 },
-  "local/no-large-inline-object-arg": { "max": 560, "target": 300 },
-  "local/no-long-condition-chain": { "max": 265, "target": 120 }
+  "no-console": { "max": 12, "target": 0 },
+  "complexity": { "max": 121, "target": 80 },
+  "max-depth": { "max": 55, "target": 30 },
+  "local/no-large-inline-object-arg": { "max": 469, "target": 300 },
+  "local/no-long-condition-chain": { "max": 217, "target": 120 }
 }


### PR DESCRIPTION
## TLDR

Problem this solves:

- Five local dashboard eslint budgets carry stale headroom
- no-console alone allows 472 net-new console statements
- Completes the zero-headroom pass from #35828, #35927, and #35928

How it solves it:

- Set the five local-rule maxes to their live counts
- Contagious @typescript-eslint/no-explicit-any keeps its headroom
- Any net-new violation in them now reddens the budget check

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Both runs below were captured at b4b5c8f0a1. This PR touches only `ui/litellm-dashboard/eslint-budgets.json`, so there is no runtime behavior to exercise; the budget check itself is the end-to-end surface

The budget check green with the tightened maxes:

```
$ npx eslint . --format json --output-file /tmp/eslint_report.json
$ node scripts/check-lint-budgets.mjs /tmp/eslint_report.json eslint-budgets.json
@typescript-eslint/no-explicit-any: 1776 | max: 2040 | target: 1500 | 264 of headroom
no-console: 12 | max: 12 | target: 0 | 0 of headroom
complexity: 121 | max: 121 | target: 80 | 0 of headroom
max-depth: 55 | max: 55 | target: 30 | 0 of headroom
local/no-large-inline-object-arg: 469 | max: 469 | target: 300 | 0 of headroom
local/no-long-condition-chain: 217 | max: 217 | target: 120 | 0 of headroom
```

A one-line console.log reddening the check (the file was deleted right after):

```
$ printf 'console.log("demo");\n' > src/_demo_console.ts
$ npx eslint . --format json --output-file /tmp/eslint_report.json
$ node scripts/check-lint-budgets.mjs /tmp/eslint_report.json eslint-budgets.json
no-console: 13 | max: 12 | target: 0 | OVER BUDGET
::error::no-console budget exceeded (13 > 12). Reduce usage; lower max in eslint-budgets.json as the count drops.
```

## Type

🚄 Infrastructure

## Changes

Same rationale as #35828, #35927, and #35928, applied to the dashboard's eslint budgets: these five rules are purely local, meaning the violation is caused entirely by the lines the change itself writes, so the fix never extends beyond the change and the rare deliberate case takes an inline `eslint-disable-next-line` with a reason. A console statement, a function over the complexity or nesting ceiling, a large inline object argument, or a long condition chain is always the new code's own doing

`ui/litellm-dashboard/eslint-budgets.json` accordingly drops the five maxes to the live count measured on this branch point:

| Rule | Old | New |
|---|---|---|
| no-console | 484 | 12 |
| local/no-large-inline-object-arg | 560 | 469 |
| local/no-long-condition-chain | 265 | 217 |
| complexity | 140 | 121 |
| max-depth | 70 | 55 |

The `target` values stay as the aspirational goals. `@typescript-eslint/no-explicit-any` keeps its headroom untouched for the same reason `reportAny` and ANN401 do on the Python side: building on an already `any`-typed API can force a new `any` that only a disproportionate refactor could avoid

One difference from the Python gates worth naming: this budget check has no merge-base guard, so a max at the live count means the very next violation fails frontend lint outright rather than being weighed against drift in the base. That is exactly how the eslint budgets have always worked; this PR just removes the slack

No tests are added because no code changes; the check enforcing these maxes is `ui/litellm-dashboard/scripts/check-lint-budgets.mjs`, exercised in CI by the frontend-lint job and shown failing above

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change to lint budget thresholds; no runtime or application behavior.
> 
> **Overview**
> **Tightens five dashboard ESLint budget ceilings** in `eslint-budgets.json` so each `max` matches the current violation count on the branch, removing large stale headroom (notably `no-console`, from 484 down to 12).
> 
> `target` values are unchanged and `@typescript-eslint/no-explicit-any` still keeps intentional headroom. **Net-new violations** in those five rules now fail `check-lint-budgets.mjs` / frontend lint immediately instead of slipping in under inflated caps—same mechanism as before, with zero slack on the local rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4b5c8f0a1101de9e14d77739044440cc97b159f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->