### PR TITLE
fix: rebuild models_by_provider in add_known_models so cost map reloads reach wildcard expansion

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -950,11 +950,11 @@ def _populate_provider_model_sets(model_cost_map: Dict) -> None:
 
 def add_known_models(model_cost_map: Optional[Dict] = None):
     """Fold `model_cost_map` (defaults to `litellm.model_cost`) into the per-provider model sets,
-    then rebuild `models_by_provider` from those sets so the additions reach wildcard expansion.
+    then refresh `models_by_provider` from those sets so the additions reach wildcard expansion.
+    The refresh updates the dict in place, so references captured before a reload stay live.
     """
-    global models_by_provider
     _populate_provider_model_sets(model_cost_map if model_cost_map is not None else model_cost)
-    models_by_provider = _build_models_by_provider()
+    models_by_provider.update(_build_models_by_provider())
 
 
 _populate_provider_model_sets(model_cost)

--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -704,9 +704,8 @@ def is_openai_finetune_model(key: str) -> bool:
     return key.startswith("ft:") and not key.count(":") > 1
 
 
-def add_known_models(model_cost_map: Optional[Dict] = None):
-    _map: Final = model_cost_map if model_cost_map is not None else model_cost
-    for key, value in _map.items():
+def _populate_provider_model_sets(model_cost_map: Dict) -> None:
+    for key, value in model_cost_map.items():
         if value.get("litellm_provider") == "openai" and not is_openai_finetune_model(key):
             open_ai_chat_completion_models.add(key)
         elif value.get("litellm_provider") == "text-completion-openai":
@@ -949,7 +948,16 @@ def add_known_models(model_cost_map: Optional[Dict] = None):
             bedrock_mantle_models.add(key)
 
 
-add_known_models()
+def add_known_models(model_cost_map: Optional[Dict] = None):
+    """Fold `model_cost_map` (defaults to `litellm.model_cost`) into the per-provider model sets,
+    then rebuild `models_by_provider` from those sets so the additions reach wildcard expansion.
+    """
+    global models_by_provider
+    _populate_provider_model_sets(model_cost_map if model_cost_map is not None else model_cost)
+    models_by_provider = _build_models_by_provider()
+
+
+_populate_provider_model_sets(model_cost)
 # known openai compatible endpoints - we'll eventually move this list to the model_prices_and_context_window.json dictionary
 
 # this is maintained for Exception Mapping
@@ -1071,112 +1079,116 @@ model_list_set = set(model_list)
 # provider_list is lazy-loaded via __getattr__ to avoid importing LlmProviders at import time
 
 
