### PR TITLE
fix(ci): make the env-key doc gate see bare get_secret and get_secret_str reads

### DIFF
--- a/tests/documentation_tests/test_env_keys.py
+++ b/tests/documentation_tests/test_env_keys.py
@@ -10,10 +10,13 @@ _GET_SECRET_ARGS = r"""\(\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]*|,\s*default_value=[^
 
 ENV_KEY_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"os\.getenv" + _GETENV_ARGS),
-    re.compile(r"litellm\.get_secret" + _GET_SECRET_ARGS),
-    re.compile(r"litellm\.get_secret_str" + _GET_SECRET_ARGS),
-    re.compile(r"(?<![\w.])(?:litellm\.)?get_secret_bool" + _GET_SECRET_ARGS),
+    re.compile(r"(?<![\w.])(?:litellm\.(?:utils\.)?)?get_secret(?:_str|_bool)?" + _GET_SECRET_ARGS),
 )
+
+DOCS_BASE = "./docs/my-website/docs"
+REFERENCE_TABLE_PATH = f"{DOCS_BASE}/proxy/config_settings.md"
+DOCS_SUFFIXES = (".md", ".mdx")
+DOCUMENTED_KEY_PATTERN = re.compile(r"\b[A-Z][A-Z0-9_]*\b")
 
 # Terminal/environment detection variables that should not be documented
 # These are internal variables used for terminal detection, not user-configurable settings
@@ -72,14 +75,16 @@ def extract_env_keys(source: str) -> frozenset[str]:
 
 def collect_env_keys(base_dir: str) -> frozenset[str]:
     """Return every documentable env var name read anywhere under ``base_dir``."""
-    return frozenset(key for file_path in _python_files(base_dir) for key in extract_env_keys(_read_text(file_path)))
+    return frozenset(
+        key for file_path in _files_with_suffix(base_dir, (".py",)) for key in extract_env_keys(_read_text(file_path))
+    )
 
 
-def _python_files(base_dir: str) -> Iterator[str]:
+def _files_with_suffix(base_dir: str, suffixes: tuple[str, ...]) -> Iterator[str]:
     for root, dirs, files in os.walk(base_dir):
         # Skip dependency/venv directories - prevents picking up env vars from installed packages
         dirs[:] = [d for d in dirs if d not in SKIP_DIRS]
-        yield from (os.path.join(root, name) for name in files if name.endswith(".py"))
+        yield from (os.path.join(root, name) for name in files if name.endswith(suffixes))
 
 
 def _read_text(file_path: str) -> str:
@@ -88,42 +93,37 @@ def _read_text(file_path: str) -> str:
 
 
 def extract_documented_keys(docs_content: str) -> frozenset[str]:
-    """Return the key names listed in the 'environment variables - Reference' table."""
-    section = re.search(
-        r"### environment variables - Reference(.*?)(?=\n###|\Z)",
-        docs_content,
-        re.DOTALL | re.MULTILINE,
-    )
-    if section is None:
-        return frozenset()
-    # Match | KEY_NAME | description | - capture first column only
+    """Return every env-var-shaped name mentioned anywhere in a documentation page."""
+    return frozenset(DOCUMENTED_KEY_PATTERN.findall(docs_content))
+
+
+def collect_documented_keys(docs_dir: str) -> frozenset[str]:
+    """Return every env-var-shaped name mentioned on any page under ``docs_dir``."""
     return frozenset(
-        match.group(1).strip()
-        for match in (re.match(r"^\|\s*([A-Z_][A-Z0-9_]*)\s*\|", line) for line in section.group(1).split("\n"))
-        if match is not None
+        key
+        for file_path in _files_with_suffix(docs_dir, DOCS_SUFFIXES)
+        for key in extract_documented_keys(_read_text(file_path))
     )
+
+
+def undocumented_env_keys(base_dir: str, docs_dir: str) -> frozenset[str]:
+    """Return the env vars read under ``base_dir`` that no page under ``docs_dir`` mentions."""
+    return collect_env_keys(base_dir) - collect_documented_keys(docs_dir)
 
 
 def main() -> None:
-    env_keys = collect_env_keys(repo_base)
-    print(env_keys)
+    if not os.path.isdir(DOCS_BASE):
+        raise Exception(f"No documentation found at {DOCS_BASE}; check out BerriAI/litellm-docs into docs/my-website")
 
-    docs_path = "./docs/my-website/docs/proxy/config_settings.md"  # Path to the documentation
-    try:
-        documented_keys = extract_documented_keys(_read_text(docs_path))
-    except Exception as e:
-        raise Exception(f"Error reading documentation: {e}, \n repo base - {os.listdir('./')}")
-
-    print(f"documented_keys: {documented_keys}")
-    undocumented_keys = env_keys - documented_keys
-
-    print("Keys expected in 'environment settings' (found in code):")
-    for key in sorted(env_keys):
-        print(key)
-
+    undocumented_keys = undocumented_env_keys(repo_base, DOCS_BASE)
     if undocumented_keys:
-        raise Exception(f"\nKeys not documented in 'environment settings - Reference': {sorted(undocumented_keys)}")
-    print(f"\nAll keys are documented in 'environment settings - Reference'. - {env_keys}")
+        raise Exception(
+            f"Environment variables read under {repo_base} but mentioned nowhere in the docs: "
+            f"{sorted(undocumented_keys)}"
+            f"\nDocument each one, either on the relevant provider page or as a row in the "
+            f"'environment variables - Reference' table in {REFERENCE_TABLE_PATH}"
+        )
+    print(f"Every environment variable read under {repo_base} is documented")
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm/test_env_key_doc_gate.py
+++ b/tests/test_litellm/test_env_key_doc_gate.py
@@ -1,11 +1,12 @@
 """Tests for the env-var extraction used by tests/documentation_tests/test_env_keys.py.
 
 That script is the CI gate that fails when a user-facing environment variable read
