### PR TITLE
fix(caching): apply default_redis_ttl to Redis writes

### DIFF
--- a/litellm/caching/dual_cache.py
+++ b/litellm/caching/dual_cache.py
@@ -111,21 +111,35 @@ class DualCache(BaseCache):
         without it, backfilled entries fall to ``InMemoryCache``'s own default
         TTL and can outlive the TTL this cache was configured with.
         """
-        if "ttl" not in kwargs and self.default_in_memory_ttl is not None:
-            return {**kwargs, "ttl": self.default_in_memory_ttl}
-        return kwargs
+        return self._write_kwargs(kwargs, self.default_in_memory_ttl)
+
+    @property
+    def _redis_write_ttl(self) -> float | None:
+        """
+        Default TTL for a Redis write.
+
+        ``default_redis_ttl`` when set, else ``default_in_memory_ttl`` so callers that
+        configure only the in-memory tier keep the Redis TTL they have always had.
+        """
+        if self.default_redis_ttl is not None:
+            return self.default_redis_ttl
+        return self.default_in_memory_ttl
+
+    @staticmethod
+    def _write_kwargs(kwargs: "dict[str, object]", default_ttl: float | None) -> "dict[str, object]":
+        """Kwargs for one tier's write: apply ``default_ttl`` unless the caller passed an explicit ``ttl``."""
+        if "ttl" in kwargs or default_ttl is None:
+            return kwargs
+        return {**kwargs, "ttl": default_ttl}
 
     def set_cache(self, key, value, local_only: bool = False, **kwargs):
         # Update both Redis and in-memory cache
         try:
             if self.in_memory_cache is not None:
-                if "ttl" not in kwargs and self.default_in_memory_ttl is not None:
-                    kwargs["ttl"] = self.default_in_memory_ttl
-
-                self.in_memory_cache.set_cache(key, value, **kwargs)
+                self.in_memory_cache.set_cache(key, value, **self._write_kwargs(kwargs, self.default_in_memory_ttl))
 
             if self.redis_cache is not None and local_only is False:
-                self.redis_cache.set_cache(key, value, **kwargs)
+                self.redis_cache.set_cache(key, value, **self._write_kwargs(kwargs, self._redis_write_ttl))
         except Exception as e:
             print_verbose(e)
 
@@ -340,12 +354,12 @@ class DualCache(BaseCache):
         print_verbose(f"async set cache: cache key: {key}; local_only: {local_only}; value: {value}")
         try:
             if self.in_memory_cache is not None:
-                if "ttl" not in kwargs and self.default_in_memory_ttl is not None:
-                    kwargs["ttl"] = self.default_in_memory_ttl
-                await self.in_memory_cache.async_set_cache(key, value, **kwargs)
+                await self.in_memory_cache.async_set_cache(
+                    key, value, **self._write_kwargs(kwargs, self.default_in_memory_ttl)
+                )
 
             if self.redis_cache is not None and local_only is False:
-                await self.redis_cache.async_set_cache(key, value, **kwargs)
+                await self.redis_cache.async_set_cache(key, value, **self._write_kwargs(kwargs, self._redis_write_ttl))
         except Exception as e:
             verbose_logger.exception("LiteLLM Cache: Excepton async add_cache: %s", e)
 
@@ -357,13 +371,13 @@ class DualCache(BaseCache):
         print_verbose(f"async batch set cache: cache keys: {cache_list}; local_only: {local_only}")
         try:
             if self.in_memory_cache is not None:
-                if "ttl" not in kwargs and self.default_in_memory_ttl is not None:
-                    kwargs["ttl"] = self.default_in_memory_ttl
-                await self.in_memory_cache.async_set_cache_pipeline(cache_list=cache_list, **kwargs)
+                await self.in_memory_cache.async_set_cache_pipeline(
+                    cache_list=cache_list, **self._write_kwargs(kwargs, self.default_in_memory_ttl)
+                )
 
             if self.redis_cache is not None and local_only is False:
                 await self.redis_cache.async_set_cache_pipeline(
-                    cache_list=cache_list, ttl=kwargs.pop("ttl", None), **kwargs
+                    cache_list=cache_list, **self._write_kwargs(kwargs, self._redis_write_ttl)
                 )
         except Exception as e:
             verbose_logger.exception("LiteLLM Cache: Excepton async add_cache: %s", e)

--- a/tests/test_litellm/caching/test_dual_cache.py
+++ b/tests/test_litellm/caching/test_dual_cache.py
@@ -445,3 +445,93 @@ async def test_dual_cache_late_attach_redis_wires_writes_and_ttl_async():
     assert mock_redis.async_set_cache.call_args[0][:2] == (key_after, val_after)
 
     assert in_memory.get_cache(key_after) == val_after
