### PR TITLE
feat(pre-commit): save full lint output to a per-worktree log file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ Python max line length is 120, not 88
 
 When you fix violations gated by `ruff-strict-budget.json`, `type-discipline-budget.json`, or `basedpyright-code-budget.json`, run `make lint-budget-update` and commit the lowered limits so the ceilings ratchet down instead of leaving stale headroom. It measures the working tree, so it must contain exactly the fixes you're committing
 
+`make pre-commit` always saves its complete output to a per-worktree log file and prints that path as its first and last output lines. To inspect a run, read or grep that log instead of re-running the multi-minute checks just to see a different slice, and re-run only after the working tree actually changed
+
 If you're trying to create a new function that relies on untyped stuff, instead of adding more Any's and pushing `reportAny` / `reportExplicitAny` closer to their basedpyright ceilings, just validate it in the caller with Pydantic (a model or `TypeAdapter` that returns the typed thing or raises will do) and then pass the now typed variable in
 
 If you get an LIT001 or LIT002 fail, refactor the code to follow functional programming best practices rather than introducing mutable data structures. For example, build values in one shot with comprehensions or generators wrapped in `tuple()` / `frozenset()` instead of seeding an empty `list`/`dict`/`set` and mutating it over time. Ideally, `# mutable-ok` is never used; reach for it only as a genuine last resort when an immutable rewrite is truly impossible, and always pair it with a real reason

--- a/scripts/pre_commit_lint.sh
+++ b/scripts/pre_commit_lint.sh
@@ -19,11 +19,19 @@ set -eu
 
 if [ -z "${PRE_COMMIT_LINT_INNER:-}" ]; then
     log_file=$(git rev-parse --path-format=absolute --git-path pre_commit_lint.log)
-    echo "pre-commit: logging full output to $log_file"
-    PRE_COMMIT_LINT_INNER=1 "$0" "$@" 2>&1 | tee "$log_file"
-    log_status="${PIPESTATUS[0]}"
-    echo "pre-commit: full log: $log_file"
-    exit "$log_status"
+    if : > "$log_file" 2>/dev/null; then
+        echo "pre-commit: logging full output to $log_file"
+        PRE_COMMIT_LINT_INNER=1 "$0" "$@" 2>&1 | tee "$log_file"
+        pipe_status=("${PIPESTATUS[@]}")
+        if [ "${pipe_status[1]}" -eq 0 ]; then
+            echo "pre-commit: full log: $log_file"
+        else
+            echo "pre-commit: WARNING - writing $log_file failed; the log may be incomplete" >&2
+        fi
+        exit "${pipe_status[0]}"
+    fi
+    echo "pre-commit: WARNING - cannot write $log_file; output will not be saved" >&2
+    PRE_COMMIT_LINT_INNER=1 exec "$0" "$@"
 fi
 
 repo_root=$(git rev-parse --show-toplevel)

--- a/scripts/pre_commit_lint.sh
+++ b/scripts/pre_commit_lint.sh
@@ -17,6 +17,15 @@
 
 set -eu
 
+if [ -z "${PRE_COMMIT_LINT_INNER:-}" ]; then
+    log_file=$(git rev-parse --path-format=absolute --git-path pre_commit_lint.log)
+    echo "pre-commit: logging full output to $log_file"
+    PRE_COMMIT_LINT_INNER=1 "$0" "$@" 2>&1 | tee "$log_file"
+    log_status="${PIPESTATUS[0]}"
+    echo "pre-commit: full log: $log_file"
+    exit "$log_status"
+fi
+
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 

--- a/tests/test_litellm/test_pre_commit_lint.py
+++ b/tests/test_litellm/test_pre_commit_lint.py
@@ -148,6 +148,29 @@ def test_all_blocks_passing_exits_zero(tmp_path: Path) -> None:
     assert proc.returncode == 0, proc.stdout + proc.stderr
 
 
+def test_full_output_is_saved_to_a_log_file_in_the_git_dir(tmp_path: Path) -> None:
+    repo, bin_dir = _sandbox(tmp_path)
+    (repo / "scratch.txt").write_text("")
+    proc = _run(repo, bin_dir, {})
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    log_file = repo / ".git" / "pre_commit_lint.log"
+    log = log_file.read_text()
+    assert "linting Python" in log
+    assert "linting dashboard" in log
+    assert "API types" in log
+    assert "unstaged/untracked changes" in log
+    assert f"pre-commit: full log: {log_file}" in proc.stdout
+    assert "pre-commit: full log:" not in log
+
+
+def test_failing_run_exit_code_survives_the_log_pipeline(tmp_path: Path) -> None:
+    repo, bin_dir = _sandbox(tmp_path)
+    proc = _run(repo, bin_dir, {"STUB_FAIL": "make-lint"})
+    assert proc.returncode == 1
+    log = (repo / ".git" / "pre_commit_lint.log").read_text()
+    assert "Python lint failed" in log
+
+
 def _wait_until(predicate: Callable[[], bool], timeout_seconds: float) -> bool:
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:

--- a/tests/test_litellm/test_pre_commit_lint.py
+++ b/tests/test_litellm/test_pre_commit_lint.py
@@ -163,6 +163,18 @@ def test_full_output_is_saved_to_a_log_file_in_the_git_dir(tmp_path: Path) -> No
     assert "pre-commit: full log:" not in log
 
 
+def test_unwritable_log_warns_and_falls_back_to_running_without_one(tmp_path: Path) -> None:
+    repo, bin_dir = _sandbox(tmp_path)
+    (repo / ".git" / "pre_commit_lint.log").mkdir()
+    proc = _run(repo, bin_dir, {})
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "linting Python" in proc.stdout
+    assert "output will not be saved" in proc.stderr
+    assert "pre-commit: full log:" not in proc.stdout
+    failing = _run(repo, bin_dir, {"STUB_FAIL": "make-lint"})
+    assert failing.returncode == 1
+
+
 def test_failing_run_exit_code_survives_the_log_pipeline(tmp_path: Path) -> None:
     repo, bin_dir = _sandbox(tmp_path)
     proc = _run(repo, bin_dir, {"STUB_FAIL": "make-lint"})


### PR DESCRIPTION
## TLDR

Problem this solves:

- `make pre-commit` output only exists on the console
- piping it through `tail`/`grep` discards the rest forever
- seeing a different slice means rerunning the multi-minute lint

How it solves it:

- the script tees its full output to a per-worktree log file
- the log path is printed as the first and last lines
- CLAUDE.md now tells agents to slice that log, not rerun

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This is local dev tooling, so the proof is the tool itself running in a worktree at a8e104ea. A run whose console output is pre-filtered with `tail` still leaves the complete log on disk, stderr included:

```
$ touch scratch_demo.txt && make pre-commit 2>&1 | tail -4; echo "exit=$?"
  won't be in a commit of only your staged changes, so this result may differ from
  CI. Stage everything you intend to commit (git add) for an accurate prediction:
    scratch_demo.txt
pre-commit: full log: /Users/mateo/Development/litellm/.git/worktrees/precommit-log/pre_commit_lint.log
exit=0

$ cat /Users/mateo/Development/litellm/.git/worktrees/precommit-log/pre_commit_lint.log
pre-commit: NOTE - unstaged/untracked changes are included in these checks but
  won't be in a commit of only your staged changes, so this result may differ from
  CI. Stage everything you intend to commit (git add) for an accurate prediction:
    scratch_demo.txt
```

The NOTE block above is written to stderr by the script, so its presence in the log proves the tee captures the merged stream, and `exit=0` alongside the failing-case test below proves exit codes pass through the pipeline

```
$ uv run pytest tests/test_litellm/test_pre_commit_lint.py -q
10 passed in 8.25s
```

## Type

🚄 Infrastructure

## Changes

`scripts/pre_commit_lint.sh` now re-execs itself through `tee` on entry: the outer invocation resolves `git rev-parse --git-path pre_commit_lint.log`, announces it, and runs the inner script with stdout and stderr merged into the pipe. Using the git path keeps the log out of the working tree and gives every worktree its own file, so parallel checkouts never clobber each other. The outer wrapper exits with the inner script's status via `PIPESTATUS` so a red run stays red even though `tee` itself succeeds. When the log cannot be created the script warns and runs without one instead of advertising a file that does not exist, and a mid-run write failure downgrades the closing line to a warning that the log may be incomplete

Three regression tests in `tests/test_litellm/test_pre_commit_lint.py` pin this down: one asserts the log lands in the sandbox repo's git dir containing every block's output plus a stderr-only line, one asserts a failing lint block's exit code 1 survives the pipeline and its failure message is in the log, and one makes the log path unwritable and asserts the run still lints, warns, and keeps its exit code

CLAUDE.md gains a paragraph documenting the log so coding agents read or grep it for the slice they need instead of re-running the whole multi-minute lint, which is what kept happening when console output was pre-filtered through tail or grep

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
