### PR TITLE
fix(lint): measure the basedpyright budget gate in a gate-owned venv

### DIFF
--- a/.github/workflows/publish-basedpyright-base-counts.yml
+++ b/.github/workflows/publish-basedpyright-base-counts.yml
@@ -43,22 +43,14 @@ jobs:
         with:
           version: "0.10.9"
 
-      - name: Install dependencies
-        run: |
-          uv sync --frozen --group proxy-dev --group e2e-dev
-
-      # Mirrors test-linting.yml's lint job: basedpyright resolves Prisma's
-      # generated client only after `prisma generate`, and the published counts
-      # must match what that job would measure for the same tree.
-      - name: Generate Prisma client
+      # The gate provisions its own measurement env (.venv-typecheck: a frozen
+      # uv sync of its canonical dependency groups plus a generated Prisma
+      # client), so no install step here can drift from what local runs measure.
+      - name: Emit basedpyright counts for HEAD
         env:
           PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
-          uv run --no-sync prisma generate --schema litellm/proxy/schema.prisma
-
-      - name: Emit basedpyright counts for HEAD
-        run: |
-          uv run --no-sync python scripts/type_check_gate.py --emit-counts-dir "$RUNNER_TEMP/basedpyright-counts"
+          python scripts/type_check_gate.py --emit-counts-dir "$RUNNER_TEMP/basedpyright-counts"
           counts_file=$(ls "$RUNNER_TEMP"/basedpyright-counts/basedpyright-counts-*.json)
           echo "COUNTS_ARTIFACT_NAME=$(basename "$counts_file" .json)" >> "$GITHUB_ENV"
 

--- a/.github/workflows/test-linting.yml
+++ b/.github/workflows/test-linting.yml
@@ -115,6 +115,7 @@ jobs:
       - name: Check basedpyright budget (delta vs base)
         env:
           GH_TOKEN: ${{ github.token }}
+          PRISMA_BINARY_CACHE_DIR: ${{ runner.temp }}/prisma-cache
         run: |
           uv run --no-sync python scripts/type_check_gate.py --base "$GATE_BASE_SHA"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .python-version
 .venv
+.venv-typecheck
 .venv_policy_test
 .env
 .claude

--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,10 @@ lint-fetch-base:
 	git fetch origin litellm_internal_staging
 
 # Mirror test-linting.yml's lint job environment: the proxy-dev group plus a generated
-# Prisma client, so basedpyright resolves the same modules CI does (without the generated
-# client the DB wrappers typed against it degrade to Unknown, drifting the budget from
-# CI's). --inexact tops up the venv instead of pruning the proxy extras gen:api and the
-# running proxy need.
+# Prisma client, so `basedpyright tests/e2e` resolves the same modules CI does. The
+# budget gate itself no longer measures here (scripts/type_check_gate.py provisions its
+# own .venv-typecheck). --inexact tops up the venv instead of pruning the proxy extras
+# gen:api and the running proxy need.
 lint-install:
 	$(UV) sync --inexact --frozen --group proxy-dev --group e2e-dev
 	$(UV_RUN) python scripts/prisma_generate_if_needed.py

--- a/scripts/prisma_generate_if_needed.py
+++ b/scripts/prisma_generate_if_needed.py
@@ -9,13 +9,21 @@ client (a fresh or reinstalled prisma package) forces a regenerate even when
 the stamp matches. The prisma package itself is never imported here: once
 generated it re-exports the whole client on import, which costs more than the
 generate this script exists to skip.
