### PR TITLE
fix(ui): sync projects list page index to ?page= so back and reload keep the page

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsTable.test.tsx
@@ -133,7 +133,7 @@ describe("ProjectsTable pagination URL state", () => {
     expect(screen.getByTestId("pagination-page")).toHaveTextContent("Page 1 of 2");
   });
 
-  it("should return to the first page when the page size changes", async () => {
+  it("should return to the first page and write ?page_size= in one history entry when the page size changes", async () => {
     const user = userEvent.setup();
     const onUrlUpdate = vi.fn();
     renderTable({ searchParams: "?page=2", onUrlUpdate });
@@ -143,7 +143,25 @@ describe("ProjectsTable pagination URL state", () => {
 
     await waitFor(() => expect(screen.getByTestId("pagination-range")).toHaveTextContent("Showing 1-14 of 14"));
     expect(firstDataRow().getByText("Project 01")).toBeInTheDocument();
+    expect(onUrlUpdate).toHaveBeenCalledTimes(1);
     const lastUpdate = onUrlUpdate.mock.calls.at(-1)?.[0];
     expect(lastUpdate.searchParams.get("page")).toBeNull();
+    expect(lastUpdate.searchParams.get("page_size")).toBe("25");
+  });
+
+  it("should apply both params from a ?page=2&page_size=25 deep link so the restored view matches", () => {
+    const manyProjects = Array.from({ length: 44 }, (_, index) => makeProject(index + 1));
+    renderTable({ projects: manyProjects, searchParams: "?page=2&page_size=25" });
+
+    expect(firstDataRow().getByText("Project 26")).toBeInTheDocument();
+    expect(screen.getByTestId("pagination-page")).toHaveTextContent("Page 2 of 2");
+    expect(screen.getByTestId("pagination-range")).toHaveTextContent("Showing 26-44 of 44");
+  });
+
+  it("should fall back to the default page size for a ?page_size= value outside the offered options", () => {
+    renderTable({ searchParams: "?page_size=7" });
+
+    expect(dataRowCount()).toBe(10);
+    expect(screen.getByTestId("pagination-page")).toHaveTextContent("Page 1 of 2");
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsTable.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsTable.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { OnUrlUpdateFunction } from "nuqs/adapters/testing";
+import { renderWithProviders, screen, waitFor, within } from "../../../../../tests/test-utils";
+import { ProjectsTable } from "./ProjectsTable";
+import { ProjectResponse } from "@/app/(dashboard)/hooks/projects/useProjects";
+
+const makeProject = (index: number): ProjectResponse => ({
+  project_id: `proj-${String(index).padStart(2, "0")}`,
+  project_alias: `Project ${String(index).padStart(2, "0")}`,
+  description: null,
+  team_id: "team-1",
+  budget_id: null,
+  metadata: null,
+  models: [],
+  spend: 0,
+  model_spend: null,
+  model_rpm_limit: null,
+  model_tpm_limit: null,
+  blocked: false,
+  object_permission_id: null,
+  created_at: "2024-01-01T00:00:00Z",
+  created_by: "user-1",
+  updated_at: "2024-01-01T00:00:00Z",
+  updated_by: "user-1",
+  litellm_budget_table: null,
+});
+
+const allProjects = Array.from({ length: 14 }, (_, index) => makeProject(index + 1));
+
+interface RenderOptions {
+  projects?: ProjectResponse[];
+  isLoading?: boolean;
+  isFiltered?: boolean;
+  searchParams?: string;
+  onUrlUpdate?: OnUrlUpdateFunction;
+}
+
+const renderTable = ({
+  projects = allProjects,
+  isLoading = false,
+  isFiltered = false,
+  ...providers
+}: RenderOptions) => {
+  const table = (projectList: ProjectResponse[], loading: boolean, filtered: boolean) => (
+    <ProjectsTable
+      projects={projectList}
+      isLoading={loading}
+      isFiltered={filtered}
+      onProjectClick={vi.fn()}
+      teamAliasMap={new Map()}
+      isTeamsLoading={false}
+    />
+  );
+  const view = renderWithProviders(table(projects, isLoading, isFiltered), providers);
+  return {
+    ...view,
+    rerenderWith: (next: ProjectResponse[], filtered = false) => view.rerender(table(next, false, filtered)),
+  };
+};
+
+const firstDataRow = () => within(screen.getAllByRole("row")[1]);
+
+const dataRowCount = () => screen.getAllByRole("row").length - 1;
+
+describe("ProjectsTable pagination URL state", () => {
+  it("should render the second page of projects for a ?page=2 deep link", () => {
+    renderTable({ searchParams: "?page=2" });
+
+    expect(firstDataRow().getByText("Project 11")).toBeInTheDocument();
+    expect(screen.queryByText("Project 01")).not.toBeInTheDocument();
+    expect(screen.getByTestId("pagination-page")).toHaveTextContent("Page 2 of 2");
+    expect(screen.getByTestId("pagination-range")).toHaveTextContent("Showing 11-14 of 14");
+  });
+
+  it("should push ?page=2 onto history when the next page control is clicked", async () => {
+    const user = userEvent.setup();
+    const onUrlUpdate = vi.fn();
+    renderTable({ onUrlUpdate });
+
+    await user.click(screen.getByTestId("pagination-next"));
+
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled());
+    const [update] = onUrlUpdate.mock.calls[0];
+    expect(update.searchParams.get("page")).toBe("2");
+    expect(update.options.history).toBe("push");
+    expect(firstDataRow().getByText("Project 11")).toBeInTheDocument();
+  });
+
+  it("should clear the page param when returning to the first page", async () => {
+    const user = userEvent.setup();
+    const onUrlUpdate = vi.fn();
+    renderTable({ searchParams: "?page=2", onUrlUpdate });
+
+    await user.click(screen.getByTestId("pagination-prev"));
+
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled());
+    const [update] = onUrlUpdate.mock.calls[0];
+    expect(update.searchParams.get("page")).toBeNull();
+    expect(firstDataRow().getByText("Project 01")).toBeInTheDocument();
+  });
+
+  it("should keep the deep-linked page when the project list arrives after the first render", async () => {
+    const onUrlUpdate = vi.fn();
+    const stillLoading: RenderOptions = { projects: [], isLoading: true, searchParams: "?page=2", onUrlUpdate };
+    const { rerenderWith } = renderTable(stillLoading);
+    await waitFor(() => expect(screen.getAllByTestId("skeleton-row").length).toBeGreaterThan(0));
+
+    rerenderWith(allProjects);
+
+    await waitFor(() => expect(screen.getByTestId("pagination-page")).toHaveTextContent("Page 2 of 2"));
+    expect(firstDataRow().getByText("Project 11")).toBeInTheDocument();
+    expect(onUrlUpdate).not.toHaveBeenCalled();
+  });
+
+  it("should fall back to the first page, not the last remaining page, when a filter leaves fewer pages", async () => {
+    const manyProjects = Array.from({ length: 44 }, (_, index) => makeProject(index + 1));
+    const { rerenderWith } = renderTable({ projects: manyProjects, searchParams: "?page=5" });
+    expect(firstDataRow().getByText("Project 41")).toBeInTheDocument();
+
+    rerenderWith(allProjects.slice(0, 12), true);
+
+    await waitFor(() => expect(screen.getByTestId("pagination-page")).toHaveTextContent("Page 1 of 2"));
+    expect(firstDataRow().getByText("Project 01")).toBeInTheDocument();
+    expect(dataRowCount()).toBe(10);
+  });
+
+  it("should show the first page instead of an empty table for an out-of-range ?page=99", () => {
+    renderTable({ searchParams: "?page=99" });
+
+    expect(firstDataRow().getByText("Project 01")).toBeInTheDocument();
+    expect(dataRowCount()).toBe(10);
+    expect(screen.getByTestId("pagination-page")).toHaveTextContent("Page 1 of 2");
+  });
+
+  it("should return to the first page when the page size changes", async () => {
+    const user = userEvent.setup();
+    const onUrlUpdate = vi.fn();
+    renderTable({ searchParams: "?page=2", onUrlUpdate });
+
+    await user.click(screen.getByTestId("pagination-page-size"));
+    await user.click(await screen.findByRole("option", { name: "25" }));
+
+    await waitFor(() => expect(screen.getByTestId("pagination-range")).toHaveTextContent("Showing 1-14 of 14"));
+    expect(firstDataRow().getByText("Project 01")).toBeInTheDocument();
+    const lastUpdate = onUrlUpdate.mock.calls.at(-1)?.[0];
+    expect(lastUpdate.searchParams.get("page")).toBeNull();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsTable.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsTable.tsx
@@ -2,10 +2,11 @@
 
 import { SortingState } from "@tanstack/react-table";
 import { FolderKanban } from "lucide-react";
+import { parseAsInteger, useQueryState } from "nuqs";
 import { useMemo, useState } from "react";
 
 import { ProjectResponse } from "@/app/(dashboard)/hooks/projects/useProjects";
-import { DataTable } from "@/components/shared/DataTable";
+import { DataTable, DataTablePagination } from "@/components/shared/DataTable";
 
 import { getProjectsTableColumns } from "./ProjectsTableColumns";
 
@@ -18,7 +19,8 @@ interface ProjectsTableProps {
   isTeamsLoading: boolean;
 }
 
-const PAGE_SIZE_OPTIONS = [10, 25, 50];
+const DEFAULT_PAGE_SIZE = 10;
+const PAGE_SIZE_OPTIONS = [DEFAULT_PAGE_SIZE, 25, 50];
 
 function EmptyState({ isFiltered }: { isFiltered: boolean }) {
   return (
@@ -45,11 +47,16 @@ export function ProjectsTable({
   isTeamsLoading,
 }: ProjectsTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [page, setPage] = useQueryState("page", parseAsInteger.withDefault(1).withOptions({ history: "push" }));
 
   const columns = useMemo(() => {
     const deps = { onProjectClick, teamAliasMap, isTeamsLoading };
     return getProjectsTableColumns(deps);
   }, [onProjectClick, teamAliasMap, isTeamsLoading]);
+
+  const pageCount = Math.max(Math.ceil(projects.length / pageSize), 1);
+  const pageIndex = page >= 1 && page <= pageCount ? page - 1 : 0;
 
   return (
     <DataTable
@@ -60,7 +67,22 @@ export function ProjectsTable({
       sorting={sorting}
       onSortingChange={setSorting}
       paginationMode="client"
+      pagination={{ pageIndex, pageSize }}
       pageSizeOptions={PAGE_SIZE_OPTIONS}
+      paginationSlot={() => (
+        <DataTablePagination
+          page={pageIndex}
+          pageSize={pageSize}
+          rowCount={projects.length}
+          onPageChange={(nextPageIndex) => void setPage(nextPageIndex + 1)}
+          onPageSizeChange={(nextPageSize) => {
+            setPageSize(nextPageSize);
+            void setPage(1);
+          }}
+          pageSizeOptions={PAGE_SIZE_OPTIONS}
+          isLoading={isLoading}
+        />
+      )}
       isLoading={isLoading}
       loadingMessage="Loading projects…"
       noDataMessage={<EmptyState isFiltered={isFiltered} />}

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsTable.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsTable.tsx
@@ -2,7 +2,7 @@
 
 import { SortingState } from "@tanstack/react-table";
 import { FolderKanban } from "lucide-react";
-import { parseAsInteger, useQueryState } from "nuqs";
+import { parseAsInteger, useQueryStates } from "nuqs";
 import { useMemo, useState } from "react";
 
 import { ProjectResponse } from "@/app/(dashboard)/hooks/projects/useProjects";
@@ -47,8 +47,11 @@ export function ProjectsTable({
   isTeamsLoading,
 }: ProjectsTableProps) {
   const [sorting, setSorting] = useState<SortingState>([]);
-  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
-  const [page, setPage] = useQueryState("page", parseAsInteger.withDefault(1).withOptions({ history: "push" }));
+  const [{ page, page_size }, setPagination] = useQueryStates(
+    { page: parseAsInteger.withDefault(1), page_size: parseAsInteger.withDefault(DEFAULT_PAGE_SIZE) },
+    { history: "push" },
+  );
+  const pageSize = PAGE_SIZE_OPTIONS.includes(page_size) ? page_size : DEFAULT_PAGE_SIZE;
 
   const columns = useMemo(() => {
     const deps = { onProjectClick, teamAliasMap, isTeamsLoading };
@@ -74,11 +77,8 @@ export function ProjectsTable({
           page={pageIndex}
           pageSize={pageSize}
           rowCount={projects.length}
-          onPageChange={(nextPageIndex) => void setPage(nextPageIndex + 1)}
-          onPageSizeChange={(nextPageSize) => {
-            setPageSize(nextPageSize);
-            void setPage(1);
-          }}
+          onPageChange={(nextPageIndex) => void setPagination({ page: nextPageIndex + 1 })}
+          onPageSizeChange={(nextPageSize) => void setPagination({ page_size: nextPageSize, page: null })}
           pageSizeOptions={PAGE_SIZE_OPTIONS}
           isLoading={isLoading}
         />


### PR DESCRIPTION
## TLDR

Problem this solves:

- Paging the Projects list never changed the URL
- Reloading page 2 silently dropped you on page 1
- Browser Back left the Projects page entirely
- A given page of projects could not be shared

How it solves it:

- Page index now lives in a `?page=` query state
- Paging pushes a history entry, so Back works
- Deep links and reloads land on the right page
- An out-of-range page falls back to page 1

## Relevant issues

## Linear ticket

Resolves LIT-5216

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Captured against a live dev proxy seeded with 14 projects, so the default 10 per page list spans two pages. The dark bar along the bottom edge of every screenshot is a script annotation, not browser chrome: headless captures have no address bar, so the capture script injects a banner printing the page's own `location.href`, which is the same value the run logged as `page.url()` and the same value quoted in each caption

Before, at commit `1f8ceddffa`, the pre-fix tree this branch started from:

![before page 1](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5216_screenshots/before-page1.png)
Projects list on page 1 at `http://localhost:3502/projects/`, showing rows 1-10 of 14

![before page 2](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5216_screenshots/before-page2.png)
After clicking next, the footer reads "Page 2 of 2" but the URL is still bare `http://localhost:3502/projects/`, so nothing about the page survives a reload or a copied link

![before back](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5216_screenshots/before-goback.png)
Browser Back from that page 2 lands on `http://localhost:3502/teams/`, the page visited before Projects, which is the reported bug: paging left no history entry to go back to

After, at the same tree as this PR's commit `fccc41a27a`:

![after page 1](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5216_screenshots/after-page1.png)
Page 1 stays on the bare `http://localhost:3502/projects/`, so the default page adds no query noise

![after page 2](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5216_screenshots/after-page2.png)
Clicking next moves to `http://localhost:3502/projects/?page=2` with rows 11-14 of 14

![after back](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5216_screenshots/after-goback.png)
Browser Back now returns to `http://localhost:3502/projects/` on page 1 rather than leaving the Projects page

![after deep link](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5216_screenshots/after-page2-deeplink.png)
A cold load of `http://localhost:3502/projects/?page=2` in a fresh tab lands on page 2, proving the deep link survives the projects query resolving after first paint

![after out of range page](https://raw.githubusercontent.com/BerriAI/litellm/litellm_lit5216_screenshots/after-page99-clamped.png)
A hand-typed `http://localhost:3502/projects/?page=99` renders page 1 instead of an empty table

## Type

🐛 Bug Fix

## Changes

`ProjectsTable` reads its page index and page size from a nuqs `?page=` plus `?page_size=` query state pair (`useQueryStates`, defaults 1 and 10, `history: "push"`), so each paging action is a real history entry and the defaults keep the URL clean. Changing the page size resets the page inside the same single history entry, which keeps every restored entry showing the rows it originally showed (raised by Greptile), and a `?page_size=` outside the offered options falls back to the default

Pagination is controlled off that URL value, and the table footer writes the URL directly through the shared `DataTablePagination` in `paginationSlot` instead of routing through the table's own `onPaginationChange`. That indirection is load bearing rather than stylistic: TanStack resets its page index whenever the `data` array identity changes, which for this list happens every time the projects query resolves or refetches. Had the table owned the state, a deep-linked page would have been cleared back to page 1 the moment data arrived, and the deep link screenshot above would not reproduce

The rendered page is derived rather than stored, so a page outside the current row set falls back to page 1. One rule covers a hand-typed `?page=99` and a search that narrows the list below the current page, and because it is derived there is no effect that could fight the URL while data loads. Clearing a transient search returns you to the page you were on, since the search text itself is not part of the URL

Tests live in a new `ProjectsTable.test.tsx` covering the deep link (including the `?page=2&page_size=25` pair), the pushed history entry, the page 1 fallback in both forms, the page size reset with its single-entry URL write, the out-of-options `?page_size=` fallback, and the async data arrival case that motivated the design. Verified by mutating the source four ways: an off by one page index (6 failures), falling back to the last page instead of the first (2 failures), swapping `push` for `replace` (1 failure), and handing pagination back to the table (1 failure, the deep link test)

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

