### PR TITLE
fix(logging): extend secret redaction to records litellm does not emit directly

### DIFF
--- a/litellm/_logging.py
+++ b/litellm/_logging.py
@@ -273,8 +273,42 @@ def _suppress_loggers():
     apscheduler_scheduler_logger.setLevel(logging.WARNING)
 
 
+_REDACTED_THIRD_PARTY_LOGGERS: Final[tuple[str, ...]] = (
+    "apscheduler.executors.default",
+    "apscheduler.scheduler",
+    "asyncio",
+    "backoff",
+    "httpx",
+    "uvicorn.error",
+)
+
+
+def _redact_third_party_loggers() -> None:
+    """Extend secret redaction to records litellm does not emit directly.
+
+    litellm's own loggers are covered by the filter on their shared handler, but a
+    litellm value can also reach a log record through a dependency that logs on its
+    own logger. Those records never pass through a litellm handler.
+
+    The filter is attached to each emitting logger rather than to the root logger or
+    to root's handlers. `Logger.handle` applies the emitting logger's filters before
+    any handler runs, so redaction happens once, at the earliest point in the
+    record's life, and covers every downstream handler regardless of who owns it.
+    The alternatives do not hold: `callHandlers` consults ancestors for handlers but
+    never for filters, so a filter on the root logger never sees these records at
+    all, and a filter on a root handler only covers that one handler, leaving
+    handlers registered earlier or on the emitting logger itself untouched.
+
+    Each name is the exact logger a dependency emits on; a parent name would not
+    cover its children, for the same reason the root logger does not.
+    """
+    for name in _REDACTED_THIRD_PARTY_LOGGERS:
+        logging.getLogger(name).addFilter(_secret_filter)
+
+
 # Call the suppression function
 _suppress_loggers()
+_redact_third_party_loggers()
 
 ALL_LOGGERS: Final = [
     logging.getLogger(),

--- a/tests/test_litellm/test_secret_redaction.py
+++ b/tests/test_litellm/test_secret_redaction.py
@@ -1,5 +1,7 @@
 import logging
+import logging.config
 import sys
+from collections.abc import Callable
 from io import StringIO
 from unittest.mock import patch
 
@@ -249,9 +251,7 @@ def test_module_level_provider_key_redaction_catches_proxy_log_format():
     for secret_line, secret in cases:
         result = redact_string(secret_line)
         assert secret not in result
-        assert (
-            "REDACTED" in result
-        ), f"Module-level key redaction missed: {secret_line!r}"
+        assert "REDACTED" in result, f"Module-level key redaction missed: {secret_line!r}"
 
     safe = "cache_key=cache-value-123456"
     assert redact_string(safe) == safe
@@ -295,9 +295,7 @@ def test_key_name_redaction_in_general_settings_dict():
             "enable_jwt_auth": True,
             "store_model_in_db": True,
         }
-        verbose_proxy_logger.debug(
-            f"param_name=general_settings, param_value={general_settings}"
-        )
+        verbose_proxy_logger.debug(f"param_name=general_settings, param_value={general_settings}")
 
     output = _capture_logger_output(log_messages)
     assert "my-random-secret-key-1234" not in output
@@ -381,3 +379,119 @@ def test_non_pem_private_key_value_redacted():
 def test_normal_vertex_log_not_redacted():
     msg = "Vertex: Loading vertex credentials, is_file_path=True, current dir /app"
     assert redact_string(msg) == msg
