### PR TITLE
fix(vertex_ai): preserve oneOf unions and null branches that follow a removed null

### DIFF
--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -574,6 +574,42 @@ def _fix_enum_types(schema, depth=0):
                 _fix_enum_types(item, depth=depth + 1)
 
 
+def _convert_oneof_to_anyof(schema, depth=0):
+    if depth > DEFAULT_MAX_RECURSE_DEPTH:
+        raise ValueError(
+            f"Max depth of {DEFAULT_MAX_RECURSE_DEPTH} exceeded while processing schema. Please check the schema for excessive nesting."
+        )
+
+    if not isinstance(schema, dict):
+        return
+
+    oneof = schema.get("oneOf", None)
+    if (
+        isinstance(oneof, list)
+        and "anyOf" not in schema
+        and "type" not in schema
+        and "properties" not in schema
+        and "items" not in schema
+    ):
+        schema.pop("oneOf")
+        schema["anyOf"] = oneof
+
+    properties: Final = schema.get("properties", None)
+    if properties is not None:
+        for value in properties.values():
+            _convert_oneof_to_anyof(value, depth=depth + 1)
+
+    items: Final = schema.get("items", None)
+    if items is not None:
+        _convert_oneof_to_anyof(items, depth=depth + 1)
+
+    anyof: Final = schema.get("anyOf", None)
+    if anyof is not None and isinstance(anyof, list):
+        for item in anyof:
+            if isinstance(item, dict):
+                _convert_oneof_to_anyof(item, depth=depth + 1)
+
+
 def _build_vertex_schema(parameters: dict, add_property_ordering: bool = False):
     """
     This is a modified version of https://github.com/google-gemini/generative-ai-python/blob/8f77cc6ac99937cd3a81299ecf79608b91b06bbb/google/generativeai/types/content_types.py#L419
@@ -596,6 +632,8 @@ def _build_vertex_schema(parameters: dict, add_property_ordering: bool = False):
     # with circular references (see issue #19098). unpack_defs handles nested
     # refs recursively and correctly detects/skips circular references.
     unpack_defs(parameters, defs)
+
+    _convert_oneof_to_anyof(parameters)
 
     # 5. Nullable fields:
     #     * https://github.com/pydantic/pydantic/issues/1270
@@ -782,7 +820,7 @@ def convert_anyof_null_to_nullable(schema, depth=0):
     anyof: Final = schema.get("anyOf", None)
     if anyof is not None:
         contains_null = False
-        for atype in anyof:
+        for atype in list(anyof):
             if isinstance(atype, dict) and atype.get("type") == "null":
                 # remove null type
                 anyof.remove(atype)

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -574,7 +574,7 @@ def _fix_enum_types(schema, depth=0):
                 _fix_enum_types(item, depth=depth + 1)
 
 
-def _convert_oneof_to_anyof(schema, depth=0):
+def _convert_oneof_to_anyof(schema: dict[str, Any], depth: int = 0) -> None:
     if depth > DEFAULT_MAX_RECURSE_DEPTH:
         raise ValueError(
             f"Max depth of {DEFAULT_MAX_RECURSE_DEPTH} exceeded while processing schema. Please check the schema for excessive nesting."

--- a/litellm/llms/vertex_ai/common_utils.py
+++ b/litellm/llms/vertex_ai/common_utils.py
@@ -820,7 +820,7 @@ def convert_anyof_null_to_nullable(schema, depth=0):
     anyof: Final = schema.get("anyOf", None)
     if anyof is not None:
         contains_null = False
-        for atype in list(anyof):
+        for atype in tuple(anyof):
             if isinstance(atype, dict) and atype.get("type") == "null":
                 # remove null type
                 anyof.remove(atype)

--- a/tests/code_coverage_tests/recursive_detector.py
+++ b/tests/code_coverage_tests/recursive_detector.py
@@ -11,6 +11,7 @@ IGNORE_FUNCTIONS = [
     "clean_message",
     "unpack_defs",
     "convert_anyof_null_to_nullable",  # has a set max depth
+    "_convert_oneof_to_anyof",  # has a set max depth
     "add_object_type",
     "strip_field",
     "_transform_prompt",

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -81,6 +81,86 @@ def test_basic_anyof_conversion():
     assert schema == expected
 
 
+def test_anyof_conversion_with_null_before_other_branches():
+    schema = {
+        "type": "object",
+        "properties": {
+            "example": {
+                "anyOf": [{"type": "null"}, {"type": "null"}, {"type": "string"}]
+            }
+        },
+    }
+
+    convert_anyof_null_to_nullable(schema)
+
+    expected = {
+        "type": "object",
+        "properties": {"example": {"anyOf": [{"type": "string", "nullable": True}]}},
+    }
+    assert schema == expected
+
+
+def test_build_vertex_schema_preserves_oneof_unions():
+    from litellm.llms.vertex_ai.common_utils import _build_vertex_schema
+
+    parameters = {
+        "$defs": {
+            "Card": {
+                "type": "object",
+                "properties": {"kind": {"type": "string"}, "number": {"type": "string"}},
+                "required": ["kind", "number"],
+            },
+            "Bank": {
+                "type": "object",
+                "properties": {"kind": {"type": "string"}, "iban": {"type": "string"}},
+                "required": ["kind", "iban"],
+            },
+        },
+        "type": "object",
+        "properties": {
+            "payment": {
+                "oneOf": [{"$ref": "#/$defs/Card"}, {"$ref": "#/$defs/Bank"}],
+                "discriminator": {"propertyName": "kind"},
+            }
+        },
+        "required": ["payment"],
+    }
+
+    result = _build_vertex_schema(parameters)
+
+    assert result["properties"]["payment"] == {
+        "anyOf": [
+            {
+                "type": "object",
+                "properties": {"kind": {"type": "string"}, "number": {"type": "string"}},
+                "required": ["kind", "number"],
+            },
+            {
+                "type": "object",
+                "properties": {"kind": {"type": "string"}, "iban": {"type": "string"}},
+                "required": ["kind", "iban"],
+            },
+        ]
+    }
+
+
+def test_build_vertex_schema_converts_null_branch_inside_oneof():
+    from litellm.llms.vertex_ai.common_utils import _build_vertex_schema
+
+    parameters = {
+        "type": "object",
+        "properties": {
+            "value": {"oneOf": [{"type": "string"}, {"type": "null"}]}
+        },
+    }
+
+    result = _build_vertex_schema(parameters)
+
+    assert result["properties"]["value"] == {
+        "anyOf": [{"type": "string", "nullable": True}]
+    }
+
+
 def test_nested_anyof_conversion():
     """Test nested conversion with 'anyOf' inside properties."""
     schema = {

--- a/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
+++ b/tests/test_litellm/llms/vertex_ai/test_vertex_ai_common_utils.py
@@ -144,6 +144,32 @@ def test_build_vertex_schema_preserves_oneof_unions():
     }
 
 
+def test_oneof_conversion_with_excessive_nesting():
+    from litellm.llms.vertex_ai.common_utils import _convert_oneof_to_anyof
+
+    schema = {"type": "object", "properties": {}}
+    current = schema
+    for _ in range(DEFAULT_MAX_RECURSE_DEPTH + 1):
+        current["properties"] = {"nested": {"oneOf": [{"type": "string"}], "properties": {}}}
+        current = current["properties"]["nested"]
+
+    with pytest.raises(
+        ValueError,
+        match=f"Max depth of {DEFAULT_MAX_RECURSE_DEPTH} exceeded while processing schema. Please check the schema for excessive nesting.",
+    ):
+        _convert_oneof_to_anyof(schema)
+
+
+def test_oneof_conversion_ignores_non_dict_nodes():
+    from litellm.llms.vertex_ai.common_utils import _convert_oneof_to_anyof
+
+    schema = {"type": "object", "properties": {"tags": {"type": "array", "items": "string"}}}
+
+    _convert_oneof_to_anyof(schema)
+
+    assert schema == {"type": "object", "properties": {"tags": {"type": "array", "items": "string"}}}
+
+
 def test_build_vertex_schema_converts_null_branch_inside_oneof():
     from litellm.llms.vertex_ai.common_utils import _build_vertex_schema
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Vertex/Gemini schema filtering drops oneOf unions entirely
- pydantic discriminated unions in tool args become empty schemas
- removing a null anyOf branch skips the branch after it

How it solves it:

- convert pure oneOf union nodes to anyOf before filtering
- iterate a copy of anyOf when removing null branches

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This is a request-transformation bug, so the proof is the transformed request body itself: the output of `_build_vertex_schema` below is byte-for-byte what gets sent as `parameters` to Vertex. I did not run a live Vertex call because I have no GCP credentials on this machine; the diff below is deterministic and independent of the network

Repro schema is what pydantic emits for a discriminated union tool argument:

```bash
python -c "
import json
from litellm.llms.vertex_ai.common_utils import _build_vertex_schema
s={'\$defs':{'Card':{'type':'object','properties':{'kind':{'type':'string'},'number':{'type':'string'}},'required':['kind','number']},'Bank':{'type':'object','properties':{'kind':{'type':'string'},'iban':{'type':'string'}},'required':['kind','iban']}},'type':'object','properties':{'payment':{'oneOf':[{'\$ref':'#/\$defs/Card'},{'\$ref':'#/\$defs/Bank'}],'discriminator':{'propertyName':'kind'}}},'required':['payment']}
print(json.dumps(_build_vertex_schema(s)['properties']['payment']))"
```

Before (b7355788): the union vanishes while `required` still demands the field

```
{}
```

After (ffa04acc): both branches survive as anyOf

```
{"anyOf": [{"type": "object", "properties": {"kind": {"type": "string"}, "number": {"type": "string"}}, "required": ["kind", "number"]}, {"type": "object", "properties": {"kind": {"type": "string"}, "iban": {"type": "string"}}, "required": ["kind", "iban"]}]}
```

Second bug, same area: `convert_anyof_null_to_nullable` removes null branches from the list it is iterating, so the element after each removed null is skipped. With `anyOf: [null, null, string]` the second null used to survive into the request as an invalid `{"type": "null", "nullable": true}` branch; now only `{"type": "string", "nullable": true}` remains

Hybrid nodes that carry oneOf next to a full object definition (type plus properties) keep today's behavior, which `test_vertex_ai_complex_response_schema` locks in; only pure union nodes are converted

## Type

🐛 Bug Fix

## Changes

`_convert_oneof_to_anyof` runs right after `unpack_defs` in `_build_vertex_schema`, so null branches inside a converted union get the existing nullable treatment and the union survives `filter_schema_fields` (Vertex's Schema has `anyOf` but no `oneOf`). `convert_anyof_null_to_nullable` now iterates a copy of the list it mutates. Three regression tests added in the mapped test file; the module passes 76/76 and the wider `tests/test_litellm/llms/vertex_ai/` failures are identical before and after the change on my machine

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