-models_by_provider: dict = {
-    "openai": open_ai_chat_completion_models | open_ai_text_completion_models,
-    "text-completion-openai": open_ai_text_completion_models,
-    "cohere": cohere_models | cohere_chat_models,
-    "cohere_chat": cohere_chat_models,
-    "anthropic": anthropic_models,
-    "replicate": replicate_models,
-    "huggingface": huggingface_models,
-    "together_ai": together_ai_models,
-    "baseten": baseten_models,
-    "openrouter": openrouter_models,
-    "vercel_ai_gateway": vercel_ai_gateway_models,
-    "datarobot": datarobot_models,
-    "vertex_ai": vertex_chat_models
-    | vertex_text_models
-    | vertex_anthropic_models
-    | vertex_vision_models
-    | vertex_language_models
-    | vertex_deepseek_models
-    | vertex_minimax_models
-    | vertex_moonshot_models
-    | vertex_zai_models,
-    "ai21": ai21_models,
-    "bedrock": bedrock_models | bedrock_converse_models,
-    "petals": petals_models,
-    "ollama": ollama_models,
-    "ollama_chat": ollama_models,
-    "deepinfra": deepinfra_models,
-    "perplexity": perplexity_models,
-    "maritalk": maritalk_models,
-    "watsonx": watsonx_models,
-    "gemini": gemini_models,
-    "fireworks_ai": fireworks_ai_models | fireworks_ai_embedding_models,
-    "aleph_alpha": aleph_alpha_models,
-    "text-completion-codestral": text_completion_codestral_models,
-    "text-completion-inception": text_completion_inception_models,
-    "xai": xai_models,
-    "zai": zai_models,
-    "fal_ai": fal_ai_models,
-    "deepseek": deepseek_models,
-    "tencent": tencent_models,
-    "runwayml": runwayml_models,
-    "mistral": mistral_chat_models,
-    "azure_ai": azure_ai_models,
-    "voyage": voyage_models,
-    "infinity": infinity_models,
-    "databricks": databricks_models,
-    "cloudflare": cloudflare_models,
-    "codestral": codestral_models,
-    "nlp_cloud": nlp_cloud_models,
-    "friendliai": friendliai_models,
-    "palm": palm_models,
-    "groq": groq_models,
-    "azure": azure_models | azure_text_models,
-    "azure_anthropic": azure_anthropic_models,
-    "azure_text": azure_text_models,
-    "anyscale": anyscale_models,
-    "cerebras": cerebras_models,
-    "galadriel": galadriel_models,
-    "nvidia_nim": nvidia_nim_models,
-    "nvidia_riva": nvidia_riva_models,
-    "soniox": soniox_models,
-    "sambanova": sambanova_models | sambanova_embedding_models,
-    "novita": novita_models,
-    "nebius": nebius_models | nebius_embedding_models,
-    "aiml": aiml_models,
-    "assemblyai": assemblyai_models,
-    "jina_ai": jina_ai_models,
-    "snowflake": snowflake_models,
-    "gradient_ai": gradient_ai_models,
-    "meta_llama": llama_models,
-    "nscale": nscale_models,
-    "featherless_ai": featherless_ai_models,
-    "deepgram": deepgram_models,
-    "elevenlabs": elevenlabs_models,
-    "heroku": heroku_models,
-    "dashscope": dashscope_models,
-    "modelscope": modelscope_models,
-    "moonshot": moonshot_models,
-    "publicai": publicai_models,
-    "darkbloom": darkbloom_models,
-    "v0": v0_models,
-    "morph": morph_models,
-    "lambda_ai": lambda_ai_models,
-    "inception": inception_models,
-    "hyperbolic": hyperbolic_models,
-    "black_forest_labs": black_forest_labs_models,
-    "recraft": recraft_models,
-    "cometapi": cometapi_models,
-    "oci": oci_models,
-    "volcengine": volcengine_models,
-    "wandb": wandb_models,
-    "ovhcloud": ovhcloud_models | ovhcloud_embedding_models,
-    "lemonade": lemonade_models,
-    "clarifai": clarifai_models,
-    "amazon_nova": amazon_nova_models,
-    "stability": stability_models,
-    "github_copilot": github_copilot_models,
-    "chatgpt": chatgpt_models,
-    "minimax": minimax_models,
-    "aws_polly": aws_polly_models,
-    "gigachat": gigachat_models,
-    "llamagate": llamagate_models,
-    "reducto": reducto_models,
-    "bedrock_mantle": bedrock_mantle_models,
-}
+def _build_models_by_provider() -> dict:
+    return {
+        "openai": open_ai_chat_completion_models | open_ai_text_completion_models,
+        "text-completion-openai": open_ai_text_completion_models,
+        "cohere": cohere_models | cohere_chat_models,
+        "cohere_chat": cohere_chat_models,
+        "anthropic": anthropic_models,
+        "replicate": replicate_models,
+        "huggingface": huggingface_models,
+        "together_ai": together_ai_models,
+        "baseten": baseten_models,
+        "openrouter": openrouter_models,
+        "vercel_ai_gateway": vercel_ai_gateway_models,
+        "datarobot": datarobot_models,
+        "vertex_ai": vertex_chat_models
+        | vertex_text_models
+        | vertex_anthropic_models
+        | vertex_vision_models
+        | vertex_language_models
+        | vertex_deepseek_models
+        | vertex_minimax_models
+        | vertex_moonshot_models
+        | vertex_zai_models,
+        "ai21": ai21_models,
+        "bedrock": bedrock_models | bedrock_converse_models,
+        "petals": petals_models,
+        "ollama": ollama_models,
+        "ollama_chat": ollama_models,
+        "deepinfra": deepinfra_models,
+        "perplexity": perplexity_models,
+        "maritalk": maritalk_models,
+        "watsonx": watsonx_models,
+        "gemini": gemini_models,
+        "fireworks_ai": fireworks_ai_models | fireworks_ai_embedding_models,
+        "aleph_alpha": aleph_alpha_models,
+        "text-completion-codestral": text_completion_codestral_models,
+        "text-completion-inception": text_completion_inception_models,
+        "xai": xai_models,
+        "zai": zai_models,
+        "fal_ai": fal_ai_models,
+        "deepseek": deepseek_models,
+        "tencent": tencent_models,
+        "runwayml": runwayml_models,
+        "mistral": mistral_chat_models,
+        "azure_ai": azure_ai_models,
+        "voyage": voyage_models,
+        "infinity": infinity_models,
+        "databricks": databricks_models,
+        "cloudflare": cloudflare_models,
+        "codestral": codestral_models,
+        "nlp_cloud": nlp_cloud_models,
+        "friendliai": friendliai_models,
+        "palm": palm_models,
+        "groq": groq_models,
+        "azure": azure_models | azure_text_models,
+        "azure_anthropic": azure_anthropic_models,
+        "azure_text": azure_text_models,
+        "anyscale": anyscale_models,
+        "cerebras": cerebras_models,
+        "galadriel": galadriel_models,
+        "nvidia_nim": nvidia_nim_models,
+        "nvidia_riva": nvidia_riva_models,
+        "soniox": soniox_models,
+        "sambanova": sambanova_models | sambanova_embedding_models,
+        "novita": novita_models,
+        "nebius": nebius_models | nebius_embedding_models,
+        "aiml": aiml_models,
+        "assemblyai": assemblyai_models,
+        "jina_ai": jina_ai_models,
+        "snowflake": snowflake_models,
+        "gradient_ai": gradient_ai_models,
+        "meta_llama": llama_models,
+        "nscale": nscale_models,
+        "featherless_ai": featherless_ai_models,
+        "deepgram": deepgram_models,
+        "elevenlabs": elevenlabs_models,
+        "heroku": heroku_models,
+        "dashscope": dashscope_models,
+        "modelscope": modelscope_models,
+        "moonshot": moonshot_models,
+        "publicai": publicai_models,
+        "darkbloom": darkbloom_models,
+        "v0": v0_models,
+        "morph": morph_models,
+        "lambda_ai": lambda_ai_models,
+        "inception": inception_models,
+        "hyperbolic": hyperbolic_models,
+        "black_forest_labs": black_forest_labs_models,
+        "recraft": recraft_models,
+        "cometapi": cometapi_models,
+        "oci": oci_models,
+        "volcengine": volcengine_models,
+        "wandb": wandb_models,
+        "ovhcloud": ovhcloud_models | ovhcloud_embedding_models,
+        "lemonade": lemonade_models,
+        "clarifai": clarifai_models,
+        "amazon_nova": amazon_nova_models,
+        "stability": stability_models,
+        "github_copilot": github_copilot_models,
+        "chatgpt": chatgpt_models,
+        "minimax": minimax_models,
+        "aws_polly": aws_polly_models,
+        "gigachat": gigachat_models,
+        "llamagate": llamagate_models,
+        "reducto": reducto_models,
+        "bedrock_mantle": bedrock_mantle_models,
+    }
+
+
+models_by_provider: dict = _build_models_by_provider()
 
 # mapping for those models which have larger equivalents
 longer_context_model_fallback_dict: dict = {

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -719,6 +719,7 @@ def test_add_known_models_refreshes_models_by_provider_for_wildcard_expansion():
     from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
 
     fake_model = "vertex_ai/gemini-lit4947-regression"
+    captured_reference = litellm.models_by_provider
     assert fake_model not in litellm.models_by_provider["vertex_ai"]
     try:
         litellm.add_known_models(
@@ -727,6 +728,8 @@ def test_add_known_models_refreshes_models_by_provider_for_wildcard_expansion():
             }
         )
         assert fake_model in litellm.models_by_provider["vertex_ai"]