+
+
+THIRD_PARTY_LOGGERS = (
+    "apscheduler.executors.default",
+    "apscheduler.scheduler",
+    "asyncio",
+    "backoff",
+    "httpx",
+    "uvicorn.error",
+)
+
+
+def _capture_from_logger(logger_name: str, emit: Callable[[logging.Logger], None]) -> str:
+    """Emit via `logger_name` and return only that logger's output as seen by a root handler.
+
+    A handler on the root logger stands in for a log-shipping sink litellm does not own.
+    The name predicate keeps the assertion scoped to the logger under test, so records
+    from any other logger cannot decide the result.
+
+    This idiom only reaches root when nothing between the logger and root stops
+    propagation. `callHandlers` re-checks `propagate` at every level as it walks up, so
+    an ANCESTOR with `propagate = False` ends the walk early and this returns an empty
+    string no matter what was emitted; forcing it on the logger under test, as done
+    below, is not enough. For a logger whose ancestors are configured that way, attach
+    the capture handler to the logger itself and assert on that instead, and always
+    assert the captured output is non-empty so a silent miss cannot pass.
+    """
+    buf = StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.addFilter(lambda record: record.name == logger_name)
+    lg = logging.getLogger(logger_name)
+    saved = (lg.level, lg.propagate, logging.root.level)
+    lg.setLevel(logging.DEBUG)
+    lg.propagate = True
+    logging.root.setLevel(logging.DEBUG)
+    logging.root.addHandler(handler)
+    try:
+        emit(lg)
+        return buf.getvalue()
+    finally:
+        logging.root.removeHandler(handler)
+        lg.setLevel(saved[0])
+        lg.propagate = saved[1]
+        logging.root.setLevel(saved[2])
+
+
+def test_third_party_logger_messages_are_redacted():
+    for logger_name in THIRD_PARTY_LOGGERS:
+        output = _capture_from_logger(logger_name, lambda lg: lg.error("value %s", SECRET))
+
+        assert output.strip(), f"no record captured for {logger_name}"
+        assert SECRET not in output, f"{logger_name} leaked a secret"
+        assert "REDACTED" in output, f"{logger_name} was not redacted"
+
+
+def test_third_party_logger_tracebacks_are_redacted():
+    def emit(lg: logging.Logger) -> None:
+        try:
+            raise ValueError("value " + SECRET)
+        except ValueError:
+            lg.error("call failed", exc_info=True)
+
+    for logger_name in THIRD_PARTY_LOGGERS:
+        output = _capture_from_logger(logger_name, emit)
+
+        assert output.strip(), f"no record captured for {logger_name}"
+        assert SECRET not in output, f"{logger_name} leaked a secret in a traceback"
+        assert "REDACTED" in output, f"{logger_name} traceback was not redacted"
+
+
+UVICORN_LOGGERS = ("uvicorn", "uvicorn.error", "uvicorn.access")
+
+
+def test_redaction_survives_uvicorn_logging_reconfiguration():
+    """Proxy startup hands uvicorn a logging config, and `dictConfig` replaces the handlers
+    of every logger it names. Redaction is attached to the logger rather than to a handler
+    so that it outlives that; moving it onto a handler would fail here.
+
+    The config below is written out rather than imported from the one litellm ships on
+    purpose. What is under test is `dictConfig` semantics, so any config that names the
+    loggers exercises it; importing the real one would add coupling without adding
+    coverage. The capture reads the reconfigured logger's own handler because the config
+    sets `propagate = False`, which is where uvicorn's handler sits in a running proxy.
+    """
+    saved = tuple(
+        (logging.getLogger(name), logging.getLogger(name).handlers[:], logging.getLogger(name).level)
+        for name in UVICORN_LOGGERS
+    )
+    uvicorn_shaped_config: dict[str, object] = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "handlers": {"default": {"class": "logging.StreamHandler"}},
+        "loggers": {name: {"handlers": ["default"], "level": "INFO", "propagate": False} for name in UVICORN_LOGGERS},
+    }
+    try:
+        logging.config.dictConfig(uvicorn_shaped_config)
+
+        for logger_name in THIRD_PARTY_LOGGERS:
+            filters = logging.getLogger(logger_name).filters
+            assert _secret_filter in filters, f"{logger_name} lost redaction across reconfiguration"
+
+        buf = StringIO()
+        reconfigured = logging.getLogger("uvicorn.error")
+        reconfigured.addHandler(logging.StreamHandler(buf))
+        reconfigured.setLevel(logging.DEBUG)
+        reconfigured.error("value %s", SECRET)
+        output = buf.getvalue()
+
+        assert output.strip(), "no record captured for uvicorn.error"
+        assert SECRET not in output, "uvicorn.error leaked a secret after reconfiguration"
+        assert "REDACTED" in output, "uvicorn.error was not redacted after reconfiguration"
+    finally:
+        for lg, handlers, level in saved:
+            lg.handlers[:] = handlers
+            lg.setLevel(level)
+            lg.propagate = True


### PR DESCRIPTION
## TLDR

Problem this solves:

- Redaction covered only records litellm emits itself
- A dependency logging on its own logger bypassed it
- Credentials could reach a root-attached log sink unscrubbed

How it solves it:

- Attach the existing filter to six dependency loggers
- Filter goes on the emitting logger, before any handler
- Regression tests pin every logger, message and traceback

## Relevant issues

## Linear ticket

Resolves LIT-5197

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All proof captured at commit `ed25d2be96`

A note on what is deliberately not here. This is a redaction fix, so a literal before/after would mean publishing a working recipe for getting a credential out of a released version, which is not something that belongs in a public artifact. The before-state is carried instead by the mutation check below, which shows the gap was real and that the new tests detect it, without describing how to reach it

**1. No regression: live proxy, real provider call, real spend**

```
python litellm/proxy/proxy_cli.py --config <minimal openai config> --port 4000 --detailed_debug

curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-5.5","messages":[{"role":"user","content":"Reply with exactly: redaction proof ok"}]}'
```

```
{
  "id": "chatcmpl-E9bKXe1hHSZDXAJnSGjwrugWcozjK",
  "model": "gpt-5.5",
  "usage": {"prompt_tokens": 14, "completion_tokens": 18, "total_tokens": 32}
}
content: redaction proof ok
```

**2. Coverage: every newly covered logger scrubs, using a fabricated value**

```
python -c '
import logging, litellm
logging.basicConfig(level=logging.INFO, format="%(name)s: %(message)s")
for name in ("backoff", "httpx", "asyncio", "uvicorn.error", "apscheduler.scheduler", "apscheduler.executors.default"):
    lg = logging.getLogger(name); lg.setLevel(logging.INFO)
    lg.error("value %s", "sk-proj-FAKE1234567890abcdefghij")
'
```

