### PR TITLE
fix(ci): run every helm test suite, not just the first one per file

### DIFF
--- a/.github/workflows/helm_unit_test.yml
+++ b/.github/workflows/helm_unit_test.yml
@@ -23,19 +23,17 @@ jobs:
         with:
           version: "3.11.1"
 
+      - name: Download and verify Helm Unit Test Plugin
+        run: |
+          curl -fsSLo "$RUNNER_TEMP/helm-unittest.tgz" https://github.com/helm-unittest/helm-unittest/releases/download/v0.8.2/helm-unittest-linux-amd64-0.8.2.tgz
+          echo "56ab3091e6fa52a7c92ee951def9bed957f295d9ce98483aed404e748d7b3a94  $RUNNER_TEMP/helm-unittest.tgz" | sha256sum -c -
+
       - name: Install Helm Unit Test Plugin
         run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.8.2
-      - name: Verify Helm Unit Test Plugin integrity
-        run: |
-          EXPECTED_SHA="b94e638e72cf00034654b70944c0d20cb5d0c3cf"
           PLUGIN_DIR="$(helm env HELM_PLUGINS)/helm-unittest"
-          ACTUAL_SHA="$(git -C "$PLUGIN_DIR" rev-parse HEAD)"
-          if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
-            echo "::error::Helm unittest plugin checksum mismatch! Expected $EXPECTED_SHA but got $ACTUAL_SHA"
-            exit 1
-          fi
-          echo "Helm unittest plugin integrity verified: $ACTUAL_SHA"
+          mkdir -p "$PLUGIN_DIR"
+          tar -xzf "$RUNNER_TEMP/helm-unittest.tgz" -C "$PLUGIN_DIR"
+          helm plugin list
 
       - name: Run unit tests
         run: |

--- a/.github/workflows/helm_unit_test.yml
+++ b/.github/workflows/helm_unit_test.yml
@@ -25,10 +25,10 @@ jobs:
 
       - name: Install Helm Unit Test Plugin
         run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.4.4
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.8.2
       - name: Verify Helm Unit Test Plugin integrity
         run: |
-          EXPECTED_SHA="e251ba198448629678ff2168e1a469249d998155"
+          EXPECTED_SHA="b94e638e72cf00034654b70944c0d20cb5d0c3cf"
           PLUGIN_DIR="$(helm env HELM_PLUGINS)/helm-unittest"
           ACTUAL_SHA="$(git -C "$PLUGIN_DIR" rev-parse HEAD)"
           if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
@@ -39,5 +39,14 @@ jobs:
 
       - name: Run unit tests
         run: |
-          helm unittest -f 'tests/*.yaml' helm/litellm-helm
-          helm unittest -f 'tests/*.yaml' helm/litellm
+          for chart in helm/litellm-helm helm/litellm; do
+            declared="$(grep -h '^suite:' "$chart"/tests/*.yaml | wc -l | tr -d '[:space:]')"
+            output="$(mktemp)"
+            helm unittest -f 'tests/*.yaml' "$chart" | tee "$output"
+            executed="$(sed -n 's/^Test Suites:.*[[:space:]]\([0-9][0-9]*\) total$/\1/p' "$output")"
+            if [ "$declared" != "$executed" ]; then
+              echo "::error::$chart declares $declared test suites but helm-unittest ran $executed. Suites are being skipped silently, so their assertions never execute."
+              exit 1
+            fi
+            echo "$chart: all $declared declared test suites ran"
+          done

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,10 @@ install-test-deps: install-proxy-dev
 	$(UV_RUN) prisma generate --schema litellm/proxy/schema.prisma
 
 install-helm-unittest:
-	helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.4.4 || echo "ignore error if plugin exists"
+	@helm plugin list | grep -qE '^unittest[[:space:]]+0\.8\.2([[:space:]]|$$)' || { \
+		helm plugin uninstall unittest >/dev/null 2>&1 || true; \
+		helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.8.2; \
+	}
 
 # Install git hooks that enforce Conventional Commits and Conventional Branches.
 # Opt-in: not chained into install-dev.


