### PR TITLE
fix(openai): map missing-credentials errors to 400 instead of 500

### DIFF
--- a/litellm/llms/openai/openai.py
+++ b/litellm/llms/openai/openai.py
@@ -797,7 +797,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         except OpenAIError as e:
             raise e
         except Exception as e:
-            status_code: Final = getattr(e, "status_code", 500)
+            status_code: Final = getattr(e, "status_code", 400)
             error_headers = getattr(e, "headers", None)
             error_text: Final = getattr(e, "text", str(e))
             error_response: Final = getattr(e, "response", None)
@@ -920,7 +920,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 # e.message
             except Exception as e:
                 exception_response = getattr(e, "response", None)
-                status_code = getattr(e, "status_code", 500)
+                status_code = getattr(e, "status_code", 400)
                 exception_body = getattr(e, "body", None)
                 error_headers = getattr(e, "headers", None)
                 if error_headers is None and exception_response:
@@ -1075,7 +1075,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                     raise e
 
                 error_headers = getattr(e, "headers", None)
-                status_code = getattr(e, "status_code", 500)
+                status_code = getattr(e, "status_code", 400)
                 error_response = getattr(e, "response", None)
                 exception_body = getattr(e, "body", None)
                 if error_headers is None and error_response:
@@ -1097,14 +1097,14 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                         )
                     elif hasattr(e, "status_code"):
                         raise OpenAIError(
-                            status_code=getattr(e, "status_code", 500),
+                            status_code=getattr(e, "status_code", 400),
                             message=str(e),
                             headers=error_headers,
                             body=exception_body,
                         )
                     else:
                         raise OpenAIError(
-                            status_code=500,
+                            status_code=400,
                             message=f"{e}",
                             headers=error_headers,
                             body=exception_body,
@@ -1228,7 +1228,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 additional_args={"complete_input_dict": data},
                 original_response=str(e),
             )
-            status_code: Final = getattr(e, "status_code", 500)
+            status_code: Final = getattr(e, "status_code", 400)
             error_headers = getattr(e, "headers", None)
             error_text: Final = getattr(e, "text", str(e))
             error_response: Final = getattr(e, "response", None)
@@ -1314,7 +1314,7 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
         except OpenAIError as e:
             raise e
         except Exception as e:
-            status_code: Final = getattr(e, "status_code", 500)
+            status_code: Final = getattr(e, "status_code", 400)
             error_headers = getattr(e, "headers", None)
             error_text: Final = getattr(e, "text", str(e))
             error_response: Final = getattr(e, "response", None)
@@ -1468,9 +1468,9 @@ class OpenAIChatCompletion(BaseLLM, BaseOpenAILLM):
                 original_response=str(e),
             )
             if hasattr(e, "status_code"):
-                raise OpenAIError(status_code=getattr(e, "status_code", 500), message=str(e))
+                raise OpenAIError(status_code=getattr(e, "status_code", 400), message=str(e))
             else:
-                raise OpenAIError(status_code=500, message=str(e))
+                raise OpenAIError(status_code=400, message=str(e))
 
     def audio_speech(
         self,

--- a/tests/test_litellm/llms/openai/completion/test_completion_handler.py
+++ b/tests/test_litellm/llms/openai/completion/test_completion_handler.py
@@ -7,7 +7,9 @@ Regression tests for https://github.com/BerriAI/litellm/issues/27410
 
 import os
 import sys
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import openai
 import pytest
 import respx
 from httpx import Response
@@ -16,11 +18,13 @@ sys.path.insert(0, os.path.abspath("../../../../.."))
 
 import litellm
 from litellm import atext_completion, text_completion
+from litellm.llms.openai.common_utils import OpenAIError
+from litellm.llms.openai.openai import OpenAIChatCompletion
 
 
 @pytest.fixture(autouse=True)
 def setup_env(monkeypatch):
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "***")
 
 
 @pytest.fixture
@@ -91,3 +95,57 @@ async def test_acompletion_forwards_client_headers_to_provider(
 
     request_headers = mock_completions_endpoint.calls.last.request.headers
     assert request_headers["x-mycorp-llmcall-id"] == "abc-123"
+
+
+class TestMissingCredentialsStatusMapping:
+    """Regression for #35860: client-construction errors (no HTTP exchange, no
+    ``status_code`` attribute) must map to 400 so retry logic does not treat a
+    permanent configuration error as a transient server error."""
+
+    def test_sync_missing_credentials_maps_to_400(self):
+        openai_chat = OpenAIChatCompletion()
+
+        with patch.object(
+            openai_chat,
+            "_get_openai_client",
+            side_effect=openai.OpenAIError(
+                "Missing credentials. Please pass one of api_key, azure_ad_token, azure_ad_token_provider, ..."
+            ),
+        ):
+            with pytest.raises(OpenAIError) as exc_info:
+                openai_chat.completion(
+                    model_response=MagicMock(),
+                    timeout=30.0,
+                    optional_params={},
+                    litellm_params={},
+                    logging_obj=MagicMock(),
+                    model="gpt-4o",
+                    messages=[{"role": "user", "content": "test"}],
+                )
+
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_async_missing_credentials_maps_to_400(self):
+        openai_chat = OpenAIChatCompletion()
+
+        with patch.object(
+            openai_chat,
+            "_get_openai_client",
+            side_effect=openai.OpenAIError(
+                "Missing credentials. Please pass one of api_key, azure_ad_token, azure_ad_token_provider, ..."
+            ),
+        ):
+            with pytest.raises(OpenAIError) as exc_info:
+                await openai_chat.acompletion(
+                    model_response=MagicMock(),
+                    timeout=30.0,
+                    optional_params={},
+                    litellm_params={},
+                    logging_obj=MagicMock(),
+                    model="gpt-4o",
+                    messages=[{"role": "user", "content": "test"}],
+                    provider_config=AsyncMock(),
+                )
+
+        assert exc_info.value.status_code == 400


### PR DESCRIPTION
## TLDR

Problem this solves:

- Missing API key (or other client-construction error) is reported as 500 InternalServerError
- 500 is retryable under standard retry policies, so a permanent config error gets retried until attempts run out
- The useful "Missing credentials" message only surfaces last

How it solves it:

- Default `status_code` to 400 instead of 500 when the OpenAI SDK exception carries no `status_code` (i.e. no HTTP exchange happened)
- 400 maps to BadRequestError — non-retryable, error surfaces immediately

## Relevant issues

Fixes #35860

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
