### PR TITLE
fix(ui): opening a project now pushes ?project= so back and deep links work

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
+import type { UrlUpdateEvent } from "nuqs/adapters/testing";
 import { renderWithProviders, screen, waitFor, within } from "../../../../../tests/test-utils";
 import { ProjectsPage } from "./ProjectsPage";
 import { ProjectResponse } from "@/app/(dashboard)/hooks/projects/useProjects";
@@ -20,7 +21,12 @@ vi.mock("./ProjectModals/CreateProjectModal", () => ({
 }));
 
 vi.mock("./ProjectDetailsPage", () => ({
-  ProjectDetail: ({ projectId }: { projectId: string }) => <div data-testid="project-detail">{projectId}</div>,
+  ProjectDetail: ({ projectId, onBack }: { projectId: string; onBack: () => void }) => (
+    <div data-testid="project-detail">
+      {projectId}
+      <button onClick={onBack}>Back to projects</button>
+    </div>
+  ),
 }));
 
 const mockProjects: ProjectResponse[] = [
@@ -198,6 +204,47 @@ describe("ProjectsPage", () => {
       expect(screen.getByText("Project 01")).toBeInTheDocument();
       expect(screen.getByTestId("pagination-page")).toHaveTextContent("Page 1 of 1");
     });
+  });
+
+  it("should open the detail view directly from a ?project= deep link", () => {
+    mockUseProjects.mockReturnValue({ data: mockProjects, isLoading: false });
+    renderWithProviders(<ProjectsPage />, { searchParams: "?project=proj-2" });
+
+    expect(screen.getByTestId("project-detail")).toHaveTextContent("proj-2");
+    expect(screen.queryByRole("heading", { name: /projects/i })).not.toBeInTheDocument();
+  });
+
+  it("should push ?project= as a new history entry when a project is opened", async () => {
+    const user = userEvent.setup();
+    const onUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>();
+    mockUseProjects.mockReturnValue({ data: mockProjects, isLoading: false });
+    renderWithProviders(<ProjectsPage />, { onUrlUpdate });
+
+    await user.click(screen.getByText("proj-1"));
+
+    await waitFor(() => {
+      expect(onUrlUpdate).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          queryString: "?project=proj-1",
+          options: expect.objectContaining({ history: "push" }),
+        }),
+      );
+    });
+  });
+
+  it("should clear ?project= and return to the list when the detail view is closed", async () => {
+    const user = userEvent.setup();
+    const onUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>();
+    mockUseProjects.mockReturnValue({ data: mockProjects, isLoading: false });
+    renderWithProviders(<ProjectsPage />, { searchParams: "?project=proj-1", onUrlUpdate });
+
+    await user.click(screen.getByRole("button", { name: /back to projects/i }));
+
+    await waitFor(() => {
+      expect(onUrlUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ queryString: "" }));
+    });
+    expect(screen.queryByTestId("project-detail")).not.toBeInTheDocument();
+    expect(screen.getByText("Alpha Project")).toBeInTheDocument();
   });
 
   it("should resolve team alias from the teams list in the Team column", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.test.tsx
@@ -243,6 +243,7 @@ describe("ProjectsPage", () => {
     await waitFor(() => {
       expect(onUrlUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ queryString: "" }));
     });
+    expect(onUrlUpdate.mock.calls.at(-1)?.[0].options.history).toBe("replace");
     expect(screen.queryByTestId("project-detail")).not.toBeInTheDocument();
     expect(screen.getByText("Alpha Project")).toBeInTheDocument();
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.tsx
@@ -3,6 +3,7 @@ import { useTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
 import { PlusOutlined } from "@ant-design/icons";
 import { Button, Flex, Input, Layout, Space, theme, Typography } from "antd";
 import { SearchIcon } from "lucide-react";
+import { parseAsString, useQueryState } from "nuqs";
 import { useMemo, useState } from "react";
 import { CreateProjectModal } from "./ProjectModals/CreateProjectModal";
 import { ProjectDetail } from "./ProjectDetailsPage";
@@ -16,7 +17,10 @@ export function ProjectsPage() {
   const { data: projects, isLoading } = useProjects();
   const { data: teams, isLoading: isTeamsLoading } = useTeams();
 
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useQueryState(
+    "project",
+    parseAsString.withOptions({ history: "push" }),
+  );
   const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
   const [searchText, setSearchText] = useState("");
 
@@ -44,7 +48,7 @@ export function ProjectsPage() {
   }, [projects, searchText, teamAliasMap]);
 
   if (selectedProjectId) {
-    return <ProjectDetail projectId={selectedProjectId} onBack={() => setSelectedProjectId(null)} />;
+    return <ProjectDetail projectId={selectedProjectId} onBack={() => void setSelectedProjectId(null)} />;
   }
 
   return (
@@ -76,7 +80,7 @@ export function ProjectsPage() {
         projects={filteredProjects}
         isLoading={isLoading}
         isFiltered={searchText.trim().length > 0}
-        onProjectClick={setSelectedProjectId}
+        onProjectClick={(id) => void setSelectedProjectId(id)}
         teamAliasMap={teamAliasMap}
         isTeamsLoading={isTeamsLoading}
       />

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.tsx
@@ -48,7 +48,12 @@ export function ProjectsPage() {
   }, [projects, searchText, teamAliasMap]);
 
   if (selectedProjectId) {
-    return <ProjectDetail projectId={selectedProjectId} onBack={() => void setSelectedProjectId(null)} />;
+    return (
+      <ProjectDetail
+        projectId={selectedProjectId}
+        onBack={() => void setSelectedProjectId(null, { history: "replace" })}
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
## TLDR

Problem this solves:

- Opening a project never changed the URL
- Browser Back skipped the Projects list entirely
- Project detail was not linkable, bookmarkable or reload-safe

How it solves it:

- Selection now lives in the `?project=` query param
- nuqs with `history: "push"` adds a real history entry
- Matches how Teams, Organizations and Virtual Keys already behave
- Builds on the nuqs refactor from #35871, now merged

## Relevant issues

## Linear ticket

Resolves LIT-5217

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured in a real browser against a live proxy and a dev Admin UI, signed in as admin, walking the exact path from the ticket: open Virtual Keys to seed a previous history entry, open Projects, click a project, then press browser Back. The dark bar at the top of each shot is an annotation the capture script injects; it prints `window.location.href` read from the live page, because a headless capture has no address bar of its own

Before, captured at `c3a8962c00`

![before-01](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5217_screenshots/before-01-project-detail-url-unchanged.png)

The project detail is on screen while the URL is still `http://localhost:3501/projects/`, so the project id appears nowhere and the view cannot be linked or reloaded

![before-02](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5217_screenshots/before-02-back-lands-on-virtual-keys.png)

Pressing Back from that detail lands on `http://localhost:3501/api-keys/`, the Virtual Keys page, skipping the Projects list

After, captured at `dc178acf5b`

![after-01](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5217_screenshots/after-01-project-detail-url-has-param.png)

The same click now yields `http://localhost:3501/projects/?project=0c78f50e-b2a8-40ad-9b57-742ee38475b7`, so the open project is in the URL

![after-02](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5217_screenshots/after-02-back-returns-to-projects-list.png)

Back now returns to `http://localhost:3501/projects/` showing the Projects list, which is the entry the push created

![after-03](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5217_screenshots/after-03-cold-deep-link-opens-detail.png)

Pasting `http://localhost:3501/projects/?project=0c78f50e-b2a8-40ad-9b57-742ee38475b7` into a fresh tab opens that project's detail directly, so the view is linkable and reload-safe

## Type

🐛 Bug Fix

## Changes

`ProjectsPage.tsx` held the open project in `useState`, so choosing one swapped the list for the detail view without any navigation. That single piece of state now comes from `useQueryState("project", parseAsString.withOptions({ history: "push" }))`, which is the same nuqs call Teams, Organizations and Virtual Keys already use; the two call sites pass the id in and `null` back out, and per review discussion the close call passes `history: "replace"` (matching PR #36013) so browser Back after an in-page close does not reopen the dismissed detail. Nothing else about the page changes, and the detail view keeps rendering exactly as before

Three tests were added to the existing `ProjectsPage.test.tsx`, covering a `?project=` deep link rendering the detail directly, a click writing `?project=` with the `push` history option, and closing the detail clearing the param and restoring the list. All three fail against the previous `useState` implementation and pass with this change; dropping only `history: "push"` fails the second one on its own

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