### PR DESCRIPTION
## TLDR

Problem this solves:

- Helm test suites after a `---` never ran
- Their assertions passed no matter what
- CI counted them as coverage anyway

How it solves it:

- Upgrade the helm-unittest pin past v0.5.0
- Fail loudly when a declared suite is skipped

## Relevant issues

## Linear ticket

Resolves LIT-5238

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The user-visible surface for this change is the Helm unit test job, so the proof is that job's runner reproduced locally on the exact pinned helm version (3.11.1), once at the base commit and once at the fix

Setup, identical for both runs:

```bash
curl -sSLo helm-3.11.1.tar.gz https://get.helm.sh/helm-v3.11.1-darwin-arm64.tar.gz && tar xzf helm-3.11.1.tar.gz
```

### Before, at `7c9c9ffbc744d10afbfc1b75ae1563ef096a6953`

`helm/litellm-helm/tests/pdb_tests.yaml` holds three suites and three tests:

```
$ HELM_PLUGINS=/tmp/old ./helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.4.4
Installed plugin: unittest

$ HELM_PLUGINS=/tmp/old ./helm unittest -f 'tests/pdb_tests.yaml' helm/litellm-helm
 PASS  pdb enabled	helm/litellm-helm/tests/pdb_tests.yaml

Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
```

Two of the three suites are gone without a word. Planting a deliberately false assertion into the third suite (`spec.minAvailable` expected as `"4242%"`) changes nothing, which is what makes this worse than missing coverage:

```
$ HELM_PLUGINS=/tmp/old ./helm unittest -f 'tests/pdb_tests.yaml' helm/litellm-helm; echo "exit=$?"
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
exit=0
```

### After, at `f6cc5ede52`, same false assertion still planted

```
$ curl -fsSLo helm-unittest.tgz https://github.com/helm-unittest/helm-unittest/releases/download/v0.8.2/helm-unittest-macos-arm64-0.8.2.tgz
$ echo "aa1520a7b156755f62e5692cd565fb4c396c540a0b40f631af826949eadceceb  helm-unittest.tgz" | shasum -a 256 -c -
helm-unittest.tgz: OK
$ tar -xzf helm-unittest.tgz -C /tmp/new/helm-unittest

$ HELM_PLUGINS=/tmp/new ./helm unittest -f 'tests/pdb_tests.yaml' helm/litellm-helm; echo "exit=$?"
 FAIL  pdb minAvailable precedence	helm/litellm-helm/tests/pdb_tests.yaml
			Expected to equal:
			Actual:
Test Suites: 1 failed, 2 passed, 3 total
Tests:       1 failed, 2 passed, 3 total
exit=1
```

The suite that could not fail before now fails on a wrong value and passes on the right one

### The whole workflow step, guard included, planted assertion reverted

```
$ HELM_PLUGINS=/tmp/new ./helm unittest -f 'tests/*.yaml' helm/litellm-helm
Test Suites: 14 passed, 14 total
Tests:       93 passed, 93 total
helm/litellm-helm: all 14 declared test suites ran

$ HELM_PLUGINS=/tmp/new ./helm unittest -f 'tests/*.yaml' helm/litellm
Test Suites: 7 passed, 7 total
Tests:       71 passed, 71 total
helm/litellm: all 7 declared test suites ran
```

Three tests came back from the dead and every one of them passes, so nothing was silently broken underneath them. For the classic chart that is 11 suites and 90 tests before, 14 suites and 93 tests after, with no edit to any test file

### The guard fails on the old pin and passes on the new one

A guard that is green the day it lands and cannot go red is decorative, so it was run both ways, using the workflow step body verbatim:

