### PR TITLE
fix(proxy): improve Headroom /v1/compress HTTP 404 diagnostics

### DIFF
--- a/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
+++ b/litellm/proxy/guardrails/guardrail_hooks/headroom/headroom.py
@@ -148,6 +148,27 @@ def _restore_protected_messages(
     ]
 
 
+def _build_compress_failure_detail(status_code: int, body: str) -> dict[str, object]:
+    """Build error details for failed /v1/compress responses.
+
+    Adds troubleshooting hints for known deployment-related errors while
+    preserving the upstream status code and response body.
+    """
+    if status_code == 404:
+        return {
+            "status_code": status_code,
+            "body": body,
+            "hint": (
+                "The Headroom compression endpoint returned HTTP 404. "
+                "Verify that the configured Headroom endpoint is correct and that "
+                "the compression endpoint is available. If you are using a "
+                "self-hosted deployment, some deployments require enabling remote "
+                "compression (for example, HEADROOM_COMPRESS_ALLOW_REMOTE=1)."
+            ),
+        }
+    return {"status_code": status_code, "body": body}
+
+
 def extract_hashes_from_messages(messages: list[dict[str, object]]) -> list[str]:
     hashes: Final[list[str]] = []
     for msg in messages:
@@ -417,7 +438,7 @@ class HeadroomGuardrail(CustomGuardrail):
                 self._handle_compress_failure(
                     messages,
                     "Headroom compression service returned an error",
-                    {"status_code": e.response.status_code, "body": e.response.text},
+                    _build_compress_failure_detail(e.response.status_code, e.response.text),
                 ),
                 False,
                 {},
@@ -449,7 +470,7 @@ class HeadroomGuardrail(CustomGuardrail):
                 self._handle_compress_failure(
                     messages,
                     "Headroom compression service returned an error",
-                    {"status_code": response.status_code, "body": response.text},
+                    _build_compress_failure_detail(response.status_code, response.text),
                 ),
                 False,
                 {},

--- a/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
+++ b/tests/test_litellm/proxy/guardrails/guardrail_hooks/test_headroom.py
@@ -1041,6 +1041,64 @@ async def test_apply_guardrail_http_status_error_raises():
 
 
 @pytest.mark.asyncio
+async def test_apply_guardrail_404_error_includes_troubleshooting_hint():
+    """404 responses include a troubleshooting hint for self-hosted Headroom deployments."""
+    guardrail = _make_guardrail()
+
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        side_effect=_make_http_status_error(404, "Not Found"),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs=inputs,
+                request_data={},
+                input_type="request",
+            )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail["status_code"] == 404
+    assert exc_info.value.detail["body"] == "Not Found"
+    assert "hint" in exc_info.value.detail
+    assert "HEADROOM_COMPRESS_ALLOW_REMOTE=1" in exc_info.value.detail["hint"]
+
+
+@pytest.mark.asyncio
+async def test_apply_guardrail_non_404_error_omits_troubleshooting_hint():
+    guardrail = _make_guardrail()
+
+    inputs = GenericGuardrailAPIInputs(
+        texts=["hello"],
+        structured_messages=ORIGINAL_MESSAGES,
+    )
+
+    with patch.object(
+        guardrail.async_handler,
+        "post",
+        new_callable=AsyncMock,
+        side_effect=_make_http_status_error(500, "headroom internal error"),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await guardrail.apply_guardrail(
+                inputs=inputs,
+                request_data={},
+                input_type="request",
+            )
+
+    assert exc_info.value.status_code == 502
+    assert exc_info.value.detail["status_code"] == 500
+    assert exc_info.value.detail["body"] == "headroom internal error"
+    assert "hint" not in exc_info.value.detail
+
+
+@pytest.mark.asyncio
 async def test_apply_guardrail_http_status_error_fail_open_forwards_uncompressed():
     guardrail = _make_guardrail(unreachable_fallback="fail_open")
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- `/v1/compress` HTTP 404 responses provide limited troubleshooting context.
- Common self-hosted deployment issues are difficult to identify from the existing error payload.

How it solves it:

- Adds a troubleshooting hint for `/v1/compress` HTTP 404 responses.
- Preserves the existing upstream status code and response body.
- Refactors error detail construction into a shared helper.
- Adds regression tests for both 404 and non-404 responses.

## Relevant issues

Related to #35933

## Linear ticket

N/A

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Regression tests added:

- `test_apply_guardrail_404_error_includes_troubleshooting_hint`
- `test_apply_guardrail_non_404_error_omits_troubleshooting_hint`

The tests verify:

- HTTP 404 responses preserve the original upstream error details and include a troubleshooting hint.
- Non-404 responses preserve the existing behavior without adding the hint.

The behavior change is limited to the error payload returned for HTTP 404 responses.

## Type

🐛 Bug Fix
✅ Test

## Changes

- Added `_build_compress_failure_detail()` to centralize `/v1/compress` error detail construction.
- Added a troubleshooting hint for HTTP 404 responses.
- Preserved the existing upstream `status_code` and `body` for all responses.
- Updated both `/v1/compress` error paths to use the shared helper.
- Added regression tests covering:
  - HTTP 404 responses include the troubleshooting hint.
  - Non-404 responses remain unchanged.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
