### PR TITLE
fix(cost): charge OpenAI and Azure OpenAI web search per billable search

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -303,8 +303,8 @@ MAX_LONG_SIDE_FOR_IMAGE_HIGH_RES: Final = int(os.getenv("MAX_LONG_SIDE_FOR_IMAGE
 MAX_TILE_WIDTH: Final = int(os.getenv("MAX_TILE_WIDTH", 512))
 MAX_TILE_HEIGHT: Final = int(os.getenv("MAX_TILE_HEIGHT", 512))
 OPENAI_FILE_SEARCH_COST_PER_1K_CALLS: Final = float(os.getenv("OPENAI_FILE_SEARCH_COST_PER_1K_CALLS", 2.5 / 1000))
-OPENAI_WEB_SEARCH_COST_PER_CALL: Final = float(os.getenv("OPENAI_WEB_SEARCH_COST_PER_CALL", 10.0 / 1000))
-AZURE_WEB_SEARCH_COST_PER_CALL: Final = float(os.getenv("AZURE_WEB_SEARCH_COST_PER_CALL", 14.0 / 1000))
+OPENAI_WEB_SEARCH_COST_PER_CALL: Final = 10.0 / 1000
+AZURE_WEB_SEARCH_COST_PER_CALL: Final = 14.0 / 1000
 GROQ_BROWSER_VISIT_WEBSITE_COST_PER_CALL: Final = 1.0 / 1000
 # Azure OpenAI Assistants feature costs
 # Source: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -303,6 +303,8 @@ MAX_LONG_SIDE_FOR_IMAGE_HIGH_RES: Final = int(os.getenv("MAX_LONG_SIDE_FOR_IMAGE
 MAX_TILE_WIDTH: Final = int(os.getenv("MAX_TILE_WIDTH", 512))
 MAX_TILE_HEIGHT: Final = int(os.getenv("MAX_TILE_HEIGHT", 512))
 OPENAI_FILE_SEARCH_COST_PER_1K_CALLS: Final = float(os.getenv("OPENAI_FILE_SEARCH_COST_PER_1K_CALLS", 2.5 / 1000))
+OPENAI_WEB_SEARCH_COST_PER_CALL: Final = float(os.getenv("OPENAI_WEB_SEARCH_COST_PER_CALL", 10.0 / 1000))
+AZURE_WEB_SEARCH_COST_PER_CALL: Final = float(os.getenv("AZURE_WEB_SEARCH_COST_PER_CALL", 14.0 / 1000))
 GROQ_BROWSER_VISIT_WEBSITE_COST_PER_CALL: Final = 1.0 / 1000
 # Azure OpenAI Assistants feature costs
 # Source: https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/

--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -22,8 +22,6 @@ from litellm.types.utils import (
     Usage,
 )
 
-_OPENAI_WEB_SEARCH_PROVIDERS: Final = frozenset({"openai", "azure"})
-
 
 class StandardBuiltInToolCostTracking:
     """
@@ -307,42 +305,17 @@ class StandardBuiltInToolCostTracking:
         response_object: object,
         custom_llm_provider: str | None,
     ) -> Usage | None:
-        """Return a Usage carrying server_tool_use.web_search_requests sourced from the
-        provider's response when the reconstructed Usage does not already expose the field.
-
-        Anthropic reports the count in the usage block of its raw /v1/messages response.
-        OpenAI and Azure OpenAI report no count at all, so their billable web_search_call
-        output items are counted instead."""
-        anthropic_usage: Final = StandardBuiltInToolCostTracking._usage_with_anthropic_web_search(
-            usage=usage, response_object=response_object
-        )
-        if custom_llm_provider not in _OPENAI_WEB_SEARCH_PROVIDERS:
-            return anthropic_usage
-        if _get_web_search_requests(getattr(anthropic_usage, "server_tool_use", None)) is not None:
-            return anthropic_usage
-
-        from litellm.llms.openai.cost_calculation import (
-            get_web_search_requests_from_response,
-        )
-
-        web_search_requests: Final = get_web_search_requests_from_response(response_object)
-        if web_search_requests is None:
-            return anthropic_usage
-        return StandardBuiltInToolCostTracking._with_web_search_requests(anthropic_usage, web_search_requests)
-
-    @staticmethod
-    def _usage_with_anthropic_web_search(usage: Usage | None, response_object: object) -> Usage | None:
-        """Return a Usage carrying server_tool_use.web_search_requests sourced from a
-        raw Anthropic /v1/messages response dict when the reconstructed Usage dropped
-        it (or was never supplied). The original Usage is returned unchanged when it
-        already exposes the field or the response is not an Anthropic dict."""
-        from litellm.llms.anthropic.cost_calculation import (
-            get_anthropic_web_search_requests_from_response,
-        )
+        """Return a Usage carrying server_tool_use.web_search_requests read off the provider's
+        raw response, for the providers whose reconstructed Usage drops the count or never
+        reported one. The Usage is returned unchanged when it already exposes the field or the
+        response carries no count."""
+        from litellm.llms import get_web_search_requests_from_response
 
         if usage is not None and (_get_web_search_requests(getattr(usage, "server_tool_use", None)) is not None):
             return usage
-        web_search_requests: Final = get_anthropic_web_search_requests_from_response(response_object)
+        web_search_requests: Final = get_web_search_requests_from_response(
+            custom_llm_provider=custom_llm_provider, response_object=response_object
+        )
         if web_search_requests is None:
             return usage
         return StandardBuiltInToolCostTracking._with_web_search_requests(usage, web_search_requests)

--- a/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py
@@ -22,6 +22,8 @@ from litellm.types.utils import (
     Usage,
 )
 
+_OPENAI_WEB_SEARCH_PROVIDERS: Final = frozenset({"openai", "azure"})
+
 
 class StandardBuiltInToolCostTracking:
     """
@@ -104,8 +106,8 @@ class StandardBuiltInToolCostTracking:
         if custom_llm_provider is None and model_info is not None:
             custom_llm_provider = model_info["litellm_provider"]
 
-        resolved_usage: Final = StandardBuiltInToolCostTracking._usage_with_anthropic_web_search(
-            usage=usage, response_object=response_object
+        resolved_usage: Final = StandardBuiltInToolCostTracking._usage_with_web_search_requests(
+            usage=usage, response_object=response_object, custom_llm_provider=custom_llm_provider
         )
 
         if model_info is not None and resolved_usage is not None and custom_llm_provider is not None:
@@ -292,6 +294,43 @@ class StandardBuiltInToolCostTracking:
         return None
 
     @staticmethod
+    def _with_web_search_requests(usage: Usage | None, web_search_requests: int) -> Usage:
+        """Return a Usage carrying ``server_tool_use.web_search_requests``."""
+        server_tool_use: Final = ServerToolUse(web_search_requests=web_search_requests)
+        if usage is None:
+            return Usage(server_tool_use=server_tool_use)
+        return usage.model_copy(update={"server_tool_use": server_tool_use})
+
+    @staticmethod
+    def _usage_with_web_search_requests(
+        usage: Usage | None,
+        response_object: object,
+        custom_llm_provider: str | None,
+    ) -> Usage | None:
+        """Return a Usage carrying server_tool_use.web_search_requests sourced from the
+        provider's response when the reconstructed Usage does not already expose the field.
+
+        Anthropic reports the count in the usage block of its raw /v1/messages response.
+        OpenAI and Azure OpenAI report no count at all, so their billable web_search_call
+        output items are counted instead."""
+        anthropic_usage: Final = StandardBuiltInToolCostTracking._usage_with_anthropic_web_search(
+            usage=usage, response_object=response_object
+        )
+        if custom_llm_provider not in _OPENAI_WEB_SEARCH_PROVIDERS:
+            return anthropic_usage
+        if _get_web_search_requests(getattr(anthropic_usage, "server_tool_use", None)) is not None:
+            return anthropic_usage
+
+        from litellm.llms.openai.cost_calculation import (
+            get_web_search_requests_from_response,
+        )
+
+        web_search_requests: Final = get_web_search_requests_from_response(response_object)
+        if web_search_requests is None:
+            return anthropic_usage
+        return StandardBuiltInToolCostTracking._with_web_search_requests(anthropic_usage, web_search_requests)
+
+    @staticmethod
     def _usage_with_anthropic_web_search(usage: Usage | None, response_object: object) -> Usage | None:
         """Return a Usage carrying server_tool_use.web_search_requests sourced from a
         raw Anthropic /v1/messages response dict when the reconstructed Usage dropped
@@ -306,10 +345,7 @@ class StandardBuiltInToolCostTracking:
         web_search_requests: Final = get_anthropic_web_search_requests_from_response(response_object)
         if web_search_requests is None:
             return usage
-        server_tool_use: Final = ServerToolUse(web_search_requests=web_search_requests)
-        if usage is None:
-            return Usage(server_tool_use=server_tool_use)
-        return usage.model_copy(update={"server_tool_use": server_tool_use})
+        return StandardBuiltInToolCostTracking._with_web_search_requests(usage, web_search_requests)
 
     @staticmethod
     def response_object_includes_web_search_call(response_object: Any, usage: Usage | None = None) -> bool:

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -78,6 +78,31 @@ def _get_web_search_requests(server_tool_use: Any) -> int | None:
     return getattr(server_tool_use, "web_search_requests", None)
 
 
+def cost_for_web_search_requests(
+    usage: Usage | None,
+    model_info: ModelInfo,
+    default_cost_per_request: float,
+) -> float | None:
+    """
+    Cost of the server-side web search requests counted on ``usage.server_tool_use``.
+
+    ``default_cost_per_request`` is the provider's list price, used when the model has no
+    ``search_context_cost_per_query`` entry in the pricing map. A model entry always wins,
+    so per-deployment pricing overrides stay in effect.
+
+    Returns ``None`` when no request count is available, so callers can fall back to
+    pricing that does not depend on a count.
+    """
+    web_search_requests: Final = _get_web_search_requests(getattr(usage, "server_tool_use", None))
+    if web_search_requests is None:
+        return None
+
+    search_costs: Final = model_info.get("search_context_cost_per_query")
+    model_cost_per_request: Final = search_costs.get("search_context_size_medium") if search_costs else None
+    cost_per_request: Final = model_cost_per_request or default_cost_per_request
+    return web_search_requests * cost_per_request
+
+
 def _is_above_128k(tokens: float) -> bool:
     if tokens > 128000:
         return True

--- a/litellm/litellm_core_utils/llm_cost_calc/utils.py
+++ b/litellm/litellm_core_utils/llm_cost_calc/utils.py
@@ -88,7 +88,7 @@ def cost_for_web_search_requests(
 
     ``default_cost_per_request`` is the provider's list price, used when the model has no
     ``search_context_cost_per_query`` entry in the pricing map. A model entry always wins,
-    so per-deployment pricing overrides stay in effect.
+    including an explicit ``0.0``, so per-deployment pricing overrides stay in effect.
 
     Returns ``None`` when no request count is available, so callers can fall back to
     pricing that does not depend on a count.
@@ -99,7 +99,7 @@ def cost_for_web_search_requests(
 
     search_costs: Final = model_info.get("search_context_cost_per_query")
     model_cost_per_request: Final = search_costs.get("search_context_size_medium") if search_costs else None
-    cost_per_request: Final = model_cost_per_request or default_cost_per_request
+    cost_per_request: Final = default_cost_per_request if model_cost_per_request is None else model_cost_per_request
     return web_search_requests * cost_per_request
 
 

--- a/litellm/llms/__init__.py
+++ b/litellm/llms/__init__.py
@@ -14,6 +14,31 @@ if TYPE_CHECKING:
     from litellm.types.utils import ModelInfo, Usage
 
 
+_RESPONSES_API_WEB_SEARCH_PROVIDERS: Final = frozenset({"openai", "azure"})
+
+
+def get_web_search_requests_from_response(custom_llm_provider: str | None, response_object: object) -> int | None:
+    """
+    Number of billable web search requests a provider's raw response reports.
+
+    OpenAI and Azure OpenAI report no count in usage, so their Responses API output items are
+    counted. Every other provider is read the Anthropic way, off the usage block of a raw
+    /v1/messages response, which also covers Claude served through Bedrock and Vertex AI.
+
+    Returns None when the response carries no count, leaving the caller's usage untouched.
+    """
+    if custom_llm_provider in _RESPONSES_API_WEB_SEARCH_PROVIDERS:
+        from .openai.cost_calculation import (
+            get_web_search_requests_from_response as openai_web_search_requests_from_response,
+        )
+
+        return openai_web_search_requests_from_response(response_object)
+
+    from .anthropic.cost_calculation import get_anthropic_web_search_requests_from_response
+
+    return get_anthropic_web_search_requests_from_response(response_object)
+
+
 def get_cost_for_web_search_request(custom_llm_provider: str, usage: "Usage", model_info: "ModelInfo") -> float | None:
     """
     Get the cost for a web search request for a given model.

--- a/litellm/llms/__init__.py
+++ b/litellm/llms/__init__.py
@@ -61,6 +61,18 @@ def get_cost_for_web_search_request(custom_llm_provider: str, usage: "Usage", mo
         )
 
         return groq_cost_per_web_search_request(usage=usage, model_info=model_info)
+    elif custom_llm_provider == "openai":
+        from .openai.cost_calculation import (
+            cost_per_web_search_request as openai_cost_per_web_search_request,
+        )
+
+        return openai_cost_per_web_search_request(usage=usage, model_info=model_info)
+    elif custom_llm_provider == "azure":
+        from .azure.cost_calculation import (
+            cost_per_web_search_request as azure_cost_per_web_search_request,
+        )
+
+        return azure_cost_per_web_search_request(usage=usage, model_info=model_info)
     else:
         return None
 

--- a/litellm/llms/azure/cost_calculation.py
+++ b/litellm/llms/azure/cost_calculation.py
@@ -6,9 +6,29 @@ Helper util for handling azure openai-specific cost calculation
 from typing import Final
 
 from litellm._logging import verbose_logger
-from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
-from litellm.types.utils import Usage
+from litellm.constants import AZURE_WEB_SEARCH_COST_PER_CALL
+from litellm.litellm_core_utils.llm_cost_calc.utils import (
+    cost_for_web_search_requests,
+    generic_cost_per_token,
+)
+from litellm.types.utils import ModelInfo, Usage
 from litellm.utils import get_model_info
+
+
+def cost_per_web_search_request(usage: Usage, model_info: ModelInfo) -> float | None:
+    """
+    Cost of the hosted web search tool on Azure OpenAI, charged per billable search.
+
+    Azure serves the tool through Grounding with Bing Search at $14 / 1k transactions,
+    so it is priced apart from OpenAI's own $10 / 1k calls.
+
+    https://www.microsoft.com/en-us/bing/apis/grounding-pricing
+    """
+    return cost_for_web_search_requests(
+        usage=usage,
+        model_info=model_info,
+        default_cost_per_request=AZURE_WEB_SEARCH_COST_PER_CALL,
+    )
 
 
 def cost_per_token(

--- a/litellm/llms/openai/cost_calculation.py
+++ b/litellm/llms/openai/cost_calculation.py
@@ -6,10 +6,77 @@ Helper util for handling openai-specific cost calculation
 from collections.abc import Mapping
 from typing import Any, Final, Literal
 
+from pydantic import BaseModel, ValidationError
+
 from litellm._logging import verbose_logger
-from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+from litellm.constants import OPENAI_WEB_SEARCH_COST_PER_CALL
+from litellm.litellm_core_utils.llm_cost_calc.utils import (
+    cost_for_web_search_requests,
+    generic_cost_per_token,
+)
 from litellm.types.utils import CallTypes, ModelInfo, Usage
 from litellm.utils import get_model_info
+
+_NON_BILLABLE_WEB_SEARCH_ACTIONS: Final = frozenset({"open_page", "find_in_page"})
+_UNBILLED_WEB_SEARCH_STATUSES: Final = frozenset({"failed", "incomplete"})
+
+
+class _WebSearchCallAction(BaseModel):
+    type: str | None = None
+
+
+class _WebSearchCallItem(BaseModel):
+    type: str | None = None
+    status: str | None = None
+    action: _WebSearchCallAction | None = None
+
+
+def _is_billable_web_search_call(output_item: object) -> bool:
+    """
+    Whether a Responses API output item is a web search that carries the per-call tool fee.
+
+    Only ``search`` actions are billable. ``open_page`` and ``find_in_page`` are free
+    navigation inside an already-grounded search, and a search that never completed is
+    not charged.
+
+    https://developers.openai.com/api/docs/guides/tools-web-search
+    https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/web-search
+    """
+    try:
+        item: Final = _WebSearchCallItem.model_validate(output_item, from_attributes=True)
+    except ValidationError:
+        return False
+
+    if item.type != "web_search_call" or item.status in _UNBILLED_WEB_SEARCH_STATUSES:
+        return False
+    return item.action is None or item.action.type not in _NON_BILLABLE_WEB_SEARCH_ACTIONS
+
+
+def get_web_search_requests_from_response(response_object: object) -> int | None:
+    """
+    Count the billable ``web_search_call`` items in a Responses API response.
+
+    OpenAI and Azure OpenAI report no search count in ``usage``, so the response output is
+    the only record of how many searches a single request performed. Returns ``None`` for
+    responses that carry no output list (e.g. chat completions), where the count is unknown.
+    """
+    output: Final = getattr(response_object, "output", None)
+    if not isinstance(output, list):
+        return None
+    return sum(1 for output_item in output if _is_billable_web_search_call(output_item))
+
+
+def cost_per_web_search_request(usage: Usage, model_info: ModelInfo) -> float | None:
+    """
+    Cost of the hosted web search tool, charged per billable search at $10.00 / 1k calls.
+
+    https://developers.openai.com/api/docs/pricing
+    """
+    return cost_for_web_search_requests(
+        usage=usage,
+        model_info=model_info,
+        default_cost_per_request=OPENAI_WEB_SEARCH_COST_PER_CALL,
+    )
 
 
 def cost_router(call_type: CallTypes) -> Literal["cost_per_token", "cost_per_second"]:

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -648,11 +648,7 @@ def _assistant_message():
     }
 
 
-# OpenAI list price for the hosted web search tool: $10.00 / 1k calls
-# https://developers.openai.com/api/docs/pricing
 OPENAI_WEB_SEARCH_LIST_PRICE_PER_CALL = 10.0 / 1000
-# Azure serves the same tool via Grounding with Bing Search: $14 / 1k transactions
-# https://www.microsoft.com/en-us/bing/apis/grounding-pricing
 AZURE_WEB_SEARCH_LIST_PRICE_PER_CALL = 14.0 / 1000
 
 
@@ -815,3 +811,76 @@ def test_completion_cost_includes_openai_web_search_fee(local_model_cost_map):
     cost = litellm.completion_cost(completion_response=response, model=model, custom_llm_provider="openai")
 
     assert cost == pytest.approx(expected_token_cost + billable_searches * OPENAI_WEB_SEARCH_LIST_PRICE_PER_CALL)
+
+
+def test_openai_responses_web_search_honors_explicit_zero_price(local_model_cost_map):
+    """
+    A deployment is free to price web search at zero, e.g. when the fee is covered elsewhere.
+    An explicit 0.0 in the cost map must be charged as zero rather than falling back to the
+    provider list price, which would inflate response costs, spend records and budgets.
+    """
+    model = "openai-zero-priced-web-search-model"
+    litellm.register_model(
+        {
+            model: {
+                "litellm_provider": "openai",
+                "mode": "responses",
+                "input_cost_per_token": 0.0,
+                "output_cost_per_token": 0.0,
+                "search_context_cost_per_query": {
+                    "search_context_size_low": 0.0,
+                    "search_context_size_medium": 0.0,
+                    "search_context_size_high": 0.0,
+                },
+            }
+        }
+    )
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model=model,
+        usage=None,
+        response_object=_responses_api_response(
+            [_web_search_call("search", index=0), _web_search_call("search", index=1)],
+            model=model,
+        ),
+        custom_llm_provider="openai",
+        standard_built_in_tools_params=None,
+    )
+
+    assert cost == 0.0, f"an explicit zero web search price must not fall back to the list price, got ${cost}"
+
+
+def test_web_search_count_on_usage_wins_over_the_raw_response_count(local_model_cost_map):
+    """
+    When the provider reported a count in usage, that count is authoritative and the raw
+    response is not re-read. Otherwise a response that also carries a count would silently
+    override reconciled usage and bill a different number of searches.
+    """
+    from litellm.types.utils import ServerToolUse, Usage
+
+    model = "claude-3-7-sonnet-20250219"
+    raw_response = {
+        "id": "msg_1",
+        "type": "message",
+        "role": "assistant",
+        "model": model,
+        "content": [{"type": "text", "text": "hi"}],
+        "usage": {"input_tokens": 100, "output_tokens": 50, "server_tool_use": {"web_search_requests": 5}},
+    }
+    usage = Usage(
+        prompt_tokens=100,
+        completion_tokens=50,
+        total_tokens=150,
+        server_tool_use=ServerToolUse(web_search_requests=1),
+    )
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model=model,
+        usage=usage,
+        response_object=raw_response,
+        custom_llm_provider="anthropic",
+        standard_built_in_tools_params=None,
+    )
+
+    per_query_cost = litellm.get_model_info(model)["search_context_cost_per_query"]["search_context_size_medium"]
+    assert cost == pytest.approx(per_query_cost), f"expected 1 search from usage, got ${cost}"

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_tool_call_cost_tracking.py
@@ -604,3 +604,214 @@ def test_web_search_provider_prefix_fallback_does_not_misprice_non_gemini_model(
 
 # Note: File search integration test removed due to complex annotation detection logic
 # The unit tests in test_azure_assistant_cost_tracking.py provide comprehensive coverage
+
+
+def _responses_api_response(output, model="gpt-5.5", input_tokens=21384, output_tokens=845):
+    """Build a minimal Responses API response carrying the given output items."""
+    from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
+
+    return ResponsesAPIResponse(
+        id="resp_1",
+        created_at=0,
+        model=model,
+        output=output,
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+        usage=ResponseAPIUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=input_tokens + output_tokens,
+        ),
+    )
+
+
+def _web_search_call(action_type, status="completed", index=0):
+    action = {"type": action_type}
+    if action_type == "search":
+        action["query"] = f"query {index}"
+    return {
+        "id": f"ws_{index}",
+        "type": "web_search_call",
+        "status": status,
+        "action": action,
+    }
+
+
+def _assistant_message():
+    return {
+        "id": "msg_1",
+        "type": "message",
+        "status": "completed",
+        "role": "assistant",
+        "content": [{"type": "output_text", "text": "hi", "annotations": []}],
+    }
+
+
+# OpenAI list price for the hosted web search tool: $10.00 / 1k calls
+# https://developers.openai.com/api/docs/pricing
+OPENAI_WEB_SEARCH_LIST_PRICE_PER_CALL = 10.0 / 1000
+# Azure serves the same tool via Grounding with Bing Search: $14 / 1k transactions
+# https://www.microsoft.com/en-us/bing/apis/grounding-pricing
+AZURE_WEB_SEARCH_LIST_PRICE_PER_CALL = 14.0 / 1000
+
+
+def test_openai_responses_web_search_charges_every_billable_search(local_model_cost_map):
+    """
+    An agentic Responses API turn runs many searches in one request, and only `search`
+    actions that completed carry the per-call fee. Every billable search must be charged,
+    not just the first one, and the free navigation actions must not be.
+    """
+    billable_searches = 3
+    response = _responses_api_response(
+        output=[
+            *(_web_search_call("search", index=i) for i in range(billable_searches)),
+            _web_search_call("open_page", index=8),
+            _web_search_call("find_in_page", index=9),
+            _web_search_call("search", status="failed", index=10),
+            _assistant_message(),
+        ]
+    )
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model="gpt-5.5",
+        usage=None,
+        response_object=response,
+        custom_llm_provider="openai",
+        standard_built_in_tools_params=None,
+    )
+
+    assert cost == pytest.approx(billable_searches * OPENAI_WEB_SEARCH_LIST_PRICE_PER_CALL)
+
+
+def test_azure_responses_web_search_uses_bing_grounding_price(local_model_cost_map):
+    """
+    Azure OpenAI bills the web search tool through Grounding with Bing Search, which is
+    priced above OpenAI's own per-call fee. The Azure request must not be charged the
+    OpenAI rate.
+    """
+    billable_searches = 2
+    output = [
+        *(_web_search_call("search", index=i) for i in range(billable_searches)),
+        _assistant_message(),
+    ]
+
+    azure_cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model="azure/gpt-5.5",
+        usage=None,
+        response_object=_responses_api_response(output, model="gpt-5.5"),
+        custom_llm_provider="azure",
+        standard_built_in_tools_params=None,
+    )
+
+    assert azure_cost == pytest.approx(billable_searches * AZURE_WEB_SEARCH_LIST_PRICE_PER_CALL)
+    assert azure_cost > billable_searches * OPENAI_WEB_SEARCH_LIST_PRICE_PER_CALL
+
+
+def test_openai_responses_web_search_prefers_model_pricing_over_list_price(local_model_cost_map):
+    """
+    A model priced in the cost map wins over the provider list price, so per-deployment
+    and custom pricing keeps working while models absent from the map are still charged.
+    """
+    model = "gpt-4o-search-preview"
+    per_query_cost = litellm.get_model_info(model)["search_context_cost_per_query"]["search_context_size_medium"]
+    assert per_query_cost != OPENAI_WEB_SEARCH_LIST_PRICE_PER_CALL
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model=model,
+        usage=None,
+        response_object=_responses_api_response(
+            [_web_search_call("search", index=0), _web_search_call("search", index=1)],
+            model=model,
+        ),
+        custom_llm_provider="openai",
+        standard_built_in_tools_params=None,
+    )
+
+    assert cost == pytest.approx(2 * per_query_cost)
+
+
+def test_openai_responses_web_search_charges_nothing_without_a_billable_search(local_model_cost_map):
+    """
+    Reading pages inside an earlier turn's search results is free. A response whose only
+    web_search_call items are navigation actions must not be charged a search fee.
+    """
+    response = _responses_api_response(
+        [
+            _web_search_call("open_page", index=0),
+            _web_search_call("find_in_page", index=1),
+            _assistant_message(),
+        ]
+    )
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model="gpt-5.5",
+        usage=None,
+        response_object=response,
+        custom_llm_provider="openai",
+        standard_built_in_tools_params=None,
+    )
+
+    assert cost == 0.0
+
+
+def test_openai_chat_completion_web_search_still_priced_by_search_context_size(local_model_cost_map):
+    """
+    Chat completions report no per-search count, only url_citation annotations, so they
+    stay on search_context_size pricing. Counting Responses API items must not disturb it.
+    """
+    from litellm.types.utils import Choices, Message, ModelResponse
+
+    model = "gpt-4o-search-preview"
+    response = ModelResponse(
+        choices=[
+            Choices(
+                message=Message(
+                    role="assistant",
+                    content="hi",
+                    annotations=[{"type": "url_citation", "url_citation": {"url": "https://x"}}],
+                )
+            )
+        ]
+    )
+
+    cost = StandardBuiltInToolCostTracking.get_cost_for_built_in_tools(
+        model=model,
+        usage=None,
+        response_object=response,
+        custom_llm_provider="openai",
+        standard_built_in_tools_params=StandardBuiltInToolsParams(
+            web_search_options=WebSearchOptions(search_context_size="high")
+        ),
+    )
+
+    assert cost == litellm.get_model_info(model)["search_context_cost_per_query"]["search_context_size_high"]
+
+
+def test_completion_cost_includes_openai_web_search_fee(local_model_cost_map):
+    """
+    End-to-end: the response cost a caller sees for a Responses API request must be the
+    token cost plus one fee per billable search, not the token cost alone.
+    """
+    model = "gpt-5.5"
+    input_tokens = 21384
+    output_tokens = 845
+    billable_searches = 4
+    response = _responses_api_response(
+        output=[
+            *(_web_search_call("search", index=i) for i in range(billable_searches)),
+            _assistant_message(),
+        ],
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+    )
+
+    model_info = litellm.get_model_info(model)
+    expected_token_cost = (
+        input_tokens * model_info["input_cost_per_token"] + output_tokens * model_info["output_cost_per_token"]
+    )
+
+    cost = litellm.completion_cost(completion_response=response, model=model, custom_llm_provider="openai")
+
+    assert cost == pytest.approx(expected_token_cost + billable_searches * OPENAI_WEB_SEARCH_LIST_PRICE_PER_CALL)


