### PR TITLE
fix(managed_files): return unified ids from unscoped file listing

### DIFF
--- a/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
+++ b/enterprise/litellm_enterprise/proxy/hooks/managed_files.py
@@ -383,9 +383,11 @@ class _PROXY_LiteLLMManagedFiles(CustomLogger, BaseFileEndpoints):
             }
         )
         return [
-            OpenAIFileObject.model_validate(file_object.file_object)
-            for file_object in file_ids
-            if file_object.file_object is not None
+            OpenAIFileObject.model_validate(row.file_object).model_copy(
+                update={"id": row.unified_file_id}
+            )
+            for row in file_ids
+            if row.file_object is not None
         ]
 
     async def check_managed_file_id_access(

--- a/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
+++ b/tests/test_litellm/enterprise/proxy/test_managed_files_hook.py
@@ -142,8 +142,11 @@ async def test_get_user_created_file_ids_skips_rows_without_file_object():
     managed_files = _make_managed_files_instance()
     managed_files.prisma_client.db.litellm_managedfiletable.find_many = AsyncMock(
         return_value=[
-            MagicMock(file_object=_make_file_object().model_dump()),
-            MagicMock(file_object=None),
+            MagicMock(
+                file_object=_make_file_object().model_dump(),
+                unified_file_id="unified-id-1",
+            ),
+            MagicMock(file_object=None, unified_file_id="unified-id-2"),
         ]
     )
 
@@ -151,7 +154,37 @@ async def test_get_user_created_file_ids_skips_rows_without_file_object():
         _make_user_api_key_dict(), ["file-output-abc"]
     )
 
-    assert [file.id for file in files] == ["file-output-abc"]
+    assert [file.id for file in files] == ["unified-id-1"]
+
+
+@pytest.mark.asyncio
+async def test_get_user_created_file_ids_remaps_stored_raw_provider_id_to_unified_id():
+    """
+    Rows registered from batch outputs store the provider's file object, whose
+    id is the raw provider id (e.g. file-abc). Listing must return the row's
+    unified_file_id so callers get ids that work on the managed routes.
+
+    Regression test for https://github.com/BerriAI/litellm/issues/35362.
+    """
+    unified_id = "bGl0ZWxsbV9wcm94eTt1bmlmaWVkX2lkLGRlYWRiZWVm"
+    raw_provider_object = _make_file_object("file-raw-provider-123")
+    managed_files = _make_managed_files_instance()
+    managed_files.prisma_client.db.litellm_managedfiletable.find_many = AsyncMock(
+        return_value=[
+            MagicMock(
+                file_object=raw_provider_object.model_dump(),
+                unified_file_id=unified_id,
+            ),
+        ]
+    )
+
+    files = await managed_files.get_user_created_file_ids(
+        _make_user_api_key_dict(), ["file-raw-provider-123"]
+    )
+
+    assert [file.id for file in files] == [unified_id]
+    assert files[0].filename == raw_provider_object.filename
+    assert files[0].purpose == raw_provider_object.purpose
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## TLDR

Problem this solves:

- Unscoped `client.files.list()` echoes stored ids verbatim
- Batch output rows store the raw provider `file-*` id
- Listed raw ids bypass managed-file ownership on content/retrieve
- Issue #35362's usable-unified-ids constraint was still unmet

How it solves it:

- Listing remaps every row's id to its `unified_file_id`
- Same remap `files.retrieve` already does for single lookups
- Listed ids now work on managed routes and enforce ownership

## User Flow

Before: the listing works and is owner-scoped, but batch results show up under the provider's own raw ID, which any other keyholder can use

1. An engineer points their OpenAI SDK script at `https://litellm-domain/v1` with their personal virtual key
2. `POST https://litellm-domain/v1/files` uploads the requests JSONL with purpose `batch` and returns a long scrambled file ID
3. `POST https://litellm-domain/v1/batches` with that input file ID gets the job accepted, and `GET https://litellm-domain/v1/batches/{batch_id}` is polled until it finishes
4. Their cleanup script calls `client.files.list()`, which sends `GET https://litellm-domain/v1/files` with no parameters
5. The listing returns only their own files, but the batch results row carries an OpenAI-style `file-abc123` instead of the long scrambled ID every other route hands back
6. Passing that `file-abc123` to `GET https://litellm-domain/v1/files/{id}/content` downloads the results with no ownership check, and any other keyholder who sees it can do the same

After: the same listing hands back scrambled IDs that behave like every other route's

1. An engineer points their OpenAI SDK script at `https://litellm-domain/v1` with their personal virtual key
2. `POST https://litellm-domain/v1/files` uploads the requests JSONL with purpose `batch` and returns a long scrambled file ID
3. `POST https://litellm-domain/v1/batches` with that input file ID gets the job accepted, and `GET https://litellm-domain/v1/batches/{batch_id}` is polled until it finishes
4. Their cleanup script calls `client.files.list()`, which sends `GET https://litellm-domain/v1/files` with no parameters
5. Every row in the listing now carries the long scrambled ID, the same one the upload and batch routes hand back
6. `GET https://litellm-domain/v1/files/{scrambled_id}/content` returns the results for the owner, while any other keyholder trying that same ID gets a 403

## Relevant issues

Fixes #35362

The 500 in that issue's title no longer reproduces on `litellm_internal_staging`: commit 17ce2c4e92 resolves deployment credentials on the provider-only listing path, and the live retest below confirms the unscoped call returns 200 and is owner-scoped. What remained open is the issue's second constraint, "returned IDs must be usable on the managed routes": rows registered from batch outputs store the provider's file object whose id is the raw `file-*`, and the listing echoed it back. This PR closes that last gap

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxies against one shared Postgres and a real OpenAI batch (gpt-5.5, real spend). Both legs follow issue #35362's repro exactly: no `OPENAI_API_KEY` in the proxy process environment, the only OpenAI credential lives on the `my-gpt` deployment in `model_list`. The before leg runs `litellm_internal_staging` at `0659738b3e`, the after leg runs this PR at `4b9872e7e8`, both reading the same database state

