### PR TITLE
fix(proxy): invalidate cached project object on project update and delete

### DIFF
--- a/enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py
+++ b/enterprise/litellm_enterprise/proxy/management_endpoints/project_endpoints.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from litellm._logging import verbose_proxy_logger
 from litellm._uuid import uuid
 from litellm.proxy._types import *
+from litellm.proxy.auth.auth_checks import delete_cached_project_object
 from litellm.proxy.auth.user_api_key_auth import user_api_key_auth
 from litellm.proxy.management_endpoints.common_utils import _set_object_metadata_field
 from litellm.proxy.management_helpers.utils import (
@@ -514,6 +515,7 @@ async def update_project(
         litellm_proxy_admin_name,
         premium_user,
         prisma_client,
+        user_api_key_cache,
     )
 
     try:
@@ -672,6 +674,11 @@ async def update_project(
             include={"litellm_budget_table": True, "object_permission": True},
         )
 
+        await delete_cached_project_object(
+            project_id=data.project_id,
+            user_api_key_cache=user_api_key_cache,
+        )
+
         return updated_project
     except Exception as e:
         verbose_proxy_logger.exception(
@@ -710,7 +717,7 @@ async def delete_project(
     }'
     ```
     """
-    from litellm.proxy.proxy_server import premium_user, prisma_client
+    from litellm.proxy.proxy_server import premium_user, prisma_client, user_api_key_cache
 
     try:
         if not premium_user:
@@ -772,6 +779,11 @@ async def delete_project(
             deleted_project: (
                 prisma_models.LiteLLM_ProjectTable | None
             ) = await prisma_client.db.litellm_projecttable.delete(where={"project_id": project_id})
+
+            await delete_cached_project_object(
+                project_id=project_id,
+                user_api_key_cache=user_api_key_cache,
+            )
 
             deleted_projects.append(deleted_project)
 

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -4262,6 +4262,10 @@ async def _project_soft_budget_check(
             )
 
 
+def _project_cache_key(project_id: str) -> str:
+    return f"project_id:{project_id}"
+
+
 async def get_project_object(
     project_id: str,
     prisma_client: PrismaClient | None,
@@ -4279,7 +4283,7 @@ async def get_project_object(
         return None
 
     # Check cache first
-    cache_key: Final = f"project_id:{project_id}"
+    cache_key: Final = _project_cache_key(project_id)
     deserialized_project: Final = await user_api_key_cache.async_get_cache(
         key=cache_key,
         model_type=LiteLLM_ProjectTableCachedObj,
@@ -4308,6 +4312,19 @@ async def get_project_object(
     )
 
     return project_obj
+
+
+async def delete_cached_project_object(
+    project_id: str,
+    user_api_key_cache: UserApiKeyCache,
+) -> None:
+    """
+    Every endpoint that mutates litellm_projecttable must call this: get_project_object
+    serves auth cache-first with no freshness check, so without invalidation a stale
+    project (e.g. a pre-update empty model allowlist) keeps being enforced until the
+    TTL expires (LIT-3803).
+    """
+    await user_api_key_cache.async_delete_cache(key=_project_cache_key(project_id))
 
 
 async def _organization_max_budget_check(

--- a/litellm/proxy/auth/auth_checks.py
+++ b/litellm/proxy/auth/auth_checks.py
@@ -4322,9 +4322,22 @@ async def delete_cached_project_object(
     Every endpoint that mutates litellm_projecttable must call this: get_project_object
     serves auth cache-first with no freshness check, so without invalidation a stale
     project (e.g. a pre-update empty model allowlist) keeps being enforced until the
-    TTL expires (LIT-3803).
+    TTL expires (LIT-3803). Best-effort on both steps: the DB write has already
+    committed, so a cache backend error must not fail the endpoint; the stale entry
+    then expires via TTL.
     """
-    await user_api_key_cache.async_delete_cache(key=_project_cache_key(project_id))
+    from litellm.proxy.common_utils.auth_cache_invalidation_pubsub import publish_auth_cache_invalidation
+
+    cache_key: Final = _project_cache_key(project_id)
+    try:
+        await user_api_key_cache.async_delete_cache(key=cache_key)
+    except Exception as e:  # noqa: BLE001  # best-effort eviction: any cache backend error must not fail the mutation
+        verbose_proxy_logger.warning(
+            "Failed to evict cached project entry %s; a stale project may be served until its TTL expires: %s",
+            cache_key,
+            e,
+        )
+    await publish_auth_cache_invalidation(cache_key=cache_key)
 
 
 async def _organization_max_budget_check(

--- a/litellm/proxy/common_utils/auth_cache_invalidation_pubsub.py
+++ b/litellm/proxy/common_utils/auth_cache_invalidation_pubsub.py
@@ -1,0 +1,153 @@
+import asyncio
+import json
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Final
+
+from litellm._logging import verbose_proxy_logger
+from litellm.proxy.common_utils.config_sync_pubsub import (
+    _ConfigSyncPubSub,
+    _pubsub_capable_client,
+    coordination_redis_cache,
+)
+
+if TYPE_CHECKING:
+    from litellm.caching.redis_cache import RedisCache
+    from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+
+AUTH_CACHE_INVALIDATION_CHANNEL: Final = "litellm_proxy.auth_cache_invalidation"
+_POLL_TIMEOUT_SECONDS: Final = 1.0
+_BACKOFF_INITIAL_SECONDS: Final = 5.0
+_BACKOFF_MAX_SECONDS: Final = 60.0
+
+
+def auth_cache_invalidation_channel(redis_cache: "RedisCache") -> str:
+    if redis_cache.namespace is None:
+        return AUTH_CACHE_INVALIDATION_CHANNEL
+    return f"{redis_cache.namespace}:{AUTH_CACHE_INVALIDATION_CHANNEL}"
+
+
+@dataclass(frozen=True, slots=True)
+class _CacheInvalidationMessage:
+    cache_key: str
+
+
+def _cache_invalidation_message_json(cache_key: str) -> str:
+    return json.dumps(asdict(_CacheInvalidationMessage(cache_key=cache_key)))
+
+
+def _cache_key_from_message_data(data: object) -> str | None:
+    if isinstance(data, bytes):
+        data = data.decode("utf-8", errors="replace")
+    if not isinstance(data, str):
+        return None
+    try:
+        parsed: Final = json.loads(data)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    cache_key: Final = parsed.get("cache_key")
+    return cache_key if isinstance(cache_key, str) else None
+
+
+async def publish_auth_cache_invalidation(cache_key: str) -> None:
+    """
+    Best-effort broadcast so every worker drops its local in-memory copy of a
+    mutated management object; without this, only the handling worker and Redis
+    are evicted and other workers keep serving the stale object until its TTL.
+    """
+    redis_cache: Final = coordination_redis_cache()
+    if redis_cache is None:
+        return
+    try:
+        client: Final = _pubsub_capable_client(redis_cache)
+        if client is None:
+            verbose_proxy_logger.debug(
+                "auth cache invalidation publish for %s skipped: cluster redis client has no pub/sub support",
+                cache_key,
+            )
+            return
+        await client.publish(auth_cache_invalidation_channel(redis_cache), _cache_invalidation_message_json(cache_key))
+    except Exception as e:  # noqa: BLE001  # best-effort publish; mutations must never fail on redis errors
+        verbose_proxy_logger.warning("auth cache invalidation publish for %s failed: %s", cache_key, e)
+
+
+class AuthCacheInvalidationSubscriber:
+    __slots__ = ("_redis_cache", "_task", "_user_api_key_cache")
+
+    def __init__(
+        self,
+        redis_cache: "RedisCache",
+        user_api_key_cache: "UserApiKeyCache",
+    ) -> None:
+        self._redis_cache = redis_cache
+        self._user_api_key_cache = user_api_key_cache
+        self._task: asyncio.Task[None] | None = None
+
+    def start(self) -> None:
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        task: Final = self._task
+        if task is None:
+            return
+        self._task = None
+        _ = task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def _run(self) -> None:
+        backoff_seconds = _BACKOFF_INITIAL_SECONDS  # rebind-ok: exponential backoff accumulator across reconnects
+        while True:
+            try:
+                client = _pubsub_capable_client(self._redis_cache)  # rebind-ok: re-resolved on every reconnect
+                if client is None:
+                    verbose_proxy_logger.warning(
+                        "auth cache invalidation subscriber disabled: cluster redis client has no pub/sub support; "
+                        "cross-worker eviction falls back to the local cache TTL"
+                    )
+                    return
+                pubsub = client.pubsub()  # rebind-ok: fresh pubsub per reconnect
+                try:
+                    await pubsub.subscribe(auth_cache_invalidation_channel(self._redis_cache))
+                    backoff_seconds = _BACKOFF_INITIAL_SECONDS  # rebind-ok: reset after successful subscribe
+                    await self._consume(pubsub)
+                finally:
+                    await self._close_pubsub(pubsub)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:  # noqa: BLE001  # any redis failure falls through to backoff and reconnect
+                verbose_proxy_logger.warning(
+                    "auth cache invalidation subscriber redis error: %s; reconnecting in %.0fs",
+                    e,
+                    backoff_seconds,
+                )
+                await asyncio.sleep(backoff_seconds)
+                backoff_seconds = min(backoff_seconds * 2, _BACKOFF_MAX_SECONDS)  # rebind-ok: backoff accumulator
+
+    async def _consume(self, pubsub: _ConfigSyncPubSub) -> None:
+        while True:
+            message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=_POLL_TIMEOUT_SECONDS)
+            if message is None:
+                continue
+            self._apply_message(message)
+
+    def _apply_message(self, message: object) -> None:
+        data: Final = message.get("data") if isinstance(message, dict) else None
+        cache_key: Final = _cache_key_from_message_data(data)
+        if cache_key is None:
+            return
+        in_memory_cache: Final = self._user_api_key_cache.in_memory_cache
+        if in_memory_cache is not None:
+            in_memory_cache.delete_cache(cache_key)
+
+    @staticmethod
+    async def _close_pubsub(pubsub: _ConfigSyncPubSub) -> None:
+        try:
+            await pubsub.aclose()
+        except Exception as e:  # noqa: BLE001  # best-effort close of a possibly-broken connection
+            verbose_proxy_logger.debug("auth cache invalidation pubsub close failed: %s", e)

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -297,10 +297,10 @@ from litellm.proxy.common_request_processing import (
     _should_return_raw_model_name,
     create_response,
 )
-from litellm.proxy.common_utils.callback_utils import initialize_callbacks_on_proxy
 from litellm.proxy.common_utils.auth_cache_invalidation_pubsub import (
     AuthCacheInvalidationSubscriber,
 )
+from litellm.proxy.common_utils.callback_utils import initialize_callbacks_on_proxy
 from litellm.proxy.common_utils.config_sync_pubsub import ConfigSyncSubscriber
 from litellm.proxy.common_utils.debug_utils import init_verbose_loggers
 from litellm.proxy.common_utils.debug_utils import router as debugging_endpoints_router
@@ -6397,7 +6397,7 @@ class ProxyConfig:
         self.auth_cache_invalidation_subscriber = None
         try:
             await subscriber.stop()
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001  # best-effort: a failing stop must not break proxy shutdown
             verbose_proxy_logger.error("Error stopping auth cache invalidation subscriber: %s", e)
 
     async def _init_non_llm_objects_in_db(self, prisma_client: PrismaClient):

--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -298,6 +298,9 @@ from litellm.proxy.common_request_processing import (
     create_response,
 )
 from litellm.proxy.common_utils.callback_utils import initialize_callbacks_on_proxy
+from litellm.proxy.common_utils.auth_cache_invalidation_pubsub import (
+    AuthCacheInvalidationSubscriber,
+)
 from litellm.proxy.common_utils.config_sync_pubsub import ConfigSyncSubscriber
 from litellm.proxy.common_utils.debug_utils import init_verbose_loggers
 from litellm.proxy.common_utils.debug_utils import router as debugging_endpoints_router
@@ -1188,6 +1191,8 @@ async def proxy_startup_event(app: FastAPI):
             verbose_proxy_logger.error("Error stopping DB health watchdog task: %s", e)
 
     await proxy_config.stop_config_sync_subscriber()
+
+    await proxy_config.stop_auth_cache_invalidation_subscriber()
 
     await proxy_shutdown_event()
 
@@ -3900,6 +3905,7 @@ class ProxyConfig:
         self._last_hashicorp_vault_config: dict[str, Any] | None = None
         self.worker_registry: list[WorkerRegistryEntry] = []
         self.config_sync_subscriber: ConfigSyncSubscriber | None = None
+        self.auth_cache_invalidation_subscriber: AuthCacheInvalidationSubscriber | None = None
         from litellm.litellm_core_utils.get_model_cost_map import (
             get_model_cost_map_loaded_at,
         )
@@ -6370,6 +6376,30 @@ class ProxyConfig:
         except Exception as e:
             verbose_proxy_logger.error("Error stopping config sync subscriber: %s", e)
 
+    def start_auth_cache_invalidation_subscriber(
+        self,
+        redis_cache: RedisCache | None,
+        user_api_key_cache: UserApiKeyCache,
+    ) -> None:
+        if redis_cache is None or self.auth_cache_invalidation_subscriber is not None:
+            return
+        subscriber: Final = AuthCacheInvalidationSubscriber(
+            redis_cache=redis_cache,
+            user_api_key_cache=user_api_key_cache,
+        )
+        self.auth_cache_invalidation_subscriber = subscriber
+        subscriber.start()
+
+    async def stop_auth_cache_invalidation_subscriber(self) -> None:
+        subscriber: Final = self.auth_cache_invalidation_subscriber
+        if subscriber is None:
+            return
+        self.auth_cache_invalidation_subscriber = None
+        try:
+            await subscriber.stop()
+        except Exception as e:
+            verbose_proxy_logger.error("Error stopping auth cache invalidation subscriber: %s", e)
+
     async def _init_non_llm_objects_in_db(self, prisma_client: PrismaClient):
         """
         Use this to read non-llm objects from the db and initialize them
@@ -8294,6 +8324,11 @@ class ProxyStartupEvent:
             id="periodic_reload_job",
             replace_existing=True,
             misfire_grace_time=APSCHEDULER_MISFIRE_GRACE_TIME,
+        )
+
+        proxy_config.start_auth_cache_invalidation_subscriber(
+            redis_cache=redis_usage_cache,
+            user_api_key_cache=user_api_key_cache,
         )
 
         if store_model_in_db is True:

--- a/tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py
+++ b/tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py
@@ -976,3 +976,66 @@ async def test_delete_project_invalidates_cached_project_object(monkeypatch):
         )
         is None
     )
+
+
+@pytest.mark.asyncio
+async def test_update_project_succeeds_when_cache_eviction_fails(monkeypatch):
+    """
+    The DB write has already committed when eviction runs, so a cache backend
+    error must not turn a successful update into a 500; the stale entry is
+    bounded by the TTL instead.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    project_id = f"project-{uuid.uuid4()}"
+    failing_cache = MagicMock()
+    failing_cache.async_delete_cache = AsyncMock(side_effect=ConnectionError("redis down"))
+
+    existing_row = MagicMock(team_id=None, budget_id=None, object_permission_id=None)
+    updated_row = MagicMock()
+
+    mock_prisma = MagicMock()
+    mock_prisma.jsonify_object = lambda data: data
+    mock_prisma.db.litellm_projecttable.find_unique = AsyncMock(return_value=existing_row)
+    mock_prisma.db.litellm_projecttable.update = AsyncMock(return_value=updated_row)
+
+    monkeypatch.setattr(litellm.proxy.proxy_server, "premium_user", True)
+    monkeypatch.setattr(litellm.proxy.proxy_server, "prisma_client", mock_prisma)
+    monkeypatch.setattr(litellm.proxy.proxy_server, "user_api_key_cache", failing_cache)
+
+    response = await update_project(
+        data=UpdateProjectRequest(project_id=project_id, models=["gpt-oss-120b"]),
+        http_request=Request(scope={"type": "http"}),
+        user_api_key_dict=UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+            api_key="sk-1234",
+            user_id="1234",
+        ),
+    )
+
+    assert response is updated_row
+    failing_cache.async_delete_cache.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_project_eviction_publishes_cross_worker_invalidation(monkeypatch):
+    """
+    Single-worker eviction only fixes the handling worker; the broadcast is what
+    lets every other worker drop its in-memory copy instead of serving the stale
+    project until the TTL expires.
+    """
+    from unittest.mock import AsyncMock, patch
+
+    from litellm.proxy.auth.auth_checks import delete_cached_project_object
+    from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+
+    project_id = f"project-{uuid.uuid4()}"
+    with patch(
+        "litellm.proxy.common_utils.auth_cache_invalidation_pubsub.publish_auth_cache_invalidation",
+        new=AsyncMock(),
+    ) as mock_publish:
+        await delete_cached_project_object(
+            project_id=project_id, user_api_key_cache=UserApiKeyCache()
+        )
+
+    mock_publish.assert_awaited_once_with(cache_key=f"project_id:{project_id}")

--- a/tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py
+++ b/tests/enterprise/litellm_enterprise/proxy/management_endpoints/test_project_endpoints_prisma.py
@@ -864,3 +864,115 @@ def test_litellm_project_table_has_timestamp_fields():
     fields = LiteLLM_ProjectTable.model_fields
     assert "created_at" in fields, "LiteLLM_ProjectTable must have created_at field"
     assert "updated_at" in fields, "LiteLLM_ProjectTable must have updated_at field"
+
+
+@pytest.mark.asyncio
+async def test_update_project_invalidates_cached_project_object(monkeypatch):
+    """
+    LIT-3803 regression: auth reads projects cache-first with no freshness check,
+    so /project/update must evict the cached project. Before the fix, a project
+    cached with models=[] kept bypassing the new allowlist until the TTL expired.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy.auth.auth_checks import get_project_object
+    from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+
+    project_id = f"project-{uuid.uuid4()}"
+    cache = UserApiKeyCache()
+
+    stale_row = MagicMock()
+    stale_row.model_dump = lambda: {"project_id": project_id, "team_id": None, "models": []}
+
+    mock_prisma = MagicMock()
+    mock_prisma.jsonify_object = lambda data: data
+    mock_prisma.db.litellm_projecttable.find_unique = AsyncMock(return_value=stale_row)
+
+    seeded = await get_project_object(
+        project_id=project_id, prisma_client=mock_prisma, user_api_key_cache=cache
+    )
+    assert seeded is not None and seeded.models == []
+
+    updated_models = ["gemini-2.5-flash-image", "gemini-3.1-flash-lite-preview"]
+    existing_row = MagicMock(team_id=None, budget_id=None, object_permission_id=None)
+    updated_row = MagicMock()
+    updated_row.model_dump = lambda: {
+        "project_id": project_id,
+        "team_id": None,
+        "models": updated_models,
+    }
+
+    mock_prisma.db.litellm_projecttable.find_unique = AsyncMock(return_value=existing_row)
+    mock_prisma.db.litellm_projecttable.update = AsyncMock(return_value=updated_row)
+
+    monkeypatch.setattr(litellm.proxy.proxy_server, "premium_user", True)
+    monkeypatch.setattr(litellm.proxy.proxy_server, "prisma_client", mock_prisma)
+    monkeypatch.setattr(litellm.proxy.proxy_server, "user_api_key_cache", cache)
+
+    await update_project(
+        data=UpdateProjectRequest(project_id=project_id, models=updated_models),
+        http_request=Request(scope={"type": "http"}),
+        user_api_key_dict=UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+            api_key="sk-1234",
+            user_id="1234",
+        ),
+    )
+
+    mock_prisma.db.litellm_projecttable.find_unique = AsyncMock(return_value=updated_row)
+    refreshed = await get_project_object(
+        project_id=project_id, prisma_client=mock_prisma, user_api_key_cache=cache
+    )
+    assert refreshed is not None
+    assert refreshed.models == updated_models
+
+
+@pytest.mark.asyncio
+async def test_delete_project_invalidates_cached_project_object(monkeypatch):
+    """
+    LIT-3803 regression: /project/delete must evict the cached project so auth
+    stops enforcing (or trusting) a project that no longer exists.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    from litellm.proxy.auth.auth_checks import get_project_object
+    from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+
+    project_id = f"project-{uuid.uuid4()}"
+    cache = UserApiKeyCache()
+
+    row = MagicMock()
+    row.model_dump = lambda: {"project_id": project_id, "team_id": None, "models": ["gpt-5.5"]}
+
+    mock_prisma = MagicMock()
+    mock_prisma.db.litellm_projecttable.find_unique = AsyncMock(return_value=row)
+
+    seeded = await get_project_object(
+        project_id=project_id, prisma_client=mock_prisma, user_api_key_cache=cache
+    )
+    assert seeded is not None
+
+    mock_prisma.db.litellm_verificationtoken.find_many = AsyncMock(return_value=[])
+    mock_prisma.db.litellm_projecttable.delete = AsyncMock(return_value=row)
+
+    monkeypatch.setattr(litellm.proxy.proxy_server, "premium_user", True)
+    monkeypatch.setattr(litellm.proxy.proxy_server, "prisma_client", mock_prisma)
+    monkeypatch.setattr(litellm.proxy.proxy_server, "user_api_key_cache", cache)
+
+    await delete_project(
+        data=DeleteProjectRequest(project_ids=[project_id]),
+        http_request=Request(scope={"type": "http"}),
+        user_api_key_dict=UserAPIKeyAuth(
+            user_role=LitellmUserRoles.PROXY_ADMIN,
+            api_key="sk-1234",
+            user_id="1234",
+        ),
+    )
+
+    mock_prisma.db.litellm_projecttable.find_unique = AsyncMock(return_value=None)
+    assert (
+        await get_project_object(
+            project_id=project_id, prisma_client=mock_prisma, user_api_key_cache=cache
+        )
+        is None
+    )

--- a/tests/test_litellm/proxy/auth/test_auth_checks.py
+++ b/tests/test_litellm/proxy/auth/test_auth_checks.py
@@ -5464,6 +5464,63 @@ async def test_get_project_object_db_fetch_returns_cached_obj():
     assert result.project_alias == "proj"
 
 
+@pytest.mark.asyncio
+async def test_project_allowlist_enforced_when_key_models_empty():
+    """
+    LIT-3803: a project-bound key with models=[] has no key-level restriction,
+    but the project allowlist must still 403 team models outside it.
+    """
+    from litellm.proxy._types import (
+        LiteLLM_ProjectTableCachedObj,
+        ProxyErrorTypes,
+        ProxyException,
+    )
+    from litellm.proxy.auth.auth_checks import _run_project_checks, can_key_call_model
+
+    valid_token = UserAPIKeyAuth(
+        api_key="hashed-key",
+        project_id="p-1",
+        team_id="t-1",
+        models=[],
+    )
+    project = LiteLLM_ProjectTableCachedObj(
+        project_id="p-1",
+        team_id="t-1",
+        models=["gemini-2.5-flash-image", "gemini-3.1-flash-lite-preview"],
+    )
+
+    assert (
+        await can_key_call_model(
+            model="gemini-2.5-flash",
+            llm_model_list=None,
+            valid_token=valid_token,
+            llm_router=None,
+        )
+        is True
+    )
+
+    await _run_project_checks(
+        project_object=project,
+        _model="gemini-2.5-flash-image",
+        llm_router=None,
+        skip_budget_checks=True,
+        valid_token=valid_token,
+        proxy_logging_obj=MagicMock(),
+    )
+
+    with pytest.raises(ProxyException) as exc_info:
+        await _run_project_checks(
+            project_object=project,
+            _model="gemini-2.5-flash",
+            llm_router=None,
+            skip_budget_checks=True,
+            valid_token=valid_token,
+            proxy_logging_obj=MagicMock(),
+        )
+    assert exc_info.value.type == ProxyErrorTypes.project_model_access_denied
+    assert exc_info.value.code == "403"
+
+
 def test_is_user_proxy_admin_rejects_view_only_admin():
     """This predicate skips `non_proxy_admin_allowed_routes_check` entirely, so an
     Admin Viewer answering True here would gain every write route. Read parity for

--- a/tests/test_litellm/proxy/common_utils/test_auth_cache_invalidation_pubsub.py
+++ b/tests/test_litellm/proxy/common_utils/test_auth_cache_invalidation_pubsub.py
@@ -1,0 +1,161 @@
+import asyncio
+import json
+from typing import Iterable, List, Optional, Tuple
+from unittest.mock import patch
+
+import pytest
+from redis.asyncio import Redis
+
+from litellm.proxy.common_utils.auth_cache_invalidation_pubsub import (
+    AUTH_CACHE_INVALIDATION_CHANNEL,
+    AuthCacheInvalidationSubscriber,
+    publish_auth_cache_invalidation,
+)
+from litellm.proxy.common_utils.user_api_key_cache import UserApiKeyCache
+
+
+class _RecordingRedisClient(Redis):
+    def __init__(self) -> None:
+        self.published: List[Tuple[str, str]] = []
+
+    async def publish(self, channel: str, message: str) -> int:
+        self.published.append((channel, message))
+        return 1
+
+
+class _FailingPublishRedisClient(Redis):
+    def __init__(self) -> None:
+        pass
+
+    async def publish(self, channel: str, message: str) -> int:
+        raise ConnectionError("redis down")
+
+
+class _QueuePubSub:
+    def __init__(self, initial_messages: Iterable[object] = ()) -> None:
+        self.queue: "asyncio.Queue[object]" = asyncio.Queue()
+        for message in initial_messages:
+            self.queue.put_nowait(message)
+        self.subscribed_channels: List[str] = []
+        self.closed = False
+
+    async def subscribe(self, *channels: str) -> None:
+        self.subscribed_channels.extend(channels)
+
+    async def get_message(self, *, ignore_subscribe_messages: bool, timeout: float) -> Optional[object]:
+        try:
+            return await asyncio.wait_for(self.queue.get(), timeout)
+        except asyncio.TimeoutError:
+            return None
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _ScriptedPubSubRedisClient(Redis):
+    def __init__(self, pubsubs: Iterable[_QueuePubSub]) -> None:
+        self._scripted_pubsubs = iter(pubsubs)
+
+    def pubsub(self) -> _QueuePubSub:
+        return next(self._scripted_pubsubs)
+
+
+class _FakeRedisCache:
+    def __init__(self, client: object, namespace: Optional[str] = None) -> None:
+        self._client = client
+        self.namespace = namespace
+
+    def init_async_client(self) -> object:
+        return self._client
+
+
+def _invalidation_message(cache_key: str) -> dict:
+    return {"type": "message", "data": json.dumps({"cache_key": cache_key}).encode()}
+
+
+@pytest.mark.asyncio
+async def test_publish_sends_cache_key_json_on_channel() -> None:
+    client = _RecordingRedisClient()
+    with patch(
+        "litellm.proxy.common_utils.auth_cache_invalidation_pubsub.coordination_redis_cache",
+        return_value=_FakeRedisCache(client=client),
+    ):
+        await publish_auth_cache_invalidation(cache_key="project_id:p-1")
+
+    assert client.published == [(AUTH_CACHE_INVALIDATION_CHANNEL, json.dumps({"cache_key": "project_id:p-1"}))]
+
+
+@pytest.mark.asyncio
+async def test_publish_uses_namespaced_channel() -> None:
+    client = _RecordingRedisClient()
+    with patch(
+        "litellm.proxy.common_utils.auth_cache_invalidation_pubsub.coordination_redis_cache",
+        return_value=_FakeRedisCache(client=client, namespace="ns1"),
+    ):
+        await publish_auth_cache_invalidation(cache_key="project_id:p-1")
+
+    assert client.published[0][0] == f"ns1:{AUTH_CACHE_INVALIDATION_CHANNEL}"
+
+
+@pytest.mark.asyncio
+async def test_publish_noops_without_coordination_redis() -> None:
+    with patch(
+        "litellm.proxy.common_utils.auth_cache_invalidation_pubsub.coordination_redis_cache",
+        return_value=None,
+    ):
+        await publish_auth_cache_invalidation(cache_key="project_id:p-1")
+
+
+@pytest.mark.asyncio
+async def test_publish_swallows_redis_errors() -> None:
+    with patch(
+        "litellm.proxy.common_utils.auth_cache_invalidation_pubsub.coordination_redis_cache",
+        return_value=_FakeRedisCache(client=_FailingPublishRedisClient()),
+    ):
+        await publish_auth_cache_invalidation(cache_key="project_id:p-1")
+
+
+@pytest.mark.asyncio
+async def test_subscriber_deletes_local_cache_entry_on_message() -> None:
+    """
+    The cross-worker half of LIT-3803: a worker that did not handle the project
+    mutation must drop its in-memory copy when the invalidation broadcast lands,
+    instead of serving the stale object until the TTL expires.
+    """
+    cache = UserApiKeyCache()
+    cache.in_memory_cache.set_cache("project_id:p-1", {"models": []})
+    assert cache.in_memory_cache.get_cache("project_id:p-1") is not None
+
+    pubsub = _QueuePubSub(initial_messages=[_invalidation_message("project_id:p-1")])
+    subscriber = AuthCacheInvalidationSubscriber(
+        redis_cache=_FakeRedisCache(client=_ScriptedPubSubRedisClient(pubsubs=[pubsub])),
+        user_api_key_cache=cache,
+    )
+    subscriber.start()
+    try:
+        for _ in range(200):
+            if cache.in_memory_cache.get_cache("project_id:p-1") is None:
+                break
+            await asyncio.sleep(0.01)
+    finally:
+        await subscriber.stop()
+
+    assert cache.in_memory_cache.get_cache("project_id:p-1") is None
+    assert pubsub.subscribed_channels == [AUTH_CACHE_INVALIDATION_CHANNEL]
+
+
+@pytest.mark.asyncio
+async def test_subscriber_ignores_malformed_messages() -> None:
+    cache = UserApiKeyCache()
+    cache.in_memory_cache.set_cache("project_id:p-1", {"models": []})
+
+    subscriber = AuthCacheInvalidationSubscriber(
+        redis_cache=_FakeRedisCache(client=_ScriptedPubSubRedisClient(pubsubs=[_QueuePubSub()])),
+        user_api_key_cache=cache,
+    )
+    subscriber._apply_message({"type": "message", "data": b"not json"})
+    subscriber._apply_message({"type": "message", "data": json.dumps({"other": "x"}).encode()})
+    subscriber._apply_message("raw string")
+    subscriber._apply_message(None)
+
+    assert cache.in_memory_cache.get_cache("project_id:p-1") is not None


### PR DESCRIPTION
## TLDR

Problem this solves:

- Project allowlist changes were invisible to auth for up to 60s
- Stale cached project with empty allowlist bypassed project model restrictions
- Other workers kept their stale in-memory copy even after eviction
- Deleted projects stayed enforceable from cache

How it solves it:

- /project/update and /project/delete now evict the cached project
- Eviction broadcasts the cache key over coordination Redis pub/sub
- Every worker drops its local copy and refetches on next auth read
- Eviction is best-effort: cache backend errors never fail the committed write

## Relevant issues

## Linear ticket

Resolves LIT-3803

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

All runs are against live local proxies backed by Postgres, making real Groq calls. Setup: a team with two models, a project under it created with no allowlist, and a virtual key bound to the project with no models assigned

```bash
curl -s http://localhost:4173/team/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"team_alias":"lit3803-qa-team","models":["gpt-oss-120b","gpt-oss-20b"]}'
curl -s http://localhost:4173/project/new -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"project_alias":"lit3803-qa-project","team_id":"6f39c40b-..."}'
curl -s http://localhost:4173/key/generate -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"key_alias":"lit3803-qa-key","team_id":"6f39c40b-...","project_id":"7629ec45-..."}'
```

### Single worker: stale cache bypass

The repro sequence is: make one completion with the key so auth caches the project (still no allowlist), then add the allowlist, then immediately call a team model outside it

```bash
curl -s http://localhost:4173/v1/chat/completions -H 'Authorization: Bearer sk-...' -H 'Content-Type: application/json' \
  -d '{"model":"gpt-oss-20b","messages":[{"role":"user","content":"Say WARMUP and nothing else"}]}'
curl -s http://localhost:4173/project/update -H 'Authorization: Bearer sk-1234' -H 'Content-Type: application/json' \
  -d '{"project_id":"7629ec45-...","models":["gpt-oss-120b"]}'
curl -s -w "\nHTTP %{http_code}\n" http://localhost:4173/v1/chat/completions -H 'Authorization: Bearer sk-...' -H 'Content-Type: application/json' \
  -d '{"model":"gpt-oss-20b","messages":[{"role":"user","content":"this should be blocked"}]}'
```

Before, with the un-fixed endpoints (parent commit c2c795fad5), the out-of-allowlist call went straight through to the provider:

```
{"id":"chatcmpl-ac54496f-fe29-4b05-894c-1317953d444e","created":1785979061,"model":"gpt-oss-20b","object":"chat.completion", ...}
HTTP 200
```

After (70b3ed3098), the same sequence is blocked immediately:

```
{"error":{"message":"project not allowed to access model. This project can only access models=['gpt-oss-120b']. Tried to access gpt-oss-20b","type":"project_model_access_denied","param":"model","code":"403"}}
HTTP 403
```

### Multi worker: cross-worker broadcast

Two proxies (A on :4173, B on :4174) share the same Postgres and a coordination Redis (`general_settings.coordination_redis`). Both warm their local project cache with one completion each while the allowlist is still empty, the allowlist is added via A, and the out-of-allowlist model is called via B immediately after

```bash
curl -s http://localhost:4173/v1/chat/completions -H 'Authorization: Bearer sk-...' -d '{"model":"gpt-oss-20b", ...}'   # warm A
curl -s http://localhost:4174/v1/chat/completions -H 'Authorization: Bearer sk-...' -d '{"model":"gpt-oss-20b", ...}'   # warm B
curl -s http://localhost:4173/project/update -H 'Authorization: Bearer sk-1234' \
  -d '{"project_id":"7629ec45-...","models":["gpt-oss-120b"]}'                                                          # update via A
curl -s -w "\nHTTP %{http_code}\n" http://localhost:4174/v1/chat/completions -H 'Authorization: Bearer sk-...' \
  -d '{"model":"gpt-oss-20b","messages":[{"role":"user","content":"this should be blocked"}]}'                          # immediately via B
```

Before (70b3ed3098, eviction without broadcast), worker B kept serving its stale in-memory copy and the call went through to the provider:

```
{"id":"chatcmpl-7d4d31f1-2c82-4c32-9ee5-e252a46c43a0","created":1785980831,"model":"gpt-oss-20b","object":"chat.completion", ...}
HTTP 200
```

After (ad00a37a77), worker B blocks immediately because the broadcast evicted its local copy:

```
{"error":{"message":"project not allowed to access model. This project can only access models=['gpt-oss-120b']. Tried to access gpt-oss-20b","type":"project_model_access_denied","param":"model","code":"403"}}
HTTP 403
```

and the allowed model still completes for real via B:

```
{"id":"chatcmpl-f8f4a753-0ca6-4358-a8e1-12cbd82444aa", ... "message":{"content":"ALLOWED","role":"assistant", ...}
HTTP 200
```

The enforcement itself lives in `common_checks` in the shared auth layer, upstream of any specific LLM endpoint, so the same 403 applies to /v1/chat/completions, /v1/messages, and /v1/responses alike

## Type

🐛 Bug Fix

## Changes

Auth reads projects through `get_project_object`, which serves `project_id:{id}` from `user_api_key_cache` with a 60s TTL and no freshness check, and nothing ever evicted that entry: neither /project/update nor /project/delete touched the cache. A project cached while its `models` list was still empty (warmed during key creation or by any completion made before the admin set the allowlist) kept an empty allowlist in cache, so `_run_project_checks` skipped `can_project_access_model` and a project-bound key could call team models outside the project allowlist until the TTL expired. This is the bypass reported in the ticket. Blocked status and budget fields had the same staleness window, and a deleted project stayed enforceable from cache

The fix adds `delete_cached_project_object` next to `get_project_object` in `auth_checks.py`, shares the cache-key derivation between the two via `_project_cache_key` so they can't drift, and calls the eviction after the DB write in `update_project` and `delete_project`. `UserApiKeyCache` is a `DualCache`, so the eviction clears both the in-memory layer and Redis where configured

Since `DualCache` reads return local in-memory hits before consulting Redis, evicting locally plus Redis still leaves every other worker serving its own stale copy. The new `auth_cache_invalidation_pubsub` module closes that: eviction publishes the cache key on a coordination Redis channel (`litellm_proxy.auth_cache_invalidation`, namespace-aware, following the existing `config_sync_pubsub` pattern), and an `AuthCacheInvalidationSubscriber` on every worker deletes the local in-memory entry so the next auth read refetches from the DB. The subscriber starts whenever a coordination Redis is configured, independent of `store_model_in_db`, and deployments without Redis fall back to the TTL exactly as before

Eviction and publish are both best-effort: the DB write has already committed when they run, so a cache backend error logs a warning instead of turning a successful update into a 500 or aborting the remaining ids in /project/delete

Tests: two endpoint regressions prove update and delete evict the cached project (both fail without the fix), the enforcement test the ticket asked for proves a key with `models: []` passes the key layer unrestricted while `_run_project_checks` returns 403 `project_model_access_denied`, pub/sub tests cover publish (channel, namespacing, no-redis no-op, error swallowing) and the subscriber (deletes the local entry on message, ignores malformed messages), and endpoint tests prove update survives a failing cache backend and eviction publishes the invalidation

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
