### PR TITLE
docs: fix relative CONTRIBUTING/LICENSE links in proxy client README

### DIFF
--- a/litellm/proxy/client/README.md
+++ b/litellm/proxy/client/README.md
@@ -294,11 +294,11 @@ keys = client.keys.list(
 
 ## Contributing
 
-Contributions are welcome! Please check out our [contributing guidelines](../../CONTRIBUTING.md) for details.
+Contributions are welcome! Please check out our [contributing guidelines](../../../CONTRIBUTING.md) for details.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](../../LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](../../../LICENSE) file for details.
 
 ## CLI Authentication Flow
 


### PR DESCRIPTION
## What

`litellm/proxy/client/README.md` is three directories deep (`litellm/proxy/client/`), but its **Contributing** and **License** links use `../../`, which resolves to the `litellm/` package directory instead of the repo root. Both links currently 404 on GitHub.

This changes them to `../../../` so they correctly point to the root `CONTRIBUTING.md` and `LICENSE`.

| Link | Before | After |
|------|--------|-------|
| contributing guidelines | `../../CONTRIBUTING.md` | `../../../CONTRIBUTING.md` |
| LICENSE | `../../LICENSE` | `../../../LICENSE` |

Verified both targets resolve from the file location. Docs-only change.