### PR TITLE
feat(providers): add QuickSilver Pro as an OpenAI-compatible provider

### DIFF
--- a/litellm/llms/openai_like/providers.json
+++ b/litellm/llms/openai_like/providers.json
@@ -183,5 +183,11 @@
       "max_completion_tokens": "max_tokens"
     },
     "supported_endpoints": ["/v1/chat/completions", "/v1/responses", "/v1/embeddings"]
+  },
+  "quicksilverpro": {
+    "base_url": "https://api.quicksilverpro.io/v1",
+    "api_key_env": "QUICKSILVERPRO_API_KEY",
+    "api_base_env": "QUICKSILVERPRO_API_BASE",
+    "supported_endpoints": ["/v1/chat/completions", "/v1/responses"]
   }
 }

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -46300,7 +46300,7 @@
         "max_input_tokens": 1048576,
         "input_cost_per_token": 1.12e-07,
         "output_cost_per_token": 2.24e-07,
-        "cache_read_input_token_cost": 2.24e-09,
+        "cache_read_input_token_cost": 1.44e-08,
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_reasoning": true,
@@ -46594,7 +46594,6 @@
         "cache_read_input_token_cost": 4.8e-08,
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true,
         "supports_reasoning": true,
         "supports_prompt_caching": true,
         "supported_endpoints": [

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -46841,15 +46841,6 @@
         ],
         "source": "https://quicksilverpro.io/docs/models/"
     },
