### PR TITLE
test: roll back runtime model registrations between tests

### DIFF
--- a/tests/test_litellm/conftest.py
+++ b/tests/test_litellm/conftest.py
@@ -19,6 +19,7 @@ sys.path.insert(
 import asyncio
 
 import litellm
+from litellm import utils as litellm_utils_module
 from litellm._logging import ALL_LOGGERS
 from litellm.litellm_core_utils.prompt_templates import (
     image_handling as image_handling_module,
@@ -238,6 +239,11 @@ def isolate_litellm_state():
         if hasattr(litellm, _attr):
             original_state[_attr] = getattr(litellm, _attr)
 
+    original_runtime_registered_model_cost = {
+        model_key: dict(model_value)
+        for model_key, model_value in litellm_utils_module._runtime_registered_model_cost.items()
+    }
+
     # Store LiteLLM logger state. Some tests reconfigure handlers/propagation for
     # JSON logging and do not restore them, which breaks later caplog-based tests.
     logger_state = {}
@@ -303,6 +309,9 @@ def isolate_litellm_state():
     for attr_name, original_value in original_state.items():
         if hasattr(litellm, attr_name):
             setattr(litellm, attr_name, original_value)
+
+    litellm_utils_module._runtime_registered_model_cost.clear()
+    litellm_utils_module._runtime_registered_model_cost.update(original_runtime_registered_model_cost)
 
     # Restore logger configuration mutated by logging-focused tests.
     for logger in ALL_LOGGERS:

--- a/tests/test_litellm/test_conftest_isolation.py
+++ b/tests/test_litellm/test_conftest_isolation.py
@@ -1,0 +1,13 @@
+import litellm
+from litellm import utils as litellm_utils_module
+
+CANARY_MODEL = "conftest-isolation-canary-model"
+
+
+def test_register_model_ledger_entry_is_scoped_to_this_test():
+    litellm.register_model({CANARY_MODEL: {"litellm_provider": "openai", "input_cost_per_token": 0.001}})
+    assert CANARY_MODEL in litellm_utils_module._runtime_registered_model_cost
+
+
+def test_register_model_ledger_entry_was_rolled_back():
+    assert CANARY_MODEL not in litellm_utils_module._runtime_registered_model_cost


### PR DESCRIPTION
## TLDR

Problem this solves:

- proxy-infra required check flakes on `test_distributed_reload_check_function`
- since #35491, cost map swaps replay every earlier `register_model` call
- any same-worker test registering `gpt-3.5-turbo` poisons the test's assert
- reruns can't save the run because the pollution is process-wide

How it solves it:

- the autouse isolation fixture now restores the registration ledger after every test
- a regression test pair proves registrations no longer outlive their test

## User Flow

Before: the contributor's PR goes red on a required check for a failure their change cannot have caused, and reruns stay red

1. A contributor pushes a branch touching anything at all and opens a PR at `https://github.com/BerriAI/litellm/pulls`
2. On the PR's Checks tab, the required check "Unit Tests: Proxy Infrastructure / proxy-infra / Run tests" turns red after ~11 minutes
3. Opening the job log at `https://github.com/BerriAI/litellm/actions/runs/{run_id}/job/{job_id}`, they see `TestPriceDataReloadIntegration::test_distributed_reload_check_function` failing on an assert that compares a two-field pricing entry against a ~106-field dump of mostly `None` values, in a file their PR never touched
4. The two automatic reruns in the same log fail with the identical assert, so the red is sticky for this CI run
5. They click "Re-run failed jobs"; whether the fresh run goes green is a coin flip depending on which tests share a worker, and they may burn several reruns and an hour before merging

After: the same PR's proxy-infra check passes, and that test no longer depends on which tests ran before it

1. A contributor pushes a branch touching anything at all and opens a PR at `https://github.com/BerriAI/litellm/pulls`
2. On the PR's Checks tab, the required check "Unit Tests: Proxy Infrastructure / proxy-infra / Run tests" turns green
3. `test_distributed_reload_check_function` passes regardless of which other tests ran earlier in the same worker, so no reruns are needed for this failure

## Relevant issues

Observed on PR #36024, where the proxy-infra required check failed three attempts in a row on a keepalive-only change

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR changes only test isolation, no proxy runtime code, so there is no end-user request to curl: the observable behavior is the CI shard itself. The proof is a deterministic reproduction of the exact CI failure and its disappearance at the exact commits

| Leg | Commit | Run | Result |
| --- | --- | --- | --- |
| staging, polluted | 60d9e6012c | polluter then flaky test | FAIL |
| this PR, polluted | 0991692e68 | polluter then flaky test | PASS |
| staging, regression pair | 60d9e6012c | new pair test | FAIL |
| this PR, regression pair | 0991692e68 | new pair test | PASS |

The reproduction plants a minimal polluter that does what many router and spend tests already do, register `gpt-3.5-turbo`. `PYTEST_XDIST_WORKER=gw0` mimics a CI xdist worker (the conftest skips its module reload exactly as it does under `-n 2`), and the polluter's function name sorts first because the conftest orders tests by bare name

```bash
cat > tests/test_litellm/test_aaa_polluter_tmp.py <<'EOF'
import litellm


def test_aaa_register_a_model_like_any_router_test_does():
    litellm.register_model({"gpt-3.5-turbo": {"litellm_provider": "openai"}})
EOF
PYTEST_XDIST_WORKER=gw0 .venv/bin/pytest tests/test_litellm/test_aaa_polluter_tmp.py \
  "tests/test_litellm/proxy/test_proxy_server.py::TestPriceDataReloadIntegration::test_distributed_reload_check_function" \
  -q -p no:cacheprovider
```

On staging (60d9e6012c) this fails with the same assert diff as the CI logs, the sparse `{"input_cost_per_token": 0.001}` mock ballooned into a ~106-field mostly-`None` `ModelInfo` dict:

```text
FAILED tests/test_litellm/proxy/test_proxy_server.py::TestPriceDataReloadIntegration::test_distributed_reload_check_function
1 failed, 1 passed, 1 warning in 1.78s
```

On this branch (0991692e68) the identical sequence passes:

```text
2 passed, 1 warning in 1.54s
```

The regression pair (`tests/test_litellm/test_conftest_isolation.py`) fails on staging at the rollback assert and passes here, plain and under `-n 2 --dist=loadscope`. The full proxy-infra shard command from `.github/workflows/test-unit-proxy-infra.yml` was also run on this branch with `-n 2 --dist=loadscope --reruns 2`: 6259 passed, with the only failures being `test_semantic_tool_filter.py` hitting a missing optional `semantic_router` package in a fresh local venv, which reproduces identically without this change and passes once that package is installed

## Type

✅ Test

## Changes

`tests/test_litellm/conftest.py`: the autouse `isolate_litellm_state` fixture snapshots `litellm.utils._runtime_registered_model_cost` before each test and restores it in place on teardown. Since #35491 that ledger records every `register_model` call and `_swap_in_model_cost_map` replays it on top of any newly adopted cost map, so a registration leaked by one test rewrote the model entries a later test swapped in. The restore is in place (clear plus update) because the replay mutates the same dict object

`tests/test_litellm/test_conftest_isolation.py`: a two-test regression pair; the first registers a canary model and asserts it landed in the ledger, the second asserts the fixture rolled it back. On current staging the second test fails, with this PR both pass

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
