### PR TITLE
fix(auto-router): stop the embedding model's context window from failing long requests

### DIFF
--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -91,6 +91,13 @@ DEFAULT_MCP_SEMANTIC_FILTER_SIMILARITY_THRESHOLD: Final = float(
 )
 MAX_MCP_SEMANTIC_FILTER_TOOLS_HEADER_LENGTH: Final = int(os.getenv("MAX_MCP_SEMANTIC_FILTER_TOOLS_HEADER_LENGTH", 150))
 
+# Embedding models used for semantic routing have far smaller context windows than the chat models
+# they route to (512 tokens is common for self-hosted ones, 8k is generous), so an unbounded prompt
+# fails the embedding call and, with it, the whole request. Routing only needs enough of the ask to
+# place it against short route utterances, so every doc is cut to this many characters. Roughly 500
+# tokens of English, which fits even a 512-token encoder.
+DEFAULT_MAX_EMBEDDING_INPUT_CHARS: Final = int(os.getenv("DEFAULT_MAX_EMBEDDING_INPUT_CHARS", 2000))
+
 # Semantic Guard Defaults
 DEFAULT_SEMANTIC_GUARD_EMBEDDING_MODEL: Final = str(
     os.getenv("DEFAULT_SEMANTIC_GUARD_EMBEDDING_MODEL", "text-embedding-3-small")

--- a/litellm/constants.py
+++ b/litellm/constants.py
@@ -91,12 +91,7 @@ DEFAULT_MCP_SEMANTIC_FILTER_SIMILARITY_THRESHOLD: Final = float(
 )
 MAX_MCP_SEMANTIC_FILTER_TOOLS_HEADER_LENGTH: Final = int(os.getenv("MAX_MCP_SEMANTIC_FILTER_TOOLS_HEADER_LENGTH", 150))
 
-# Embedding models used for semantic routing have far smaller context windows than the chat models
-# they route to (512 tokens is common for self-hosted ones, 8k is generous), so an unbounded prompt
-# fails the embedding call and, with it, the whole request. Routing only needs enough of the ask to
-# place it against short route utterances, so every doc is cut to this many characters. Roughly 500
-# tokens of English, which fits even a 512-token encoder.
-DEFAULT_MAX_EMBEDDING_INPUT_CHARS: Final = int(os.getenv("DEFAULT_MAX_EMBEDDING_INPUT_CHARS", 2000))
+DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS: Final = 2000
 
 # Semantic Guard Defaults
 DEFAULT_SEMANTIC_GUARD_EMBEDDING_MODEL: Final = str(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -44,6 +44,7 @@ from litellm.caching.caching import (
 from litellm.constants import (
     DEFAULT_HEALTH_CHECK_INTERVAL,
     DEFAULT_HEALTH_CHECK_STALENESS_MULTIPLIER,
+    DEFAULT_MAX_EMBEDDING_INPUT_CHARS,
     DEFAULT_MAX_LRU_CACHE_SIZE,
 )
 from litellm.integrations.custom_logger import CustomLogger
@@ -7605,6 +7606,8 @@ class Router:
                 "auto_router_embedding_model is required for auto-router deployments. Please set it in the litellm_params"
             )
 
+        max_input_chars: Final[int | None] = deployment.litellm_params.auto_router_max_input_chars
+
         autor_router: Final[AutoRouter] = AutoRouter(
             model_name=deployment.model_name,
             auto_router_config_path=auto_router_config_path,
@@ -7612,6 +7615,7 @@ class Router:
             default_model=default_model,
             embedding_model=embedding_model,
             litellm_router_instance=self,
+            max_input_chars=(max_input_chars if max_input_chars is not None else DEFAULT_MAX_EMBEDDING_INPUT_CHARS),
         )
         self._register_pre_routing_strategy(
             registry=self.auto_routers,

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -42,9 +42,9 @@ from litellm.caching.caching import (
     RedisClusterCache,
 )
 from litellm.constants import (
+    DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS,
     DEFAULT_HEALTH_CHECK_INTERVAL,
     DEFAULT_HEALTH_CHECK_STALENESS_MULTIPLIER,
-    DEFAULT_MAX_EMBEDDING_INPUT_CHARS,
     DEFAULT_MAX_LRU_CACHE_SIZE,
 )
 from litellm.integrations.custom_logger import CustomLogger
@@ -7615,7 +7615,7 @@ class Router:
             default_model=default_model,
             embedding_model=embedding_model,
             litellm_router_instance=self,
-            max_input_chars=(max_input_chars if max_input_chars is not None else DEFAULT_MAX_EMBEDDING_INPUT_CHARS),
+            max_input_chars=(max_input_chars if max_input_chars is not None else DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS),
         )
         self._register_pre_routing_strategy(
             registry=self.auto_routers,

--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -5,7 +5,7 @@ Auto-Routing Strategy that works with a Semantic Router Config
 from typing import TYPE_CHECKING, Any, Final, Optional
 
 from litellm._logging import verbose_router_logger
-from litellm.constants import DEFAULT_MAX_EMBEDDING_INPUT_CHARS
+from litellm.constants import DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS
 from litellm.integrations.custom_logger import CustomLogger
 
 if TYPE_CHECKING:
@@ -32,7 +32,7 @@ class AutoRouter(CustomLogger):
         litellm_router_instance: "Router",
         auto_router_config_path: str | None = None,
         auto_router_config: str | None = None,
-        max_input_chars: int = DEFAULT_MAX_EMBEDDING_INPUT_CHARS,
+        max_input_chars: int = DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS,
     ):
         """
         Auto-Router class that uses a semantic router to route requests to the appropriate model.
@@ -154,10 +154,6 @@ class AutoRouter(CustomLogger):
             self.routelayer = routelayer
 
         message_content: Final = self._extract_text_from_messages(messages)
-
-        # `model` arrives as the auto-router alias, which is not a routable deployment: leaving it in
-        # place when nothing matched fails downstream with "Unmapped LLM provider", so every path that
-        # does not name a route resolves to the default model.
         route_name: Final = self._matched_route_name(routelayer, message_content)
 
         return PreRoutingHookResponse(

--- a/litellm/router_strategy/auto_router/auto_router.py
+++ b/litellm/router_strategy/auto_router/auto_router.py
@@ -5,9 +5,11 @@ Auto-Routing Strategy that works with a Semantic Router Config
 from typing import TYPE_CHECKING, Any, Final, Optional
 
 from litellm._logging import verbose_router_logger
+from litellm.constants import DEFAULT_MAX_EMBEDDING_INPUT_CHARS
 from litellm.integrations.custom_logger import CustomLogger
 
 if TYPE_CHECKING:
+    from semantic_router.routers import SemanticRouter
     from semantic_router.routers.base import Route
 
     from litellm.router import Router
@@ -16,6 +18,7 @@ else:
     Router = Any
     PreRoutingHookResponse = Any
     Route = Any
+    SemanticRouter = Any
 
 
 class AutoRouter(CustomLogger):
@@ -29,6 +32,7 @@ class AutoRouter(CustomLogger):
         litellm_router_instance: "Router",
         auto_router_config_path: str | None = None,
         auto_router_config: str | None = None,
+        max_input_chars: int = DEFAULT_MAX_EMBEDDING_INPUT_CHARS,
     ):
         """
         Auto-Router class that uses a semantic router to route requests to the appropriate model.
@@ -40,6 +44,9 @@ class AutoRouter(CustomLogger):
             default_model: The default model to use if no route is found.
             embedding_model: The embedding model to use for the auto-router.
             litellm_router_instance: The instance of the LiteLLM Router.
+            max_input_chars: Longest prompt, in characters, handed to the embedding model. Longer
+                prompts are cut to this length so an embedding context window far smaller than the
+                routed model's never fails the request.
         """
         from semantic_router.routers import SemanticRouter
 
@@ -50,6 +57,7 @@ class AutoRouter(CustomLogger):
         self.routelayer: SemanticRouter | None = None
         self.default_model = default_model
         self.embedding_model: str = embedding_model
+        self.max_input_chars: int = max_input_chars
         self.litellm_router_instance: Router = litellm_router_instance
 
     def _load_semantic_routing_routes(self) -> list[Route]:
@@ -119,7 +127,6 @@ class AutoRouter(CustomLogger):
         Used for the litellm auto-router to modify the request before the routing decision is made.
         """
         from semantic_router.routers import SemanticRouter
-        from semantic_router.schema import RouteChoice
 
         from litellm.router_strategy.auto_router.litellm_encoder import (
             LiteLLMRouterEncoder,
@@ -140,20 +147,43 @@ class AutoRouter(CustomLogger):
                 encoder=LiteLLMRouterEncoder(
                     litellm_router_instance=self.litellm_router_instance,
                     model_name=self.embedding_model,
+                    max_input_chars=self.max_input_chars,
                 ),
                 auto_sync=self.auto_sync_value,
             )
             self.routelayer = routelayer
 
         message_content: Final = self._extract_text_from_messages(messages)
-        route_choice: Final[RouteChoice | list[RouteChoice] | None] = routelayer(text=message_content)
-        verbose_router_logger.debug("route_choice: %s", route_choice)
-        if isinstance(route_choice, RouteChoice):
-            model = route_choice.name or self.default_model
-        elif isinstance(route_choice, list):
-            model = route_choice[0].name or self.default_model
+
+        # `model` arrives as the auto-router alias, which is not a routable deployment: leaving it in
+        # place when nothing matched fails downstream with "Unmapped LLM provider", so every path that
+        # does not name a route resolves to the default model.
+        route_name: Final = self._matched_route_name(routelayer, message_content)
 
         return PreRoutingHookResponse(
-            model=model,
+            model=route_name or self.default_model,
             messages=messages,
         )
+
+    def _matched_route_name(self, routelayer: "SemanticRouter", text: str) -> str | None:
+        """Name of the route `text` matches, or None when nothing matched or the match failed.
+
+        The route layer embeds `text` to compare it against the routes, and that embedding call can
+        fail (context limit, timeout, provider error). Choosing a model is a routing decision, so a
+        failure here falls back to the default model rather than failing the user's request.
+        """
+        from semantic_router.schema import RouteChoice
+
+        try:
+            route_choice: Final = routelayer(text=text)
+        except Exception as e:  # noqa: BLE001 -- the embedding call behind the route layer can fail many ways (context limit, timeout, provider/network error); none of them may fail the request
+            verbose_router_logger.warning(
+                "AutoRouter: semantic routing failed (%s), falling back to default model %s", e, self.default_model
+            )
+            return None
+        verbose_router_logger.debug("route_choice: %s", route_choice)
+        if isinstance(route_choice, RouteChoice):
+            return route_choice.name
+        if isinstance(route_choice, list) and route_choice:
+            return route_choice[0].name
+        return None

--- a/litellm/router_strategy/auto_router/litellm_encoder.py
+++ b/litellm/router_strategy/auto_router/litellm_encoder.py
@@ -5,6 +5,8 @@ from semantic_router.encoders import DenseEncoder
 from semantic_router.encoders.base import AsymmetricDenseMixin
 
 import litellm
+from litellm._logging import verbose_router_logger
+from litellm.constants import DEFAULT_MAX_EMBEDDING_INPUT_CHARS
 
 if TYPE_CHECKING:
     from litellm.router import Router
@@ -50,6 +52,7 @@ class LiteLLMRouterEncoder(CustomDenseEncoder, AsymmetricDenseMixin):
         litellm_router_instance: "Router",
         model_name: str,
         score_threshold: float | None = None,
+        max_input_chars: int = DEFAULT_MAX_EMBEDDING_INPUT_CHARS,
     ):
         """Initialize the LiteLLMEncoder.
 
@@ -60,6 +63,10 @@ class LiteLLMRouterEncoder(CustomDenseEncoder, AsymmetricDenseMixin):
         :type model_name: str
         :param score_threshold: The score threshold for the embeddings.
         :type score_threshold: float
+        :param max_input_chars: Longest doc, in characters, sent to the embedding model. Anything
+            longer is cut to this length. Raise it for an encoder with a large context window,
+            lower it for a 512-token one. Non-positive disables clamping.
+        :type max_input_chars: int
         """
         super().__init__(
             name=model_name,
@@ -67,6 +74,24 @@ class LiteLLMRouterEncoder(CustomDenseEncoder, AsymmetricDenseMixin):
         )
         self.model_name = model_name
         self.litellm_router_instance = litellm_router_instance
+        self.max_input_chars = max_input_chars
+
+    def _clamp(self, docs: list[str]) -> list[str]:  # mutable-ok: embedding() takes `input: str | list`
+        """Cut every doc to `max_input_chars`, keeping the head.
+
+        The head carries the ask often enough to place it against a route, and a cut prompt still
+        routes where an over-long one just errors out. Kept here rather than in each caller so the
+        auto-router, complexity-router, semantic guard and MCP tool filter share one limit.
+        """
+        limit: Final = self.max_input_chars
+        if limit <= 0:
+            return docs
+        clamped: Final = [doc[:limit] for doc in docs]  # mutable-ok: embedding() takes `input: str | list`
+        if clamped != docs:
+            verbose_router_logger.debug(
+                "LiteLLMRouterEncoder: cut input to %s chars for embedding model %s", limit, self.model_name
+            )
+        return clamped
 
     def __call__(self, docs: list[Any], **kwargs) -> list[list[float]]:
         """Encode a list of text documents into embeddings using LiteLLM.
@@ -86,7 +111,9 @@ class LiteLLMRouterEncoder(CustomDenseEncoder, AsymmetricDenseMixin):
         if self.litellm_router_instance is None:
             raise ValueError("litellm_router_instance is not set")
         try:
-            embeds: Final = self.litellm_router_instance.embedding(input=docs, model=self.model_name, **kwargs)
+            embeds: Final = self.litellm_router_instance.embedding(
+                input=self._clamp(docs), model=self.model_name, **kwargs
+            )
             return litellm_to_list(embeds)
         except Exception as e:
             raise ValueError(f"{self.type.capitalize()} API call failed. Error: {e}") from e
@@ -95,7 +122,9 @@ class LiteLLMRouterEncoder(CustomDenseEncoder, AsymmetricDenseMixin):
         if self.litellm_router_instance is None:
             raise ValueError("litellm_router_instance is not set")
         try:
-            embeds: Final = self.litellm_router_instance.embedding(input=docs, model=self.model_name, **kwargs)
+            embeds: Final = self.litellm_router_instance.embedding(
+                input=self._clamp(docs), model=self.model_name, **kwargs
+            )
             return litellm_to_list(embeds)
         except Exception as e:
             raise ValueError(f"{self.type.capitalize()} API call failed. Error: {e}") from e
@@ -104,7 +133,9 @@ class LiteLLMRouterEncoder(CustomDenseEncoder, AsymmetricDenseMixin):
         if self.litellm_router_instance is None:
             raise ValueError("litellm_router_instance is not set")
         try:
-            embeds: Final = await self.litellm_router_instance.aembedding(input=docs, model=self.model_name, **kwargs)
+            embeds: Final = await self.litellm_router_instance.aembedding(
+                input=self._clamp(docs), model=self.model_name, **kwargs
+            )
             return litellm_to_list(embeds)
         except Exception as e:
             raise ValueError(f"{self.type.capitalize()} API call failed. Error: {e}") from e
@@ -113,7 +144,9 @@ class LiteLLMRouterEncoder(CustomDenseEncoder, AsymmetricDenseMixin):
         if self.litellm_router_instance is None:
             raise ValueError("litellm_router_instance is not set")
         try:
-            embeds: Final = await self.litellm_router_instance.aembedding(input=docs, model=self.model_name, **kwargs)
+            embeds: Final = await self.litellm_router_instance.aembedding(
+                input=self._clamp(docs), model=self.model_name, **kwargs
+            )
             return litellm_to_list(embeds)
         except Exception as e:
             raise ValueError(f"{self.type.capitalize()} API call failed. Error: {e}") from e

--- a/litellm/router_strategy/auto_router/litellm_encoder.py
+++ b/litellm/router_strategy/auto_router/litellm_encoder.py
@@ -6,7 +6,6 @@ from semantic_router.encoders.base import AsymmetricDenseMixin
 
 import litellm
 from litellm._logging import verbose_router_logger
-from litellm.constants import DEFAULT_MAX_EMBEDDING_INPUT_CHARS
 
 if TYPE_CHECKING:
     from litellm.router import Router
@@ -52,7 +51,7 @@ class LiteLLMRouterEncoder(CustomDenseEncoder, AsymmetricDenseMixin):
         litellm_router_instance: "Router",
         model_name: str,
         score_threshold: float | None = None,
-        max_input_chars: int = DEFAULT_MAX_EMBEDDING_INPUT_CHARS,
+        max_input_chars: int = 0,
     ):
         """Initialize the LiteLLMEncoder.
 
@@ -63,9 +62,12 @@ class LiteLLMRouterEncoder(CustomDenseEncoder, AsymmetricDenseMixin):
         :type model_name: str
         :param score_threshold: The score threshold for the embeddings.
         :type score_threshold: float
-        :param max_input_chars: Longest doc, in characters, sent to the embedding model. Anything
-            longer is cut to this length. Raise it for an encoder with a large context window,
-            lower it for a 512-token one. Non-positive disables clamping.
+        :param max_input_chars: Longest doc, in characters, sent to the embedding model; anything
+            longer is cut to this length. Opt-in, defaulting to 0 (send docs whole), because a
+            caller that has to see the entire text to be correct must not be cut silently: a
+            semantic guard that inspects only a prefix can be walked past with a benign opener.
+            Callers that only rank text against short utterances, such as the auto-router, pass a
+            limit so the encoder's context window cannot fail their request.
         :type max_input_chars: int
         """
         super().__init__(
@@ -77,11 +79,10 @@ class LiteLLMRouterEncoder(CustomDenseEncoder, AsymmetricDenseMixin):
         self.max_input_chars = max_input_chars
 
     def _clamp(self, docs: list[str]) -> list[str]:  # mutable-ok: embedding() takes `input: str | list`
-        """Cut every doc to `max_input_chars`, keeping the head.
+        """Cut every doc to `max_input_chars`, keeping the head, or return them whole when unset.
 
         The head carries the ask often enough to place it against a route, and a cut prompt still
-        routes where an over-long one just errors out. Kept here rather than in each caller so the
-        auto-router, complexity-router, semantic guard and MCP tool filter share one limit.
+        routes where an over-long one just errors out.
         """
         limit: Final = self.max_input_chars
         if limit <= 0:

--- a/litellm/router_utils/auto_router_model_naming.py
+++ b/litellm/router_utils/auto_router_model_naming.py
@@ -23,6 +23,7 @@ STRATEGY_ROUTER_PARAM_FIELDS: Final[frozenset[str]] = frozenset(
         "auto_router_config_path",
         "auto_router_default_model",
         "auto_router_embedding_model",
+        "auto_router_max_input_chars",
         "complexity_router_config",
         "complexity_router_default_model",
         "adaptive_router_config",

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -259,6 +259,7 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     auto_router_config: str | None = None
     auto_router_default_model: str | None = None
     auto_router_embedding_model: str | None = None
+    auto_router_max_input_chars: int | None = None
 
     # complexity-router params
     complexity_router_config: dict | None = None

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3493,6 +3493,7 @@ all_litellm_params = (
         "auto_router_config",
         "auto_router_default_model",
         "auto_router_embedding_model",
+        "auto_router_max_input_chars",
         "complexity_router_config",
         "complexity_router_default_model",
         "adaptive_router_config",

--- a/tests/test_litellm/router_strategy/test_auto_router.py
+++ b/tests/test_litellm/router_strategy/test_auto_router.py
@@ -1,7 +1,8 @@
 import asyncio
+import json
 import os
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Final, List, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -316,3 +317,148 @@ class TestAutoRouter:
 
         # Assert
         assert result is None
+
+
+semantic_router = pytest.importorskip("semantic_router", reason="auto-router needs the semantic-router extra")
+
+ROUTER_CONFIG: Final = json.dumps(
+    {
+        "routes": [
+            {
+                "name": "code-model",
+                "description": "coding asks",
+                "utterances": ["fix this stack trace", "refactor this function"],
+                "score_threshold": 0.5,
+            }
+        ]
+    }
+)
+
+
+class FailingRouteLayer:
+    """Route layer whose embedding call fails, as it does when the prompt exceeds the encoder's window."""
+
+    def __call__(self, text: str) -> Any:
+        raise ValueError(
+            "Internal_litellm_router API call failed. Error: litellm.InternalServerError: "
+            "input is too large to process. increase the physical batch size"
+        )
+
+
+class FixedRouteLayer:
+    """Route layer that returns whatever the test tells it to, recording the text it was asked about."""
+
+    def __init__(self, route_choice: Any) -> None:
+        self.route_choice = route_choice
+        self.seen_text: str | None = None
+
+    def __call__(self, text: str) -> Any:
+        self.seen_text = text
+        return self.route_choice
+
+
+class StubEmbeddingRouter:
+    """Stands in for the LiteLLM Router when the route index has to be built for real."""
+
+    def embedding(self, input: List[str], model: str, **kwargs: Any) -> Any:
+        import litellm
+
+        return litellm.EmbeddingResponse(
+            data=[{"embedding": [0.1, 0.2], "index": i, "object": "embedding"} for i in range(len(input))]
+        )
+
+
+def _auto_router(routelayer: Any, litellm_router_instance: Any = None, **kwargs: Any) -> AutoRouter:
+    auto_router: Final = AutoRouter(
+        model_name="my-auto-router",
+        auto_router_config=ROUTER_CONFIG,
+        default_model="fallback-model",
+        embedding_model="text-embedding-3-small",
+        litellm_router_instance=litellm_router_instance or MagicMock(),
+        **kwargs,
+    )
+    auto_router.routelayer = routelayer
+    return auto_router
+
+
+class TestAutoRouterAlwaysResolvesARoutableModel:
+    """The hook returns the alias's default model instead of failing or leaking the alias downstream."""
+
+    @pytest.mark.asyncio
+    async def test_should_fall_back_to_default_model_when_the_embedding_call_fails(self):
+        auto_router: Final = _auto_router(FailingRouteLayer())
+
+        result: Final = await auto_router.async_pre_routing_hook(
+            model="my-auto-router",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "a" * 100_000}],
+        )
+
+        assert result is not None
+        assert result.model == "fallback-model"
+
+    @pytest.mark.asyncio
+    async def test_should_fall_back_to_default_model_when_no_route_matches(self):
+        auto_router: Final = _auto_router(FixedRouteLayer(None))
+
+        result: Final = await auto_router.async_pre_routing_hook(
+            model="my-auto-router",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "nothing like any route"}],
+        )
+
+        assert result is not None
+        # Leaving "my-auto-router" here fails downstream with "Unmapped LLM provider".
+        assert result.model == "fallback-model"
+
+    @pytest.mark.asyncio
+    async def test_should_fall_back_to_default_model_when_the_route_layer_returns_an_empty_list(self):
+        auto_router: Final = _auto_router(FixedRouteLayer([]))
+
+        result: Final = await auto_router.async_pre_routing_hook(
+            model="my-auto-router",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "nothing like any route"}],
+        )
+
+        assert result is not None
+        assert result.model == "fallback-model"
+
+    @pytest.mark.asyncio
+    async def test_should_still_route_to_the_matched_route_when_one_matches(self):
+        from semantic_router.schema import RouteChoice
+
+        layer: Final = FixedRouteLayer(RouteChoice(name="code-model"))
+        auto_router: Final = _auto_router(layer)
+
+        result: Final = await auto_router.async_pre_routing_hook(
+            model="my-auto-router",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "fix this stack trace"}],
+        )
+
+        assert result is not None
+        assert result.model == "code-model"
+        assert layer.seen_text == "fix this stack trace"
+
+
+class TestAutoRouterEmbeddingInputCap:
+    """The cap configured on the deployment is what the encoder enforces."""
+
+    def test_should_default_the_cap_to_the_shared_constant(self):
+        from litellm.constants import DEFAULT_MAX_EMBEDDING_INPUT_CHARS
+
+        assert _auto_router(FixedRouteLayer(None)).max_input_chars == DEFAULT_MAX_EMBEDDING_INPUT_CHARS
+
+    @pytest.mark.asyncio
+    async def test_should_build_its_encoder_with_the_configured_cap(self):
+        auto_router: Final = _auto_router(None, litellm_router_instance=StubEmbeddingRouter(), max_input_chars=777)
+
+        await auto_router.async_pre_routing_hook(
+            model="my-auto-router",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "fix this stack trace"}],
+        )
+
+        assert auto_router.routelayer is not None
+        assert auto_router.routelayer.encoder.max_input_chars == 777

