### PR TITLE
fix(logging): resolve standard logging trace_id and session_id independently

### DIFF
--- a/litellm/integrations/posthog.py
+++ b/litellm/integrations/posthog.py
@@ -285,9 +285,11 @@ class PostHogLogger(CustomBatchLogger):
         end_user: Final = self._safe_get(standard_logging_object, "end_user")
         if end_user:
             return str(end_user)
-        trace_id: Final = self._safe_get(standard_logging_object, "trace_id")
-        if trace_id:
-            return str(trace_id)
+        session_id: Final = self._safe_get(standard_logging_object, "session_id") or self._safe_get(
+            standard_logging_object, "trace_id"
+        )
+        if session_id:
+            return str(session_id)
 
         return self._safe_uuid()
 

--- a/litellm/litellm_core_utils/litellm_logging.py
+++ b/litellm/litellm_core_utils/litellm_logging.py
@@ -5051,32 +5051,46 @@ class StandardLoggingPayloadSetup:
             return end_time_float - start_time_float
 
     @staticmethod
+    def _get_standard_logging_payload_session_id(
+        logging_obj: Logging,
+        litellm_params: dict,
+    ) -> str:
+        """
+        Returns the session id for this request, preferring session-scoped values.
+
+        This links multiple requests made in a single session
+        """
+        metadata: Final = litellm_params.get("metadata") or {}
+        for candidate in (
+            litellm_params.get("litellm_session_id"),
+            metadata.get("session_id"),
+            litellm_params.get("litellm_trace_id"),
+            metadata.get("trace_id"),
+        ):
+            if candidate:
+                return str(candidate)
+        return logging_obj.litellm_trace_id
+
+    @staticmethod
     def _get_standard_logging_payload_trace_id(
         logging_obj: Logging,
         litellm_params: dict,
     ) -> str:
         """
-        Returns the `litellm_trace_id` for this request
+        Returns the trace id for this request, preferring trace-scoped values.
 
-        This helps link sessions when multiple requests are made in a single session
+        This groups the LLM calls belonging to one overall request, such as fallbacks
+        and retries
         """
-        dynamic_litellm_session_id: Final = litellm_params.get("litellm_session_id")
-        dynamic_litellm_trace_id: Final = litellm_params.get("litellm_trace_id")
-
-        # Note: we recommend using `litellm_session_id` for session tracking
-        # `litellm_trace_id` is an internal litellm param
-        if dynamic_litellm_session_id:
-            return str(dynamic_litellm_session_id)
-        elif dynamic_litellm_trace_id:
-            return str(dynamic_litellm_trace_id)
-        # Fallback: use metadata.session_id or metadata.trace_id for call chaining
         metadata: Final = litellm_params.get("metadata") or {}
-        metadata_session_id: Final = metadata.get("session_id")
-        metadata_trace_id: Final = metadata.get("trace_id")
-        if metadata_session_id:
-            return str(metadata_session_id)
-        if metadata_trace_id:
-            return str(metadata_trace_id)
+        for candidate in (
+            litellm_params.get("litellm_trace_id"),
+            metadata.get("trace_id"),
+            litellm_params.get("litellm_session_id"),
+            metadata.get("session_id"),
+        ):
+            if candidate:
+                return str(candidate)
         return logging_obj.litellm_trace_id
 
     @staticmethod
