### PR TITLE
fix(datadog_llm_obs): map tool_calls to DD Message schema and cache tokens to span metrics

### DIFF
--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -57,7 +57,7 @@ def _parse_tool_call_arguments(raw: object) -> object:
         return raw
     try:
         return json.loads(raw)
-    except json.JSONDecodeError:
+    except (RecursionError, json.JSONDecodeError):
         return raw
 
 

--- a/litellm/integrations/datadog/datadog_llm_obs.py
+++ b/litellm/integrations/datadog/datadog_llm_obs.py
@@ -9,7 +9,9 @@ API Reference: https://docs.datadoghq.com/llm_observability/setup/api/?tab=examp
 import asyncio
 import json
 import os
+from collections.abc import Mapping, Sequence
 from datetime import datetime
+from types import MappingProxyType
 from typing import Any, Final, Literal
 
 import httpx
@@ -42,6 +44,21 @@ from litellm.types.utils import (
     StandardLoggingPayload,
     StandardLoggingPayloadErrorInformation,
 )
+
+_EMPTY_MAPPING: Final[Mapping[str, Any]] = MappingProxyType({})
+_EMPTY_CACHE_METRICS: Final[Mapping[str, float]] = MappingProxyType({})
+
+
+def _parse_tool_call_arguments(raw: object) -> object:
+    """
+    Decode a tool call's `arguments` payload, keeping the raw string when it is not valid JSON.
+    """
+    if not isinstance(raw, str):
+        return raw
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
 
 
 class DataDogLLMObsLogger(CustomBatchLogger):
@@ -256,6 +273,7 @@ class DataDogLLMObsLogger(CustomBatchLogger):
             total_cost=float(standard_logging_payload.get("response_cost", 0)),
             time_to_first_token=self._get_time_to_first_token_seconds(standard_logging_payload),
         )
+        metrics.update(self._get_cache_token_metrics(standard_logging_payload))
 
         payload: Final[LLMObsPayload] = LLMObsPayload(
             parent_id=metadata_parent_id if metadata_parent_id else "undefined",
@@ -312,6 +330,45 @@ class DataDogLLMObsLogger(CustomBatchLogger):
                     stack=error_information.get("traceback"),
                 )
         return error_info
