### PR TITLE
fix(ui): in-page close pops its own history entry so back always goes back

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useDetailHistoryClose.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useDetailHistoryClose.test.ts
@@ -1,0 +1,59 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useDetailHistoryClose } from "./useDetailHistoryClose";
+
+const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
+
+afterEach(() => {
+  backSpy.mockClear();
+});
+
+describe("useDetailHistoryClose", () => {
+  it("close after an in-session open pops the pushed entry instead of clearing params", () => {
+    const clearParams = vi.fn();
+    const { result } = renderHook(() => useDetailHistoryClose(clearParams));
+
+    act(() => result.current.markOpened());
+    act(() => result.current.close());
+
+    expect(backSpy).toHaveBeenCalledTimes(1);
+    expect(clearParams).not.toHaveBeenCalled();
+  });
+
+  it("close without an in-session open clears params so a deep-linked visitor is not ejected", () => {
+    const clearParams = vi.fn();
+    const { result } = renderHook(() => useDetailHistoryClose(clearParams));
+
+    act(() => result.current.close());
+
+    expect(backSpy).not.toHaveBeenCalled();
+    expect(clearParams).toHaveBeenCalledTimes(1);
+  });
+
+  it("a browser Back consumes the pushed entry, so a later close falls back to clearing", () => {
+    const clearParams = vi.fn();
+    const { result } = renderHook(() => useDetailHistoryClose(clearParams));
+
+    act(() => result.current.markOpened());
+    act(() => window.dispatchEvent(new PopStateEvent("popstate")));
+    act(() => result.current.close());
+
+    expect(backSpy).not.toHaveBeenCalled();
+    expect(clearParams).toHaveBeenCalledTimes(1);
+  });
+
+  it("the popstate caused by close itself does not consume a second entry", () => {
+    const clearParams = vi.fn();
+    const { result } = renderHook(() => useDetailHistoryClose(clearParams));
+
+    act(() => result.current.markOpened());
+    act(() => result.current.markOpened());
+    act(() => result.current.close());
+    act(() => window.dispatchEvent(new PopStateEvent("popstate")));
+    act(() => result.current.close());
+
+    expect(backSpy).toHaveBeenCalledTimes(2);
+    expect(clearParams).not.toHaveBeenCalled();
+  });
+});

