### PR TITLE
fix(auto-router): accept every reminder marker pair a harness emits

### DIFF
--- a/litellm/router_strategy/complexity_router/README.md
+++ b/litellm/router_strategy/complexity_router/README.md
@@ -171,6 +171,27 @@ If 2+ reasoning markers are detected in the user message, the request is automat
 
 Reasoning markers in the system prompt do **not** trigger the reasoning override. This prevents system prompts like "Think step by step before answering" from forcing all requests to the reasoning tier.
 
+### Harness Reminder Blocks
+
+Agent harnesses inject their own context into the conversation as ordinary message text. That text is plumbing, not something a human asked for, so the router strips complete reminder blocks before classifying and picking a tier. A turn that is nothing but a reminder block strips to empty and is skipped, and the router falls back to the last real ask instead
+
+By default a block is anything between `<system-reminder>` and `</system-reminder>`. `reminder_markers` replaces that with your harness's own delimiters. Many harnesses use a different envelope per agent type, so list every pair you emit:
+
+```yaml
+model_list:
+  - model_name: smart-router
+    litellm_params:
+      model: auto_router/complexity_router
+      complexity_router_config:
+        reminder_markers:
+          - open: "<<<BEGIN_CONTEXT>>>"
+            close: "<<<END_CONTEXT>>>"
+          - open: "[[SUBAGENT_CONTEXT_BEGIN]]"
+            close: "[[SUBAGENT_CONTEXT_END]]"
+```
+
+Setting `reminder_markers` replaces the built-in `<system-reminder>` pair rather than adding to it, so list that pair too if your harness also emits it. Matching is case-insensitive. Blocks that nest or overlap across pairs are stripped whole. An unclosed delimiter is not a block and is left in place, which keeps prose that merely mentions a delimiter from being eaten
+
 ### Code Detection
 
 Technical code keywords are detected case-insensitively and include:

