### PR TITLE
fix(batches): persist managed file ids for cancelled/failed/expired batches

### DIFF
--- a/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
+++ b/enterprise/litellm_enterprise/proxy/common_utils/check_batch_cost.py
@@ -656,6 +656,20 @@ class CheckBatchCost:
 
             elif response.status in ("failed", "expired", "cancelled"):
                 try:
+                    from litellm.proxy.openai_files_endpoints.common_utils import (
+                        _is_base64_encoded_unified_file_id,
+                        ensure_batch_response_managed_file_ids,
+                    )
+
+                    response.id = job.unified_object_id
+                    await ensure_batch_response_managed_file_ids(
+                        response=response,
+                        managed_files_obj=self.proxy_logging_obj.get_proxy_hook("managed_files"),
+                        prisma_client=self.prisma_client,
+                        verbose_proxy_logger=verbose_proxy_logger,
+                        db_batch_object=job,
+                        unified_batch_id=_is_base64_encoded_unified_file_id(job.unified_object_id),
+                    )
                     update_data = {
                         "status": response.status,
                         "file_object": response.model_dump_json(),

--- a/litellm/proxy/batches_endpoints/endpoints.py
+++ b/litellm/proxy/batches_endpoints/endpoints.py
@@ -961,6 +961,7 @@ async def cancel_batch(
             prisma_client=prisma_client,
             verbose_proxy_logger=verbose_proxy_logger,
             operation="cancel",
+            user_api_key_dict=user_api_key_dict,
         )
 
         ### CALL HOOKS ### - modify outgoing data

--- a/tests/proxy_unit_tests/test_check_batch_cost.py
+++ b/tests/proxy_unit_tests/test_check_batch_cost.py
@@ -499,7 +499,7 @@ class TestCheckBatchCost:
         must be written back with that status and batch_processed=True so it stops being
         polled forever.
         """
-        from unittest.mock import patch
+        import base64
 
         mock_prisma_client.db.litellm_managedobjecttable.update_many = AsyncMock(
             return_value=0
@@ -511,7 +511,9 @@ class TestCheckBatchCost:
 
         mock_job = MagicMock()
         mock_job.id = "job-terminal-1"
-        mock_job.unified_object_id = "dW5pZmllZF9iYXRjaF9pZA=="
+        mock_job.unified_object_id = base64.urlsafe_b64encode(
+            b"litellm_proxy;model_id:model-123;llm_batch_id:batch-456"
+        ).decode()
         mock_job.created_by = "user-1"
 
         assert check_batch_cost_instance._has_batch_processed_column is True
@@ -527,23 +529,7 @@ class TestCheckBatchCost:
 
         mock_llm_router.aretrieve_batch = AsyncMock(return_value=mock_response)
 
-        decoded_id = "llm_model_id,model-123;llm_batch_id,batch-456;"
-
-        with (
-            patch(
-                "litellm.proxy.openai_files_endpoints.common_utils._is_base64_encoded_unified_file_id",
-                side_effect=[decoded_id, None],
-            ),
-            patch(
-                "litellm.proxy.openai_files_endpoints.common_utils.get_model_id_from_unified_batch_id",
-                return_value="model-123",
-            ),
-            patch(
-                "litellm.proxy.openai_files_endpoints.common_utils.get_batch_id_from_unified_batch_id",
-                return_value="batch-456",
-            ),
-        ):
-            await check_batch_cost_instance.check_batch_cost()
+        await check_batch_cost_instance.check_batch_cost()
 
         assert (
             mock_prisma_client.db.litellm_managedobjecttable.update.call_count == 1
@@ -555,6 +541,133 @@ class TestCheckBatchCost:
         assert (
             update_data["batch_processed"] is True
         ), "terminal-status update() must set batch_processed=True so polling stops"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("terminal_status", ["failed", "expired", "cancelled"])
+    async def test_terminal_status_persists_managed_output_file_ids(
+        self,
+        check_batch_cost_instance,
+        mock_prisma_client,
+        mock_llm_router,
+        terminal_status,
+    ):
+        """A cancelled/failed/expired batch with provider output files must be persisted
+        with unified managed file IDs, never raw provider IDs. Raw IDs written here leak
+        to every later GET /batches/{id} and GET /batches because the terminal row is
+        final (batch_processed=True) and read paths only resolve, never mint.
+        """
+        import base64
+        import json
+
+        from litellm.types.utils import LiteLLMBatch
+
+        unified_batch_uid = base64.urlsafe_b64encode(
+            b"litellm_proxy;model_id:model-123;llm_batch_id:batch-456"
+        ).decode()
+        raw_output_file_id = "file-terminal-out-abc"
+        raw_error_file_id = "file-terminal-err-xyz"
+        raw_input_file_id = "file-terminal-in-123"
+        unified_input_file_id = base64.urlsafe_b64encode(
+            b"litellm_proxy:application/octet-stream;unified_id,in-1;target_model_names,gpt-5-batch"
+        ).decode()
+        unified_output_file_id = base64.urlsafe_b64encode(
+            f"litellm_proxy:application/octet-stream;unified_id,u-1;llm_output_file_id,{raw_output_file_id}".encode()
+        ).decode()
+        unified_error_file_id = base64.urlsafe_b64encode(
+            f"litellm_proxy:application/octet-stream;unified_id,u-2;llm_output_file_id,{raw_error_file_id}".encode()
+        ).decode()
+
+        mock_prisma_client.db.litellm_managedobjecttable.update_many = AsyncMock(
+            return_value=0
+        )
+        mock_prisma_client.db.litellm_managedobjecttable.update = AsyncMock()
+        mock_prisma_client.db.litellm_usertable.find_unique = AsyncMock(
+            return_value=None
+        )
+
+        input_file_row = MagicMock()
+        input_file_row.unified_file_id = unified_input_file_id
+
+        def find_managed_file(where):
+            if where["flat_model_file_ids"]["has"] == raw_input_file_id:
+                return input_file_row
+            return None
+
+        mock_prisma_client.db.litellm_managedfiletable.find_first = AsyncMock(
+            side_effect=find_managed_file
+        )
+
+        mock_job = MagicMock()
+        mock_job.id = "job-terminal-mint-1"
+        mock_job.unified_object_id = unified_batch_uid
+        mock_job.created_by = "user-1"
+        mock_job.team_id = "team-1"
+
+        check_batch_cost_instance._has_batch_processed_column = True
+        mock_prisma_client.db.litellm_managedobjecttable.find_many = AsyncMock(
+            return_value=[mock_job]
+        )
+
+        response = LiteLLMBatch(
+            id="batch-456",
+            completion_window="24h",
+            created_at=1,
+            endpoint="/v1/chat/completions",
+            input_file_id=raw_input_file_id,
+            object="batch",
+            status=terminal_status,
+            output_file_id=raw_output_file_id,
+            error_file_id=raw_error_file_id,
+        )
+        mock_llm_router.aretrieve_batch = AsyncMock(return_value=response)
+
+        mock_hook = MagicMock()
+        mock_hook.get_unified_output_file_id.side_effect = [
+            unified_output_file_id,
+            unified_error_file_id,
+        ]
+        mock_hook.store_unified_file_id = AsyncMock()
+        check_batch_cost_instance.proxy_logging_obj.get_proxy_hook.return_value = (
+            mock_hook
+        )
+
+        await check_batch_cost_instance.check_batch_cost()
+
+        mock_hook.get_unified_output_file_id.assert_any_call(
+            output_file_id=raw_output_file_id,
+            model_id="model-123",
+            model_name="gpt-5-batch",
+        )
+        mock_hook.get_unified_output_file_id.assert_any_call(
+            output_file_id=raw_error_file_id,
+            model_id="model-123",
+            model_name="gpt-5-batch",
+        )
+        stored = {
+            next(iter(c.kwargs["model_mappings"].values())): c.kwargs["file_id"]
+            for c in mock_hook.store_unified_file_id.call_args_list
+        }
+        assert stored == {
+            raw_output_file_id: unified_output_file_id,
+            raw_error_file_id: unified_error_file_id,
+        }
+        for store_call in mock_hook.store_unified_file_id.call_args_list:
+            assert store_call.kwargs["user_api_key_dict"].user_id == "user-1"
+            assert store_call.kwargs["user_api_key_dict"].team_id == "team-1"
+
+        assert mock_prisma_client.db.litellm_managedobjecttable.update.call_count == 1
+        update_call = mock_prisma_client.db.litellm_managedobjecttable.update.call_args
+        assert update_call.kwargs["where"] == {"id": "job-terminal-mint-1"}
+        update_data = update_call.kwargs["data"]
+        assert update_data["status"] == terminal_status
+        assert update_data["batch_processed"] is True
+        persisted = json.loads(update_data["file_object"])
+        assert persisted["id"] == unified_batch_uid
+        assert persisted["input_file_id"] == unified_input_file_id
+        assert persisted["output_file_id"] == unified_output_file_id
+        assert persisted["error_file_id"] == unified_error_file_id
+        assert raw_output_file_id not in update_data["file_object"]
+        assert raw_error_file_id not in update_data["file_object"]
 
     @pytest.mark.asyncio
     async def test_raw_output_file_id_converted_to_managed_id(

--- a/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
+++ b/tests/test_litellm/proxy/batches_endpoints/test_endpoints.py
@@ -1897,6 +1897,17 @@ async def test_cancel__unified_batch_id_routes_to_router(cancel_harness):
 
 
 @pytest.mark.asyncio
+async def test_cancel__db_write_receives_caller_auth(cancel_harness):
+    """update_batch_in_database can only mint managed IDs for a cancelled batch's
+    output files when it has an auth context, so cancel must forward the caller's."""
+    caller = UserAPIKeyAuth(api_key="sk-test", user_id="user-cancel-1")
+    with patch.object(endpoints, "_is_base64_encoded_unified_file_id", return_value=UNIFIED_BATCH_ID):
+        await call_cancel(cancel_harness, "batch-unified-blob", user=caller)
+
+    assert cancel_harness.update_batch_in_db.call_args.kwargs["user_api_key_dict"] is caller
+
+
+@pytest.mark.asyncio
 async def test_cancel__unified_missing_model_id_400(cancel_harness):
     # unified id with no model_id segment -> get_model_id returns None -> 400.
     with patch.object(


### PR DESCRIPTION
## TLDR

Problem this solves:

- A cancelled batch's output and error file ids stay provider-native
- Every later retrieve and list of that batch leaks raw `file-...` ids

How it solves it:

- Mint unified file ids before persisting a terminal (cancelled, failed, expired) batch
- Forward caller auth on cancel so minting is possible on that path too

## User Flow

Before, the flow breaks at steps 5 and 6, where the gateway starts handing out OpenAI's own file ids:

1. `POST https://litellm-domain/v1/files` with a 400 request JSONL, `purpose=batch`, and `target_model_names=gpt-5.4-nano-batch`, and get back a long scrambled file id starting `bGl0ZWxsbV9wcm94eT...`
2. `POST https://litellm-domain/v1/batches` with that file id, and get a scrambled batch id with status `validating`
3. `POST https://litellm-domain/v1/batches/{batch_id}/cancel` once it is running, and see status `cancelling`
4. Wait a few minutes for the provider to finish cancelling
5. `GET https://litellm-domain/v1/batches/{batch_id}` shows status `cancelled`, but `output_file_id` and `error_file_id` are OpenAI's own `file-8L97...` and `file-5JKe...` instead of the scrambled shape every other response used
6. `GET https://litellm-domain/v1/batches` shows the same raw ids on the cancelled row, right next to a completed row whose output id is scrambled
7. Anyone else with a key on the same gateway can replay the leaked `file-...` id against `GET https://litellm-domain/v1/files/{id}/content` and read this user's partial results through the shared provider credential

After, the same walk succeeds end to end with gateway ids only:

1. `POST https://litellm-domain/v1/files` with a 400 request JSONL, `purpose=batch`, and `target_model_names=gpt-5.4-nano-batch`, and get back a long scrambled file id starting `bGl0ZWxsbV9wcm94eT...`
2. `POST https://litellm-domain/v1/batches` with that file id, and get a scrambled batch id with status `validating`
3. `POST https://litellm-domain/v1/batches/{batch_id}/cancel` once it is running, and see status `cancelling`
4. Wait a few minutes for the provider to finish cancelling
5. `GET https://litellm-domain/v1/batches/{batch_id}` shows status `cancelled` with scrambled `output_file_id` and `error_file_id`, the same shape as at upload
6. `GET https://litellm-domain/v1/batches` shows the cancelled row with those same scrambled ids
7. `GET https://litellm-domain/v1/files/{output_file_id}/content` with the scrambled id returns the partial results the batch finished before cancelling, and no provider-native id was ever handed out for anyone to replay

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy against real OpenAI batches (gpt-5.4-nano, 400 chat requests per run, real spend). Setup for both legs: fresh postgres DB, `PROXY_BATCH_POLLING_INTERVAL=20` so the batch cost job cycles quickly, a config with one `openai/gpt-5.4-nano` deployment named `gpt-5.4-nano-batch`, and a virtual key from `/key/generate`

```bash
PROXY_BATCH_POLLING_INTERVAL=20 DATABASE_URL=postgresql://... \
  python litellm/proxy/proxy_cli.py --config qa_config.yaml --port 47311 --detailed_debug

curl -s http://localhost:47311/v1/files -H "Authorization: Bearer $KEY" \
  -F purpose=batch -F target_model_names=gpt-5.4-nano-batch -F file=@batch_input.jsonl
curl -s http://localhost:47311/v1/batches -H "Authorization: Bearer $KEY" \
  -H "Content-Type: application/json" \
  -d '{"input_file_id": "<unified file id>", "endpoint": "/v1/chat/completions", "completion_window": "24h"}'
curl -s -X POST http://localhost:47311/v1/batches/<unified batch id>/cancel -H "Authorization: Bearer $KEY"
```

**Before, captured at `litellm_internal_staging` commit 0659738b3e** (port 47311). After OpenAI finalized the cancellation (259 of 400 requests had completed) and the polling job persisted the batch, every read leaks raw provider ids

```bash
curl -s http://localhost:47311/v1/batches -H "Authorization: Bearer $KEY"
```

```json
{"id": "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDo2N2FhODc3...", "status": "cancelled",
 "input_file_id": "file-QWJFJBcQ6qt3afGS3YfPLL",
 "output_file_id": "file-8L97YZ3rQzVn9f4hh7aS1n",
 "error_file_id": "file-5JKehRkefm9vk2Q4iWwLgj"}
{"id": "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDo2N2FhODc3...", "status": "completed",
 "output_file_id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29u...", "error_file_id": null}
```

```bash
curl -s http://localhost:47311/v1/batches/<unified batch id> -H "Authorization: Bearer $KEY"
```

```json
{"id": "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDo2N2FhODc3...", "status": "cancelled",
 "input_file_id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9vY3RldC1zdHJlYW07...",
 "output_file_id": "file-8L97YZ3rQzVn9f4hh7aS1n",
 "error_file_id": "file-5JKehRkefm9vk2Q4iWwLgj"}
```

The persisted record keeps the raw ids forever, so this never self-heals

```
select status, file_object->>'output_file_id' as output, file_object->>'error_file_id' as error
  from "LiteLLM_ManagedObjectTable" where file_purpose = 'batch' and status = 'cancelled';
 cancelled | file-8L97YZ3rQzVn9f4hh7aS1n | file-5JKehRkefm9vk2Q4iWwLgj
```

**After, captured at this PR's head 5339ec50e7** (port 47513, same flow, 42 of 400 requests completed before the cancel finalized). The polling job persisted unified ids and marked the batch processed

```
select status, batch_processed, file_object->>'id', file_object->>'output_file_id', file_object->>'error_file_id' ...
 cancelled | t | bGl0ZWxsbV9wcm94eTttb2RlbF9pZDo2N2FhODc3... | bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsMGE5... | bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsMDk1...
```

```bash
curl -s http://localhost:47513/v1/batches -H "Authorization: Bearer $KEY"
curl -s http://localhost:47513/v1/batches/<unified batch id> -H "Authorization: Bearer $KEY"
```

```json
{"id": "bGl0ZWxsbV9wcm94eTttb2RlbF9pZDo2N2FhODc3...", "status": "cancelled",
 "output_file_id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsMGE5...",
 "error_file_id": "bGl0ZWxsbV9wcm94eTphcHBsaWNhdGlvbi9qc29uO3VuaWZpZWRfaWQsMDk1..."}
```

The returned `output_file_id` decodes to `litellm_proxy:application/json;unified_id,0a9b8f07-1909-5b4b-b71f-0723e43a4c50;target_model_names,gpt-5.4-nano-batch;llm_output_file_id,file-3Z5qZDZgjFXgHHdThrfykN;llm_output_file_model_id,67aa8771...` and fetching it through the gateway returns the partial results

```bash
curl -s http://localhost:47513/v1/files/<unified output_file_id>/content -H "Authorization: Bearer $KEY" | wc -l
      42
curl -s http://localhost:47513/v1/files/<unified output_file_id>/content -H "Authorization: Bearer $KEY" | head -c 500
{"id": "batch_req_6a740c0516fc819089aa949b9861a55d", "custom_id": "req-25", "response": {"status_code": 200, "request_id": "569be7a1-77d9-49fa-aa81-eb4aa09d5339", "body": {"id": "chatcmpl-E9jpWWf4qlmKX4vss8o0Wa1NAGk5o", "object": "chat.completion", "created": 1785989830, "model": "gpt-5.4-nano-2026-03-17", "choices": [{"index": 0, "message": {"role": "assistant", "content": "## The Number 25: History, Culture, and Science of a Quiet Square\n\nThe number **25**\u2014a tidy square of five\u2014see
```

## Type

🐛 Bug Fix

## Changes

The batch cost polling job's terminal branch (`failed`, `expired`, `cancelled`) persisted the provider response verbatim and marked the job processed, so raw OpenAI file ids became the batch's permanent record; the completed branch already registered managed ids first. The terminal branch now runs the same `ensure_batch_response_managed_file_ids` helper the read paths use, with the DB row supplying the owner's auth context and the decoded unified batch id supplying the model, before persisting. If normalization throws, the job stays unprocessed and is retried on the next cycle

`cancel_batch` in `litellm/proxy/batches_endpoints/endpoints.py` now forwards `user_api_key_dict` to `update_batch_in_database`, since without an auth context that write can never register managed ids

Rows already persisted with raw ids are healed at read time by the companion list fix in #36049

Tests: `tests/proxy_unit_tests/test_check_batch_cost.py` gains a parametrized regression test asserting the persisted record for each terminal status contains only unified ids, maps both raw output ids to minted unified ids under the batch owner's identity, and marks the job processed; the pre-existing terminal-status test now runs against real id decoding instead of patched helpers. `tests/test_litellm/proxy/batches_endpoints/test_endpoints.py` gains a test asserting cancel forwards the caller's auth to the DB write. All of these fail on the unfixed code

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