+
+prisma resolves its generator command (``prisma-client-py``) through a plain
+PATH lookup, never through the interpreter that invoked ``prisma generate``,
+so the generate runs with this interpreter's own bin directory pinned to the
+front of PATH; without that pin the client lands in whichever venv the caller
+happened to have on PATH (or the generate fails outright when none is).
 """
 
 import hashlib
 import importlib.metadata
 import importlib.util
+import os
 import subprocess
 import sys
+from collections.abc import Callable, Mapping
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -46,6 +54,25 @@ def client_is_generated() -> bool:
     )
 
 
+def env_with_own_bin_first(base_env: Mapping[str, str]) -> dict[str, str]:
+    bin_dir = str(Path(sys.executable).parent)
+    inherited = base_env.get("PATH")
+    path = os.pathsep.join((bin_dir, inherited)) if inherited else bin_dir
+    return {**base_env, "PATH": path}
+
+
+def _run_command(cmd: list[str], cwd: Path, env: dict[str, str]) -> int:
+    return subprocess.run(cmd, cwd=cwd, env=env).returncode
+
+
+def run_generate(run: Callable[[list[str], Path, dict[str, str]], int] = _run_command) -> int:
+    return run(
+        [sys.executable, "-m", "prisma", "generate", "--schema", str(SCHEMA)],
+        REPO_ROOT,
+        env_with_own_bin_first(os.environ),
+    )
+
+
 def main() -> int:
     version = importlib.metadata.version("prisma")
     expected = stamp_value(SCHEMA.read_bytes(), version)
@@ -55,12 +82,9 @@ def main() -> int:
             f"(prisma {version}); skipping prisma generate"
         )
         return 0
-    result = subprocess.run(
-        [sys.executable, "-m", "prisma", "generate", "--schema", str(SCHEMA)],
-        cwd=REPO_ROOT,
-    )
-    if result.returncode != 0:
-        return result.returncode
+    returncode = run_generate()
+    if returncode != 0:
+        return returncode
     STAMP.write_text(expected)
     return 0
 

--- a/scripts/type_check_gate.py
+++ b/scripts/type_check_gate.py
@@ -63,7 +63,7 @@ import sys
 import tempfile
 import zipfile
 from collections import Counter
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from pathlib import Path
 from typing import Final, NamedTuple
 
@@ -73,6 +73,7 @@ PYRIGHT_CONFIG = REPO_ROOT / "pyrightconfig.json"
 UV_LOCK = REPO_ROOT / "uv.lock"
 DEFAULT_BASE = "origin/litellm_internal_staging"
 CACHE_FILE_PREFIX = "basedpyright-base-"
+CACHE_KEEP_ENTRIES = 8
 ARTIFACT_NAME_PREFIX = "basedpyright-counts-"
 GH_TIMEOUT_SECONDS = 10
 
@@ -367,16 +368,30 @@ def counts_payload(base_point: str, counts: Mapping[str, int]) -> str:
     )
 
 
+def entry_recency(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def evicted_beyond_cap(entries: Sequence[Path], keep: int) -> tuple[Path, ...]:
+    newest_first: Final = sorted(entries, key=entry_recency, reverse=True)
+    return tuple(newest_first[keep:])
+
+
 def store_counts(
     directory: Path, path: Path, base_point: str, counts: Mapping[str, int]
 ) -> None:
     directory.mkdir(parents=True, exist_ok=True)
-    for stale in directory.glob(f"{CACHE_FILE_PREFIX}*.json"):
-        if stale != path:
-            stale.unlink(missing_ok=True)
     scratch = scratch_path(path)
     scratch.write_text(counts_payload(base_point, counts))
     scratch.replace(path)
+    siblings: Final = tuple(
+        entry for entry in directory.glob(f"{CACHE_FILE_PREFIX}*.json") if entry != path
+    )
+    for stale in evicted_beyond_cap(siblings, CACHE_KEEP_ENTRIES - 1):
+        stale.unlink(missing_ok=True)
 
 
 def parse_origin_slug(url: str) -> str | None:

--- a/scripts/type_check_gate.py
+++ b/scripts/type_check_gate.py
@@ -12,6 +12,18 @@ a red once two PRs each land near the limit and their sum crosses it: the
 bystander's count equals its base, so it is spared, while any PR that actually
 grows the rule past its limit still fails.
 
+Installed packages are part of the measurement: a typed dependency that is
+present changes what basedpyright can prove (and therefore which diagnostics
+fire) versus when it is absent, so counts from two differently provisioned
+venvs are not comparable and their comparison produces phantom breaches no
+diff hunk explains. The gate therefore provisions its own environment at
+``.venv-typecheck`` (a frozen ``uv sync`` of one canonical dependency-group
+set, plus a generated Prisma client) and runs every basedpyright pass from it,
+so pre-commit, the CI lint job, and the artifact publisher measure one package
+set by construction; re-syncs of an up-to-date env are a near-instant no-op.
+The group set is folded into the cache and artifact fingerprint, so counts
+recorded under a different set are never matched, only recomputed.
+
 The gate runs basedpyright itself, for both the head and the base pass, with
 ``NODE_OPTIONS`` raised to the heap this repo needs: basedpyright's node
 process OOMs at the ~4 GB default, and when callers had to remember the flag,
@@ -21,8 +33,8 @@ matters once some rule is over its limit, so when none is the base pass is
 skipped outright. When it is needed, it is a second basedpyright pass over a
 detached worktree at the merge-base, run under the same environment so import
 resolution matches, and its per-rule counts are cached under the repo's git
-common dir keyed by merge-base commit,
-``pyrightconfig.json``, and ``uv.lock``, so re-runs against the same branch
+common dir keyed by merge-base commit, ``pyrightconfig.json``, ``uv.lock``,
+and the dependency-group set, so re-runs against the same branch
 point pay for it once. A CI workflow publishes every staging commit's counts as
 an artifact (``--emit-counts-dir`` is its entry point), and on a disk-cache miss
 the gate first tries to download the merge-base's artifact through the ``gh``
@@ -64,10 +76,18 @@ CACHE_FILE_PREFIX = "basedpyright-base-"
 ARTIFACT_NAME_PREFIX = "basedpyright-counts-"
 GH_TIMEOUT_SECONDS = 10
 
+# The one environment every basedpyright pass measures in. The group set is
+# the slim one the CI publisher has always installed (not bootstrap's fatter
+# --extra proxy env), so the committed budgets stay valid; changing it re-keys
+# every cache and artifact fingerprint, so stale counts can never be matched.
+TYPECHECK_ENV_DIR = REPO_ROOT / ".venv-typecheck"
+TYPECHECK_DEP_GROUPS = ("proxy-dev", "e2e-dev")
+PRISMA_GENERATE_SCRIPT = REPO_ROOT / "scripts" / "prisma_generate_if_needed.py"
+
 # basedpyright's node process needs more than the ~4 GB default heap on this
 # repo; appended last so it wins node's last-flag-wins resolution over any
 # caller-set value while preserving the caller's other NODE_OPTIONS flags.
-NODE_HEAP_OPTION = "--max-old-space-size=12288"
+NODE_HEAP_OPTION = "--max-old-space-size=8192"
 
 # Bucket for a basedpyright diagnostic with no `rule`. Counted so it's gated.
 UNCODED = "<uncoded>"
@@ -129,14 +149,78 @@ def node_options_with_heap(base_env: Mapping[str, str]) -> str:
     return f"{base_env.get('NODE_OPTIONS', '')} {NODE_HEAP_OPTION}".strip()
 
 
-def run_basedpyright(cwd: Path = REPO_ROOT) -> str:
-    """One basedpyright pass over `cwd` with the raised node heap exported.
+def typecheck_python_version() -> str | None:
+    """The interpreter version to build the owned env with, read from
+    pyrightconfig's `pythonVersion` so the packages installed for basedpyright
+    to see always come from the same version it type-checks against."""
+    try:
+        config = json.loads(PYRIGHT_CONFIG.read_text())
+    except (OSError, ValueError):
+        return None
+    version: Final = config.get("pythonVersion") if isinstance(config, dict) else None
+    return version if isinstance(version, str) else None
 