--- a/tests/test_litellm/router_strategy/test_auto_router.py
+++ b/tests/test_litellm/router_strategy/test_auto_router.py
@@ -425,6 +425,23 @@ class TestAutoRouterAlwaysResolvesARoutableModel:
         assert result.model == "fallback-model"
 
     @pytest.mark.asyncio
+    async def test_should_route_to_the_first_choice_when_the_route_layer_returns_a_populated_list(self):
+        from semantic_router.schema import RouteChoice
+
+        auto_router: Final = _auto_router(
+            FixedRouteLayer([RouteChoice(name="code-model"), RouteChoice(name="chat-model")])
+        )
+
+        result: Final = await auto_router.async_pre_routing_hook(
+            model="my-auto-router",
+            request_kwargs={},
+            messages=[{"role": "user", "content": "fix this stack trace"}],
+        )
+
+        assert result is not None
+        assert result.model == "code-model"
+
+    @pytest.mark.asyncio
     async def test_should_still_route_to_the_matched_route_when_one_matches(self):
         from semantic_router.schema import RouteChoice
 

--- a/tests/test_litellm/router_strategy/test_auto_router.py
+++ b/tests/test_litellm/router_strategy/test_auto_router.py
@@ -446,9 +446,9 @@ class TestAutoRouterEmbeddingInputCap:
     """The cap configured on the deployment is what the encoder enforces."""
 
     def test_should_default_the_cap_to_the_shared_constant(self):
