### PR TITLE
fix(ci): make every remaining CI checkout shallow

### DIFF
--- a/.github/workflows/create_daily_oss_agent_shin_branch.yml
+++ b/.github/workflows/create_daily_oss_agent_shin_branch.yml
@@ -13,35 +13,16 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
       - name: Create daily oss-agent-shin branch
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Configure Git user
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Generate branch name with MM_DD_YYYY format
           BRANCH_NAME="litellm_oss_agent_shin_$(date +'%m_%d_%Y')"
           echo "Creating branch: $BRANCH_NAME"
-
-          # Fetch all branches
-          git fetch --all
-
-          # Check if the branch already exists
-          if git show-ref --verify --quiet refs/remotes/origin/$BRANCH_NAME; then
+          if gh api "repos/${{ github.repository }}/git/ref/heads/$BRANCH_NAME" --silent 2>/dev/null; then
             echo "Branch $BRANCH_NAME already exists. Skipping creation."
-          else
-            echo "Creating new branch: $BRANCH_NAME"
-            # Create the new branch from main
-            git checkout -b $BRANCH_NAME origin/main
-            # Push the new branch
-            git push origin $BRANCH_NAME
-            echo "Successfully created and pushed branch: $BRANCH_NAME"
+            exit 0
           fi
+          MAIN_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha')
+          gh api "repos/${{ github.repository }}/git/refs" -f ref="refs/heads/$BRANCH_NAME" -f sha="$MAIN_SHA" --silent
+          echo "Successfully created branch: $BRANCH_NAME at $MAIN_SHA"

--- a/.github/workflows/create_daily_staging_branch.yml
+++ b/.github/workflows/create_daily_staging_branch.yml
@@ -13,38 +13,19 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
       - name: Create daily staging branch
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Configure Git user
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Generate branch name with MM_DD_YYYY format
           BRANCH_NAME="litellm_oss_staging_$(date +'%m_%d_%Y')"
           echo "Creating branch: $BRANCH_NAME"
-
-          # Fetch all branches
-          git fetch --all
-
-          # Check if the branch already exists
-          if git show-ref --verify --quiet refs/remotes/origin/$BRANCH_NAME; then
+          if gh api "repos/${{ github.repository }}/git/ref/heads/$BRANCH_NAME" --silent 2>/dev/null; then
             echo "Branch $BRANCH_NAME already exists. Skipping creation."
-          else
-            echo "Creating new branch: $BRANCH_NAME"
-            # Create the new branch from main
-            git checkout -b $BRANCH_NAME origin/main
-            # Push the new branch
-            git push origin $BRANCH_NAME
-            echo "Successfully created and pushed branch: $BRANCH_NAME"
+            exit 0
           fi
+          MAIN_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha')
+          gh api "repos/${{ github.repository }}/git/refs" -f ref="refs/heads/$BRANCH_NAME" -f sha="$MAIN_SHA" --silent
+          echo "Successfully created branch: $BRANCH_NAME at $MAIN_SHA"
 
   create-internal-dev-branch:
     if: github.repository == 'BerriAI/litellm'
@@ -53,35 +34,16 @@ jobs:
       contents: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
       - name: Create internal dev branch
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Configure Git user
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          # Generate branch name with MM_DD_YYYY format
           BRANCH_NAME="litellm_internal_dev_$(date +'%m_%d_%Y')"
           echo "Creating branch: $BRANCH_NAME"
-
-          # Fetch all branches
-          git fetch --all
-
-          # Check if the branch already exists
-          if git show-ref --verify --quiet refs/remotes/origin/$BRANCH_NAME; then
+          if gh api "repos/${{ github.repository }}/git/ref/heads/$BRANCH_NAME" --silent 2>/dev/null; then
             echo "Branch $BRANCH_NAME already exists. Skipping creation."
-          else
-            echo "Creating new branch: $BRANCH_NAME"
-            # Create the new branch from main
-            git checkout -b $BRANCH_NAME origin/main
-            # Push the new branch
-            git push origin $BRANCH_NAME
-            echo "Successfully created and pushed branch: $BRANCH_NAME"
+            exit 0
           fi
+          MAIN_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha')
+          gh api "repos/${{ github.repository }}/git/refs" -f ref="refs/heads/$BRANCH_NAME" -f sha="$MAIN_SHA" --silent
+          echo "Successfully created branch: $BRANCH_NAME at $MAIN_SHA"