```
$ HELM_PLUGINS=/tmp/old bash -eo pipefail ./run-unit-tests-step.sh; echo "exit=$?"
::error::helm/litellm-helm declares 14 test suites but helm-unittest ran 11. Suites are being skipped silently, so their assertions never execute.
exit=1

$ HELM_PLUGINS=/tmp/new bash -eo pipefail ./run-unit-tests-step.sh; echo "exit=$?"
helm/litellm-helm: all 14 declared test suites ran
helm/litellm: all 7 declared test suites ran
exit=0
```

### On the real runner

The job self-triggers, since the workflow has no `paths:` filter and runs on every pull request, which is how a change to the workflow file itself gets exercised by the same workflow. From this PR's own run:

```
/home/runner/work/_temp/helm-unittest.tgz: OK
unittest	0.8.2  	Unit test for helm chart in YAML with ease to keep your chart functional and robust.
Test Suites: 14 passed, 14 total
Tests:       93 passed, 93 total
helm/litellm-helm: all 14 declared test suites ran
Test Suites: 7 passed, 7 total
Tests:       71 passed, 71 total
helm/litellm: all 7 declared test suites ran
```

`make install-helm-unittest` was exercised in all three states: nothing installed, v0.8.2 already installed (no-op, no network), and a stale v0.4.4 installed, which it now replaces instead of leaving in place

## Type

🐛 Bug Fix

🚄 Infrastructure

## Changes

helm-unittest reads a single YAML document per test file up to and including v0.4.4, and gained multi-suite support in v0.5.0. CI and the Makefile both pinned v0.4.4, so a test file that separates suites with `---` ran only its first suite. Everything after the separator was parsed away, printed nothing, and reported a clean pass. Two files were affected: `helm/litellm-helm/tests/hpa_tests.yaml` lost one suite and `helm/litellm-helm/tests/pdb_tests.yaml` lost two, the disabled path and the `minAvailable` over `maxUnavailable` precedence path, which is PodDisruptionBudget rendering that had never actually been verified

The fix is the pin, since the files were never wrong. v0.8.2 is the newest release that still installs under the pinned helm 3.11.1: v1.x declares `platformHooks` in its plugin manifest, which helm 3.11.1 rejects outright with `unknown field "platformHooks"`, so taking the very latest would drag a helm bump along with it. A helm bump changes the rendering engine under every assertion in both charts and deserves to be judged on its own, so it is deliberately not in here

To stop the condition returning quietly, the workflow step now counts the `suite:` documents declared across each chart's test files and compares that against the suite total the runner prints, failing the job when they disagree. That is worth more than the version bump on its own: it catches a downgraded pin, a suite the parser chokes on, and anything else that drops a suite on the floor. Banning the `---` separator would have worked too, but it would ban a feature upstream supports, churn every multi-document file, and have to be undone the next time anyone upgrades the plugin

The plugin install was tightened while it was being touched. `helm plugin install <git url>` clones the plugin repo and runs its install hook, and that hook is what downloads the release tarball; the old integrity step then checked the cloned repo's HEAD, which is after the hook has already executed and never covers the downloaded binary at all. It now comes from a full pinned release URL and is verified against the SHA-256 the project publishes in its `helm-unittest-checksum.sha` sidecar before anything is unpacked, so nothing remote executes ahead of the check and a re-published release asset fails the job rather than installing silently

The digest is committed here as a literal rather than fetched from the sidecar at run time on purpose: a sidecar re-published alongside a re-published artifact verifies against itself and proves nothing, whereas a literal in our tree is a claim about one specific artifact that cannot be restated from the outside

The Makefile deliberately keeps `helm plugin install`. It runs on developer machines across four OS and architecture combinations, and hand-rolling multi-arch checksum selection there is more machinery than the risk justifies, so the hardening is scoped to the CI download

The Makefile target no longer swallows the install error with `|| echo "ignore error if plugin exists"`, which would have left every developer already carrying v0.4.4 on the broken version forever. It now checks the installed version and replaces a stale one

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
