### PR TITLE
fix(docker): bake the pip image's prisma engines at a world-readable path

### DIFF
--- a/docker/build_from_pip/Dockerfile.build_from_pip
+++ b/docker/build_from_pip/Dockerfile.build_from_pip
@@ -47,7 +47,13 @@ RUN uv venv --python python && \
       "prisma==0.11.0" \
       "openai==2.24.0"
 
-RUN prisma generate --schema=./schema.prisma
+RUN HOME=/opt/prisma XDG_CACHE_HOME=/opt/prisma/.cache PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \
+    npm_config_cache=/root/.npm \
+    prisma generate --schema=./schema.prisma && \
+    chmod -R a+rX /opt/prisma && \
+    python -c "import sys; from prisma.client import BINARY_PATHS; bad = sorted(p for group in BINARY_PATHS.model_dump().values() for p in group.values() if not p.startswith('/opt/prisma/')); sys.exit('prisma engines baked outside /opt/prisma: %r' % bad) if bad else None"
+
+ENV PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries
 
 EXPOSE 4000/tcp
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- Pip-built image bakes a root-only prisma engine path
- Non-root `runAsUser` crashes the proxy at startup
- CI runs that image as root, so it never caught it

How it solves it:

- Generate under a fixed, world-readable `/opt/prisma`
- Pin `PRISMA_BINARY_CACHE_DIR` so runtime resolves the bake
- Assert at build time that no engine path escapes it

## Relevant issues

## Linear ticket

Resolves LIT-5170

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`proxy_build_from_pip_tests` builds this Dockerfile and then runs the container as root; that is the whole reason a root-pathed engine shipped here and survived, and it is why the fix carries a build-time assertion rather than leaning on the existing job

