### PR TITLE
fix(proxy): send keepalive pings on anthropic messages SSE streams during upstream silence

### DIFF
--- a/litellm/__init__.py
+++ b/litellm/__init__.py
@@ -244,6 +244,7 @@ use_chat_completions_url_for_anthropic_messages: bool = bool(
 # Or via `litellm_settings.strip_anthropic_total_tokens: true` in
 # config.yaml.
 strip_anthropic_total_tokens: bool = False
+anthropic_sse_ping_interval_seconds: float = 15.0
 route_all_chat_openai_to_responses: bool = (
     os.getenv("LITELLM_ROUTE_ALL_CHAT_OPENAI_TO_RESPONSES", "false").lower() == "true"
 )  # When True, routes all OpenAI /chat/completions requests through the Responses API bridge

--- a/litellm/proxy/common_request_processing.py
+++ b/litellm/proxy/common_request_processing.py
@@ -46,6 +46,7 @@ from litellm.proxy.common_utils.callback_utils import (
     get_logging_caching_headers,
     get_remaining_tokens_and_requests_from_request_data,
 )
+from litellm.proxy.common_utils.sse_keepalive import wrap_sse_stream_with_keepalive_pings
 from litellm.proxy.dd_span_tagger import DDSpanTagger
 from litellm.proxy.route_llm_request import route_request
 from litellm.proxy.utils import ProxyLogging, _check_and_merge_model_level_guardrails
@@ -1950,7 +1951,10 @@ class ProxyBaseLLMRequestProcessing:
                             request=request,
                         )
                         return await create_response(
-                            generator=selected_data_generator,
+                            generator=wrap_sse_stream_with_keepalive_pings(
+                                stream=selected_data_generator,
+                                ping_interval_seconds=litellm.anthropic_sse_ping_interval_seconds,
+                            ),
                             media_type="text/event-stream",
                             headers=custom_headers,
                             request=request,

--- a/litellm/proxy/common_utils/sse_keepalive.py
+++ b/litellm/proxy/common_utils/sse_keepalive.py
@@ -1,0 +1,43 @@
+import asyncio
+import contextlib
+from collections.abc import AsyncGenerator
+from typing import Final
+
+import anyio
+
+ANTHROPIC_PING_SSE_CHUNK: Final = 'event: ping\ndata: {"type": "ping"}\n\n'
+
+
+def wrap_sse_stream_with_keepalive_pings(
+    stream: AsyncGenerator[str, None],
+    ping_interval_seconds: float,
+) -> AsyncGenerator[str, None]:
+    if ping_interval_seconds <= 0:
+        return stream
+    return _keepalive_ping_stream(stream=stream, ping_interval_seconds=ping_interval_seconds)
+
+
+async def _keepalive_ping_stream(
+    stream: AsyncGenerator[str, None],
+    ping_interval_seconds: float,
+) -> AsyncGenerator[str, None]:
+    pending = asyncio.ensure_future(
+        stream.__anext__()
+    )  # rebind-ok: re-armed with the next __anext__ after each delivered chunk
+    try:
+        while True:
+            await asyncio.wait({pending}, timeout=ping_interval_seconds)
+            if not pending.done():
+                yield ANTHROPIC_PING_SSE_CHUNK
+                continue
+            try:
+                yield pending.result()
+            except StopAsyncIteration:
+                return
+            pending = asyncio.ensure_future(stream.__anext__())
+    finally:
+        pending.cancel()
+        with anyio.CancelScope(shield=True):
+            with contextlib.suppress(BaseException):
+                await pending
+            await stream.aclose()

--- a/litellm/proxy/common_utils/sse_keepalive.py
+++ b/litellm/proxy/common_utils/sse_keepalive.py
@@ -14,7 +14,7 @@ def _coerce_interval(ping_interval_seconds: float | str | None) -> float | None:
         return None
     try:
         interval: Final = float(ping_interval_seconds)
-    except ValueError:
+    except (TypeError, ValueError):
         return None
     if not math.isfinite(interval) or interval <= 0:
         return None

--- a/litellm/proxy/common_utils/sse_keepalive.py
+++ b/litellm/proxy/common_utils/sse_keepalive.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import math
 from collections.abc import AsyncGenerator
 from typing import Final
 
@@ -8,13 +9,26 @@ import anyio
 ANTHROPIC_PING_SSE_CHUNK: Final = 'event: ping\ndata: {"type": "ping"}\n\n'
 
 
+def _coerce_interval(ping_interval_seconds: float | str | None) -> float | None:
+    if ping_interval_seconds is None:
+        return None
+    try:
+        interval: Final = float(ping_interval_seconds)
+    except ValueError:
+        return None
+    if not math.isfinite(interval) or interval <= 0:
+        return None
+    return interval
+
+
 def wrap_sse_stream_with_keepalive_pings(
     stream: AsyncGenerator[str, None],
-    ping_interval_seconds: float,
+    ping_interval_seconds: float | str | None,
 ) -> AsyncGenerator[str, None]:
-    if ping_interval_seconds <= 0:
+    interval: Final = _coerce_interval(ping_interval_seconds)
+    if interval is None:
         return stream
-    return _keepalive_ping_stream(stream=stream, ping_interval_seconds=ping_interval_seconds)
+    return _keepalive_ping_stream(stream=stream, ping_interval_seconds=interval)
 
 
 async def _keepalive_ping_stream(

--- a/tests/test_litellm/proxy/common_utils/test_sse_keepalive.py
+++ b/tests/test_litellm/proxy/common_utils/test_sse_keepalive.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import AsyncGenerator
-from typing import Final
+from typing import Final, cast
 
 import pytest
 from fastapi.responses import StreamingResponse
@@ -105,7 +105,19 @@ async def test_non_positive_interval_returns_stream_unwrapped():
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("bad_interval", [None, "abc", "", float("inf"), float("nan"), "-3"])
+@pytest.mark.parametrize(
+    "bad_interval",
+    [
+        None,
+        "abc",
+        "",
+        float("inf"),
+        float("nan"),
+        "-3",
+        cast("float | str | None", [15]),
+        cast("float | str | None", {"seconds": 15}),
+    ],
+)
 async def test_invalid_config_interval_returns_stream_unwrapped(bad_interval: float | str | None):
     async def any_stream() -> AsyncGenerator[str, None]:
         yield MESSAGE_START_CHUNK

--- a/tests/test_litellm/proxy/common_utils/test_sse_keepalive.py
+++ b/tests/test_litellm/proxy/common_utils/test_sse_keepalive.py
@@ -1,0 +1,122 @@
+import asyncio
+from collections.abc import AsyncGenerator
+from typing import Final
+
+import pytest
+from fastapi.responses import StreamingResponse
+
+from litellm.proxy.common_request_processing import create_response
+from litellm.proxy.common_utils.sse_keepalive import (
+    ANTHROPIC_PING_SSE_CHUNK,
+    wrap_sse_stream_with_keepalive_pings,
+)
+
+MESSAGE_START_CHUNK: Final = 'data: {"type": "message_start"}\n\n'
+TEXT_DELTA_CHUNK: Final = 'data: {"type": "content_block_delta"}\n\n'
+
+
+@pytest.mark.asyncio
+async def test_pings_fill_mid_stream_silence_and_preserve_chunk_order():
+    async def gappy_stream() -> AsyncGenerator[str, None]:
+        yield MESSAGE_START_CHUNK
+        await asyncio.sleep(0.3)
+        yield TEXT_DELTA_CHUNK
+
+    wrapped: Final = wrap_sse_stream_with_keepalive_pings(stream=gappy_stream(), ping_interval_seconds=0.05)
+    collected: Final = [chunk async for chunk in wrapped]
+
+    assert collected[0] == MESSAGE_START_CHUNK
+    assert collected[-1] == TEXT_DELTA_CHUNK
+    assert ANTHROPIC_PING_SSE_CHUNK in collected[1:-1]
+    assert [chunk for chunk in collected if chunk != ANTHROPIC_PING_SSE_CHUNK] == [
+        MESSAGE_START_CHUNK,
+        TEXT_DELTA_CHUNK,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ping_emitted_while_waiting_for_first_chunk():
+    async def slow_start_stream() -> AsyncGenerator[str, None]:
+        await asyncio.sleep(0.2)
+        yield MESSAGE_START_CHUNK
+
+    wrapped: Final = wrap_sse_stream_with_keepalive_pings(stream=slow_start_stream(), ping_interval_seconds=0.05)
+    collected: Final = [chunk async for chunk in wrapped]
+
+    assert collected[0] == ANTHROPIC_PING_SSE_CHUNK
+    assert collected[-1] == MESSAGE_START_CHUNK
+
+
+@pytest.mark.asyncio
+async def test_no_pings_when_chunks_arrive_faster_than_interval():
+    async def fast_stream() -> AsyncGenerator[str, None]:
+        yield MESSAGE_START_CHUNK
+        yield TEXT_DELTA_CHUNK
+        yield TEXT_DELTA_CHUNK
+
+    wrapped: Final = wrap_sse_stream_with_keepalive_pings(stream=fast_stream(), ping_interval_seconds=1.0)
+    collected: Final = [chunk async for chunk in wrapped]
+
+    assert collected == [MESSAGE_START_CHUNK, TEXT_DELTA_CHUNK, TEXT_DELTA_CHUNK]
+
+
+@pytest.mark.asyncio
+async def test_upstream_exception_propagates():
+    async def failing_stream() -> AsyncGenerator[str, None]:
+        yield MESSAGE_START_CHUNK
+        raise ValueError("upstream broke")
+
+    wrapped: Final = wrap_sse_stream_with_keepalive_pings(stream=failing_stream(), ping_interval_seconds=5.0)
+
+    assert await wrapped.__anext__() == MESSAGE_START_CHUNK
+    with pytest.raises(ValueError, match="upstream broke"):
+        await wrapped.__anext__()
+
+
+@pytest.mark.asyncio
+async def test_aclose_mid_silence_cancels_upstream_and_runs_its_cleanup():
+    upstream_cleaned_up: Final = asyncio.Event()
+
+    async def hung_stream() -> AsyncGenerator[str, None]:
+        try:
+            yield MESSAGE_START_CHUNK
+            await asyncio.Event().wait()
+            yield TEXT_DELTA_CHUNK
+        finally:
+            upstream_cleaned_up.set()
+
+    wrapped: Final = wrap_sse_stream_with_keepalive_pings(stream=hung_stream(), ping_interval_seconds=0.05)
+
+    assert await wrapped.__anext__() == MESSAGE_START_CHUNK
+    assert await wrapped.__anext__() == ANTHROPIC_PING_SSE_CHUNK
+    await wrapped.aclose()
+
+    assert upstream_cleaned_up.is_set()
+
+
+@pytest.mark.asyncio
+async def test_non_positive_interval_returns_stream_unwrapped():
+    async def any_stream() -> AsyncGenerator[str, None]:
+        yield MESSAGE_START_CHUNK
+
+    stream: Final = any_stream()
+    assert wrap_sse_stream_with_keepalive_pings(stream=stream, ping_interval_seconds=0) is stream
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_create_response_streams_ping_first_for_slow_upstream():
+    async def slow_start_stream() -> AsyncGenerator[str, None]:
+        await asyncio.sleep(0.2)
+        yield MESSAGE_START_CHUNK
+
+    response: Final = await create_response(
+        generator=wrap_sse_stream_with_keepalive_pings(stream=slow_start_stream(), ping_interval_seconds=0.05),
+        media_type="text/event-stream",
+        headers={},
+    )
+
+    assert isinstance(response, StreamingResponse)
+    collected: Final = [chunk async for chunk in response.body_iterator]
+    assert collected[0] == ANTHROPIC_PING_SSE_CHUNK
+    assert collected[-1] == MESSAGE_START_CHUNK

--- a/tests/test_litellm/proxy/common_utils/test_sse_keepalive.py
+++ b/tests/test_litellm/proxy/common_utils/test_sse_keepalive.py
@@ -105,6 +105,30 @@ async def test_non_positive_interval_returns_stream_unwrapped():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("bad_interval", [None, "abc", "", float("inf"), float("nan"), "-3"])
+async def test_invalid_config_interval_returns_stream_unwrapped(bad_interval: float | str | None):
+    async def any_stream() -> AsyncGenerator[str, None]:
+        yield MESSAGE_START_CHUNK
+
+    stream: Final = any_stream()
+    assert wrap_sse_stream_with_keepalive_pings(stream=stream, ping_interval_seconds=bad_interval) is stream
+    await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_numeric_string_interval_from_yaml_config_enables_pings():
+    async def slow_start_stream() -> AsyncGenerator[str, None]:
+        await asyncio.sleep(0.2)
+        yield MESSAGE_START_CHUNK
+
+    wrapped: Final = wrap_sse_stream_with_keepalive_pings(stream=slow_start_stream(), ping_interval_seconds="0.05")
+    collected: Final = [chunk async for chunk in wrapped]
+
+    assert collected[0] == ANTHROPIC_PING_SSE_CHUNK
+    assert collected[-1] == MESSAGE_START_CHUNK
+
+
+@pytest.mark.asyncio
 async def test_create_response_streams_ping_first_for_slow_upstream():
     async def slow_start_stream() -> AsyncGenerator[str, None]:
         await asyncio.sleep(0.2)


### PR DESCRIPTION
## TLDR

Problem this solves:

- Claude Code blips "Waiting for API response" banners mid-turn
- Anthropic pings only every ~30s inside long thinking silences
- The CLI stall watchdog fires after 20s with zero bytes
- Intermediaries with 60s idle timeouts can kill quiet streams

How it solves it:

- Inject an SSE ping frame after 15s of upstream silence
- Applies only to /v1/messages streaming responses
- litellm.anthropic_sse_ping_interval_seconds tunes it, non-positive disables

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Repro setup: a real Claude Code v2.1.222 session runs in tmux with ANTHROPIC_BASE_URL pointed at a local LiteLLM proxy (model claude-fable-5, real Anthropic API, real $), a byte-level tap between the CLI and the proxy records inter-chunk gaps on the wire, and a watcher samples the CLI pane every 300ms for the stall banner. Both legs get the same "ultrathink" long-multiplication prompt, which produces extended thinking silences

Before, litellm_internal_staging at 0659738b3e: the turn hits upstream silences of 26.8s and 29.9s, the CLI watchdog (20s without bytes) trips, and the pane shows the exact banner users report

```
[16:09:07] ✻ Waiting for API response · will retry in 2m 40s · check your network
```

Tap record for that turn (gap_s is seconds of wire silence, after_bytes is bytes received when the gap started):

```json
{"n_messages": 2, "elapsed_s": 62.627, "stream_bytes": 17846, "max_gap_s": 29.887,
 "big_gaps": [{"gap_s": 26.79, "at_s": 31.11, "after_bytes": 638}, {"gap_s": 29.89, "at_s": 61.0, "after_bytes": 674}]}
```

After, this PR at 097c03eebb: same prompt, the upstream thinking silences still happen, but the client now receives a 36-byte ping frame each 15s of silence, so the largest client-side gap is 15.0s, the banner watcher records zero hits for the whole turn, and the turn completes with the correct answer

```json
{"n_messages": 2, "elapsed_s": 69.014, "max_gap_s": 15.004,
 "big_gaps": [{"gap_s": 15.0, "at_s": 18.52, "after_bytes": 630}, {"gap_s": 12.1, "at_s": 30.61, "after_bytes": 666}, {"gap_s": 15.0, "at_s": 45.62, "after_bytes": 702}, {"gap_s": 15.0, "at_s": 60.62, "after_bytes": 738}, {"gap_s": 7.28, "at_s": 67.91, "after_bytes": 810}]}
```

A plain curl against the same proxy at 097c03eebb, timestamped per SSE event, shows the injected pings bridging a 31s thinking silence with the stream finishing intact

```
curl -sN http://127.0.0.1:47857/v1/messages \
  -H "Authorization: Bearer sk-localqa-keepalive" \
  -H "content-type: application/json" \
  -d '{"model":"claude-fable-5","max_tokens":16000,"stream":true,"thinking":{"type":"enabled","budget_tokens":12000},"messages":[{"role":"user","content":"Without tools, compute 987654321987654321 * 123456789123456789 by long multiplication and verify by casting out nines before answering with only the product."}]}'

t=   1.10s  gap=  1.10s  event: message_start
t=   1.51s  gap=  0.41s  event: content_block_start
t=  16.51s  gap= 15.00s  event: ping
t=  30.25s  gap= 13.74s  event: ping
t=  32.59s  gap=  2.34s  event: ping
t=  32.59s  gap=  0.00s  event: content_block_delta
t=  32.62s  gap=  0.02s  event: content_block_stop
t=  32.67s  gap=  0.05s  event: message_delta
t=  32.68s  gap=  0.00s  event: message_stop
```

## Type

🐛 Bug Fix

## Changes

litellm/proxy/common_utils/sse_keepalive.py adds wrap_sse_stream_with_keepalive_pings, which races the wrapped generator's next chunk against a timer and yields Anthropic's standard ping event frame whenever the upstream stays silent for litellm.anthropic_sse_ping_interval_seconds (default 15.0). The interval is coerced and validated first: numeric strings from YAML config work, while null, junk strings, lists, mappings, non-finite, or non-positive values return the stream unwrapped instead of breaking it. It is applied at the outermost layer of the /v1/messages streaming path in base_process_llm_request, outside the logging and guardrail generators, so pings never reach spend tracking or callbacks, and the Anthropic SSE contract already tells clients to expect and ignore ping events so compliant clients are unaffected. On teardown the wrapper cancels the in-flight read inside a shielded cancel scope and closes the inner generator, so disconnect and billing cleanup still runs

Why 15s: Claude Code's stall watchdog shows "Waiting for API response, will retry" once it sees 20s with zero stream bytes, while the upstream API pings only about every 30s inside long extended-thinking silences, so those silences blip the banner even though nothing is wrong. A 15s cadence stays under the watchdog with margin and also keeps streams alive through intermediaries that drop connections idle for 60s

Known limitation: the wrapper cannot cover the window before the upstream sends its first byte, because the upstream holds the response status until then and committing a 200 early would break error handling. That pre-first-byte case reproduces identically against the Anthropic API hit directly, so it is out of scope here

tests/test_litellm/proxy/common_utils/test_sse_keepalive.py covers chunk ordering around pings, pings while awaiting the first chunk, no pings when chunks are fast, upstream exception propagation, cancellation running the inner generator's cleanup, the disable path, invalid config values falling back to an unwrapped stream, numeric string config enabling pings, and integration with create_response's first-chunk buffering

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