-        from litellm.constants import DEFAULT_MAX_EMBEDDING_INPUT_CHARS
+        from litellm.constants import DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS
 
-        assert _auto_router(FixedRouteLayer(None)).max_input_chars == DEFAULT_MAX_EMBEDDING_INPUT_CHARS
+        assert _auto_router(FixedRouteLayer(None)).max_input_chars == DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS
 
     @pytest.mark.asyncio
     async def test_should_build_its_encoder_with_the_configured_cap(self):

--- a/tests/test_litellm/router_strategy/test_litellm_encoder.py
+++ b/tests/test_litellm/router_strategy/test_litellm_encoder.py
@@ -1,0 +1,117 @@
+"""Tests for litellm/router_strategy/auto_router/litellm_encoder.py"""
+
+import os
+import sys
+from typing import Any, Final
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../.."))
+
+import litellm
+from litellm.constants import DEFAULT_MAX_EMBEDDING_INPUT_CHARS
+from litellm.router_strategy.auto_router.litellm_encoder import LiteLLMRouterEncoder
+
+
+class RecordingRouter:
+    """Stand-in for the LiteLLM Router that records what reached the embedding call.
+
+    Injected through the encoder's constructor so the assertion is on the real code path
+    rather than on a patched attribute.
+    """
+
+    def __init__(self) -> None:
+        self.embedded_inputs: list[list[str]] = []
+
+    def _response(self, input: list[str]) -> litellm.EmbeddingResponse:
+        self.embedded_inputs.append(list(input))
+        return litellm.EmbeddingResponse(
+            data=[{"embedding": [0.1, 0.2], "index": i, "object": "embedding"} for i in range(len(input))]
+        )
+
+    def embedding(self, input: list[str], model: str, **kwargs: Any) -> litellm.EmbeddingResponse:
+        return self._response(input)
+
+    async def aembedding(self, input: list[str], model: str, **kwargs: Any) -> litellm.EmbeddingResponse:
+        return self._response(input)
+
+
+def _encoder(router: RecordingRouter, **kwargs: Any) -> LiteLLMRouterEncoder:
+    return LiteLLMRouterEncoder(
+        litellm_router_instance=router,  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # test double stands in for Router
+        model_name="text-embedding-3-small",
+        **kwargs,
+    )
+
+
+class TestEmbeddingInputCap:
+    """An embedding model's context window must not become the router's context window."""
+
+    def test_should_cut_long_doc_to_default_cap_on_sync_encode(self):
+        router: Final = RecordingRouter()
+        long_doc: Final = "x" * 50_000
+
+        _encoder(router).encode_queries([long_doc])
+
+        assert router.embedded_inputs == [["x" * DEFAULT_MAX_EMBEDDING_INPUT_CHARS]]
+
+    @pytest.mark.asyncio
+    async def test_should_cut_long_doc_to_default_cap_on_async_encode(self):
+        router: Final = RecordingRouter()
+        long_doc: Final = "x" * 50_000
+
+        await _encoder(router).aencode_queries([long_doc])
+
+        assert router.embedded_inputs == [["x" * DEFAULT_MAX_EMBEDDING_INPUT_CHARS]]
+
+    def test_should_cut_documents_as_well_as_queries(self):
+        router: Final = RecordingRouter()
+
+        _encoder(router).encode_documents(["y" * 9_000])
+
+        assert router.embedded_inputs == [["y" * DEFAULT_MAX_EMBEDDING_INPUT_CHARS]]
+
+    @pytest.mark.asyncio
+    async def test_should_cut_documents_as_well_as_queries_async(self):
+        router: Final = RecordingRouter()
+
+        await _encoder(router).aencode_documents(["y" * 9_000])
+
+        assert router.embedded_inputs == [["y" * DEFAULT_MAX_EMBEDDING_INPUT_CHARS]]
+
+    def test_should_leave_docs_within_the_cap_untouched(self):
+        router: Final = RecordingRouter()
+        docs: Final = ["a short prompt", "b" * DEFAULT_MAX_EMBEDDING_INPUT_CHARS]
+
+        _encoder(router).encode_queries(docs)
+
+        assert router.embedded_inputs == [docs]
+
+    def test_should_cut_each_doc_independently(self):
+        router: Final = RecordingRouter()
+
+        _encoder(router).encode_queries(["short", "z" * 5_000])
+
+        assert router.embedded_inputs == [["short", "z" * DEFAULT_MAX_EMBEDDING_INPUT_CHARS]]
+
+    def test_should_honor_a_configured_cap(self):
+        router: Final = RecordingRouter()
+
+        _encoder(router, max_input_chars=10).encode_queries(["0123456789abcdef"])
+
+        assert router.embedded_inputs == [["0123456789"]]
+
+    def test_should_disable_cutting_when_cap_is_not_positive(self):
+        router: Final = RecordingRouter()
+        long_doc: Final = "x" * 50_000
+
+        _encoder(router, max_input_chars=0).encode_queries([long_doc])
+
+        assert router.embedded_inputs == [[long_doc]]
+
+    def test_should_keep_the_head_of_the_doc(self):
+        router: Final = RecordingRouter()
+
+        _encoder(router, max_input_chars=20).encode_queries(["route me please, then a huge pasted file"])
+
+        assert router.embedded_inputs == [["route me please, the"]]

