### PR TITLE
fix(bedrock): sign Bedrock managed-file S3 requests with S3SigV4Auth

### DIFF
--- a/litellm/llms/bedrock/files/transformation.py
+++ b/litellm/llms/bedrock/files/transformation.py
@@ -759,7 +759,7 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
             import hashlib
 
             import requests
-            from botocore.auth import SigV4Auth
+            from botocore.auth import S3SigV4Auth
             from botocore.awsrequest import AWSRequest
         except ImportError:
             raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
@@ -804,7 +804,7 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         # Get region name for non-LLM API calls (same as s3_v2.py)
         signing_region: Final = self.get_aws_region_name_for_non_llm_api_calls(aws_region_name=aws_region_name)
 
-        SigV4Auth(credentials, "s3", signing_region).add_auth(aws_request)
+        S3SigV4Auth(credentials, "s3", signing_region).add_auth(aws_request)
 
         # Return signed headers and body
         signed_body = aws_request.body
@@ -1015,7 +1015,7 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
         try:
             import hashlib
 
-            from botocore.auth import SigV4Auth
+            from botocore.auth import S3SigV4Auth
             from botocore.awsrequest import AWSRequest
         except ImportError:
             raise ImportError("Missing boto3 to call bedrock. Run 'pip install boto3'.")
@@ -1038,7 +1038,7 @@ class BedrockFilesConfig(BaseAWSLLM, BaseFilesConfig):
             url=api_base,
             headers={"x-amz-content-sha256": empty_body_hash},
         )
-        auth: Final = SigV4Auth(credentials, "s3", aws_region_name)  # any-ok: botocore untyped
+        auth: Final = S3SigV4Auth(credentials, "s3", aws_region_name)  # any-ok: botocore untyped
         auth.add_auth(aws_request)  # any-ok: botocore request mutation is untyped
         return dict(aws_request.headers)  # any-ok: botocore headers are untyped
 

--- a/tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py
+++ b/tests/test_litellm/llms/bedrock/files/test_bedrock_files_transformation.py
@@ -4,10 +4,14 @@ Test bedrock files transformation functionality
 
 import json
 import os
+from collections.abc import Mapping
 from unittest.mock import MagicMock
 from urllib.parse import unquote, urlparse
 
 import pytest
+from botocore.auth import S3SigV4Auth, SigV4Auth
+from botocore.awsrequest import AWSRequest
+from botocore.credentials import Credentials
 
 from litellm.llms.bedrock.files.transformation import BedrockJsonlFilesTransformation
 
@@ -1213,9 +1217,16 @@ class TestBedrockFileContentTransformation:
         assert params == {}
 
         signed_headers = litellm_params[S3_SIGNED_GET_HEADERS_PARAM]
-        assert (
-            signed_headers["x-amz-content-sha256"] == hashlib.sha256(b"").hexdigest()
-        ), "GET has no payload, so the content hash must be the empty-body hash"
+        content_hashes = {
+            value
+            for name, value in signed_headers.items()
+            if name.lower() == "x-amz-content-sha256"
+        }
+        assert content_hashes == {hashlib.sha256(b"").hexdigest()}, (
+            "GET has no payload, so the content hash must be the empty-body hash."
+            " The header name is matched case-insensitively because botocore picks"
+            " its own casing and HTTP header names are case-insensitive"
+        )
         authorization = signed_headers["Authorization"]
         assert authorization.startswith("AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/")
         assert "/us-west-2/s3/aws4_request" in authorization
@@ -1487,3 +1498,129 @@ class TestBedrockFileContentTransformation:
             .startswith("AWS4-HMAC-SHA256")
         )
         assert response.content == b'{"recordId": "x"}'