--- a/litellm/router_strategy/complexity_router/__init__.py
+++ b/litellm/router_strategy/complexity_router/__init__.py
@@ -16,6 +16,7 @@ from litellm.router_strategy.complexity_router.config import (
     DEFAULT_COMPLEXITY_CONFIG,
     ComplexityRouterConfig,
     ComplexityTier,
+    ReminderMarkerPair,
 )
 
 __all__ = [
@@ -24,5 +25,6 @@ __all__ = [
     "ComplexityRouter",
     "ComplexityRouterConfig",
     "ComplexityTier",
+    "ReminderMarkerPair",
     "classification_system_prompt",
 ]

--- a/litellm/router_strategy/complexity_router/complexity_router.py
+++ b/litellm/router_strategy/complexity_router/complexity_router.py
@@ -19,7 +19,7 @@ import asyncio
 import random
 import re
 from collections.abc import Iterator, Mapping, Sequence
-from itertools import islice
+from itertools import accumulate, islice
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final, Literal, NamedTuple, cast
 
@@ -233,6 +233,7 @@ def _effective_turn_off_message_logging(request_kwargs: Mapping[str, Any] | None
 
 _REMINDER_OPEN: Final = "<system-reminder>"
 _REMINDER_CLOSE: Final = "</system-reminder>"
+_DEFAULT_REMINDER_MARKERS: Final = ((_REMINDER_OPEN, _REMINDER_CLOSE),)
 
 _TRUNCATION_MARKER: Final = "..."
 
@@ -253,10 +254,8 @@ def _message_text(content: object) -> str:
     return content if isinstance(content, str) else ""
 
 
-def _reminder_block_spans(
-    lowered: str, open_marker: str = _REMINDER_OPEN, close_marker: str = _REMINDER_CLOSE
-) -> Iterator[tuple[int, int]]:
-    """Span of each complete reminder block, left to right.
+def _reminder_block_spans(lowered: str, open_marker: str, close_marker: str) -> Iterator[tuple[int, int]]:
+    """Span of each complete reminder block for one marker pair, left to right.
 
     Literal `str.find`, not a regex: the delimiters are fixed strings, and `<system-reminder>.*?`
     retried its lazy quantifier from every opening tag, so repeated unclosed tags were quadratic
@@ -272,17 +271,36 @@ def _reminder_block_spans(
         yield start, cursor
 
 
-def _strip_reminder_blocks(text: str, open_marker: str = _REMINDER_OPEN, close_marker: str = _REMINDER_CLOSE) -> str:
-    """Remove every complete reminder block from text, keeping everything written around them."""
-    spans: Final = tuple(_reminder_block_spans(text.lower(), open_marker, close_marker))
+def _strip_reminder_blocks(text: str, marker_pairs: tuple[tuple[str, str], ...] = _DEFAULT_REMINDER_MARKERS) -> str:
+    """Remove every complete reminder block from text, keeping everything written around them.
+
+    Blocks from different pairs can nest or overlap, which the gap construction below would
+    otherwise mishandle: an inner block's end would resume the kept text partway through the outer
+    block, leaking the rest of that block into the classified ask. Running the block ends through a
+    maximum resumes each gap past the furthest block seen so far, which collapses nested and
+    overlapping spans without a separate merge pass. A single pair's ends already increase, so the
+    maximum is the identity there and the default path is byte-identical to a plain scan.
+
+    Deliberately linear in both the text and the block count. This runs pre-routing on input any
+    keyholder controls, and both a regex scan and a fold that rebuilds a growing tuple of merged
+    spans go quadratic on inputs that are cheap to send.
+    """
+    lowered: Final = text.lower()
+    spans: Final = tuple(
+        sorted(
+            span
+            for open_marker, close_marker in marker_pairs
+            for span in _reminder_block_spans(lowered, open_marker, close_marker)
+        )
+    )
     if not spans:
         return text.strip()
-    keep_from: Final = (0, *(end for _, end in spans))
+    keep_from: Final = (0, *accumulate((end for _, end in spans), max))
     keep_to: Final = (*(start for start, _ in spans), len(text))
     return " ".join(kept for a, b in zip(keep_from, keep_to) if (kept := text[a:b].strip()))
 
 
-def _human_text(content: object, open_marker: str = _REMINDER_OPEN, close_marker: str = _REMINDER_CLOSE) -> str:
+def _human_text(content: object, marker_pairs: tuple[tuple[str, str], ...] = _DEFAULT_REMINDER_MARKERS) -> str:
     """Message content as the text a human wrote, with complete reminder blocks removed.
 
     Harnesses inject reminders as ordinary text alongside the live ask, so the block is stripped and
@@ -291,18 +309,18 @@ def _human_text(content: object, open_marker: str = _REMINDER_OPEN, close_marker
     one, and this same string drives escalation keywords and keyword_tier_rules, which choose the
     model and therefore the spend. An unclosed tag is not a block and is left intact.
     """
-    return _strip_reminder_blocks(_message_text(content), open_marker, close_marker)
+    return _strip_reminder_blocks(_message_text(content), marker_pairs)
 
 
 def _iter_human_asks_newest_first(
-    messages: Sequence[Mapping[str, object]], markers: tuple[str, str] = (_REMINDER_OPEN, _REMINDER_CLOSE)
+    messages: Sequence[Mapping[str, object]],
+    marker_pairs: tuple[tuple[str, str], ...] = _DEFAULT_REMINDER_MARKERS,
 ) -> Iterator[str]:
     """Yield user-turn texts that carry a real human ask, newest first, with harness noise removed."""
-    open_marker, close_marker = markers
     return (
         text
         for msg in reversed(messages)
-        if msg.get("role") == "user" and (text := _human_text(msg.get("content"), open_marker, close_marker))
+        if msg.get("role") == "user" and (text := _human_text(msg.get("content"), marker_pairs))
     )
 
 
@@ -341,7 +359,8 @@ def _conversation_is_continuing(messages: Sequence[Mapping[str, object]] | None)
 
 
 def _newest_turn_ask(
-    messages: Sequence[Mapping[str, object]], markers: tuple[str, str] = (_REMINDER_OPEN, _REMINDER_CLOSE)
+    messages: Sequence[Mapping[str, object]],
+    marker_pairs: tuple[tuple[str, str], ...] = _DEFAULT_REMINDER_MARKERS,
 ) -> str | None:
     """The human ask on the newest user turn, or None when that turn carries only plumbing.
 
@@ -352,12 +371,12 @@ def _newest_turn_ask(
     newest_user_turn: Final = next((msg for msg in reversed(messages) if msg.get("role") == "user"), None)
     if newest_user_turn is None:
         return None
-    return _human_text(newest_user_turn.get("content"), *markers) or None
+    return _human_text(newest_user_turn.get("content"), marker_pairs) or None
 
 
 def _extract_current_ask_and_system_prompt(
     messages: Sequence[Mapping[str, object]],
-    markers: tuple[str, str] = (_REMINDER_OPEN, _REMINDER_CLOSE),
+    marker_pairs: tuple[tuple[str, str], ...] = _DEFAULT_REMINDER_MARKERS,
 ) -> tuple[str | None, str | None]:
     """The last real human ask and the last system prompt; either is None if absent.
 
@@ -365,7 +384,7 @@ def _extract_current_ask_and_system_prompt(
     the caller routes to its default model. That is the correct answer rather than a gap to fill:
     filling it would hand tier selection to harness-injected text.
     """
-    current_ask: Final = next(_iter_human_asks_newest_first(messages, markers), None)
+    current_ask: Final = next(_iter_human_asks_newest_first(messages, marker_pairs), None)
     system_prompt: Final = next(
         (
             text
@@ -385,7 +404,7 @@ def _truncate(text: str, limit: int) -> str:
 def _iter_context_turns_newest_first(
     messages: Sequence[Mapping[str, object]],
     include_assistant: bool,
-    markers: tuple[str, str] = (_REMINDER_OPEN, _REMINDER_CLOSE),
+    marker_pairs: tuple[tuple[str, str], ...] = _DEFAULT_REMINDER_MARKERS,
 ) -> Iterator[tuple[str, str]]:
     """Yield (role, text) for turns eligible as classifier context, newest first.
 
@@ -401,7 +420,7 @@ def _iter_context_turns_newest_first(
         for msg in reversed(messages)
         if isinstance(role := msg.get("role"), str)
         and role in roles
-        and (text := _human_text(msg.get("content"), *markers))
+        and (text := _human_text(msg.get("content"), marker_pairs))
     )
 
 
@@ -411,7 +430,7 @@ def _extract_prior_turns(
     window_size: int,
     per_turn_chars: int,
     include_assistant: bool,
-    markers: tuple[str, str] = (_REMINDER_OPEN, _REMINDER_CLOSE),
+    marker_pairs: tuple[tuple[str, str], ...] = _DEFAULT_REMINDER_MARKERS,
 ) -> tuple[tuple[str, str], ...]:
     """Up to window_size turns other than current_ask, oldest first, as (role, text).
 
@@ -431,7 +450,7 @@ def _extract_prior_turns(
     prior: Final = islice(
         (
             turn
-            for turn in _iter_context_turns_newest_first(messages, include_assistant, markers)
+            for turn in _iter_context_turns_newest_first(messages, include_assistant, marker_pairs)
             if turn[1] != current_ask
         ),
         window_size,
@@ -556,7 +575,11 @@ class ComplexityRouter(CustomLogger):
             if self.config.escalation_keywords is not None
             else DEFAULT_ESCALATION_KEYWORDS
         )
-        self._reminder_markers: tuple[str, str] = self.config.reminder_markers or (_REMINDER_OPEN, _REMINDER_CLOSE)
+        self._reminder_markers: tuple[tuple[str, str], ...] = (
+            tuple((pair.open, pair.close) for pair in self.config.reminder_markers)
+            if self.config.reminder_markers
+            else _DEFAULT_REMINDER_MARKERS
+        )
 
         # Lazily built on first semantic request and cached for reuse (route
         # embeddings are static, only the prompt is embedded per request). The lock
@@ -993,7 +1016,7 @@ class ComplexityRouter(CustomLogger):
                 window_size=self.config.classifier_context_window_size,
                 per_turn_chars=self.config.classifier_context_per_turn_chars,
                 include_assistant=include_assistant,
-                markers=self._reminder_markers,
+                marker_pairs=self._reminder_markers,
             )
             if context_enabled
             else ()

--- a/litellm/router_strategy/complexity_router/config.py
+++ b/litellm/router_strategy/complexity_router/config.py
@@ -59,6 +59,30 @@ class KeywordTierRule(BaseModel):
         return self
 
 
+class ReminderMarkerPair(BaseModel):
+    """One open/close delimiter pair a harness wraps injected context in.
+
+    Normalizing here rather than at the scan is what makes matching case-insensitive: markers reach
+    the scan already lowered, so it lowercases only the haystack and never the needles. Stripping
+    keeps YAML indentation whitespace from becoming part of the delimiter.
+    """
+
+    open: str = Field(description="Opening delimiter, e.g. '<system-reminder>'")
+    close: str = Field(description="Closing delimiter, e.g. '</system-reminder>'")
+
+    @model_validator(mode="after")
+    def _normalize(self) -> "ReminderMarkerPair":
+        open_marker: Final = self.open.strip().lower()
+        close_marker: Final = self.close.strip().lower()
+        if not open_marker or not close_marker:
+            raise ValueError("reminder_markers entries must not be blank")
+        if open_marker == close_marker:
+            raise ValueError("reminder_markers open and close must be different strings")
+        self.open = open_marker
+        self.close = close_marker
+        return self
+
+
 # ─── Default Keyword Lists ───
 # Note: Keywords should be full words/phrases to avoid substring false positives.
 # The matching logic uses word boundary detection for single-word keywords.
@@ -498,12 +522,15 @@ class ComplexityRouterConfig(BaseModel):
         description="RoutingPlugin instances that narrow the classified tier's candidate models before selection",
     )
 
-    reminder_markers: tuple[str, str] | None = Field(
+    reminder_markers: tuple[ReminderMarkerPair, ...] | None = Field(
         default=None,
+        min_length=1,
         description=(
-            "Override the (open, close) marker pair used to recognize and strip harness-injected "
-            "reminder blocks before classification. Defaults to Claude Code's convention, "
-            "('<system-reminder>', '</system-reminder>'), when unset. Matching is case-insensitive."
+            "Override the delimiter pairs used to recognize and strip harness-injected reminder "
+            "blocks before classification. A harness that wraps injected context differently per "
+            "agent type (main, subagent, cron) lists every pair it emits. Replaces, rather than "
+            "adds to, the built-in default of ('<system-reminder>', '</system-reminder>'), so a "
+            "harness that also emits that pair lists it too. Matching is case-insensitive."
         ),
     )
 
@@ -599,18 +626,6 @@ class ComplexityRouterConfig(BaseModel):
                 "plugins and adaptive=True cannot both be set: adaptive's bandit selection doesn't yet "
                 "consume plugin-narrowed candidate pools. Disable adaptive or remove plugins."
             )
-        return self
-
-    @model_validator(mode="after")
-    def _normalize_reminder_markers(self) -> "ComplexityRouterConfig":
-        if self.reminder_markers is None:
-            return self
-        open_marker, close_marker = (marker.strip().lower() for marker in self.reminder_markers)
-        if not open_marker or not close_marker:
-            raise ValueError("reminder_markers entries must not be blank")
-        if open_marker == close_marker:
-            raise ValueError("reminder_markers open and close must be different strings")
-        self.reminder_markers = (open_marker, close_marker)
         return self
 
     def tier_label(self, tier: ComplexityTier) -> str:

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -5963,7 +5963,9 @@ class TestCustomClassifierSystemPrompt:
 
     @pytest.mark.asyncio
     async def test_custom_prompt_is_sent_verbatim_as_the_system_role(self, mock_router_instance, llm_classifier_config):
-        custom = "Classify the data sensitivity: SIMPLE=public, MEDIUM=internal, COMPLEX=confidential, REASONING=regulated."
+        custom = (
+            "Classify the data sensitivity: SIMPLE=public, MEDIUM=internal, COMPLEX=confidential, REASONING=regulated."
+        )
         router = ComplexityRouter(
             model_name="test-complexity-router",
             litellm_router_instance=mock_router_instance,

--- a/tests/test_litellm/router_strategy/test_complexity_router.py
+++ b/tests/test_litellm/router_strategy/test_complexity_router.py
@@ -112,6 +112,52 @@ class TestComplexityRouterInit:
         assert router.config.tiers["SIMPLE"] == "gpt-4o-mini"
         assert router.config.tiers["REASONING"] == "o1-preview"
 
+    def test_configured_marker_pairs_reach_the_ask_extraction(self, mock_router_instance, basic_config):
+        """Marker pairs configured in YAML must actually reach the code that strips them.
+
+        The config field, the validator and the scan were each covered on their own, but nothing
+        exercised config.reminder_markers -> self._reminder_markers, so the router could have parsed
+        a valid config and still classified on unstripped text. Asserting through the extraction the
+        router feeds its classifier is what makes that wiring a regression rather than a silent gap.
+        """
+        from litellm.router_strategy.complexity_router.complexity_router import (
+            _extract_current_ask_and_system_prompt,
+        )
+
+        ask = "Derive the amortized complexity of a splay tree access"
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config={
+                **basic_config,
+                "reminder_markers": [
+                    {"open": "<<<BEGIN_MAIN>>>", "close": "<<<END_MAIN>>>"},
+                    {"open": "[[SUBAGENT_BEGIN]]", "close": "[[SUBAGENT_END]]"},
+                ],
+            },
+        )
+
+        assert router._reminder_markers == (
+            ("<<<begin_main>>>", "<<<end_main>>>"),
+            ("[[subagent_begin]]", "[[subagent_end]]"),
+        )
+        messages = [
+            {"role": "user", "content": ask},
+            {"role": "assistant", "content": "Working on it."},
+            {"role": "user", "content": "[[SUBAGENT_BEGIN]]Budget: 42 tokens remaining.[[SUBAGENT_END]]"},
+        ]
+        assert _extract_current_ask_and_system_prompt(messages, router._reminder_markers)[0] == ask
+
+    def test_unconfigured_marker_pairs_fall_back_to_the_builtin_default(self, mock_router_instance, basic_config):
+        """A config that never mentions reminder_markers keeps stripping <system-reminder>."""
+        router = ComplexityRouter(
+            model_name="test-router",
+            litellm_router_instance=mock_router_instance,
+            complexity_router_config=basic_config,
+        )
+
+        assert router._reminder_markers == (("<system-reminder>", "</system-reminder>"),)
+
     def test_init_without_config(self, mock_router_instance):
         """Test initialization without configuration uses defaults."""
         router = ComplexityRouter(
@@ -2991,17 +3037,68 @@ class TestSemanticConfigValidation:
     def test_reminder_markers_are_normalized(self):
         """Markers are stripped and lowercased, matching how the built-in constants are compared."""
         config = ComplexityRouterConfig(
-            reminder_markers=("  <<<BEGIN_CTX>>>  ", "<<<END_CTX>>>"),
+            reminder_markers=[{"open": "  <<<BEGIN_CTX>>>  ", "close": "<<<END_CTX>>>"}],
         )
-        assert config.reminder_markers == ("<<<begin_ctx>>>", "<<<end_ctx>>>")
+        assert config.reminder_markers is not None
+        assert (config.reminder_markers[0].open, config.reminder_markers[0].close) == (
+            "<<<begin_ctx>>>",
+            "<<<end_ctx>>>",
+        )
+
+    def test_reminder_markers_keep_every_configured_pair_in_order(self):
+        """Every pair a harness emits survives validation, not just the first."""
+        config = ComplexityRouterConfig(
+            reminder_markers=[
+                {"open": "<<<BEGIN_MAIN>>>", "close": "<<<END_MAIN>>>"},
+                {"open": "[[SUBAGENT_BEGIN]]", "close": "[[SUBAGENT_END]]"},
+                {"open": "%%CRON_BEGIN%%", "close": "%%CRON_END%%"},
+            ],
+        )
+        assert config.reminder_markers is not None
+        assert [(pair.open, pair.close) for pair in config.reminder_markers] == [
+            ("<<<begin_main>>>", "<<<end_main>>>"),
+            ("[[subagent_begin]]", "[[subagent_end]]"),
+            ("%%cron_begin%%", "%%cron_end%%"),
+        ]
 
     def test_reminder_markers_reject_blank_entry(self):
         with pytest.raises(ValidationError, match="must not be blank"):
-            ComplexityRouterConfig(reminder_markers=("", "<<<END_CTX>>>"))
+            ComplexityRouterConfig(reminder_markers=[{"open": "", "close": "<<<END_CTX>>>"}])
 
     def test_reminder_markers_reject_identical_open_and_close(self):
         with pytest.raises(ValidationError, match="must be different"):
-            ComplexityRouterConfig(reminder_markers=("<<<CTX>>>", "<<<CTX>>>"))
+            ComplexityRouterConfig(reminder_markers=[{"open": "<<<CTX>>>", "close": "<<<CTX>>>"}])
+
+    def test_reminder_markers_reject_a_bad_pair_anywhere_in_the_list(self):
+        """Validation runs per pair, so a broken entry after a good one is still caught."""
+        with pytest.raises(ValidationError, match="must be different"):
+            ComplexityRouterConfig(
+                reminder_markers=[
+                    {"open": "<<<BEGIN_CTX>>>", "close": "<<<END_CTX>>>"},
+                    {"open": "<<<CTX>>>", "close": "<<<CTX>>>"},
+                ],
+            )
+
+    def test_reminder_markers_reject_empty_list(self):
+        """An explicitly empty list is ambiguous, so it fails loudly instead of silently defaulting.
+
+        Left to fall through, an empty list resolves to the built-in <system-reminder> pair, which
+        reads as "strip nothing" in the config and does the opposite. Matching on the length error
+        keeps this from passing for some unrelated reason if the field type changes.
+        """
+        with pytest.raises(ValidationError, match="at least 1 item"):
+            ComplexityRouterConfig(reminder_markers=[])
+
+    def test_reminder_markers_reject_the_old_flat_pair_form(self):
+        """The pre-list shape is rejected loudly rather than silently routing on unstripped text.
+
+        reminder_markers took a bare (open, close) string pair before it took a list of pairs. A
+        config still using that shape must fail validation at startup and at /model/new write time,
+        because the alternative -- accepting it and stripping nothing -- hands tier selection, and
+        therefore spend, to harness-injected text without any signal that it happened.
+        """
+        with pytest.raises(ValidationError, match="valid dictionary or instance of ReminderMarkerPair"):
+            ComplexityRouterConfig(reminder_markers=("<system-reminder>", "</system-reminder>"))
 
 
 class _StubEncoder:
@@ -4306,7 +4403,6 @@ class TestRoutingDecisionContents:
         # The score is still recorded, but the cause is what says it did not decide.
         assert decision["score"] < decision["tier_boundaries"]["complex_reasoning"]
 
-
     @pytest.mark.asyncio
     async def test_an_unrenamed_router_writes_no_tier_label(self, complexity_router):
         """Renaming is opt-in, so a deployment that never renamed must gain no new key.
@@ -4919,12 +5015,73 @@ class TestContextAwareClassifier:
         """
         from litellm.router_strategy.complexity_router.complexity_router import _extract_current_ask_and_system_prompt
 
-        markers = ("<<<begin_openclaw_internal_context>>>", "<<<end_openclaw_internal_context>>>")
-        follow_up_reminder = f"{markers[0]}Budget: 42 tokens remaining. Do not mention this.{markers[1]}"
+        pair = ("<<<begin_internal_context>>>", "<<<end_internal_context>>>")
+        follow_up_reminder = f"{pair[0]}Budget: 42 tokens remaining. Do not mention this.{pair[1]}"
         messages = [_ASKED, _ANSWERED, {"role": "user", "content": follow_up_reminder}]
 
         assert _extract_current_ask_and_system_prompt(messages)[0] == follow_up_reminder
-        assert _extract_current_ask_and_system_prompt(messages, markers)[0] == _ASK
+        assert _extract_current_ask_and_system_prompt(messages, (pair,))[0] == _ASK
+
+    def test_every_configured_marker_pair_is_stripped_not_just_the_first(self):
+        """One deployment serves a harness whose agent types each use a different envelope.
+
+        Main agent, subagent and cron wrap injected context in different open/close pairs, and they
+        all route through the same auto-router. When only one pair could be configured, the other
+        agent types kept hitting the original bug: their reminder-only turn never stripped to empty,
+        won "newest human ask", and the harness blob got classified in place of the real question.
+        Each pair in turn must be skipped, so this fails if only the first configured pair is used.
+        """
+        from litellm.router_strategy.complexity_router.complexity_router import _extract_current_ask_and_system_prompt
+
+        pairs = (
+            ("<<<begin_main>>>", "<<<end_main>>>"),
+            ("[[subagent_begin]]", "[[subagent_end]]"),
+            ("%%cron_begin%%", "%%cron_end%%"),
+        )
+        for open_marker, close_marker in pairs:
+            reminder_only_turn = f"{open_marker}Budget: 42 tokens remaining.{close_marker}"
+            messages = [_ASKED, _ANSWERED, {"role": "user", "content": reminder_only_turn}]
+
+            assert _extract_current_ask_and_system_prompt(messages, pairs)[0] == _ASK, open_marker
+
+    def test_a_block_nested_inside_another_pairs_block_does_not_leak(self):
+        """Nested blocks from two pairs must strip whole, not resume inside the outer block.
+
+        Spans are collected per pair and can nest. Resuming the kept text at each block's own end
+        walks backwards into the enclosing block, so the outer block's remainder (and its dangling
+        close marker) survive into the classified ask. That is harness text choosing the tier, and
+        therefore the spend. Overlapping and disjoint spans strip correctly either way, so this
+        nested case is what pins the behavior.
+        """
+        from litellm.router_strategy.complexity_router.complexity_router import _strip_reminder_blocks
+
+        pairs = (("<<<begin_main>>>", "<<<end_main>>>"), ("[[subagent_begin]]", "[[subagent_end]]"))
+        nested = "<<<begin_main>>>budget[[subagent_begin]]inner[[subagent_end]]do not mention<<<end_main>>>"
+
+        assert _strip_reminder_blocks(f"{nested} what is a splay tree?", pairs) == "what is a splay tree?"
+
+    def test_overlapping_blocks_from_two_pairs_strip_whole(self):
+        """Interleaved (not nested) blocks still strip everything they jointly cover."""
+        from litellm.router_strategy.complexity_router.complexity_router import _strip_reminder_blocks
+
+        pairs = (("<<<begin_main>>>", "<<<end_main>>>"), ("[[subagent_begin]]", "[[subagent_end]]"))
+        overlapping = "<<<begin_main>>>a[[subagent_begin]]b<<<end_main>>>c[[subagent_end]]"
+
+        assert _strip_reminder_blocks(f"{overlapping} what is a splay tree?", pairs) == "what is a splay tree?"
+
+    def test_an_unclosed_marker_in_one_pair_does_not_suppress_another_pairs_blocks(self):
+        """Each pair scans independently, so one pair's dangling opener is not a global stop.
+
+        An unclosed tag ends that pair's scan by design and is left intact as prose. It must not
+        also swallow a different pair's complete block, which would put harness text back in front
+        of the classifier.
+        """
+        from litellm.router_strategy.complexity_router.complexity_router import _strip_reminder_blocks
+
+        pairs = (("<<<begin_main>>>", "<<<end_main>>>"), ("[[subagent_begin]]", "[[subagent_end]]"))
+        text = "<<<begin_main>>> why is [[subagent_begin]]noise[[subagent_end]] my tag stripped?"
+
+        assert _strip_reminder_blocks(text, pairs) == "<<<begin_main>>> why is my tag stripped?"
 
     @pytest.mark.parametrize(
         "messages,current_ask,window,per_turn_chars,include_assistant,expected",
@@ -5084,6 +5241,28 @@ class TestContextAwareClassifier:
 
         assert _extract_prior_turns(messages, current_ask, window, per_turn_chars, include_assistant) == expected
 
+    def test_prior_turn_context_strips_every_configured_pair(self):
+        """The classifier's context window is stripped with the same pairs as the ask.
+
+        Prior turns are quoted verbatim into the LLM classifier payload, so a pair that is honored
+        when picking the ask but ignored when building context puts the harness blob back in front
+        of the classifier through the other door. This covers the _extract_prior_turns call the ask
+        extraction tests never reach.
+        """
+        from litellm.router_strategy.complexity_router.complexity_router import _extract_prior_turns
+
+        pairs = (("<<<begin_main>>>", "<<<end_main>>>"), ("[[subagent_begin]]", "[[subagent_end]]"))
+        messages = [
+            {"role": "user", "content": "[[subagent_begin]]budget blob[[subagent_end]]what about b-trees?"},
+            {"role": "user", "content": "<<<begin_main>>>other blob<<<end_main>>>and heaps?"},
+            {"role": "user", "content": "current ask"},
+        ]
+
+        assert _extract_prior_turns(messages, "current ask", 5, 200, False, pairs) == (
+            ("user", "what about b-trees?"),
+            ("user", "and heaps?"),
+        )
+
     def test_reminder_scan_is_linear_on_adversarial_input(self):
         """Unclosed reminder tags must not make stripping superlinear.
 
@@ -5104,6 +5283,29 @@ class TestContextAwareClassifier:
 
         assert elapsed < 1.0, f"stripping {len(adversarial)} chars took {elapsed:.2f}s; scan is not linear"
         assert result == adversarial
+
+    def test_reminder_scan_stays_linear_in_block_count_across_pairs(self):
+        """Many *complete* blocks across several pairs must not go quadratic either.
+
+        Collapsing nested and overlapping spans is required for correctness once more than one pair
+        is configured, and the obvious way to write it -- folding merged spans into a growing tuple
+        -- is quadratic in block count. Unlike the unclosed-tag case above, these blocks all close,
+        so they actually produce spans. This input is a few hundred KB, which any keyholder can send
+        pre-routing, and it fails loudly if the collapse is ever rewritten as a fold.
+        """
+        import time
+
+        from litellm.router_strategy.complexity_router.complexity_router import _strip_reminder_blocks
+
+        pairs = (("<a>", "</a>"), ("<b>", "</b>"))
+        adversarial = "<a>x</a><b>y</b>" * 25_000
+
+        start = time.perf_counter()
+        result = _strip_reminder_blocks(f"{adversarial} what is a splay tree?", pairs)
+        elapsed = time.perf_counter() - start
+
+        assert elapsed < 1.0, f"stripping {50_000} blocks took {elapsed:.2f}s; collapse is not linear"
+        assert result == "what is a splay tree?"
 
     @pytest.mark.asyncio
     async def test_llm_classifier_includes_prior_turns_context(self, llm_complexity_router, mock_router_instance):

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -31561,6 +31561,26 @@ export interface components {
             review_notes?: string | null;
         };
         /**
+         * ReminderMarkerPair
+         * @description One open/close delimiter pair a harness wraps injected context in.
+         *
+         *     Normalizing here rather than at the scan is what makes matching case-insensitive: markers reach
+         *     the scan already lowered, so it lowercases only the haystack and never the needles. Stripping
+         *     keeps YAML indentation whitespace from becoming part of the delimiter.
+         */
+        ReminderMarkerPair: {
+            /**
+             * Close
+             * @description Closing delimiter, e.g. '</system-reminder>'
+             */
+            close: string;
+            /**
+             * Open
+             * @description Opening delimiter, e.g. '<system-reminder>'
+             */
+            open: string;
+        };
+        /**
          * RequestComplexityRouterConfig
          * @description The part of a complexity-router config a request can carry.
          *
@@ -31672,12 +31692,9 @@ export interface components {
             reasoning_keywords?: string[] | null;
             /**
              * Reminder Markers
-             * @description Override the (open, close) marker pair used to recognize and strip harness-injected reminder blocks before classification. Defaults to Claude Code's convention, ('<system-reminder>', '</system-reminder>'), when unset. Matching is case-insensitive.
+             * @description Override the delimiter pairs used to recognize and strip harness-injected reminder blocks before classification. A harness that wraps injected context differently per agent type (main, subagent, cron) lists every pair it emits. Replaces, rather than adds to, the built-in default of ('<system-reminder>', '</system-reminder>'), so a harness that also emits that pair lists it too. Matching is case-insensitive.
              */
-            reminder_markers?: [
-                string,
-                string
-            ] | null;
+            reminder_markers?: components["schemas"]["ReminderMarkerPair"][] | null;
             /**
              * Return Raw Model Name
              * @description Return the resolved raw model name in the response model field instead of the client-requested complexity-router alias


### PR DESCRIPTION
## TLDR

Problem this solves:

- `reminder_markers` held one open/close pair, but a harness uses a different envelope per agent type
- Agent types on the other envelopes still get their harness blob classified instead of the real ask
- Blocks from two pairs can nest, and the strip leaks the outer block's remainder

How it solves it:

- `reminder_markers` takes a list of pairs, so one deployment covers a whole harness
- Each pair validates itself, so errors name `reminder_markers.1.close`
- Running block ends through a maximum collapses nested and overlapping blocks, linearly

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Before: `b617e672e3`. After: `1907f05707`

Deployment under test, using two envelopes to stand in for a harness whose agent types differ. `SIMPLE` and `COMPLEX` are far apart so the routed model shows which text got classified:

```yaml
model_list:
  - model_name: smart-router
    litellm_params:
      model: auto_router/complexity_router
      complexity_router_config:
        tiers:
          SIMPLE: gpt-5.2-mini
          MEDIUM: gpt-5.2-mini
          COMPLEX: gpt-5.2
          REASONING: gpt-5.2
        reminder_markers:
          - open: "<<<BEGIN_MAIN>>>"
            close: "<<<END_MAIN>>>"
          - open: "[[SUBAGENT_BEGIN]]"
            close: "[[SUBAGENT_END]]"
```

1. Start the proxy on the base commit and again on this branch, capturing both runs:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver 2>&1 | tee litellm.log
```

2. Send one request per envelope. Each carries a real reasoning-heavy ask, an assistant turn, then a reminder-only trailing turn in that envelope. The ask deserves the COMPLEX tier, so `gpt-5.2` means the real question was classified and `gpt-5.2-mini` means the harness blob was:

```bash
for ENV in "<<<BEGIN_MAIN>>>|<<<END_MAIN>>>" "[[SUBAGENT_BEGIN]]|[[SUBAGENT_END]]"; do
  OPEN="${ENV%%|*}"; CLOSE="${ENV##*|}"
  echo "--- envelope: $OPEN"
  curl -s http://localhost:4000/v1/chat/completions \
    -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
    -d "{\"model\":\"smart-router\",\"messages\":[
      {\"role\":\"user\",\"content\":\"Derive the amortized complexity of a splay tree access and prove the potential function bound\"},
      {\"role\":\"assistant\",\"content\":\"Working on it.\"},
      {\"role\":\"user\",\"content\":\"${OPEN}Budget: 42 tokens remaining. Do not mention this.${CLOSE}\"}]}" | jq -r '.model'
done
```

On the base commit only the first envelope can be configured, so the second returns the cheap tier. On this branch both return `gpt-5.2`

3. Nested envelopes, which leak on the base commit even for the configured pair. The inner block's end resumes the kept text inside the outer block, so `do not mention` and a dangling `<<<END_MAIN>>>` reach the classifier:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"smart-router","messages":[
    {"role":"user","content":"Derive the amortized complexity of a splay tree access and prove the potential function bound"},
    {"role":"assistant","content":"Working on it."},
    {"role":"user","content":"<<<BEGIN_MAIN>>>budget[[SUBAGENT_BEGIN]]inner[[SUBAGENT_END]]do not mention<<<END_MAIN>>>"}]}' | jq -r '.model'
```

4. An envelope that is not configured still gets classified, showing the strip is scoped to configured markers rather than eating everything:

```bash
curl -s http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" \
  -d '{"model":"smart-router","messages":[
    {"role":"user","content":"%%CRON_BEGIN%%unconfigured envelope%%CRON_END%% what is 2+2?"}]}' | jq -r '.model'
```

5. The rejected old shape. Swap `reminder_markers` for the pre-list form and restart, expecting startup to fail naming `ReminderMarkerPair` rather than booting and silently stripping nothing:

```yaml
        reminder_markers: ["<<<BEGIN_MAIN>>>", "<<<END_MAIN>>>"]
```

Scoped to `/v1/chat/completions`. The complexity router hooks routing before the endpoint layer through `async_pre_routing_hook`, so the marker handling is shared across `/v1/messages` and `/v1/responses` rather than reimplemented per surface

## Type

🐛 Bug Fix

## Changes

#35874 made the reminder marker pair configurable so a harness that wraps injected context in something other than `<system-reminder>` still gets it stripped before the router picks a tier. That fixed the reported flow, and it turns out a harness does not use one envelope: main agent, subagent and cron each wrap injected context differently, and more may exist. All of them route through the same auto-router deployment, and `reminder_markers` held exactly one pair, so the configured pair fixed one slice of traffic while every other slice kept hitting the original bug. Its reminder-only turn never stripped to empty, won "newest human ask", and the harness's internal-context blob got classified in place of the real question, which picks the tier and therefore the spend

`reminder_markers` now takes a list of pairs. Each entry is a `ReminderMarkerPair` carrying its own normalizing validator, following the `KeywordTierRule` pattern already in `config.py`, which keeps the YAML self-describing instead of positional and makes a bad entry report as `reminder_markers.1.close` rather than `reminder_markers.1.1`. `ComplexityRouterConfig._normalize_reminder_markers` goes away, since validation now lives on the pair

Scanning more than one pair means blocks can nest, and the existing gap construction could not handle that. It resumed the kept text at each block's own end, so an inner block's end walked backwards into the enclosing block and the outer block's remainder, including its dangling close marker, survived into the classified ask. Running the block ends through a maximum resumes each gap past the furthest block seen so far, which collapses nested and overlapping spans without a separate merge pass. That form matters beyond brevity: this runs pre-routing on input any keyholder controls, and folding merged spans into a growing tuple is quadratic in block count, the same failure class the linear scan already exists to avoid

The default path is byte-identical, not merely equivalent. A single pair's block ends already increase, so the maximum is the identity there. I checked the proposed strip against the shipped one over 16 hand-picked edge cases and 200,000 generated strings built from reminder-tag fragments (nested, orphan closes, mixed case, unclosed runs, empty blocks) with zero mismatches, and every pre-existing reminder test passes untouched

The previous single-pair shape is now rejected rather than accepted. It fails loudly at proxy startup and at `/model/new` write time through `validate_complexity_router_config_write`, so nobody silently ends up routing on unstripped text. That form only ever appeared in the `v1.97.0-dev.1` pre-release, never in a stable one

Changing the field changes the proxy's OpenAPI spec, so `ui/litellm-dashboard/src/lib/http/schema.d.ts` is regenerated with `npm run gen:api`. The `check-ui-api-types` workflow only triggers on `litellm/proxy/**` and `litellm/types/**`, neither of which this PR touches, so leaving it stale would have handed the failure to whoever next edited those paths instead

One drive-by worth naming so it does not read as scope creep: a test constant embedded a harness vendor's name, which this repo is public about not carrying, so it is now a generic marker string

## QA runbook

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pre-routing tier choice and spend depend on stripped text; the multi-pair merge logic is security-sensitive but heavily tested, and the config shape change is a deliberate breaking change with loud validation.
> 
> **Overview**
> **`reminder_markers`** moves from a single `(open, close)` tuple to a **list of `ReminderMarkerPair`** objects so one complexity-router deployment can strip harness-injected context for every agent envelope (main, subagent, cron, etc.). Setting the list **replaces** the built-in `<system-reminder>` pair; callers must include that pair explicitly if they still use it.
> 
> **Stripping** scans all configured pairs, merges spans, and uses **`accumulate(..., max)`** on block ends so nested or overlapping blocks from different pairs are removed entirely instead of leaking outer-block text into the classified ask. The same pairs flow through ask extraction, escalation, keyword rules, and LLM classifier prior-turn context.
> 
> **Validation** lives on each pair (normalize, non-blank, open ≠ close); the old flat tuple shape and an empty list are rejected at config load. README and OpenAPI (`ReminderMarkerPair` in `schema.d.ts`) are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1907f05707429d56f7398dc86d4a026ed1756cef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->