Before proof captured at `d3d30353aa` (branch point), after proof at `cd9597bdcb` (this PR's only commit). Both are real image builds and real container starts against a live Postgres; nothing below is inspection-only or mocked

### Before: the baked path is root-owned and root-pathed

```bash
docker build -t lit5170-pip-before:latest -f docker/build_from_pip/Dockerfile.build_from_pip .
docker run --rm --entrypoint sh lit5170-pip-before:latest -c \
  'grep -n BINARY_PATHS /app/.venv/lib/python3.13/site-packages/prisma/client.py; ls -ld /root'
```

```
79:BINARY_PATHS = model_parse(BinaryPaths, {'queryEngine': {'linux-arm64-openssl-3.0.x':
'/root/.cache/prisma-python/binaries/5.4.2/ac9d7041ed77bcc8a8dbd2ab6616b39013829574/node_modules/prisma/query-engine-linux-arm64-openssl-3.0.x',
...}})
drwx------ 1 root root 4096 Aug  5 19:04 /root
```

`/root` is mode 0700, so reading that engine is a permission error for every uid but 0

```bash
for U in root 12345:0; do
  docker run --rm --user $U -e HOME=/tmp --entrypoint python lit5170-pip-before:latest -c "
from prisma.client import BINARY_PATHS
p = list(BINARY_PATHS.query_engine.values())[0]
try:
    open(p,'rb').read(4); print('engine readable: YES')
except Exception as e:
    print('engine readable: NO ->', type(e).__name__, e)
"; done
```

```
===== as root =====
engine readable: YES
===== as 12345:0 =====
engine readable: NO -> PermissionError [Errno 13] Permission denied: '/root/.cache/prisma-python/binaries/5.4.2/.../query-engine-linux-arm64-openssl-3.0.x'
```

### Before: the proxy dies at startup under a non-root uid

Schema was migrated first by a root run, and `DISABLE_SCHEMA_UPDATE=true` is set, so the migration path is not a confound; the only variable is the uid

```bash
docker run --rm --network lit5170-net --user 12345:0 \
  -e DATABASE_URL=postgresql://postgres:pw@lit5170-pg:5432/litellm \
  -e LITELLM_MASTER_KEY=sk-lit5170 -e DISABLE_SCHEMA_UPDATE=true -e HOME=/tmp \
  lit5170-pip-before:latest --port 4000
```

```
LiteLLM Proxy:ERROR: utils.py:4292 - Error getting LiteLLM_SpendLogs row count: Not connected to the query engine
ERROR:    Traceback (most recent call last):
  ...
  File "/app/.venv/lib/python3.13/site-packages/prisma/engine/http.py", line 97, in request
    raise errors.NotConnectedError('Not connected to the query engine')
prisma.engine.errors.NotConnectedError: Not connected to the query engine

ERROR:    Application startup failed. Exiting.
```

### After: the bake is world-readable and resolves for any uid

```bash
docker build -t lit5170-pip-after:latest -f docker/build_from_pip/Dockerfile.build_from_pip .
for U in root 12345:0; do docker run --rm --user $U -e HOME=/tmp --entrypoint python lit5170-pip-after:latest -c "
from prisma.client import BINARY_PATHS
p = list(BINARY_PATHS.query_engine.values())[0]
print('baked engine path:', p)
try:
    open(p,'rb').read(4); print('engine readable: YES')
except Exception as e:
    print('engine readable: NO ->', type(e).__name__, e)
"; done
docker run --rm --entrypoint sh lit5170-pip-after:latest -c 'ls -ld /opt/prisma'
```

```
===== as root =====
baked engine path: /opt/prisma/binaries/node_modules/prisma/query-engine-linux-arm64-openssl-3.0.x
engine readable: YES
===== as 12345:0 =====
baked engine path: /opt/prisma/binaries/node_modules/prisma/query-engine-linux-arm64-openssl-3.0.x
engine readable: YES

drwxr-xr-x 4 root root 4096 Aug  5 19:07 /opt/prisma
```

### After: root on a brand-new database still works

This is the case CI actually exercises, so it is the no-regression check

```bash
docker run -d --name lit5170-after-root --network lit5170-net -p 14000:4000 \
  -e DATABASE_URL=postgresql://postgres:pw@lit5170-pg:5432/lit5170_after \
  -e LITELLM_MASTER_KEY=sk-lit5170 lit5170-pip-after:latest --port 4000
curl -s http://localhost:14000/health/readiness
docker exec lit5170-pg psql -U postgres -d lit5170_after -tAc \
  "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';"
```

```
{"status":"healthy","db":"connected","cache":null,"litellm_version":"1.83.0","success_callbacks":[],"use_aiohttp_transport":true,"log_level":"WARNING","is_detailed_debug":false}
77
```

### After: the uid that crashed before now serves traffic

```bash
docker run -d --name lit5170-after-nonroot --network lit5170-net -p 14001:4000 --user 12345:0 \
  -e DATABASE_URL=postgresql://postgres:pw@lit5170-pg:5432/lit5170_after \
  -e LITELLM_MASTER_KEY=sk-lit5170 -e DISABLE_SCHEMA_UPDATE=true -e HOME=/tmp \
  lit5170-pip-after:latest --port 4000
docker exec lit5170-after-nonroot id
curl -s http://localhost:14001/health/readiness
```

```
uid=12345 gid=0(root) groups=0(root)
{"status":"healthy","db":"connected","cache":null,"litellm_version":"1.83.0","success_callbacks":[],"use_aiohttp_transport":true,"log_level":"WARNING","is_detailed_debug":false}
```

### The build-time assertion has teeth

Rebuilt with the bake reverted to the bare `prisma generate` but the assertion kept, to confirm the guard is not decorative. The build fails and names the offending paths

```
#14 10.28 prisma engines baked outside /opt/prisma: ['/root/.cache/prisma-python/binaries/5.4.2/.../query-engine-debian-openssl-1.1.x', '/root/.cache/prisma-python/binaries/5.4.2/.../query-engine-debian-openssl-3.0.x', ...]
#14 ERROR: process "/bin/sh -c prisma generate --schema=./schema.prisma && python -c ..." did not complete successfully: exit code: 1
```

## Type

🐛 Bug Fix

## Changes

`prisma generate` records absolute engine paths into the generated client at build time, and the client reads them back at runtime. This Dockerfile ran it bare, so the paths landed under `$HOME/.cache`, which is `/root/.cache` here. `/root` is mode 0700 on `python:3.13-slim`, so a container run under any other uid cannot even traverse it, and the proxy crashes during prisma client initialisation. The Readme points this image at teams with strict image-building requirements, which is precisely the population that imposes a non-root `runAsUser`

The fix mirrors what the shipped images already do: generate with `HOME`, `XDG_CACHE_HOME` and `PRISMA_BINARY_CACHE_DIR` pinned at `/opt/prisma`, `chmod -R a+rX` it, and pin `PRISMA_BINARY_CACHE_DIR` at runtime so resolution never falls back to `$HOME`. `npm_config_cache` stays at `/root/.npm` to keep the npm cache out of the world-readable bake

It differs from `Dockerfile`, `docker/Dockerfile.database` and `docker/Dockerfile.non_root` in one respect: it does not set `PRISMA_CLI_PATH`, `PRISMA_CLI_QUERY_ENGINE_TYPE` or `PRISMA_OFFLINE_MODE`. `PRISMA_CLI_PATH` is only read by `litellm_proxy_extras.utils._get_prisma_command` when offline mode is on, and turning offline mode on also redirects `NPM_CONFIG_CACHE` to `/app/.cache/npm`, a path this image never creates, so all three would be dead or actively wrong config here. The root-on-a-fresh-database run above confirms `PRISMA_BINARY_CACHE_DIR` alone is sufficient for migrations

The build-time assertion is the regression net, and it is the only place one can live for this file. `image-scan.yml` builds only `docker/Dockerfile.non_root` and `migrations/Dockerfile`, and `tests/proxy_migration_tests/test_offline_image_migration.py` is gated on `LITELLM_IMAGE` and only invoked from that workflow, so neither touches the pip image. `proxy_build_from_pip_tests` does build this Dockerfile on every backend-relevant PR (confirmed: `printf 'docker/build_from_pip/Dockerfile.build_from_pip\n' | bash .circleci/scripts/classify_changes.sh backend` returns `run`), so the assertion runs there. Broadening that job to also start the container under a non-root uid is worth doing and is filed separately rather than bundled here

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the pip build Dockerfile and aligns with existing main/database/non-root images; build-time assertion reduces regression risk without touching application logic.
> 
> **Overview**
> **Fixes non-root startup failures** in the PyPI-based `Dockerfile.build_from_pip` image by baking Prisma query engines at a fixed, world-readable path instead of under `/root/.cache`.
> 
> `prisma generate` now runs with `HOME`, `XDG_CACHE_HOME`, and `PRISMA_BINARY_CACHE_DIR` pinned to `/opt/prisma`, followed by `chmod -R a+rX` and a **build-time Python check** that fails if any engine path in `BINARY_PATHS` is outside `/opt/prisma`. Runtime **`PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries`** is set so the client resolves the same bake as root or non-root UIDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd9597bdcb3b79a51c0bd47f7f88cb16b4303b9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->