Setup, shared by both legs

```bash
# owner and second-user keys
curl -s http://localhost:53779/key/generate -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -d '{"user_id": "b13-user"}'
curl -s http://localhost:53779/key/generate -H "Authorization: Bearer sk-1234" \
  -H "Content-Type: application/json" -d '{"user_id": "b13-other"}'

# owner uploads a 1-line JSONL and runs a real OpenAI batch to completion
curl -s http://localhost:53779/v1/files -H "Authorization: Bearer $OWNER_KEY" \
  -F purpose=batch -F file=@b13_input.jsonl -F target_model_names=my-gpt
curl -s http://localhost:53779/v1/batches -H "Authorization: Bearer $OWNER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"input_file_id": "<unified id from the upload>", "endpoint": "/v1/chat/completions", "completion_window": "24h"}'
curl -s http://localhost:53779/v1/batches/$BATCH_ID -H "Authorization: Bearer $OWNER_KEY"   # poll to completed
```

The terminal retrieve registers the batch results file, and its database row stores the provider's raw id (the batch's single request failed at the provider over `max_tokens`, so its results row is the error JSONL, which registers through the same path)

```
SELECT file_object->>'id', created_by FROM "LiteLLM_ManagedFileTable"
WHERE 'file-DAeAzwkWd2hcHqEw1i7oCy' = ANY(flat_model_file_ids);
 file-DAeAzwkWd2hcHqEw1i7oCy | b13-user
```

**Before, `litellm_internal_staging` at `0659738b3e`:** the unscoped list is 200 and owner-scoped (issue #35362's original 500 is already gone at this commit), but the batch results row leaks the raw provider id, and that raw id serves the file to a different user's key with no ownership check

```bash
$ curl -s -w "\nHTTP %{http_code}" http://localhost:53779/v1/files -H "Authorization: Bearer $OWNER_KEY"
{"data": [
  {"id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07dW5pZmll...", "purpose": "batch"},
  {"id": "file-DAeAzwkWd2hcHqEw1i7oCy", "purpose": "batch_output"}], ...}
HTTP 200

$ curl -s -w "\nHTTP %{http_code}" http://localhost:53779/v1/files/file-DAeAzwkWd2hcHqEw1i7oCy/content \
  -H "Authorization: Bearer $OTHER_KEY"
{"id": "batch_req_6a73f64707fc819097ad90f939f79639", "custom_id": "b13-1", ...}
HTTP 200

$ curl -s http://localhost:53779/v1/files -H "Authorization: Bearer $OTHER_KEY"
{"data": [], ...}
```

**After, this PR at `4b9872e7e8`, same database state:** every listed row carries its unified id, the listed id works on the managed routes for the owner, and the other key is denied

```bash
$ curl -s -w "\nHTTP %{http_code}" http://localhost:55143/v1/files -H "Authorization: Bearer $OWNER_KEY"
{"data": [
  {"id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07dW5pZmll...", "purpose": "batch"},
  {"id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsYjQy...", "purpose": "batch_output"}], ...}
HTTP 200

$ curl -s -w "\nHTTP %{http_code}" http://localhost:55143/v1/files/$LISTED_ID/content \
  -H "Authorization: Bearer $OWNER_KEY"
{"id": "batch_req_6a73f64707fc819097ad90f939f79639", "custom_id": "b13-1", ...}
HTTP 200

$ curl -s -w "\nHTTP %{http_code}" http://localhost:55143/v1/files/$LISTED_ID/content \
  -H "Authorization: Bearer $OTHER_KEY"
{"error":{"message":"User b13-other does not have access to the file bGl0ZWxsbV9wcm94eTph...", ...}}
HTTP 403

$ curl -s http://localhost:55143/v1/files -H "Authorization: Bearer $OTHER_KEY"
{"data": [], ...}
```

| Checkpoint | Commit | Check | Result |
| --- | --- | --- | --- |
| Unscoped list | `0659738b3e` | GET /v1/files status | 200, PASS |
| Batch output id in list | `0659738b3e` | id shape | raw `file-*`, FAIL |
| Other key, listed raw id | `0659738b3e` | GET /v1/files/{id}/content | 200 leak, FAIL |
| Batch output id in list | `4b9872e7e8` | id shape | unified, PASS |
| Owner, listed id | `4b9872e7e8` | GET /v1/files/{id}/content | 200, PASS |
| Owner, listed id | `4b9872e7e8` | GET /v1/files/{id} | 200, PASS |
| Other key, listed id | `4b9872e7e8` | GET /v1/files/{id}/content | 403, PASS |
| Other key, unscoped list | both | data | empty, PASS |

## Type

🐛 Bug Fix
✅ Test

## Changes

- `get_user_created_file_ids` in `enterprise/litellm_enterprise/proxy/hooks/managed_files.py` now returns each row's `file_object` with its id remapped to the row's `unified_file_id` via `model_copy`, mirroring what `afile_retrieve` already does for single lookups. Upload rows already store the unified id, so the remap is a no-op for them; batch output rows store the provider's raw id and are the rows this fixes
- Regression test `test_get_user_created_file_ids_remaps_stored_raw_provider_id_to_unified_id` in `tests/test_litellm/enterprise/proxy/test_managed_files_hook.py`: a row whose stored `file_object.id` is a raw provider id lists under its `unified_file_id` with the other fields preserved. The existing skip-null-rows test now pins the remap too

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
