### PR TITLE
fix(proxy)!: apply request-parameter checks consistently across body, path and form inputs

### DIFF
--- a/litellm/proxy/auth/auth_utils.py
+++ b/litellm/proxy/auth/auth_utils.py
@@ -20,6 +20,7 @@ from litellm.litellm_core_utils.url_utils import (
     validate_url,
 )
 from litellm.proxy._types import *
+from litellm.proxy.common_utils.http_parsing_utils import extract_nested_form_metadata
 from litellm.types.passthrough_endpoints.pass_through_endpoints import (
     LITELLM_PASS_THROUGH_ENDPOINT_MARKER,
 )
@@ -440,6 +441,13 @@ def is_request_body_safe(request_body: dict, general_settings: dict, llm_router:
         metadata = _coerce_metadata_to_dict(request_body.get(metadata_key))
         if metadata is not None:
             _check_banned_params(metadata, general_settings, llm_router, model)
+        if any(isinstance(key, str) and key.startswith(f"{metadata_key}[") for key in request_body):
+            _check_banned_params(
+                extract_nested_form_metadata(form_data=request_body, prefix=f"{metadata_key}["),
+                general_settings,
+                llm_router,
+                model,
+            )
     for target in iter_request_fallback_targets(request_body):
         if isinstance(target, dict):
             _check_banned_params(target, general_settings, llm_router, model)

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -67,7 +67,10 @@ if TYPE_CHECKING:
     ProxyConfig = _ProxyConfig
 else:
     ProxyConfig = Any
-from litellm.proxy.litellm_pre_call_utils import add_litellm_data_to_request
+from litellm.proxy.litellm_pre_call_utils import (
+    add_litellm_data_to_request,
+    reject_url_valued_destination,
+)
 from litellm.types.utils import (
     ModelResponse,
     ModelResponseStream,
@@ -1285,6 +1288,9 @@ class ProxyBaseLLMRequestProcessing:
             if not isinstance(self.data[_metadata_variable_name], dict):
                 self.data[_metadata_variable_name] = {}
             self.data[_metadata_variable_name]["queue_time_seconds"] = queue_time_seconds
+
+        if isinstance(model, str):
+            reject_url_valued_destination("model", model)
 
         self.data["model"] = (
             general_settings.get("completion_model", None)  # server default

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -88,7 +88,11 @@ def _reject_os_environ_references(params: dict) -> None:
 
 
 _CONFIG_CONNECTION_FIELDS: Final[frozenset[str]] = frozenset(
-    (*_ADMIN_CONFIG_FIELDS_TO_CLEAR_ON_BASE_OVERRIDE, *clientside_credential_keys)
+    (
+        *_ADMIN_CONFIG_FIELDS_TO_CLEAR_ON_BASE_OVERRIDE,
+        *clientside_credential_keys,
+        "litellm_credential_name",
+    )
 )
 
 
@@ -104,6 +108,11 @@ def _config_base_for_health_check(
     to the endpoint the configuration names. Anything the request does not set
     still comes from the configuration, which is what lets a request name a
     configured model and test it as configured.
+
+    ``litellm_credential_name`` is dropped alongside the literal credential
+    fields: it names a stored credential that ``load_credentials_from_list``
+    resolves into the same secrets further down the call, so leaving it in place
+    would reintroduce them by reference.
 
     ``general_settings.allow_client_side_credentials`` is the existing proxy-wide
     opt-in for callers supplying their own connection parameters. Where an admin

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -93,7 +93,9 @@ _CONFIG_CONNECTION_FIELDS: Final[frozenset[str]] = frozenset(
 
 
 def _config_base_for_health_check(
-    config_params: Mapping[str, object], request_params: Mapping[str, object]
+    config_params: Mapping[str, object],
+    request_params: Mapping[str, object],
+    allow_client_side_credentials: bool = False,
 ) -> dict[str, object]:
     """Return the configured parameters to merge under a connection-test request.
 
@@ -102,7 +104,14 @@ def _config_base_for_health_check(
     to the endpoint the configuration names. Anything the request does not set
     still comes from the configuration, which is what lets a request name a
     configured model and test it as configured.
+
+    ``general_settings.allow_client_side_credentials`` is the existing proxy-wide
+    opt-in for callers supplying their own connection parameters. Where an admin
+    has enabled it, a request may pair its own endpoint with the configured
+    credentials, as it could before.
     """
+    if allow_client_side_credentials:
+        return dict(config_params)
     if not any(param in request_params for param in _BANNED_REQUEST_BODY_PARAMS):
         return dict(config_params)
     return {key: value for key, value in config_params.items() if key not in _CONFIG_CONNECTION_FIELDS}
@@ -1813,7 +1822,12 @@ async def test_model_connection(
     from litellm.proxy.management_endpoints.model_management_endpoints import (
         ModelManagementAuthChecks,
     )
-    from litellm.proxy.proxy_server import llm_router, premium_user, prisma_client
+    from litellm.proxy.proxy_server import (
+        general_settings,
+        llm_router,
+        premium_user,
+        prisma_client,
+    )
     from litellm.types.router import Deployment, LiteLLM_Params
 
     try:
@@ -1883,7 +1897,11 @@ async def test_model_connection(
 
         # Merge: config params (from proxy config) as base, request params override
         litellm_params = {
-            **_config_base_for_health_check(config_litellm_params, request_litellm_params),
+            **_config_base_for_health_check(
+                config_litellm_params,
+                request_litellm_params,
+                allow_client_side_credentials=general_settings.get("allow_client_side_credentials") is True,
+            ),
             **request_litellm_params,
         }
 

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -46,6 +46,10 @@ from litellm.proxy.middleware.in_flight_requests_middleware import (
     get_in_flight_requests,
 )
 from litellm.proxy.shutdown.graceful_shutdown_manager import GracefulShutdownManager
+from litellm.router_utils.clientside_credential_handler import (
+    _ADMIN_CONFIG_FIELDS_TO_CLEAR_ON_BASE_OVERRIDE,  # pyright: ignore[reportPrivateUsage]  # one canonical list, shared with the router path
+    clientside_credential_keys,
+)
 
 #### Health ENDPOINTS ####
 
@@ -83,25 +87,25 @@ def _reject_os_environ_references(params: dict) -> None:
                 stack.append(value)
 
 
-def _reject_banned_param_overrides(request_params: Mapping[str, object]) -> None:
-    """Reject request params that would replace a configured deployment's routing or credentials.
+_CONFIG_CONNECTION_FIELDS: Final[frozenset[str]] = frozenset(
+    (*_ADMIN_CONFIG_FIELDS_TO_CLEAR_ON_BASE_OVERRIDE, *clientside_credential_keys)
+)
 
-    Applied only when a configured deployment supplies the base parameters. The
-    request may still adjust benign fields; routing and credential fields come
-    from the configuration. A caller who wants a fully custom connection supplies
-    the complete parameter set instead of naming a configured model.
+
+def _config_base_for_health_check(
+    config_params: Mapping[str, object], request_params: Mapping[str, object]
+) -> dict[str, object]:
+    """Return the configured parameters to merge under a connection-test request.
+
+    A request that sets its own connection fields describes a connection of its
+    own, so the configuration's credentials are not carried into it: they belong
+    to the endpoint the configuration names. Anything the request does not set
+    still comes from the configuration, which is what lets a request name a
+    configured model and test it as configured.
     """
-    for param in _BANNED_REQUEST_BODY_PARAMS:
-        if param in request_params:
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": (
-                        f"{param} cannot be overridden when testing a configured model. "
-                        "Provide the full connection parameters instead of naming a configured model."
-                    )
-                },
-            )
+    if not any(param in request_params for param in _BANNED_REQUEST_BODY_PARAMS):
+        return dict(config_params)
+    return {key: value for key, value in config_params.items() if key not in _CONFIG_CONNECTION_FIELDS}
 
 
 def get_callback_identifier(callback):
@@ -1878,7 +1882,10 @@ async def test_model_connection(
                 )
 
         # Merge: config params (from proxy config) as base, request params override
-        litellm_params = {**config_litellm_params, **request_litellm_params}
+        litellm_params = {
+            **_config_base_for_health_check(config_litellm_params, request_litellm_params),
+            **request_litellm_params,
+        }
 
         ## Auth check
         auth_model_info: Final = loaded_model_info if loaded_model_info is not None else model_info
@@ -1892,8 +1899,6 @@ async def test_model_connection(
             prisma_client=prisma_client,
             premium_user=premium_user,
         )
-        if config_litellm_params:
-            _reject_banned_param_overrides(request_litellm_params)
         # Include health_check_params if provided
         litellm_params = _update_litellm_params_for_health_check(
             model_info={},

--- a/litellm/proxy/health_endpoints/_health_endpoints.py
+++ b/litellm/proxy/health_endpoints/_health_endpoints.py
@@ -5,7 +5,7 @@ import os
 import secrets
 import time
 import traceback
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from datetime import datetime, timedelta
 from typing import Any, Final, Literal, TypedDict, cast
 
@@ -28,6 +28,9 @@ from litellm.proxy._types import (
     SpecialModelNames,
     UserAPIKeyAuth,
     WebhookEvent,
+)
+from litellm.proxy.auth.auth_utils import (
+    _BANNED_REQUEST_BODY_PARAMS,  # pyright: ignore[reportPrivateUsage]  # one canonical list, shared with the request-body check
 )
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.db.exception_handler import PrismaDBExceptionHandler
@@ -78,6 +81,27 @@ def _reject_os_environ_references(params: dict) -> None:
             if isinstance(value, (dict, list)) and id(value) not in seen:
                 seen.add(id(value))
                 stack.append(value)
+
+
+def _reject_banned_param_overrides(request_params: Mapping[str, object]) -> None:
+    """Reject request params that would replace a configured deployment's routing or credentials.
+
+    Applied only when a configured deployment supplies the base parameters. The
+    request may still adjust benign fields; routing and credential fields come
+    from the configuration. A caller who wants a fully custom connection supplies
+    the complete parameter set instead of naming a configured model.
+    """
+    for param in _BANNED_REQUEST_BODY_PARAMS:
+        if param in request_params:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": (
+                        f"{param} cannot be overridden when testing a configured model. "
+                        "Provide the full connection parameters instead of naming a configured model."
+                    )
+                },
+            )
 
 
 def get_callback_identifier(callback):
@@ -1854,7 +1878,6 @@ async def test_model_connection(
                 )
 
         # Merge: config params (from proxy config) as base, request params override
-        # This allows users to override specific params while using config for credentials
         litellm_params = {**config_litellm_params, **request_litellm_params}
 
         ## Auth check
@@ -1869,6 +1892,8 @@ async def test_model_connection(
             prisma_client=prisma_client,
             premium_user=premium_user,
         )
+        if config_litellm_params:
+            _reject_banned_param_overrides(request_litellm_params)
         # Include health_check_params if provided
         litellm_params = _update_litellm_params_for_health_check(
             model_info={},

--- a/litellm/proxy/image_endpoints/endpoints.py
+++ b/litellm/proxy/image_endpoints/endpoints.py
@@ -70,6 +70,7 @@ async def image_generation(
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
     model: str | None = None,
 ):
+    from litellm.proxy.litellm_pre_call_utils import reject_url_valued_destination
     from litellm.proxy.proxy_server import (
         add_litellm_data_to_request,
         general_settings,
@@ -95,6 +96,9 @@ async def image_generation(
             version=version,
             proxy_config=proxy_config,
         )
+
+        if isinstance(model, str):
+            reject_url_valued_destination("model", model)
 
         data["model"] = (
             model

--- a/litellm/proxy/litellm_pre_call_utils.py
+++ b/litellm/proxy/litellm_pre_call_utils.py
@@ -262,29 +262,37 @@ def _reject_url_valued_destinations(data: dict[str, Any]) -> None:
     are unaffected, while admins can opt specific hosts back in via
     ``litellm.provider_url_destination_allowed_hosts``.
     """
-    allowed_hosts: Final = getattr(litellm, "provider_url_destination_allowed_hosts", []) or []
     for field in _URL_DESTINATION_REQUEST_FIELDS:
         value = data.get(field)
-        if not isinstance(value, str):
+        if isinstance(value, str):
+            reject_url_valued_destination(field, value)
+
+
+def reject_url_valued_destination(field: str, value: str) -> None:
+    """Reject a URL-valued destination identifier unless admin-allowlisted.
+
+    Operates on one field/value pair. ``_reject_url_valued_destinations`` applies
+    it across ``_URL_DESTINATION_REQUEST_FIELDS`` for a request body.
+    """
+    allowed_hosts: Final = getattr(litellm, "provider_url_destination_allowed_hosts", []) or []
+    for candidate in provider_url_destination_candidates(value):
+        if not candidate.lower().startswith(("http://", "https://")):
             continue
-        for candidate in provider_url_destination_candidates(value):
-            if not candidate.lower().startswith(("http://", "https://")):
-                continue
-            if is_url_destination_allowed_by_host(candidate, allowed_hosts):
-                continue
-            raise HTTPException(
-                status_code=400,
-                detail={
-                    "error": "invalid_request",
-                    "param": field,
-                    "message": (
-                        f"URL-valued '{field}' is not allowed. Configure custom "
-                        "endpoints with api_base instead, or add the destination "
-                        "host to `provider_url_destination_allowed_hosts` in "
-                        "litellm_settings."
-                    ),
-                },
-            )
+        if is_url_destination_allowed_by_host(candidate, allowed_hosts):
+            continue
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "invalid_request",
+                "param": field,
+                "message": (
+                    f"URL-valued '{field}' is not allowed. Configure custom "
+                    "endpoints with api_base instead, or add the destination "
+                    "host to `provider_url_destination_allowed_hosts` in "
+                    "litellm_settings."
+                ),
+            },
+        )
 
 
 def _strip_untrusted_request_header_controls(

--- a/tests/test_litellm/proxy/auth/test_auth_utils.py
+++ b/tests/test_litellm/proxy/auth/test_auth_utils.py
@@ -3010,3 +3010,80 @@ class TestGetKeyTagRateLimits:
     def test_returns_none_when_unset(self):
         key = UserAPIKeyAuth(api_key="sk-123")
         assert get_key_tag_rpm_limit(key) is None
+
+
+class TestIsRequestBodySafeChecksBracketNotationMetadata:
+    """Bracket notation is how multipart callers express nested metadata; it is
+    validated the same way the dict form is."""
+
+    @pytest.mark.parametrize("metadata_key", ["metadata", "litellm_metadata"])
+    def test_bracket_notation_banned_param_is_rejected(self, metadata_key):
+        with pytest.raises(ValueError, match="langfuse_host"):
+            is_request_body_safe(
+                request_body={
+                    "purpose": "assistants",
+                    f"{metadata_key}[langfuse_host]": "https://example.invalid",
+                },
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+
+    def test_bracket_notation_api_base_is_rejected(self):
+        with pytest.raises(ValueError, match="api_base"):
+            is_request_body_safe(
+                request_body={"litellm_metadata[api_base]": "https://example.invalid"},
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+
+    def test_bracket_notation_allowed_under_proxy_wide_opt_in(self):
+        assert (
+            is_request_body_safe(
+                request_body={"litellm_metadata[langfuse_host]": "https://byok.example"},
+                general_settings={"allow_client_side_credentials": True},
+                llm_router=None,
+                model="gpt-4",
+            )
+            is True
+        )
+
+    def test_benign_bracket_notation_metadata_is_allowed(self):
+        assert (
+            is_request_body_safe(
+                request_body={
+                    "purpose": "assistants",
+                    "litellm_metadata[spend_logs_metadata][owner]": "john",
+                    "litellm_metadata[tags]": "production",
+                },
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+            is True
+        )
+
+    def test_bracket_notation_matches_json_encoding_for_deeper_nesting(self):
+        """A value nested below the first level is treated the same either way:
+        the check descends one level into metadata, for both encodings."""
+        deep_bracket = {
+            "litellm_metadata[spend_logs_metadata][langfuse_host]": "https://example.invalid"
+        }
+        deep_json = {
+            "litellm_metadata": {"spend_logs_metadata": {"langfuse_host": "https://example.invalid"}}
+        }
+        kwargs = dict(general_settings={}, llm_router=None, model="gpt-4")
+        assert is_request_body_safe(request_body=deep_bracket, **kwargs) is True
+        assert is_request_body_safe(request_body=deep_json, **kwargs) is True
+
+    def test_body_without_bracket_keys_is_unaffected(self):
+        assert (
+            is_request_body_safe(
+                request_body={"model": "gpt-4", "messages": [{"role": "user", "content": "hi"}]},
+                general_settings={},
+                llm_router=None,
+                model="gpt-4",
+            )
+            is True
+        )

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -2379,12 +2379,14 @@ class TestConfigBaseForHealthCheck:
         "rpm": 100,
     }
 
-    def _base(self, config, request):
+    def _base(self, config, request, allow_client_side_credentials=False):
         from litellm.proxy.health_endpoints._health_endpoints import (
             _config_base_for_health_check,
         )
 
-        return _config_base_for_health_check(config, request)
+        return _config_base_for_health_check(
+            config, request, allow_client_side_credentials=allow_client_side_credentials
+        )
 
     def test_request_without_connection_fields_inherits_config(self):
         base = self._base(self.CONFIG, {"model": "openai/gpt-4o"})
@@ -2426,3 +2428,13 @@ class TestConfigBaseForHealthCheck:
         )
         assert "api_key" not in base
         assert "aws_secret_access_key" not in base
+
+    def test_opt_in_restores_configured_credentials_under_a_request_endpoint(self):
+        """With general_settings.allow_client_side_credentials enabled, a request
+        may pair its own endpoint with the configured credentials, as before."""
+        base = self._base(
+            self.CONFIG,
+            {"api_base": "https://caller.example/v1"},
+            allow_client_side_credentials=True,
+        )
+        assert base["api_key"] == "sk-configured"

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -2364,3 +2364,32 @@ def test_clean_endpoint_data_strips_credentials_keeps_routing_fields():
     assert "aws_access_key_id" not in cleaned
     assert cleaned.get("api_base") == "https://example.test/v1"
     assert cleaned.get("api_version") == "2024-10-21"
+
+
+class TestRejectBannedParamOverrides:
+    """Routing and credential fields come from the deployment configuration when a
+    request names a configured model; a request that wants its own connection
+    supplies the whole parameter set instead."""
+
+    def test_banned_param_is_refused(self):
+        from fastapi import HTTPException
+
+        from litellm.proxy.health_endpoints._health_endpoints import (
+            _reject_banned_param_overrides,
+        )
+
+        for param in ("api_base", "base_url", "vertex_credentials", "aws_web_identity_token"):
+            with pytest.raises(HTTPException) as exc_info:
+                _reject_banned_param_overrides({"model": "gpt-4o", param: "caller-supplied"})
+            assert exc_info.value.status_code == 400
+            assert param in str(exc_info.value.detail)
+
+    def test_benign_params_are_allowed(self):
+        from litellm.proxy.health_endpoints._health_endpoints import (
+            _reject_banned_param_overrides,
+        )
+
+        _reject_banned_param_overrides({})
+        _reject_banned_param_overrides({"model": "gpt-4o"})
+        _reject_banned_param_overrides({"model": "gpt-4o", "api_key": "sk-caller-owned"})
+        _reject_banned_param_overrides({"mode": "chat", "timeout": 30})

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -2438,3 +2438,22 @@ class TestConfigBaseForHealthCheck:
             allow_client_side_credentials=True,
         )
         assert base["api_key"] == "sk-configured"
+
+    def test_stored_credential_reference_is_dropped_with_the_credentials(self):
+        """A stored-credential name resolves to the same secrets downstream, so a
+        request that redirects the destination must not keep it either."""
+        config = {**self.CONFIG, "litellm_credential_name": "OpenAI-prod"}
+        base = self._base(config, {"api_base": "https://caller.example/v1"})
+        assert "litellm_credential_name" not in base
+        assert "api_key" not in base
+
+    def test_stored_credential_reference_kept_when_request_sets_no_connection(self):
+        """The Admin UI tests a configured model by naming it plus its stored
+        credential and nothing else; that keeps working."""
+        config = {**self.CONFIG, "litellm_credential_name": "OpenAI-prod"}
+        base = self._base(
+            config,
+            {"model": "openai/gpt-4o", "litellm_credential_name": "OpenAI-prod", "custom_llm_provider": "openai"},
+        )
+        assert base["litellm_credential_name"] == "OpenAI-prod"
+        assert base["api_key"] == "sk-configured"

--- a/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
+++ b/tests/test_litellm/proxy/health_endpoints/test_health_endpoints.py
@@ -2366,30 +2366,63 @@ def test_clean_endpoint_data_strips_credentials_keeps_routing_fields():
     assert cleaned.get("api_version") == "2024-10-21"
 
 
-class TestRejectBannedParamOverrides:
-    """Routing and credential fields come from the deployment configuration when a
-    request names a configured model; a request that wants its own connection
-    supplies the whole parameter set instead."""
+class TestConfigBaseForHealthCheck:
+    """A request that sets its own connection fields gets a base without the
+    configuration's credentials; anything it leaves unset still comes from
+    the configuration."""
 
-    def test_banned_param_is_refused(self):
-        from fastapi import HTTPException
+    CONFIG = {
+        "model": "openai/gpt-4o",
+        "api_key": "sk-configured",
+        "api_base": "https://configured.example/v1",
+        "vertex_credentials": "configured-creds",
+        "rpm": 100,
+    }
 
+    def _base(self, config, request):
         from litellm.proxy.health_endpoints._health_endpoints import (
-            _reject_banned_param_overrides,
+            _config_base_for_health_check,
         )
 
-        for param in ("api_base", "base_url", "vertex_credentials", "aws_web_identity_token"):
-            with pytest.raises(HTTPException) as exc_info:
-                _reject_banned_param_overrides({"model": "gpt-4o", param: "caller-supplied"})
-            assert exc_info.value.status_code == 400
-            assert param in str(exc_info.value.detail)
+        return _config_base_for_health_check(config, request)
 
-    def test_benign_params_are_allowed(self):
-        from litellm.proxy.health_endpoints._health_endpoints import (
-            _reject_banned_param_overrides,
+    def test_request_without_connection_fields_inherits_config(self):
+        base = self._base(self.CONFIG, {"model": "openai/gpt-4o"})
+        assert base["api_key"] == "sk-configured"
+        assert base["api_base"] == "https://configured.example/v1"
+
+    def test_request_setting_api_base_does_not_inherit_config_credentials(self):
+        base = self._base(self.CONFIG, {"api_base": "https://caller.example/v1"})
+        assert "api_key" not in base
+        assert "api_base" not in base
+        assert "vertex_credentials" not in base
+        assert base["rpm"] == 100
+
+    def test_add_model_flow_keeps_its_own_credentials(self):
+        """Adding a second deployment for an already-configured name sends a
+        complete connection; it is tested as sent, not as configured."""
+        request = {
+            "model": "openai/gpt-4o",
+            "api_base": "https://new-deployment.example/v1",
+            "api_key": "sk-new-deployment",
+        }
+        merged = {**self._base(self.CONFIG, request), **request}
+        assert merged["api_base"] == "https://new-deployment.example/v1"
+        assert merged["api_key"] == "sk-new-deployment"
+        assert "sk-configured" not in str(merged)
+
+    def test_destination_override_without_own_key_inherits_no_credential(self):
+        """A request that redirects the destination but supplies no credential
+        of its own gets none from the configuration."""
+        request = {"api_base": "https://elsewhere.example"}
+        merged = {**self._base(self.CONFIG, request), **request}
+        assert "api_key" not in merged
+        assert "sk-configured" not in str(merged)
+
+    def test_non_api_base_destination_field_also_drops_credentials(self):
+        base = self._base(
+            {**self.CONFIG, "aws_secret_access_key": "configured-secret"},
+            {"aws_bedrock_runtime_endpoint": "https://caller.example"},
         )
-
-        _reject_banned_param_overrides({})
-        _reject_banned_param_overrides({"model": "gpt-4o"})
-        _reject_banned_param_overrides({"model": "gpt-4o", "api_key": "sk-caller-owned"})
-        _reject_banned_param_overrides({"mode": "chat", "timeout": 30})
+        assert "api_key" not in base
+        assert "aws_secret_access_key" not in base

--- a/tests/test_litellm/proxy/image_endpoints/test_azure_routes.py
+++ b/tests/test_litellm/proxy/image_endpoints/test_azure_routes.py
@@ -120,3 +120,28 @@ def test_azure_image_edit_route(client_no_auth):
     assert called_kwargs["prompt"] == "A cute baby sea otter"
     assert response.status_code == 200
     assert response.json()["data"]
+
+
+def test_azure_image_generation_route_rejects_url_valued_path_model(client_no_auth):
+    """A URL-valued deployment segment is refused before any provider call."""
+    client, mock_aimage_generation, _ = client_no_auth
+    response = client.post(
+        "/openai/deployments/oobabooga/https://example.invalid/images/generations",
+        json={"prompt": "A cute baby sea otter", "n": 1, "size": "1024x1024"},
+    )
+
+    assert response.status_code == 400
+    assert "URL-valued" in response.text
+    mock_aimage_generation.assert_not_called()
+
+
+def test_azure_image_generation_route_allows_ordinary_path_model(client_no_auth):
+    """A deployment name that merely contains a provider prefix still routes."""
+    client, mock_aimage_generation, _ = client_no_auth
+    response = client.post(
+        "/openai/deployments/dall-e-3/images/generations",
+        json={"prompt": "A cute baby sea otter", "n": 1, "size": "1024x1024"},
+    )
+
+    assert response.status_code == 200
+    mock_aimage_generation.assert_called_once()

--- a/tests/test_litellm/proxy/test_provider_url_destination_guard.py
+++ b/tests/test_litellm/proxy/test_provider_url_destination_guard.py
@@ -177,3 +177,16 @@ async def test_add_litellm_data_to_request_rejects_url_valued_model():
         )
     assert exc_info.value.status_code == 400
     assert exc_info.value.detail["param"] == "model"
+
+
+class TestNonStringDestinationValues:
+    """Only string identifiers are inspected. Anything else is left alone for the
+    request's normal validation to handle."""
+
+    @pytest.mark.parametrize("value", [123, None, True, {"a": 1}, ["x"], 1.5])
+    def test_non_string_model_is_ignored(self, value):
+        _reject_url_valued_destinations({"model": value})
+
+    @pytest.mark.parametrize("value", [123, None, True, {"a": 1}, ["x"]])
+    def test_non_string_file_id_is_ignored(self, value):
+        _reject_url_valued_destinations({"file_id": value})


### PR DESCRIPTION
## TLDR

Problem this solves:

- Request-parameter checks covered the body only
- Path-supplied deployment names skipped the destination check
- Bracket-notation form metadata skipped the parameter check
- Connection tests could borrow a configured model's credentials

How it solves it:

- One destination check shared by body and path inputs
- Form metadata rebuilt with the helper endpoints already use
- Configured credentials stay with the endpoint they belong to
- Three admin opt-outs preserved for legitimate overrides

## Relevant issues

## Linear ticket

Resolves LIT-5261

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Verified against a live proxy on a dedicated port, with a local listener standing in for a
caller-chosen destination and a wildcard deployment so routing was not what stopped the request

Each of the three changes was exercised before and after, with the adjacent legitimate flows run
in the same pass: an ordinary chat completion, a normal deployment-path request, a plain file
upload, benign bracket metadata, a connection test that names a configured model, and a
connection test that supplies its own complete connection. All of those behave the same before
and after

Full request and response detail is available on request rather than published here, since the
before runs double as a working reproduction

Captured at 59173c3a20 (after) against origin/litellm_internal_staging at 8ec562f279 (before)

## Type

🐛 Bug Fix

## Changes

`reject_url_valued_destination(field, value)` is split out of
`_reject_url_valued_destinations` so a single field can be checked on its own. The body loop
delegates to it, and a deployment name resolved from the request path now runs through it too,
against the same `provider_url_destination_allowed_hosts` allowlist. Only a caller-supplied path
value is checked, so an operator who pins a URL-valued model through `completion_model` or the
`--model` CLI argument is unaffected

`is_request_body_safe` rebuilds bracket-notation metadata with
`extract_nested_form_metadata`, the same helper the endpoints already use to reconstruct that
dict. Reusing it keeps the two from drifting apart, and the reconstruction is inspected at the
same single level of nesting the dict form already gets, so the two encodings agree

`/health/test_connection` no longer merges a configured deployment's credentials underneath a
request that sets its own connection fields: those credentials belong to the endpoint the
configuration names. Anything the request leaves unset still comes from the configuration, so
naming a configured model and testing it as configured is unchanged, and the Add Model wizard,
which sends a complete connection, works whether or not its model name matches an existing
deployment. `general_settings.allow_client_side_credentials`, the existing proxy-wide opt-in for
callers supplying their own connection parameters, restores the previous merge behaviour

Three breaking changes, each with an existing opt-out:

- A URL-valued deployment name in the request path is refused; add the host to
  `provider_url_destination_allowed_hosts`
- A multipart `litellm_metadata[...]` field carrying a restricted parameter is refused; set
  `general_settings.allow_client_side_credentials` or the deployment's
  `configurable_clientside_auth_params`
- A connection test that sets its own connection fields no longer inherits the configured
  deployment's credentials; supply the credential alongside the endpoint, or set
  `general_settings.allow_client_side_credentials`

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches proxy auth, SSRF boundaries, and credential merging on admin health endpoints; behavior changes are intentional breaking fixes with opt-outs, but misconfiguration could block legitimate BYOK or deployment-path flows.
> 
> **Overview**
> Closes gaps where proxy security checks only applied to JSON bodies, letting path segments, multipart form metadata, and health-test merges bypass the same rules.
> 
> **URL-valued destinations** — `reject_url_valued_destination` is extracted so one check runs on JSON `model`/`file_id` and on **path-derived** deployment names (completions and Azure image routes). Non-string values are skipped.
> 
> **Multipart metadata** — `is_request_body_safe` now rebuilds `metadata[...]` / `litellm_metadata[...]` bracket keys via `extract_nested_form_metadata` and runs the same banned-param logic as nested dicts.
> 
> **Connection tests** — `/health/test_connection` merges router config through `_config_base_for_health_check`: if the request sets any `_BANNED_REQUEST_BODY_PARAMS` connection field, configured credentials (including `litellm_credential_name`) are stripped from the base unless `general_settings.allow_client_side_credentials` is enabled.
> 
> Each tightening has documented opt-outs (`provider_url_destination_allowed_hosts`, `allow_client_side_credentials`, deployment-level configurable auth params).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 298fb8ce56099774f310594c9970cc24a9b8f900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->