### PR TITLE
fix(ai21): resolve the documented AI21_API_KEY instead of a misspelled name

### DIFF
--- a/litellm/utils.py
+++ b/litellm/utils.py
@@ -4789,7 +4789,7 @@ def get_api_key(llm_provider: str, dynamic_api_key: str | None):
         api_key = api_key or litellm.anthropic_key or get_secret("ANTHROPIC_API_KEY")
     # ai21
     elif llm_provider == "ai21":
-        api_key = api_key or litellm.ai21_key or get_secret("AI211_API_KEY")
+        api_key = api_key or litellm.ai21_key or get_secret("AI21_API_KEY")
     # aleph_alpha
     elif llm_provider == "aleph_alpha":
         api_key = api_key or litellm.aleph_alpha_key or get_secret("ALEPH_ALPHA_API_KEY")

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -26,6 +26,7 @@ from litellm.utils import (
     TextCompletionStreamWrapper,
     _check_provider_match,
     _is_streaming_request,
+    get_api_key,
     get_llm_provider,
     get_optional_params_image_gen,
     get_prompt_cache_min_tokens,
@@ -5108,3 +5109,14 @@ def test_reapply_runtime_registrations_drops_request_scoped_registrations(monkey
     finally:
         litellm.model_cost = saved_model_cost
         _invalidate_model_cost_lowercase_map()
+
+
+def test_ai21_api_key_is_resolved_from_the_documented_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ai21 branch resolved a misspelled env var, so the name every other ai21 code path
+    reads, and the only name documented, was ignored."""
+    monkeypatch.setattr(litellm, "api_key", None)
+    monkeypatch.setattr(litellm, "ai21_key", None)
+    monkeypatch.delenv("AI211_API_KEY", raising=False)
+    monkeypatch.setenv("AI21_API_KEY", "sk-ai21-resolved-from-env")
+
+    assert get_api_key(llm_provider="ai21", dynamic_api_key=None) == "sk-ai21-resolved-from-env"


### PR DESCRIPTION
## TLDR

Problem this solves:

- `get_api_key` read `AI211_API_KEY`, with a doubled 1
- Every other ai21 site reads `AI21_API_KEY`
- Documenting the typo would make it public API

How it solves it:

- One line: read the documented name instead
- Regression test pins the resolved variable name

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

There is no end-to-end reproduction to show, and that is a finding rather than an omission: no request path reaches this branch. Being straight about that is more useful than a proof that only appears to exercise it.

Two independent reasons it is unreachable. The branch condition is `llm_provider == "ai21"`, but all three provider-resolution sites that handle ai21 rewrite `custom_llm_provider` to `"ai21_chat"` first, at `get_llm_provider_logic.py:262`, `:414` and `:615`, including the one whose own condition is `custom_llm_provider == "ai21"`. And all three set `dynamic_api_key` from a correctly spelled `AI21_API_KEY` read, so `dynamic_api_key or litellm.ai21_key or get_secret(...)` short-circuits before the misspelling is consulted even when the provider name does arrive as `ai21`. Beyond that, `litellm.utils.get_api_key` has no callers anywhere in `litellm/`, `tests/` or `enterprise/`; the one bare `get_api_key(` call, at `user_api_key_auth.py:1094`, resolves to an unrelated function defined at line 563 of that same file.

What can be shown directly is the resolution itself, before and after, at the same commit pair as this PR:

```
# before, at 2a9843e649
$ AI21_API_KEY=sk-ai21-live python -c 'from litellm.utils import get_api_key; print(repr(get_api_key(llm_provider="ai21", dynamic_api_key=None)))'
None

# after, at e80319f918
$ AI21_API_KEY=sk-ai21-live python -c 'from litellm.utils import get_api_key; print(repr(get_api_key(llm_provider="ai21", dynamic_api_key=None)))'
'sk-ai21-live'
```

## Type

🐛 Bug Fix

✅ Test

## Changes

`utils.py:4741` resolved the ai21 key from `AI211_API_KEY`. Every other ai21 code path reads `AI21_API_KEY`, including the three `validate_environment` branches that report `AI21_API_KEY` as the one a user is missing, so this site ignored the only name a user is ever told to set.

The reason to fix it now rather than leave it as harmless dead code is the environment-variable documentation gate. That gate requires every env var read under `litellm/` to be documented, and a change widening it to see bare `get_secret` calls makes it read this call site for the first time. Leaving the misspelling would require a row for `AI211_API_KEY` in the environment variables reference table, which would turn a typo into documented public API and make it permanent. Correcting the spelling means the gate sees a name that is already documented.

`litellm.utils.get_api_key` having no callers at all is a separate matter, filed separately. Deleting it is a public API removal and does not belong in a one-line spelling correction.

## Tests

`tests/test_litellm/test_utils.py::test_ai21_api_key_is_resolved_from_the_documented_env_var` sets `AI21_API_KEY`, clears `AI211_API_KEY`, and pins both `litellm.api_key` and `litellm.ai21_key` to None so the fallback chain actually reaches the env read rather than short-circuiting.

Mutation-checked: reverting `utils.py` to its parent commit while keeping the test turns it red, and restoring the fix turns it green again.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
