### PR TITLE
fix(proxy): include today's UTC bucket when a daily activity range ends at the caller's current day

### DIFF
--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -422,6 +422,7 @@ def _adjust_dates_for_timezone(
     start_date: str,
     end_date: str,
     timezone_offset_minutes: int | None,
+    include_current_utc_day: bool = False,
     utc_now: datetime | None = None,
 ) -> tuple[str, str]:
     """
@@ -449,10 +450,14 @@ def _adjust_dates_for_timezone(
     cannot over-count, because the only part of that bucket outside the caller's range
     is the future, and the future is empty. ``timezone_offset_minutes`` follows the
     JS ``Date.getTimezoneOffset`` convention: UTC minus local, positive west of UTC.
+
+    The extension is strictly opt-in via ``include_current_utc_day`` so a consumer
+    whose axis or reconciliation expects the range to stop at the requested end date
+    keeps today's byte-for-byte behaviour; the cost optimization dashboard opts in.
     """
-    now: Final = utc_now if utc_now is not None else datetime.now(timezone.utc)
-    if timezone_offset_minutes is None:
+    if not include_current_utc_day or timezone_offset_minutes is None:
         return start_date, end_date
+    now: Final = utc_now if utc_now is not None else datetime.now(timezone.utc)
     caller_local_today: Final = (now - timedelta(minutes=timezone_offset_minutes)).date().isoformat()
     if end_date < caller_local_today:
         return start_date, end_date
@@ -469,10 +474,13 @@ def _build_where_conditions(
     api_key: str | list[str] | None,
     exclude_entity_ids: list[str] | None = None,
     timezone_offset_minutes: int | None = None,
+    include_current_utc_day: bool = False,
 ) -> dict[str, "_WhereValue"]:
     """Build prisma where clause for daily activity queries."""
     # Adjust dates for timezone if provided