### PR DESCRIPTION
## TLDR

Problem this solves:

- OpenAI and Azure web search tool fees bill as $0
- Agentic turns run many searches, at most one was charged
- Azure web search costs more than OpenAI's, same price used

How it solves it:

- Counts billable `web_search_call` items in Responses output
- Routes openai and azure to their own web search calculators
- Falls back to each provider's published per-call list price

## Relevant issues

Fixes #31316

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live Azure OpenAI `gpt-5.5` deployment, `/v1/responses` with the hosted `web_search` tool, no mocks. Only `/v1/responses` is affected: `/v1/chat/completions` and `/v1/messages` keep the pricing path they had, see Changes

Proxy config used for both runs:

```yaml
model_list:
  - model_name: azure-gpt-5.5
    litellm_params:
      model: azure/gpt-5.5
      api_base: os.environ/AZURE_API_BASE
      api_key: os.environ/AZURE_API_KEY

general_settings:
  master_key: sk-1234
```

Same request in both runs:

```bash
curl -sS -X POST http://localhost:4000/v1/responses \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -D /tmp/headers.txt -o /tmp/body.json \
  -d '{"model": "azure-gpt-5.5", "reasoning": {"effort": "high"}, "tools": [{"type": "web_search"}], "input": "Search the web and tell me the current stable release version of Python, Node.js and Go. Cite a source for each one."}'

grep -i x-litellm-response-cost: /tmp/headers.txt
jq -c '[.output[] | select(.type == "web_search_call") | {status, action: .action.type}]' /tmp/body.json
jq -c '.usage | {input_tokens, cached: .input_tokens_details.cached_tokens, output_tokens}' /tmp/body.json
```