--- a/tests/test_litellm/router_strategy/test_litellm_encoder.py
+++ b/tests/test_litellm/router_strategy/test_litellm_encoder.py
@@ -9,7 +9,7 @@ import pytest
 sys.path.insert(0, os.path.abspath("../../.."))
 
 import litellm
-from litellm.constants import DEFAULT_MAX_EMBEDDING_INPUT_CHARS
+from litellm.constants import DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS
 from litellm.router_strategy.auto_router.litellm_encoder import LiteLLMRouterEncoder
 
 
@@ -38,76 +38,93 @@ class RecordingRouter:
 
 def _encoder(router: RecordingRouter, **kwargs: Any) -> LiteLLMRouterEncoder:
     return LiteLLMRouterEncoder(
-        litellm_router_instance=router,  # type: ignore[arg-type]  # pyright: ignore[reportArgumentType]  # test double stands in for Router
+        litellm_router_instance=router,  # pyright: ignore[reportArgumentType]  # test double stands in for Router
         model_name="text-embedding-3-small",
         **kwargs,
     )
 
 
-class TestEmbeddingInputCap:
-    """An embedding model's context window must not become the router's context window."""
+class TestSendsDocsWholeUnlessAskedNotTo:
+    """Cutting is opt-in: a caller that must see the whole text is never cut behind its back.
 
-    def test_should_cut_long_doc_to_default_cap_on_sync_encode(self):
+    The semantic guard and the MCP tool filter build this encoder without a limit. If a default
+    limit ever creeps back in, a prompt-injection payload placed after a benign opener would be
+    invisible to the guard while the full message still reaches the model.
+    """
+
+    def test_should_send_a_long_doc_whole_when_no_cap_is_configured(self):
         router: Final = RecordingRouter()
         long_doc: Final = "x" * 50_000
 
         _encoder(router).encode_queries([long_doc])
 