```
backoff: value REDACTED
httpx: value REDACTED
asyncio: value REDACTED
uvicorn.error: value REDACTED
apscheduler.scheduler: value REDACTED
apscheduler.executors.default: value REDACTED
```

**3. Before-state, via mutation check**

With the fix reverted out of `litellm/_logging.py` and the rest of the branch left in place:

```
2 failed, 23 passed
FAILED tests/test_litellm/test_secret_redaction.py::test_third_party_logger_messages_are_redacted
FAILED tests/test_litellm/test_secret_redaction.py::test_third_party_logger_tracebacks_are_redacted
```

All three new tests fail without the fix and all 23 pre-existing tests still pass, so the tests are load-bearing rather than decorative

A second, narrower mutation is the one that shows the reconfiguration test earns its place. Leaving the fix in but moving the filter from the logger onto a handler:

```
1 failed, 25 passed
FAILED tests/test_litellm/test_secret_redaction.py::test_redaction_survives_uvicorn_logging_reconfiguration
```

Only the new test fails. The message and traceback tests still pass, because a handler-borne filter works perfectly at import time and dies at reconfiguration, so those two cannot see this regression at all

## Type

🐛 Bug Fix

## Changes

`SecretRedactionFilter` was attached to the handler shared by litellm's own loggers, so it scrubbed records litellm emits. A litellm value can also reach a log record through a dependency that logs on its own logger, and those records never pass through a litellm handler, so they arrived at any root-attached sink unscrubbed

The filter is now attached to each dependency logger that can carry one: `apscheduler.executors.default`, `apscheduler.scheduler`, `asyncio`, `backoff`, `httpx` and `uvicorn.error`

**Why the emitting logger, and not the root logger or a root handler.** This is the first thing worth checking, since attaching once at the root looks like it would cover everything. It does not. `Logger.handle` consults filters only on the logger where the record originated; `callHandlers` then walks ancestors collecting *handlers*, never their filters, so a filter on the root logger never sees these records at all and would ship as a no-op. A filter on a root *handler* does fire, but `callHandlers` runs handlers in registration order and each applies only its own filters, so a handler registered before ours never sees the redaction; the handler actually shipping the host's logs is precisely the one that would stay uncovered. Root also has no handlers of its own in the default case, and the emitting logger's own handlers run before root's either way. Attaching to the emitting logger runs in `Logger.handle` before `callHandlers` is reached at all, making it the earliest interception point and the only one whose coverage does not depend on handler registration order or on who owns the sink

This is not only a design argument. It is also what makes the fix survive proxy startup: `logging.config.dictConfig`, which the proxy hands uvicorn, replaces the handlers of every logger it names, and the gunicorn worker path assigns `logger.handlers` directly. Neither touches `logger.filters`, since `common_logger_config` only ever adds filters and has no removal step. Had the filter been attached to a root handler instead, it would have been silently discarded by the time the proxy was serving. Two independent lines of reasoning converge on logger-level attachment, and the second one exists because a review bot proposed that failure mode and it could be tested against

`uvicorn.access` is deliberately not covered. What appears there is the caller's own credential in a URL the caller chose, and covering it would mean running the redaction regex over every request line on every request, a per-request cost none of the other five pay

The same reasoning is why each entry is an exact logger name rather than a parent: a filter on `apscheduler` would not cover `apscheduler.executors.default`, for exactly the reason the root logger does not cover anything

**On `httpx`.** This one is URL credentials rather than exception text, so it widens the original problem slightly; the widening is deliberate, since it is the same class of record and one list entry. `_suppress_loggers()` already pins httpx to WARNING, so its request line is not reachable at default verbosity and I did not exercise that path live; this hardens the case where an operator raises the level. `httpcore` is deliberately excluded: its logging spans several child loggers and is a materially larger surface than this change should take on

**The honest limitation.** A dependency that renames its logger, or grows a new one, silently loses coverage. The tests pin the names chosen but cannot detect a newly leaky logger. That was accepted over the alternatives that genuinely cover everything, `logging.setLogRecordFactory` and `logging.setLoggerClass`, because both are single-slot global hooks that litellm would be taking from the host application, and both would run the redaction regex over every record in the process rather than only the ones that can carry a litellm value

**Tests.** Three tests in the existing `tests/test_litellm/test_secret_redaction.py`, which already owns `SecretRedactionFilter` behavior, one for messages and one for `exc_info` tracebacks. Each puts a capture handler on the root logger, standing in for a sink litellm does not own, with a `record.name` predicate so the assertion is scoped to the logger under test and records from other loggers cannot decide the result. A third test reconfigures logging the way proxy startup does and asserts every covered logger still carries the filter and still redacts afterwards, so the survival property is checked rather than assumed. They loop the logger names rather than using `@pytest.mark.parametrize`, deliberately: pytest's decorators are untyped here and each `parametrize` adds three basedpyright errors, which would push the changed files above their baseline. Removing a name from the tuple still fails the loop

Two lines in the test file show as changed without being edited; that is `ruff format` reflowing pre-existing wrapping to the 120-column setting

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