-    "quicksilverpro/flux.2-pro": {
-        "litellm_provider": "quicksilverpro",
-        "mode": "image_generation",
-        "input_cost_per_image": 0.027,
-        "supported_endpoints": [
-            "/v1/images/generations"
-        ],
-        "source": "https://quicksilverpro.io/docs/models/"
-    },
     "fallback_generalizations": {
         "rules": [
             {

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -46294,6 +46294,562 @@
         "supports_reasoning": false,
         "source": "https://pinstripes.io/pricing"
     },
+    "quicksilverpro/deepseek-v4-flash": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.12e-07,
+        "output_cost_per_token": 2.24e-07,
+        "cache_read_input_token_cost": 2.24e-09,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/deepseek-v4-pro": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 3.48e-07,
+        "output_cost_per_token": 6.96e-07,
+        "cache_read_input_token_cost": 2.784e-09,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/qwen3.8-max": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "max_tokens": 131072,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 2e-06,
+        "output_cost_per_token": 6e-06,
+        "cache_read_input_token_cost": 2.5e-07,
+        "cache_creation_input_token_cost": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/qwen3.7-max": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.25e-06,
+        "output_cost_per_token": 3.75e-06,
+        "cache_read_input_token_cost": 2.5e-07,
+        "cache_creation_input_token_cost": 1.5625e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/qwen3.7-plus": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.56e-07,
+        "output_cost_per_token": 1.024e-06,
+        "cache_read_input_token_cost": 5.12e-08,
+        "cache_creation_input_token_cost": 3.2e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/qwen3.7-flash": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.4e-08,
+        "output_cost_per_token": 1.04e-07,
+        "cache_read_input_token_cost": 4.8e-09,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/qwen3.6-plus": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.6e-07,
+        "output_cost_per_token": 1.56e-06,
+        "cache_creation_input_token_cost": 3.25e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/qwen3.6-35b": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 262144,
+        "input_cost_per_token": 1.12e-07,
+        "output_cost_per_token": 8e-07,
+        "cache_read_input_token_cost": 4e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/kimi-k2.6": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 256000,
+        "input_cost_per_token": 5.472e-07,
+        "output_cost_per_token": 2.728e-06,
+        "cache_read_input_token_cost": 2.92e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/kimi-k2.7-code": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 256000,
+        "input_cost_per_token": 5.84e-07,
+        "output_cost_per_token": 2.8e-06,
+        "cache_read_input_token_cost": 1.278e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/kimi-k3": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.4e-06,
+        "output_cost_per_token": 1.2e-05,
+        "cache_read_input_token_cost": 2.4e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/glm-5.2": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.12e-06,
+        "output_cost_per_token": 3.52e-06,
+        "cache_read_input_token_cost": 2.08e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gpt-5.6-luna": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "max_tokens": 131072,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 8e-08,
+        "output_cost_per_token": 4.8e-07,
+        "cache_read_input_token_cost": 8e-09,
+        "cache_creation_input_token_cost": 1e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gpt-5.6-terra": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "max_tokens": 131072,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 8e-07,
+        "output_cost_per_token": 4.8e-06,
+        "cache_read_input_token_cost": 8e-08,
+        "cache_creation_input_token_cost": 1e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gpt-5.6-sol": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "max_tokens": 131072,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 4e-06,
+        "output_cost_per_token": 2.4e-05,
+        "cache_read_input_token_cost": 4e-07,
+        "cache_creation_input_token_cost": 5e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/grok-4.5": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 500000,
+        "input_cost_per_token": 1.6e-06,
+        "output_cost_per_token": 4.8e-06,
+        "cache_read_input_token_cost": 4e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/minimax-m3": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.4e-07,
+        "output_cost_per_token": 9.6e-07,
+        "cache_read_input_token_cost": 4.8e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/mimo-v2.5": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.12e-07,
+        "output_cost_per_token": 2.24e-07,
+        "cache_read_input_token_cost": 2.24e-09,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/hy3": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 262144,
+        "input_cost_per_token": 1.056e-07,
+        "output_cost_per_token": 4.224e-07,
+        "cache_read_input_token_cost": 2.64e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/claude-opus-5": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1000000,
+        "max_tokens": 128000,
+        "max_output_tokens": 128000,
+        "input_cost_per_token": 4e-06,
+        "output_cost_per_token": 2e-05,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/claude-fable-5": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1000000,
+        "max_tokens": 128000,
+        "max_output_tokens": 128000,
+        "input_cost_per_token": 8e-06,
+        "output_cost_per_token": 4e-05,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/claude-opus-4-8": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1000000,
+        "input_cost_per_token": 4e-06,
+        "output_cost_per_token": 2e-05,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/claude-opus-4-6": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1000000,
+        "input_cost_per_token": 4e-06,
+        "output_cost_per_token": 2e-05,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/claude-sonnet-4-6": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1000000,
+        "input_cost_per_token": 2.4e-06,
+        "output_cost_per_token": 1.2e-05,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/claude-haiku-4-5": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 200000,
+        "input_cost_per_token": 8e-07,
+        "output_cost_per_token": 4e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3.6-flash": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.275e-06,
+        "output_cost_per_token": 6.375e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3.5-flash-lite": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.55e-07,
+        "output_cost_per_token": 2.125e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3.5-flash": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.275e-06,
+        "output_cost_per_token": 7.65e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3.1-pro-preview": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.7e-06,
+        "output_cost_per_token": 1.02e-05,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3-pro-image": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.7e-06,
+        "output_cost_per_token": 0.000102,
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3-flash-preview": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 4.25e-07,
+        "output_cost_per_token": 2.55e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3.1-flash-lite": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.125e-07,
+        "output_cost_per_token": 1.275e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/flux.2-pro": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.027,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
     "fallback_generalizations": {
         "rules": [
             {

--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -46414,6 +46414,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_reasoning": true,
+        "supports_prompt_caching": true,
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/responses"
@@ -46844,7 +46845,7 @@
     "quicksilverpro/flux.2-pro": {
         "litellm_provider": "quicksilverpro",
         "mode": "image_generation",
-        "output_cost_per_image": 0.027,
+        "input_cost_per_image": 0.027,
         "supported_endpoints": [
             "/v1/images/generations"
         ],

--- a/litellm/provider_endpoints_support_backup.json
+++ b/litellm/provider_endpoints_support_backup.json
@@ -2534,6 +2534,23 @@
         "messages": true,
         "responses": true
       }
+    },
+    "quicksilverpro": {
+      "display_name": "QuickSilver Pro (`quicksilverpro`)",
+      "url": "https://docs.litellm.ai/docs/providers/quicksilverpro",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
     }
   },
   "endpoints": {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -46422,7 +46422,7 @@
         "max_input_tokens": 1048576,
         "input_cost_per_token": 1.12e-07,
         "output_cost_per_token": 2.24e-07,
-        "cache_read_input_token_cost": 2.24e-09,
+        "cache_read_input_token_cost": 1.44e-08,
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_reasoning": true,
@@ -46716,7 +46716,6 @@
         "cache_read_input_token_cost": 4.8e-08,
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_vision": true,
         "supports_reasoning": true,
         "supports_prompt_caching": true,
         "supported_endpoints": [

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -46963,15 +46963,6 @@
         ],
         "source": "https://quicksilverpro.io/docs/models/"
     },
-    "quicksilverpro/flux.2-pro": {
-        "litellm_provider": "quicksilverpro",
-        "mode": "image_generation",
-        "input_cost_per_image": 0.027,
-        "supported_endpoints": [
-            "/v1/images/generations"
-        ],
-        "source": "https://quicksilverpro.io/docs/models/"
-    },
     "fallback_generalizations": {
         "rules": [
             {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -46416,6 +46416,562 @@
         "supports_system_messages": true,
         "supports_tool_choice": true
     },
+    "quicksilverpro/deepseek-v4-flash": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.12e-07,
+        "output_cost_per_token": 2.24e-07,
+        "cache_read_input_token_cost": 2.24e-09,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/deepseek-v4-pro": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 3.48e-07,
+        "output_cost_per_token": 6.96e-07,
+        "cache_read_input_token_cost": 2.784e-09,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/qwen3.8-max": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "max_tokens": 131072,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 2e-06,
+        "output_cost_per_token": 6e-06,
+        "cache_read_input_token_cost": 2.5e-07,
+        "cache_creation_input_token_cost": 2.5e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/qwen3.7-max": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.25e-06,
+        "output_cost_per_token": 3.75e-06,
+        "cache_read_input_token_cost": 2.5e-07,
+        "cache_creation_input_token_cost": 1.5625e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/qwen3.7-plus": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.56e-07,
+        "output_cost_per_token": 1.024e-06,
+        "cache_read_input_token_cost": 5.12e-08,
+        "cache_creation_input_token_cost": 3.2e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/qwen3.7-flash": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.4e-08,
+        "output_cost_per_token": 1.04e-07,
+        "cache_read_input_token_cost": 4.8e-09,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/qwen3.6-plus": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.6e-07,
+        "output_cost_per_token": 1.56e-06,
+        "cache_creation_input_token_cost": 3.25e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/qwen3.6-35b": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 262144,
+        "input_cost_per_token": 1.12e-07,
+        "output_cost_per_token": 8e-07,
+        "cache_read_input_token_cost": 4e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/kimi-k2.6": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 256000,
+        "input_cost_per_token": 5.472e-07,
+        "output_cost_per_token": 2.728e-06,
+        "cache_read_input_token_cost": 2.92e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/kimi-k2.7-code": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 256000,
+        "input_cost_per_token": 5.84e-07,
+        "output_cost_per_token": 2.8e-06,
+        "cache_read_input_token_cost": 1.278e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/kimi-k3": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.4e-06,
+        "output_cost_per_token": 1.2e-05,
+        "cache_read_input_token_cost": 2.4e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/glm-5.2": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.12e-06,
+        "output_cost_per_token": 3.52e-06,
+        "cache_read_input_token_cost": 2.08e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gpt-5.6-luna": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "max_tokens": 131072,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 8e-08,
+        "output_cost_per_token": 4.8e-07,
+        "cache_read_input_token_cost": 8e-09,
+        "cache_creation_input_token_cost": 1e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gpt-5.6-terra": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "max_tokens": 131072,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 8e-07,
+        "output_cost_per_token": 4.8e-06,
+        "cache_read_input_token_cost": 8e-08,
+        "cache_creation_input_token_cost": 1e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gpt-5.6-sol": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "max_tokens": 131072,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 4e-06,
+        "output_cost_per_token": 2.4e-05,
+        "cache_read_input_token_cost": 4e-07,
+        "cache_creation_input_token_cost": 5e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/grok-4.5": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 500000,
+        "input_cost_per_token": 1.6e-06,
+        "output_cost_per_token": 4.8e-06,
+        "cache_read_input_token_cost": 4e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/minimax-m3": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.4e-07,
+        "output_cost_per_token": 9.6e-07,
+        "cache_read_input_token_cost": 4.8e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/mimo-v2.5": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.12e-07,
+        "output_cost_per_token": 2.24e-07,
+        "cache_read_input_token_cost": 2.24e-09,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/hy3": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 262144,
+        "input_cost_per_token": 1.056e-07,
+        "output_cost_per_token": 4.224e-07,
+        "cache_read_input_token_cost": 2.64e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_reasoning": true,
+        "supports_prompt_caching": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/claude-opus-5": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1000000,
+        "max_tokens": 128000,
+        "max_output_tokens": 128000,
+        "input_cost_per_token": 4e-06,
+        "output_cost_per_token": 2e-05,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/claude-fable-5": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1000000,
+        "max_tokens": 128000,
+        "max_output_tokens": 128000,
+        "input_cost_per_token": 8e-06,
+        "output_cost_per_token": 4e-05,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/claude-opus-4-8": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1000000,
+        "input_cost_per_token": 4e-06,
+        "output_cost_per_token": 2e-05,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/claude-opus-4-6": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1000000,
+        "input_cost_per_token": 4e-06,
+        "output_cost_per_token": 2e-05,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/claude-sonnet-4-6": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1000000,
+        "input_cost_per_token": 2.4e-06,
+        "output_cost_per_token": 1.2e-05,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/claude-haiku-4-5": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 200000,
+        "input_cost_per_token": 8e-07,
+        "output_cost_per_token": 4e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3.6-flash": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.275e-06,
+        "output_cost_per_token": 6.375e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3.5-flash-lite": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.55e-07,
+        "output_cost_per_token": 2.125e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3.5-flash": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.275e-06,
+        "output_cost_per_token": 7.65e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3.1-pro-preview": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.7e-06,
+        "output_cost_per_token": 1.02e-05,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3-pro-image": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 1.7e-06,
+        "output_cost_per_token": 0.000102,
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3-flash-preview": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 4.25e-07,
+        "output_cost_per_token": 2.55e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supports_reasoning": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/gemini-3.1-flash-lite": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "chat",
+        "max_input_tokens": 1048576,
+        "input_cost_per_token": 2.125e-07,
+        "output_cost_per_token": 1.275e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_vision": true,
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/responses"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
+    "quicksilverpro/flux.2-pro": {
+        "litellm_provider": "quicksilverpro",
+        "mode": "image_generation",
+        "output_cost_per_image": 0.027,
+        "supported_endpoints": [
+            "/v1/images/generations"
+        ],
+        "source": "https://quicksilverpro.io/docs/models/"
+    },
     "fallback_generalizations": {
         "rules": [
             {

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -46536,6 +46536,7 @@
         "supports_function_calling": true,
         "supports_response_schema": true,
         "supports_reasoning": true,
+        "supports_prompt_caching": true,
         "supported_endpoints": [
             "/v1/chat/completions",
             "/v1/responses"
@@ -46966,7 +46967,7 @@
     "quicksilverpro/flux.2-pro": {
         "litellm_provider": "quicksilverpro",
         "mode": "image_generation",
-        "output_cost_per_image": 0.027,
+        "input_cost_per_image": 0.027,
         "supported_endpoints": [
             "/v1/images/generations"
         ],

--- a/provider_endpoints_support.json
+++ b/provider_endpoints_support.json
@@ -2941,6 +2941,23 @@
         "rerank": false,
         "a2a": false
       }
+    },
+    "quicksilverpro": {
+      "display_name": "QuickSilver Pro (`quicksilverpro`)",
+      "url": "https://docs.litellm.ai/docs/providers/quicksilverpro",
+      "endpoints": {
+        "chat_completions": true,
+        "messages": false,
+        "responses": true,
+        "embeddings": false,
+        "image_generations": false,
+        "audio_transcriptions": false,
+        "audio_speech": false,
+        "moderations": false,
+        "batches": false,
+        "rerank": false,
+        "a2a": false
+      }
     }
   },
   "endpoints": {

--- a/tests/test_litellm/llms/openai_like/test_quicksilverpro_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_quicksilverpro_provider.py
@@ -1,0 +1,182 @@
+"""
+Tests for QuickSilver Pro provider configuration and cost map registration.
+"""
+
+import pytest
+
+import litellm
+
+QUICKSILVERPRO_CHAT_MODELS = [
+    "quicksilverpro/deepseek-v4-flash",
+    "quicksilverpro/deepseek-v4-pro",
+    "quicksilverpro/qwen3.8-max",
+    "quicksilverpro/qwen3.7-max",
+    "quicksilverpro/kimi-k3",
+    "quicksilverpro/glm-5.2",
+    "quicksilverpro/gpt-5.6-luna",
+    "quicksilverpro/grok-4.5",
+    "quicksilverpro/claude-haiku-4-5",
+    "quicksilverpro/gemini-3.5-flash",
+]
+
+
+class TestQuickSilverProProviderConfig:
+    """Test QuickSilver Pro provider configuration"""
+
+    def test_quicksilverpro_json_config_exists(self):
+        """Test that quicksilverpro is configured in providers.json"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+
+        assert JSONProviderRegistry.exists("quicksilverpro")
+
+        provider = JSONProviderRegistry.get("quicksilverpro")
+        assert provider is not None
+        assert provider.base_url == "https://api.quicksilverpro.io/v1"
+        assert provider.api_key_env == "QUICKSILVERPRO_API_KEY"
+        assert provider.api_base_env == "QUICKSILVERPRO_API_BASE"
+
+    def test_quicksilverpro_provider_resolution(self):
+        """Provider resolution finds quicksilverpro and its default base URL"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        model, provider, _api_key, api_base = get_llm_provider(
+            model="quicksilverpro/qwen3.8-max",
+            custom_llm_provider=None,
+            api_base=None,
+            api_key=None,
+        )
+
+        assert model == "qwen3.8-max"
+        assert provider == "quicksilverpro"
+        assert api_base == "https://api.quicksilverpro.io/v1"
+
+    def test_quicksilverpro_api_base_override(self):
+        """An explicit api_base / api_key overrides the default"""
+        from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+
+        _model, provider, api_key, api_base = get_llm_provider(
+            model="quicksilverpro/qwen3.8-max",
+            custom_llm_provider=None,
+            api_base="https://custom.example.com/v1",
+            api_key="sk-test",
+        )
+
+        assert provider == "quicksilverpro"
+        assert api_base == "https://custom.example.com/v1"
+        assert api_key == "sk-test"
+
+    def test_quicksilverpro_responses_api_enabled(self):
+        """quicksilverpro declares /v1/responses, so litellm resolves a responses config"""
+        from litellm.llms.openai_like.json_loader import JSONProviderRegistry
+        from litellm.utils import ProviderConfigManager
+
+        assert JSONProviderRegistry.supports_responses_api("quicksilverpro") is True
+        config = ProviderConfigManager.get_provider_responses_api_config(
+            provider="quicksilverpro",
+            model="quicksilverpro/qwen3.8-max",
+        )
+        assert config is not None
+        assert config.custom_llm_provider == "quicksilverpro"
+
+    def test_quicksilverpro_router_config(self):
+        """quicksilverpro can be used in Router configuration"""
+        from litellm import Router
+
+        router = Router(
+            model_list=[
+                {
+                    "model_name": "qsp-chat",
+                    "litellm_params": {
+                        "model": "quicksilverpro/qwen3.8-max",
+                        "api_key": "test-key",
+                    },
+                }
+            ]
+        )
+
+        assert len(router.model_list) == 1
+        assert router.model_list[0]["model_name"] == "qsp-chat"
+
+
+class TestQuickSilverProCostMap:
+    """The published models are registered in the cost map so LiteLLM can price
+    requests on the JSON provider path."""
+
+    @pytest.fixture(autouse=True)
+    def _use_local_model_cost_map(self, monkeypatch):
+        original_model_cost = litellm.model_cost
+        monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+        litellm.model_cost = litellm.get_model_cost_map(url="")
+        litellm.get_model_info.cache_clear()
+        try:
+            yield
+        finally:
+            litellm.model_cost = original_model_cost
+            litellm.get_model_info.cache_clear()
+
+    def test_models_registered_as_chat(self):
+        for model in QUICKSILVERPRO_CHAT_MODELS:
+            info = litellm.get_model_info(model)
+            assert info["litellm_provider"] == "quicksilverpro", model
+            assert info["mode"] == "chat", model
+            assert litellm.supports_function_calling(model) is True, model
+            assert litellm.supports_response_schema(model) is True, model
+
+    def test_vision_models_declare_vision(self):
+        """Only assert the positive case. litellm.supports_vision() falls back to a
+        bare-model-name lookup, so a model id shared with another provider can report
+        True from that entry rather than this one -- that is pre-existing helper
+        behaviour, not something these entries assert."""
+        vision_models = [
+            "quicksilverpro/qwen3.8-max",
+            "quicksilverpro/kimi-k3",
+            "quicksilverpro/claude-haiku-4-5",
+            "quicksilverpro/gemini-3.5-flash",
+        ]
+        for model in vision_models:
+            assert litellm.get_model_info(model)["supports_vision"] is True, model
+
+    def test_text_only_models_do_not_declare_vision(self):
+        for model in ["quicksilverpro/deepseek-v4-flash", "quicksilverpro/glm-5.2"]:
+            assert litellm.get_model_info(model).get("supports_vision") is not True, model
+
+    def test_cost_per_token_matches_published_rates(self):
+        """Rates are per 1M tokens on the published pricing page, stored per token here."""
+        expected = {
+            "quicksilverpro/deepseek-v4-flash": (0.112, 0.224),
+            "quicksilverpro/qwen3.8-max": (2.0, 6.0),
+            "quicksilverpro/kimi-k3": (2.4, 12.0),
+            "quicksilverpro/claude-haiku-4-5": (0.8, 4.0),
+        }
+        for model, (in_1m, out_1m) in expected.items():
+            prompt_cost, completion_cost = litellm.cost_per_token(
+                model=model, prompt_tokens=1_000_000, completion_tokens=1_000_000
+            )
+            assert prompt_cost == pytest.approx(in_1m), model
+            assert completion_cost == pytest.approx(out_1m), model
+
+    def test_prompt_caching_models_have_cache_read_cost(self):
+        model = "quicksilverpro/deepseek-v4-flash"
+        info = litellm.get_model_info(model)
+        assert info["supports_prompt_caching"] is True
+        assert litellm.model_cost[model]["cache_read_input_token_cost"] == pytest.approx(
+            2.24e-09
+        )
+
+    def test_image_model_registered(self):
+        info = litellm.get_model_info("quicksilverpro/flux.2-pro")
+        assert info["litellm_provider"] == "quicksilverpro"
+        assert info["mode"] == "image_generation"
+        assert litellm.model_cost["quicksilverpro/flux.2-pro"][
+            "output_cost_per_image"
+        ] == pytest.approx(0.027)
+
+    def test_every_entry_carries_a_source(self):
+        entries = {
+            k: v
+            for k, v in litellm.model_cost.items()
+            if v.get("litellm_provider") == "quicksilverpro"
+        }
+        assert len(entries) == 33
+        for model, info in entries.items():
+            assert info["source"] == "https://quicksilverpro.io/docs/models/", model

--- a/tests/test_litellm/llms/openai_like/test_quicksilverpro_provider.py
+++ b/tests/test_litellm/llms/openai_like/test_quicksilverpro_provider.py
@@ -160,23 +160,26 @@ class TestQuickSilverProCostMap:
         info = litellm.get_model_info(model)
         assert info["supports_prompt_caching"] is True
         assert litellm.model_cost[model]["cache_read_input_token_cost"] == pytest.approx(
-            2.24e-09
+            1.44e-08
         )
 
-    def test_image_model_registered(self):
-        info = litellm.get_model_info("quicksilverpro/flux.2-pro")
-        assert info["litellm_provider"] == "quicksilverpro"
-        assert info["mode"] == "image_generation"
-        assert litellm.model_cost["quicksilverpro/flux.2-pro"][
-            "output_cost_per_image"
-        ] == pytest.approx(0.027)
+    def test_only_chat_models_are_registered(self):
+        """Image generation dispatches from a hardcoded provider list that a
+        declarative openai_like provider is not part of, so litellm.image_generation()
+        would return an empty ImageResponse with no upstream request. No image entry
+        is published until that path exists."""
+        for info in self._entries().values():
+            assert info["mode"] == "chat"
 
-    def test_every_entry_carries_a_source(self):
-        entries = {
+    def _entries(self):
+        return {
             k: v
             for k, v in litellm.model_cost.items()
             if v.get("litellm_provider") == "quicksilverpro"
         }
-        assert len(entries) == 33
+
+    def test_every_entry_carries_a_source(self):
+        entries = self._entries()
+        assert len(entries) == 32
         for model, info in entries.items():
             assert info["source"] == "https://quicksilverpro.io/docs/models/", model


### PR DESCRIPTION
## TLDR

Problem this solves:

- QuickSilver Pro models cannot be addressed as `quicksilverpro/<model>`; provider resolution raises `BadRequestError`
- Its models are absent from the cost map, so spend cannot be computed for them

How it solves it:

- Registers `quicksilverpro` in the declarative `openai_like` provider registry
- Adds the 32 chat models it serves to the cost map with per-token prices and context limits

## Proof of Working

Captured at `b3684f23`, against a real deployment with a funded key. No mocks.

**1. Completions — five model families, `response_cost` computed from the prices in this PR**

| model | prompt/completion tokens | response_cost | reply |
|---|---|---|---|
| `quicksilverpro/qwen3.7-flash` | 17/1 | $0.00000051 | ok |
| `quicksilverpro/gpt-5.6-luna` | 11/5 | $0.00000328 | ok |
| `quicksilverpro/claude-haiku-4-5` | 485/4 | $0.00040400 | ok |
| `quicksilverpro/gemini-3.5-flash-lite` | 5/1 | $0.00000340 | ok |
| `quicksilverpro/hy3` | 20/2 | $0.00000296 | ok |

**2. Streaming**

```
chunks=4 content='1, 2, 3.'
```

**3. Tool calling**

```
tool_calls: [('get_weather', '{"city": "Paris"}')]
```

**4. `/v1/responses`**

```
status: completed | usage: 8 / 5
```

**5. Provider resolution and cost map**

```
registry exists: True
base_url: https://api.quicksilverpro.io/v1 | key_env: QUICKSILVERPRO_API_KEY
supports_responses_api: True
get_llm_provider("quicksilverpro/qwen3.8-max") -> ('qwen3.8-max', 'quicksilverpro', 'https://api.quicksilverpro.io/v1')
pricing entries: 32
```

| model | $/1M in | $/1M out |
|---|---|---|
| `quicksilverpro/deepseek-v4-flash` | $0.112 | $0.224 |
| `quicksilverpro/qwen3.8-max` | $2.0 | $6.0 |
| `quicksilverpro/kimi-k3` | $2.4 | $12.0 |

**6. New unit tests**

```
12 passed, 3 warnings in 5.13s
```

**Cost accuracy.** Each `response_cost` above was reconciled against the amount the
service itself billed for the same request. They agree exactly — e.g. a 6-prompt
(2 cached) / 16-completion call on `deepseek-v4-flash` gives `4.03648e-06` on both sides.

## Relevant issues

<!-- none -->

## Linear ticket

<!-- external contributor -->

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** (scored 4/5; its P1 on image dispatch is addressed)

## Type

🆕 New Feature

## Changes

QuickSilver Pro is an inference provider serving an OpenAI-compatible API at
`https://api.quicksilverpro.io/v1`. It needs no new Python module — it fits the
existing declarative `openai_like` registry, the same shape as `empiriolabs`,
`crusoe` and `pinstripes`.

| file | change |
|---|---|
| `litellm/llms/openai_like/providers.json` | register `quicksilverpro` (base URL, key env, `/v1/chat/completions` + `/v1/responses`) |
| `provider_endpoints_support.json` | endpoint support matrix entry |
| `litellm/provider_endpoints_support_backup.json` | same entry in the packaged copy, which is what `public_endpoints.py` reads at runtime |
| `model_prices_and_context_window.json` | 32 chat model entries |
| `litellm/model_prices_and_context_window_backup.json` | same 32 entries in the packaged mirror |
| `tests/test_litellm/llms/openai_like/test_quicksilverpro_provider.py` | 12 mocked tests |

Notes for review:

- **The diff is purely additive** — 0 deletions to existing content. The two files that
  round-trip through `json.dumps(indent=4)` were edited programmatically and verified
  byte-identical outside the insertion; the hand-formatted files (inline arrays, and a
  pre-existing duplicate `charity_engine` key in `provider_endpoints_support.json`) were
  edited textually so nothing else moves.
- **Prices are per token**, generated from the published per-1M rates at
  https://quicksilverpro.io/docs/models/ rather than transcribed, and every entry carries
  that URL as its `source`. Each was checked to round-trip
  per-1M → per-token → per-1M back to the published figure exactly.
- **The entry list matches the chat models in `GET /v1/models` exactly**, by count and id.
- **No capability or endpoint is claimed that was not observed working.** `/v1/embeddings`
  and `/v1/audio/transcriptions` are deliberately absent — that deployment returns 501 for
  both. Capability flags are omitted rather than set to `false`, matching the surrounding
  convention.
- **No image entry is published.** `litellm.image_generation()` dispatches from a
  hardcoded provider list that a declarative `openai_like` provider is not part of, so
  such an entry would return an empty `ImageResponse` with no upstream request and no
  error. Withheld until that path exists; the support matrix reports
  `image_generations: false` to match.
- No `LlmProviders` enum member is added; `JSONProviderRegistry` is consulted ahead of the
  enum in `get_llm_provider`, and the tests cover that path. Happy to add one if preferred.
- A docs page for `docs.litellm.ai/docs/providers/quicksilverpro` will follow as a separate
  PR to `BerriAI/litellm-docs`, matching the `url` referenced in the support matrix.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
