### PR TITLE
fix(ui): link project page keys to their virtual key detail

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectKeysTable.test.tsx
@@ -8,6 +8,12 @@ vi.mock("@/components/common_components/DefaultProxyAdminTag", () => ({
   default: ({ userId }: { userId: string }) => <span data-testid="owner-tag">{userId}</span>,
 }));
 
+const push = vi.fn();
+vi.mock("next/navigation", async () => ({
+  ...(await vi.importActual("next/navigation")),
+  useRouter: () => ({ push }),
+}));
+
 const defaultProps = {
   totalCount: 0,
   isLoading: false,
@@ -98,6 +104,40 @@ describe("ProjectKeysTable", () => {
       <ProjectKeysTable {...defaultProps} keys={[makeKey({ key_alias: null as any, user_id: "owner-1" })]} />,
     );
     expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("should link the key name to that key's detail on the Virtual Keys page", () => {
+    renderWithProviders(
+      <ProjectKeysTable {...defaultProps} keys={[makeKey({ token: "tok-abc123", key_alias: "My API Key" })]} />,
+    );
+    expect(screen.getByRole("link", { name: "My API Key" })).toHaveAttribute("href", "/ui/api-keys?key=tok-abc123");
+  });
+
+  it("should navigate to the key detail without a full page load when the key name is clicked", async () => {
+    const user = userEvent.setup();
+    push.mockClear();
+    renderWithProviders(
+      <ProjectKeysTable {...defaultProps} keys={[makeKey({ token: "tok-abc123", key_alias: "My API Key" })]} />,
+    );
+    await user.click(screen.getByRole("link", { name: "My API Key" }));
+    expect(push).toHaveBeenCalledWith("/ui/api-keys?key=tok-abc123");
+  });
+
+  it("should still link a key that has no alias", () => {
+    renderWithProviders(
+      <ProjectKeysTable
+        {...defaultProps}
+        keys={[makeKey({ token: "tok-no-alias", key_alias: "", user_id: "owner-1" })]}
+      />,
+    );
+    expect(screen.getByRole("link", { name: "—" })).toHaveAttribute("href", "/ui/api-keys?key=tok-no-alias");
+  });
+
+  it("should give each row a link to its own key", () => {
+    const keys = [makeKey({ token: "tok-1", key_alias: "Key One" }), makeKey({ token: "tok-2", key_alias: "Key Two" })];
+    renderWithProviders(<ProjectKeysTable {...defaultProps} keys={keys} />);
+    expect(screen.getByRole("link", { name: "Key One" })).toHaveAttribute("href", "/ui/api-keys?key=tok-1");
+    expect(screen.getByRole("link", { name: "Key Two" })).toHaveAttribute("href", "/ui/api-keys?key=tok-2");
   });
 
   it("should display the owner using user.user_email when available", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectKeysTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectKeysTableColumns.tsx
@@ -4,8 +4,7 @@ import { ColumnDef } from "@tanstack/react-table";
 
 import DefaultProxyAdminTag from "@/components/common_components/DefaultProxyAdminTag";
 import { KeyResponse } from "@/components/key_team_helpers/key_list";
-import { BadgeLink } from "@/components/shared/BadgeLink";
-import { CellTooltip, DateCell } from "@/components/shared/table_cells";
+import { CellTooltip, DateCell, IdentityCell } from "@/components/shared/table_cells";
 import { keyDetailHref } from "@/utils/entityLinks";
 
 function OwnerCell({ record }: { record: KeyResponse }) {
@@ -31,15 +30,11 @@ export const getProjectKeysTableColumns = (): ColumnDef<KeyResponse>[] => [
     header: "Key Name",
     enableSorting: false,
     cell: ({ row }) => (
-      <BadgeLink
-        variant="link"
+      <IdentityCell
+        title={<span title={row.original.key_alias ?? undefined}>{row.original.key_alias || "—"}</span>}
         href={row.original.token ? keyDetailHref(row.original.token) : undefined}
-        className="max-w-60 px-0 py-0 font-medium"
-      >
-        <span className="min-w-0 truncate" title={row.original.key_alias ?? undefined}>
-          {row.original.key_alias || "—"}
-        </span>
-      </BadgeLink>
+        className="max-w-60"
+      />
     ),
   },
   {

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectKeysTableColumns.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectKeysTableColumns.tsx
@@ -4,7 +4,9 @@ import { ColumnDef } from "@tanstack/react-table";
 
 import DefaultProxyAdminTag from "@/components/common_components/DefaultProxyAdminTag";
 import { KeyResponse } from "@/components/key_team_helpers/key_list";
+import { BadgeLink } from "@/components/shared/BadgeLink";
 import { CellTooltip, DateCell } from "@/components/shared/table_cells";
+import { keyDetailHref } from "@/utils/entityLinks";
 
 function OwnerCell({ record }: { record: KeyResponse }) {
   const email = record.user?.user_email ?? record.user_id ?? null;
@@ -29,9 +31,15 @@ export const getProjectKeysTableColumns = (): ColumnDef<KeyResponse>[] => [
     header: "Key Name",
     enableSorting: false,
     cell: ({ row }) => (
-      <span className="block max-w-60 truncate text-sm font-medium" title={row.original.key_alias ?? undefined}>
-        {row.original.key_alias || "—"}
-      </span>
+      <BadgeLink
+        variant="link"
+        href={row.original.token ? keyDetailHref(row.original.token) : undefined}
+        className="max-w-60 px-0 py-0 font-medium"
+      >
+        <span className="min-w-0 truncate" title={row.original.key_alias ?? undefined}>
+          {row.original.key_alias || "—"}
+        </span>
+      </BadgeLink>
     ),
   },
   {

--- a/ui/litellm-dashboard/src/components/shared/table_cells/identity_cell.test.tsx
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/identity_cell.test.tsx
@@ -4,6 +4,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import { IdentityCell } from "./identity_cell";
 
+const routerPush = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: routerPush }) }));
+
 describe("IdentityCell", () => {
   it("renders the title", () => {
     render(<IdentityCell title="prod-gateway" />);
@@ -37,5 +40,26 @@ describe("IdentityCell", () => {
     expect(button.className).toContain("cursor-pointer");
     await user.click(button);
     expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders an anchor with the chevron affordance and routes through the client router when href is set", async () => {
+    const user = userEvent.setup();
+    render(<IdentityCell title="routing-qa-key-alpha" href="/api-keys?key=abc123" />);
+    const link = screen.getByRole("link", { name: /routing-qa-key-alpha/ });
+    expect(link).toHaveAttribute("href", "/api-keys?key=abc123");
+    expect(link.querySelector(".lucide-chevron-right")).not.toBeNull();
+    expect(link.className).toContain("hover:bg-muted");
+    await user.click(link);
+    expect(routerPush).toHaveBeenCalledWith("/api-keys?key=abc123");
+  });
+
+  it("leaves modifier clicks to the browser so open-in-new-tab keeps working", async () => {
+    routerPush.mockClear();
+    const user = userEvent.setup();
+    render(<IdentityCell title="routing-qa-key-alpha" href="/api-keys?key=abc123" />);
+    await user.keyboard("{Meta>}");
+    await user.click(screen.getByRole("link", { name: /routing-qa-key-alpha/ }));
+    await user.keyboard("{/Meta}");
+    expect(routerPush).not.toHaveBeenCalled();
   });
 });

--- a/ui/litellm-dashboard/src/components/shared/table_cells/identity_cell.tsx
+++ b/ui/litellm-dashboard/src/components/shared/table_cells/identity_cell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { ChevronRight } from "lucide-react";
+import { useRouter } from "next/navigation";
 import * as React from "react";
 
 import { cn } from "@/lib/cva.config";
@@ -10,11 +11,19 @@ interface IdentityCellProps {
   subtitle?: React.ReactNode;
   badge?: React.ReactNode;
   onClick?: () => void;
+  href?: string;
   className?: string;
   titleClassName?: string;
 }
 
-export function IdentityCell({ title, subtitle, badge, onClick, className, titleClassName }: IdentityCellProps) {
+const INTERACTIVE_CELL_CLASSES =
+  "group -mx-2 flex w-[calc(100%+1rem)] cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-left transition-colors hover:bg-muted";
+
+const HoverChevron = () => (
+  <ChevronRight className="ml-auto size-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+);
+
+export function IdentityCell({ title, subtitle, badge, onClick, href, className, titleClassName }: IdentityCellProps) {
   const hasSubtitleRow = (subtitle != null && subtitle !== "") || badge != null;
 
   const body = (
@@ -31,21 +40,37 @@ export function IdentityCell({ title, subtitle, badge, onClick, className, title
     </div>
   );
 
+  if (href != null) {
+    return <IdentityCellLink href={href} className={className} body={body} />;
+  }
+
   if (onClick != null) {
     return (
-      <button
-        type="button"
-        onClick={onClick}
-        className={cn(
-          "group -mx-2 flex w-[calc(100%+1rem)] cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-left transition-colors hover:bg-muted",
-          className,
-        )}
-      >
+      <button type="button" onClick={onClick} className={cn(INTERACTIVE_CELL_CLASSES, className)}>
         {body}
-        <ChevronRight className="ml-auto size-4 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+        <HoverChevron />
       </button>
     );
   }
 
   return <div className={cn("min-w-0", className)}>{body}</div>;
+}
+
+function IdentityCellLink({ href, className, body }: { href: string; className?: string; body: React.ReactNode }) {
+  const router = useRouter();
+
+  const handleClick = (e: React.MouseEvent) => {
+    const hasModifierKey = e.metaKey || e.ctrlKey || e.shiftKey;
+    const isNativeNewTabClick = hasModifierKey || e.button === 1;
+    if (isNativeNewTabClick) return;
+    e.preventDefault();
+    router.push(href);
+  };
+
+  return (
+    <a href={href} onClick={handleClick} className={cn(INTERACTIVE_CELL_CLASSES, className)}>
+      {body}
+      <HoverChevron />
+    </a>
+  );
 }

--- a/ui/litellm-dashboard/src/utils/entityLinks.ts
+++ b/ui/litellm-dashboard/src/utils/entityLinks.ts
@@ -3,3 +3,7 @@ import { migratedHref } from "@/utils/migratedPages";
 export function teamDetailHref(teamId: string): string {
   return `${migratedHref("teams")}?team=${encodeURIComponent(teamId)}`;
 }
+
+export function keyDetailHref(keyToken: string): string {
+  return `${migratedHref("api-keys")}?key=${encodeURIComponent(keyToken)}`;
+}


### PR DESCRIPTION
## TLDR

Problem this solves:

- Project page key names are inert text
- Inspecting a key means searching Virtual Keys by hand

How it solves it:

- Key name cell now renders a real link
- Link points at /api-keys?key=<key hash>
- Shared keyDetailHref helper keeps base-path handling correct

## Relevant issues

## Linear ticket

Resolves LIT-5218

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured against a live proxy and an Admin UI dev server, on a project seeded with two keys. The captures are headless and therefore have no browser address bar, so the dark bar across the top of each image is a script annotation printing `page.url()` into the page just before the shot; it is not part of the UI

Before, at commit `1f8ceddffa`, the commit this work branched from. The Keys card renders routing-qa-key-alpha and routing-qa-key-beta as plain text; querying the DOM for that cell returns a bare `<span>`, not inside any anchor, with `cursor: auto`, and clicking it leaves the banner reading `http://localhost:3503/projects/`

![before](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5218_screenshots/v2-before-project-keys.png)

After, with the fix applied, captured at commit `11d8936988`. The banner still reads `http://localhost:3503/projects/`, and the same cell now sits inside an `<a>` with `cursor: pointer`; routing-qa-key-alpha carries `href="/api-keys?key=b559db7c0a8e1000c232ecb1e01c6a78b9640537133e23baa41d8c37c62e8a77"`, routing-qa-key-beta carries its own hash, and the hovered alpha row shows the same hover chevron affordance the Virtual Keys table uses, per review feedback

![after](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5218_screenshots/v3-after-keys-chevron.png)

Clicking routing-qa-key-alpha lands on that key's Virtual Keys detail, with the banner reading `http://localhost:3503/api-keys/?key=b559db7c0a8e1000c232ecb1e01c6a78b9640537133e23baa41d8c37c62e8a77` and the page showing the routing-qa-key-alpha header with a matching Key ID

![after key detail](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5218_screenshots/v3-after-key-detail.png)

## Type

🐛 Bug Fix

## Changes

`keyDetailHref` joins `teamDetailHref` in `src/utils/entityLinks.ts`, so the Virtual Keys deep link is built through `migratedHref` and stays correct under `/ui` and a custom `server_root_path`

The Key Name column in `ProjectKeysTableColumns.tsx` swaps its plain span for the shared `IdentityCell`, which per review feedback keeps the established keys-table affordance of a hover chevron rather than an underlined link. `IdentityCell` gains an `href` variant for this: it renders a real anchor with the same hover treatment as its button form and pushes client-side while leaving cmd-click and middle-click to the browser, with unit tests covering both. The alias text, its truncation and its title tooltip are unchanged, and a row whose alias is empty still links through its placeholder

Four tests in `ProjectKeysTable.test.tsx` cover the href for a normal row, the client-side navigation on click, a row with no alias, and two rows each linking to their own key

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