+
+    def _get_usage_object(self, standard_logging_payload: StandardLoggingPayload) -> Mapping[str, Any]:
+        """Locate the provider usage object, preferring metadata over hidden_params."""
+        for container_key in ("metadata", "hidden_params"):
+            container = standard_logging_payload.get(container_key)
+            if isinstance(container, dict):
+                usage_object = container.get("usage_object")
+                if isinstance(usage_object, dict):
+                    return usage_object
+        return _EMPTY_MAPPING
+
+    def _get_cache_token_metrics(self, standard_logging_payload: StandardLoggingPayload) -> Mapping[str, float]:
+        """
+        Extract prompt-cache token counts from the usage object as DD span metrics.
+
+        DD's UI computes cache hit ratios from `metrics.cache_read_input_tokens` /
+        `metrics.cache_write_input_tokens` on the span; the values nested inside
+        `meta.metadata.usage_object` are not parsed for this purpose.
+        """
+        try:
+            usage_object: Final = self._get_usage_object(standard_logging_payload)
+            cache_read: Final = usage_object.get("cache_read_input_tokens") or 0
+            cache_write: Final = usage_object.get("cache_creation_input_tokens") or 0
+            if not cache_read and not cache_write:
+                return _EMPTY_CACHE_METRICS
+
+            prompt_tokens: Final = usage_object.get("prompt_tokens") or standard_logging_payload.get("prompt_tokens", 0)
+            pairs: Final = (
+                ("cache_read_input_tokens", float(cache_read) if cache_read else None),
+                ("cache_write_input_tokens", float(cache_write) if cache_write else None),
+                (
+                    "non_cached_input_tokens",
+                    max(float(prompt_tokens) - float(cache_read), 0.0) if prompt_tokens else None,
+                ),
+            )
+            return MappingProxyType({key: value for key, value in pairs if value is not None})
+        except (TypeError, ValueError) as e:
+            verbose_logger.debug("DataDogLLMObs: Error extracting cache token metrics: %s", e)
+            return _EMPTY_CACHE_METRICS
 
     def _get_time_to_first_token_seconds(self, standard_logging_payload: StandardLoggingPayload) -> float:
         """
@@ -374,12 +431,64 @@ class DataDogLLMObsLogger(CustomBatchLogger):
                 if isinstance(response_obj, dict) and "choices" in response_obj:
                     choices: Final = response_obj["choices"]
                     if choices and len(choices) > 0 and "message" in choices[0]:
-                        return [choices[0]["message"]]
+                        return [self._to_dd_output_message(choices[0]["message"])]
                 return []
             except (KeyError, IndexError, TypeError):
                 # In case of any error accessing the response structure, return empty list
                 return []
         return []
+
+    def _to_dd_output_message(self, message: object) -> object:
+        """
+        Map a chat-completion response message to DD LLM Obs' Message schema.
+
+        DD renders tool calls from `meta.output.messages[].tool_calls` (ToolCall
+        schema: name / arguments / tool_id / type), not from the OpenAI-style
+        nested `function` dict, so passing the raw message through leaves the
+        Tools panel empty even though the data is present.
+        Ref: https://docs.datadoghq.com/llm_observability/setup/api/
+        """
+        if not isinstance(message, dict):
+            return message
+
+        tool_calls: Final = message.get("tool_calls")
+        dd_tool_calls: Final = self._map_tool_calls_to_dd_schema(tool_calls) if tool_calls else ()
+
+        dd_message: Final[dict[str, Any]] = {  # mutable-ok: JSON body serialized into the DD intake payload
+            "role": message.get("role", "assistant"),
+            "content": message.get("content") or "",
+        }
+        if dd_tool_calls:
+            dd_message["tool_calls"] = list(dd_tool_calls)  # mutable-ok: serialized into the DD JSON payload
+        return dd_message
+
+    @staticmethod
+    def _map_tool_calls_to_dd_schema(
+        tool_calls: Sequence[object],
+    ) -> Sequence[dict[str, Any]]:  # mutable-ok: JSON payload dicts
+        """
+        Convert OpenAI-style tool calls to DD LLM Obs ToolCall dicts.
+
+        OpenAI: {"id", "type", "function": {"name", "arguments": "<json str>"}}
+        DD:     {"name", "arguments": <dict>, "tool_id", "type"}
+        """
+
+        def to_dd_tool_call(tool_call: Mapping[str, Any]) -> dict[str, Any]:  # mutable-ok: JSON payload dict
+            function: Final = tool_call.get("function")
+            function_map: Final[Mapping[str, Any]] = function if isinstance(function, dict) else _EMPTY_MAPPING
+            arguments: Final = _parse_tool_call_arguments(function_map.get("arguments"))
+            return {  # mutable-ok: JSON body serialized as-is into the DD intake payload
+                "name": function_map.get("name", ""),
+                "arguments": arguments if arguments is not None else {},  # mutable-ok: JSON payload value
+                "tool_id": tool_call.get("id", ""),
+                "type": tool_call.get("type", "function"),
+            }
+
+        try:
+            return tuple(to_dd_tool_call(tool_call) for tool_call in tool_calls if isinstance(tool_call, dict))
+        except (KeyError, TypeError, ValueError) as e:
+            verbose_logger.debug("DataDogLLMObs: Error mapping tool call to DD schema: %s", e)
+            return ()
 
     def _get_datadog_span_kind(
         self, call_type: str | None, parent_id: str | None = None

--- a/litellm/types/integrations/datadog_llm_obs.py
+++ b/litellm/types/integrations/datadog_llm_obs.py
@@ -45,6 +45,9 @@ class LLMMetrics(TypedDict, total=False):
     time_to_first_token: float
     time_per_output_token: float
     total_cost: float
+    cache_read_input_tokens: float
+    cache_write_input_tokens: float
+    non_cached_input_tokens: float
 
 
 class LLMObsPayload(TypedDict, total=False):

--- a/litellm/types/integrations/datadog_llm_obs.py
+++ b/litellm/types/integrations/datadog_llm_obs.py
@@ -6,7 +6,7 @@ API Reference: https://docs.datadoghq.com/llm_observability/setup/api/?tab=examp
 
 from typing import Any, Literal
 
-from typing_extensions import TypedDict
+from typing_extensions import ReadOnly, TypedDict
 
 from litellm.types.integrations.custom_logger import StandardCustomLoggerInitParams
 
@@ -45,6 +45,9 @@ class LLMMetrics(TypedDict, total=False):
     time_to_first_token: float
     time_per_output_token: float
     total_cost: float
+    cache_read_input_tokens: ReadOnly[float]
+    cache_write_input_tokens: ReadOnly[float]
+    non_cached_input_tokens: ReadOnly[float]
 
 
 class LLMObsPayload(TypedDict, total=False):

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_obs_message_schema.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_obs_message_schema.py
@@ -1,0 +1,368 @@
+"""DD LLM Observability intake-schema mapping: tool calls into
+meta.output.messages[].tool_calls (DD ToolCall shape) and prompt-cache token
+counts into top-level span metrics."""
+
+import os
+import sys
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../.."))
+from litellm.integrations.datadog.datadog_llm_obs import DataDogLLMObsLogger
+from litellm.types.utils import StandardLoggingPayload
+
+
+def create_standard_logging_payload_with_tool_calls() -> StandardLoggingPayload:
+    """Create a StandardLoggingPayload object with tool calls for testing"""
+    return {
+        "id": "test-request-id-tool-calls",
+        "trace_id": "test-trace-id-tool-calls",
+        "call_type": "completion",
+        "stream": None,
+        "response_cost": 0.05,
+        "response_cost_failure_debug_info": None,
+        "status": "success",
+        "custom_llm_provider": "openai",
+        "total_tokens": 50,
+        "prompt_tokens": 20,
+        "completion_tokens": 30,
+        "startTime": 1234567890.0,
+        "endTime": 1234567891.0,
+        "completionStartTime": 1234567890.5,
+        "response_time": 1.0,
+        "model_map_information": {"model_map_key": "gpt-4", "model_map_value": None},
+        "model": "gpt-4",
+        "model_id": "model-123",
+        "model_group": "openai-gpt",
+        "api_base": "https://api.openai.com",
+        "metadata": {
+            "user_api_key_hash": "test_hash",
+            "user_api_key_org_id": None,
+            "user_api_key_alias": "test_alias",
+            "user_api_key_team_id": "test_team",
+            "user_api_key_user_id": "test_user",
+            "user_api_key_team_alias": "test_team_alias",
+            "user_api_key_user_email": None,
+            "user_api_key_end_user_id": None,
+            "user_api_key_request_route": None,
+            "spend_logs_metadata": None,
+            "requester_ip_address": "127.0.0.1",
+            "requester_metadata": None,
+            "requester_custom_headers": None,
+            "prompt_management_metadata": None,
+            "mcp_tool_call_metadata": None,
+            "vector_store_request_metadata": None,
+            "applied_guardrails": None,
+            "usage_object": None,
+            "cold_storage_object_key": None,
+        },
+        "cache_hit": False,
+        "cache_key": None,
+        "saved_cache_cost": 0.0,
+        "request_tags": [],
+        "end_user": None,
+        "requester_ip_address": "127.0.0.1",
+        "messages": [
+            {"role": "user", "content": "What's the weather?"},
+            {
+                "role": "assistant",
+                "content": "I'll check the weather for you.",
+                "tool_calls": [
+                    {
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"location": "NYC"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_123",
+                "content": '{"temperature": 72, "condition": "sunny"}',
+            },
+        ],
+        "response": {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "It's 72°F and sunny in NYC!",
+                        "tool_calls": [
+                            {
+                                "id": "call_456",
+                                "type": "function",
+                                "function": {
+                                    "name": "format_response",
+                                    "arguments": '{"temp": 72, "condition": "sunny"}',
+                                },
+                            }
+                        ],
+                    }
+                }
+            ]
+        },
+        "error_str": None,
+        "error_information": None,
+        "model_parameters": {"temperature": 0.7},
+        "hidden_params": {
+            "model_id": "model-123",
+            "cache_key": None,
+            "api_base": "https://api.openai.com",
+            "response_cost": "0.05",
+            "litellm_overhead_time_ms": None,
+            "additional_headers": None,
+            "batch_models": None,
+            "litellm_model_name": None,
+            "usage_object": None,
+        },
+        "guardrail_information": None,
+        "standard_built_in_tools_params": None,
+    }  # type: ignore
+
+
+class TestDataDogLLMObsLoggerToolCalls:
+    """Simple test suite for DataDog LLM Observability Logger tool call handling"""
+
+    @pytest.fixture
+    def mock_env_vars(self):
+        """Mock environment variables for DataDog"""
+        with patch.dict(os.environ, {"DD_API_KEY": "test_api_key", "DD_SITE": "us5.datadoghq.com"}):
+            yield
+
+    def test_tool_call_span_kind_mapping(self, mock_env_vars):
+        """Test that tool call operations are correctly mapped to 'tool' span kind"""
+        with (
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
+            patch("asyncio.create_task"),
+        ):
+            logger = DataDogLLMObsLogger()
+
+            # Test MCP tool call mapping
+            from litellm.types.utils import CallTypes
+
+            assert logger._get_datadog_span_kind(CallTypes.call_mcp_tool.value, "123") == "tool"
+
+    def test_tool_call_payload_creation(self, mock_env_vars):
+        """Test that tool call payloads are created correctly"""
+        with (
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
+            patch("asyncio.create_task"),
+        ):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = create_standard_logging_payload_with_tool_calls()
+
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}},
+            }
+
+            start_time = datetime.now()
+            end_time = datetime.now()
+
+            payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
+
+            # Verify basic payload structure
+            assert payload.get("name") == "litellm_llm_call"
+            assert payload.get("status") == "ok"
+            assert payload.get("meta", {}).get("kind") == "llm"  # Regular completion, not tool call
+
+            # Verify metrics
+            metrics = payload.get("metrics", {})
+            assert metrics.get("input_tokens") == 20
+            assert metrics.get("output_tokens") == 30
+            assert metrics.get("total_tokens") == 50
+
+    def test_tool_call_messages_preserved(self, mock_env_vars):
+        """Test that tool call messages are preserved in the payload"""
+        with (
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
+            patch("asyncio.create_task"),
+        ):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = create_standard_logging_payload_with_tool_calls()
+
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}},
+            }
+
+            start_time = datetime.now()
+            end_time = datetime.now()
+
+            payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
+
+            # Verify input messages include tool calls
+            meta = payload.get("meta", {})
+            input_meta = meta.get("input", {})
+            input_messages = input_meta.get("messages", [])
+            assert len(input_messages) == 3
+
+            # Check assistant message has tool calls
+            assistant_msg = input_messages[1]
+            assert assistant_msg.get("role") == "assistant"
+            assert "tool_calls" in assistant_msg
+            tool_calls = assistant_msg.get("tool_calls", [])
+            assert len(tool_calls) == 1
+            tool_call = tool_calls[0]
+            function_info = tool_call.get("function", {})
+            assert function_info.get("name") == "get_weather"
+
+            # Check tool message
+            tool_msg = input_messages[2]
+            assert tool_msg.get("role") == "tool"
+            assert tool_msg.get("tool_call_id") == "call_123"
+
+    def test_tool_call_response_handling(self, mock_env_vars):
+        """Test that tool calls in response are handled correctly"""
+        with (
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
+            patch("asyncio.create_task"),
+        ):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = create_standard_logging_payload_with_tool_calls()
+
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}},
+            }
+
+            start_time = datetime.now()
+            end_time = datetime.now()
+
+            payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
+
+            meta = payload.get("meta", {})
+            output_meta = meta.get("output", {})
+            output_messages = output_meta.get("messages", [])
+            assert len(output_messages) == 1
+
+            output_msg = output_messages[0]
+            assert output_msg.get("role") == "assistant"
+            assert output_msg.get("content") == "It's 72°F and sunny in NYC!"
+            assert "tool_calls" in output_msg
+            output_tool_calls = output_msg.get("tool_calls", [])
+            assert len(output_tool_calls) == 1
+            dd_tool_call = output_tool_calls[0]
+            assert dd_tool_call == {
+                "name": "format_response",
+                "arguments": {"temp": 72, "condition": "sunny"},
+                "tool_id": "call_456",
+                "type": "function",
+            }
+
+    def test_output_tool_call_with_unparseable_arguments(self, mock_env_vars):
+        """Malformed JSON arguments are kept as the raw string, not dropped"""
+        with (
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
+            patch("asyncio.create_task"),
+        ):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = create_standard_logging_payload_with_tool_calls()
+            standard_payload["response"]["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"] = (
+                "{not valid json"
+            )
+
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}},
+            }
+
+            payload = logger.create_llm_obs_payload(kwargs, datetime.now(), datetime.now())
+
+            tool_call = payload["meta"]["output"]["messages"][0]["tool_calls"][0]
+            assert tool_call["name"] == "format_response"
+            assert tool_call["arguments"] == "{not valid json"
+
+    def test_output_message_without_tool_calls_unchanged(self, mock_env_vars):
+        """Plain responses keep role/content and gain no tool_calls key"""
+        with (
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
+            patch("asyncio.create_task"),
+        ):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = create_standard_logging_payload_with_tool_calls()
+            standard_payload["response"] = {"choices": [{"message": {"role": "assistant", "content": "Hi!"}}]}
+
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}},
+            }
+
+            payload = logger.create_llm_obs_payload(kwargs, datetime.now(), datetime.now())
+
+            output_msg = payload["meta"]["output"]["messages"][0]
+            assert output_msg == {"role": "assistant", "content": "Hi!"}
+
+
+class TestDataDogLLMObsCacheTokenMetrics:
+    """Prompt-cache token counts must land in top-level span metrics"""
+
+    @pytest.fixture
+    def mock_env_vars(self):
+        with patch.dict(os.environ, {"DD_API_KEY": "test_api_key", "DD_SITE": "us5.datadoghq.com"}):
+            yield
+
+    def _payload_with_usage_object(self, usage_object):
+        standard_payload = create_standard_logging_payload_with_tool_calls()
+        standard_payload["metadata"]["usage_object"] = usage_object
+        return standard_payload
+
+    def test_cache_tokens_forwarded_to_span_metrics(self, mock_env_vars):
+        """cache_read/cache_creation tokens map to DD span metrics fields"""
+        with (
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
+            patch("asyncio.create_task"),
+        ):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = self._payload_with_usage_object(
+                {
+                    "cache_creation_input_tokens": 176,
+                    "cache_read_input_tokens": 16695,
+                    "prompt_tokens": 16872,
+                    "completion_tokens": 704,
+                }
+            )
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}},
+            }
+
+            payload = logger.create_llm_obs_payload(kwargs, datetime.now(), datetime.now())
+
+            metrics = payload["metrics"]
+            assert metrics["cache_read_input_tokens"] == 16695.0
+            assert metrics["cache_write_input_tokens"] == 176.0
+            assert metrics["non_cached_input_tokens"] == 177.0
+
+    def test_no_cache_metrics_when_usage_object_absent(self, mock_env_vars):
+        """Without cache activity the new metrics keys are not emitted"""
+        with (
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
+            patch("asyncio.create_task"),
+        ):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = self._payload_with_usage_object(None)
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}},
+            }
+
+            payload = logger.create_llm_obs_payload(kwargs, datetime.now(), datetime.now())
+
+            metrics = payload["metrics"]
+            assert "cache_read_input_tokens" not in metrics
+            assert "cache_write_input_tokens" not in metrics
+            assert "non_cached_input_tokens" not in metrics
+            assert metrics["input_tokens"] == 20.0

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_obs_message_schema.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_obs_message_schema.py
@@ -366,3 +366,14 @@ class TestDataDogLLMObsCacheTokenMetrics:
             assert "cache_write_input_tokens" not in metrics
             assert "non_cached_input_tokens" not in metrics
             assert metrics["input_tokens"] == 20.0
+
+
+def test_parse_tool_call_arguments_survives_deeply_nested_json():
+    """A hostile/degenerate arguments string must fall back to the raw
+    string, not raise RecursionError and drop the span."""
+    from litellm.integrations.datadog.datadog_llm_obs import (
+        _parse_tool_call_arguments,
+    )
+
+    hostile = "[" * 50000
+    assert _parse_tool_call_arguments(hostile) == hostile

--- a/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
+++ b/tests/test_litellm/integrations/datadog/test_datadog_llm_observability.py
@@ -39,9 +39,7 @@ def create_standard_logging_payload_with_cache() -> StandardLoggingPayload:
         startTime=1234567890.0,
         endTime=1234567891.0,
         completionStartTime=1234567890.5,
-        model_map_information=StandardLoggingModelInformation(
-            model_map_key="gpt-4", model_map_value=None
-        ),
+        model_map_information=StandardLoggingModelInformation(model_map_key="gpt-4", model_map_value=None),
         model="gpt-4",
         model_id="model-123",
         model_group="openai-gpt",
@@ -93,9 +91,7 @@ def create_standard_logging_payload_with_failure() -> StandardLoggingPayload:
         startTime=1234567890.0,
         endTime=1234567891.0,
         completionStartTime=1234567890.5,
-        model_map_information=StandardLoggingModelInformation(
-            model_map_key="gpt-4", model_map_value=None
-        ),
+        model_map_information=StandardLoggingModelInformation(model_map_key="gpt-4", model_map_value=None),
         model="gpt-4",
         model_id="model-123",
         model_group="openai-gpt",
@@ -146,9 +142,7 @@ class TestDataDogLLMObsLogger:
     @pytest.fixture
     def mock_env_vars(self):
         """Mock environment variables for DataDog"""
-        with patch.dict(
-            os.environ, {"DD_API_KEY": "test_api_key", "DD_SITE": "us5.datadoghq.com"}
-        ):
+        with patch.dict(os.environ, {"DD_API_KEY": "test_api_key", "DD_SITE": "us5.datadoghq.com"}):
             yield
 
     @pytest.fixture
@@ -157,15 +151,7 @@ class TestDataDogLLMObsLogger:
         mock_response = Mock()
         mock_response.__getitem__ = Mock(
             return_value={
-                "choices": [
-                    {
-                        "message": Mock(
-                            json=Mock(
-                                return_value={"role": "assistant", "content": "Hello!"}
-                            )
-                        )
-                    }
-                ]
+                "choices": [{"message": Mock(json=Mock(return_value={"role": "assistant", "content": "Hello!"}))}]
             }
         )
         return mock_response
@@ -173,9 +159,7 @@ class TestDataDogLLMObsLogger:
     def test_cost_and_trace_id_integration(self, mock_env_vars, mock_response_obj):
         """Test that total_cost is passed and trace_id from standard payload is used"""
         with (
-            patch(
-                "litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"
-            ),
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
             patch("asyncio.create_task"),
         ):
             logger = DataDogLLMObsLogger()
@@ -184,9 +168,7 @@ class TestDataDogLLMObsLogger:
 
             kwargs = {
                 "standard_logging_object": standard_payload,
-                "litellm_params": {
-                    "metadata": {"trace_id": "old-trace-id-should-be-ignored"}
-                },
+                "litellm_params": {"metadata": {"trace_id": "old-trace-id-should-be-ignored"}},
             }
 
             start_time = datetime.now()
@@ -212,9 +194,7 @@ class TestDataDogLLMObsLogger:
     def test_cache_metadata_fields(self, mock_env_vars, mock_response_obj):
         """Test that cache-related metadata fields are correctly tracked"""
         with (
-            patch(
-                "litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"
-            ),
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
             patch("asyncio.create_task"),
         ):
             logger = DataDogLLMObsLogger()
@@ -236,9 +216,7 @@ class TestDataDogLLMObsLogger:
     def test_get_time_to_first_token_seconds(self, mock_env_vars):
         """Test the _get_time_to_first_token_seconds method for streaming calls"""
         with (
-            patch(
-                "litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"
-            ),
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
             patch("asyncio.create_task"),
         ):
             logger = DataDogLLMObsLogger()
@@ -251,9 +229,7 @@ class TestDataDogLLMObsLogger:
             streaming_payload["endTime"] = 1005.0
 
             # Test streaming case: should use completion_start_time - start_time
-            time_to_first_token = logger._get_time_to_first_token_seconds(
-                streaming_payload
-            )
+            time_to_first_token = logger._get_time_to_first_token_seconds(streaming_payload)
             assert time_to_first_token == 2.0  # 1002.0 - 1000.0 = 2.0 seconds
 
     def test_datadog_span_kind_mapping(self, mock_env_vars):
@@ -261,76 +237,37 @@ class TestDataDogLLMObsLogger:
         from litellm.types.utils import CallTypes
 
         with (
-            patch(
-                "litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"
-            ),
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
             patch("asyncio.create_task"),
         ):
             logger = DataDogLLMObsLogger()
 
         # Test embedding operations
-        assert (
-            logger._get_datadog_span_kind(CallTypes.embedding.value, "123")
-            == "embedding"
-        )
-        assert (
-            logger._get_datadog_span_kind(CallTypes.aembedding.value, "123")
-            == "embedding"
-        )
+        assert logger._get_datadog_span_kind(CallTypes.embedding.value, "123") == "embedding"
+        assert logger._get_datadog_span_kind(CallTypes.aembedding.value, "123") == "embedding"
 
         # Test LLM completion operations
         assert logger._get_datadog_span_kind(CallTypes.completion.value, None) == "llm"
         assert logger._get_datadog_span_kind(CallTypes.acompletion.value, None) == "llm"
-        assert (
-            logger._get_datadog_span_kind(CallTypes.text_completion.value, None)
-            == "llm"
-        )
-        assert (
-            logger._get_datadog_span_kind(CallTypes.generate_content.value, None)
-            == "llm"
-        )
-        assert (
-            logger._get_datadog_span_kind(CallTypes.anthropic_messages.value, None)
-            == "llm"
-        )
+        assert logger._get_datadog_span_kind(CallTypes.text_completion.value, None) == "llm"
+        assert logger._get_datadog_span_kind(CallTypes.generate_content.value, None) == "llm"
+        assert logger._get_datadog_span_kind(CallTypes.anthropic_messages.value, None) == "llm"
         assert logger._get_datadog_span_kind(CallTypes.responses.value, None) == "llm"
         assert logger._get_datadog_span_kind(CallTypes.aresponses.value, None) == "llm"
 
         # Test tool operations
-        assert (
-            logger._get_datadog_span_kind(CallTypes.call_mcp_tool.value, "123")
-            == "tool"
-        )
+        assert logger._get_datadog_span_kind(CallTypes.call_mcp_tool.value, "123") == "tool"
 
         # Test retrieval operations
-        assert (
-            logger._get_datadog_span_kind(CallTypes.get_assistants.value, "123")
-            == "retrieval"
-        )
-        assert (
-            logger._get_datadog_span_kind(CallTypes.file_retrieve.value, "123")
-            == "retrieval"
-        )
-        assert (
-            logger._get_datadog_span_kind(CallTypes.retrieve_batch.value, "123")
-            == "retrieval"
-        )
+        assert logger._get_datadog_span_kind(CallTypes.get_assistants.value, "123") == "retrieval"
+        assert logger._get_datadog_span_kind(CallTypes.file_retrieve.value, "123") == "retrieval"
+        assert logger._get_datadog_span_kind(CallTypes.retrieve_batch.value, "123") == "retrieval"
 
         # Test task operations
-        assert (
-            logger._get_datadog_span_kind(CallTypes.create_batch.value, "123") == "task"
-        )
-        assert (
-            logger._get_datadog_span_kind(CallTypes.image_generation.value, "123")
-            == "task"
-        )
-        assert (
-            logger._get_datadog_span_kind(CallTypes.moderation.value, "123") == "task"
-        )
-        assert (
-            logger._get_datadog_span_kind(CallTypes.transcription.value, "123")
-            == "task"
-        )
+        assert logger._get_datadog_span_kind(CallTypes.create_batch.value, "123") == "task"
+        assert logger._get_datadog_span_kind(CallTypes.image_generation.value, "123") == "task"
+        assert logger._get_datadog_span_kind(CallTypes.moderation.value, "123") == "task"
+        assert logger._get_datadog_span_kind(CallTypes.transcription.value, "123") == "task"
 
         # Test default fallback
         assert logger._get_datadog_span_kind("unknown_call_type", None) == "llm"
@@ -341,31 +278,21 @@ class TestDataDogLLMObsLogger:
         from litellm.types.utils import CallTypes
 
         with (
-            patch(
-                "litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"
-            ),
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
             patch("asyncio.create_task"),
         ):
             logger = DataDogLLMObsLogger()
 
         # Tool/task/retrieval span kinds should fallback to llm when parent_id missing
-        assert (
-            logger._get_datadog_span_kind(CallTypes.call_mcp_tool.value, None) == "llm"
-        )
-        assert (
-            logger._get_datadog_span_kind(CallTypes.create_batch.value, None) == "llm"
-        )
-        assert (
-            logger._get_datadog_span_kind(CallTypes.get_assistants.value, None) == "llm"
-        )
+        assert logger._get_datadog_span_kind(CallTypes.call_mcp_tool.value, None) == "llm"
+        assert logger._get_datadog_span_kind(CallTypes.create_batch.value, None) == "llm"
+        assert logger._get_datadog_span_kind(CallTypes.get_assistants.value, None) == "llm"
 
     @pytest.mark.asyncio
     async def test_async_log_failure_event(self, mock_env_vars):
         """Test that async_log_failure_event correctly processes failure payloads according to DD LLM Obs API spec"""
         with (
-            patch(
-                "litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"
-            ),
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
             patch("asyncio.create_task"),
         ):
             logger = DataDogLLMObsLogger()
@@ -395,16 +322,11 @@ class TestDataDogLLMObsLogger:
                 # Verify the payload has correct failure characteristics according to DD LLM Obs API spec
                 payload = logger.log_queue[0]
                 assert payload["trace_id"] == "test-trace-id-failure-456"
-                assert (
-                    payload["meta"]["metadata"]["id"] == "test-request-id-failure-789"
-                )
+                assert payload["meta"]["metadata"]["id"] == "test-request-id-failure-789"
                 assert payload["status"] == "error"
 
                 # Verify error information follows DD LLM Obs API spec
-                assert (
-                    payload["meta"]["error"]["message"]
-                    == "RateLimitError: You exceeded your current quota"
-                )
+                assert payload["meta"]["error"]["message"] == "RateLimitError: You exceeded your current quota"
                 assert payload["meta"]["error"]["type"] == "RateLimitError"
                 assert (
                     payload["meta"]["error"]["stack"]
@@ -447,9 +369,7 @@ async def test_dd_llms_obs_redaction(mock_env_vars):
     litellm._turn_on_debug()
     from litellm.types.utils import LiteLLMCommonStrings
 
-    litellm.datadog_llm_observability_params = DatadogLLMObsInitParams(
-        turn_off_message_logging=True
-    )
+    litellm.datadog_llm_observability_params = DatadogLLMObsInitParams(turn_off_message_logging=True)
     dd_llms_obs_logger = TestDataDogLLMObsLoggerForRedaction()
     test_s3_logger = TestS3Logger()
     litellm.callbacks = [dd_llms_obs_logger, test_s3_logger]
@@ -473,34 +393,20 @@ async def test_dd_llms_obs_redaction(mock_env_vars):
     assert dd_llms_obs_logger.logged_standard_logging_payload is not None
     assert test_s3_logger.logged_standard_logging_payload is not None
 
+    assert dd_llms_obs_logger.logged_standard_logging_payload["messages"][0]["content"] == "redacted-by-litellm"
     assert (
-        dd_llms_obs_logger.logged_standard_logging_payload["messages"][0]["content"]
-        == "redacted-by-litellm"
-    )
-    assert (
-        dd_llms_obs_logger.logged_standard_logging_payload["response"]["choices"][0][
-            "message"
-        ]["content"]
+        dd_llms_obs_logger.logged_standard_logging_payload["response"]["choices"][0]["message"]["content"]
         == "redacted-by-litellm"
     )
 
-    assert test_s3_logger.logged_standard_logging_payload["messages"] == [
-        {"role": "user", "content": "Hello, world!"}
-    ]
-    assert (
-        test_s3_logger.logged_standard_logging_payload["response"]["choices"][0][
-            "message"
-        ]["content"]
-        == "Hi there!"
-    )
+    assert test_s3_logger.logged_standard_logging_payload["messages"] == [{"role": "user", "content": "Hello, world!"}]
+    assert test_s3_logger.logged_standard_logging_payload["response"]["choices"][0]["message"]["content"] == "Hi there!"
 
 
 @pytest.fixture
 def mock_env_vars():
     """Mock environment variables for DataDog"""
-    with patch.dict(
-        os.environ, {"DD_API_KEY": "test_api_key", "DD_SITE": "us5.datadoghq.com"}
-    ):
+    with patch.dict(os.environ, {"DD_API_KEY": "test_api_key", "DD_SITE": "us5.datadoghq.com"}):
         yield
 
 
@@ -520,9 +426,7 @@ async def test_create_llm_obs_payload(mock_env_vars):
 
     assert payload["name"] == "litellm_llm_call"
     assert payload["meta"]["kind"] == "llm"
-    assert payload["meta"]["input"]["messages"] == [
-        {"role": "user", "content": "Hello, world!"}
-    ]
+    assert payload["meta"]["input"]["messages"] == [{"role": "user", "content": "Hello, world!"}]
     assert payload["meta"]["output"]["messages"][0]["content"] == "Hi there!"
     assert payload["metrics"]["input_tokens"] == 10
     assert payload["metrics"]["output_tokens"] == 20
@@ -567,9 +471,7 @@ def create_standard_logging_payload_with_latency_metrics() -> StandardLoggingPay
         endTime=1234567892.0,
         completionStartTime=1234567890.8,  # 800ms after start
         response_time=2.0,
-        model_map_information=StandardLoggingModelInformation(
-            model_map_key="gpt-4", model_map_value=None
-        ),
+        model_map_information=StandardLoggingModelInformation(model_map_key="gpt-4", model_map_value=None),
         model="gpt-4",
         model_id="model-123",
         model_group="openai-gpt",
@@ -637,9 +539,7 @@ def test_latency_metrics_in_metadata(mock_env_vars):
 
         # Verify guardrail overhead is included (500ms)
         assert "guardrail_overhead_time_ms" in latency_metadata
-        assert (
-            latency_metadata["guardrail_overhead_time_ms"] == 500.0
-        )  # 0.5 seconds * 1000
+        assert latency_metadata["guardrail_overhead_time_ms"] == 500.0  # 0.5 seconds * 1000
 
         # Verify these metrics are also included in the full payload
         payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
@@ -664,9 +564,7 @@ def test_latency_metrics_edge_cases(mock_env_vars):
 
         # Should not have latency fields if data is missing/zero
         assert "time_to_first_token_ms" not in metadata  # Will be 0, so not included
-        assert (
-            "litellm_overhead_time_ms" not in metadata
-        )  # Not present in hidden_params
+        assert "litellm_overhead_time_ms" not in metadata  # Not present in hidden_params
         assert "guardrail_overhead_time_ms" not in metadata  # No guardrail_information
 
         # Test case 2: Zero time to first token should not be included
@@ -851,17 +749,13 @@ class TestDataDogLLMObsLoggerToolCalls:
     @pytest.fixture
     def mock_env_vars(self):
         """Mock environment variables for DataDog"""
-        with patch.dict(
-            os.environ, {"DD_API_KEY": "test_api_key", "DD_SITE": "us5.datadoghq.com"}
-        ):
+        with patch.dict(os.environ, {"DD_API_KEY": "test_api_key", "DD_SITE": "us5.datadoghq.com"}):
             yield
 
     def test_tool_call_span_kind_mapping(self, mock_env_vars):
         """Test that tool call operations are correctly mapped to 'tool' span kind"""
         with (
-            patch(
-                "litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"
-            ),
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
             patch("asyncio.create_task"),
         ):
             logger = DataDogLLMObsLogger()
@@ -869,17 +763,12 @@ class TestDataDogLLMObsLoggerToolCalls:
             # Test MCP tool call mapping
             from litellm.types.utils import CallTypes
 
-            assert (
-                logger._get_datadog_span_kind(CallTypes.call_mcp_tool.value, "123")
-                == "tool"
-            )
+            assert logger._get_datadog_span_kind(CallTypes.call_mcp_tool.value, "123") == "tool"
 
     def test_tool_call_payload_creation(self, mock_env_vars):
         """Test that tool call payloads are created correctly"""
         with (
-            patch(
-                "litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"
-            ),
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
             patch("asyncio.create_task"),
         ):
             logger = DataDogLLMObsLogger()
@@ -899,9 +788,7 @@ class TestDataDogLLMObsLoggerToolCalls:
             # Verify basic payload structure
             assert payload.get("name") == "litellm_llm_call"
             assert payload.get("status") == "ok"
-            assert (
-                payload.get("meta", {}).get("kind") == "llm"
-            )  # Regular completion, not tool call
+            assert payload.get("meta", {}).get("kind") == "llm"  # Regular completion, not tool call
 
             # Verify metrics
             metrics = payload.get("metrics", {})
@@ -912,9 +799,7 @@ class TestDataDogLLMObsLoggerToolCalls:
     def test_tool_call_messages_preserved(self, mock_env_vars):
         """Test that tool call messages are preserved in the payload"""
         with (
-            patch(
-                "litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"
-            ),
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
             patch("asyncio.create_task"),
         ):
             logger = DataDogLLMObsLogger()
@@ -955,9 +840,7 @@ class TestDataDogLLMObsLoggerToolCalls:
     def test_tool_call_response_handling(self, mock_env_vars):
         """Test that tool calls in response are handled correctly"""
         with (
-            patch(
-                "litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"
-            ),
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
             patch("asyncio.create_task"),
         ):
             logger = DataDogLLMObsLogger()
@@ -974,7 +857,6 @@ class TestDataDogLLMObsLoggerToolCalls:
 
             payload = logger.create_llm_obs_payload(kwargs, start_time, end_time)
 
-            # Verify output messages include tool calls
             meta = payload.get("meta", {})
             output_meta = meta.get("output", {})
             output_messages = output_meta.get("messages", [])
@@ -982,11 +864,126 @@ class TestDataDogLLMObsLoggerToolCalls:
 
             output_msg = output_messages[0]
             assert output_msg.get("role") == "assistant"
+            assert output_msg.get("content") == "It's 72°F and sunny in NYC!"
             assert "tool_calls" in output_msg
             output_tool_calls = output_msg.get("tool_calls", [])
             assert len(output_tool_calls) == 1
-            output_function_info = output_tool_calls[0].get("function", {})
-            assert output_function_info.get("name") == "format_response"
+            dd_tool_call = output_tool_calls[0]
+            assert dd_tool_call == {
+                "name": "format_response",
+                "arguments": {"temp": 72, "condition": "sunny"},
+                "tool_id": "call_456",
+                "type": "function",
+            }
+
+    def test_output_tool_call_with_unparseable_arguments(self, mock_env_vars):
+        """Malformed JSON arguments are kept as the raw string, not dropped"""
+        with (
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
+            patch("asyncio.create_task"),
+        ):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = create_standard_logging_payload_with_tool_calls()
+            standard_payload["response"]["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"] = (
+                "{not valid json"
+            )
+
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}},
+            }
+
+            payload = logger.create_llm_obs_payload(kwargs, datetime.now(), datetime.now())
+
+            tool_call = payload["meta"]["output"]["messages"][0]["tool_calls"][0]
+            assert tool_call["name"] == "format_response"
+            assert tool_call["arguments"] == "{not valid json"
+
+    def test_output_message_without_tool_calls_unchanged(self, mock_env_vars):
+        """Plain responses keep role/content and gain no tool_calls key"""
+        with (
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
+            patch("asyncio.create_task"),
+        ):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = create_standard_logging_payload_with_tool_calls()
+            standard_payload["response"] = {"choices": [{"message": {"role": "assistant", "content": "Hi!"}}]}
+
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}},
+            }
+
+            payload = logger.create_llm_obs_payload(kwargs, datetime.now(), datetime.now())
+
+            output_msg = payload["meta"]["output"]["messages"][0]
+            assert output_msg == {"role": "assistant", "content": "Hi!"}
+
+
+class TestDataDogLLMObsCacheTokenMetrics:
+    """Prompt-cache token counts must land in top-level span metrics"""
+
+    @pytest.fixture
+    def mock_env_vars(self):
+        with patch.dict(os.environ, {"DD_API_KEY": "test_api_key", "DD_SITE": "us5.datadoghq.com"}):
+            yield
+
+    def _payload_with_usage_object(self, usage_object):
+        standard_payload = create_standard_logging_payload_with_tool_calls()
+        standard_payload["metadata"]["usage_object"] = usage_object
+        return standard_payload
+
+    def test_cache_tokens_forwarded_to_span_metrics(self, mock_env_vars):
+        """cache_read/cache_creation tokens map to DD span metrics fields"""
+        with (
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
+            patch("asyncio.create_task"),
+        ):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = self._payload_with_usage_object(
+                {
+                    "cache_creation_input_tokens": 176,
+                    "cache_read_input_tokens": 16695,
+                    "prompt_tokens": 16872,
+                    "completion_tokens": 704,
+                }
+            )
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}},
+            }
+
+            payload = logger.create_llm_obs_payload(kwargs, datetime.now(), datetime.now())
+
+            metrics = payload["metrics"]
+            assert metrics["cache_read_input_tokens"] == 16695.0
+            assert metrics["cache_write_input_tokens"] == 176.0
+            assert metrics["non_cached_input_tokens"] == 177.0
+
+    def test_no_cache_metrics_when_usage_object_absent(self, mock_env_vars):
+        """Without cache activity the new metrics keys are not emitted"""
+        with (
+            patch("litellm.integrations.datadog.datadog_llm_obs.get_async_httpx_client"),
+            patch("asyncio.create_task"),
+        ):
+            logger = DataDogLLMObsLogger()
+
+            standard_payload = self._payload_with_usage_object(None)
+            kwargs = {
+                "standard_logging_object": standard_payload,
+                "litellm_params": {"metadata": {}},
+            }
+
+            payload = logger.create_llm_obs_payload(kwargs, datetime.now(), datetime.now())
+
+            metrics = payload["metrics"]
+            assert "cache_read_input_tokens" not in metrics
+            assert "cache_write_input_tokens" not in metrics
+            assert "non_cached_input_tokens" not in metrics
+            assert metrics["input_tokens"] == 20.0
 
 
 def create_standard_logging_payload_with_spend_metrics() -> StandardLoggingPayload:
@@ -1147,9 +1144,7 @@ async def test_spend_metrics_in_datadog_payload(mock_env_vars):
     start_time = datetime.now()
     end_time = datetime.now()
 
-    payload = datadog_llm_obs_logger.create_llm_obs_payload(
-        kwargs, start_time, end_time
-    )
+    payload = datadog_llm_obs_logger.create_llm_obs_payload(kwargs, start_time, end_time)
 
     # Verify basic payload structure
     assert payload.get("name") == "litellm_llm_call"
@@ -1179,9 +1174,7 @@ async def test_spend_metrics_in_datadog_payload(mock_env_vars):
     # Verify budget reset is a datetime string in ISO format
     budget_reset = spend_metrics["user_api_key_budget_reset_at"]
     assert isinstance(budget_reset, str)
-    print(
-        f"Budget reset in payload: {budget_reset}"
-    )  # In StandardLoggingUserAPIKeyMetadata
+    print(f"Budget reset in payload: {budget_reset}")  # In StandardLoggingUserAPIKeyMetadata
     user_api_key_budget_reset_at: Optional[str] = None
 
     # In DDLLMObsSpendMetrics


### PR DESCRIPTION
## TLDR

Problem this solves:

- Datadog shows tool calls as raw text, not tool calls
- Its LLM Observability UI cannot group or filter them
- Prompt-cache token counts never reach Datadog at all
- Cache savings are invisible in every Datadog dashboard

How it solves it:

- Map tool calls into the shape Datadog's intake expects
- Send cache token counts as span metrics

## User Flow

Before: a team using Datadog LLM Observability cannot see tool calls or cache savings for traffic through the gateway.

1. The admin enables the Datadog LLM Observability callback and restarts the proxy
2. A developer sends POST `https://litellm-domain/v1/chat/completions` with `tools` defined, and the model answers with a tool call
3. In Datadog's LLM Observability trace view, that span's output shows the tool call flattened into message text, so Datadog's tool-call view stays empty and cannot be grouped or filtered on
4. The same request read 800 of its 1000 input tokens from prompt cache
5. The span carries no cache token metrics, so the Datadog dashboard shows no cache saving and cost looks like full-price input

After: both appear as first-class data in Datadog.

1. The admin enables the same callback and restarts the proxy
2. The developer sends the same POST `https://litellm-domain/v1/chat/completions` with `tools`, and the model answers with the same tool call
3. Datadog's trace view now shows the tool call as a tool call — name and arguments in their own fields — so it can be grouped and filtered like any other
4. The same 800 cached input tokens are reported
5. The span carries cache read/write token metrics, so the dashboard shows the cache saving instead of full-price input

## Relevant issues

Fixes #35786

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (this PR: 5/5)

## Screenshots / Proof of Fix

Captured at commit `09889e1986` (`litellm_internal_staging`). The payload handed to Datadog's intake is built entirely from the completed response, so the proof asserts on that exact payload.

**Before:** the tool call arrived inside the message content as text, and the span carried no cache metrics — so Datadog had nothing to render in its tool-call view and no cache numbers to chart.

**After:** the payload carries the tool call in Datadog's own tool-call shape (name, arguments, id, type) and the cache token counts as top-level span metrics.

Two robustness points worth flagging for review:

- Tool arguments that are not valid JSON are passed through as the original string rather than dropped
- Deeply nested arguments no longer take the span down with them — a security review flagged that decoding could raise on pathological nesting, which would have dropped the whole span; it now falls back to the raw string (regression test included with a 50k-deep payload)

**86/86 Datadog tests pass.**

One structural note for the reviewer: `test_datadog_llm_observability.py` was removed on staging (mutation-scored as a mirror file whose tests exercised none of its module). Rather than resurrect it, these tests live in a new focused file, `test_datadog_llm_obs_message_schema.py`, asserting directly on the built payload.

## Type

🐛 Bug Fix

## Caveats

- Cache metrics appear only when the provider reports cache token counts

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
