### PR TITLE
fix(autorouter): match CJK keyword_tier_rules that regex word boundaries miss

### DIFF
--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -211,6 +211,8 @@ _REMINDER_CLOSE: Final = "</system-reminder>"
 
 _TRUNCATION_MARKER: Final = "..."
 
+_CJK_CHARACTER: Final = re.compile("[぀-ヿㇰ-ㇿ㐀-䶿一-鿿豈-﫿ｦ-ﾝ\U00020000-\U0002fa1f]")
+
 
 def _message_text(content: object) -> str:
     """Flatten message content to plain text, joining multi-part text blocks.
@@ -586,23 +588,25 @@ class ComplexityRouter(CustomLogger):
         return DimensionScore("tokenCount", 0, None)
 
     def _keyword_matches(self, text: str, keyword: str) -> bool:
-        """
-        Check if a keyword matches in text using word boundary matching.
+        r"""
+        Check if a keyword matches in text.
 
-        For single-word keywords, uses regex word boundaries to avoid
-        false positives (e.g., "error" matching "terrorism", "class" matching "classical").
-        For multi-word phrases, uses substring matching.
+        Single-word keywords use regex word boundaries to avoid false positives, e.g. "api"
+        must not match "capital" and "error" must not match "terrorism".
+
+        Multi-word phrases and keywords containing CJK match as plain substrings. CJK is
+        written without spaces and every CJK character is a regex word character, so `\b`
+        never fires between two of them: `\b发票\b` misses "我需要开发票" entirely. The gate is
+        on the keyword rather than the text, so a keyword with no CJK in it keeps word
+        boundary matching no matter what script the prompt is written in.
         """
         kw_lower: Final = keyword.lower()
 
-        # For single-word keywords, use word boundary matching to avoid false positives
-        # e.g., "api" should not match "capital", "error" should not match "terrorism"
-        if " " not in kw_lower:
-            pattern: Final = r"\b" + re.escape(kw_lower) + r"\b"
-            return bool(re.search(pattern, text))
+        if " " in kw_lower or _CJK_CHARACTER.search(kw_lower):
+            return kw_lower in text
 