-    Exit 0 (clean) and 1 (errors found) are both output-bearing runs; anything
-    else is a crash and fails loudly instead of reading as zero errors."""
-    exe = shutil.which("basedpyright") or "basedpyright"
+
+def typecheck_env_commands(env_dir: Path = TYPECHECK_ENV_DIR) -> tuple[tuple[str, ...], ...]:
+    python_pin: Final = typecheck_python_version()
+    sync: Final = (
+        "uv",
+        "sync",
+        "--frozen",
+        *(("--python", python_pin) if python_pin else ()),
+        *(flag for group in TYPECHECK_DEP_GROUPS for flag in ("--group", group)),
+    )
+    generate: Final = (str(env_dir / "bin" / "python"), str(PRISMA_GENERATE_SCRIPT))
+    return (sync, generate)
+
+
+def _run_provision_step(cmd: tuple[str, ...], env: Mapping[str, str]) -> int:
     proc = subprocess.run(
-        [exe, "--outputjson"],
+        list(cmd), cwd=REPO_ROOT, env=dict(env), capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stdout)
+        sys.stderr.write(proc.stderr)
+    return proc.returncode
+
+
+def ensure_typecheck_env(
+    env_dir: Path = TYPECHECK_ENV_DIR,
+    run: Callable[[tuple[str, ...], Mapping[str, str]], int] = _run_provision_step,
+) -> Path:
+    """Sync the gate-owned venv (and its generated Prisma client) before a
+    measurement pass. Unconditional on purpose: an up-to-date env makes both
+    steps near-instant no-ops, and skipping them on a heuristic is how the
+    measured environment and the fingerprinted one drift apart."""
+    env: Final = {**os.environ, "UV_PROJECT_ENVIRONMENT": str(env_dir)}
+    for cmd in typecheck_env_commands(env_dir):
+        if run(cmd, env) != 0:
+            raise SystemExit(
+                f"could not provision the type-check environment at {env_dir}: "
+                f"`{' '.join(cmd)}` failed"
+            )
+    return env_dir
+
+
+def run_basedpyright(cwd: Path = REPO_ROOT, env_dir: Path = TYPECHECK_ENV_DIR) -> str:
+    """One basedpyright pass over `cwd` from the gate-owned venv, with the
+    raised node heap exported.
+
+    `--pythonpath` pins import resolution to the owned env's interpreter; it is
+    the only pin that works, because basedpyright auto-detects a `.venv` in the
+    project root and that beats both PATH order and VIRTUAL_ENV, silently
+    measuring the caller's fatter venv (whose extra typed packages flip
+    diagnostics) whenever the repo has one. Exit 0 (clean) and 1 (errors
+    found) are both output-bearing runs; anything else is a crash and fails
+    loudly instead of reading as zero errors."""
+    bin_dir: Final = env_dir / "bin"
+    proc = subprocess.run(
+        [
+            str(bin_dir / "basedpyright"),
+            "--outputjson",
+            "--pythonpath",
+            str(bin_dir / "python"),
+        ],
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -208,11 +292,16 @@ def over_ceiling(
     )
 
 
-def environment_fingerprints() -> tuple[str, ...]:
-    return tuple(
-        hashlib.sha256(path.read_bytes()).hexdigest()
-        for path in (PYRIGHT_CONFIG, UV_LOCK)
-        if path.exists()
+def environment_fingerprints(
+    dep_groups: tuple[str, ...] = TYPECHECK_DEP_GROUPS,
+) -> tuple[str, ...]:
+    return (
+        *(
+            hashlib.sha256(path.read_bytes()).hexdigest()
+            for path in (PYRIGHT_CONFIG, UV_LOCK)
+            if path.exists()
+        ),
+        "groups:" + ",".join(dep_groups),
     )
 
 
@@ -560,6 +649,7 @@ def main() -> None:
     parser.add_argument("--update", action="store_true")
     parser.add_argument("--emit-counts-dir", type=Path)
     args = parser.parse_args()
+    ensure_typecheck_env()
     head = count_basedpyright(run_basedpyright())
     if args.emit_counts_dir is not None:
         cmd_emit_counts(

--- a/scripts/type_check_gate.py
+++ b/scripts/type_check_gate.py
@@ -34,8 +34,8 @@ skipped outright. When it is needed, it is a second basedpyright pass over a
 detached worktree at the merge-base, run under the same environment so import
 resolution matches, and its per-rule counts are cached under the repo's git
 common dir keyed by merge-base commit, ``pyrightconfig.json``, ``uv.lock``,
-and the dependency-group set, so re-runs against the same branch
-point pay for it once. A CI workflow publishes every staging commit's counts as
+the Prisma schema, and the dependency-group set, so re-runs against the same
+branch point pay for it once. A CI workflow publishes every staging commit's counts as
 an artifact (``--emit-counts-dir`` is its entry point), and on a disk-cache miss
 the gate first tries to download the merge-base's artifact through the ``gh``
 CLI; any fetch failure falls back silently to the local base pass, so the gate
@@ -83,6 +83,7 @@ GH_TIMEOUT_SECONDS = 10
 TYPECHECK_ENV_DIR = REPO_ROOT / ".venv-typecheck"
 TYPECHECK_DEP_GROUPS = ("proxy-dev", "e2e-dev")
 PRISMA_GENERATE_SCRIPT = REPO_ROOT / "scripts" / "prisma_generate_if_needed.py"
+PRISMA_SCHEMA = REPO_ROOT / "litellm" / "proxy" / "schema.prisma"
 
 # basedpyright's node process needs more than the ~4 GB default heap on this
 # repo; appended last so it wins node's last-flag-wins resolution over any
@@ -192,6 +193,11 @@ def ensure_typecheck_env(
     measurement pass. Unconditional on purpose: an up-to-date env makes both
     steps near-instant no-ops, and skipping them on a heuristic is how the
     measured environment and the fingerprinted one drift apart."""