### Before, at `b735578822`

```
x-litellm-response-cost: 0.17197

[{"status":"completed","action":"search"},{"status":"completed","action":"open_page"},{"status":"completed","action":"search"},{"status":"completed","action":"open_page"},{"status":"completed","action":"open_page"},{"status":"completed","action":"open_page"},{"status":"completed","action":"search"}]

{"input_tokens":24530,"cached":0,"output_tokens":1644}
```

3 billable searches ran and the reported cost is the token cost alone, so they were billed at $0:

```
24530 x $5e-06 + 1644 x $3e-05 = $0.17197   (reported: $0.17197, web search fee: $0.00)
```

### After, at `f186b079c5` (later commits changed no price: `8895cc5b95` drops an env lookup, `e3471293da` addresses review feedback)

```
x-litellm-response-cost: 0.165655

[{"status":"completed","action":"search"},{"status":"completed","action":"open_page"},{"status":"completed","action":"search"}]

{"input_tokens":16689,"cached":0,"output_tokens":1807}
```

2 billable searches, each charged at Azure's Grounding with Bing rate, and the `open_page` navigation charged nothing:

```
16689 x $5e-06 + 1807 x $3e-05 = $0.137655
$0.165655 - $0.137655            = $0.028 = 2 x $0.014
```

The two runs differ in search count and token totals because the model decides how much to browse. What matters is that the fee is $0.00 for 3 searches before, and exactly $0.014 per search after

