### PR TITLE
fix(jina_ai): resolve the documented JINA_API_KEY as a fallback

### DIFF
--- a/litellm/llms/jina_ai/embedding/transformation.py
+++ b/litellm/llms/jina_ai/embedding/transformation.py
@@ -82,10 +82,7 @@ class JinaAIEmbeddingConfig(BaseEmbeddingConfig):
         """
         api_base = api_base or get_secret_str("JINA_AI_API_BASE") or "https://api.jina.ai/v1"
         dynamic_api_key: Final = api_key or (
-            get_secret_str("JINA_AI_API_KEY")
-            or get_secret_str("JINA_AI_API_KEY")
-            or get_secret_str("JINA_AI_API_KEY")
-            or get_secret_str("JINA_AI_TOKEN")
+            get_secret_str("JINA_AI_API_KEY") or get_secret_str("JINA_API_KEY") or get_secret_str("JINA_AI_TOKEN")
         )
         return LlmProviders.JINA_AI.value, api_base, dynamic_api_key
 

--- a/tests/test_litellm/llms/jina_ai/embedding/test_jina_embedding_transformation.py
+++ b/tests/test_litellm/llms/jina_ai/embedding/test_jina_embedding_transformation.py
@@ -2,11 +2,19 @@ import os
 import sys
 from unittest.mock import MagicMock
 
-sys.path.insert(
-    0, os.path.abspath("../../../../../..")
-)  # Adds the parent directory to the system path
+import pytest
+
+sys.path.insert(0, os.path.abspath("../../../../../.."))  # Adds the parent directory to the system path
 
 from litellm.llms.jina_ai.embedding.transformation import JinaAIEmbeddingConfig
+
+JINA_KEY_ENV_NAMES = ("JINA_AI_API_KEY", "JINA_API_KEY", "JINA_AI_TOKEN")
+
+
+@pytest.fixture
+def no_jina_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in JINA_KEY_ENV_NAMES:
+        monkeypatch.delenv(name, raising=False)
 
 
 class TestJinaAIEmbeddingTransform:
@@ -54,15 +62,57 @@ class TestJinaAIEmbeddingTransform:
             headers={},
         )
         expected_input = [
-            {
-                "image": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
-            }
+            {"image": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="}
         ]
         expected_result = {
             "model": self.model,
             "input": expected_input,
         }
         assert result == expected_result
+
+    @pytest.mark.parametrize("env_name", JINA_KEY_ENV_NAMES)
+    def test_every_accepted_env_name_resolves_a_key(
+        self,
+        env_name: str,
+        no_jina_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Each accepted spelling must be reachable on its own, not shadowed by a repeated read of another name."""
+        sentinel = f"resolved-via-{env_name.lower()}"
+        monkeypatch.setenv(env_name, sentinel)
+
+        _, _, dynamic_api_key = self.config._get_openai_compatible_provider_info(api_base=None, api_key=None)
+
+        assert dynamic_api_key == sentinel
+
+    def test_env_name_precedence_is_stable(
+        self,
+        no_jina_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Earlier names in the chain win, so adding later fallbacks never re-points an already working install."""
+        for name in JINA_KEY_ENV_NAMES:
+            monkeypatch.setenv(name, f"resolved-via-{name.lower()}")
+
+        for expected_name in JINA_KEY_ENV_NAMES:
+            _, _, dynamic_api_key = self.config._get_openai_compatible_provider_info(api_base=None, api_key=None)
+            assert dynamic_api_key == f"resolved-via-{expected_name.lower()}"
+            monkeypatch.delenv(expected_name)
+
+    def test_explicit_api_key_beats_every_env_name(
+        self,
+        no_jina_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """An api_key passed by the caller short-circuits the whole environment chain."""
+        for name in JINA_KEY_ENV_NAMES:
+            monkeypatch.setenv(name, f"resolved-via-{name.lower()}")
+
+        _, _, dynamic_api_key = self.config._get_openai_compatible_provider_info(
+            api_base=None, api_key="passed-in-by-caller"
+        )
+
+        assert dynamic_api_key == "passed-in-by-caller"
 
     def test_transform_embedding_request_mixed_input(self):
         """Test transformation of a mixed text and image embedding request"""
@@ -77,9 +127,7 @@ class TestJinaAIEmbeddingTransform:
         )
         expected_input = [
             {"text": "hello world"},
-            {
-                "image": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
-            },
+            {"image": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="},
         ]
         expected_result = {
             "model": self.model,


### PR DESCRIPTION
## TLDR

Problem this solves:

- Jina key chain read JINA_AI_API_KEY three times
- JINA_API_KEY, the name Jina publishes, was never read
- Setting only JINA_API_KEY resolved no key at all

How it solves it:

- Add JINA_API_KEY as a fallback, drop the repeats
- Keep JINA_AI_API_KEY first, so no existing install changes key
- Pin reachability and order with unit tests

This adds a name; it does not rename or remove one. Nothing that resolves a key today resolves a different one after this change

## Relevant issues

Companion docs change, already merged: BerriAI/litellm-docs#786 adds the `JINA_API_KEY` row to the environment variables reference table, so the name this PR starts reading is documented

## Linear ticket

Resolves LIT-5247

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`JinaAIEmbeddingConfig._get_openai_compatible_provider_info` is the single key resolver for both Jina embeddings and Jina rerank, so both endpoints are covered below. Every sibling provider fills these slots with distinct spellings; Fireworks resolves `FIREWORKS_API_KEY`, `FIREWORKS_AI_API_KEY`, `FIREWORKSAI_API_KEY`, `FIREWORKS_AI_TOKEN`. Jina's own docs publish `JINA_API_KEY`, and `JinaAIRerankConfig.validate_environment` already raises "Set via `api_key` parameter or `JINA_API_KEY` environment variable", so the name was already promised to users while nothing read it. That string is in fact the only occurrence of `JINA_API_KEY` anywhere under `litellm/` before this PR. `JINAAI_API_KEY` is not attested anywhere, so I did not invent that slot

I do not have a paid Jina credential, so the runs below use a placeholder value and let api.jina.ai itself report what it received. The distinction that matters is `AUTH_MISSING_API_KEY` (litellm sent no Authorization header, because no key resolved) versus `AUTH_INVALID_API_KEY` (litellm sent the header and Jina rejected the value). With a real key the second run returns 200

Config used for both runs, with no `api_key` set so the environment chain is exercised:

```yaml
model_list:
  - model_name: jina-embed
    litellm_params:
      model: jina_ai/jina-embeddings-v3
  - model_name: jina-rerank
    litellm_params:
      model: jina_ai/jina-reranker-v2-base-multilingual

general_settings:
  master_key: sk-1234
```

Both runs were started with only `JINA_API_KEY` in the environment:

```bash
unset JINA_AI_API_KEY JINA_AI_TOKEN
export JINA_API_KEY="jina_placeholder_not_a_real_credential"
python -m litellm.proxy.proxy_cli --config /tmp/jina_proof_config.yaml --port 4017
```

### Before, at 7c9c9ffbc7

```bash
curl -s http://127.0.0.1:4017/v1/embeddings -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"jina-embed","input":["hello from litellm"]}'
```

```json
{"error":{"message":"litellm.APIConnectionError: Jina_aiException - {\"detail\":\"Authentication required. Provide your API key via the Authorization header: 'Authorization: Bearer <api-key>'. Get your API key at https://jina.ai/api-dashboard/key-manager.\",\"request_id\":\"b3c4690c997b78405ce91e34a642909f\",\"code\":\"AUTH_MISSING_API_KEY\"}. Received Model Group=jina-embed\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"500"}}
```

```bash
curl -s http://127.0.0.1:4017/v1/rerank -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"jina-rerank","query":"what is litellm","documents":["litellm is an llm gateway","bananas are yellow"],"top_n":1}'
```

```json
{"error":{"message":"litellm.APIConnectionError: Jina AI API key is required, please set 'JINA_AI_API_KEY' in your environment\n...","code":"500"}}
```

### After, at 926e0be9bb

That is the commit the runs were captured at; it was later reworded to ee760dc0c4 with an identical tree, so the output stands unchanged. Same two commands, same environment:

```json
{"error":{"message":"litellm.APIConnectionError: Jina_aiException - {\"detail\":\"Invalid API key. Verify your API key at https://jina.ai/api-dashboard/key-manager or generate a new one.\",\"request_id\":\"8e7d4a83847cb2b85c41de53b084c8d5\",\"code\":\"AUTH_INVALID_API_KEY\"}. Received Model Group=jina-embed\nAvailable Model Group Fallbacks=None","type":null,"param":null,"code":"500"}}
```

```json
{"error":{"message":"{\"detail\":\"Invalid API key. Verify your API key at https://jina.ai/api-dashboard/key-manager or generate a new one.\",\"request_id\":\"960904af95b6fe935c41de53b084c91d\",\"code\":\"AUTH_INVALID_API_KEY\"}. Received Model Group=jina-rerank\nAvailable Model Group Fallbacks=None","type":"None","param":"None","code":"401"}}
```

## Type

🐛 Bug Fix

## Changes

`litellm/llms/jina_ai/embedding/transformation.py` now resolves `JINA_AI_API_KEY`, then `JINA_API_KEY`, then `JINA_AI_TOKEN`. `JINA_AI_API_KEY` deliberately stays in the first slot even though `JINA_API_KEY` is the vendor's own spelling; anyone who has both names exported today resolves the former, and leading with the vendor name would silently re-point those installs at a different credential. The change is therefore purely additive: configurations that resolve a key today resolve the same key, and configurations that resolved nothing now work

`tests/test_litellm/llms/jina_ai/embedding/test_jina_embedding_transformation.py` gains three tests. One parametrizes over all three accepted names and asserts each resolves on its own, which is what the duplicate reads broke. One walks the chain top down, deleting the winner each time, which pins the order rather than merely proving some key was found. One asserts an explicitly passed `api_key` short-circuits the environment entirely

Both new assertions are mutation checked. Restoring the triple read fails `test_every_accepted_env_name_resolves_a_key[JINA_API_KEY]` and `test_env_name_precedence_is_stable`; swapping the first two slots fails `test_env_name_precedence_is_stable` alone

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive credential fallback with unchanged precedence for JINA_AI_API_KEY; covered by unit tests only.
> 
> **Overview**
> Fixes Jina embedding (and shared provider) API key resolution so **`JINA_API_KEY`**—the name Jina documents—is actually read from the environment.
> 
> In `JinaAIEmbeddingConfig._get_openai_compatible_provider_info`, the env chain no longer calls `get_secret_str("JINA_AI_API_KEY")` three times. It now tries **`JINA_AI_API_KEY`**, then **`JINA_API_KEY`**, then **`JINA_AI_TOKEN`**, with caller **`api_key`** still winning. Existing installs that only set `JINA_AI_API_KEY` keep the same precedence.
> 
> Tests in `test_jina_embedding_transformation.py` cover each env var in isolation, stable fallback order when multiple are set, and explicit `api_key` overriding env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee760dc0c4bc3939196b4ae3b320f53559074d30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->