--- a/ui/litellm-dashboard/src/app/(dashboard)/hooks/useDetailHistoryClose.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/hooks/useDetailHistoryClose.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export interface DetailHistoryClose {
+  markOpened: () => void;
+  close: () => void;
+}
+
+export function useDetailHistoryClose(clearParams: () => void): DetailHistoryClose {
+  const pushedCountRef = useRef(0);
+  const suppressPopRef = useRef(false);
+
+  useEffect(() => {
+    const onPop = () => {
+      if (suppressPopRef.current) {
+        suppressPopRef.current = false;
+        return;
+      }
+      if (pushedCountRef.current > 0) {
+        pushedCountRef.current -= 1;
+      }
+    };
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  const markOpened = useCallback(() => {
+    pushedCountRef.current += 1;
+  }, []);
+
+  const close = useCallback(() => {
+    if (pushedCountRef.current > 0) {
+      pushedCountRef.current -= 1;
+      suppressPopRef.current = true;
+      window.history.back();
+      return;
+    }
+    clearParams();
+  }, [clearParams]);
+
+  return { markOpened, close };
+}

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/detailNavigation.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/detailNavigation.test.ts
@@ -47,6 +47,24 @@ describe("useModelDetailRouting", () => {
     expect(event?.options.history).toBe("replace");
   });
 
+  it("close after an in-session open pops the pushed entry instead of writing the URL", async () => {
+    const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    const onUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>();
+    const { result } = renderHook(() => useModelDetailRouting(), {
+      wrapper: withNuqsTestingAdapter({ onUrlUpdate }),
+    });
+    await act(async () => {
+      result.current.openModel("abc-1");
+    });
+    await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled());
+    await act(async () => {
+      result.current.close();
+    });
+    expect(backSpy).toHaveBeenCalledTimes(1);
+    expect(onUrlUpdate.mock.calls.at(-1)?.[0].options.history).toBe("push");
+    backSpy.mockRestore();
+  });
+
   it("reads modelId and teamId from the query string", () => {
     const { result } = renderHook(() => useModelDetailRouting(), {
       wrapper: withNuqsTestingAdapter({ searchParams: "?model=xyz" }),

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/detailNavigation.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/detailNavigation.test.ts
@@ -44,6 +44,7 @@ describe("useModelDetailRouting", () => {
     const event = onUrlUpdate.mock.calls.at(-1)?.[0];
     expect(event?.searchParams.has("model")).toBe(false);
     expect(event?.searchParams.has("team")).toBe(false);
+    expect(event?.options.history).toBe("replace");
   });
 
   it("reads modelId and teamId from the query string", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/detailNavigation.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/detailNavigation.ts
@@ -30,7 +30,7 @@ export function useModelDetailRouting(): ModelDetailRouting {
   );
 
   const close = useCallback(() => {
-    void setParams({ model: null, team: null });
+    void setParams({ model: null, team: null }, { history: "replace" });
   }, [setParams]);
 
   return {

--- a/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/detailNavigation.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/models-and-endpoints/detailNavigation.ts
@@ -1,6 +1,8 @@
 import { parseAsString, useQueryStates } from "nuqs";
 import { useCallback } from "react";
 
+import { useDetailHistoryClose } from "@/app/(dashboard)/hooks/useDetailHistoryClose";
+
 export interface ModelDetailRouting {
   modelId: string | null;
   teamId: string | null;
@@ -15,23 +17,26 @@ export function useModelDetailRouting(): ModelDetailRouting {
     { history: "push" },
   );
 
+  const clearParams = useCallback(() => {
+    void setParams({ model: null, team: null }, { history: "replace" });
+  }, [setParams]);
+  const { markOpened, close } = useDetailHistoryClose(clearParams);
+
   const openModel = useCallback(
     (id: string) => {
+      markOpened();
       void setParams({ model: id, team: null });
     },
-    [setParams],
+    [markOpened, setParams],
   );
 
   const openTeam = useCallback(
     (id: string) => {
+      markOpened();
       void setParams({ model: null, team: id });
     },
-    [setParams],
+    [markOpened, setParams],
   );
-
-  const close = useCallback(() => {
-    void setParams({ model: null, team: null }, { history: "replace" });
-  }, [setParams]);
 
   return {
     modelId: model,

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.test.tsx
@@ -135,6 +135,9 @@ describe("OrganizationsPanel - org detail deep link (?org=)", () => {
     act(() => mockOrgInfoView.mock.calls.at(-1)?.[0].onClose());
 
     await expectQueryString("");
+    expect(onUrlUpdate).toHaveBeenLastCalledWith(
+      expect.objectContaining({ options: expect.objectContaining({ history: "replace" }) }),
+    );
     expect(screen.queryByTestId("organization-info-view")).not.toBeInTheDocument();
     expect(screen.getByTestId("organizations-table")).toBeInTheDocument();
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.test.tsx
@@ -142,6 +142,19 @@ describe("OrganizationsPanel - org detail deep link (?org=)", () => {
     expect(screen.getByTestId("organizations-table")).toBeInTheDocument();
   });
 
+  it("closing an org opened this session pops history instead of writing the URL", async () => {
+    const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    renderPanel();
+
+    act(() => capturedTableProps?.onOrganizationClick("org-in-session"));
+    await waitFor(() => expect(mockOrgInfoView).toHaveBeenCalled());
+
+    act(() => mockOrgInfoView.mock.calls.at(-1)?.[0].onClose());
+
+    expect(backSpy).toHaveBeenCalledTimes(1);
+    backSpy.mockRestore();
+  });
+
   it("the edit action opens the detail in edit mode with ?org= set", async () => {
     renderPanel();
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
@@ -109,7 +109,7 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
         <OrganizationInfoView
           organizationId={selectedOrgId}
           onClose={() => {
-            void setSelectedOrgId(null);
+            void setSelectedOrgId(null, { history: "replace" });
             setEditOrg(false);
           }}
           accessToken={accessToken}

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
@@ -1,9 +1,10 @@
 import { organizationKeys, useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 import { useUserModels } from "@/app/(dashboard)/hooks/models/useModels";
 import OrganizationFilters, { FilterState } from "@/app/(dashboard)/organizations/OrganizationFilters";
+import { useDetailHistoryClose } from "@/app/(dashboard)/hooks/useDetailHistoryClose";
 import { useQueryClient } from "@tanstack/react-query";
 import { parseAsString, useQueryState } from "nuqs";
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import DeleteResourceModal from "@/components/common_components/DeleteResourceModal";
 import NotificationsManager from "@/components/molecules/notifications_manager";
 import { organizationDeleteCall } from "@/components/networking";
@@ -21,6 +22,8 @@ interface OrganizationsPanelProps {
 
 const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, accessToken, premiumUser }) => {
   const [selectedOrgId, setSelectedOrgId] = useQueryState("org", parseAsString.withOptions({ history: "push" }));
+  const clearSelectedOrg = useCallback(() => void setSelectedOrgId(null, { history: "replace" }), [setSelectedOrgId]);
+  const { markOpened: markOrgOpened, close: closeOrgDetail } = useDetailHistoryClose(clearSelectedOrg);
   const [editOrg, setEditOrg] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [orgToDelete, setOrgToDelete] = useState<string | null>(null);
@@ -109,7 +112,7 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
         <OrganizationInfoView
           organizationId={selectedOrgId}
           onClose={() => {
-            void setSelectedOrgId(null, { history: "replace" });
+            closeOrgDetail();
             setEditOrg(false);
           }}
           accessToken={accessToken}
@@ -135,9 +138,11 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
             searchActive={searchActive}
             onOrganizationClick={(organizationId) => {
               setEditOrg(false);
+              markOrgOpened();
               void setSelectedOrgId(organizationId);
             }}
             onEditClick={(organizationId) => {
+              markOrgOpened();
               void setSelectedOrgId(organizationId);
               setEditOrg(true);
             }}

--- a/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/organizations/_components/OrganizationsPanel.tsx
@@ -51,6 +51,18 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
     setFilters({ org_id: "", org_alias: "" });
   };
 
+  const handleOrganizationOpen = (organizationId: string) => {
+    setEditOrg(false);
+    markOrgOpened();
+    void setSelectedOrgId(organizationId);
+  };
+
+  const handleOrganizationEdit = (organizationId: string) => {
+    markOrgOpened();
+    void setSelectedOrgId(organizationId);
+    setEditOrg(true);
+  };
+
   const handleDelete = (orgId: string | null) => {
     if (!orgId) return;
 
@@ -136,16 +148,8 @@ const OrganizationsPanel: React.FC<OrganizationsPanelProps> = ({ userRole, acces
             isLoading={isLoading}
             userRole={userRole}
             searchActive={searchActive}
-            onOrganizationClick={(organizationId) => {
-              setEditOrg(false);
-              markOrgOpened();
-              void setSelectedOrgId(organizationId);
-            }}
-            onEditClick={(organizationId) => {
-              markOrgOpened();
-              void setSelectedOrgId(organizationId);
-              setEditOrg(true);
-            }}
+            onOrganizationClick={handleOrganizationOpen}
+            onEditClick={handleOrganizationEdit}
             onDeleteClick={handleDelete}
           />
         </>

--- a/ui/litellm-dashboard/src/components/Teams.test.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.test.tsx
@@ -500,6 +500,22 @@ describe("Teams - team detail deep link (?team=)", () => {
     expect(onUrlUpdate.mock.calls.at(-1)![0].options.history).toBe("replace");
     await waitFor(() => expect(screen.queryByTestId("team-info-view")).not.toBeInTheDocument());
   });
+
+  it("closing a team opened this session pops history instead of writing the URL", async () => {
+    const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    const onUrlUpdate = vi.fn();
+    renderWithQueryClient(<Teams accessToken="test-token" userID="user-123" userRole="Admin" />, { onUrlUpdate });
+
+    await waitFor(() => expect(mockTeamsTableProps).not.toBeNull());
+    act(() => mockTeamsTableProps.onSelectTeam({ ...baseTableTeam, team_id: "team-in-session" }));
+    await waitFor(() => expect(mockTeamInfoView).toHaveBeenCalled());
+
+    act(() => mockTeamInfoView.mock.calls.at(-1)?.[0].onClose());
+
+    expect(backSpy).toHaveBeenCalledTimes(1);
+    expect(onUrlUpdate.mock.calls.at(-1)![0].options.history).toBe("push");
+    backSpy.mockRestore();
+  });
 });
 
 describe("Teams - Create Team CTA is grouped with the tabs on the left", () => {

--- a/ui/litellm-dashboard/src/components/Teams.test.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.test.tsx
@@ -497,6 +497,7 @@ describe("Teams - team detail deep link (?team=)", () => {
 
     await waitFor(() => expect(onUrlUpdate).toHaveBeenCalled());
     expect(onUrlUpdate.mock.calls.at(-1)![0].searchParams.has("team")).toBe(false);
+    expect(onUrlUpdate.mock.calls.at(-1)![0].options.history).toBe("replace");
     await waitFor(() => expect(screen.queryByTestId("team-info-view")).not.toBeInTheDocument());
   });
 });

--- a/ui/litellm-dashboard/src/components/Teams.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.tsx
@@ -538,7 +538,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
           }}
           onClose={() => {
             setSelectedTeam(null);
-            void setSelectedTeamId(null);
+            void setSelectedTeamId(null, { history: "replace" });
             setEditTeam(false);
           }}
           accessToken={accessToken}

--- a/ui/litellm-dashboard/src/components/Teams.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.tsx
@@ -142,7 +142,10 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
 
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
   const [selectedTeamId, setSelectedTeamId] = useQueryState("team", parseAsString.withOptions({ history: "push" }));
-  const clearSelectedTeam = useCallback(() => void setSelectedTeamId(null, { history: "replace" }), [setSelectedTeamId]);
+  const clearSelectedTeam = useCallback(
+    () => void setSelectedTeamId(null, { history: "replace" }),
+    [setSelectedTeamId],
+  );
   const { markOpened: markTeamOpened, close: closeTeamDetail } = useDetailHistoryClose(clearSelectedTeam);
   const [editTeam, setEditTeam] = useState<boolean>(false);
 

--- a/ui/litellm-dashboard/src/components/Teams.tsx
+++ b/ui/litellm-dashboard/src/components/Teams.tsx
@@ -7,11 +7,12 @@ import { InfoCircleOutlined } from "@ant-design/icons";
 import { Accordion, AccordionBody, AccordionHeader, TextInput } from "@tremor/react";
 import { Button, Form, Input, Layout, Modal, Select, Switch, Tabs, theme, Tooltip, Typography } from "antd";
 import { Plus, Users } from "lucide-react";
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { PageHeader } from "@/components/shared/PageHeader";
 import { Button as UIButton } from "@/components/ui/button";
 import { teamsTableKeys } from "@/app/(dashboard)/hooks/teams/useTeams";
+import { useDetailHistoryClose } from "@/app/(dashboard)/hooks/useDetailHistoryClose";
 import { parseAsString, useQueryState } from "nuqs";
 import { TeamsTable } from "./TeamsPage/TeamsTable";
 import AccessGroupSelector from "./common_components/AccessGroupSelector";
@@ -141,6 +142,8 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
 
   const [selectedTeam, setSelectedTeam] = useState<Team | null>(null);
   const [selectedTeamId, setSelectedTeamId] = useQueryState("team", parseAsString.withOptions({ history: "push" }));
+  const clearSelectedTeam = useCallback(() => void setSelectedTeamId(null, { history: "replace" }), [setSelectedTeamId]);
+  const { markOpened: markTeamOpened, close: closeTeamDetail } = useDetailHistoryClose(clearSelectedTeam);
   const [editTeam, setEditTeam] = useState<boolean>(false);
 
   const [isTeamModalVisible, setIsTeamModalVisible] = useState(false);
@@ -473,11 +476,13 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
             userID={userID}
             onSelectTeam={(team) => {
               setSelectedTeam(team);
+              markTeamOpened();
               void setSelectedTeamId(team.team_id);
               setEditTeam(false);
             }}
             onEditTeam={(team) => {
               setSelectedTeam(team);
+              markTeamOpened();
               void setSelectedTeamId(team.team_id);
               setEditTeam(true);
             }}
@@ -538,7 +543,7 @@ const Teams: React.FC<TeamProps> = ({ accessToken, userID, userRole, premiumUser
           }}
           onClose={() => {
             setSelectedTeam(null);
-            void setSelectedTeamId(null, { history: "replace" });
+            closeTeamDetail();
             setEditTeam(false);
           }}
           accessToken={accessToken}

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -388,6 +388,7 @@ it("renders KeyInfoView when the URL has ?key= for a key on the current page, wi
   await waitFor(() => {
     expect(lastKeyParam(onUrlUpdate)).toBeNull();
   });
+  expect(onUrlUpdate.mock.calls.at(-1)?.[0].options.history).toBe("replace");
   expect(screen.getByTestId("pagination-range")).toBeInTheDocument();
 });
 

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.test.tsx
@@ -392,6 +392,29 @@ it("renders KeyInfoView when the URL has ?key= for a key on the current page, wi
   expect(screen.getByTestId("pagination-range")).toBeInTheDocument();
 });
 
+it("closing a key opened this session pops history instead of writing the URL", async () => {
+  const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
+  const onUrlUpdate = vi.fn<OnUrlUpdateFunction>();
+  renderWithProviders(<VirtualKeysTable />, { onUrlUpdate });
+
+  await waitFor(() => {
+    expect(screen.getByText("Test Key Alias")).toBeInTheDocument();
+  });
+  fireEvent.click(screen.getByText("Test Key Alias"));
+  await waitFor(() => {
+    expect(screen.getByText("Back to Keys")).toBeInTheDocument();
+  });
+  expect(lastKeyParam(onUrlUpdate)).toBe(mockKey.token);
+
+  fireEvent.click(screen.getByText("Back to Keys"));
+
+  await waitFor(() => {
+    expect(backSpy).toHaveBeenCalledTimes(1);
+  });
+  expect(onUrlUpdate.mock.calls.at(-1)?.[0].options.history).toBe("push");
+  backSpy.mockRestore();
+});
+
 it("fetches the key by id when the URL has ?key= for a key not in the loaded page", async () => {
   mockUseKeyInfo.mockReturnValue(
     keyInfoResult({ ...mockKey, token: "other-key-hash", key_alias: "Fetched Key Alias" }),

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useDetailHistoryClose } from "@/app/(dashboard)/hooks/useDetailHistoryClose";
 import { useKeyInfo } from "@/app/(dashboard)/hooks/keys/useKeyInfo";
 import { useKeys } from "@/app/(dashboard)/hooks/keys/useKeys";
 import { useOrganizations } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
@@ -50,6 +51,8 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
   const allTeams = useMemo<Team[]>(() => fetchedTeams ?? [], [fetchedTeams]);
 
   const [selectedKeyId, setSelectedKeyId] = useQueryState("key", parseAsString.withOptions({ history: "push" }));
+  const clearSelectedKey = useCallback(() => void setSelectedKeyId(null, { history: "replace" }), [setSelectedKeyId]);
+  const { markOpened, close: closeKeyDetail } = useDetailHistoryClose(clearSelectedKey);
   const [sorting, setSorting] = useState<SortingState>(DEFAULT_SORTING);
   const [tablePagination, setTablePagination] = useState<PaginationState>({ pageIndex: 0, pageSize: 50 });
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -105,8 +108,16 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
   }, []);
 
   const columns = useMemo(
-    () => getKeyTableColumns({ allTeams, organizations, onSelectKey: (key) => void setSelectedKeyId(key.token) }),
-    [allTeams, organizations, setSelectedKeyId],
+    () =>
+      getKeyTableColumns({
+        allTeams,
+        organizations,
+        onSelectKey: (key) => {
+          markOpened();
+          void setSelectedKeyId(key.token);
+        },
+      }),
+    [allTeams, organizations, markOpened, setSelectedKeyId],
   );
 
   const selectedKeyFromList = useMemo(
@@ -161,7 +172,7 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
       <div className="w-full h-full overflow-hidden">
         <KeyInfoView
           keyId={selectedKeyId}
-          onClose={() => void setSelectedKeyId(null, { history: "replace" })}
+          onClose={closeKeyDetail}
           keyData={selectedKey}
           teams={allTeams}
           onDelete={refetch}

--- a/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
+++ b/ui/litellm-dashboard/src/components/VirtualKeysPage/VirtualKeysTable.tsx
@@ -161,7 +161,7 @@ export function VirtualKeysTable({ headerActions }: VirtualKeysTableProps) {
       <div className="w-full h-full overflow-hidden">
         <KeyInfoView
           keyId={selectedKeyId}
-          onClose={() => void setSelectedKeyId(null)}
+          onClose={() => void setSelectedKeyId(null, { history: "replace" })}
           keyData={selectedKey}
           teams={allTeams}
           onDelete={refetch}

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
@@ -310,6 +310,7 @@ describe("RequestLogsPanel", () => {
 
       await waitFor(() => expect(urlParams().get("log_id")).toBeNull());
       await waitFor(() => expect(drawer()).toHaveTextContent("closed"));
+      expect(historyModes()).toEqual(["push", "replace"]);
     });
 
     it("switching logs inside the drawer replaces the URL, so back closes the drawer in one step", async () => {

--- a/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/RequestLogsPanel.test.tsx
@@ -297,7 +297,8 @@ describe("RequestLogsPanel", () => {
       expect(byIdCall.page_size).toBe(1);
     });
 
-    it("closing the drawer removes ?log_id= from the URL and closes the drawer", async () => {
+    it("closing a drawer opened this session pops the pushed history entry", async () => {
+      const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
       const user = userEvent.setup();
       respondWith([logEntry({ request_id: "req-1" })]);
       renderPanel();
@@ -308,9 +309,26 @@ describe("RequestLogsPanel", () => {
 
       await user.click(screen.getByRole("button", { name: "close-drawer" }));
 
+      await waitFor(() => expect(backSpy).toHaveBeenCalledTimes(1));
+      expect(historyModes()).toEqual(["push"]);
+      backSpy.mockRestore();
+    });
+
+    it("closing a deep-linked drawer clears the URL with replace instead of ejecting the visitor", async () => {
+      const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
+      const user = userEvent.setup();
+      respondWith([logEntry({ request_id: "req-1" })]);
+      renderPanel("?log_id=req-1");
+
+      await waitFor(() => expect(drawer()).toHaveTextContent("open"));
+
+      await user.click(screen.getByRole("button", { name: "close-drawer" }));
+
       await waitFor(() => expect(urlParams().get("log_id")).toBeNull());
       await waitFor(() => expect(drawer()).toHaveTextContent("closed"));
-      expect(historyModes()).toEqual(["push", "replace"]);
+      expect(historyModes()).toEqual(["replace"]);
+      expect(backSpy).not.toHaveBeenCalled();
+      backSpy.mockRestore();
     });
 
     it("switching logs inside the drawer replaces the URL, so back closes the drawer in one step", async () => {
@@ -371,7 +389,8 @@ describe("RequestLogsPanel", () => {
       });
     });
 
-    it("closing a drawer opened via a session id clears both params", async () => {
+    it("closing a session drawer opened this session pops the pushed history entry", async () => {
+      const backSpy = vi.spyOn(window.history, "back").mockImplementation(() => {});
       const user = userEvent.setup();
       respondWith([logEntry({ request_id: "req-solo", session_id: "sess-solo", session_total_count: 1 })]);
       renderPanel();
@@ -382,9 +401,23 @@ describe("RequestLogsPanel", () => {
 
       await user.click(screen.getByRole("button", { name: "close-drawer" }));
 
+      await waitFor(() => expect(backSpy).toHaveBeenCalledTimes(1));
+      backSpy.mockRestore();
+    });
+
+    it("closing a deep-linked session drawer clears both params with replace", async () => {
+      const user = userEvent.setup();
+      respondWith([logEntry({ request_id: "req-solo", session_id: "sess-solo", session_total_count: 1 })]);
+      renderPanel("?log_id=req-solo&session_id=sess-solo");
+
+      await waitFor(() => expect(drawer()).toHaveTextContent("open"));
+
+      await user.click(screen.getByRole("button", { name: "close-drawer" }));
+
       await waitFor(() => expect(drawer()).toHaveTextContent("closed"));
       expect(urlParams().get("session_id")).toBeNull();
       expect(urlParams().get("log_id")).toBeNull();
+      expect(historyModes()).toEqual(["replace"]);
     });
 
     it("opens a deep-linked multi-call session log in session mode", async () => {

--- a/ui/litellm-dashboard/src/components/view_logs/logDetailRouting.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/logDetailRouting.ts
@@ -1,6 +1,8 @@
 import { parseAsString, useQueryStates } from "nuqs";
 import { useCallback } from "react";
 
+import { useDetailHistoryClose } from "@/app/(dashboard)/hooks/useDetailHistoryClose";
+
 export const LOG_ID_QUERY_PARAM = "log_id";
 export const SESSION_ID_QUERY_PARAM = "session_id";
 
@@ -19,18 +21,25 @@ export function useLogDetailRouting(): LogDetailRouting {
     { history: "push" },
   );
 
+  const clearParams = useCallback(() => {
+    void setParams({ log_id: null, session_id: null }, { history: "replace" });
+  }, [setParams]);
+  const { markOpened, close } = useDetailHistoryClose(clearParams);
+
   const openLog = useCallback(
     (requestId: string) => {
+      markOpened();
       void setParams({ log_id: requestId, session_id: null });
     },
-    [setParams],
+    [markOpened, setParams],
   );
 
   const openSession = useCallback(
     (sessionId: string, requestId: string | null) => {
+      markOpened();
       void setParams({ session_id: sessionId, log_id: requestId });
     },
-    [setParams],
+    [markOpened, setParams],
   );
 
   const selectLog = useCallback(
@@ -41,10 +50,6 @@ export function useLogDetailRouting(): LogDetailRouting {
     },
     [setParams],
   );
-
-  const close = useCallback(() => {
-    void setParams({ log_id: null, session_id: null }, { history: "replace" });
-  }, [setParams]);
 
   return {
     logId: log_id,

--- a/ui/litellm-dashboard/src/components/view_logs/logDetailRouting.ts
+++ b/ui/litellm-dashboard/src/components/view_logs/logDetailRouting.ts
@@ -43,7 +43,7 @@ export function useLogDetailRouting(): LogDetailRouting {
   );
 
   const close = useCallback(() => {
-    void setParams({ log_id: null, session_id: null });
+    void setParams({ log_id: null, session_id: null }, { history: "replace" });
   }, [setParams]);
 
   return {


### PR DESCRIPTION
## TLDR

Problem this solves:

- Closing a detail view then pressing Back reopened it
- Replacing on close instead left a dead Back press

How it solves it:

- Close pops its own pushed history entry via history.back
- Deep-linked visitors fall back to a replace clear
- One shared useDetailHistoryClose hook, applied to all five detail pages

## Relevant issues

## Linear ticket

Refs LIT-5217

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

The change is history-stack behavior, which a static screenshot cannot capture, so the proof is the manual QA below plus unit tests on the shared hook and on every page's close path (regressions to push-on-close or to clearing for in-session opens each fail a pinned test)

Manual QA against a local proxy (each page behaves identically):

1. Open http://localhost:4000/ui/?page=api-keys and click a key; the URL gains ?key=
2. Click "Back to Keys" in the page, then press browser Back once; you leave the Virtual Keys page for wherever you were before, with no dead press and no reopened detail
3. Paste a ?key= deep link into a fresh tab, click "Back to Keys"; you stay on the list (the URL clears in place) instead of being thrown out of the site
4. Open a detail and press browser Back without using the in-page close; the detail still closes
5. Repeat on teams (?team=), organizations (?org=), models (?model=) and logs (?log_id=)

## Type

🐛 Bug Fix

## Changes

Greptile raised on an earlier PR that clearing a query param through a push-configured setter turns every in-page close into a new history entry, so browser Back resurrects the view the user dismissed. The first iteration of this PR switched close to replace, which trades that for a duplicate list entry and one dead Back press. Neither is what a user expects: Back should just go back

Close now goes through a new shared hook, `useDetailHistoryClose`. Opening a detail calls `markOpened`, so the hook knows the current entry was pushed in this session; in-page close then consumes that entry with `history.back()`, leaving the stack exactly as it was before the detail opened. A visitor who arrived on a deep link never marked an open, so close falls back to clearing the params with replace, which keeps them on the list instead of ejecting them to whatever preceded the site in their history. A popstate listener decrements the count when the user closes with browser Back themselves (with the hook's own back() suppressed), so a later in-page close does not pop an entry it no longer owns

All five detail surfaces adopt it: VirtualKeysTable ?key=, Teams ?team=, OrganizationsPanel ?org=, models detailNavigation ?model=/?team=, and logs logDetailRouting ?log_id=/?session_id= (log switching inside the drawer keeps its replace semantics). The projects page detail (open PR #36001) currently closes with replace and adopts this hook in a follow-up once both land, since the hook ships here

The hook has its own unit tests covering the pop, the deep-link fallback, the browser-Back consumption, and the self-popstate suppression; every page keeps a deep-link close test pinning the replace fallback and gains an in-session close test pinning the history.back path

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
