### PR TITLE
test(utils): pin the register_model replay test to the recorded half

### DIFF
--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -5035,6 +5035,11 @@ def test_reapply_runtime_registrations_replays_register_model_overrides(monkeypa
         "_runtime_registered_model_cost",
         dict(litellm_utils._runtime_registered_model_cost),
     )
+    # Only the recorded half is under test here; the live-router rebuild is covered
+    # in test_router_model_cost_isolation.py. Routers built by earlier tests in this
+    # process stay in the weak set until they are collected, so leaving the callback
+    # installed would make this depend on when that happens.
+    monkeypatch.setattr(litellm_utils._LiveDeploymentReplay, "callback", None)
 
     saved_model_cost = litellm.model_cost
     try:


### PR DESCRIPTION
## TLDR

Problem this solves:

- A test added in #35491 fails intermittently depending on when a garbage collection happens

How it solves it:

- The test now runs with the live-router replay callback unset, so only the recorded registrations it is about are exercised

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This one is a test-only change, so the proof is the failure itself, made deterministic. `reapply_runtime_model_cost_registrations` asks every Router still alive in the process to re-assert its deployments before it replays the recorded `register_model` overrides. The test asserts that a value the fetched catalog supplies, and that the operator's override does not mention, survives the replay. A router serving the same backend key writes its own `model_info` over exactly that value.

Holding one such router alive turns the intermittent failure into a certain one. On `litellm_internal_staging`:

```
$ python - <<'PY'
from litellm import Router
_alive = Router(model_list=[{
    "model_name": "some-alias",
    "litellm_params": {"model": "openai/gpt-4o"},
    "model_info": {"id": "alive-router-deployment", "max_input_tokens": 111},
}])
import pytest; raise SystemExit(pytest.main(["tests/test_litellm/test_utils.py", "-k", "reapply", "-q", "-p", "no:randomly"]))
PY
>           assert litellm.model_cost["openai/gpt-4o"]["max_input_tokens"] == 4242
E           assert 111 == 4242
FAILED tests/test_litellm/test_utils.py::test_reapply_runtime_registrations_replays_register_model_overrides
1 failed, 1 passed, 257 deselected
```

With this branch checked out, the same script:

```
2 passed, 257 deselected
```

and the file on its own stays green:

```
$ python -m pytest tests/test_litellm/test_utils.py -q -p no:randomly
259 passed in 0.90s
```

Nothing in `litellm/` changes, so there is no live-proxy behaviour to show. The behaviour the flake exposed is the intended precedence: a deployment's `model_info` owns its backend key, and an operator override on top of it only rewrites the fields it names.

## Type

✅ Test

## Changes

`test_reapply_runtime_registrations_replays_register_model_overrides` covers the recorded half of the replay: a `litellm.register_model` override has to survive a price data reload rather than reverting to the catalog. It also asserts that a field the override does not carry keeps the freshly fetched catalog's value, and that second assertion is what makes it sensitive to unrelated state.

The replay runs live routers first and recorded overrides second. `_live_routers` is a `weakref.WeakSet`, so a Router built by an earlier test in the same process keeps contributing until it is collected. When one of those serves `openai/gpt-4o`, its deployment `model_info` lands on the shared backend key before the override replays, and the assertion reads the deployment's number rather than the catalog's. Whether that happens depends on collection timing, which is why it showed up in some shard orderings and not others.

Unsetting the callback for this test leaves it exercising the recorded registrations it is named after. The live-router rebuild has its own coverage in `tests/test_litellm/test_router_model_cost_isolation.py`, which builds the routers it needs rather than inheriting whatever the process is still holding.

The sibling test in the same file, `test_reapply_runtime_registrations_drops_request_scoped_registrations`, is left alone. It asserts only on pricing, and `shared_backend_model_info` strips custom pricing from the shared backend key, so a live router on either of its keys cannot move what it checks; driving the repro above with a router on both keys leaves it green

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