+
+
+def _redis_ttl(mock_call):
+    return mock_call.kwargs.get("ttl")
+
+
+def test_default_redis_ttl_applies_to_sync_redis_write():
+    mock_redis = MagicMock(spec=RedisCache)
+    dual_cache = DualCache(
+        in_memory_cache=InMemoryCache(), redis_cache=mock_redis, default_redis_ttl=600.0
+    )
+
+    dual_cache.set_cache("key", "value")
+
+    assert _redis_ttl(mock_redis.set_cache.call_args) == 600.0
+
+
+@pytest.mark.asyncio
+async def test_default_redis_ttl_applies_to_async_redis_writes():
+    mock_redis = MagicMock(spec=RedisCache)
+    mock_redis.async_set_cache = AsyncMock()
+    mock_redis.async_set_cache_pipeline = AsyncMock()
+    dual_cache = DualCache(
+        in_memory_cache=InMemoryCache(), redis_cache=mock_redis, default_redis_ttl=600.0
+    )
+
+    await dual_cache.async_set_cache("key", "value")
+    await dual_cache.async_set_cache_pipeline([("key", "value")])
+
+    assert _redis_ttl(mock_redis.async_set_cache.call_args) == 600.0
+    assert _redis_ttl(mock_redis.async_set_cache_pipeline.call_args) == 600.0
+
+
+def test_update_cache_ttl_redis_only_applies_to_redis_write():
+    mock_redis = MagicMock(spec=RedisCache)
+    dual_cache = DualCache(in_memory_cache=InMemoryCache(), redis_cache=mock_redis)
+
+    dual_cache.update_cache_ttl(default_in_memory_ttl=None, default_redis_ttl=600.0)
+    dual_cache.set_cache("key", "value")
+
+    assert _redis_ttl(mock_redis.set_cache.call_args) == 600.0
+
+
+def test_attach_redis_cache_default_redis_ttl_applies_to_redis_write():
+    mock_redis = MagicMock(spec=RedisCache)
+    dual_cache = DualCache(in_memory_cache=InMemoryCache())
+
+    dual_cache.attach_redis_cache(mock_redis, default_redis_ttl=600.0)
+    dual_cache.set_cache("key", "value")
+
+    assert _redis_ttl(mock_redis.set_cache.call_args) == 600.0
+
+
+def test_explicit_ttl_overrides_default_redis_ttl():
+    mock_redis = MagicMock(spec=RedisCache)
+    dual_cache = DualCache(
+        in_memory_cache=InMemoryCache(),
+        redis_cache=mock_redis,
+        default_in_memory_ttl=300.0,
+        default_redis_ttl=600.0,
+    )
+
+    dual_cache.set_cache("key", "value", ttl=42)
+
+    assert _redis_ttl(mock_redis.set_cache.call_args) == 42
+
+
+def test_default_in_memory_ttl_still_propagates_to_redis_when_no_redis_ttl():
+    mock_redis = MagicMock(spec=RedisCache)
+    dual_cache = DualCache(
+        in_memory_cache=InMemoryCache(), redis_cache=mock_redis, default_in_memory_ttl=5.0
+    )
+
+    dual_cache.set_cache("key", "value")
+
+    assert _redis_ttl(mock_redis.set_cache.call_args) == 5.0
+
+
+def test_default_redis_ttl_does_not_leak_into_in_memory_write():
+    mock_in_memory = MagicMock(spec=InMemoryCache)
+    dual_cache = DualCache(
+        in_memory_cache=mock_in_memory,
+        redis_cache=MagicMock(spec=RedisCache),
+        default_in_memory_ttl=300.0,
+        default_redis_ttl=600.0,
+    )
+
+    dual_cache.set_cache("key", "value")
+
+    assert _redis_ttl(mock_in_memory.set_cache.call_args) == 300.0


### PR DESCRIPTION
## TLDR

Problem this solves:

- `DualCache.default_redis_ttl` was never applied to Redis writes
- Redis keys silently fell back to `RedisCache.default_ttl` (60s)
- `user_api_key_cache_ttl`, CLI SSO sessions got the wrong Redis expiry
- `default_in_memory_ttl` leaked into Redis writes via mutated `kwargs`

How it solves it:

- Each tier now builds its own write kwargs, no shared mutation
- Redis writes use `default_redis_ttl`, falling back to `default_in_memory_ttl`
- An explicit `ttl=` argument still wins over both defaults
- Covers `set_cache`, `async_set_cache`, and `async_set_cache_pipeline`

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy capture is still pending and will be posted here shortly

The setup is a proxy on `localhost:4000` backed by a real Redis, calling Anthropic for real, configured with `general_settings.user_api_key_cache_ttl: 300` and `litellm_settings.enable_redis_auth_cache: true`. That config path calls `user_api_key_cache.update_cache_ttl(default_in_memory_ttl=300, default_redis_ttl=300)`, so the virtual key's Redis entry should expire in 300 seconds. Before, at `732bba00`, the entry ignores the configured 300 and expires on `RedisCache`'s own 60 second default. After, at `fba12c38`, it carries the configured 300

Commands, run once on each commit:

1. `redis-cli FLUSHALL`
2. Start the proxy: `python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log`
3. Mint a key: `curl -sS -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"models": ["claude-sonnet-5"]}'`
4. Spend on it: `curl -sS -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer <generated key>" -H "Content-Type: application/json" -d '{"model": "claude-sonnet-5", "messages": [{"role": "user", "content": "say hi"}]}'`
5. Read the TTL the auth cache wrote: `for k in $(redis-cli --scan --pattern '*<generated key hash>*'); do echo "$k -> $(redis-cli TTL "$k")"; done`

## Type

🐛 Bug Fix

## Changes

`litellm/caching/dual_cache.py` gains a `_write_kwargs` helper that returns the kwargs for one tier's write, applying that tier's default TTL only when the caller did not pass an explicit `ttl`. A `_redis_write_ttl` property picks `default_redis_ttl` when set and otherwise `default_in_memory_ttl`, so anyone who configures only the in-memory tier keeps the Redis TTL they have today

The three write paths (`set_cache`, `async_set_cache`, `async_set_cache_pipeline`) now derive per tier kwargs instead of mutating the shared `kwargs` dict in the in-memory branch and letting the Redis branch inherit it. `async_set_cache_pipeline` also drops its `ttl=kwargs.pop("ttl", None)` special case, which was how the in-memory default reached Redis on that path

`tests/test_litellm/caching/test_dual_cache.py` adds regressions for the sync write, both async writes, `update_cache_ttl`, `attach_redis_cache`, an explicit `ttl` overriding both defaults, the in-memory fallback still reaching Redis, and `default_redis_ttl` not leaking into the in-memory write

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
