### PR TITLE
refactor(ui): drop unreferenced locals from tests and narrow destructures

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/_components/pricing_calculator/multi_cost_results.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/_components/pricing_calculator/multi_cost_results.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, within } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../../../../../../tests/test-utils";
 import MultiCostResults from "./multi_cost_results";

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/_components/pricing_calculator/multi_export_dropdown.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/_components/pricing_calculator/multi_export_dropdown.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../../../../../../tests/test-utils";

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/_components/provider_discount_table.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-tracking/_components/provider_discount_table.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { screen, within } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../../../../../tests/test-utils";
 import ProviderDiscountTable from "./provider_discount_table";

--- a/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/guardrails/_components/guardrail_info.test.tsx
@@ -229,7 +229,7 @@ describe("Guardrail Info", () => {
     vi.mocked(networking.getGuardrailProviderSpecificParams).mockResolvedValue({});
     vi.mocked(networking.updateGuardrailCall).mockResolvedValue({ status: "success" });
 
-    const { getByText, getByRole, getAllByRole, getByLabelText } = render(
+    const { getByText, getByLabelText } = render(
       <GuardrailInfoView guardrailId="123" onClose={() => {}} accessToken="123" isAdmin={true} />,
     );
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPLogoSelector.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/mcp-servers/_components/MCPLogoSelector.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 import MCPLogoSelector from "./MCPLogoSelector";

--- a/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/playground/components/chat_ui/ChatUI.test.tsx
@@ -60,7 +60,7 @@ describe("ChatUI", () => {
   });
 
   it("should show the voice selector when the endpoint type is audio_speech", async () => {
-    const { getByText, container } = render(
+    const { getByText } = render(
       <ChatUI
         accessToken="1234567890"
         token="1234567890"
@@ -110,7 +110,7 @@ describe("ChatUI", () => {
   });
 
   it("should allow the user to select a model", async () => {
-    const { getByText, container } = render(
+    const { getByText } = render(
       <ChatUI
         accessToken="1234567890"
         token="1234567890"
@@ -148,7 +148,7 @@ describe("ChatUI", () => {
       { model_group: "ResponsesModel", mode: "responses" },
     ]);
 
-    const { getByText, baseElement } = render(
+    const { getByText } = render(
       <ChatUI
         accessToken="1234567890"
         token="1234567890"

--- a/ui/litellm-dashboard/src/app/(dashboard)/ui-theme/UIThemeSettings.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/ui-theme/UIThemeSettings.tsx
@@ -15,7 +15,7 @@ interface UIThemeSettingsProps {
 }
 
 const UIThemeSettings: React.FC<UIThemeSettingsProps> = ({ userID, userRole, accessToken }) => {
-  const { logoUrl, setLogoUrl, faviconUrl, setFaviconUrl } = useTheme();
+  const { setLogoUrl, setFaviconUrl } = useTheme();
   const [logoUrlInput, setLogoUrlInput] = useState<string>("");
   const [faviconUrlInput, setFaviconUrlInput] = useState<string>("");
   const [loading, setLoading] = useState(false);

--- a/ui/litellm-dashboard/src/components/CreateUserButton.tsx
+++ b/ui/litellm-dashboard/src/components/CreateUserButton.tsx
@@ -15,7 +15,7 @@ import {
   Tooltip,
   Typography,
 } from "antd";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import BulkCreateUsers from "./bulk_create_users_button";
 import TeamDropdown from "./common_components/team_dropdown";
 import { getModelDisplayName } from "./key_team_helpers/fetch_available_models_team_key";
@@ -29,7 +29,7 @@ import {
 } from "./networking";
 import OnboardingModal, { InvitationLink } from "./onboarding_link";
 const { Option } = Select;
-const { Text, Link, Title } = Typography;
+const { Text, Link } = Typography;
 // Helper function to generate UUID compatible across all environments
 const generateUUID = (): string => {
   if (typeof crypto !== "undefined" && crypto.randomUUID) {
@@ -80,11 +80,6 @@ export const CreateUserButton: React.FC<CreateuserProps> = ({
   const { data: organizations = [] } = useOrganizations();
 
   // Derive teams from the user's organizations, falling back to the teams prop
-  const availableTeams = useMemo(() => {
-    const orgTeams = organizations.flatMap((org) => org.teams || []);
-    if (orgTeams.length > 0) return orgTeams;
-    return teams || [];
-  }, [organizations, teams]);
 
   useEffect(() => {
     const fetchData = async () => {

--- a/ui/litellm-dashboard/src/components/HelpLink.test.tsx
+++ b/ui/litellm-dashboard/src/components/HelpLink.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { renderWithProviders } from "../../tests/test-utils";

--- a/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.tsx
+++ b/ui/litellm-dashboard/src/components/ModelSelect/ModelSelect.tsx
@@ -2,7 +2,7 @@ import { ProxyModel, useAllProxyModels } from "@/app/(dashboard)/hooks/models/us
 import { useOrganization } from "@/app/(dashboard)/hooks/organizations/useOrganizations";
 import { useTeam } from "@/app/(dashboard)/hooks/teams/useTeams";
 import { useCurrentUser } from "@/app/(dashboard)/hooks/users/useCurrentUser";
-import { Select, Skeleton, Tooltip, type SelectProps } from "antd";
+import { Select, Skeleton, Tooltip } from "antd";
 import { Organization, Team } from "../networking";
 import { splitWildcardModels } from "./modelUtils";
 
@@ -93,8 +93,7 @@ const filterModels = (
 
 export const ModelSelect = (props: ModelSelectProps) => {
   const { teamID, organizationID, options, context, dataTestId, value = [], onChange, style } = props;
-  const { includeUserModels, showAllTeamModelsOption, showAllProxyModelsOverride, includeSpecialOptions } =
-    options || {};
+  const { showAllProxyModelsOverride, includeSpecialOptions } = options || {};
   const { data: allProxyModels, isLoading: isLoadingAllProxyModels } = useAllProxyModels();
   const { data: team, isLoading: isLoadingTeam } = useTeam(teamID);
   const { data: organization, isLoading: isLoadingOrganization } = useOrganization(organizationID);
@@ -112,10 +111,6 @@ export const ModelSelect = (props: ModelSelectProps) => {
   if (isLoading) {
     return <Skeleton.Input active block />;
   }
-
-  const optionRender: NonNullable<SelectProps["optionRender"]> = (option) => {
-    return <span>{option.label}</span>;
-  };
 
   const handleChange = (values: string[]) => {
     const specialValues = values.filter(isSpecialOption);

--- a/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/TopKeyView.tsx
+++ b/ui/litellm-dashboard/src/components/UsagePage/components/EntityUsage/TopKeyView.tsx
@@ -20,7 +20,7 @@ interface TopKeyViewProps {
 }
 
 const TopKeyView: React.FC<TopKeyViewProps> = ({ topKeys, teams, showTags = false, topKeysLimit, setTopKeysLimit }) => {
-  const { accessToken, userRole, userId: userID, premiumUser } = useAuthorized();
+  const { accessToken } = useAuthorized();
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
   const [keyData, setKeyData] = useState<any | undefined>(undefined);

--- a/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
+++ b/ui/litellm-dashboard/src/components/add_model/AddModelForm.tsx
@@ -66,7 +66,7 @@ const AddModelForm: React.FC<AddModelFormProps> = ({
   } = useProviderFields();
   const { data: guardrailsData } = useGuardrails();
   const guardrailsList = guardrailsData?.guardrails.map((g) => g.guardrail_name);
-  const { data: tagsList, isLoading: isTagsLoading, error: tagsError } = useTags();
+  const { data: tagsList } = useTags();
 
   const handleTestConnection = async () => {
     setIsTestingConnection(true);

--- a/ui/litellm-dashboard/src/components/agent_management/AgentSelector.test.tsx
+++ b/ui/litellm-dashboard/src/components/agent_management/AgentSelector.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 // Mock networking module

--- a/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.tsx
+++ b/ui/litellm-dashboard/src/components/common_components/DeleteResourceModal.tsx
@@ -32,7 +32,7 @@ export default function DeleteResourceModal({
   confirmLoading,
   requiredConfirmation,
 }: DeleteResourceModalProps) {
-  const { Title, Text } = Typography;
+  const { Text } = Typography;
   const { token } = theme.useToken();
   const [requiredConfirmationInput, setRequiredConfirmationInput] = useState("");
 

--- a/ui/litellm-dashboard/src/components/model_add/reuse_credentials.tsx
+++ b/ui/litellm-dashboard/src/components/model_add/reuse_credentials.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Form, Button, Tooltip, Typography, Modal } from "antd";
 import { TextInput } from "@tremor/react";
 import { CredentialItem } from "../networking";
-const { Title, Link } = Typography;
+const { Link } = Typography;
 
 interface ReuseCredentialsModalProps {
   isVisible: boolean;

--- a/ui/litellm-dashboard/src/components/navbar.test.tsx
+++ b/ui/litellm-dashboard/src/components/navbar.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import React, { useState } from "react";
+import React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen, waitFor } from "../../tests/test-utils";
 import Navbar from "./navbar";

--- a/ui/litellm-dashboard/src/components/onboarding_link.tsx
+++ b/ui/litellm-dashboard/src/components/onboarding_link.tsx
@@ -58,7 +58,7 @@ export default function OnboardingModal({
   invitationLinkData,
   modalType = "invitation",
 }: OnboardingProps) {
-  const { Title, Paragraph } = Typography;
+  const { Paragraph } = Typography;
   const handleInvitationOk = () => {
     setIsInvitationLinkModalVisible(false);
   };

--- a/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
+++ b/ui/litellm-dashboard/src/components/templates/key_info_view.test.tsx
@@ -1,11 +1,9 @@
 import useAuthorized from "@/app/(dashboard)/hooks/useAuthorized";
-import { useProjects } from "@/app/(dashboard)/hooks/projects/useProjects";
 import useTeams from "@/app/(dashboard)/hooks/useTeams";
 import { renderWithProviders } from "../../../tests/test-utils";
 import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useResetKeySpend } from "@/app/(dashboard)/hooks/keys/useResetKeySpend";
 import { KeyResponse, Team } from "../key_team_helpers/key_list";
 import { keyDeleteCall, keyUpdateCall } from "../networking";
 import { QueryClient } from "@tanstack/react-query";

--- a/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RealtimePrettyView.test.tsx
+++ b/ui/litellm-dashboard/src/components/view_logs/LogDetailsDrawer/RealtimePrettyView.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { RealtimePrettyView, isRealtimeResponse } from "./RealtimePrettyView";


### PR DESCRIPTION
## TLDR

Problem this solves:

- Dead locals still sitting in test files and destructures
- The eslint rule that catches them is disabled
- They dominate CodeQL's nightly scan output

How it solves it:

- Deletes unreferenced symbols across 9 test files
- Narrows 10 destructures to the keys actually read

## Relevant issues

Follows #35819 (merged) and #35821

## Linear ticket

Resolves LIT-5162

## Pre-Submission checklist

- [ ] I have added meaningful tests (nothing to add: this only deletes code nothing reads; the existing suite is the regression check)
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

**This PR needs no manual QA.** Nothing here has a runtime path to exercise: every removal is either a symbol whose only mention was its own declaration, or a destructured key that was never read. The evidence is that the change is provably inert, captured at `888f911133`

Type checking is unchanged. Same 950 pre-existing errors as `litellm_internal_staging`, and the same error set once line numbers are normalized (a deletion shifts every line below it, so the raw text differs while the errors do not):

```bash
npx tsc --noEmit > after.log 2>&1
git checkout origin/litellm_internal_staging -- <the 19 files> && npx tsc --noEmit > base.log 2>&1 && git checkout HEAD -- <the 19 files>
for f in base.log after.log; do grep 'error TS' $f | sed -E 's/\([0-9]+,[0-9]+\)//' | sort > $f.norm; done
diff base.log.norm after.log.norm && echo IDENTICAL
```

```
base(staging)=950  after=950
tsc: IDENTICAL error set vs staging
```

Full dashboard suite green on the toolchain's Node (24.19.0, per `.nvmrc`):

```bash
npx vitest run --reporter=dot
```

```
 Test Files  585 passed (585)
      Tests  6247 passed (6247)
```

Lint and format on exactly the files CI would check:

```bash
npx eslint --no-warn-ignored --pass-on-unpruned-suppressions <the 19 files>
npx prettier --check <the 19 files>
```

```
✖ 58 problems (0 errors, 58 warnings)
All matched files use Prettier code style!
```

## Type

🧹 Refactoring

## Changes

`@typescript-eslint/no-unused-vars` is set to `"off"` in the dashboard's eslint config, leaving `unused-imports/no-unused-imports` as the only unused-code rule. That catches unused imports but not unused locals, so dead symbols built up with nothing to stop them, and CodeQL's `js/unused-local-variable` became the only check that sees them

This combines the third and fourth slices of that cleanup, because they ask the reviewer nearly the same question and neither changes what runs. Nine test files and one source file lose symbols whose sole mention was their own declaration. Ten more narrow a destructure to the keys actually read, so `const { accessToken, userRole, userId: userID, premiumUser } = useAuthorized()` becomes `const { accessToken } = useAuthorized()`, with aliases preserved exactly as written

`ignoreRestSiblings` is on, which deliberately leaves the omit idiom `const { tags, ...rest } = metadata` alone. Dropping `tags` there is not a cleanup; it would fold the key back into `rest` and change what the object contains

`ToolDetail.tsx` is held back for the second time and is worth explaining, because it looks like it belongs here. On the first pass eslint flags only its `teams` memo, since `teamsData` is still read by that memo. Run the sweep to a fixpoint and a `useQuery` surfaces underneath, one that still issues a `/team/list` request on mount. Removing it drops a network call, so it goes in a slice that gets QA'd rather than one claiming nothing observable moves

The remaining slices carry the parts that need real thought: declarations whose initializer has a side effect, dead React state together with its writes, and two write-only stream accumulators. A separate change then turns the eslint rule back on so none of this comes back

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