-under litellm/ has no row in the docs reference table. It only sees a key if one of its
+under litellm/ is mentioned nowhere on the docs site. It only sees a key if one of its
 patterns matches the call, so a call shape the patterns miss silently bypasses the gate.
 Each supported shape is asserted here, along with the shapes that must not be treated as
 env var reads, so narrowing a pattern makes a test fail instead of quietly reopening the
-hole.
+hole. The docs side is asserted too, since a key documented on a provider page rather
+than in the central reference table still counts as documented.
 """
 
 import importlib.util
@@ -39,6 +40,36 @@ def test_get_secret_bool_with_keyword_default_is_captured() -> None:
 
 def test_litellm_prefixed_get_secret_bool_is_captured() -> None:
     assert gate.extract_env_keys('litellm.get_secret_bool("QSTASH_FLUSH_ON_BOOT")') == {"QSTASH_FLUSH_ON_BOOT"}
+
+
+def test_bare_get_secret_is_captured() -> None:
+    assert gate.extract_env_keys('key = get_secret("QSTASH_ALPHA")') == {"QSTASH_ALPHA"}
+
+
+def test_bare_get_secret_with_default_is_captured() -> None:
+    assert gate.extract_env_keys('key = get_secret("QSTASH_ALPHA", "fallback")') == {"QSTASH_ALPHA"}
+
+
+def test_bare_get_secret_str_is_captured() -> None:
+    assert gate.extract_env_keys('key = get_secret_str("QSTASH_BRAVO")') == {"QSTASH_BRAVO"}
+
+
+def test_bare_get_secret_str_with_keyword_default_is_captured() -> None:
+    assert gate.extract_env_keys('get_secret_str("QSTASH_BRAVO", default_value=None)') == {"QSTASH_BRAVO"}
+
+
+def test_get_secret_reached_through_the_utils_module_is_captured() -> None:
+    assert gate.extract_env_keys('litellm.utils.get_secret("QSTASH_ALPHA")') == {"QSTASH_ALPHA"}
+
+
+def test_get_secret_on_an_unrelated_utils_attribute_is_not_an_env_read() -> None:
+    source = "\n".join(
+        (
+            'vault.utils.get_secret("QSTASH_ALPHA")',
+            'self.utils.get_secret_str("QSTASH_BRAVO")',
+        )
+    )
+    assert gate.extract_env_keys(source) == frozenset()
 
 
 def test_previously_supported_call_shapes_are_still_captured() -> None:
@@ -83,21 +114,77 @@ def test_excluded_keys_are_filtered_for_every_call_shape() -> None:
     assert gate.extract_env_keys(source) == frozenset()
 
 
-def test_documented_keys_are_read_from_the_reference_table_only() -> None:
+def test_a_key_mentioned_outside_the_reference_table_counts_as_documented() -> None:
     docs = "\n".join(
         (
-            "### general_settings - Reference",
-            "| BEFORE_THE_TABLE | not the env var table",
+            "# Qstash",
             "",
-            "### environment variables - Reference",
+            "Set `QSTASH_ALPHA` to your endpoint before calling the provider.",
             "",
-            "| Name | Description |",
-            "|------|-------------|",
-            "| QSTASH_ALPHA | first key",
-            "| QSTASH_BRAVO | second key",
-            "",
-            "### another section - Reference",
-            "| AFTER_THE_TABLE | also not the env var table",
+            "```bash",
+            'export QSTASH_BRAVO="sk-..."',
+            "```",
         )
     )
-    assert gate.extract_documented_keys(docs) == {"QSTASH_ALPHA", "QSTASH_BRAVO"}
+    documented = gate.extract_documented_keys(docs)
+    assert "QSTASH_ALPHA" in documented
+    assert "QSTASH_BRAVO" in documented
+
+
+def test_a_name_glued_to_surrounding_text_is_not_a_mention() -> None:
+    documented = gate.extract_documented_keys("the useQSTASH_ALPHA helper reads it")
+    assert "QSTASH_ALPHA" not in documented
+
+
+def test_a_longer_name_does_not_document_the_key_it_ends_with() -> None:
+    documented = gate.extract_documented_keys("Set AZURE_QSTASH_ALPHA in your environment")
+    assert "AZURE_QSTASH_ALPHA" in documented
+    assert "QSTASH_ALPHA" not in documented
+
+
+def test_lowercase_mentions_are_not_treated_as_env_var_names() -> None:
+    assert gate.extract_documented_keys("pass qstash_alpha as a config key") == frozenset()
+
+
+def test_documented_keys_are_collected_from_every_page_of_the_docs_site(tmp_path: Path) -> None:
+    (tmp_path / "providers").mkdir()
+    (tmp_path / "providers" / "qstash.md").write_text("Set `QSTASH_ALPHA` to your endpoint.\n", encoding="utf-8")
+    (tmp_path / "providers" / "qstash_batches.mdx").write_text("| QSTASH_BRAVO | second key |\n", encoding="utf-8")
+    documented = gate.collect_documented_keys(str(tmp_path))
+    assert "QSTASH_ALPHA" in documented
+    assert "QSTASH_BRAVO" in documented
+    assert "QSTASH_CHARLIE" not in documented
+
+
+def _write_tree(tmp_path: Path, source: str, docs_page: str) -> tuple[str, str]:
+    source_dir = tmp_path / "litellm"
+    docs_dir = tmp_path / "docs" / "providers"
+    source_dir.mkdir()
+    docs_dir.mkdir(parents=True)
+    (source_dir / "qstash.py").write_text(source, encoding="utf-8")
+    (docs_dir / "qstash.md").write_text(docs_page, encoding="utf-8")
+    return str(source_dir), str(tmp_path / "docs")
+
+
+def test_a_key_documented_only_on_a_provider_page_satisfies_the_gate(tmp_path: Path) -> None:
+    source_dir, docs_dir = _write_tree(
+        tmp_path,
+        'api_key = get_secret_str("QSTASH_ALPHA")\n',
+        "# Qstash\n\nSet `QSTASH_ALPHA` to your API key.\n",
+    )
+    assert gate.undocumented_env_keys(source_dir, docs_dir) == frozenset()
+
+
+def test_a_key_documented_on_no_page_at_all_fails_the_gate(tmp_path: Path) -> None:
+    source_dir, docs_dir = _write_tree(
+        tmp_path,
+        'api_key = get_secret_str("QSTASH_ALPHA")\n',
+        "# Qstash\n\nThis provider needs an API key.\n",
+    )
+    assert gate.undocumented_env_keys(source_dir, docs_dir) == {"QSTASH_ALPHA"}
+
+
+def test_only_documentation_pages_are_scanned_for_mentions(tmp_path: Path) -> None:
+    (tmp_path / "notes.txt").write_text("QSTASH_ALPHA\n", encoding="utf-8")
+    (tmp_path / "example.py").write_text('get_secret("QSTASH_BRAVO")\n', encoding="utf-8")
+    assert gate.collect_documented_keys(str(tmp_path)) == frozenset()


### PR DESCRIPTION
## TLDR

Problem this solves:

- Bare `get_secret`/`get_secret_str` reads bypassed the env-key doc gate
- 334 environment variables were invisible to it
- It exited 0 while 142 live keys were undocumented

How it solves it:

- One pattern, prefix optional, with a negative lookbehind
- Gate accepts a key documented on any docs page
- Provider credentials count where they are actually documented

## Relevant issues

## Linear ticket

Resolves LIT-5178

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The gate is the artefact being changed, so the proof is the gate's own output rather than a proxy request. Each run is `python tests/documentation_tests/test_env_keys.py` from the repo root with `BerriAI/litellm-docs` checked out at `docs/my-website`, which is exactly how `test-code-quality.yml` and `test-unit-documentation.yml` invoke it.

Before, litellm at 8ec562f279, the commit this branch sits on, and litellm-docs at b8a9bfb1, the state before its rows landed. The gate passes, and passing is the bug:

```
$ python tests/documentation_tests/test_env_keys.py; echo "exit=$?"
All keys are documented in 'environment settings - Reference'. - frozenset({...683 keys...})
exit=0
```

At that same commit pair the widened patterns show what it was not looking at. It sees 683 keys where 1017 are actually read, and 142 of the 334 it had been blind to are mentioned nowhere on the docs site:

```
$ python tests/documentation_tests/test_env_keys.py
Exception: Environment variables read under ./litellm but mentioned nowhere in the docs:
['A2A_API_BASE', 'AI21_API_BASE', 'AIMLAPI_KEY', ... 'ZAI_API_BASE']
```

After, same litellm commit 8ec562f279, litellm-docs at 5464d203, which carries the 142 rows from litellm-docs#785:

```
$ python tests/documentation_tests/test_env_keys.py; echo "exit=$?"
Every environment variable read under ./litellm is documented
exit=0
```

Only the docs tree differs between those two runs, so the 142 rows are demonstrably what closes the gap rather than anything else moving underneath.

One number to explain rather than leave looking inconsistent: the first measurement of this work found 143 undocumented keys and 1018 read, and both are one higher than the figures above. The extra key was `AI211_API_KEY`, a misspelling this gate surfaced, corrected in #35985 which is now in the base commit. Its correct spelling `AI21_API_KEY` was already read elsewhere and already documented, so removing it drops both counts by exactly one.

The middle run is the one that matters: the gate now names the keys it used to be blind to, and the only way to make it quiet is to document them.

## Type

🐛 Bug Fix

✅ Test

## Changes

`tests/documentation_tests/test_env_keys.py` is the gate that fails CI when a user-facing environment variable read under `litellm/` is undocumented. Two of its patterns required a `litellm.` prefix, so a module importing `get_secret` or `get_secret_str` directly and calling it bare was invisible to it. Measured on the commit this PR branches from, that hid 334 keys: 99 reached through bare `get_secret` across 195 call sites, and 319 through bare `get_secret_str` across 738. The gate saw 683 keys where 1017 are actually read.

The three `get_secret` patterns collapse into one, `(?<![\w.])(?:litellm\.(?:utils\.)?)?get_secret(?:_str|_bool)?`. The prefix is optional, `litellm.utils.` is accepted because four call sites reach `get_secret` through the module, and the negative lookbehind keeps that from matching `client.get_secret(` on an unrelated object, of which there are two in the tree.

Both of those last two parts are defensive, and neither should be simplified out later on the grounds that it changes nothing. With and without them the pattern finds the same 380 keys today, because all six attribute-style call sites pass a variable or a keyword argument and so fail the quoted-literal capture. What they change is the next call written there: `litellm.utils.get_secret("SOME_NAME")` would otherwise be an env read the gate cannot see, and `client.get_secret("SOME_NAME")` on a vault client would otherwise be reported as an undocumented env var.

Widening the patterns alone would have demanded over 300 new rows in the central reference table, nearly all of them provider credentials and base URLs. A docs change at that scale gets rubber-stamped, and rubber-stamped documentation is worse than none. Rather than narrow what the gate checks, this widens where it looks: a key counts as documented if it is mentioned on any page of the docs site, not only in `proxy/config_settings.md`. Provider credentials genuinely are documented, on their own provider pages; the gate simply was not looking there. That resolved 179 of the 321 keys the table alone was missing.

The tradeoff is real and worth stating rather than absorbing: this gives a weaker guarantee about where a reader will find the key. It could be tightened later by requiring the mention to appear in a table rather than anywhere on the page.

The scan covers `docs/` only, not `blog/` or `release_notes/`. Including them buys exactly one additional key, and a release note mentioning a variable is not documentation of it.

One case shows the edge of that guarantee. Of the 179 keys accepted on a non-table mention, exactly one, `REGION`, is accepted on a coincidence: `routing.md` contains the prose `SET 'EU' REGION NAME`, which is not documentation of an environment variable. Requiring the mention to contain an underscore would rule that out, but it would also make `HOSTNAME` and `JITTER` unsatisfiable by any text, including the reference-table rows they already have, so the rule is broken rather than merely stricter. Every other one of the 179 is a genuine mention on the relevant provider page.

Two smaller consequences. Since a table row is itself a mention, parsing the reference table separately became a code path that can never disagree with the general one, so it is gone rather than kept alongside a duplicate. And the pass/fail decision moved into `undocumented_env_keys(base_dir, docs_dir)` so it can be tested against a synthetic source tree and docs tree, leaving `main` a thin shell; a missing docs checkout now says so explicitly instead of reporting all 1017 keys as undocumented, which would read as a catastrophic regression rather than a setup error.

Two call shapes stay invisible on purpose, named here so the boundary reads as considered rather than incomplete. A keyword-only `get_secret(secret_name="X")` is not matched, because the argument regex requires a quoted first positional; there are four such sites today and all pass a name that is documented anyway. And a bare `utils.get_secret("X")` reached through `from litellm import utils` is not matched, because the pattern requires `litellm.` before `utils.`; there are zero such sites today. Neither is worth widening for, and the second would be actively harmful: matching a bare `utils.` prefix would match any of the 39 modules named `utils.py` under `litellm/`, reintroducing the false-positive class the lookbehind exists to prevent. The one `from . import utils` in the tree, in the opik integration, refers to one of those unrelated modules.

The remaining 142 keys needed documenting first, or `code-quality` and `documentation` would go red for every open PR the moment this merged. They landed as BerriAI/litellm-docs#785, merged as 0e7f3231, each row written from its call site. That docs PR was safe to merge ahead of this one because the gate as it exists on staging passes against it too, which I checked rather than assumed.

Worth recording that the widened gate justified itself before landing. It surfaced a genuine source defect nobody was looking for: `utils.py` resolved the ai21 key from `AI211_API_KEY`, with a doubled 1, where every other ai21 site reads `AI21_API_KEY`. That was corrected in #35985, merged as 8ec562f279 ahead of this, so no misspelling ended up documented. Tracing it also turned up that the containing function has no callers at all, filed separately as a follow-up rather than folded in here, since removing it is a public API removal.

## Tests

`tests/test_litellm/test_env_key_doc_gate.py` covers the call shapes the gate must see and the ones it must not, following the placement the earlier `get_secret_bool` fix used, since `tests/documentation_tests/` is invoked as a script and never collected by pytest.

Mutation-checked, 7 of 7 killed: restoring the `litellm.` prefix requirement, dropping the lookbehind, refusing the `litellm.utils.` prefix, narrowing the mention scan back to reference-table rows, scanning only the reference table page, dropping the word boundaries from the mention pattern, and skipping `.mdx` pages each turn at least one test red.

Two of those mutations are the reason the tests are shaped the way they are. Reverting the docs lookup inside `main` originally left every test green, because the tests only exercised the helpers, which is the same class of defect this PR fixes; hence `undocumented_env_keys` being a separately testable function rather than inline logic. And the word-boundary test needs a glued-prefix fixture such as `useQSTASH_ALPHA`, because a longer-token fixture cannot distinguish the two patterns: a greedy non-overlapping `findall` never yields the suffix either way.

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