-    adjusted_start, adjusted_end = _adjust_dates_for_timezone(start_date, end_date, timezone_offset_minutes)
+    adjusted_start, adjusted_end = _adjust_dates_for_timezone(
+        start_date, end_date, timezone_offset_minutes, include_current_utc_day
+    )
 
     where_conditions: Final[dict[str, _WhereValue]] = {
         "date": {
@@ -918,6 +926,7 @@ async def get_daily_activity(
     exclude_entity_ids: list[str] | None = None,
     metadata_metrics_func: Callable[[Sequence[DailySpendRecord]], SpendMetrics] | None = None,
     timezone_offset_minutes: int | None = None,
+    include_current_utc_day: bool = False,
     resolve_entity_metadata: Callable[[Sequence[DailySpendRecord]], Awaitable[dict[str, dict[str, object]]]]
     | None = None,
 ) -> SpendAnalyticsPaginatedResponse:
@@ -951,6 +960,7 @@ async def get_daily_activity(
             api_key=api_key,
             exclude_entity_ids=exclude_entity_ids,
             timezone_offset_minutes=timezone_offset_minutes,
+            include_current_utc_day=include_current_utc_day,
         )
 
         # Get total count for pagination

--- a/litellm/proxy/management_endpoints/common_daily_activity.py
+++ b/litellm/proxy/management_endpoints/common_daily_activity.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Final, Protocol
 
@@ -422,26 +422,41 @@ def _adjust_dates_for_timezone(
     start_date: str,
     end_date: str,
     timezone_offset_minutes: int | None,
+    utc_now: datetime | None = None,
 ) -> tuple[str, str]:
     """
-    Pass-through for the local date range; the timezone offset is intentionally ignored here.
+    Map a caller-local date range onto UTC bucket keys, extending only the live end.
 
     The aggregation table (e.g. LiteLLM_DailyUserSpend) stores spend in whole-UTC-day
-    buckets keyed on date as YYYY-MM-DD. Any conversion from a local date range to a
-    UTC date range using only date arithmetic must round to whole UTC days, allowing up
-    to 24h of slop at each boundary. The previous implementation expanded the SQL range
-    by an extra full UTC day on whichever side the offset pointed, which pulled in 24h
-    of unrelated bucket data per boundary and produced approximately 100% over-counting
-    on single-day queries (e.g. IST May 29 returning UTC May 28 + UTC May 29 in full).
+    buckets keyed on date as YYYY-MM-DD. Any conversion of an interior local-day
+    boundary using only date arithmetic must round to whole UTC days, allowing up to
+    24h of slop at each boundary. A previous implementation expanded the SQL range by
+    an extra full UTC day on whichever side the offset pointed, which pulled in 24h of
+    unrelated bucket data per boundary and produced approximately 100% over-counting on
+    single-day queries (e.g. IST May 29 returning UTC May 28 + UTC May 29 in full).
     Sums of single-day queries then exceeded the equivalent multi-day aggregate, which
-    is mathematically impossible.
+    is mathematically impossible. Historical dates therefore stay a pass-through: the
+    local date is the UTC bucket key, trading boundary slop for monotonic, additive
+    results. Hour-level buckets or pro-rata weighting would fix that properly; both
+    require data the current schema does not store.
 
-    Treating the local date as the UTC date trades a small one-time boundary slop for
-    correct, monotonic, additive results across single-day and multi-day queries. A
-    later fix can introduce hour-level buckets or pro-rata weighting on adjacent UTC
-    days; both require data the current schema does not store.
+    The end boundary is different when the range reaches the caller's current day. A
+    caller west of UTC asking for a range ending "today" is asking for data up to now,
+    but once UTC has rolled past their local midnight, everything they sent since then
+    sits in the next UTC bucket, which the pass-through excludes: a PT dashboard goes
+    stale every evening from 5pm until local midnight, showing $0 for anything that
+    only started accruing that evening. Extending such a range to today's UTC bucket
+    cannot over-count, because the only part of that bucket outside the caller's range
+    is the future, and the future is empty. ``timezone_offset_minutes`` follows the
+    JS ``Date.getTimezoneOffset`` convention: UTC minus local, positive west of UTC.
     """
-    return start_date, end_date
+    now: Final = utc_now if utc_now is not None else datetime.now(timezone.utc)
+    if timezone_offset_minutes is None:
+        return start_date, end_date
+    caller_local_today: Final = (now - timedelta(minutes=timezone_offset_minutes)).date().isoformat()
+    if end_date < caller_local_today:
+        return start_date, end_date
+    return start_date, max(end_date, now.date().isoformat())
 
 
 def _build_where_conditions(

--- a/litellm/proxy/management_endpoints/internal_user_endpoints.py
+++ b/litellm/proxy/management_endpoints/internal_user_endpoints.py
@@ -2650,6 +2650,13 @@ async def get_user_daily_activity(
         description="Timezone offset in minutes from UTC (e.g., 480 for PST). "
         "Matches JavaScript's Date.getTimezoneOffset() convention.",
     ),
+    include_current_utc_day: bool = fastapi.Query(
+        default=False,
+        description="When the range ends on the caller's current local day, extend it to "
+        "today's UTC bucket so spend written after the caller's local midnight (in UTC "
+        "terms) is included. Requires the timezone parameter. Historical ranges are "
+        "never extended.",
+    ),
     user_api_key_dict: UserAPIKeyAuth = Depends(user_api_key_auth),
 ) -> SpendAnalyticsPaginatedResponse:
     """
@@ -2711,6 +2718,7 @@ async def get_user_daily_activity(
             page=page,
             page_size=page_size,
             timezone_offset_minutes=timezone,
+            include_current_utc_day=include_current_utc_day,
             resolve_entity_metadata=lambda records: _resolve_user_email_metadata(prisma_client, records),
         )
 

--- a/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
@@ -1,6 +1,8 @@
 import os
 import sys
+from datetime import datetime, timezone
 from types import SimpleNamespace
+from typing import Final
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -868,6 +870,58 @@ class TestAdjustDatesForTimezone:
         assert max(per_day_ends) == multi_day_range[1]
         assert per_day_starts == days
         assert per_day_ends == days
+
+
+class TestAdjustDatesForTimezoneLiveEnd:
+    """
+    Regression tests for the stale-evening bug: a caller west of UTC whose range
+    ends on their local "today" was capped at that local date's UTC bucket, so
+    once UTC rolled past their local midnight (5pm PT), everything sent that
+    evening sat in the next UTC bucket and the dashboard reported $0 for it
+    until local midnight. A range that reaches the caller's current day must
+    extend to today's UTC bucket; the only part of that bucket outside the
+    range is the future, which is empty, so the extension cannot over-count.
+    """
+
+    PT_EVENING_UTC: Final = datetime(2026, 8, 6, 4, 30, tzinfo=timezone.utc)
+
+    def test_pt_evening_range_ending_today_extends_to_utc_today(self):
+        start, end = _adjust_dates_for_timezone(
+            "2026-07-06", "2026-08-05", 420, utc_now=self.PT_EVENING_UTC
+        )
+        assert (start, end) == ("2026-07-06", "2026-08-06")
+
+    def test_pt_historical_range_is_untouched(self):
+        start, end = _adjust_dates_for_timezone(
+            "2026-07-01", "2026-08-04", 420, utc_now=self.PT_EVENING_UTC
+        )
+        assert (start, end) == ("2026-07-01", "2026-08-04")
+
+    def test_east_of_utc_local_today_already_covers_utc_today(self):
+        ist_evening_utc: Final = datetime(2026, 8, 5, 17, 0, tzinfo=timezone.utc)
+        start, end = _adjust_dates_for_timezone(
+            "2026-07-07", "2026-08-06", -330, utc_now=ist_evening_utc
+        )
+        assert (start, end) == ("2026-07-07", "2026-08-06")
+
+    def test_missing_offset_stays_pass_through_even_for_live_range(self):
+        start, end = _adjust_dates_for_timezone(
+            "2026-07-06", "2026-08-05", None, utc_now=self.PT_EVENING_UTC
+        )
+        assert (start, end) == ("2026-07-06", "2026-08-05")
+
+    def test_utc_caller_range_ending_today_is_unchanged(self):
+        utc_noon: Final = datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc)
+        start, end = _adjust_dates_for_timezone(
+            "2026-07-06", "2026-08-05", 0, utc_now=utc_noon
+        )
+        assert (start, end) == ("2026-07-06", "2026-08-05")
+
+    def test_future_end_date_extends_no_further_than_requested(self):
+        start, end = _adjust_dates_for_timezone(
+            "2026-07-06", "2026-08-09", 420, utc_now=self.PT_EVENING_UTC
+        )
+        assert (start, end) == ("2026-07-06", "2026-08-09")
 
 
 class TestBuildAggregatedSqlQuery:

--- a/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_common_daily_activity.py
@@ -878,48 +878,56 @@ class TestAdjustDatesForTimezoneLiveEnd:
     ends on their local "today" was capped at that local date's UTC bucket, so
     once UTC rolled past their local midnight (5pm PT), everything sent that
     evening sat in the next UTC bucket and the dashboard reported $0 for it
-    until local midnight. A range that reaches the caller's current day must
-    extend to today's UTC bucket; the only part of that bucket outside the
-    range is the future, which is empty, so the extension cannot over-count.
+    until local midnight. A range that reaches the caller's current day and
+    opts in via include_current_utc_day must extend to today's UTC bucket; the
+    only part of that bucket outside the range is the future, which is empty,
+    so the extension cannot over-count. Callers that do not opt in keep the
+    pass-through byte for byte.
     """
 
     PT_EVENING_UTC: Final = datetime(2026, 8, 6, 4, 30, tzinfo=timezone.utc)
 
     def test_pt_evening_range_ending_today_extends_to_utc_today(self):
         start, end = _adjust_dates_for_timezone(
-            "2026-07-06", "2026-08-05", 420, utc_now=self.PT_EVENING_UTC
+            "2026-07-06", "2026-08-05", 420, include_current_utc_day=True, utc_now=self.PT_EVENING_UTC
         )
         assert (start, end) == ("2026-07-06", "2026-08-06")
 
+    def test_without_opt_in_live_range_keeps_pass_through(self):
+        start, end = _adjust_dates_for_timezone(
+            "2026-07-06", "2026-08-05", 420, utc_now=self.PT_EVENING_UTC
+        )
+        assert (start, end) == ("2026-07-06", "2026-08-05")
+
     def test_pt_historical_range_is_untouched(self):
         start, end = _adjust_dates_for_timezone(
-            "2026-07-01", "2026-08-04", 420, utc_now=self.PT_EVENING_UTC
+            "2026-07-01", "2026-08-04", 420, include_current_utc_day=True, utc_now=self.PT_EVENING_UTC
         )
         assert (start, end) == ("2026-07-01", "2026-08-04")
 
     def test_east_of_utc_local_today_already_covers_utc_today(self):
         ist_evening_utc: Final = datetime(2026, 8, 5, 17, 0, tzinfo=timezone.utc)
         start, end = _adjust_dates_for_timezone(
-            "2026-07-07", "2026-08-06", -330, utc_now=ist_evening_utc
+            "2026-07-07", "2026-08-06", -330, include_current_utc_day=True, utc_now=ist_evening_utc
         )
         assert (start, end) == ("2026-07-07", "2026-08-06")
 
     def test_missing_offset_stays_pass_through_even_for_live_range(self):
         start, end = _adjust_dates_for_timezone(
-            "2026-07-06", "2026-08-05", None, utc_now=self.PT_EVENING_UTC
+            "2026-07-06", "2026-08-05", None, include_current_utc_day=True, utc_now=self.PT_EVENING_UTC
         )
         assert (start, end) == ("2026-07-06", "2026-08-05")
 
     def test_utc_caller_range_ending_today_is_unchanged(self):
         utc_noon: Final = datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc)
         start, end = _adjust_dates_for_timezone(
-            "2026-07-06", "2026-08-05", 0, utc_now=utc_noon
+            "2026-07-06", "2026-08-05", 0, include_current_utc_day=True, utc_now=utc_noon
         )
         assert (start, end) == ("2026-07-06", "2026-08-05")
 
     def test_future_end_date_extends_no_further_than_requested(self):
         start, end = _adjust_dates_for_timezone(
-            "2026-07-06", "2026-08-09", 420, utc_now=self.PT_EVENING_UTC
+            "2026-07-06", "2026-08-09", 420, include_current_utc_day=True, utc_now=self.PT_EVENING_UTC
         )
         assert (start, end) == ("2026-07-06", "2026-08-09")
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.test.tsx
@@ -209,9 +209,9 @@ describe("UsageTab", () => {
   it("says what the line means and over what range", async () => {
     const { getByText, getByRole } = renderWith(twoDays());
 
-    expect(getByText("Running total saved · Jul 1 – Jul 14")).toBeInTheDocument();
+    expect(getByText("Running total saved · Jul 1 – Jul 14 (UTC)")).toBeInTheDocument();
     await userEvent.click(getByRole("tab", { name: "Per day" }));
-    expect(getByText("Saved per day · Jul 1 – Jul 14")).toBeInTheDocument();
+    expect(getByText("Saved per day · Jul 1 – Jul 14 (UTC)")).toBeInTheDocument();
   });
 
   it("builds the per-driver donut from the range totals, not the running total", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/UsageTab.tsx
@@ -141,7 +141,7 @@ const UsageTab: React.FC<UsageTabProps> = ({ accessToken, activity }) => {
   const rangeLabel = formatRangeLabel(startTime ?? undefined, endTime ?? undefined);
   const savingsSubtitle = [
     accumulation === "cumulative" ? "Running total saved" : `Saved ${intervalLabel.toLowerCase()}`,
-    rangeLabel,
+    rangeLabel && `${rangeLabel} (UTC)`,
   ]
     .filter(Boolean)
     .join(" \u00b7 ");
@@ -179,6 +179,7 @@ const UsageTab: React.FC<UsageTabProps> = ({ accessToken, activity }) => {
   return (
     <div className="w-full space-y-6">
       <div className="flex flex-wrap items-center justify-end gap-4">
+        <span className="text-sm text-muted-foreground">Spend is bucketed by UTC day</span>
         <AdvancedDatePicker value={dateValue} onValueChange={onDateChange} />
       </div>
 

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.test.tsx
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.test.tsx
@@ -22,13 +22,13 @@ describe("useDailyActivityRange", () => {
   it("queries every user's activity for an admin", () => {
     renderHook(() => useDailyActivityRange("test-token", "u1", "proxy_admin"));
 
-    expect(argsOfLastCall()).toEqual(["test-token", expect.any(Date), expect.any(Date), null]);
+    expect(argsOfLastCall()).toEqual(["test-token", expect.any(Date), expect.any(Date), null, true]);
   });
 
   it("scopes the query to the caller for a non-admin", () => {
     renderHook(() => useDailyActivityRange("test-token", "u1", "internal_user"));
 
-    expect(argsOfLastCall()).toEqual(["test-token", expect.any(Date), expect.any(Date), "u1"]);
+    expect(argsOfLastCall()).toEqual(["test-token", expect.any(Date), expect.any(Date), "u1", true]);
   });
 
   it("stays disabled until an access token is available", () => {

--- a/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.ts
+++ b/ui/litellm-dashboard/src/app/(dashboard)/cost-optimization/_components/useDailyActivityRange.ts
@@ -35,7 +35,7 @@ export const useDailyActivityRange = (
 
   const { data, loading, isFetchingMore } = usePaginatedDailyActivity({
     fetchFn: userDailyActivityCall,
-    args: [accessToken, startTime, endTime, effectiveUserId],
+    args: [accessToken, startTime, endTime, effectiveUserId, true],
     enabled: !!accessToken && !!startTime && !!endTime,
   });
 

--- a/ui/litellm-dashboard/src/components/networking.tsx
+++ b/ui/litellm-dashboard/src/components/networking.tsx
@@ -1388,6 +1388,7 @@ export const userDailyActivityCall = async (
   endTime: Date,
   page: number = 1,
   userId: string | null = null,
+  includeCurrentUtcDay: boolean = false,
 ) => {
   /**
    * Get daily user activity on proxy
@@ -1400,6 +1401,7 @@ export const userDailyActivityCall = async (
     page,
     extraQueryParams: {
       user_id: userId,
+      include_current_utc_day: includeCurrentUtcDay ? "true" : undefined,
     },
   });
 };

--- a/ui/litellm-dashboard/src/lib/http/schema.d.ts
+++ b/ui/litellm-dashboard/src/lib/http/schema.d.ts
@@ -53883,6 +53883,8 @@ export interface operations {
                 page_size?: number;
                 /** @description Timezone offset in minutes from UTC (e.g., 480 for PST). Matches JavaScript's Date.getTimezoneOffset() convention. */
                 timezone?: number | null;
+                /** @description When the range ends on the caller's current local day, extend it to today's UTC bucket so spend written after the caller's local midnight (in UTC terms) is included. Requires the timezone parameter. Historical ranges are never extended. */
+                include_current_utc_day?: boolean;
             };
             header?: never;
             path?: never;


### PR DESCRIPTION
## TLDR

Problem this solves:

- Daily activity tables bucket spend by UTC day
- Dashboard ranges end at the browser's local "today"
- West-of-UTC viewers lose everything sent after UTC midnight
- A PT dashboard reads $0 for the whole evening, every evening

How it solves it:

- New opt-in `include_current_utc_day` param on `/user/daily/activity`
- When set and the range reaches the caller's current day, the end extends to today's UTC bucket
- Only the cost optimization dashboard opts in; every other caller is unchanged
- Historical ranges keep the existing pass-through, so no over-counting is reintroduced

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

Live repro at 21:30 PT on Aug 5 (04:30 UTC Aug 6): the proxy's daily rollups held that evening's compression and auto-router savings in the `2026-08-06` UTC bucket, written by real traffic through a headroom guardrail and a `complexity_router` auto-router earlier that evening

Before (commit `1aff2795b5`), the exact query the dashboard sends (range ending local today, `timezone=420`) excludes the live bucket, so every savings card reads zero even though the data exists:

```
$ curl -s "localhost:4998/user/daily/activity?start_date=2026-07-06&end_date=2026-08-05&page_size=50&timezone=420" \
    -H "Authorization: Bearer sk-..." | jq '.metadata | {total_spend, total_compression_savings_spend, total_autorouter_savings_spend}'
{"total_spend": 0.0, "total_compression_savings_spend": 0.0, "total_autorouter_savings_spend": 0.0}
```

After (commit `e1dfbb14da`), the same query with the new opt-in param returns the live bucket:

```
$ curl -s "localhost:4999/user/daily/activity?start_date=2026-07-06&end_date=2026-08-05&page_size=50&timezone=420&include_current_utc_day=true" \
    -H "Authorization: Bearer sk-..." | jq '.metadata | {total_compression_savings_spend, total_autorouter_savings_spend}'
{"total_compression_savings_spend": 0.001143, "total_autorouter_savings_spend": 0.001692}
```

Everything that does not opt in is byte-for-byte unchanged, verified on the after build: the identical query without the param (what the main Usage page sends), with the param but no `timezone`, and a historical range with both all return the untouched pass-through result

```
$ curl -s "localhost:4999/user/daily/activity?start_date=2026-07-06&end_date=2026-08-05&page_size=50&timezone=420" ...
{"total_compression_savings_spend": 0.0, "total_autorouter_savings_spend": 0.0}
$ curl -s "localhost:4999/user/daily/activity?start_date=2026-07-06&end_date=2026-08-05&page_size=50&include_current_utc_day=true" ...
{"total_compression_savings_spend": 0.0, "total_autorouter_savings_spend": 0.0}
```

## Type

🐛 Bug Fix

## Changes

`_adjust_dates_for_timezone` in `common_daily_activity.py` is the single chokepoint every daily activity endpoint (`/user|team|tag|organization/daily/activity`) resolves its date range through. It was a deliberate pass-through: local dates are used verbatim as UTC bucket keys because the rollup tables only store whole UTC days, and the previous offset-expansion implementation caused up to 100% over-counting on single-day queries

That pass-through has one asymmetric blind spot: a range ending at the caller's current local day is a request for data up to now, but once UTC rolls past the caller's local midnight (5pm PT), everything newer sits in the next UTC bucket, which the pass-through excludes. This change extends only that live end boundary to today's UTC date, and only for callers that opt in with the new `include_current_utc_day` query param on `/user/daily/activity` alongside the `timezone` offset the dashboard already sends (JS `getTimezoneOffset` convention). The extension cannot over-count because the only part of today's UTC bucket outside the caller's range is the future, which is empty. Historical interior boundaries keep the documented pass-through and its additivity invariant even for opted-in callers; the existing regression tests for the over-counting bug still pass unchanged

The cost optimization dashboard's `useDailyActivityRange` is the single opt-in: its cards and savings chart now include live evening data for west-of-UTC viewers. The main Usage page and every other consumer of the daily activity endpoints send the same requests as before and get identical responses. `schema.d.ts` is regenerated for the new query param

`utc_now` is injectable for tests only; production call sites are unchanged and default to `datetime.now(timezone.utc)`

The cost optimization page also now says what its dates mean: the savings chart subtitle carries a "(UTC)" marker and a muted caption beside the range picker reads "Spend is bucketed by UTC day", since the rollup buckets are UTC days regardless of the viewer's timezone

## QA runbook

1. Set your machine's timezone to `America/Los_Angeles` and pick a time after 5pm local (so UTC has rolled to the next day)
2. Start the proxy with a DB that has daily rollup rows, send a few chat completions through any model so today's UTC bucket gets fresh spend
3. `curl "localhost:4000/user/daily/activity?start_date=<30d ago>&end_date=<local today>&timezone=420&include_current_utc_day=true" -H "Authorization: Bearer $MASTER_KEY"` and confirm the response includes a `results` entry for tomorrow's local date (today's UTC date) carrying the fresh spend
4. Repeat without `&include_current_utc_day=true` and confirm that entry is absent (pass-through preserved)
5. In the Admin UI, open Cost Optimization: the cards and savings chart should now include the traffic you just sent instead of reading stale until local midnight. The main Usage page intentionally keeps its previous behavior

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in query param defaults false; only the cost optimization client enables it, so existing analytics callers are unchanged aside from clearer UTC labeling in that UI.
> 
> **Overview**
> Fixes **stale evening spend** for viewers west of UTC: daily rollups are keyed by UTC day, but dashboard ranges end on local “today,” so after UTC midnight (e.g. 5pm PT) new spend lands in the next UTC bucket and was excluded until local midnight.
> 
> **Proxy:** `_adjust_dates_for_timezone` gains optional **`include_current_utc_day`** (with injectable `utc_now` for tests). When enabled together with **`timezone`**, if `end_date` reaches the caller’s current local day, the SQL end date extends to **today’s UTC date**; historical ranges and callers without the flag keep the existing pass-through. The flag is threaded through `_build_where_conditions` and `get_daily_activity`, and exposed on **`GET /user/daily/activity`** as `include_current_utc_day` (default `false`).
> 
> **Dashboard:** Cost optimization **`useDailyActivityRange`** passes `true` into **`userDailyActivityCall`**, which sends `include_current_utc_day` in the query string. The Usage tab adds **“(UTC)”** on chart subtitles and a **“Spend is bucketed by UTC day”** caption.
> 
> **Tests:** New `TestAdjustDatesForTimezoneLiveEnd` cases cover PT evening extension, opt-out, historical ranges, missing offset, and future end dates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a19b7b7abac27f5e6f8a24667f456a265ccca5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->