### PR TITLE
fix: expired-miss share over all measured turns + cost-optimization tab labels

### DIFF
--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
@@ -155,12 +155,12 @@ describe("AutoRouterBenchmarksTab", () => {
     expect(screen.getByText(/turns measured/)).toBeInTheDocument();
   });
 
-  it("recomputes the expired-miss share from the miss counts", () => {
+  it("computes the expired-miss share over every measured turn, not just return-to-tier misses", () => {
     mockHook({ data: response([group()]) });
     renderTab();
 
     expect(screen.getByText("Expired-miss")).toBeInTheDocument();
-    expect(screen.getByText("27.1%")).toBeInTheDocument();
+    expect(screen.getByText("2.3%")).toBeInTheDocument();
   });
 
   it("exposes the whole expired-miss row as a focusable tooltip trigger", () => {
@@ -168,14 +168,30 @@ describe("AutoRouterBenchmarksTab", () => {
     renderTab();
 
     const trigger = screen.getByRole("button", { name: /Expired-miss/ });
-    expect(trigger).toHaveTextContent("27.1%");
+    expect(trigger).toHaveTextContent("2.3%");
   });
 
-  it("hides the expired-miss row when every return turn hit", () => {
+  it("shows a zero expired-miss share, rather than hiding the row, when every return turn hit", () => {
     const allHits = totals({
       cache: cache({ return_to_tier: { turns: 381, hits: 381, hit_rate_pct: 100 }, return_misses_expired: 0 }),
     });
     mockHook({ data: response([group(allHits)], allHits) });
+    renderTab();
+
+    const trigger = screen.getByRole("button", { name: /Expired-miss/ });
+    expect(trigger).toHaveTextContent("0.0%");
+  });
+
+  it("hides the expired-miss row only when no turns were measured at all", () => {
+    const empty = { turns: 0, hits: 0, hit_rate_pct: 0 };
+    const nothingMeasured = {
+      same_model: empty,
+      first_visit: empty,
+      return_to_tier: empty,
+      return_misses_expired: 0,
+    };
+    const noTurns = totals({ cache: cache(nothingMeasured) });
+    mockHook({ data: response([group(noTurns)], noTurns) });
     renderTab();
 
     expect(screen.queryByText("Expired-miss")).not.toBeInTheDocument();

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.test.tsx
@@ -163,6 +163,14 @@ describe("AutoRouterBenchmarksTab", () => {
     expect(screen.getByText("27.1%")).toBeInTheDocument();
   });
 
+  it("exposes the whole expired-miss row as a focusable tooltip trigger", () => {
+    mockHook({ data: response([group()]) });
+    renderTab();
+
+    const trigger = screen.getByRole("button", { name: /Expired-miss/ });
+    expect(trigger).toHaveTextContent("27.1%");
+  });
+
   it("hides the expired-miss row when every return turn hit", () => {
     const allHits = totals({
       cache: cache({ return_to_tier: { turns: 381, hits: 381, hit_rate_pct: 100 }, return_misses_expired: 0 }),

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
@@ -183,23 +183,26 @@ const CachingCard: React.FC<{ cache: AutoRouterCacheStats }> = ({ cache }) => {
             <p className="text-5xl font-semibold tracking-tight text-foreground">{pctLabel(cache.hit_rate_pct)}</p>
           </div>
           {expiredMissPct === null ? null : (
-            <div className="flex items-baseline justify-between gap-2 border-t pt-3">
-              <TooltipProvider delay={200}>
-                <Tooltip>
-                  <TooltipTrigger
-                    render={
-                      <p className="cursor-default text-sm text-muted-foreground underline decoration-dotted underline-offset-2">
-                        Expired-miss
-                      </p>
-                    }
-                  />
-                  <TooltipContent className="max-w-64">
-                    percentage of return-to-tier cache misses caused by cache expiring
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-              <p className="font-medium tabular-nums text-foreground">{pctLabel(expiredMissPct)}</p>
-            </div>
+            <TooltipProvider delay={200}>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <button
+                      type="button"
+                      className="flex w-full cursor-default items-baseline justify-between gap-2 border-t pt-3 text-left"
+                    />
+                  }
+                >
+                  <span className="text-sm text-muted-foreground underline decoration-dotted underline-offset-2">
+                    Expired-miss
+                  </span>
+                  <span className="font-medium tabular-nums text-foreground">{pctLabel(expiredMissPct)}</span>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-64">
+                  percentage of return-to-tier cache misses caused by cache expiring
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           )}
         </div>
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/AutoRouterBenchmarksTab.tsx
@@ -199,7 +199,8 @@ const CachingCard: React.FC<{ cache: AutoRouterCacheStats }> = ({ cache }) => {
                   <span className="font-medium tabular-nums text-foreground">{pctLabel(expiredMissPct)}</span>
                 </TooltipTrigger>
                 <TooltipContent className="max-w-64">
-                  percentage of return-to-tier cache misses caused by cache expiring
+                  share of all measured turns that missed cache because a return to an earlier tier came after its TTL
+                  lapsed
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.test.tsx
@@ -17,21 +17,21 @@ describe("CostOptimizationView", () => {
   it("renders the four cost-optimization tabs", () => {
     const { getByText } = renderView();
 
-    expect(getByText("Usage")).toBeInTheDocument();
+    expect(getByText("Overall")).toBeInTheDocument();
     expect(getByText("Prompt Compression")).toBeInTheDocument();
     expect(getByText("Prompt Caching")).toBeInTheDocument();
-    expect(getByText("Auto-Router Usage")).toBeInTheDocument();
+    expect(getByText("Auto-Router")).toBeInTheDocument();
   });
 
-  it("defaults to the Usage tab and switches the active tab on click", () => {
+  it("defaults to the Overall tab and switches the active tab on click", () => {
     const { getByRole } = renderView();
 
-    expect(getByRole("tab", { name: "Usage" })).toHaveAttribute("aria-selected", "true");
+    expect(getByRole("tab", { name: "Overall" })).toHaveAttribute("aria-selected", "true");
     expect(getByRole("tab", { name: "Prompt Compression" })).toHaveAttribute("aria-selected", "false");
 
     fireEvent.click(getByRole("tab", { name: "Prompt Compression" }));
 
-    expect(getByRole("tab", { name: "Usage" })).toHaveAttribute("aria-selected", "false");
+    expect(getByRole("tab", { name: "Overall" })).toHaveAttribute("aria-selected", "false");
     expect(getByRole("tab", { name: "Prompt Compression" })).toHaveAttribute("aria-selected", "true");
   });
 });

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/CostOptimizationView.tsx
@@ -22,7 +22,7 @@ const CostOptimizationView: React.FC<CostOptimizationViewProps> = ({ accessToken
   const items = [
     {
       key: "usage",
-      label: "Usage",
+      label: "Overall",
       children: <UsageTab accessToken={accessToken} activity={activity} />,
     },
     {
@@ -37,7 +37,7 @@ const CostOptimizationView: React.FC<CostOptimizationViewProps> = ({ accessToken
     },
     {
       key: "autorouter-usage",
-      label: "Auto-Router Usage",
+      label: "Auto-Router",
       children: <AutoRouterBenchmarksTab accessToken={accessToken} />,
     },
   ];

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/autoRouterBenchmarks.test.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/autoRouterBenchmarks.test.ts
@@ -131,12 +131,25 @@ describe("bucketRows", () => {
 });
 
 describe("expiredMissShare", () => {
-  it("recomputes the expired share from the miss counts", () => {
-    expect(expiredMissShare(cache())).toBeCloseTo((100 * 19) / 70);
+  it("computes the expired share over every measured turn, not just return-to-tier misses", () => {
+    expect(expiredMissShare(cache())).toBeCloseTo((100 * 19) / 818);
   });
 
-  it("is absent when every return turn hit", () => {
-    expect(expiredMissShare(cache({ return_to_tier: { turns: 10, hits: 10, hit_rate_pct: 100 } }))).toBeNull();
+  it("is zero, not absent, when every return turn hit", () => {
+    expect(
+      expiredMissShare(cache({ return_to_tier: { turns: 10, hits: 10, hit_rate_pct: 100 }, return_misses_expired: 0 })),
+    ).toBe(0);
+  });
+
+  it("is absent only when no turns were measured at all", () => {
+    const empty = { turns: 0, hits: 0, hit_rate_pct: 0 };
+    const nothingMeasured = {
+      same_model: empty,
+      first_visit: empty,
+      return_to_tier: empty,
+      return_misses_expired: 0,
+    };
+    expect(expiredMissShare(cache(nothingMeasured))).toBeNull();
   });
 });
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/autoRouterBenchmarks.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/autoRouterBenchmarks.ts
@@ -91,9 +91,9 @@ export const bucketRows = (cache: AutoRouterCacheStats): BucketRow[] => {
 };
 
 export const expiredMissShare = (cache: AutoRouterCacheStats): number | null => {
-  const misses = cache.return_to_tier.turns - cache.return_to_tier.hits;
-  if (misses <= 0) return null;
-  return (100 * cache.return_misses_expired) / misses;
+  const total = bucketTurnsTotal(cache);
+  if (total <= 0) return null;
+  return (100 * cache.return_misses_expired) / total;
 };
 
 export const pctLabel = (value: number, digits: number = 1): string => `${value.toFixed(digits)}%`;


### PR DESCRIPTION
## TLDR

Problem this solves:

- expired-miss percentage denominator was showing only return-to-tier misses, hiding the fact that rapid tier flips become cache hits
- cost-optimization tab names were verbose

How it solves it:

- change expired-miss denominator to all measured turns (same_model + first_visit + return_to_tier), contextualizing expired misses as a share of overall coverage
- rename 'Usage' tab to 'Overall' and 'Auto-Router Usage' tab to 'Auto-Router'
- update all unit and component tests to match new semantics

## Relevant issues

Follow-up to #35995, which introduced the caching card and expired-miss stat

## Linear ticket

## Pre-Submission checklist

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile Confidence Score of at least 4/5 before requesting a maintainer review

## Screenshots / Proof of Fix

Live verification at http://localhost:3000/cost-optimization/ (Auto-Router tab):
- Expired-miss tooltip appears on hover over the whole row (label plus percentage)
- Percentage shows 30.0% (6 expired / 20 measured turns from seeded test sessions)
- Tab bar shows Overall, Prompt Compression, Prompt Caching, Auto-Router

Unit tests: 91/91 pass, mutation check confirms the formula change is locked by tests

## Type

Bug Fix

## Changes

- `autoRouterBenchmarks.ts`: expired-miss percentage now computed as (expired_misses / all_measured_turns) instead of (expired_misses / return_to_tier_misses)
- `CostOptimizationView.tsx`: tab labels renamed to 'Overall' and 'Auto-Router'
- `autoRouterBenchmarks.test.ts` and `AutoRouterBenchmarksTab.test.tsx`: updated assertions to match new denominator and label names

## QA runbook

1. Run the proxy (`python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --reload --use_v2_migration_resolver`) and the dashboard (`npm run dev` in `ui/litellm-dashboard`)
2. Open http://localhost:3000/cost-optimization/ and switch to the Auto-Router tab
3. Hover over the 'Expired-miss' row: the tooltip should appear
4. Confirm the percentage reflects a share of all measured turns, not just return-to-tier misses

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard-only analytics display and label changes with unit tests; no API or auth changes.
> 
> **Overview**
> **Auto-router cache “Expired-miss”** now uses **all measured turns** (same model + first visit + return to tier) as the denominator instead of only return-to-tier misses, so the percentage reflects TTL-related misses as a share of overall coverage (e.g. fixture drops from ~27% to ~2.3%). The row stays visible at **0.0%** when there are measured turns but no expired misses, and is hidden only when **no turns** were measured.
> 
> The expired-miss row is a **single focusable tooltip trigger** (button) for the whole label + value, with tooltip copy updated to describe the new definition.
> 
> **Cost Optimization** tab labels are shortened: **Usage → Overall** and **Auto-Router Usage → Auto-Router**, with matching test updates in `expiredMissShare`, `AutoRouterBenchmarksTab`, and `CostOptimizationView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8cd1b58f56b8d6fe17d6d27564d503ee7a3ec79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->