+    if not env_dir.exists():
+        sys.stderr.write(
+            f"provisioning {env_dir.name} (first run installs packages and "
+            "generates the Prisma client; re-runs are near-instant no-ops)\n"
+        )
     env: Final = {**os.environ, "UV_PROJECT_ENVIRONMENT": str(env_dir)}
     for cmd in typecheck_env_commands(env_dir):
         if run(cmd, env) != 0:
@@ -298,7 +304,7 @@ def environment_fingerprints(
     return (
         *(
             hashlib.sha256(path.read_bytes()).hexdigest()
-            for path in (PYRIGHT_CONFIG, UV_LOCK)
+            for path in (PYRIGHT_CONFIG, UV_LOCK, PRISMA_SCHEMA)
             if path.exists()
         ),
         "groups:" + ",".join(dep_groups),

--- a/tests/test_litellm/test_prisma_generate_if_needed.py
+++ b/tests/test_litellm/test_prisma_generate_if_needed.py
@@ -1,4 +1,6 @@
 import importlib.util
+import os
+import sys
 from pathlib import Path
 
 _MODULE_PATH = (
@@ -33,3 +35,30 @@ def test_skip_requires_a_generated_client_even_with_a_matching_stamp(tmp_path):
     expected = mod.stamp_value(b"schema", "0.11.0")
     stamp.write_text(expected)
     assert mod.should_skip(stamp, expected, client_generated=False) is False
+
+
+def test_env_puts_this_interpreters_bin_dir_first_on_path():
+    env = mod.env_with_own_bin_first({"PATH": "/usr/bin", "HOME": "/home"})
+    bin_dir = str(Path(sys.executable).parent)
+    assert env["PATH"].split(os.pathsep) == [bin_dir, "/usr/bin"]
+    assert env["HOME"] == "/home"
+
+
+def test_env_without_an_inherited_path_is_just_the_bin_dir():
+    env = mod.env_with_own_bin_first({})
+    assert env["PATH"] == str(Path(sys.executable).parent)
+
+
+def test_generate_runs_prisma_with_its_own_bin_dir_leading_the_childs_path():
+    seen = {}
+
+    def recorder(cmd, cwd, env):
+        seen["cmd"] = cmd
+        seen["cwd"] = cwd
+        seen["env"] = env
+        return 0
+
+    assert mod.run_generate(run=recorder) == 0
+    assert seen["cmd"][:4] == [sys.executable, "-m", "prisma", "generate"]
+    assert seen["cwd"] == mod.REPO_ROOT
+    assert seen["env"]["PATH"].split(os.pathsep)[0] == str(Path(sys.executable).parent)

--- a/tests/test_litellm/test_type_check_gate.py
+++ b/tests/test_litellm/test_type_check_gate.py
@@ -1,6 +1,7 @@
 import hashlib
 import importlib.util
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -387,13 +388,43 @@ def test_store_prune_spares_a_concurrent_runs_in_flight_scratch(tmp_path):
     assert gate.load_cached_counts(mine) == {"reportAny": 1}
 
 
-def test_store_prunes_entries_for_other_branch_points(tmp_path):
+def test_store_keeps_a_concurrent_worktrees_entry_for_another_branch_point(tmp_path):
     old = gate.cache_path(tmp_path, "old", ("f",))
     gate.store_counts(tmp_path, old, "old", {"reportAny": 1})
     new = gate.cache_path(tmp_path, "new", ("f",))
     gate.store_counts(tmp_path, new, "new", {"reportAny": 2})
-    assert not old.exists()
+    assert gate.load_cached_counts(old) == {"reportAny": 1}
     assert gate.load_cached_counts(new) == {"reportAny": 2}
+
+
+def test_store_evicts_only_the_oldest_entries_beyond_the_cap(tmp_path):
+    aged = [
+        gate.cache_path(tmp_path, f"base{i}", ("f",))
+        for i in range(gate.CACHE_KEEP_ENTRIES)
+    ]
+    for age, path in enumerate(aged):
+        gate.store_counts(tmp_path, path, f"base{age}", {"reportAny": age})
+        os.utime(path, (age, age))
+    newest = gate.cache_path(tmp_path, "newest", ("f",))
+    gate.store_counts(tmp_path, newest, "newest", {"reportAny": 99})
+    assert not aged[0].exists()
+    assert all(path.exists() for path in aged[1:])
+    assert gate.load_cached_counts(newest) == {"reportAny": 99}
+
+
+def test_store_never_evicts_the_entry_it_just_wrote_even_on_mtime_ties(tmp_path):
+    others = [
+        gate.cache_path(tmp_path, f"base{i}", ("f",))
+        for i in range(gate.CACHE_KEEP_ENTRIES + 2)
+    ]
+    for path in others:
+        gate.store_counts(tmp_path, path, path.name, {"reportAny": 1})
+        os.utime(path, (9_999_999_999, 9_999_999_999))
+    mine = gate.cache_path(tmp_path, "mine", ("f",))
+    gate.store_counts(tmp_path, mine, "mine", {"reportAny": 2})
+    assert gate.load_cached_counts(mine) == {"reportAny": 2}
+    survivors = list(tmp_path.glob(f"{gate.CACHE_FILE_PREFIX}*.json"))
+    assert len(survivors) == gate.CACHE_KEEP_ENTRIES
 
 
 def _no_fetch(ref):

--- a/tests/test_litellm/test_type_check_gate.py
+++ b/tests/test_litellm/test_type_check_gate.py
@@ -1,3 +1,4 @@
+import hashlib
 import importlib.util
 import json
 import subprocess
@@ -278,6 +279,11 @@ def test_fingerprints_carry_the_dependency_group_set():
     )
 
 
+def test_fingerprints_cover_the_prisma_schema():
+    schema_hash = hashlib.sha256(gate.PRISMA_SCHEMA.read_bytes()).hexdigest()
+    assert schema_hash in gate.environment_fingerprints()
+
+
 def test_env_commands_sync_the_canonical_groups_then_generate_prisma():
     sync, generate = gate.typecheck_env_commands(Path("/envdir"))
     assert sync[:3] == ("uv", "sync", "--frozen")
@@ -325,6 +331,22 @@ def test_ensure_env_fails_loudly_and_stops_at_the_first_failed_step(tmp_path):
     with pytest.raises(SystemExit):
         gate.ensure_typecheck_env(env_dir=tmp_path, run=failing)
     assert len(calls) == 1
+
+
+def test_ensure_env_announces_a_cold_provision(tmp_path, capsys):
+    def runner(cmd, env):
+        return 0
+
+    gate.ensure_typecheck_env(env_dir=tmp_path / "fresh", run=runner)
+    assert "provisioning" in capsys.readouterr().err
+
+
+def test_ensure_env_is_silent_when_the_env_already_exists(tmp_path, capsys):
+    def runner(cmd, env):
+        return 0
+
+    gate.ensure_typecheck_env(env_dir=tmp_path, run=runner)
+    assert capsys.readouterr().err == ""
 
 
 def test_cached_counts_round_trip(tmp_path):

--- a/tests/test_litellm/test_type_check_gate.py
+++ b/tests/test_litellm/test_type_check_gate.py
@@ -1,6 +1,5 @@
 import importlib.util
 import json
-import os
 import subprocess
 from pathlib import Path
 
@@ -84,33 +83,51 @@ def test_node_options_with_heap_appends_after_caller_flags_so_it_wins():
     assert merged == f"--max-old-space-size=4096 --no-warnings {gate.NODE_HEAP_OPTION}"
 
 
-def _stub_basedpyright(tmp_path, monkeypatch, script_body):
-    stub = tmp_path / "basedpyright"
+def _stub_env(tmp_path, script_body):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    stub = bin_dir / "basedpyright"
     stub.write_text(f"#!/bin/sh\n{script_body}\n")
     stub.chmod(0o755)
-    monkeypatch.setenv("PATH", str(tmp_path), prepend=os.pathsep)
+    return tmp_path
 
 
 def test_run_basedpyright_exports_the_raised_heap_to_the_child(tmp_path, monkeypatch):
     captured = tmp_path / "node_options.txt"
-    _stub_basedpyright(
+    env_dir = _stub_env(
         tmp_path,
-        monkeypatch,
         f'echo "$NODE_OPTIONS" > "{captured}"\necho \'{{"generalDiagnostics": []}}\'',
     )
     monkeypatch.delenv("NODE_OPTIONS", raising=False)
-    assert json.loads(gate.run_basedpyright(cwd=tmp_path)) == {"generalDiagnostics": []}
+    assert json.loads(gate.run_basedpyright(cwd=tmp_path, env_dir=env_dir)) == {
+        "generalDiagnostics": []
+    }
     assert captured.read_text().strip() == gate.NODE_HEAP_OPTION
 
 
-def test_run_basedpyright_fails_loudly_on_a_crash_exit_code(tmp_path, monkeypatch):
+def test_run_basedpyright_pins_import_resolution_to_the_owned_env(tmp_path):
+    # basedpyright auto-detects a `.venv` in the project root, and that beats
+    # PATH order and VIRTUAL_ENV; only an explicit --pythonpath keeps the
+    # caller's fatter venv (whose extra typed packages flip diagnostics vs CI)
+    # out of the measurement.
+    captured = tmp_path / "argv.txt"
+    env_dir = _stub_env(
+        tmp_path,
+        f'echo "$@" > "{captured}"\necho \'{{"generalDiagnostics": []}}\'',
+    )
+    gate.run_basedpyright(cwd=tmp_path, env_dir=env_dir)
+    argv = captured.read_text().split()
+    assert argv[argv.index("--pythonpath") + 1] == str(env_dir / "bin" / "python")
+
+
+def test_run_basedpyright_fails_loudly_on_a_crash_exit_code(tmp_path):
     import pytest
 
     # 134 is SIGABRT, what node dies with on a heap OOM; it must never read as a
     # clean zero-error run.
-    _stub_basedpyright(tmp_path, monkeypatch, "exit 134")
+    env_dir = _stub_env(tmp_path, "exit 134")
     with pytest.raises(SystemExit):
-        gate.run_basedpyright(cwd=tmp_path)
+        gate.run_basedpyright(cwd=tmp_path, env_dir=env_dir)
 
 
 def test_at_or_under_ceiling_passes():
@@ -246,6 +263,68 @@ def test_cache_key_changes_with_base_point_and_each_fingerprint():
     assert gate.cache_key("def", ("cfg", "lock")) != key
     assert gate.cache_key("abc", ("cfg2", "lock")) != key
     assert gate.cache_key("abc", ("cfg", "lock2")) != key
+
+
+def test_fingerprints_carry_the_dependency_group_set():
+    # Counts measured under one group set must never be compared against
+    # another's: the fingerprint difference re-keys every cache entry and
+    # artifact name, so a changed canonical set falls back to recompute.
+    assert gate.environment_fingerprints() == gate.environment_fingerprints()
+    assert gate.environment_fingerprints(
+        dep_groups=("proxy-dev",)
+    ) != gate.environment_fingerprints(dep_groups=("proxy-dev", "e2e-dev"))
+    assert gate.environment_fingerprints()[-1] == "groups:" + ",".join(
+        gate.TYPECHECK_DEP_GROUPS
+    )
+
+
+def test_env_commands_sync_the_canonical_groups_then_generate_prisma():
+    sync, generate = gate.typecheck_env_commands(Path("/envdir"))
+    assert sync[:3] == ("uv", "sync", "--frozen")
+    adjacent = list(zip(sync, sync[1:]))
+    for group in gate.TYPECHECK_DEP_GROUPS:
+        assert ("--group", group) in adjacent
+    assert generate == (
+        str(Path("/envdir") / "bin" / "python"),
+        str(gate.PRISMA_GENERATE_SCRIPT),
+    )
+
+
+def test_env_interpreter_pin_tracks_pyrightconfigs_python_version():
+    configured = json.loads((ROOT / "pyrightconfig.json").read_text())[
+        "pythonVersion"
+    ]
+    assert gate.typecheck_python_version() == configured
+    sync = gate.typecheck_env_commands()[0]
+    assert sync[sync.index("--python") + 1] == configured
+
+
+def test_ensure_env_targets_the_owned_dir_and_runs_sync_then_generate(tmp_path):
+    calls = []
+
+    def runner(cmd, env):
+        calls.append((cmd[:2], env["UV_PROJECT_ENVIRONMENT"]))
+        return 0
+
+    assert gate.ensure_typecheck_env(env_dir=tmp_path, run=runner) == tmp_path
+    assert calls == [
+        (("uv", "sync"), str(tmp_path)),
+        ((str(tmp_path / "bin" / "python"), str(gate.PRISMA_GENERATE_SCRIPT)), str(tmp_path)),
+    ]
+
+
+def test_ensure_env_fails_loudly_and_stops_at_the_first_failed_step(tmp_path):
+    import pytest
+
+    calls = []
+
+    def failing(cmd, env):
+        calls.append(cmd)
+        return 2
+
+    with pytest.raises(SystemExit):
+        gate.ensure_typecheck_env(env_dir=tmp_path, run=failing)
+    assert len(calls) == 1
 
 
 def test_cached_counts_round_trip(tmp_path):


### PR DESCRIPTION
## TLDR

Problem this solves:

- Local basedpyright gate runs breach with a phantom +1
- CI passes the identical tree, so contributors hunt nonexistent errors
- Cause: the gate measured whatever venv the caller had
- Local bootstrap venvs carry fastapi-sso, CI's slim venv doesn't
- That one package flips a `reportUnnecessaryIsInstance` diagnostic (866 vs 865)

How it solves it:

- The gate now provisions and measures its own `.venv-typecheck`
- Frozen sync of the same dependency groups CI installs
- Every pass pinned there with `--pythonpath` (the only pin basedpyright honors)
- Prisma client generated into that env too: the generate runs with the target interpreter's bin directory pinned to the front of the child PATH, since prisma resolves its generator via PATH only
- Dependency-group set and the Prisma schema folded into the environment fingerprint, so mismatched caches/artifacts never compare
- Counts cache keeps one entry per merge-base and fingerprint (up to eight) instead of a single slot, so concurrent worktrees stop evicting each other
- Node heap lowered from 12GB to 8GB (measured peak 5.4GB)

## User Flow

Before: the gate fails a contributor's local run with an error their change never added, while CI passes the identical tree

1. A contributor runs `make bootstrap`, branches off `litellm_internal_staging`, and makes a small change that adds no new type errors
2. They run `make lint-basedpyright` (or commit a `litellm/` change, letting pre-commit run the gate)
3. The run ends with `FAIL: basedpyright errors exceed the per-rule limit: reportUnnecessaryIsInstance: total 866 over limit 865 (this change added 1)`
4. They search their diff for the new error and find nothing, because it isn't there; pushing anyway turns the same gate green in CI, so they burn time hunting a phantom or learn to distrust the gate

After: the same local run measures the same environment CI does and passes

1. A contributor runs `make bootstrap`, branches off `litellm_internal_staging`, and makes a small change that adds no new type errors
2. They run `make lint-basedpyright` (or commit a `litellm/` change, letting pre-commit run the gate)
3. The first run prints `provisioning .venv-typecheck (first run installs packages and generates the Prisma client; re-runs are near-instant no-ops)`, spends a moment doing that, then ends with `OK: every rule is within its basedpyright limit or no higher than base`, matching what CI reports; later runs reuse the env through a near-instant frozen sync

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

This PR changes lint infrastructure, not proxy behavior, so the end-to-end proof is the gate itself run for real (full basedpyright passes over the tree, no mocks)

Before: the stock gate from merge base ba917681 run in a standard `make bootstrap` checkout of this branch at fa47c47020, which changes no `litellm/` files, so the measured tree is identical to base

```
$ git show ba917681:scripts/type_check_gate.py > scripts/type_check_gate.py
$ uv run --no-sync python scripts/type_check_gate.py --base origin/litellm_internal_staging
base counts fetched from CI artifact basedpyright-counts-c0a20735eb32caf5
FAIL: basedpyright errors exceed the per-rule limit:
  reportUnnecessaryIsInstance: total 866 over limit 865 (this change added 1)
Reduce the new errors or remove an equal number elsewhere; the ceiling is the limit in basedpyright-code-budget.json.
BREACHED RULES: reportUnnecessaryIsInstance 866/865 (+1)
```

An unchanged tree breaches by +1 purely because the local venv contains fastapi-sso and the CI environment behind the base counts does not

After, captured at e824510765 (this branch's head):

```
$ uv run --no-sync python scripts/type_check_gate.py --base origin/litellm_internal_staging
no usable CI artifact named basedpyright-counts-6c4878a6c1b29c4a; computing base counts locally
OK: every rule is within its basedpyright limit or no higher than base (149609 errors total)
```

The artifact miss is expected: base artifacts recorded under the old environment fingerprint no longer match (the fingerprint now also covers the Prisma schema, so clientless counts from before e824510765 can never compare against clientful ones), and the gate falls back to computing base counts locally in the owned env. New artifacts appear once the publisher workflow runs after this merges

The publisher was proven in its exact CI shape: `env -i` with only uv and a bare uv-managed python 3.12 on PATH, no venv anywhere, running `python scripts/type_check_gate.py --emit-counts-dir`. Before the Prisma fix that invocation failed six out of six times with `/bin/sh: prisma-client-py: command not found`, because prisma resolves its generator through a PATH lookup only. With the fix it exits 0 from a cold start (93.8s including provisioning, 3.4GB RSS) and emits a counts artifact reporting 149609 errors total. After that run `.venv-typecheck/lib/python3.12/site-packages/prisma/client.py` exists, the root `.venv` client's mtime is untouched, and a re-run skips with `Prisma client already generated for litellm/proxy/schema.prisma (prisma 0.11.0); skipping prisma generate` in 0.06s

Timing, memory, and disk measurements are in the Benchmarks section below; every measured run stayed well under the new 8192MB heap ceiling

The retired cache race was also proven live at 526f6d793e, with another session's gate genuinely running in a sibling worktree:

```
$ uv run --no-sync python scripts/type_check_gate.py --base origin/litellm_internal_staging
no usable CI artifact named basedpyright-counts-6c4878a6c1b29c4a; computing base counts locally
OK: every rule is within its basedpyright limit or no higher than base (149609 errors total)
$ ls .git/litellm-lint-cache/ | grep basedpyright-base
basedpyright-base-4dc5bdf26c28ef82.json
basedpyright-base-6c4878a6c1b29c4a.json
$ uv run --no-sync python scripts/type_check_gate.py --base origin/litellm_internal_staging
OK: every rule is within its basedpyright limit or no higher than base (149609 errors total)
```

The first entry is the concurrent session's baseline, which the old store would have deleted; the re-run stayed warm (no recompute line) because this worktree's entry survived alongside it

Unit tests: `pytest tests/test_litellm/test_type_check_gate.py tests/test_litellm/test_prisma_generate_if_needed.py` passes 69 tests at 526f6d793e

## Benchmarks

Setup: Apple M5 Pro (18 cores, 24GB RAM), tree at fa47c47020 for both legs since this branch touches no `litellm/` files, so before and after measure the identical tree. Each leg is `/usr/bin/time -l uv run --no-sync python scripts/type_check_gate.py --base origin/litellm_internal_staging` three times, legs run back to back at comparable machine load. Before is the gate script from merge base ba917681 measuring the bootstrap venv, after is this branch measuring `.venv-typecheck` (at fa47c47020 still without a generated Prisma client; a re-measurement at e824510765 follows below)

| Measure | Before | After |
|---|---|---|
| Warm run, wall | 38.3s, 39.6s | 37.1s, 37.3s |
| Warm run, peak RSS | 4.1 to 4.9GB | 3.9 to 4.0GB |
| Cache-miss run, wall | not measured | 75.7s |
| CI lint gate step | 108s | 229s |

Re-measured at e824510765, where the Prisma client now lands in the owned env so basedpyright really resolves it: warm runs clocked 82.1s and 86.8s at 3.1 to 3.4GB RSS, on a night when the machine carried roughly twice the background load. A same-night control of the ba917681 script measuring the bootstrap venv came in at 73.3s, and failed with the same phantom +1 yet again, so under identical load the clientful owned env runs within about 15 percent of the old gate while keeping the lower RSS. The publisher-shaped cold run (`env -i`, no venv on PATH) finished in 93.8s including provisioning at 3.4GB RSS, and the fingerprint-transition double pass took 121.1s that night against 75.7s on the idle night. The single-slot cache race also fired three more times during this re-measurement: a concurrent gate run in another worktree, and then the control's own artifact store, each evicted the new-fingerprint entry and turned the next run into a fresh double pass. 526f6d793e retires that race, proven live against a genuinely concurrent session: after a store under the new code the cache held both worktrees' entries side by side, and the follow-up run loaded its baseline warm without recomputing

Warm steady state is slightly faster and lighter after the change: the owned env holds 193 packages against the bootstrap venv's 225, so basedpyright has less to resolve. A third before run clocked 40.9s but included a CI artifact download, so it is excluded. No warm run in either leg touched the network, so warm runs also work offline

Provisioning overhead is noise once the env exists: the unconditional `uv sync --frozen` no-ops in 0.03 to 0.06s across five timed runs. Rebuilding `.venv-typecheck` from scratch with a warm uv cache took 0.52s (`Installed 193 packages in 339ms`)

Disk: `du` reports 673MB for `.venv-typecheck` with the generated client (645MB before it), but the real cost measured by `df` deltas around a cold provision is about 18MB per worktree, because uv installs by cloning from its cache on APFS. Filesystems without copy-on-write reflinks pay the apparent size

Memory never approaches the lowered heap: single-pass runs peaked at 3.1 to 4.0GB RSS and double-pass runs at 4.6 to 5.4GB across every measurement, all under the new 8192MB node ceiling (previously 12288MB)

The 75.7s cache-miss run is the fingerprint transition: the first run after this change misses both cache and artifact and computes base counts locally, and later runs reuse the cached counts at warm speed. CI pays the same shape. The gate step took 229s on this PR's lint run (123s to provision and measure head, 106s for the local base pass) against 108s on the old script, and settles around 123s once base artifacts exist under the new fingerprint, which the publisher delivers on the first staging push after this merges

The before leg also reproduced the bug this PR fixes, live: fed the CI-published artifact for the old fingerprint, all three before runs failed with the phantom `reportUnnecessaryIsInstance 866/865 (+1)` on an unchanged tree, while all after runs passed by measuring base and head in the same owned env. The e824510765 control run reproduced the phantom a fourth time

## Caveats

Four earlier caveats (the Prisma client landing in the caller's venv instead of the owned one, the generate step never no-oping and mutating the root venv, provisioning failing outright with no venv on PATH, and the rewritten publisher failing for that reason) are fixed as of e824510765: the generate now runs with the target interpreter's bin directory pinned to the front of the child PATH, and a publisher-shaped run (`env -i` with only uv and a bare python 3.12 on PATH) exits 0 and emits counts. Two more (the gate step missing the Prisma binary cache, and provisioning sitting silent) are fixed by the same commit. And 526f6d793e retires the single-slot counts cache after it bit six times during benchmarking: the store now keeps entries for different merge-bases and fingerprints side by side and evicts only the oldest beyond eight, so concurrent worktrees no longer wipe each other's baselines. What remains:

- CI provisions twice: the lint job still syncs the root venv for ruff and the e2e basedpyright step, then the gate builds `.venv-typecheck` again, roughly 15 to 25s of the gate step even after artifacts exist
- Only the budget gate is fixed: `make lint-e2e-basedpyright` still runs the root venv's basedpyright over `tests/e2e`, and editors keep measuring the root `.venv` because `pyrightconfig.json` pins no venv, so IDE diagnostics and gate counts can still disagree
- Totals shift with the env: the owned env reports 149609 errors against 148927 in a bootstrap venv (fastapi-sso exists only in the latter), so plain `basedpyright` in a dev venv reads differently from the gate
- The fingerprint still omits OS and platform (it hashes `pyrightconfig.json`, `uv.lock`, and the Prisma schema, then appends the dependency-group list), so macOS runs deliberately reuse ubuntu-published artifacts. Group pinning removes the known package-set skew, and any future platform-dependent diagnostic would reintroduce a phantom
- Because the schema is fingerprinted, any edit to `litellm/proxy/schema.prisma` re-keys the cache and invalidates published artifacts, so the first gate run after a schema change pays a local base recompute. That is the intended trade: a schema edit changes the generated client basedpyright measures
- The env layout is POSIX only: the gate invokes `<env>/bin/basedpyright` and `<env>/bin/python`, which do not exist under the `Scripts` layout on Windows, so local Windows runs break where the old script ran whatever basedpyright was on PATH. CI is unaffected
- The gate now hard-requires `uv` on PATH in every context, where the old script only needed basedpyright itself
- Each worktree carries its own `.venv-typecheck` at 673MB apparent with the generated client (645MB without), about 18MB real on APFS with a warm uv cache since uv clones from its cache, and the full size on filesystems without reflinks

## Type

🚄 Infrastructure
✅ Test

## Changes

`scripts/type_check_gate.py` now owns its measurement environment. Before any pass it syncs `.venv-typecheck` with `uv sync --frozen` for the canonical dependency groups (`proxy-dev`, `e2e-dev`, the set CI installs), pins the interpreter to `pyrightconfig.json`'s `pythonVersion`, and generates the Prisma client into that env. The sync is unconditional because an up-to-date env makes it a near-instant no-op, and skipping it on a heuristic is how the measured environment and the fingerprinted one drift apart. A cold provision announces itself on stderr instead of sitting silent for the install

The generate needs one non-obvious move: prisma resolves its `prisma-client-py` generator through a plain `/bin/sh` PATH lookup, never through the interpreter that invoked `prisma generate`, so `scripts/prisma_generate_if_needed.py` runs the generate with the invoking interpreter's bin directory pinned to the front of the child PATH. Without that pin the client lands in whichever venv the caller happens to have on PATH, or the generate fails outright when none is, which is exactly the publisher's shape. Once the client exists the script's stamp check makes re-runs a skip

Every basedpyright invocation passes `--pythonpath <env>/bin/python`. This is load-bearing: basedpyright auto-detects a `.venv` directory in the project root, and that auto-detection beats both PATH order and the `VIRTUAL_ENV` variable, so without the flag the gate silently measures the caller's fatter venv whenever the repo has one (which is exactly how the phantom +1 happened, and why PATH-based pinning was not enough)

`environment_fingerprints()` now hashes the Prisma schema alongside `pyrightconfig.json` and `uv.lock` and appends the dependency-group set, so CI artifacts and local caches recorded under a different group set, or before the client existed in the measured env, miss instead of matching, and every miss already falls back to computing base counts locally

`publish-basedpyright-base-counts.yml` drops its own `uv sync` and Prisma steps and lets the script build the measurement env, so the published counts can never drift from what local runs measure. The lint job in `test-linting.yml` keeps its own venv for ruff and the e2e-basedpyright step, and its gate step now sets `PRISMA_BINARY_CACHE_DIR` so the inner generate reuses the job's engine-binary cache instead of re-downloading

The counts cache is no longer single slot: storing a baseline now writes alongside existing entries and evicts only the oldest beyond eight (the entry just written is never a candidate, so an mtime tie cannot evict it), where the old store pruned every sibling. Concurrent gate runs in different worktrees therefore stop evicting each other's baselines, which they did six observed times during benchmarking

The node heap for the full-tree pass drops from 12GB to 8GB, sized against the measured 5.4GB peak. `.venv-typecheck` is gitignored and the `lint-install` comment in the Makefile now describes what the target still covers

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect CI lint timing and gate behavior (new venv provisioning, fingerprint invalidation of old artifacts); no runtime proxy/auth changes, but a mis-provisioned gate could block merges until env issues are fixed.
> 
> **Overview**
> Fixes **phantom basedpyright budget failures** when local bootstrap venvs differ from CI (extra packages change diagnostics) by making `scripts/type_check_gate.py` **provision and measure only in `.venv-typecheck`**: frozen `uv sync` for `proxy-dev` + `e2e-dev`, Prisma generate into that env, and every pass via **`--pythonpath`** on the owned interpreter (so root `.venv` auto-detection cannot skew counts).
> 
> **`prisma_generate_if_needed.py`** now pins the invoking interpreter’s `bin` first on **PATH** so `prisma-client-py` lands in the target venv—required for publisher runs with no pre-existing venv.
> 
> **Fingerprints** for caches/CI artifacts now include the Prisma schema and dependency-group set; **base-count cache** keeps up to eight entries (LRU-style eviction) instead of wiping siblings. Node heap for the gate is **8GB** (was 12GB). **`.venv-typecheck`** is gitignored; **publish-basedpyright-base-counts** defers env setup to the gate; **lint** sets `PRISMA_BINARY_CACHE_DIR` on the budget step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526f6d793ec96d9ba1ce93a854f6486499bff0e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->