-        assert router.embedded_inputs == [["x" * DEFAULT_MAX_EMBEDDING_INPUT_CHARS]]
+        assert router.embedded_inputs == [[long_doc]]
 
     @pytest.mark.asyncio
-    async def test_should_cut_long_doc_to_default_cap_on_async_encode(self):
+    async def test_should_send_a_long_doc_whole_when_no_cap_is_configured_async(self):
         router: Final = RecordingRouter()
         long_doc: Final = "x" * 50_000
 
         await _encoder(router).aencode_queries([long_doc])
 
-        assert router.embedded_inputs == [["x" * DEFAULT_MAX_EMBEDDING_INPUT_CHARS]]
+        assert router.embedded_inputs == [[long_doc]]
 
-    def test_should_cut_documents_as_well_as_queries(self):
-        router: Final = RecordingRouter()
-
-        _encoder(router).encode_documents(["y" * 9_000])
-
-        assert router.embedded_inputs == [["y" * DEFAULT_MAX_EMBEDDING_INPUT_CHARS]]
-
-    @pytest.mark.asyncio
-    async def test_should_cut_documents_as_well_as_queries_async(self):
-        router: Final = RecordingRouter()
-
-        await _encoder(router).aencode_documents(["y" * 9_000])
-
-        assert router.embedded_inputs == [["y" * DEFAULT_MAX_EMBEDDING_INPUT_CHARS]]
-
-    def test_should_leave_docs_within_the_cap_untouched(self):
-        router: Final = RecordingRouter()
-        docs: Final = ["a short prompt", "b" * DEFAULT_MAX_EMBEDDING_INPUT_CHARS]
-
-        _encoder(router).encode_queries(docs)
-
-        assert router.embedded_inputs == [docs]
-
-    def test_should_cut_each_doc_independently(self):
-        router: Final = RecordingRouter()
-
-        _encoder(router).encode_queries(["short", "z" * 5_000])
-
-        assert router.embedded_inputs == [["short", "z" * DEFAULT_MAX_EMBEDDING_INPUT_CHARS]]
-
-    def test_should_honor_a_configured_cap(self):
-        router: Final = RecordingRouter()
-
-        _encoder(router, max_input_chars=10).encode_queries(["0123456789abcdef"])
-
-        assert router.embedded_inputs == [["0123456789"]]
-
-    def test_should_disable_cutting_when_cap_is_not_positive(self):
+    def test_should_send_a_long_doc_whole_when_the_cap_is_not_positive(self):
         router: Final = RecordingRouter()
         long_doc: Final = "x" * 50_000
 
         _encoder(router, max_input_chars=0).encode_queries([long_doc])
 
         assert router.embedded_inputs == [[long_doc]]
