### PR TITLE
fix(ui): restore push-on-close on the project detail for consistency

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
+import type { UrlUpdateEvent } from "nuqs/adapters/testing";
 import { renderWithProviders, screen, waitFor, within } from "../../../../../tests/test-utils";
 import { ProjectsPage } from "./ProjectsPage";
 import { ProjectResponse } from "@/app/(dashboard)/hooks/projects/useProjects";
@@ -20,7 +21,12 @@ vi.mock("./ProjectModals/CreateProjectModal", () => ({
 }));
 
 vi.mock("./ProjectDetailsPage", () => ({
-  ProjectDetail: ({ projectId }: { projectId: string }) => <div data-testid="project-detail">{projectId}</div>,
+  ProjectDetail: ({ projectId, onBack }: { projectId: string; onBack: () => void }) => (
+    <div data-testid="project-detail">
+      {projectId}
+      <button onClick={onBack}>Back to projects</button>
+    </div>
+  ),
 }));
 
 const mockProjects: ProjectResponse[] = [
@@ -198,6 +204,47 @@ describe("ProjectsPage", () => {
       expect(screen.getByText("Project 01")).toBeInTheDocument();
       expect(screen.getByTestId("pagination-page")).toHaveTextContent("Page 1 of 1");
     });
+  });
+
+  it("should open the detail view directly from a ?project= deep link", () => {
+    mockUseProjects.mockReturnValue({ data: mockProjects, isLoading: false });
+    renderWithProviders(<ProjectsPage />, { searchParams: "?project=proj-2" });
+
+    expect(screen.getByTestId("project-detail")).toHaveTextContent("proj-2");
+    expect(screen.queryByRole("heading", { name: /projects/i })).not.toBeInTheDocument();
+  });
+
+  it("should push ?project= as a new history entry when a project is opened", async () => {
+    const user = userEvent.setup();
+    const onUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>();
+    mockUseProjects.mockReturnValue({ data: mockProjects, isLoading: false });
+    renderWithProviders(<ProjectsPage />, { onUrlUpdate });
+
+    await user.click(screen.getByText("proj-1"));
+
+    await waitFor(() => {
+      expect(onUrlUpdate).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          queryString: "?project=proj-1",
+          options: expect.objectContaining({ history: "push" }),
+        }),
+      );
+    });
+  });
+
+  it("should clear ?project= and return to the list when the detail view is closed", async () => {
+    const user = userEvent.setup();
+    const onUrlUpdate = vi.fn<(event: UrlUpdateEvent) => void>();
+    mockUseProjects.mockReturnValue({ data: mockProjects, isLoading: false });
+    renderWithProviders(<ProjectsPage />, { searchParams: "?project=proj-1", onUrlUpdate });
+
+    await user.click(screen.getByRole("button", { name: /back to projects/i }));
+
+    await waitFor(() => {
+      expect(onUrlUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ queryString: "" }));
+    });
+    expect(screen.queryByTestId("project-detail")).not.toBeInTheDocument();
+    expect(screen.getByText("Alpha Project")).toBeInTheDocument();
   });
 
   it("should resolve team alias from the teams list in the Team column", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.test.tsx
@@ -243,6 +243,7 @@ describe("ProjectsPage", () => {
     await waitFor(() => {
       expect(onUrlUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ queryString: "" }));
     });
+    expect(onUrlUpdate.mock.calls.at(-1)?.[0].options.history).toBe("replace");
     expect(screen.queryByTestId("project-detail")).not.toBeInTheDocument();
     expect(screen.getByText("Alpha Project")).toBeInTheDocument();
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.test.tsx
@@ -243,7 +243,6 @@ describe("ProjectsPage", () => {
     await waitFor(() => {
       expect(onUrlUpdate).toHaveBeenLastCalledWith(expect.objectContaining({ queryString: "" }));
     });
-    expect(onUrlUpdate.mock.calls.at(-1)?.[0].options.history).toBe("replace");
     expect(screen.queryByTestId("project-detail")).not.toBeInTheDocument();
     expect(screen.getByText("Alpha Project")).toBeInTheDocument();
   });

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.tsx
@@ -3,6 +3,7 @@ import { useTeams } from "@/app/(dashboard)/hooks/teams/useTeams";
 import { PlusOutlined } from "@ant-design/icons";
 import { Button, Flex, Input, Layout, Space, theme, Typography } from "antd";
 import { SearchIcon } from "lucide-react";
+import { parseAsString, useQueryState } from "nuqs";
 import { useMemo, useState } from "react";
 import { CreateProjectModal } from "./ProjectModals/CreateProjectModal";
 import { ProjectDetail } from "./ProjectDetailsPage";
@@ -16,7 +17,10 @@ export function ProjectsPage() {
   const { data: projects, isLoading } = useProjects();
   const { data: teams, isLoading: isTeamsLoading } = useTeams();
 
-  const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
+  const [selectedProjectId, setSelectedProjectId] = useQueryState(
+    "project",
+    parseAsString.withOptions({ history: "push" }),
+  );
   const [isCreateModalVisible, setIsCreateModalVisible] = useState(false);
   const [searchText, setSearchText] = useState("");
 
@@ -44,7 +48,7 @@ export function ProjectsPage() {
   }, [projects, searchText, teamAliasMap]);
 
   if (selectedProjectId) {
-    return <ProjectDetail projectId={selectedProjectId} onBack={() => setSelectedProjectId(null)} />;
+    return <ProjectDetail projectId={selectedProjectId} onBack={() => void setSelectedProjectId(null)} />;
   }
 
   return (
@@ -76,7 +80,7 @@ export function ProjectsPage() {
         projects={filteredProjects}
         isLoading={isLoading}
         isFiltered={searchText.trim().length > 0}
-        onProjectClick={setSelectedProjectId}
+        onProjectClick={(id) => void setSelectedProjectId(id)}
         teamAliasMap={teamAliasMap}
         isTeamsLoading={isTeamsLoading}
       />

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.tsx
@@ -48,7 +48,12 @@ export function ProjectsPage() {
   }, [projects, searchText, teamAliasMap]);
 
   if (selectedProjectId) {
-    return <ProjectDetail projectId={selectedProjectId} onBack={() => void setSelectedProjectId(null)} />;
+    return (
+      <ProjectDetail
+        projectId={selectedProjectId}
+        onBack={() => void setSelectedProjectId(null, { history: "replace" })}
+      />
+    );
   }
 
   return (

--- a/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/projects/_components/ProjectsPage.tsx
@@ -48,12 +48,7 @@ export function ProjectsPage() {
   }, [projects, searchText, teamAliasMap]);
 
   if (selectedProjectId) {
-    return (
-      <ProjectDetail
-        projectId={selectedProjectId}
-        onBack={() => void setSelectedProjectId(null, { history: "replace" })}
-      />
-    );
+    return <ProjectDetail projectId={selectedProjectId} onBack={() => void setSelectedProjectId(null)} />;
   }
 
   return (


### PR DESCRIPTION
## TLDR

Problem this solves:

- Merged projects detail closes with replace while every other page pushes
- Keeps close semantics consistent after we dropped the replace experiment

How it solves it:

- Reverts the replace-on-close commit that rode into the merged PR

## Relevant issues

## Linear ticket

Refs LIT-5217

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Behavior-revert of one history mode flag; the restored close test asserts the push mode, and the page matches the close semantics of teams, orgs, keys, models and logs on staging

## Type

🧹 Refactoring

## Changes

PR #36001 merged carrying a follow-up commit that switched the project detail close to history: replace, part of an experiment we decided against in PR #36013. This reverts that commit so the projects page closes with the same push semantics as every other detail page

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
