### PR TITLE
fix(batches): register managed output files on batch cancel

### DIFF
--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -1141,7 +1141,7 @@ async def update_batch_in_database(
         managed_files_obj: The managed_files proxy hook object
         prisma_client: Prisma database client
         verbose_proxy_logger: Logger instance
-        db_batch_object: Optional existing database object (for comparison)
+        db_batch_object: Optional existing database object; fetched by unified_object_id when omitted
         operation: Description of operation ("update", "cancel", etc.)
         user_api_key_dict: Optional auth context for creating managed file IDs
     """
@@ -1154,6 +1154,12 @@ async def update_batch_in_database(
         if not prisma_client:
             return
 
+        effective_db_batch_object: Final = (
+            db_batch_object
+            if db_batch_object is not None
+            else await ManagedObjectRepository(prisma_client).table.find_first(where={"unified_object_id": batch_id})
+        )
+
         # Always normalize the response's file IDs to unified managed IDs
         # (mutates in place) so the caller returns unified IDs to the user
         # even when we skip the DB update below for an unchanged status.
@@ -1163,16 +1169,17 @@ async def update_batch_in_database(
             prisma_client=prisma_client,
             verbose_proxy_logger=verbose_proxy_logger,
             user_api_key_dict=user_api_key_dict,
-            db_batch_object=db_batch_object,
+            db_batch_object=effective_db_batch_object,
+            unified_batch_id=unified_batch_id,
         )
 
         # Only update if status has changed (when db_batch_object is provided)
-        if db_batch_object and response.status == db_batch_object.status:
+        if effective_db_batch_object and response.status == effective_db_batch_object.status:
             return
 
-        if db_batch_object:
+        if effective_db_batch_object:
             verbose_proxy_logger.info(
-                "Updating batch %s status from %s to %s", batch_id, db_batch_object.status, response.status
+                "Updating batch %s status from %s to %s", batch_id, effective_db_batch_object.status, response.status
             )
         else:
             verbose_proxy_logger.info("Updating batch %s status to %s after %s", batch_id, response.status, operation)

--- a/tests/openai_endpoints_tests/test_openai_batches_endpoint.py
+++ b/tests/openai_endpoints_tests/test_openai_batches_endpoint.py
@@ -414,7 +414,7 @@ async def test_batch_status_sync_from_provider_to_database():
 
     # Verify logger was called with status change message
     mock_logger.info.assert_called()
-    log_message = mock_logger.info.call_args[0][0]
+    log_message = mock_logger.info.call_args[0][0] % mock_logger.info.call_args[0][1:]
     assert "validating" in log_message
     assert "completed" in log_message
 
@@ -450,6 +450,9 @@ async def test_batch_cancel_updates_database():
 
     # Mock prisma client
     mock_prisma_client = MagicMock()
+    mock_prisma_client.db.litellm_managedobjecttable.find_first = AsyncMock(
+        return_value=None
+    )
     mock_prisma_client.db.litellm_managedobjecttable.update = AsyncMock()
 
     # Mock managed_files_obj
@@ -482,7 +485,7 @@ async def test_batch_cancel_updates_database():
 
     # Verify logger was called
     mock_logger.info.assert_called()
-    log_message = mock_logger.info.call_args[0][0]
+    log_message = mock_logger.info.call_args[0][0] % mock_logger.info.call_args[0][1:]
     assert "cancel" in log_message.lower()
     assert "cancelled" in log_message
 

--- a/tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py
+++ b/tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py
@@ -45,9 +45,10 @@ def _build_managed_files_mock(unified_id: str = "file-bWFuYWdlZF9vdXRwdXRfaWQ=")
     return mock
 
 
-def _build_prisma_mock():
+def _build_prisma_mock(db_batch_object=None):
     mock = MagicMock()
     mock.db.litellm_managedfiletable.find_first = AsyncMock(return_value=None)
+    mock.db.litellm_managedobjecttable.find_first = AsyncMock(return_value=db_batch_object)
     mock.db.litellm_managedobjecttable.update = AsyncMock()
     return mock
 
@@ -87,6 +88,67 @@ async def test_update_batch_in_database_stores_unified_output_file_id():
     )
     assert stored["output_file_id"] == unified_output_file_id
     assert stored["output_file_id"] != raw_output_file_id
+
+
+@pytest.mark.asyncio
+async def test_cancel_path_registers_output_file_under_batch_owner():
+    unified_id = "file-bWFuYWdlZF9vdXRwdXRfaWQ="
+    db_batch_object = SimpleNamespace(
+        created_by="batch-owner", team_id="batch-team", status="in_progress"
+    )
+    response = _build_batch_response(
+        status="cancelling",
+        output_file_id="file-raw-output",
+        hidden_params={"model_id": "my-model", "model_name": "openai/gpt-4o"},
+    )
+    mock_managed_files = _build_managed_files_mock(unified_id=unified_id)
+    mock_prisma = _build_prisma_mock(db_batch_object=db_batch_object)
+
+    await update_batch_in_database(
+        batch_id="batch_managed_ids_test",
+        unified_batch_id="litellm_proxy;model_id:my-model;llm_batch_id:batch_managed_ids_test",
+        response=response,
+        managed_files_obj=mock_managed_files,
+        prisma_client=mock_prisma,
+        verbose_proxy_logger=MagicMock(),
+        operation="cancel",
+    )
+
+    forwarded_auth = mock_managed_files.store_unified_file_id.call_args.kwargs[
+        "user_api_key_dict"
+    ]
+    assert forwarded_auth.user_id == "batch-owner"
+    assert forwarded_auth.team_id == "batch-team"
+    stored = json.loads(
+        mock_prisma.db.litellm_managedobjecttable.update.call_args.kwargs["data"][
+            "file_object"
+        ]
+    )
+    assert stored["output_file_id"] == unified_id
+
+
+@pytest.mark.asyncio
+async def test_update_batch_derives_model_id_from_unified_batch_id():
+    unified_id = "file-bWFuYWdlZF9vdXRwdXRfaWQ="
+    response = _build_batch_response(output_file_id="file-raw-output", hidden_params={})
+    mock_managed_files = _build_managed_files_mock(unified_id=unified_id)
+    mock_prisma = _build_prisma_mock()
+
+    await update_batch_in_database(
+        batch_id="batch_managed_ids_test",
+        unified_batch_id="litellm_proxy;model_id:model-from-batch-id;llm_batch_id:batch_managed_ids_test",
+        response=response,
+        managed_files_obj=mock_managed_files,
+        prisma_client=mock_prisma,
+        verbose_proxy_logger=MagicMock(),
+        user_api_key_dict=UserAPIKeyAuth(user_id="user-abc"),
+    )
+
+    assert (
+        mock_managed_files.get_unified_output_file_id.call_args.kwargs["model_id"]
+        == "model-from-batch-id"
+    )
+    assert response.output_file_id == unified_id
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py
+++ b/tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py
@@ -128,6 +128,42 @@ async def test_cancel_path_registers_output_file_under_batch_owner():
 
 
 @pytest.mark.asyncio
+async def test_update_batch_skips_lookup_when_db_batch_object_supplied():
+    unified_id = "file-bWFuYWdlZF9vdXRwdXRfaWQ="
+    caller_row = SimpleNamespace(
+        created_by="caller-owner", team_id="caller-team", status="in_progress"
+    )
+    decoy_row = SimpleNamespace(
+        created_by="decoy-owner", team_id="decoy-team", status="in_progress"
+    )
+    response = _build_batch_response(
+        status="cancelling",
+        output_file_id="file-raw-output",
+        hidden_params={"model_id": "my-model", "model_name": "openai/gpt-4o"},
+    )
+    mock_managed_files = _build_managed_files_mock(unified_id=unified_id)
+    mock_prisma = _build_prisma_mock(db_batch_object=decoy_row)
+
+    await update_batch_in_database(
+        batch_id="batch_managed_ids_test",
+        unified_batch_id="litellm_proxy;model_id:my-model;llm_batch_id:batch_managed_ids_test",
+        response=response,
+        managed_files_obj=mock_managed_files,
+        prisma_client=mock_prisma,
+        verbose_proxy_logger=MagicMock(),
+        db_batch_object=caller_row,
+        operation="retrieve",
+    )
+
+    mock_prisma.db.litellm_managedobjecttable.find_first.assert_not_called()
+    forwarded_auth = mock_managed_files.store_unified_file_id.call_args.kwargs[
+        "user_api_key_dict"
+    ]
+    assert forwarded_auth.user_id == "caller-owner"
+    assert forwarded_auth.team_id == "caller-team"
+
+
+@pytest.mark.asyncio
 async def test_update_batch_derives_model_id_from_unified_batch_id():
     unified_id = "file-bWFuYWdlZF9vdXRwdXRfaWQ="
     response = _build_batch_response(output_file_id="file-raw-output", hidden_params={})


### PR DESCRIPTION
## TLDR

Problem this solves:

- Batch cancel never registers the batch's output and error files
- Files get registered later by whoever's request first sees them
- An admin cancelling a user's batch locks the owner out of the error file
- Cancel also persists raw provider file ids in the batch DB blob

How it solves it:

- The cancel path now looks up the batch's database row itself
- Output and error files register under the batch owner before the post-call hook
- The hook then reuses the already-unified ids, so ownership is preserved

## User Flow

Before: the flow breaks at the last step, where the batch owner is denied their own batch's result files after an admin cancelled it

1. A user uploads a batch input file with `POST https://litellm-domain/v1/files` (purpose `batch`, `target_model_names=gpt-5.5`) and gets back a long scrambled gateway file id
2. They start the batch with `POST https://litellm-domain/v1/batches` using that file id, get a long scrambled batch id, and watch it reach `in_progress`
3. A proxy admin stops the runaway batch with `POST https://litellm-domain/v1/batches/{batch_id}/cancel` using their admin key and gets 200 with status `cancelling` and no file ids yet
4. Once the provider finishes cancelling, the admin repeats the same cancel call and gets 200 with status `cancelled`, now carrying an `output_file_id` and an `error_file_id` in the gateway's long scrambled format
5. The owner checks their batch with `GET https://litellm-domain/v1/batches/{batch_id}` and sees status `cancelled` with that same scrambled `error_file_id`
6. The owner tries to see which requests ran with `GET https://litellm-domain/v1/files/{error_file_id}/content` and gets 403 "User qa-batch-owner does not have access to the file ..."
7. From then on only admin keys can read the batch's output and error files; the user who created and paid for the batch is locked out of them permanently

After: the same flow succeeds end to end, with the owner reading their cancelled batch's files even though an admin performed the cancel

1. A user uploads a batch input file with `POST https://litellm-domain/v1/files` (purpose `batch`, `target_model_names=gpt-5.5`) and gets back a long scrambled gateway file id
2. They start the batch with `POST https://litellm-domain/v1/batches` using that file id, get a long scrambled batch id, and watch it reach `in_progress`
3. A proxy admin stops the runaway batch with `POST https://litellm-domain/v1/batches/{batch_id}/cancel` using their admin key and gets 200 with status `cancelling` and no file ids yet
4. Once the provider finishes cancelling, the admin repeats the same cancel call and gets 200 with status `cancelled`, now carrying an `output_file_id` and an `error_file_id` in the gateway's long scrambled format
5. The owner checks their batch with `GET https://litellm-domain/v1/batches/{batch_id}` and sees status `cancelled` with that same scrambled `error_file_id`
6. The owner reads `GET https://litellm-domain/v1/files/{error_file_id}/content` and gets 200 with one JSON line per request explaining it was not executed because the batch was cancelled
7. Admin keys can still read the same files, and nobody outside the owner's existing access gains anything new

## Relevant issues

Follow-up to #34092, which fixed the same gap on the retrieve path

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proof against a real OpenAI batch (gpt-5.5, 8 chat requests, real spend), same flow on both runs. The owner (a virtual key for user `qa-batch-owner`) uploads an input file and creates a batch through the proxy, an org admin (the master key) cancels it while it is in progress, and once OpenAI settles the batch to `cancelled` the admin issues a second, idempotent cancel: that is the first response carrying the batch's `output_file_id` and `error_file_id`, so it is the moment the proxy converts and registers them as managed files. The owner then retrieves their batch and tries to read its error file content. The batch had 4 of 8 requests completed at cancel time, so both an output and an error file exist and both flow through the same registration path

The commands behind each step (`$PORT` is the proxy port for that run):

```bash
curl http://127.0.0.1:$PORT/v1/files -H "Authorization: Bearer $OWNER_KEY" \
  -F purpose=batch -F file=@input.jsonl -F target_model_names=gpt-5.5
curl http://127.0.0.1:$PORT/v1/batches -H "Authorization: Bearer $OWNER_KEY" \
  -H "Content-Type: application/json" \
  -d '{"input_file_id": "<unified file id>", "endpoint": "/v1/chat/completions", "completion_window": "24h"}'
curl -X POST http://127.0.0.1:$PORT/v1/batches/<unified batch id>/cancel -H "Authorization: Bearer $MASTER_KEY"
# wait until OpenAI reports the batch as cancelled, then repeat the cancel
curl -X POST http://127.0.0.1:$PORT/v1/batches/<unified batch id>/cancel -H "Authorization: Bearer $MASTER_KEY"
psql "$DATABASE_URL" -c "SELECT created_by, team_id FROM \"LiteLLM_ManagedFileTable\" WHERE '<raw error file id>' = ANY(flat_model_file_ids);"
curl http://127.0.0.1:$PORT/v1/batches/<unified batch id> -H "Authorization: Bearer $OWNER_KEY"
curl http://127.0.0.1:$PORT/v1/files/<error_file_id from the retrieve>/content -H "Authorization: Bearer $OWNER_KEY"
curl http://127.0.0.1:$PORT/v1/files/<error_file_id from the retrieve>/content -H "Authorization: Bearer $MASTER_KEY"
```

Before, at staging HEAD 60d9e6012ceff4c4234b53fac5d9b283e5786a70 (proxy on port 53691): the admin's terminal cancel registers the files under `default_user_id`, and the owner is locked out of their own batch's error file with a 403 while the admin reads it fine (validating polls trimmed)

```text
== 1. owner uploads input file (target_model_names=gpt-5.5) ==
{"id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07dW5pZmllZF9pZCwwOTgyODc4Yy1iOGM2LTRkNDYtOGI2Zi1jOTlkNDRlY2FiZjI7dGFyZ2V0X21vZGVsX25hbWVzLGdwdC01LjU7bGxtX291dHB1dF9maWxlX2lkLGZpbGUtVjNlWm1x
== 2. owner creates batch ==
{"status": "validating", "output_file_id": null, "error_file_id": null}
provider batch id: batch_6a73ec993c208190ad2cf95028ef4bf0
== 3. wait for provider status in_progress (direct OpenAI poll) ==
  poll 21: in_progress
== 4. ADMIN (master key) cancels the owner's batch via proxy ==
admin cancel HTTP 200
{"status": "cancelling", "output_file_id": null, "error_file_id": null}
== 5. wait for provider terminal state (direct OpenAI poll) ==
provider terminal: {"status": "cancelled", "output_file_id": "file-XxywAff6b2QbjrS3d73KJX", "error_file_id": "file-AWZKaTVWosj88JQ4aFSzrw"}
request_counts: {'total': 8, 'completed': 4, 'failed': 0}
== 6. ADMIN cancels the already-cancelled batch (idempotent 200; first response carrying file ids) ==
admin second cancel HTTP 200
{"status": "cancelled", "output_file_id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsNGJkZGUxYjYtOGIzOC00NDg5LTllOTYtM2IyYmQ1M2IzMTI5O3RhcmdldF9tb2RlbF9uYW1lcyw7bGxtX291dHB1dF9maWxlX2lkLGZpbGUtWHh5d0FmZjZiMlFianJTM2Q3M0tKWDtsbG1fb3V0cHV0X2ZpbGVfbW9kZWxfaWQsZDBiNzZjYjViNzNjOWFkMDQ5MTkxOGJmOWVmMTQ2NzlmMzc2ZTAwNDJjZDEyNjgxMTQzZDA4NDE0MGE3MTMxZg", "error_file_id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsZTI0ZTRhOGEtOGMzOC00Mzc3LTlkMDktMzMwNTIyZDJhODhjO3RhcmdldF9tb2RlbF9uYW1lcyw7bGxtX291dHB1dF9maWxlX2lkLGZpbGUtQVdaS2FUVldvc2o4OEpRNGFGU3pydztsbG1fb3V0cHV0X2ZpbGVfbW9kZWxfaWQsZDBiNzZjYjViNzNjOWFkMDQ5MTkxOGJmOWVmMTQ2NzlmMzc2ZTAwNDJjZDEyNjgxMTQzZDA4NDE0MGE3MTMxZg"}
== 7. managed-file row attribution for raw provider error id ==
 default_user_id | 

== 8. OWNER retrieves their batch via proxy ==
owner retrieve HTTP 200
{"status": "cancelled"}
error_file_id prefix: bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsZTI0 ...
== 9. OWNER fetches their batch's error file content ==
owner content HTTP 403
{"error":{"message":"User qa-batch-owner does not have access to the file bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsZTI0ZTRhOGEtOGMzOC00Mzc3LTlkMDktMzMwNTIyZDJhODhjO3RhcmdldF9tb2RlbF9uYW1lcyw7bGxtX291dHB1dF9maWxlX2lkLGZpbGUtQVdaS2FUVldvc2o4OEpRNGFGU3pydztsbG1fb3V0cHV0X2ZpbGVfbW9kZWxfaW
== 10. ADMIN fetches the same error file content (control) ==
admin content HTTP 200
{"id": "batch_req_6a73f2bbc5d081909569a31159b031b3", "custom_id": "qa-cancel-1", "response": null, "error": {"code": "batch_cancelled", "message": "This request was not executed because the batch was cancelled."}}
{"id": "batch_req_6a73f2bbca4881908dd37d1934ae58ea", "custom_id": "qa-cancel-2", "resp
```

After, at eef908d4ad542e8003f22d76dd12ad559f25733d (proxy on port 51737); the only commit since, 470ebc2089, is test-only, so the runtime behavior at head is identical: the same flow registers the files under `qa-batch-owner`, and the owner reads the error file content with a 200 (validating polls trimmed)

```text
== 1. owner uploads input file (target_model_names=gpt-5.5) ==
{"id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07dW5pZmllZF9pZCw4M2FjZTY0Zi0wNzk1LTQ1OTItYWY0OS0zYjAwYjE5ZGZlNjE7dGFyZ2V0X21vZGVsX25hbWVzLGdwdC01LjU7bGxtX291dHB1dF9maWxlX2lkLGZpbGUtNXhGSHFw
== 2. owner creates batch ==
{"status": "validating", "output_file_id": null, "error_file_id": null}
provider batch id: batch_6a73f2f85ee881908c4c0758d913e801
== 3. wait for provider status in_progress (direct OpenAI poll) ==
  poll 21: in_progress
== 4. ADMIN (master key) cancels the owner's batch via proxy ==
admin cancel HTTP 200
{"status": "cancelling", "output_file_id": null, "error_file_id": null}
== 5. wait for provider terminal state (direct OpenAI poll) ==
provider terminal: {"status": "cancelled", "output_file_id": "file-3fcQ3spTMYfM6h8KdAXEVf", "error_file_id": "file-PpRjsSKit6Fx6GyrSakByf"}
request_counts: {'total': 8, 'completed': 4, 'failed': 0}
== 6. ADMIN cancels the already-cancelled batch (idempotent 200; first response carrying file ids) ==
admin second cancel HTTP 200
{"status": "cancelled", "output_file_id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsZmQyYTkwMzctNDQ3My00YTVkLTg5OWQtODg5MGFiMTQ3ZjY0O3RhcmdldF9tb2RlbF9uYW1lcyw7bGxtX291dHB1dF9maWxlX2lkLGZpbGUtM2ZjUTNzcFRNWWZNNmg4S2RBWEVWZjtsbG1fb3V0cHV0X2ZpbGVfbW9kZWxfaWQsZDBiNzZjYjViNzNjOWFkMDQ5MTkxOGJmOWVmMTQ2NzlmMzc2ZTAwNDJjZDEyNjgxMTQzZDA4NDE0MGE3MTMxZg", "error_file_id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsNjlkMTYwMTQtY2YyZi00NDgxLWIyYTYtYmJlYmUxNDY3YjBkO3RhcmdldF9tb2RlbF9uYW1lcyw7bGxtX291dHB1dF9maWxlX2lkLGZpbGUtUHBSanNTS2l0NkZ4Nkd5clNha0J5ZjtsbG1fb3V0cHV0X2ZpbGVfbW9kZWxfaWQsZDBiNzZjYjViNzNjOWFkMDQ5MTkxOGJmOWVmMTQ2NzlmMzc2ZTAwNDJjZDEyNjgxMTQzZDA4NDE0MGE3MTMxZg"}
== 7. managed-file row attribution for raw provider error id ==
 qa-batch-owner | 

== 8. OWNER retrieves their batch via proxy ==
owner retrieve HTTP 200
{"status": "cancelled"}
error_file_id prefix: bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsNjlk ...
== 9. OWNER fetches their batch's error file content ==
owner content HTTP 200
{"id": "batch_req_6a73f91acc2481908f07db3a894477cb", "custom_id": "qa-cancel-3", "response": null, "error": {"code": "batch_cancelled", "message": "This request was not executed because the batch was cancelled."}}
{"id": "batch_req_6a73f91acc588190826eace4d84242b7", "custom_id": "qa-cancel-5", "resp
== 10. ADMIN fetches the same error file content (control) ==
admin content HTTP 200
{"id": "batch_req_6a73f91acc2481908f07db3a894477cb", "custom_id": "qa-cancel-3", "response": null, "error": {"code": "batch_cancelled", "message": "This request was not executed because the batch was cancelled."}}
{"id": "batch_req_6a73f91acc588190826eace4d84242b7", "custom_id": "qa-cancel-5", "resp
```

## Type

🐛 Bug Fix
✅ Test

## Changes

`update_batch_in_database` in `litellm/proxy/openai_files_endpoints/common_utils.py` now falls back to fetching the batch's `LiteLLM_ManagedObjectTable` row by `unified_object_id` when the caller does not pass `db_batch_object`, and forwards both the row and the decoded `unified_batch_id` to `ensure_batch_response_managed_file_ids`. The cancel endpoint calls `update_batch_in_database` with neither `db_batch_object` nor `user_api_key_dict`, so before this change the ensure step had no auth context and returned without registering anything: the DB blob was written with raw provider file ids, and the managed-file registration was left to the post-call managed-files hook, which attributes the file to the caller of the cancel request instead of the batch owner. Since `store_unified_file_id` is an upsert that never rewrites `created_by`, whoever cancelled first owned the error file forever, and the real batch owner got a 403 on their own batch's error file content. With the row fetched, ensure derives the owner's auth from `created_by`/`team_id` and registers the files under the batch owner before the hook runs; the hook then sees already-unified ids and reuses them, preserving ownership. The status-skip and logging paths use the fetched row too, and `unified_batch_id` forwarding lets ensure derive the model id when the response's hidden params lack it

Tests: `tests/test_litellm/enterprise/proxy/test_batch_update_db_managed_output_file_id.py` gains `test_cancel_path_registers_output_file_under_batch_owner` (cancel-shaped call with no auth or row passed registers the error file under the batch owner found in the DB), `test_update_batch_derives_model_id_from_unified_batch_id`, and `test_update_batch_skips_lookup_when_db_batch_object_supplied` (a caller-supplied row is used as-is and no lookup fires, covering the retrieve-path branch Codecov flagged). Two pre-existing tests in `tests/openai_endpoints_tests/test_openai_batches_endpoint.py` had rotted when logging moved to lazy %-formatting (they asserted on the unformatted template string); they now format `call_args` before asserting, and the cancel test stubs the managed-object lookup this change introduces

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

