### PR TITLE
fix(migrations): keep the toolchain heal from raising on an unreadable nodeenv cache

### DIFF
--- a/.github/workflows/image-scan.yml
+++ b/.github/workflows/image-scan.yml
@@ -11,7 +11,8 @@ on:
       - docker/Dockerfile.non_root
       - migrations/Dockerfile
       - migrations/run.py
-      - tests/proxy_migration_tests/test_offline_image_migration.py
+      - litellm-proxy-extras/**
+      - tests/proxy_migration_tests/**
       - uv.lock
       - ui/litellm-dashboard/package-lock.json
       - .github/workflows/image-scan.yml

--- a/litellm-proxy-extras/litellm_proxy_extras/prisma_toolchain.py
+++ b/litellm-proxy-extras/litellm_proxy_extras/prisma_toolchain.py
@@ -121,9 +121,13 @@ def heal_incomplete_nodeenv_cache() -> bool:
     Prisma invocation reinstalls it instead of failing on a missing binary.
     """
     cache_dir = nodeenv_cache_dir()
-    if cache_dir is None or not cache_dir.is_dir():
+    if cache_dir is None:
         return False
-    if node_binary_path(cache_dir).exists():
+    try:
+        if not cache_dir.is_dir() or node_binary_path(cache_dir).exists():
+            return False
+    except OSError as e:
+        logger.warning("Could not inspect the Node toolchain at %s: %s", cache_dir, e)
         return False
     logger.warning(
         "Node toolchain at %s has no %s, so a previous install was interrupted. "

--- a/tests/proxy_migration_tests/test_prisma_toolchain.py
+++ b/tests/proxy_migration_tests/test_prisma_toolchain.py
@@ -119,6 +119,32 @@ def test_absent_toolchain_is_not_an_error(toolchain_env: tuple[Path, Path]) -> N
     assert not cache_dir.exists()
 
 
+_CAN_DENY_ACCESS = os.name != "nt" and hasattr(os, "geteuid") and os.geteuid() != 0
+
+
+@pytest.mark.skipif(
+    not _CAN_DENY_ACCESS, reason="root and Windows do not honour a 0o000 directory"
+)
+def test_unreadable_cache_dir_is_not_an_error(
+    toolchain_env: tuple[Path, Path],
+) -> None:
+    """A cache dir this process cannot stat means nothing to heal, not a crash.
+
+    Images bake the cache under the build user's home, and a container started
+    under any other uid cannot search that directory. `Path.is_dir()` only
+    swallows ENOENT-shaped errnos, so it raises `PermissionError` there and
+    kills the migration before Prisma is ever invoked.
+    """
+    cache_dir, _ = toolchain_env
+    _make_incomplete_cache(cache_dir)
+    cache_dir.parent.chmod(0o000)
+
+    try:
+        assert heal_incomplete_nodeenv_cache() is False
+    finally:
+        cache_dir.parent.chmod(0o700)
+
+
 def test_bootstrap_clears_the_cache_before_invoking_prisma(
     toolchain_env: tuple[Path, Path],
 ) -> None:


### PR DESCRIPTION
## TLDR

Problem this solves:

- Migrations crash under any non-root uid before Prisma runs
- A bare `Path.is_dir()` lets `EACCES` escape instead of answering False
- `image-scan` is red on every PR that triggers it

How it solves it:

- Tolerate `OSError` while inspecting the nodeenv cache
- An unreachable cache means nothing to heal, not a crash
- Restores the never-raises contract the module already documents
- Lets changes to that package trigger the image job at all

## Relevant issues

## Linear ticket

Resolves LIT-5243

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before at `54f83b2614`, after at `d98ef29b5b`

1. Before. CI's own `migrations-image` job, which builds `migrations/Dockerfile` and runs the migration as an arbitrary uid on a network with no egress, fails before Prisma is invoked ([job 92417519889](https://github.com/BerriAI/litellm/actions/runs/31038751990/job/92417519889)):

```
2026-08-05 19:22:32,883 - litellm_proxy_extras - INFO - Using custom Prisma CLI at /opt/prisma/binaries/node_modules/.bin/prisma
Traceback (most recent call last):
  File "/app/run.py", line 55, in main
    ok = ProxyExtrasDBManager.setup_database(
  File "/app/.venv/.../litellm_proxy_extras/utils.py", line 738, in setup_database
    ensure_prisma_toolchain(
  File "/app/.venv/.../litellm_proxy_extras/prisma_toolchain.py", line 150, in ensure_prisma_toolchain
    healed = heal_incomplete_nodeenv_cache()
  File "/app/.venv/.../litellm_proxy_extras/prisma_toolchain.py", line 124, in heal_incomplete_nodeenv_cache
    if cache_dir is None or not cache_dir.is_dir():
  File "/usr/lib/python3.13/pathlib/_local.py", line 515, in stat
    return os.stat(self, follow_symlinks=follow_symlinks)
PermissionError: [Errno 13] Permission denied: '/home/nonroot/.cache/prisma-python/nodeenv'

FAILED tests/proxy_migration_tests/test_offline_image_migration.py::test_migration_offline_as_non_root_uid
```

2. After. Same image built from this branch, same invocation the workflow uses:

```
$ docker build -f migrations/Dockerfile -t lit5243-migrations .
$ LITELLM_IMAGE=lit5243-migrations \
  LITELLM_MIGRATION_INTERPRETER=python3 \
  LITELLM_MIGRATION_SCRIPT=/app/run.py \
  python -m pytest tests/proxy_migration_tests/test_offline_image_migration.py -v

tests/proxy_migration_tests/test_offline_image_migration.py::test_migration_offline_as_non_root_uid PASSED [ 50%]
tests/proxy_migration_tests/test_offline_image_migration.py::test_runtime_cache_env_not_read_only   PASSED [100%]
2 passed in 13.53s
```

That test runs the migration entrypoint as uid `12345:0` against a brand-new Postgres on an `--internal` network, then asserts the schema was actually created, so it fails both when the entrypoint dies and when it exits 0 having applied nothing

3. The added unit test fails without the fix. The pre-fix module was restored from `HEAD` into a scratch copy so nothing in the working tree moved:

```
$ git show HEAD:litellm-proxy-extras/litellm_proxy_extras/prisma_toolchain.py > $SCRATCH/litellm_proxy_extras/prisma_toolchain.py
$ PYTHONPATH=$SCRATCH python -m pytest tests/proxy_migration_tests/test_prisma_toolchain.py -k unreadable

E   PermissionError: [Errno 13] Permission denied: '.../test_unreadable_cache_dir_is_n0/nodeenv'
FAILED tests/proxy_migration_tests/test_prisma_toolchain.py::test_unreadable_cache_dir_is_not_an_error
1 failed, 18 deselected

$ python -m pytest tests/proxy_migration_tests/test_prisma_toolchain.py
19 passed in 8.67s
```

Same errno and same call as the container failure

## Type

🐛 Bug Fix

## Changes

`heal_incomplete_nodeenv_cache()` stats a `$HOME`-derived path with a bare `Path.is_dir()`. `pathlib` only swallows the ENOENT-shaped errnos in `_IGNORED_ERRNOS`, so a directory the process cannot search raises `PermissionError` rather than answering False. The images bake that cache under the build user's home, and the base image ships that home at mode 0700, so a container started under any other uid dies there before the Prisma CLI is ever invoked and the migration never runs. `ensure_prisma_toolchain()` documents itself as never raising; this made that untrue

The fix tolerates `OSError` while inspecting the cache, so an unreachable cache means there is nothing to heal. One `try` covers both stats rather than two separate guards, since a cache directory whose `bin/` is unreadable is the same class of failure. The guard already existed one function above: `nodeenv_cache_dir()` catches `OSError` on its other branch, so this brings the two into line. The warning fires only on the `OSError` path, leaving a legitimately absent cache silent while telling an operator why healing was skipped

Worth stating plainly, because it is the argument for fixing it here rather than elsewhere: this is the same defect class as an unguarded `pathlib` existence check in prisma-client-py itself, reproduced inside the code we wrote to make prisma's toolchain more robust. An unguarded stat is easy to write and invisible until someone runs as a different uid

Why not just fix where the cache is baked, which is the other obvious remedy: the two are independent and both are worth having. The `non_root` image already bakes at `/opt/prisma`, so its `$HOME`-derived nodeenv path stays reachable and `test_migration_offline_as_non_root_uid` passes there; the migrations image still bakes under the build user's home, so the same line raises. Moving a bake removes one unreadable path, while this change makes the stat tolerate an unreadable path wherever anything is baked. Fixing only the bake location would leave this raising the next time any path is unreachable, so the bake move is being handled separately rather than folded in here

The test drives the cache location through the existing `PRISMA_NODEENV_CACHE_DIR` override and the file's own fixture rather than patching anything, which matters here because the bug is precisely about which path gets stat-ed. It is skipped as root and on Windows, since neither honours a 0o000 directory, and the skip carries that reason inline so it does not get deleted later as unexplained

One line of CI wiring comes with it, because the fix is otherwise untested by the job it repairs. `image-scan` triggers on a `paths` list that names `migrations/Dockerfile`, `migrations/run.py` and one test file, but not `litellm-proxy-extras/**`, which is where the code the migration Job actually executes lives. The change that introduced this behaviour touched only that package, so the job never ran on it:

```
$ gh pr checks 35832 | grep -i image-scan
(no output; the job was never queued on that PR)
```

That is the whole explanation for how a two-line defect shipped green. Nothing was watching, rather than someone missing it. The single-file entry is replaced with `litellm-proxy-extras/**` and `tests/proxy_migration_tests/**`, so a change to the migration code path exercises the migration image from now on. To be precise about what this PR proves: `image-scan` runs here because the PR edits the workflow file, which was already a trigger, so its green is not itself evidence that the new entries work. What the new entries change is the next PR that touches only `litellm-proxy-extras/**`, which is the exact shape that shipped this bug

The cost is real and worth stating: `image-scan` now triggers on any change under either path, and it builds two images at roughly nine minutes. PRs touching that package previously skipped it and no longer will

A note on formatting, so the untouched reflow does not read as an oversight: `ruff format` wants to reformat both files at `HEAD` as well, since the package is written at 88 columns while the repo config is 120, so that drift is pre-existing. Bundling a whole-file reflow into a two-line urgent fix would bury the change; the added lines conform and `ruff check` is clean

Related and deliberately not fixed here: `tests/proxy_migration_tests/test_prisma_toolchain.py` is not referenced by any workflow, and `assert-shard-coverage` only enumerates `tests/proxy_unit_tests/`, so those unit tests have never run in CI. Picking a shard for them, or extending the coverage assertion so the next unlisted directory is caught automatically, is a broader change than this fix and belongs on its own

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the migration entrypoint’s Prisma toolchain prep on a security-sensitive startup path, but behavior is limited to swallowing stat failures and is covered by new tests; CI will run heavier image jobs on more PRs.
> 
> **Overview**
> Fixes migrations aborting before Prisma runs when the container uid cannot read the baked-in nodeenv cache under another user’s home.
> 
> **`heal_incomplete_nodeenv_cache()`** now wraps cache inspection in **`OSError`** handling so **`PermissionError`** from **`Path.is_dir()`** is treated as “nothing to heal” (with a warning) instead of violating **`ensure_prisma_toolchain()`**’s never-raise contract. A unit test covers an unreadable parent directory (skipped on root/Windows).
> 
> **`image-scan`** PR path filters now include **`litellm-proxy-extras/**`** and **`tests/proxy_migration_tests/**`** (replacing a single migration test file), so edits to the migration execution path trigger the migration image checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98ef29b5bdebcf9188dbadba0c39b131a75bd9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->