### PR TITLE
fix(proxy): handle BaseModel responses during deprecated key lookup

### DIFF
--- a/litellm/proxy/utils.py
+++ b/litellm/proxy/utils.py
@@ -63,6 +63,8 @@ except ImportError:
     raise ImportError("backoff is not installed. Please install it via 'pip install backoff'")
 
 from fastapi import HTTPException, status
+from pydantic import BaseModel
+
 
 import litellm
 import litellm.litellm_core_utils
@@ -3754,13 +3756,15 @@ class PrismaClient:
                             return deprecated_response
 
                     if response is not None:
-                        if response["team_models"] is None:
+                        if isinstance(response, BaseModel):
+                            response = response.model_dump()
+                        if response.get("team_models") is None:
                             response["team_models"] = []
-                        if response["team_blocked"] is None:
+                        if response.get("team_blocked") is None:
                             response["team_blocked"] = False
 
                         team_member: Member | None = None
-                        if response["team_members_with_roles"] is not None and response["user_id"] is not None:
+                        if response.get("team_members_with_roles") is not None and response.get("user_id") is not None:
                             ## find the team member corresponding to user id
                             """
                             [
@@ -3780,6 +3784,7 @@ class PrismaClient:
                                 if tm.get("user_id") is not None and response["user_id"] == tm.get("user_id"):
                                     team_member = Member(**tm)
                         response["team_member"] = team_member
+                        response.pop("last_refreshed_at", None)
                         response = LiteLLM_VerificationTokenView(**response, last_refreshed_at=time.time())
                         # for prisma we need to cast the expires time to str
                         if response.expires is not None and isinstance(response.expires, datetime):

--- a/tests/test_litellm/proxy/test_proxy_utils.py
+++ b/tests/test_litellm/proxy/test_proxy_utils.py
@@ -17,7 +17,7 @@ sys.path.insert(
 )  # Adds the parent directory to the system path
 
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from litellm.proxy.utils import get_custom_url, join_paths
 
@@ -1085,3 +1085,71 @@ async def test_post_mcp_call_hook_propagates_guardrail_block(restore_callbacks):
             request_data={"mcp_tool_name": "echo"},
             user_api_key_dict=None,
         )
+
+
+@pytest.mark.asyncio
+async def test_get_data_normalizes_pydantic_model():
+    """Verify get_data handles a Pydantic BaseModel response without raising TypeError: object is not subscriptable."""
+    from litellm.proxy._types import LiteLLM_VerificationTokenView
+    from litellm.proxy.proxy_server import PrismaClient
+
+    prisma_client = PrismaClient.__new__(PrismaClient)
+    prisma_client.db = MagicMock()
+    mock_token_view = LiteLLM_VerificationTokenView(
+        token="hash_123",
+        user_id="user_123",
+        team_models=[],
+        team_blocked=False,
+    )
+
+    with patch.object(
+        prisma_client,
+        "_query_first_with_cached_plan_fallback",
+        new=AsyncMock(return_value=mock_token_view),
+    ):
+        result = await prisma_client.get_data(
+            token="sk-test-123",
+            table_name="combined_view",
+            query_type="find_unique",
+            check_deprecated=False,
+        )
+        assert isinstance(result, LiteLLM_VerificationTokenView)
+        assert result.token == "hash_123"
+        assert result.team_models == []
+        assert result.team_blocked is False
+
+
+
+@pytest.mark.asyncio
+async def test_get_data_deprecated_key_grace_period():
+    """Verify get_data gracefully resolves deprecated key lookup during rotation grace period."""
+    from litellm.proxy._types import LiteLLM_VerificationTokenView
+    from litellm.proxy.proxy_server import PrismaClient
+
+    prisma_client = PrismaClient.__new__(PrismaClient)
+    prisma_client.db = MagicMock()
+
+    active_token_view = LiteLLM_VerificationTokenView(
+        token="active_hash_456",
+        user_id="user_456",
+        team_models=[],
+        team_blocked=False,
+    )
+
+    async def mock_query_first(sql, param):
+        if param == "deprecated_hash_123":
+            return None
+        return active_token_view
+
+    with patch.object(prisma_client, "_query_first_with_cached_plan_fallback", side_effect=mock_query_first), \
+         patch("litellm.proxy.utils._lookup_deprecated_key", new=AsyncMock(return_value="active_hash_456")):
+        result = await prisma_client.get_data(
+            token="sk-deprecated-key",
+            table_name="combined_view",
+            query_type="find_unique",
+            check_deprecated=True,
+        )
+        assert isinstance(result, LiteLLM_VerificationTokenView)
+        assert result.token == "active_hash_456"
+
+


### PR DESCRIPTION
## Summary

Fixes #35797.

During key rotation with a grace period, `get_data()` can receive a `LiteLLM_VerificationTokenView` (Pydantic `BaseModel`) from the recursive deprecated-key lookup path. The subsequent normalization logic assumes `response` is a dictionary and performs item access (e.g. `response["team_models"]`), resulting in:

```
TypeError: 'LiteLLM_VerificationTokenView' object is not subscriptable
```

## Changes

- Normalize `BaseModel` responses to dictionaries before dictionary-based post-processing in `get_data()`.
- Remove an existing `last_refreshed_at` value before reconstructing `LiteLLM_VerificationTokenView` to avoid duplicate keyword arguments.
- Add regression tests in `test_proxy_utils.py` covering:
  - `BaseModel` normalization.
  - Deprecated key lookup during key rotation grace period.

## Testing

```bash
pytest tests/test_litellm/proxy/test_proxy_utils.py -k "test_get_data"
```
**Result**: `2 passed in 4.18s`
