### PR TITLE
fix(docker): bake the componentized prisma engines at /opt/prisma so any uid can start

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -59,9 +59,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --extra semantic-router \
         --python python3
 
-RUN mkdir -p /home/nonroot && \
-    HOME=/home/nonroot prisma generate --schema=./schema.prisma && \
-    chown -R nonroot:nonroot /home/nonroot/.cache
+RUN HOME=/opt/prisma XDG_CACHE_HOME=/opt/prisma/.cache PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \
+    npm_config_cache=/root/.npm \
+    prisma generate --schema=./schema.prisma
 
 RUN sed -i 's/\r$//' docker/component_entrypoint.sh && chmod +x docker/component_entrypoint.sh
 
@@ -83,13 +83,16 @@ ENV HOME=/home/nonroot \
     PATH="/app/.venv/bin:${PATH}" \
     PYTHONPATH="/app" \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries
 
 COPY --from=builder --chown=nonroot:nonroot /app /app
-COPY --from=builder --chown=nonroot:nonroot /home/nonroot/.cache /home/nonroot/.cache
+COPY --from=builder /opt/prisma /opt/prisma
 
 RUN find /app/.venv -type f -path "*/tornado/test/*" -delete && \
-    find /app/.venv -type d -path "*/tornado/test" -delete
+    find /app/.venv -type d -path "*/tornado/test" -delete && \
+    chmod -R a+rX /opt/prisma && \
+    python -c "from prisma.client import BINARY_PATHS; paths = list(BINARY_PATHS.query_engine.values()); assert paths and all(p.startswith('/opt/prisma/') for p in paths), paths"
 
 USER nonroot
 

--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -61,9 +61,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --extra bedrock-realtime \
         --python python3
 
-RUN mkdir -p /home/nonroot && \
-    HOME=/home/nonroot prisma generate --schema=./schema.prisma && \
-    chown -R nonroot:nonroot /home/nonroot/.cache
+RUN HOME=/opt/prisma XDG_CACHE_HOME=/opt/prisma/.cache PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \
+    npm_config_cache=/root/.npm \
+    prisma generate --schema=./schema.prisma
 
 RUN sed -i 's/\r$//' docker/component_entrypoint.sh && chmod +x docker/component_entrypoint.sh
 
@@ -85,13 +85,16 @@ ENV HOME=/home/nonroot \
     PATH="/app/.venv/bin:${PATH}" \
     PYTHONPATH="/app" \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries
 
 COPY --from=builder --chown=nonroot:nonroot /app /app
-COPY --from=builder --chown=nonroot:nonroot /home/nonroot/.cache /home/nonroot/.cache
+COPY --from=builder /opt/prisma /opt/prisma
 
 RUN find /app/.venv -type f -path "*/tornado/test/*" -delete && \
-    find /app/.venv -type d -path "*/tornado/test" -delete
+    find /app/.venv -type d -path "*/tornado/test" -delete && \
+    chmod -R a+rX /opt/prisma && \
+    python -c "from prisma.client import BINARY_PATHS; paths = list(BINARY_PATHS.query_engine.values()); assert paths and all(p.startswith('/opt/prisma/') for p in paths), paths"
 
 USER nonroot
 


### PR DESCRIPTION
## TLDR

Problem this solves:

- The gateway image cannot start under any uid but 65532
- Engine paths are baked inside a home directory at mode 0700
- The crash is a bare PermissionError no env override can rescue
- OpenShift assigns an arbitrary uid by design, so this is its default

How it solves it:

- Bake to `/opt/prisma`, the fixed path the other images already use
- Assert at build time that every baked path lands there
- `chmod a+rX` so the engine stays executable for every uid

## Relevant issues

## Linear ticket

Resolves LIT-5241

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Neither of these images is built by any CI job, so unlike a change to the shipped runtime images there is no CI leg here; the four runs below are the whole verification, and the build-time assertion added here will not execute anywhere until someone wires these images into a workflow

Before at `0b8c58735d`, after at `c2b1f56947`. Four legs, each naming the image it ran on

1. Backend, before. A real `backend/Dockerfile` build, running the generated client the way `proxy_server` does at startup:

```
$ docker build -f backend/Dockerfile -t backend-before .
$ docker run --rm --user 65532:65532 --entrypoint python backend-before -c "$PROG"
baked:    /home/nonroot/.cache/prisma-python/binaries/5.4.2/ac9d7041.../query-engine-linux-arm64-openssl-3.0.x
resolved: /home/nonroot/.cache/prisma-python/binaries/5.4.2/ac9d7041.../query-engine-linux-arm64-openssl-3.0.x

$ docker run --rm --user 12345:0 --entrypoint python backend-before -c "$PROG"
PermissionError: [Errno 13] Permission denied: '/home/nonroot/.cache/prisma-python/binaries/5.4.2/ac9d7041.../query-engine-linux-arm64-openssl-3.0.x'
```

where `$PROG` is `from prisma.client import BINARY_PATHS; from prisma.engine import utils; utils.ensure(BINARY_PATHS.query_engine)`, the same call `prisma/engine/query.py` makes on connect

2. Backend, after. Same file, this branch:

```
$ docker run --rm --user 12345:0 --entrypoint python backend-after -c "$PROG"
PRISMA_BINARY_CACHE_DIR = /opt/prisma/binaries
resolved: /opt/prisma/binaries/node_modules/prisma/query-engine-linux-arm64-openssl-3.0.x

$ docker run --rm --user 65532:65532 --entrypoint python backend-after -c "$PROG"
resolved: /opt/prisma/binaries/node_modules/prisma/query-engine-linux-arm64-openssl-3.0.x
```