+
+
+class TestBedrockFilesS3SignatureEncoding:
+    """
+    S3 rebuilds the canonical request from the wire path with single percent-encoding,
+    which botocore models as S3SigV4Auth. Plain SigV4Auth quotes the already encoded
+    path a second time, so an object key holding any character that percent-encodes
+    (a configured bucket prefix with a space) is signed over %2520 while the request
+    carries %20, and S3 answers 403 SignatureDoesNotMatch.
+    """
+
+    ACCESS_KEY = "AKIAIOSFODNN7EXAMPLE"
+    SECRET_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    BUCKET_WITH_SPACED_PREFIX = "my-bucket/LLM AI Projects"
+    REGION = "us-west-2"
+
+    def _credential_params(self) -> dict[str, str]:
+        return {
+            "aws_access_key_id": self.ACCESS_KEY,
+            "aws_secret_access_key": self.SECRET_KEY,
+            "aws_region_name": self.REGION,
+        }
+
+    def _signature_under(
+        self,
+        signer_cls: type[SigV4Auth],
+        method: str,
+        url: str,
+        body: bytes | None,
+        headers: Mapping[str, str],
+    ) -> str:
+        sent = {name.lower(): value for name, value in headers.items()}
+        signed_names = (
+            sent["authorization"].split("SignedHeaders=")[1].split(",")[0].split(";")
+        )
+        request = AWSRequest(
+            method=method,
+            url=url,
+            data=body,
+            headers={name: sent[name] for name in signed_names if name in sent},
+        )
+        request.context["timestamp"] = sent["x-amz-date"]
+        signer = signer_cls(
+            Credentials(self.ACCESS_KEY, self.SECRET_KEY), "s3", self.REGION
+        )
+        return signer.signature(
+            signer.string_to_sign(request, signer.canonical_request(request)), request
+        )
+
+    def _assert_signed_the_way_s3_reads_it(
+        self,
+        method: str,
+        url: str,
+        body: bytes | None,
+        headers: Mapping[str, str],
+    ) -> None:
+        assert "%20" in url, "the object key must reach the wire percent-encoded"
+        sent_signature = headers["Authorization"].split("Signature=")[1].strip()
+        assert sent_signature == self._signature_under(
+            S3SigV4Auth, method, url, body, headers
+        )
+        assert sent_signature != self._signature_under(
+            SigV4Auth, method, url, body, headers
+        )
+
+    def test_create_file_signs_spaced_object_key_the_way_s3_does(self) -> None:
+        from litellm.llms.bedrock.files.transformation import BedrockFilesConfig
+
+        content = json.dumps(
+            {
+                "custom_id": "1",
+                "body": {
+                    "model": "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
+                    "messages": [{"role": "user", "content": "hello"}],
+                },
+            }
+        )
+        signed = BedrockFilesConfig().transform_create_file_request(
+            model="bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
+            create_file_data={
+                "file": ("batch.jsonl", content.encode("utf-8"), "application/jsonl"),
+                "purpose": "batch",
+            },
+            optional_params=self._credential_params(),
+            litellm_params={
+                "s3_bucket_name": self.BUCKET_WITH_SPACED_PREFIX,
+                "s3_region_name": self.REGION,
+            },
+        )
+
+        self._assert_signed_the_way_s3_reads_it(
+            method="PUT",
+            url=signed["url"],
+            body=signed["data"].encode("utf-8"),
+            headers=signed["headers"],
+        )
+
+    def test_file_content_signs_spaced_object_key_the_way_s3_does(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from litellm.llms.bedrock.files.transformation import (
+            S3_SIGNED_GET_HEADERS_PARAM,
+            BedrockFilesConfig,
+        )
+
+        monkeypatch.setenv("AWS_S3_BUCKET_NAME", self.BUCKET_WITH_SPACED_PREFIX)
+        litellm_params = {
+            "s3_bucket_name": self.BUCKET_WITH_SPACED_PREFIX,
+            "s3_region_name": self.REGION,
+            **self._credential_params(),
+        }
+
+        url, _ = BedrockFilesConfig().transform_file_content_request(
+            file_content_request={
+                "file_id": "s3://my-bucket/LLM AI Projects/litellm-bedrock-files-model-abc.jsonl"
+            },
+            optional_params={},
+            litellm_params=litellm_params,
+        )
+
+        self._assert_signed_the_way_s3_reads_it(
+            method="GET",
+            url=url,
+            body=None,
+            headers=litellm_params[S3_SIGNED_GET_HEADERS_PARAM],
+        )


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bedrock managed-file S3 calls 403 on object keys with a space
- Every file upload and file read fails under a spaced bucket prefix
- Same defect #35726 fixed for the S3 logger, left in this path

How it solves it:

- Sign with `S3SigV4Auth` on the S3 PUT and the S3 GET
- S3 canonicalizes the wire path single-encoded, so `%20` stays `%20`

## Relevant issues

## Linear ticket

Resolves LIT-5024

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

S3 rebuilds the canonical request from the wire path with single percent-encoding, which botocore models as `S3SigV4Auth` (its `_normalize_url_path` returns the path untouched). Generic `SigV4Auth` quotes the already encoded path a second time, so a key holding any character that percent-encodes is signed over `%2520` while the request carries `%20` and S3 answers 403 `SignatureDoesNotMatch`. #35726 corrected this for the S3 logger; `_sign_s3_request` and `_sign_s3_get_request` in the Bedrock managed-files path carry a docstring saying they reuse "the exact pattern from litellm/integrations/s3_v2.py" and still held the pre-fix pattern, so they were left behind

Reachable through an ordinary config, in two ways. `sanitize_cloud_object_component` scrubs the caller's filename to `[A-Za-z0-9._-]`, but it is never applied to the prefix taken from the supported `s3_bucket_name: "<bucket>/<prefix>"` form, which only passes through `_validate_cloud_object_path` and that permits spaces: `split_configured_cloud_bucket_name("bkt/My Prefix")` returns `('bkt', 'My Prefix')`. Under such a bucket every upload and every read double-signs, not just an unlucky filename. Separately, the retrieval path needs no prefix and no `allow_legacy_cloud_file_ids`, because the allowlist constrains only the start of the key: `validate_managed_cloud_file_id("s3://bkt/litellm-bedrock-files/my file.jsonl", configured_bucket_name="bkt", allow_legacy_cloud_file_ids=False)` returns that key intact, so any existing object with a space under a managed prefix reads back as a 403 rather than its contents

Stating the limit plainly so this is not read as broader than it is: with a bare `s3_bucket_name: "<bucket>"` and only litellm-generated object names, the defect is unreachable, since the filename is scrubbed. It needs the bucket prefix or a pre-existing key

Both legs below run against a real S3 bucket in a real AWS account (`litellm-lit5024-proof`, us-west-2) with real credentials. Each leg carries a control with no space in the key, which must come back 200 in both legs, so a failure cannot be a bucket or credential problem. The two probe scripts are at the end

Before, at base commit `54f83b2614`:

```
--- file upload (transform_create_file_request -> real S3 PUT) ---

s3_bucket_name with a space in the prefix: 'litellm-lit5024-proof/LLM AI Projects'
  PUT https://s3.us-west-2.amazonaws.com/litellm-lit5024-proof/LLM%20AI%20Projects/litellm-bedrock-files-anthropic.claude-3-5-sonnet-20240620-v1-0-e93581c8-85a8-47aa-ab0e-897a6d70729f.jsonl
  -> HTTP 403
  -> S3 error code: SignatureDoesNotMatch

s3_bucket_name without a space (control): 'litellm-lit5024-proof/LLM-AI-Projects'
  PUT https://s3.us-west-2.amazonaws.com/litellm-lit5024-proof/LLM-AI-Projects/litellm-bedrock-files-anthropic.claude-3-5-sonnet-20240620-v1-0-aa45ced0-f3f4-43ab-aa71-476dbea849f4.jsonl
  -> HTTP 200

--- file content (_sign_s3_get_request -> real S3 GET) ---

key WITH a space
  GET https://s3.us-west-2.amazonaws.com/litellm-lit5024-proof/LOGS/LLM%20AI%20Projects/prod-key/2026-08-05/time-13-01-00-000000_AFTER-with-space.json
  -> HTTP 403
  -> S3 error code: SignatureDoesNotMatch

key without a space (control)
  GET https://s3.us-west-2.amazonaws.com/litellm-lit5024-proof/LOGS/LLM-AI-Projects/prod-key/2026-08-05/time-13-01-00-000000_AFTER-no-space.json
  -> HTTP 200
```

After, at `2780579757`, which the current head `0fd7058873` carries forward unchanged: the rebase onto `54f83b2614` moved only staging's own commits, and `git diff 2780579757 HEAD -- litellm/llms/bedrock/files/transformation.py` is empty, so the signed path in the run below is the code in this PR

```
--- file upload (transform_create_file_request -> real S3 PUT) ---

s3_bucket_name with a space in the prefix: 'litellm-lit5024-proof/LLM AI Projects'
  PUT https://s3.us-west-2.amazonaws.com/litellm-lit5024-proof/LLM%20AI%20Projects/litellm-bedrock-files-anthropic.claude-3-5-sonnet-20240620-v1-0-b4302c1c-6ea6-48b8-917a-9556a81edf71.jsonl
  -> HTTP 200

s3_bucket_name without a space (control): 'litellm-lit5024-proof/LLM-AI-Projects'
  PUT https://s3.us-west-2.amazonaws.com/litellm-lit5024-proof/LLM-AI-Projects/litellm-bedrock-files-anthropic.claude-3-5-sonnet-20240620-v1-0-b4101618-0e6b-4663-b0ae-86e7575d2d5a.jsonl
  -> HTTP 200

--- file content (_sign_s3_get_request -> real S3 GET) ---

key WITH a space
  GET https://s3.us-west-2.amazonaws.com/litellm-lit5024-proof/LOGS/LLM%20AI%20Projects/prod-key/2026-08-05/time-13-01-00-000000_AFTER-with-space.json
  -> HTTP 200

key without a space (control)
  GET https://s3.us-west-2.amazonaws.com/litellm-lit5024-proof/LOGS/LLM-AI-Projects/prod-key/2026-08-05/time-13-01-00-000000_AFTER-no-space.json
  -> HTTP 200
```

The two probes drive the production transforms and put the response of real AWS S3 on screen, which curl cannot do here because the request has to be signed by the code under test. Upload probe:

```python
config = BedrockFilesConfig()
content = json.dumps({"custom_id": "1", "body": {"model": "bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
                                                 "messages": [{"role": "user", "content": "hello"}]}})
for label, bucket_setting in (("with a space in the prefix", f"{BUCKET}/LLM AI Projects"),
                              ("without a space (control)", f"{BUCKET}/LLM-AI-Projects")):
    signed = config.transform_create_file_request(
        model="bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0",
        create_file_data={"file": ("batch.jsonl", content.encode("utf-8"), "application/jsonl"), "purpose": "batch"},
        optional_params=aws_credentials,
        litellm_params={"s3_bucket_name": bucket_setting, "s3_region_name": REGION},
    )
    response = httpx.put(signed["url"], content=signed["data"], headers=signed["headers"])
    print(label, "->", response.status_code, response.text)
```

Retrieval probe:

```python
for label, key in (("key WITH a space", KEY_WITH_SPACE), ("key without a space (control)", KEY_NO_SPACE)):
    url = f"https://s3.{REGION}.amazonaws.com/{BUCKET}/{encode_s3_object_key_for_url(key)}"
    headers = config._sign_s3_get_request(api_base=url, aws_region_name=REGION, request_params=params)
    response = httpx.get(url, headers=headers)
    print(label, "->", response.status_code, response.text)
```

## Type

🐛 Bug Fix

## Changes

`litellm/llms/bedrock/files/transformation.py` signs both S3 calls with `S3SigV4Auth`: `_sign_s3_request` (the PUT behind `transform_create_file_request`) and `_sign_s3_get_request` (the GET behind `transform_file_content_request`)

Two regression tests drive the public transforms with a bucket prefix containing a space and assert the sent signature equals the one S3 itself computes and differs from the one generic `SigV4Auth` computes, so reverting either signer fails its own test. Mutating each call site on its own kills exactly one test and leaves the other green, so neither site is covered only by its sibling

One existing assertion in `test_transform_file_content_request_signs_s3_get` moved from a fixed header spelling to a case-insensitive lookup of the same value: botocore rewrites the content hash header under its own casing, and HTTP header names are case-insensitive, so the value is the invariant and the spelling is not. The live GET above confirms S3 accepts it

The S3 logger itself needs no change here, since #35726 already landed the same swap in `litellm/integrations/s3_v2.py`. I re-verified that merged fix against the same real bucket while scoping this: a team alias of `LLM AI Projects` under `s3_use_team_prefix` 403s on the parent of that commit and writes the object on it. Sweeping the rest of the tree, every other `SigV4Auth` call signs a non-S3 service (bedrock, sagemaker, polly, sqs, secretsmanager, and `s3vectors`, whose endpoints are fixed literal API paths), where generic `SigV4Auth` is the correct signer

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow signing change for Bedrock file S3 PUT/GET only, aligned with an existing S3 logger pattern and covered by targeted regression tests.
> 
> **Overview**
> Fixes **403 SignatureDoesNotMatch** on Bedrock managed-file uploads and downloads when the S3 object key is percent-encoded (e.g. a `s3_bucket_name` prefix or key containing spaces).
> 
> **`_sign_s3_request`** (batch file PUT) and **`_sign_s3_get_request`** (file content GET) now use **`S3SigV4Auth`** instead of generic **`SigV4Auth`**, matching the S3 logger fix so the canonical path stays single-encoded (`%20`) instead of double-encoded (`%2520`).
> 
> Tests add **`TestBedrockFilesS3SignatureEncoding`** for spaced prefixes on create and content flows, and relax the GET content-hash assertion to a case-insensitive header lookup for botocore’s casing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 597b9e464481b62ab6ee28b41f39b195c4a19ba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->