+
+
+class TestEmbeddingInputCap:
+    """With a cap configured, an embedding model's context window cannot fail the caller's request."""
+
+    def test_should_cut_a_long_doc_to_the_cap_on_sync_encode(self):
+        router: Final = RecordingRouter()
+
+        _encoder(router, max_input_chars=DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS).encode_queries(["x" * 50_000])
+
+        assert router.embedded_inputs == [["x" * DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS]]
+
+    @pytest.mark.asyncio
+    async def test_should_cut_a_long_doc_to_the_cap_on_async_encode(self):
+        router: Final = RecordingRouter()
+
+        await _encoder(router, max_input_chars=DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS).aencode_queries(["x" * 50_000])
+
+        assert router.embedded_inputs == [["x" * DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS]]
+
+    def test_should_cut_documents_as_well_as_queries(self):
+        router: Final = RecordingRouter()
+
+        _encoder(router, max_input_chars=100).encode_documents(["y" * 9_000])
+
+        assert router.embedded_inputs == [["y" * 100]]
+
+    @pytest.mark.asyncio
+    async def test_should_cut_documents_as_well_as_queries_async(self):
+        router: Final = RecordingRouter()
+
+        await _encoder(router, max_input_chars=100).aencode_documents(["y" * 9_000])
+
+        assert router.embedded_inputs == [["y" * 100]]
+
+    def test_should_leave_docs_within_the_cap_untouched(self):
+        router: Final = RecordingRouter()
+        docs: Final = ["a short prompt", "b" * 100]
+
+        _encoder(router, max_input_chars=100).encode_queries(docs)
+
+        assert router.embedded_inputs == [docs]
+
+    def test_should_cut_each_doc_in_a_batch_independently(self):
+        router: Final = RecordingRouter()
+
+        _encoder(router, max_input_chars=100).encode_queries(["short", "z" * 5_000])
+
+        assert router.embedded_inputs == [["short", "z" * 100]]
 
     def test_should_keep_the_head_of_the_doc(self):
         router: Final = RecordingRouter()

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -7288,3 +7288,49 @@ def test_pre_call_checks_keeps_deployment_when_provider_is_unresolvable(monkeypa
     )
 
     assert len(result) == 1