-        # For multi-word phrases, substring matching is fine
-        return kw_lower in text
+        pattern: Final = r"\b" + re.escape(kw_lower) + r"\b"
+        return bool(re.search(pattern, text))
 
     def _score_keyword_match(
         self,

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -211,7 +211,7 @@ _REMINDER_CLOSE: Final = "</system-reminder>"
 
 _TRUNCATION_MARKER: Final = "..."
 
-_CJK_CHARACTER: Final = re.compile("[぀-ヿㇰ-ㇿ㐀-䶿一-鿿豈-﫿ｦ-ﾝ\U00020000-\U0002fa1f]")
+_CJK_CHARACTER: Final = re.compile("[぀-ヿㇰ-ㇿ㐀-䶿一-鿿豈-﫿ｦ-ﾝ\U00020000-\U0003ffff]")
 
 
 def _message_text(content: object) -> str:

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2423,6 +2423,7 @@ class TestCjkKeywordTierRules:
             ("請求", "這個請求要怎麼處理"),
             ("見積", "見積をお願いします"),
             ("キャンセル", "注文をキャンセルしたい"),
+            ("\U00030000", "这个\U00030000很少见"),
         ],
     )
     def test_cjk_keyword_matches_without_surrounding_whitespace(

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -2400,6 +2400,83 @@ class TestLexicalKeywordTierRules:
         assert router._lexical_tier_override("what is a k8scluster thing") is None
 
 
+class TestCjkKeywordTierRules:
+    """CJK keyword_tier_rules must fire mid-sentence, where regex word boundaries cannot."""
+
+    def _router(self, mock_router_instance, basic_config, keywords: List[str]) -> ComplexityRouter:
+        return ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                **basic_config,
+                "keyword_tier_rules": [{"keywords": keywords, "tier": "REASONING"}],
+            },
+        )
+
+    @pytest.mark.parametrize(
+        "keyword, prompt",
+        [
+            ("发票", "我需要开发票"),
+            ("退款", "我要退款，谢谢"),
+            ("账单查询", "我的账单查询怎么做"),
+            ("API文档", "请问在哪里看API文档"),
+            ("請求", "這個請求要怎麼處理"),
+            ("見積", "見積をお願いします"),
+            ("キャンセル", "注文をキャンセルしたい"),
+        ],
+    )
+    def test_cjk_keyword_matches_without_surrounding_whitespace(
+        self, mock_router_instance, basic_config, keyword, prompt
+    ):
+        """CJK is written without spaces, so `\\b<kw>\\b` never fires between two CJK characters."""
+        router = self._router(mock_router_instance, basic_config, [keyword])
+        assert router._lexical_tier_override(prompt) == KeywordOverride(
+            tier=ComplexityTier.REASONING, matched_keyword=keyword
+        )
+
+    def test_cjk_keyword_does_not_match_unrelated_prompt(self, mock_router_instance, basic_config):
+        """Substring matching must still be a real test, not a match-all."""
+        router = self._router(mock_router_instance, basic_config, ["发票"])
+        assert router._lexical_tier_override("我想查一下订单状态") is None
+
+    @pytest.mark.asyncio
+    async def test_cjk_keyword_overrides_scoring_end_to_end(self, mock_router_instance, basic_config):
+        """The whole hook, not just the matcher: a Chinese prompt reaches the tier it was mapped to."""
+        prompt = "我需要开发票"
+        router = self._router(mock_router_instance, basic_config, ["发票"])
+        scored_tier, _, _ = router.classify(prompt)
+        assert scored_tier != ComplexityTier.REASONING
+
+        result = await router.async_pre_routing_hook(
+            model="test-model",
+            request_kwargs={},
+            messages=[{"role": "user", "content": prompt}],
+        )
+        assert result is not None
+        assert result.model == "o1-preview"
+
+    def test_latin_keywords_keep_word_boundary_matching(self, mock_router_instance, basic_config):
+        """The CJK gate reads the keyword, so a Latin keyword is unaffected by the prompt's script."""
+        router = self._router(mock_router_instance, basic_config, ["k8s"])
+        assert router._lexical_tier_override("what is a k8scluster thing") is None
+        assert router._lexical_tier_override("running my k8s cluster") == KeywordOverride(
+            tier=ComplexityTier.REASONING, matched_keyword="k8s"
+        )
+
+    def test_latin_keyword_against_cjk_prompt_still_needs_a_boundary(self, mock_router_instance, basic_config):
+        """A Latin keyword glued to CJK characters is still a substring false positive."""
+        router = self._router(mock_router_instance, basic_config, ["api"])
+        assert router._lexical_tier_override("请解释一下rapid这个词") is None
+        assert router._lexical_tier_override("请问 api 怎么调用") == KeywordOverride(
+            tier=ComplexityTier.REASONING, matched_keyword="api"
+        )
+
+    def test_accented_latin_keeps_word_boundary_semantics(self, complexity_router):
+        """Guards the alternative fix (ASCII-only lookarounds), which would break diacritics."""
+        assert complexity_router._keyword_matches("un café apiculteur", "api") is False
+        assert complexity_router._keyword_matches("appelle l' api maintenant", "api") is True
+
+
 def _make_embedding_response(vectors: List[List[float]]) -> "litellm.EmbeddingResponse":
     return litellm.EmbeddingResponse(
         model="fake-embed",


### PR DESCRIPTION
## TLDR

Problem this solves:

- CJK `keyword_tier_rules` silently never matched
- `\b发票\b` cannot match inside `我需要开发票`
- Chinese traffic fell through to complexity scoring
- Scoring is English-biased, so it under-routed

How it solves it:

- Keywords containing CJK match as substrings
- Gate reads the keyword, not the prompt
- Latin keywords keep word boundary matching unchanged

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Runbook below. Before is `54f83b2614` (the merge-base), after is `aef2e5329f`

1. Add this deployment to `litellm/proxy/dev_config.yaml`

```yaml
  - model_name: cjk-tier-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        tiers:
          SIMPLE: bedrock-invoke-haiku-4-5
          MEDIUM: bedrock-invoke-haiku-4-5
          COMPLEX: bedrock-invoke-opus-4-5
          REASONING: bedrock-invoke-opus-4-5
        keyword_tier_rules:
          - keywords: ["发票", "退款"]
            tier: COMPLEX
```

2. Start the proxy

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

3. Send a Chinese request whose keyword sits mid-sentence, with no surrounding spaces

```bash
curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"cjk-tier-router","messages":[{"role":"user","content":"我需要开发票"}]}' | jq '.model'
```

On `54f83b2614` this returns the haiku deployment: the rule never fired, and the prompt fell through to complexity scoring, which reads it as short and simple. On `aef2e5329f` it returns the opus deployment, matching the configured COMPLEX tier

4. Confirm the same on the Anthropic Messages surface

```bash
curl -s http://localhost:4000/v1/messages -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"model":"cjk-tier-router","max_tokens":64,"messages":[{"role":"user","content":"我要退款，谢谢"}]}' | jq '.model'
```

5. Confirm Latin keywords did not change. Add `- keywords: ["k8s"] / tier: REASONING` to the rules, then check that `k8scluster` still does not trip it while `k8s` does

```bash
for prompt in "what is a k8scluster thing" "running my k8s cluster"; do curl -s http://localhost:4000/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{\"model\":\"cjk-tier-router\",\"messages\":[{\"role\":\"user\",\"content\":\"$prompt\"}]}" | jq -r '.model'; done
```

6. The routing decision for each call is visible at http://localhost:4000/ui/?page=logs under the log's routing decision, where `cause` should read `literal_keyword_match` and `matched_keyword` should be the CJK term

## Type

🐛 Bug Fix

## Changes

`_keyword_matches` sent every space-free keyword down a `\b<kw>\b` regex path. Chinese has no spaces, so every CJK keyword took that path, and Python treats CJK characters as regex word characters, which means `\b` never fires between two of them. A rule for 发票 matched only when the term stood alone between spaces or punctuation, so realistic prompts missed it and fell through to complexity scoring

Scoring then leans cheap for Chinese in two independent ways: all 119 default scoring keywords are English, and `_estimate_tokens` is `len(text) // 4`, which is roughly right for English but badly undercounts Chinese, where a character is about one token. So a Chinese prompt someone mapped to COMPLEX was landing on the cheap tier. Anyone who already has CJK keywords configured should expect their routing, and their spend, to shift once this lands. That is the rules taking effect for the first time

Keywords containing CJK now match as plain substrings, the same way multi-word phrases already did. The gate reads the keyword rather than the prompt, so a keyword with no CJK in it keeps word boundary matching regardless of the script the prompt is written in. That keeps the change provably inert for every existing config: all 119 defaults are ASCII, and accented Latin is untouched, which the alternative fix of swapping `\b` for ASCII-only lookarounds would have broken by making "api" match inside "caféapi"

Scope is Han plus kana, covering Chinese and Japanese. Thai, Lao, Khmer, and Burmese have the same underlying problem and the same character class extends to them, left out here because this change is about verified scripts rather than a guess at segmentation semantics

One caveat worth knowing when authoring rules: substring matching makes short CJK keywords broad, since 码 sits inside 密码, 号码, and 代码 alike. Two or more characters, and specific terms, behave as expected. Escalation keywords have always matched by substring, so this is the same property that field already has

Note the asymmetry this removes: escalation keywords used a plain `in` check and worked with Chinese, while the keyword tier rules right next to them in the same form did not

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