3. Gateway, after. A real `gateway/Dockerfile` build from this branch, both uids:

```
resolved: /opt/prisma/binaries/node_modules/prisma/query-engine-linux-arm64-openssl-3.0.x
```

4. Drift. A real `backend/Dockerfile` with only the bake location reverted, so the build should die at the assertion rather than ship:

```
AssertionError: ['/home/nonroot/.cache/prisma-python/binaries/5.4.2/.../query-engine-linux-arm64-openssl-3.0.x', ...]
ERROR: failed to build: ... did not complete successfully: exit code: 1
```

The drift variant also needs a bare `mkdir -p /opt/prisma`, and that is load-bearing rather than cruft: without it the build dies at the `COPY` instead, and a red log that says "build failed" reads exactly like the guard working while proving nothing about it. What matters is that the assertion failed the build, not that the build failed

Stated gap: there is no gateway before-build. Rather than assert the two images are the same, here is the evidence. The bake and copy lines are byte-identical in both files, `diff` empty at both revisions

before, in `backend/Dockerfile` and `gateway/Dockerfile` alike:

```
RUN mkdir -p /home/nonroot && \
    HOME=/home/nonroot prisma generate --schema=./schema.prisma && \
    chown -R nonroot:nonroot /home/nonroot/.cache
COPY --from=builder --chown=nonroot:nonroot /home/nonroot/.cache /home/nonroot/.cache
```

after, likewise identical in both:

```
RUN HOME=/opt/prisma XDG_CACHE_HOME=/opt/prisma/.cache PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries \
    npm_config_cache=/root/.npm \
    prisma generate --schema=./schema.prisma
COPY --from=builder /opt/prisma /opt/prisma
```

## Type

🐛 Bug Fix

## Changes

The gateway image is the one that matters most here, because it serves requests. It generated the prisma client with `HOME=/home/nonroot`, so the absolute engine paths baked into the generated client sat inside a directory the base image ships at mode 0700. Only uid 65532 can search it. `chown -R nonroot:nonroot` does not change mode bits, and `mkdir -p` is a no-op against an existing directory, so neither of the two lines that look like they grant access actually does

prisma-client-py resolves those baked paths eagerly, at `prisma/engine/utils.py:81`, before it reads `PRISMA_QUERY_ENGINE_BINARY` at line 86, and it tests each candidate with a bare `Path.exists()` that propagates `EACCES` rather than skipping it. So a container started under any other uid dies with a `PermissionError` out of `pathlib`, with no actionable message, and the documented override cannot rescue it because computing the baked paths happens first. A chart that sets `runAsUser`, a `docker run --user`, or an OpenShift restricted-v2 namespace assigning an arbitrary uid from its range all produce that shape; on OpenShift it is the platform default rather than a misconfiguration. The backend image has the same defect, so the admin surface fails the same way

Both images now bake to `/opt/prisma`, the fixed world-readable path `Dockerfile`, `docker/Dockerfile.database` and `docker/Dockerfile.non_root` already use, and carry the same build-time assertion those images carry, so a future regression in the generate step fails the build instead of shipping an image that starts only under the uid that built it

Three details worth calling out. `chmod -R a+rX` rather than `a+r`, because `_can_execute_binary()` actually executes the engine to check it runs on this machine, so the `X` bit is load-bearing. The runtime `PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries` makes the CLI wrapper's own resolution follow the bake rather than pointing at a `/home/nonroot/.cache` that no longer exists after this change. And `PRISMA_CLI_PATH` and `PRISMA_OFFLINE_MODE` are deliberately not copied from the sibling images: both reads in `_get_prisma_command()` are gated on offline mode, and enabling offline mode would point `NPM_CONFIG_CACHE` at `/app/.cache/npm`, a directory these images never create

One thing this does not change, so nobody reads it as a regression: `PrismaManager.setup_database`'s shell-out to the prisma CLI cannot work in these images for any uid, because their runtime layer installs no nodejs. It is unreachable in a chart deployment anyway, since `helm/litellm` pins `DISABLE_SCHEMA_UPDATE=true` for app pods and the migrations Job owns `migrate deploy`

The crash is interpreter-dependent, and the reprieve does not apply to what we ship. CPython through 3.13 lets `EACCES` escape `Path.exists()`, while 3.14 delegates to `os.path.exists()` and swallows it. These images run Python 3.13, so the before-state above is what a user actually gets

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docker build/runtime packaging only; no application logic changes, and the pattern is already used in other shipped Dockerfiles.
> 
> **Overview**
> **Backend and gateway images** no longer bake Prisma query-engine paths under `/home/nonroot/.cache` (mode `0700`), which caused `PermissionError` on startup for any UID other than `65532` (e.g. OpenShift `runAsUser`).
> 
> Both `backend/Dockerfile` and `gateway/Dockerfile` now run `prisma generate` with `HOME=/opt/prisma` and related cache env vars (matching `docker/Dockerfile.database` / `docker/Dockerfile.non_root`), copy `/opt/prisma` into the runtime image, set `PRISMA_BINARY_CACHE_DIR=/opt/prisma/binaries`, apply `chmod -R a+rX` on that tree, and **fail the build** if generated `BINARY_PATHS` do not all start with `/opt/prisma/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2b1f5694787aa1cec7dc7089ea8eb6e9944e319. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->