### OpenAI direct

Not captured against a live key. Same code path, priced at $10 / 1k instead of $14 / 1k, covered by `test_openai_responses_web_search_charges_every_billable_search` and `test_completion_cost_includes_openai_web_search_fee`. To reproduce, point a deployment at `openai/gpt-5.5` (`litellm/proxy/dev_config.yaml` already has one) and repeat the curl above, expecting $0.01 per billable search

## Type

🐛 Bug Fix

## Changes

`get_cost_for_web_search_request` had no `openai` or `azure` branch, so both providers fell through to the boolean `search_context_cost_per_query` path. That path charges at most one query per response and needs a pricing entry that no `gpt-5.x`, `gpt-4.1` or `azure/*` model has, which left the tool fee at $0

- `litellm/llms/openai/cost_calculation.py`: counts the billable `web_search_call` items in a Responses API output. Only `search` actions carry the fee, `open_page` and `find_in_page` are free navigation inside an already grounded search, and searches that never completed are not charged. Returns `None` for responses with no output list (chat completions), where the count is genuinely unknown, so that path keeps its existing `search_context_size` pricing
- `litellm/llms/azure/cost_calculation.py`: same accounting at the Grounding with Bing price, which is what Azure actually bills for the tool
- `litellm/litellm_core_utils/llm_cost_calc/utils.py`: shared per-request pricing. A model's `search_context_cost_per_query` entry always wins over the provider list price, including an explicit `0.0`, so custom and per-deployment pricing is unaffected
- `litellm/constants.py`: the two list prices as plain constants, matching `GROQ_BROWSER_VISIT_WEBSITE_COST_PER_CALL` next to them. No env indirection, since a model entry in the cost map already overrides them per deployment
- `litellm/litellm_core_utils/llm_cost_calc/tool_call_cost_tracking.py`: feeds the count into `usage.server_tool_use.web_search_requests`, the same way the Anthropic raw response count is already resolved. Which parser reads a given response is decided by `get_web_search_requests_from_response` in `litellm/llms/__init__.py`, so the shared cost tracker names no providers and a count already present on usage stays authoritative

Known gaps, both pre-existing and left out to keep this isolated: chat completions still price web search off `search_context_size` because the response carries no per-search count, and `web_search_preview` on non-reasoning models is billed at $25 / 1k rather than $10 / 1k

Prices verified against https://developers.openai.com/api/docs/pricing and https://www.microsoft.com/en-us/bing/apis/grounding-pricing. Billable actions verified against https://developers.openai.com/api/docs/guides/tools-web-search and https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/web-search

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