+
+
+class TestAutoRouterMaxInputCharsWiring:
+    """`auto_router_max_input_chars` on the deployment has to reach the AutoRouter that embeds prompts.
+
+    Without it the cap silently reverts to the default, so an operator whose embedding model has a
+    512-token window cannot lower it and every long prompt falls back to the default model instead
+    of being routed.
+    """
+
+    @staticmethod
+    def _router(**extra_params) -> "litellm.Router":
+        pytest.importorskip("semantic_router", reason="auto-router needs the semantic-router extra")
+        return litellm.Router(
+            model_list=[
+                {"model_name": "gpt-4o", "litellm_params": {"model": "gpt-4o"}},
+                {
+                    "model_name": "my-auto-router",
+                    "litellm_params": {
+                        "model": "auto_router/my-auto-router",
+                        "auto_router_config": json.dumps(
+                            {"routes": [{"name": "gpt-4o", "utterances": ["write me code"]}]}
+                        ),
+                        "auto_router_default_model": "gpt-4o",
+                        "auto_router_embedding_model": "text-embedding-3-small",
+                        **extra_params,
+                    },
+                },
+            ]
+        )
+
+    @staticmethod
+    def _registered_auto_router(router: "litellm.Router"):
+        return router.auto_routers["my-auto-router"][0].strategy
+
+    def test_should_pass_the_configured_cap_to_the_auto_router(self):
+        router = self._router(auto_router_max_input_chars=512)
+
+        assert self._registered_auto_router(router).max_input_chars == 512
+
+    def test_should_fall_back_to_the_shared_default_when_the_deployment_omits_it(self):
+        from litellm.constants import DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS
+
+        router = self._router()
+
+        assert self._registered_auto_router(router).max_input_chars == DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -26497,6 +26497,8 @@ export interface components {
             auto_router_default_model?: string | null;
             /** Auto Router Embedding Model */
             auto_router_embedding_model?: string | null;
+            /** Auto Router Max Input Chars */
+            auto_router_max_input_chars?: number | null;
             /** Aws Access Key Id */
             aws_access_key_id?: string | null;
             /** Aws Bedrock Project Id */
@@ -35072,6 +35074,8 @@ export interface components {
             auto_router_default_model?: string | null;
             /** Auto Router Embedding Model */
             auto_router_embedding_model?: string | null;
+            /** Auto Router Max Input Chars */
+            auto_router_max_input_chars?: number | null;
             /** Aws Access Key Id */
             aws_access_key_id?: string | null;
             /** Aws Bedrock Project Id */


### PR DESCRIPTION
## TLDR

Problem this solves:

- Auto-router sent the full prompt to the embedding model
- Embedding windows are 512 to 8k, chat windows 200k+
- Long prompts 400'd at routing, never reached the model

How it solves it:

- Auto-router cuts the prompt before embedding it
- 2000 chars, per-deployment `auto_router_max_input_chars`
- Opt-in, so guards and filters still see whole prompts
- Any route failure falls back to the default model
- Every no-match path now resolves to the default model

## Relevant issues

Fixes #17869
Fixes #20277

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured on a live proxy at localhost:4000 against the real OpenAI embeddings API, same config and payloads on both commits: https://github.com/BerriAI/litellm/pull/35956#issuecomment-5196058947

A 179,500-character prompt (30,268 `cl100k_base` tokens) returns 500 before, with `maximum input length is 8192 tokens` from `text-embedding-3-small`, and 200 after. The `auto_router_max_input_chars` knob is exercised too, at 50 chars. The AFTER run still routes to the coding route rather than the default, so the head carried enough of the ask for the match to survive the cut

A short prompt matching a route, and one matching nothing, return the same model on both commits, so ordinary routing is unchanged

## Type

🐛 Bug Fix

## Changes

The auto-router embeds the last user message to pick a model, and sent it to the embedding model unbounded. Embedding models carry 512 to 8k token windows while the chat models they route to carry 200k+, so any prompt over the encoder's window failed at the routing step with a 400 the destination model would never have raised. In practice that made the auto-router impose its embedding model's context window on every request routed through it, which is what both issues report

The cutting lives in `LiteLLMRouterEncoder`, the one choke point every semantic consumer shares, but it is opt-in rather than a default. The encoder sends docs whole unless a caller passes `max_input_chars`, and the auto-router is the only caller that does, at `DEFAULT_AUTO_ROUTER_MAX_INPUT_CHARS`, 2000 characters or roughly 500 tokens of English, which fits even a 512-token self-hosted encoder. Operators raise or lower it per deployment with `auto_router_max_input_chars`. The head of each doc is kept, which is what the reporter asked for and what `_truncate` in the complexity router already does

Opt-in matters for correctness, not just tidiness. The semantic guard builds this same encoder, and a default cap would have had it classify only the first 2000 characters while the full message still reached the model, so a benign opener in front of an injection payload would walk past the guard. Review caught that on the first commit and it is fixed in the second. The MCP tool filter and the complexity router keep their current behaviour for the same reason

Characters rather than tokens keeps this free of a tokenizer dependency, and matches the existing `classifier_context_per_turn_chars` precedent. Deriving the budget from `max_input_tokens` was the other option, but it resolves to `None` for exactly the self-hosted models where the bug bites, since they aren't in `model_prices_and_context_window.json`

The cap is a quality knob rather than a correctness one, given the fallback below: set it too high for your encoder and the embedding call fails, the router falls back to its default model, and the request still succeeds

Truncation alone cannot cover provider-side batch and byte limits, so `AutoRouter._matched_route_name` now catches any failure of the route call, logs a warning and falls back to the auto-router's default model. That fallback is what actually guarantees a routing problem can never be what fails a user's request

Correcting something an earlier revision of this description got wrong: the old `if/elif` had no branch for a `None` route choice, so the auto-router alias would have stayed as the model name, and `route_choice[0]` on an empty list would have raised `IndexError`. Neither is reachable through semantic-router 0.1.15, whose `_pass_routes` returns `RouteChoice()` with `name=None` when nothing clears the threshold rather than `None`, and only returns a list when more than one route passes. So the old code already reached `default_model` on a no-match, which the live capture below confirms. Those two paths are hardening against a library change or a different route layer, not live bugs, and the tests pin them as such

The complexity router is untouched. Its semantic keyword path has the same unbounded embed, but it already swallows the failure, so a long prompt drops to heuristic scoring rather than erroring. Capping it is worth doing and belongs in its own change, since it is a routing-quality question rather than the reported bug

Chunking the input and averaging the chunk vectors was considered and rejected: averaging pulls the result toward a generic centroid and away from every route utterance, so threshold matching degrades as the input grows, which defeats the purpose. #17933 was already closed on that shape

Not addressed here, and worth its own PR: #33204, the route layer's embedding call running synchronously on the event loop

### Tests

`tests/test_litellm/router_strategy/test_litellm_encoder.py` is new, since the encoder had no mapped test file. It injects a recording router through the constructor and asserts on the string that actually reaches `embedding()` and `aembedding()`. One class covers the cap itself: long docs cut, short docs untouched, each doc in a batch cut independently, and the head being what survives. The other covers the guard, asserting a 50k-character doc arrives whole when no cap is configured, so a default can't creep back in and blind the guard to anything past the first 2000 characters

`tests/test_litellm/router_strategy/test_auto_router.py` gains the hook-level cases: an embedding failure resolving to the default model instead of propagating, a `None` route choice and an empty list both resolving to the default model rather than leaving the alias, the configured cap reaching the encoder the hook builds, and a matched route still routing where it did before

Checked against the base commit: 8 of the 10 encoder tests and 5 of the 5 auto-router behaviour tests fail without the change, and the ones that pass either way are the no-regression cases they're meant to be

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