@@ -5383,6 +5397,10 @@ def get_standard_logging_object_payload(
             id=str(id),
             litellm_call_id=kwargs.get("litellm_call_id") or litellm_params.get("litellm_call_id"),
             trace_id=StandardLoggingPayloadSetup._get_standard_logging_payload_trace_id(
+                logging_obj=logging_obj,
+                litellm_params=litellm_params,
+            ),
+            session_id=StandardLoggingPayloadSetup._get_standard_logging_payload_session_id(
                 logging_obj=logging_obj,
                 litellm_params=litellm_params,
             ),

--- a/litellm/proxy/spend_tracking/spend_tracking_utils.py
+++ b/litellm/proxy/spend_tracking/spend_tracking_utils.py
@@ -481,8 +481,10 @@ def _get_session_id_for_spend_log(
     """
     from litellm._uuid import uuid
 
-    if standard_logging_payload is not None and standard_logging_payload.get("trace_id") is not None:
-        return str(standard_logging_payload.get("trace_id"))
+    if standard_logging_payload is not None:
+        session_id: Final = standard_logging_payload.get("session_id") or standard_logging_payload.get("trace_id")
+        if session_id is not None:
+            return str(session_id)
 
     # Users can dynamically set the trace_id for each request by passing `litellm_trace_id` in kwargs
     if kwargs.get("litellm_trace_id") is not None:

--- a/litellm/types/utils.py
+++ b/litellm/types/utils.py
@@ -3127,6 +3127,7 @@ class StandardAuditLogPayload(TypedDict):
 class StandardLoggingPayload(TypedDict):
     id: str
     trace_id: str  # Trace multiple LLM calls belonging to same overall request (e.g. fallbacks/retries)
+    session_id: str
     litellm_call_id: str | None  # UUID returned in x-litellm-call-id response header
     call_type: str
     stream: bool | None

--- a/tests/logging_callback_tests/test_standard_logging_payload.py
+++ b/tests/logging_callback_tests/test_standard_logging_payload.py
@@ -509,6 +509,59 @@ def test_get_standard_logging_payload_trace_id():
     assert isinstance(result, str)
 
 
+def test_trace_id_and_session_id_are_resolved_independently():
+    """A caller setting both must get their trace_id as the trace and their session_id as the session."""
+    from unittest.mock import MagicMock
+
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.litellm_trace_id = "fallback-id"
+
+    litellm_params = {"metadata": {"trace_id": "caller-trace", "session_id": "caller-session"}}
+
+    assert (
+        StandardLoggingPayloadSetup._get_standard_logging_payload_trace_id(
+            logging_obj=mock_logging_obj, litellm_params=litellm_params
+        )
+        == "caller-trace"
+    )
+    assert (
+        StandardLoggingPayloadSetup._get_standard_logging_payload_session_id(
+            logging_obj=mock_logging_obj, litellm_params=litellm_params
+        )
+        == "caller-session"
+    )
+
+
+def test_trace_id_and_session_id_fall_back_to_each_other():
+    """Either id alone still populates both, so existing single-id callers are unaffected."""
+    from unittest.mock import MagicMock
+
+    mock_logging_obj = MagicMock()
+    mock_logging_obj.litellm_trace_id = "fallback-id"
+
+    session_only = {"litellm_session_id": "s-1"}
+    assert (
+        StandardLoggingPayloadSetup._get_standard_logging_payload_trace_id(
+            logging_obj=mock_logging_obj, litellm_params=session_only
+        )
+        == "s-1"
+    )
+    assert (
+        StandardLoggingPayloadSetup._get_standard_logging_payload_session_id(
+            logging_obj=mock_logging_obj, litellm_params=session_only
+        )
+        == "s-1"
+    )
+
+    trace_only = {"litellm_trace_id": "t-1"}
+    assert (
+        StandardLoggingPayloadSetup._get_standard_logging_payload_session_id(
+            logging_obj=mock_logging_obj, litellm_params=trace_only
+        )
+        == "t-1"
+    )
+
+
 def test_truncate_standard_logging_payload():
     """
     1. original messages, response, and error_str should NOT BE MODIFIED, since these are from kwargs

--- a/tests/test_litellm/integrations/test_posthog.py
+++ b/tests/test_litellm/integrations/test_posthog.py
@@ -1,0 +1,13 @@
+
+
+def test_distinct_id_prefers_session_id_over_trace_id():
+    """PostHog identifies a person, so it needs session grouping rather than the trace."""
+    from litellm.integrations.posthog import PostHogLogger
+
+    logger = PostHogLogger.__new__(PostHogLogger)
+    payload = {"trace_id": "per-trace", "session_id": "per-session"}
+
+    assert logger._get_distinct_id(standard_logging_object=payload, kwargs={}) == "per-session"
+
+    legacy = {"trace_id": "only-trace"}
+    assert logger._get_distinct_id(standard_logging_object=legacy, kwargs={}) == "only-trace"

--- a/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
+++ b/tests/test_litellm/proxy/spend_tracking/test_spend_tracking_utils.py
@@ -2959,3 +2959,16 @@ def test_user_traffic_carries_no_internal_call_origin():
     )
     metadata = json.loads(payload["metadata"])
     assert metadata["internal_call_origin"] is None
+
+
+def test_spend_log_session_id_prefers_session_over_trace():
+    """SpendLogs.session_id must keep session semantics now that trace_id is trace-first."""
+    from litellm.proxy.spend_tracking.spend_tracking_utils import (
+        _get_session_id_for_spend_log,
+    )
+
+    payload = {"trace_id": "caller-trace", "session_id": "caller-session"}
+    assert _get_session_id_for_spend_log(kwargs={}, standard_logging_payload=payload) == "caller-session"
+
+    legacy_payload = {"trace_id": "only-trace"}
+    assert _get_session_id_for_spend_log(kwargs={}, standard_logging_payload=legacy_payload) == "only-trace"


### PR DESCRIPTION
## TLDR

Problem this solves:

- `StandardLoggingPayload` has one `trace_id` field doing two jobs, and its resolver returns the caller's `session_id` whenever one is set, so the field documented as "trace multiple LLM calls belonging to same overall request" actually holds a session id
- Integrations that read it as a trace get a session: Arize sets it as `litellm.trace_id`, New Relic uses it as the SLO trace id, and Langfuse falls back to it when the caller supplied no `metadata.trace_id`. All of them collapse a whole session onto one trace id
- A caller who supplies both a `trace_id` and a `session_id` has no way to get the first one honored, which is the second half of the behavior reported in the linked issue

How it solves it:

- `StandardLoggingPayload` gains a `session_id` field that resolves session-first, exactly the order `trace_id` used to resolve in, so session grouping keeps the value it has today
- `trace_id` now resolves trace-first, so it means what its own docstring says
- Either id alone still populates both, so a caller who supplies only one of them sees no change at all

## Relevant issues

Second defect described in https://github.com/BerriAI/litellm/issues/34226. The first, the caller's `metadata` never reaching the logging callbacks on `/v1/responses`, is fixed separately in #35866. This PR is independent of that one and can land in either order

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Two proxies, same config, same request, one on `litellm_internal_staging` and one on this branch, each with its own Postgres and with Langfuse pointed at a local ingestion endpoint so the raw trace body is visible. The caller sets both ids and no `metadata.trace_id`, which is what makes Langfuse consult the standard logging payload:

```bash
curl -sS localhost:<port>/v1/chat/completions \
  -H 'Authorization: Bearer sk-1234' -H 'content-type: application/json' \
  -d '{"model":"gemini-flash","messages":[{"role":"user","content":"hi"}],
       "litellm_trace_id":"TRACE-1785985430","litellm_session_id":"SESSION-1785985430"}'
```

```console
# base, on litellm_internal_staging
HTTP 200
langfuse trace-create id : SESSION-1785985430      <- the caller's trace_id is discarded
SpendLogs.session_id     : SESSION-1785985430

# head, this branch
HTTP 200
langfuse trace-create id : TRACE-1785985430        <- the caller's trace_id is honored
SpendLogs.session_id     : SESSION-1785985430      <- unchanged
```

The second line of each pair is the point: the trace consumer starts getting a trace id, and session grouping keeps the exact value it had before, so no existing session view is re-keyed

## Type

🐛 Bug Fix

## Changes

`StandardLoggingPayloadSetup` gains `_get_standard_logging_payload_session_id`, which resolves `litellm_session_id`, then `metadata.session_id`, then the two trace-scoped values, then the logging object's id. That is the exact order `_get_standard_logging_payload_trace_id` used before this change, so the session value is bit-for-bit what it was.

`_get_standard_logging_payload_trace_id` now walks the same four candidates trace-first. Both are written as a single ordered tuple rather than an if-chain so the precedence is readable at a glance and the two functions are visibly mirror images.

`StandardLoggingPayload` gains `session_id: str`, populated alongside `trace_id`.

`_get_session_id_for_spend_log` reads the new `session_id` and falls back to `trace_id`, which keeps the `SpendLogs.session_id` column correct both for payloads built by this version and for any payload that predates the new field.

`PostHogLogger._get_distinct_id` gets the same treatment. It identifies a person, and its third fallback was the payload `trace_id`, so leaving it alone would have scattered one session's events across several identities and inflated user counts for anyone sending both ids.

## Behavior changes

Consumers that read `standard_logging_payload["trace_id"]` as a trace now receive the caller's `trace_id` rather than their `session_id`, for callers who set both. That is the fix, and it changes the id those integrations report: Arize `litellm.trace_id`, the New Relic SLO trace id, and the Langfuse fallback path. Anyone who set only one of the two ids sees no change, since each still falls back to the other.

`SpendLogs.session_id` is deliberately unaffected, verified above.

## QA runbook

Point the proxy at any HTTP server that accepts `POST /api/public/ingestion` and returns 207, enable the langfuse success callback, then send the curl above with both ids set and no `metadata.trace_id`. The captured `trace-create` body should carry the `litellm_trace_id` value. Then query the spend log and confirm `session_id` still carries the `litellm_session_id` value:

```bash
psql "$DATABASE_URL" -c 'select session_id from "LiteLLM_SpendLogs" order by "startTime" desc limit 1'
```

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