+        assert litellm.models_by_provider is captured_reference
+        assert fake_model in captured_reference["vertex_ai"]
         assert fake_model in get_known_models_from_wildcard("vertex_ai/*")
     finally:
         litellm.vertex_language_models.discard(fake_model)

--- a/tests/test_litellm/proxy/auth/test_model_checks.py
+++ b/tests/test_litellm/proxy/auth/test_model_checks.py
@@ -709,3 +709,26 @@ def test_expand_wildcard_invalid_litellm_params_passthrough():
     # Even if LiteLLM_Params construction fails the deployment should survive
     result = expand_wildcard_deployments_for_model_info([deployment])
     assert result == [deployment]
+
+
+def test_add_known_models_refreshes_models_by_provider_for_wildcard_expansion():
+    """models_by_provider was a frozen import-time snapshot of set unions, so cost map
+    reloads (which call add_known_models) never reached wildcard expansion until a
+    process restart (LIT-4947)."""
+    import litellm
+    from litellm.proxy.auth.model_checks import get_known_models_from_wildcard
+
+    fake_model = "vertex_ai/gemini-lit4947-regression"
+    assert fake_model not in litellm.models_by_provider["vertex_ai"]
+    try:
+        litellm.add_known_models(
+            model_cost_map={
+                fake_model: {"litellm_provider": "vertex_ai-language-models", "mode": "chat"}
+            }
+        )
+        assert fake_model in litellm.models_by_provider["vertex_ai"]
+        assert fake_model in get_known_models_from_wildcard("vertex_ai/*")
+    finally:
+        litellm.vertex_language_models.discard(fake_model)
+        litellm.add_known_models(model_cost_map={})
+    assert fake_model not in litellm.models_by_provider["vertex_ai"]


### PR DESCRIPTION
## TLDR

Problem this solves:

- Reload Price Data updates litellm.model_cost but wildcard model lists stay stale
- Newly priced models never reach /v1/models or key/team dropdowns until a restart

