### PR TITLE
fix(proxy): stop dropping bedrock batch credentials and model in batch endpoints

### DIFF
--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -189,6 +189,7 @@ async def create_batch(
                 llm_router=llm_router,
                 model_id=model_from_file_id,
                 operation_context="batch creation (file created with model)",
+                include_model=True,
             )
 
             original_file_id: Final = get_original_file_id(input_file_id)
@@ -280,6 +281,7 @@ async def create_batch(
                     llm_router=llm_router,
                     model_id=model_param,
                     operation_context="batch creation",
+                    include_model=True,
                 )
 
                 prepare_data_with_credentials(
@@ -489,6 +491,7 @@ async def retrieve_batch(
                 llm_router=llm_router,
                 model_id=model_from_id,
                 operation_context="batch retrieval (batch created with model)",
+                include_model=True,
             )
 
             original_batch_id: Final = get_original_file_id(batch_id)
@@ -699,6 +702,7 @@ async def list_batches(
                 llm_router=llm_router,
                 model_id=model_param,
                 operation_context="batch listing",
+                include_model=True,
             )
 
             data.update(credentials)
@@ -880,6 +884,7 @@ async def cancel_batch(
                 llm_router=llm_router,
                 model_id=model_from_id,
                 operation_context="batch cancellation (batch created with model)",
+                include_model=True,
             )
 
             original_batch_id: Final = get_original_file_id(batch_id)

--- a/litellm/proxy/openai_files_endpoints/common_utils.py
+++ b/litellm/proxy/openai_files_endpoints/common_utils.py
@@ -272,6 +272,7 @@ def get_credentials_for_model(
     llm_router,  # Router instance
     model_id: str,
     operation_context: str = "file operation",
+    include_model: bool = False,
 ):
     """
     Retrieve API credentials for a model from the LLM Router.
@@ -280,6 +281,9 @@ def get_credentials_for_model(
         llm_router: LiteLLM Router instance
         model_id: Model name or deployment ID
         operation_context: Description for error messages (e.g., "file upload", "batch creation")
+        include_model: Include the deployment's underlying model in the returned credentials.
+            Only safe for call sites that dispatch directly to litellm.* functions; router-bound
+            paths must keep the router alias in "model" for deployment lookup to succeed.
 
     Returns:
         Dictionary with credentials (api_key, api_base, custom_llm_provider, etc.)
@@ -295,7 +299,9 @@ def get_credentials_for_model(
             detail={"error": "Router not initialized. Cannot use model-based routing."},
         )
 
-    credentials: Final = llm_router.get_deployment_credentials_with_provider(model_id=model_id)
+    credentials: Final = llm_router.get_deployment_credentials_with_provider(
+        model_id=model_id, include_model=include_model
+    )
 
     if credentials is None:
         raise HTTPException(

--- a/litellm/router.py
+++ b/litellm/router.py
@@ -8712,7 +8712,7 @@ class Router:
         )
 
     def get_deployment_credentials_with_provider(
-        self, model_id: str, team_id: str | None = None
+        self, model_id: str, team_id: str | None = None, include_model: bool = False
     ) -> dict[str, Any] | None:
         """
         Get API credentials and provider info from a model name in model_list.
@@ -8729,6 +8729,13 @@ class Router:
                 wildcard lookups never resolve a deployment owned by a
                 different team, so shared model names can't leak another
                 team's credentials.
+            include_model: When True, the deployment's `litellm_params.model`
+                is returned under the "model" key. Batch and file operations
+                need it so `litellm.acreate_batch` / `aretrieve_batch` can
+                resolve provider configs (e.g. Bedrock) and set the provider
+                model id. Off by default because callers that merge these
+                credentials into router-bound request data (e.g. vector store
+                files) must keep the router alias in "model".
 
         Returns:
             Dictionary containing api_key, api_base, custom_llm_provider, etc.
@@ -8796,6 +8803,9 @@ class Router:
             credentials.update(credential_values)
             # Remove the credential name since we've resolved it
             credentials.pop("litellm_credential_name", None)
+
+        if include_model:
+            credentials["model"] = deployment.litellm_params.model
 
         # Add custom_llm_provider
         if deployment.litellm_params.custom_llm_provider:

--- a/litellm/types/router.py
+++ b/litellm/types/router.py
@@ -200,6 +200,9 @@ class CredentialLiteLLMParams(BaseModel):
     aws_bedrock_runtime_endpoint: str | None = None
     aws_bedrock_project_id: str | None = None
     s3_bucket_name: str | None = None
+    s3_region_name: str | None = None
+    s3_encryption_key_id: str | None = None
+    aws_batch_role_arn: str | None = None
     ## IBM WATSONX ##
     watsonx_region_name: str | None = None
 
@@ -271,11 +274,6 @@ class GenericLiteLLMParams(CredentialLiteLLMParams, CustomPricingLiteLLMParams):
     # quality-router params
     quality_router_config: dict | None = None
     quality_router_default_model: str | None = None
-
-    # Batch/File API Params
-    s3_bucket_name: str | None = None
-    s3_encryption_key_id: str | None = None
-    gcs_bucket_name: str | None = None
 
     # Vector Store Params
     vector_store_id: str | None = None

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -146,9 +146,12 @@ class Harness:
         return dict(self.router_acreate.call_args.kwargs)
 
 
-def _creds_lookup(*, model_id: str) -> Dict[str, str]:
+def _creds_lookup(*, model_id: str, include_model: bool = False) -> Dict[str, str]:
     # KeyError on an unknown/hardcoded model_id - the bug cannot hide.
-    return dict(CREDS[model_id])
+    creds = dict(CREDS[model_id])
+    if not include_model:
+        creds.pop("model")
+    return creds
 
 
 @pytest.fixture
@@ -259,7 +262,7 @@ async def test_create__model_encoded_file_id(harness):
     harness.router_acreate.assert_not_called()
 
     # 2. CREDENTIALS - resolved for the model decoded FROM the file id.
-    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", include_model=True)
 
     # 3. SEAM PAYLOAD - exact, whole dict. A new forwarded key breaks this.
     assert harness.acreate_kwargs() == {
@@ -315,7 +318,7 @@ async def test_create__model_encoded_file_id__resolver_gets_decoded_model(harnes
 
     await call_create(harness)
 
-    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", include_model=True)
 
 
 # =========================================================================== #
@@ -339,7 +342,7 @@ async def test_create__model_from_body(harness):
 
     assert harness.litellm_acreate.call_count == 1
     harness.router_acreate.assert_not_called()
-    harness.creds_resolver.assert_called_once_with(model_id="vertex-model")
+    harness.creds_resolver.assert_called_once_with(model_id="vertex-model", include_model=True)
     payload = harness.acreate_kwargs()
     assert payload["custom_llm_provider"] == "vertex_ai"
     assert payload["input_file_id"] == "file-plain"
@@ -359,7 +362,7 @@ async def test_create__model_from_header(harness):
 
     await call_create(harness, headers={"x-litellm-model": "vertex-model"})
 
-    harness.creds_resolver.assert_called_once_with(model_id="vertex-model")
+    harness.creds_resolver.assert_called_once_with(model_id="vertex-model", include_model=True)
     harness.router_acreate.assert_not_called()
 
 
@@ -376,7 +379,7 @@ async def test_create__model_from_query(harness):
 
     await call_create(harness, query={"model": "vertex-model"})
 
-    harness.creds_resolver.assert_called_once_with(model_id="vertex-model")
+    harness.creds_resolver.assert_called_once_with(model_id="vertex-model", include_model=True)
     harness.router_acreate.assert_not_called()
 
 
@@ -399,7 +402,7 @@ async def test_create__body_model_beats_header_and_query(harness):
         query={"model": "vertex-model"},
     )
 
-    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", include_model=True)
 
 
 # =========================================================================== #
@@ -707,7 +710,7 @@ async def test_create__model_encoded_beats_unified(harness):
 
     assert harness.litellm_acreate.call_count == 1
     harness.router_acreate.assert_not_called()
-    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", include_model=True)
 
 
 # =========================================================================== #
@@ -753,7 +756,7 @@ async def test_create__model_encoded_beats_loadbalancing(harness):
 
     assert harness.litellm_acreate.call_count == 1
     harness.router_acreate.assert_not_called()
-    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", include_model=True)
 
 
 # =========================================================================== #
@@ -1060,7 +1063,7 @@ async def test_retrieve__model_encoded_id(retrieve_harness):
     retrieve_harness.router_aretrieve.assert_not_called()
 
     # 2. CREDENTIALS - resolved for the model decoded FROM the batch id.
-    retrieve_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    retrieve_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", include_model=True)
 
     # 3. SEAM PAYLOAD - exact, whole dict forwarded to the provider call.
     #    Note `model` is the DECODED model, not the deployment from creds: the
@@ -1118,7 +1121,7 @@ async def test_retrieve__model_encoded_beats_loadbalancing(retrieve_harness):
 
     assert retrieve_harness.litellm_aretrieve.call_count == 1
     retrieve_harness.router_aretrieve.assert_not_called()
-    retrieve_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    retrieve_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", include_model=True)
 
 
 # --------------------------------------------------------------------------- #
@@ -1536,7 +1539,7 @@ async def test_list__model_from_body_routes_and_encodes(list_harness):
 
     assert list_harness.litellm_alist.call_count == 1
     list_harness.router_alist.assert_not_called()
-    list_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    list_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", include_model=True)
     assert resp.data[0].id == encode_file_id_with_model("batch-1", "azure/gpt-4o", id_type="batch")
     assert resp.data[1].id == encode_file_id_with_model("batch-2", "azure/gpt-4o", id_type="batch")
 
@@ -1826,7 +1829,7 @@ async def test_cancel__model_encoded_id(cancel_harness):
     cancel_harness.router_acancel.assert_not_called()
 
     # CREDENTIALS - resolved for the model decoded from the batch id.
-    cancel_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    cancel_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", include_model=True)
 
     # SEAM PAYLOAD - exact dict. NOTE current behavior: `model` is the
     # DEPLOYMENT name from creds, NOT the decoded model (cancel, unlike
@@ -1864,7 +1867,7 @@ async def test_cancel__model_encoded_beats_unified(cancel_harness):
 
     assert cancel_harness.litellm_acancel.call_count == 1
     cancel_harness.router_acancel.assert_not_called()
-    cancel_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o")
+    cancel_harness.creds_resolver.assert_called_once_with(model_id="azure/gpt-4o", include_model=True)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_endpoints.py
@@ -158,7 +158,6 @@ async def test_vector_store_file_list_resolves_credentials_from_model_query_para
         "api_key": "sk-team-openai",
         "api_base": "https://api.openai.com/v1",
         "custom_llm_provider": "openai",
-        "model": "openai/gpt-4o-mini",
     }
 
     data = {
@@ -174,10 +173,10 @@ async def test_vector_store_file_list_resolves_credentials_from_model_query_para
 
     assert result["api_key"] == "sk-team-openai"
     assert result["api_base"] == "https://api.openai.com/v1"
-    assert result["model"] == "openai/gpt-4o-mini"
+    assert "model" not in result
     assert "custom_llm_provider" not in result
     llm_router.get_deployment_credentials_with_provider.assert_called_once_with(
-        model_id="team-openai"
+        model_id="team-openai", include_model=False
     )
 
 

--- a/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_tenant_guard.py
+++ b/tests/test_litellm/proxy/vector_store_endpoints/test_vector_store_tenant_guard.py
@@ -138,12 +138,12 @@ async def test_vector_store_file_list_resolves_managed_vector_store_before_team_
 
     llm_router = MagicMock()
 
-    def get_credentials(model_id):
+    def get_credentials(model_id, include_model=False):
+        assert include_model is False
         return {
             "api_key": f"sk-{model_id}",
             "api_base": "https://api.openai.com/v1",
             "custom_llm_provider": "openai",
-            "model": f"openai/{model_id}",
         }
 
     llm_router.get_deployment_credentials_with_provider.side_effect = get_credentials
@@ -169,9 +169,9 @@ async def test_vector_store_file_list_resolves_managed_vector_store_before_team_
     assert response == {"ok": True}
     assert captured_data["vector_store_id"] == "vs_provider_native"
     assert captured_data["api_key"] == "sk-managed-deployment"
-    assert captured_data["model"] == "openai/managed-deployment"
+    assert captured_data["model"] == "managed-deployment"
     llm_router.get_deployment_credentials_with_provider.assert_called_once_with(
-        model_id="managed-deployment"
+        model_id="managed-deployment", include_model=False
     )
 
 

--- a/tests/test_litellm/test_router.py
+++ b/tests/test_litellm/test_router.py
@@ -3976,6 +3976,72 @@ def test_get_deployment_credentials_with_provider_includes_bucket_name():
     assert credentials["custom_llm_provider"] == "vertex_ai"
 
 
+def test_get_deployment_credentials_with_provider_includes_bedrock_batch_fields():
+    """
+    Regression (#25104): s3_region_name, s3_encryption_key_id, and
+    aws_batch_role_arn must survive the CredentialLiteLLMParams filter.
+    Previously they were dropped, so Bedrock batch file uploads failed with
+    "S3 bucket_name is required" style errors even when configured in
+    litellm_params.
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "bedrock-batch-model",
+                "litellm_params": {
+                    "model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+                    "aws_region_name": "us-east-1",
+                    "s3_bucket_name": "my-batch-bucket",
+                    "s3_region_name": "us-west-2",
+                    "s3_encryption_key_id": "my-kms-key",
+                    "aws_batch_role_arn": "arn:aws:iam::123456789012:role/bedrock-batch",
+                },
+            }
+        ],
+    )
+
+    credentials = router.get_deployment_credentials_with_provider(
+        model_id="bedrock-batch-model"
+    )
+
+    assert credentials is not None
+    assert credentials["s3_bucket_name"] == "my-batch-bucket"
+    assert credentials["s3_region_name"] == "us-west-2"
+    assert credentials["s3_encryption_key_id"] == "my-kms-key"
+    assert credentials["aws_batch_role_arn"] == "arn:aws:iam::123456789012:role/bedrock-batch"
+    assert credentials["custom_llm_provider"] == "bedrock"
+    assert "model" not in credentials
+
+
+def test_get_deployment_credentials_with_provider_include_model():
+    """
+    Regression (#25104): with include_model=True the deployment's
+    litellm_params.model is returned under "model" so batch/file operations can
+    resolve provider configs (litellm.acreate_batch needs a model kwarg to load
+    BedrockBatchesConfig and set the Bedrock modelId). Off by default so
+    router-bound callers keep the router alias in "model".
+    """
+    router = litellm.Router(
+        model_list=[
+            {
+                "model_name": "bedrock-batch-model",
+                "litellm_params": {
+                    "model": "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0",
+                    "aws_region_name": "us-east-1",
+                },
+            }
+        ],
+    )
+
+    credentials = router.get_deployment_credentials_with_provider(
+        model_id="bedrock-batch-model", include_model=True
+    )
+
+    assert credentials is not None
+    assert credentials["model"] == "bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0"
+    assert credentials["custom_llm_provider"] == "bedrock"
+
+
 def test_get_deployment_credentials_with_provider_resolves_credential_name():
     """
     Test that get_deployment_credentials_with_provider correctly resolves

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -26716,6 +26716,8 @@ export interface components {
             auto_router_max_input_chars?: number | null;
             /** Aws Access Key Id */
             aws_access_key_id?: string | null;
+            /** Aws Batch Role Arn */
+            aws_batch_role_arn?: string | null;
             /** Aws Bedrock Project Id */
             aws_bedrock_project_id?: string | null;
             /** Aws Bedrock Runtime Endpoint */
@@ -26945,6 +26947,8 @@ export interface components {
             s3_bucket_name?: string | null;
             /** S3 Encryption Key Id */
             s3_encryption_key_id?: string | null;
+            /** S3 Region Name */
+            s3_region_name?: string | null;
             /** Search Context Cost Per Query */
             search_context_cost_per_query?: {
                 [key: string]: unknown;
@@ -35295,6 +35299,8 @@ export interface components {
             auto_router_max_input_chars?: number | null;
             /** Aws Access Key Id */
             aws_access_key_id?: string | null;
+            /** Aws Batch Role Arn */
+            aws_batch_role_arn?: string | null;
             /** Aws Bedrock Project Id */
             aws_bedrock_project_id?: string | null;
             /** Aws Bedrock Runtime Endpoint */
@@ -35524,6 +35530,8 @@ export interface components {
             s3_bucket_name?: string | null;
             /** S3 Encryption Key Id */
             s3_encryption_key_id?: string | null;
+            /** S3 Region Name */
+            s3_region_name?: string | null;
             /** Search Context Cost Per Query */
             search_context_cost_per_query?: {
                 [key: string]: unknown;


### PR DESCRIPTION
## TLDR

Problem this solves:

- POST /v1/batches on bedrock deployments fails with "unsupported provider" (#25104)
- Credential filtering silently drops s3_region_name, s3_encryption_key_id, aws_batch_role_arn
- Resolved credentials never include the deployment model, breaking provider dispatch

How it solves it:

- Whitelists the three dropped fields in CredentialLiteLLMParams
- Batch endpoints opt in to receiving the deployment's underlying model
- Router-bound callers keep the router alias in "model" untouched

## User Flow

Before: the flow dies at batch creation, where the gateway rejects every Bedrock batch with an unsupported-provider error no matter what the config declares

1. An admin adds a Bedrock model to the gateway config with the batch S3 bucket, S3 region, and batch job role ARN, then starts the proxy
2. `POST https://litellm-domain/v1/files?model=bedrock-batch-haiku` with `purpose=batch` and a JSONL of 100 chat requests returns 200 with a long id like `file-bGl0ZWxsbTpzMzovL2xpdGVsbG0t...`, so the input visibly landed
3. `POST https://litellm-domain/v1/batches` with that `input_file_id`, endpoint `/v1/chat/completions`, and completion window `24h` returns 400: `litellm.BadRequestError: LiteLLM doesn't support custom_llm_provider=bedrock for 'create_batch'`
4. There is no batch to retrieve or cancel, and no model-invocation job ever appears in the AWS account

After: the same request now returns a live batch the user can poll

1. An admin adds a Bedrock model to the gateway config with the batch S3 bucket, S3 region, and batch job role ARN, then starts the proxy
2. `POST https://litellm-domain/v1/files?model=bedrock-batch-haiku` with `purpose=batch` and a JSONL of 100 chat requests returns 200 with a long id like `file-bGl0ZWxsbTpzMzovL2xpdGVsbG0t...`, so the input visibly landed
3. `POST https://litellm-domain/v1/batches` with that `input_file_id`, endpoint `/v1/chat/completions`, and completion window `24h` returns 200 with `"object": "batch"`, an id like `batch_bGl0ZWxsbTphcm46YXdz...`, and `"status": "validating"`
4. `GET https://litellm-domain/v1/batches/{batch_id}` returns 200 with that same batch, and the matching model-invocation job shows up as Submitted in the AWS account

## Relevant issues

Fixes #25104. Overlaps with the community fix in #24548

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [x] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Two live proxies against real AWS Bedrock (us-west-2), same config and same 100-record JSONL (each line a `/v1/chat/completions` body with `max_tokens: 5`, since Bedrock requires at least 100 records). The before proxy runs `litellm_internal_staging` @ 0659738b3e on port 47031, the after proxy runs this branch @ d210cd272c on port 52739. Both are DB-backed

```yaml
model_list:
  - model_name: bedrock-batch-haiku
    litellm_params:
      model: bedrock/us.anthropic.claude-haiku-4-5-20251001-v1:0
      aws_region_name: us-west-2
      s3_bucket_name: litellm-proxy
      s3_region_name: us-west-2
      aws_batch_role_arn: arn:aws:iam::<aws-account-id>:role/<bedrock-batch-role>
    model_info:
      mode: batch
```

| Route | before @ 0659738b3e | after @ d210cd272c |
| --- | --- | --- |
| POST /v1/files?model=... | PASS (200) | PASS (200) |
| POST /v1/batches | FAIL (400) | PASS (200) |
| GET /v1/batches/{id} | PASS (200) | PASS (200) |
| Job visible in AWS | n/a (never created) | PASS (Submitted) |

Before, file upload works but batch creation dead-ends on the exact #25104 error

```
$ curl -sS -X POST "http://localhost:47031/v1/files?model=bedrock-batch-haiku" \
    -H "Authorization: Bearer sk-b05-qa-1234" -F purpose=batch -F file=@batch_input.jsonl
{
    "id": "file-bGl0ZWxsbTpzMzovL2xpdGVsbG0t...(truncated)",
    "filename": "litellm-bedrock-files-bedrock-batch-haiku-0016ba4a-df12-4d43-bb33-ca91e264197f.jsonl",
    "object": "file",
    "purpose": "batch",
    "status": "uploaded"
}

$ curl -sS -X POST "http://localhost:47031/v1/batches" \
    -H "Authorization: Bearer sk-b05-qa-1234" -H "Content-Type: application/json" \
    -d '{"input_file_id": "<file id from above>", "endpoint": "/v1/chat/completions", "completion_window": "24h"}'
{
    "error": {
        "message": "litellm.BadRequestError: LiteLLM doesn't support custom_llm_provider=bedrock for 'create_batch'",
        "type": "internal_server_error",
        "param": null,
        "code": "400"
    }
}
```

After, the same two calls return a real batch

```
$ curl -sS -X POST "http://localhost:52739/v1/files?model=bedrock-batch-haiku" \
    -H "Authorization: Bearer sk-b05-qa-1234" -F purpose=batch -F file=@batch_input.jsonl
{
    "id": "file-bGl0ZWxsbTpzMzovL2xpdGVsbG0t...(truncated)",
    "filename": "litellm-bedrock-files-bedrock-batch-haiku-95418e37-14f3-4391-894e-d346325be0b9.jsonl",
    "object": "file",
    "purpose": "batch",
    "status": "uploaded"
}

$ curl -sS -X POST "http://localhost:52739/v1/batches" \
    -H "Authorization: Bearer sk-b05-qa-1234" -H "Content-Type: application/json" \
    -d '{"input_file_id": "<file id from above>", "endpoint": "/v1/chat/completions", "completion_window": "24h"}'
{
    "id": "batch_bGl0ZWxsbTphcm46YXdz...(truncated)",
    "completion_window": "24h",
    "created_at": 1785990163,
    "endpoint": "/v1/chat/completions",
    "object": "batch",
    "status": "validating",
    ...
}

$ curl -sS "http://localhost:52739/v1/batches/<batch id from above>" -H "Authorization: Bearer sk-b05-qa-1234"
{
    "id": "batch_bGl0ZWxsbTphcm46YXdz...(truncated)",
    "object": "batch",
    "status": "validating",
    ...
}
```

The job exists on AWS itself, created by the after proxy with the role and S3 region from litellm_params

```
$ aws bedrock get-model-invocation-job \
    --job-identifier arn:aws:bedrock:us-west-2:<aws-account-id>:model-invocation-job/wmc63yc8e0wl \
    --region us-west-2 --query '{status: status, modelId: modelId, submitTime: submitTime}'
{
    "status": "Submitted",
    "modelId": "arn:aws:bedrock:us-west-2:<aws-account-id>:inference-profile/us.anthropic.claude-haiku-4-5-20251001-v1:0",
    "submitTime": "2026-08-06T04:22:43.934000+00:00"
}
```

Retrieval also passes on the before proxy against the same batch id (that path re-derives the model from the id), so nothing regresses for existing users

```
$ curl -sS "http://localhost:47031/v1/batches/<same batch id>" -H "Authorization: Bearer sk-b05-qa-1234"
{
    "id": "batch_bGl0ZWxsbTphcm46YXdz...(truncated)",
    "object": "batch",
    "status": "validating",
    ...
}
```

## Type

🐛 Bug Fix

## Changes

`litellm/types/router.py` adds `s3_region_name`, `s3_encryption_key_id`, and `aws_batch_role_arn` to the `CredentialLiteLLMParams` whitelist, and moves the duplicate `s3_bucket_name`, `s3_encryption_key_id`, and `gcs_bucket_name` declarations from `GenericLiteLLMParams` into that shared base so the credential filter and the params model can no longer drift apart

`litellm/router.py` gives `get_deployment_credentials_with_provider` an `include_model` flag: when set, the deployment's `litellm_params.model` is returned under `"model"` so `litellm.acreate_batch` and `aretrieve_batch` can resolve the Bedrock provider config and derive the modelId

`litellm/proxy/openai_files_endpoints/common_utils.py` threads `include_model` through `get_credentials_for_model` (default False), and `litellm/proxy/batches_endpoints/endpoints.py` opts in at all five batch call sites (create by file id, create by model param, retrieve, list, cancel)

The flag is opt-in because vector store file endpoints merge these credentials into router-bound request data, where `"model"` must stay the router alias for deployment lookup; the vector store tests now lock that contract explicitly. Router tests cover the new whitelist fields surviving the credential round trip and the model being returned only when requested; the batches endpoint tests assert every call site passes `include_model=True`

`ui/litellm-dashboard/src/lib/http/schema.d.ts` is the deterministic regeneration picking up the new whitelist fields in the OpenAPI schema

Known gap left for a follow-up: `aws_session_token` is still missing from `CredentialLiteLLMParams`, so deployments pinned to temporary STS credentials remain affected by the same filtering

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
