### PR TITLE
fix(ci): fetch only head and merge-base in lint jobs instead of every branch

### DIFF
--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -23,9 +23,20 @@ jobs:
         # Any-discipline) would otherwise blame on this branch.
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
+          fetch-depth: 1
           clean: true
           persist-credentials: false
+
+      - name: Fetch gate base (merge-base with target branch)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          MERGE_BASE=$(gh api "repos/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}?per_page=1" --jq '.merge_base_commit.sha')
+          test -n "$MERGE_BASE"
+          git fetch --no-tags --depth=1 origin "$MERGE_BASE"
+          echo "GATE_BASE_SHA=$MERGE_BASE" >> "$GITHUB_ENV"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -60,10 +71,8 @@ jobs:
           uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
 
       - name: Check ruff format
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          git diff --name-only --diff-filter=ACMR "$BASE_SHA"...HEAD -- 'litellm/**/*.py' | grep -v '^litellm/enterprise/' > "$RUNNER_TEMP/ruff_format_files.txt" || true
+          git diff --name-only --diff-filter=ACMR "$GATE_BASE_SHA" HEAD -- 'litellm/**/*.py' | grep -v '^litellm/enterprise/' > "$RUNNER_TEMP/ruff_format_files.txt" || true
           if [ ! -s "$RUNNER_TEMP/ruff_format_files.txt" ]; then
             echo "No changed litellm Python files to check with ruff format."
             exit 0
@@ -86,32 +95,24 @@ jobs:
           cd ..
 
       - name: Check strict-rule budget (delta vs base)
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          uv run --no-sync python scripts/ruff_strict_gate.py --base "$BASE_SHA"
+          uv run --no-sync python scripts/ruff_strict_gate.py --base "$GATE_BASE_SHA"
 
       - name: Check type-discipline budget (mutable collections / casts / type guards / kwargs / unexplained suppressions, delta vs base)
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          uv run --no-sync python scripts/type_discipline_gate.py --base "$BASE_SHA"
+          uv run --no-sync python scripts/type_discipline_gate.py --base "$GATE_BASE_SHA"
 
       - name: Print OpenAI version
         run: |
           uv run --no-sync python -c "import openai; print(f'OpenAI version: {openai.__version__}')"
 
       - name: Check basedpyright budget (delta vs base)
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          uv run --no-sync python scripts/type_check_gate.py --base "$BASE_SHA"
+          uv run --no-sync python scripts/type_check_gate.py --base "$GATE_BASE_SHA"
 
       - name: Check tests/e2e basedpyright (zero errors)
-        env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          if git diff --name-only --diff-filter=ACMRD "$BASE_SHA"...HEAD -- 'tests/e2e/**/*.py' | grep -q .; then
+          if git diff --name-only --diff-filter=ACMRD "$GATE_BASE_SHA" HEAD -- 'tests/e2e/**/*.py' | grep -q .; then
             uv run --no-sync basedpyright tests/e2e
           else
             echo "No changed tests/e2e Python files; skipping."
@@ -140,8 +141,14 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
+
+      - name: Fetch ratchet base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0


### PR DESCRIPTION
## TLDR

Problem this solves:

- fetch-depth: 0 downloads every branch and tag on checkout
- that checkout alone can eat a lint job's whole timeout
- two runs on PR #35870 were cancelled this way in one day

How it solves it:

- lint checks out only the PR head at depth 1
- one extra depth-1 fetch brings in the merge-base for the gates
- budget-ratchet does the same with the base branch tip

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before, at 824608c42b (PR #35870): on [run 31029277328 attempt 1](https://github.com/BerriAI/litellm/actions/runs/31029277328) the lint job's checkout step alone ran 12m50s (17:16:56 to 17:29:46 UTC), so the job was cancelled by its 15 minute timeout mid dependency install

```
$ gh api "repos/BerriAI/litellm/actions/runs/31029277328/attempts/1/jobs" \
    --jq '.jobs[] | select(.name=="lint") | {conclusion, started_at, completed_at,
          checkout: [.steps[] | select(.number==2) | {started_at, completed_at}]}'
{"conclusion":"cancelled","started_at":"2026-08-05T17:16:54Z","completed_at":"2026-08-05T17:32:15Z",
 "checkout":[{"started_at":"2026-08-05T17:16:56Z","completed_at":"2026-08-05T17:29:46Z"}]}
```

Same failure mode at ebc31f7e06: [run 31033319589 attempt 1](https://github.com/BerriAI/litellm/actions/runs/31033319589) passed lint but budget-ratchet was cancelled by its own 5 minute timeout inside the same fetch-depth: 0 checkout, and the identical job then finished in 67 seconds on a manual re-run, confirming the failures are pure checkout time variance

```
$ gh api "repos/BerriAI/litellm/actions/runs/31033319589/attempts/1/jobs" \
    --jq '.jobs[] | select(.name=="budget-ratchet") | {conclusion, started_at, completed_at}'
{"conclusion":"cancelled","started_at":"2026-08-05T18:08:31Z","completed_at":"2026-08-05T18:13:34Z"}
$ gh api "repos/BerriAI/litellm/actions/runs/31033319589/jobs" \
    --jq '.jobs[] | select(.name=="budget-ratchet") | {conclusion, started_at, completed_at}'
{"conclusion":"success","started_at":"2026-08-05T19:14:10Z","completed_at":"2026-08-05T19:15:17Z"}
```

After, at f649fa56f3: this PR's own LiteLLM Linting run exercises the changed workflow end to end, including the gates' merge-base fallback for real, because the depth-1 head and the depth-1 fetched merge-base share no fetched history, so git merge-base inside each gate returns nothing and the gate uses the passed SHA directly. Timings from that run will be appended here once it completes

## Type

🚄 Infrastructure

## Changes

The lint job now checks out just the PR head at depth 1. A new step asks the compare API for the true merge-base between the PR base and head, fetches that single commit with --no-tags --depth=1, and exports it as GATE_BASE_SHA. The ruff format file list, the strict-rule gate, the type-discipline gate, the basedpyright gate, and the tests/e2e basedpyright trigger all take GATE_BASE_SHA as their base. No script changes were needed: each gate's resolve_base_point already falls back to the given ref when git merge-base comes back empty, and all their other git usage is tree only (worktree add --detach, show ref:path, two dot diff), so disjoint shallow commits work. The workflow's own three dot diffs become two dot against GATE_BASE_SHA, which is equivalent since the left side is the merge-base itself

budget-ratchet keeps comparing against the base branch tip on purpose: a ceiling left stale while the base ratcheted down must still show up red. It now checks out at depth 1 and fetches just the base tip; scripts/budget_ratchet_check.py has the same merge-base fallback. secret-scan stays at fetch-depth: 0 because ggshield scans repository history

Gates were also verified against shallow disjoint history locally before pushing: in a depth-1 file:// clone with the head fetched as a disconnected island, git merge-base exits 1 with empty output, budget_ratchet_check.py passes against the island SHA, and forcing an over-ceiling budget exercised ruff_strict_gate.py's full base-worktree path (git worktree add of the island plus ruff over its tree) successfully

### Final Attestation

- [ ] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