--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -170,7 +170,7 @@ jobs:
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
 
       - name: Set up Python
@@ -185,13 +185,14 @@ jobs:
 
       - name: Run secret scan test
         run: |
-          uv run --frozen --with 'pytest==9.0.2' pytest tests/litellm/test_no_hardcoded_secrets.py -v
+          uv run --no-project --with 'pytest==9.0.2' pytest tests/litellm/test_no_hardcoded_secrets.py -v
 
       - name: Run ggshield secret scan
         env:
           GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
         run: |
           if [ -n "$GITGUARDIAN_API_KEY" ]; then
+            git fetch --no-tags --unshallow origin
             uv tool run --from 'ggshield==1.48.0' ggshield secret scan repo .
           else
             echo "GITGUARDIAN_API_KEY not set, skipping ggshield scan"

--- a/.github/workflows/test-litellm-ui-lint.yml
+++ b/.github/workflows/test-litellm-ui-lint.yml
@@ -22,12 +22,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
 
       - name: Collect changed files
         id: changed
         env:
+          GH_TOKEN: ${{ github.token }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
@@ -37,7 +38,9 @@ jobs:
           # landed since, so a PR that touches no UI file still gets linted
           # against hundreds of other people's files. Diff the PR head against its
           # own merge base instead, which is exactly what this PR changed.
-          merge_base=$(git merge-base "$BASE_SHA" "$HEAD_SHA")
+          merge_base=$(gh api "repos/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}?per_page=1" --jq '.merge_base_commit.sha')
+          test -n "$merge_base"
+          git fetch --no-tags --depth=1 origin "$merge_base" "$HEAD_SHA"
           : > "$RUNNER_TEMP/prettier_files.txt"
           : > "$RUNNER_TEMP/eslint_files.txt"
           while IFS= read -r f; do

--- a/.github/workflows/test-litellm-ui-unit.yml
+++ b/.github/workflows/test-litellm-ui-unit.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           persist-credentials: false
 
       - name: Setup Node.js
@@ -45,11 +45,25 @@ jobs:
       - name: Run UI unit tests (Vitest)
         env:
           CI: "true"
+          GH_TOKEN: ${{ github.token }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           if [ -n "$BASE_SHA" ]; then
-            echo "Pull request: running only tests related to changes since $BASE_SHA"
-            npm run test -- --run --changed "$BASE_SHA" --passWithNoTests \
+            merge_base=$(gh api "repos/${{ github.repository }}/compare/${BASE_SHA}...${HEAD_SHA}?per_page=1" --jq '.merge_base_commit.sha')
+            test -n "$merge_base"
+            git fetch --no-tags --depth=1 origin "$merge_base" "$HEAD_SHA"
+            changed_files=()
+            while IFS= read -r f; do
+              [ -f "$f" ] || continue
+              changed_files+=("$f")
+            done < <(git diff --name-only --diff-filter=ACMR --relative "$merge_base" "$HEAD_SHA" -- .)
+            if [ ${#changed_files[@]} -eq 0 ]; then
+              echo "No UI files changed in this PR; skipping unit tests."
+              exit 0
+            fi
+            echo "Pull request: running tests related to ${#changed_files[@]} changed UI files"
+            npm run test -- related "${changed_files[@]}" --run --passWithNoTests \
               --pool forks --poolOptions.forks.maxForks=14
           else
             echo "Push to $GITHUB_REF_NAME: running the full suite"

--- a/.github/workflows/test-litellm-ui-unit.yml
+++ b/.github/workflows/test-litellm-ui-unit.yml
@@ -55,9 +55,8 @@ jobs:
             git fetch --no-tags --depth=1 origin "$merge_base" "$HEAD_SHA"
             changed_files=()
             while IFS= read -r f; do
-              [ -f "$f" ] || continue
               changed_files+=("$f")
-            done < <(git diff --name-only --diff-filter=ACMR --relative "$merge_base" "$HEAD_SHA" -- .)
+            done < <(git diff --name-only --relative "$merge_base" "$HEAD_SHA" -- .)
             if [ ${#changed_files[@]} -eq 0 ]; then
               echo "No UI files changed in this PR; skipping unit tests."
               exit 0


### PR DESCRIPTION
## TLDR

Problem this solves:

- PR #35982 fixed lint only; secret-scan still fetched every branch
- secret-scan kept hitting its 5 minute timeout on unrelated PRs
- UI lint and UI unit carried the same fetch-depth 0 checkout
- daily branch workflows fail every run: git push has no credentials

How it solves it:

- every remaining fetch-depth 0 checkout is now depth 1
- the secret scan pytest runs without building the project env
- ggshield deepens history itself when a key is configured
- UI unit computes changed files itself and runs vitest related
- daily branch workflows create refs through the GitHub API, no checkout

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [ ] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before, at 3728f3ea62 (PR #35809): on [run 31043164238](https://github.com/BerriAI/litellm/actions/runs/31043164238) the secret-scan checkout spent 2m46s downloading every branch, the pytest step then had to build the full project environment (uv was still compiling Rust deps via maturin when the runner killed it), and the job was cancelled by its 5 minute timeout. Same shape on [run 31044189713](https://github.com/BerriAI/litellm/actions/runs/31044189713), where the checkout alone ran past the 5 minute mark

Before, daily branch workflows: every scheduled run of Create Daily Staging Branch and Create Daily oss-agent-shin Branch fails at `git push` with `fatal: could not read Username for 'https://github.com': No such device or address`, e.g. [run 31006836580](https://github.com/BerriAI/litellm/actions/runs/31006836580) and [run 30964036117](https://github.com/BerriAI/litellm/actions/runs/30964036117), because persist-credentials: false strips the checkout credentials and plain git push has none

After, at 54b9373874: this PR's own CI runs use the updated workflow definitions (timings below will be updated once the runs at this head finish)

The ref-create calls the daily workflows now use, exercised against the live repo (create off main, verify, delete):

```
$ BRANCH_NAME="litellm_scratch_ref_api_qa_08_05_2026"
$ MAIN_SHA=$(gh api "repos/BerriAI/litellm/git/ref/heads/main" --jq '.object.sha')
$ gh api "repos/BerriAI/litellm/git/refs" -f ref="refs/heads/$BRANCH_NAME" -f sha="$MAIN_SHA" --silent && echo "created at $MAIN_SHA"
created at ead62528e607b9d8e61273def638799c9c3a69ba
$ gh api "repos/BerriAI/litellm/git/ref/heads/$BRANCH_NAME" --jq '.ref'
refs/heads/litellm_scratch_ref_api_qa_08_05_2026
$ gh api -X DELETE "repos/BerriAI/litellm/git/refs/heads/$BRANCH_NAME" && echo deleted
deleted
```

Why UI unit could not just fetch deeper and keep --changed: vitest resolves `--changed <sha>` as a three-dot `git diff <sha>...HEAD`, which needs merge-base connectivity and comes back empty on a shallow clone, so with --passWithNoTests the job would go green having selected zero tests. `vitest related` feeds the same filter (vitest resolves --changed into config.related internally, forceRerunTriggers included), with the file list computed from the API merge base instead. Deleted paths stay in that list for parity with --changed, and vitest handles them without complaint: passing a nonexistent path alongside detailNavigation.ts below still selects the same 4 test files, and a nonexistent path alone exits 0 under --passWithNoTests. Live check that related selection still catches the mapped tests:

```
$ npm run test -- related "src/app/(dashboard)/models-and-endpoints/detailNavigation.ts" --run --passWithNoTests --pool forks --poolOptions.forks.maxForks=4

 Test Files  4 passed (4)
      Tests  24 passed (24)
   Duration  6.71s
```

The reworked daily workflows only run from the default branch, so they can be exercised via workflow_dispatch right after merge; the API round trip above is the same call sequence they make

## Type

🐛 Bug Fix
🚄 Infrastructure

## Changes

test-linting.yml: secret-scan checks out at depth 1, the hardcoded-secret pytest runs with `uv run --no-project` (it only needs pytest and the working tree, and this cuts a ~2 minute full env build, Rust compiles included, down to seconds), and the ggshield step runs `git fetch --unshallow` first so a keyed run still scans full history

test-litellm-ui-lint.yml: depth 1 checkout; the merge base comes from the compare API and the two commits it diffs are fetched at depth 1, replacing the local `git merge-base` that needed full history

test-litellm-ui-unit.yml: depth 1 checkout; the job now computes the PR's changed UI files (deletions included, matching what --changed fed the filter) and passes them to `vitest related`, skipping the suite outright when a PR touches no UI file

create_daily_staging_branch.yml, create_daily_oss_agent_shin_branch.yml: the checkout, `git fetch --all`, and credential-less `git push` are gone; each job asks the API for the main tip and creates the ref through `gh api`, which also un-breaks workflows that have failed on every scheduled run