How it solves it:

- add_known_models now rebuilds models_by_provider from the live per-provider sets
- Both reload paths already call add_known_models, so no proxy changes needed

## Relevant issues

Overlaps with #35145, which bundles this same core fix with a bare vertex_ai bucket and a reload no-op status. This PR ships only the staleness fix. #35889 is the full registry refactor that removes the mutable globals entirely; it stays open as the long-term cleanup

## Linear ticket

Resolves LIT-4947

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs use a live proxy on 127.0.0.1:4947 with a `vertex_ai/*` wildcard deployment, the real dev Postgres, and `LITELLM_MODEL_COST_MAP_URL` pointing at a locally served copy of the production cost map so a brand new model (`vertex_ai/gemini-proof-lit4947`, provider `vertex_ai-language-models`) can be introduced between boot and reload: exactly the Admin UI "Reload Price Data" flow

### Before the fix (base `f54cd287a2`)

Reload reports success, but the freshly priced model never reaches the wildcard-backed `/v1/models`, so it stays invisible to the dropdowns until a restart

```
$ curl -s http://127.0.0.1:4947/v1/models -H "Authorization: Bearer sk-1234" | python -c "
import json,sys
ids=[m['id'] for m in json.load(sys.stdin)['data']]
print(json.dumps({'total': len(ids), 'fake_present': 'vertex_ai/gemini-proof-lit4947' in ids}))"
{"total": 104, "fake_present": false}

# add vertex_ai/gemini-proof-lit4947 to the served cost map, then:
$ curl -s -X POST http://127.0.0.1:4947/reload/model_cost_map -H "Authorization: Bearer sk-1234"
{"message":"Price data reloaded successfully! 2988 models updated.","status":"success","models_count":2988,"timestamp":"2026-08-05T22:11:04.264773+00:00"}

$ curl -s http://127.0.0.1:4947/v1/models -H "Authorization: Bearer sk-1234" | python -c "..."
{"total": 104, "fake_present": false}
```

### After the fix (`e08c9d5c45`)

Same flow, and the reloaded model shows up immediately

```
$ curl -s http://127.0.0.1:4947/v1/models -H "Authorization: Bearer sk-1234" | python -c "..."
{"total": 104, "fake_present": false}

# add vertex_ai/gemini-proof-lit4947 to the served cost map, then:
$ curl -s -X POST http://127.0.0.1:4947/reload/model_cost_map -H "Authorization: Bearer sk-1234"
{"message":"Price data reloaded successfully! 2988 models updated.","status":"success","models_count":2988,"timestamp":"2026-08-05T22:10:03.574051+00:00"}

$ curl -s http://127.0.0.1:4947/v1/models -H "Authorization: Bearer sk-1234" | python -c "..."
{"total": 105, "fake_present": true}
```

Real traffic through a wildcard deployment on the same proxy (`e08c9d5c45`, real provider call costing real money):

```
$ curl -s http://127.0.0.1:4947/v1/chat/completions -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d '{"model":"groq/llama-3.3-70b-versatile","messages":[{"role":"user","content":"Say LIT-4947 fixed in five words or fewer"}]}'
{"model": "groq/llama-3.3-70b-versatile", "content": "LIT-4947 is now fixed.", "usage": 57}
```

## Type

🐛 Bug Fix

## Changes

`models_by_provider` was built exactly once at import time, and nine of its entries (`openai`, `cohere`, `vertex_ai`, `bedrock`, `fireworks_ai`, `sambanova`, `nebius`, `azure`, `ovhcloud`) are `|` unions of the per-provider sets. The `|` operator allocates new set objects, so those entries were frozen snapshots disconnected from the sets `add_known_models` mutates. `get_valid_models`, and `get_known_models_from_wildcard` on top of it, read `litellm.models_by_provider`, which is why a cost map reload never changed what `/v1/models` returned for a wildcard deployment

The dict literal now lives in `_build_models_by_provider()`, the population loop moved to `_populate_provider_model_sets()`, and `add_known_models` composes the two: fold the new map into the per-provider sets, then refresh `models_by_provider` from them. The refresh is an in-place `dict.update`, so the exported object keeps its identity and any reference captured before a reload stays live. Every existing caller keeps its signature and behavior, import-time initialization is unchanged, and both proxy reload sites (`_swap_in_model_cost_map`) pick up the fix with no proxy changes

Regression test: `test_add_known_models_refreshes_models_by_provider_for_wildcard_expansion` asserts that after `add_known_models` sees a map with a new `vertex_ai-language-models` model, both `litellm.models_by_provider["vertex_ai"]` and `get_known_models_from_wildcard("vertex_ai/*")` contain it, and that the dict object's identity is preserved so previously captured references see the new model too. It fails on current base and passes with this PR

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
