### PR TITLE
fix(proxy): stop resolving the UI session sentinel team on /search_tools/list

### DIFF
--- a/litellm/proxy/search_endpoints/search_tool_management.py
+++ b/litellm/proxy/search_endpoints/search_tool_management.py
@@ -2,13 +2,15 @@
 CRUD ENDPOINTS FOR SEARCH TOOLS
 """
 
+from collections.abc import Awaitable, Callable
 from datetime import datetime
-from typing import Any, Final
+from typing import Any, Final, TypeAlias
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from litellm._logging import verbose_proxy_logger
+from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
 from litellm.proxy._types import (
     LiteLLM_TeamTable,
     LitellmUserRoles,
@@ -46,9 +48,46 @@ def _convert_datetime_to_str(value: datetime | str | None) -> str | None:
     return value
 
 
+TeamObjectLookup: TypeAlias = Callable[[str, UserAPIKeyAuth], Awaitable[LiteLLM_TeamTable]]
+
+
+async def _team_object_from_db(team_id: str, user_api_key_dict: UserAPIKeyAuth) -> LiteLLM_TeamTable:
+    from litellm.proxy.auth.auth_checks import get_team_object
+    from litellm.proxy.proxy_server import (
+        prisma_client,
+        proxy_logging_obj,
+        user_api_key_cache,
+    )
+
+    return await get_team_object(
+        team_id=team_id,
+        prisma_client=prisma_client,
+        user_api_key_cache=user_api_key_cache,
+        parent_otel_span=user_api_key_dict.parent_otel_span,
+        proxy_logging_obj=proxy_logging_obj,
+    )
+
+
+def _allowlist_team_id(user_api_key_dict: UserAPIKeyAuth) -> str | None:
+    """
+    The team whose object_permission allowlist scopes this caller, or None when there is none.
+
+    Every Admin UI session key is stamped with UI_SESSION_TOKEN_TEAM_ID, a reserved sentinel that
+    never has a row in LiteLLM_TeamTable (`/team/new` rejects it as a real team id), so looking it
+    up would raise 404 instead of resolving a team. It carries no allowlist of its own, so the
+    caller is scoped by its key-level allowlist alone. Any other team id is looked up for real and
+    a failed lookup still surfaces.
+    """
+    team_id: Final = user_api_key_dict.team_id
+    if not team_id or team_id == UI_SESSION_TOKEN_TEAM_ID:
+        return None
+    return team_id
+
+
 async def _filter_visible_search_tools(
     search_tools: list[SearchToolInfoResponse],
     user_api_key_dict: UserAPIKeyAuth,
+    lookup_team_object: TeamObjectLookup = _team_object_from_db,
 ) -> list[SearchToolInfoResponse]:
     """
     Drop search tools the caller is not authorized to invoke, applying the same
@@ -60,25 +99,12 @@ async def _filter_visible_search_tools(
     ):
         return search_tools
 
-    from litellm.proxy.auth.auth_checks import (
-        can_user_view_search_tool,
-        get_team_object,
-    )
-    from litellm.proxy.proxy_server import (
-        prisma_client,
-        proxy_logging_obj,
-        user_api_key_cache,
-    )
+    from litellm.proxy.auth.auth_checks import can_user_view_search_tool
 
-    team_object: LiteLLM_TeamTable | None = None
-    if user_api_key_dict.team_id:
-        team_object = await get_team_object(
-            team_id=user_api_key_dict.team_id,
-            prisma_client=prisma_client,
-            user_api_key_cache=user_api_key_cache,
-            parent_otel_span=user_api_key_dict.parent_otel_span,
-            proxy_logging_obj=proxy_logging_obj,
-        )
+    allowlist_team_id: Final = _allowlist_team_id(user_api_key_dict)
+    team_object: Final[LiteLLM_TeamTable | None] = (
+        await lookup_team_object(allowlist_team_id, user_api_key_dict) if allowlist_team_id else None
+    )
 
     visible: Final[list[SearchToolInfoResponse]] = []
     for tool in search_tools:
@@ -213,6 +239,8 @@ async def list_search_tools(
         visible_search_tools: Final = await _filter_visible_search_tools(search_tool_configs, user_api_key_dict)
 
         return ListSearchToolsResponse(search_tools=visible_search_tools)
+    except HTTPException:
+        raise
     except Exception as e:
         verbose_proxy_logger.exception("Error getting search tools: %s", e)
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
+++ b/tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
@@ -24,6 +24,7 @@ import litellm.proxy.proxy_server as ps
 
 # Now we can safely import app
 from litellm.proxy.proxy_server import app
+from litellm.types.search import SearchToolInfoResponse
 
 client = TestClient(app)
 
@@ -818,9 +819,7 @@ async def test_list_search_tools_admin_with_restricted_key_still_sees_all():
     assert names == {"db-tool-1", "db-tool-2", "db-tool-3"}
 
 
-def _search_tool_responses(*names):
-    from litellm.types.search import SearchToolInfoResponse
-
+def _search_tool_responses(*names: str) -> list[SearchToolInfoResponse]:
     return [
         SearchToolInfoResponse(
             search_tool_id=f"id-{name}",
@@ -835,17 +834,8 @@ def _search_tool_responses(*names):
     ]
 
 
-def _recording_team_lookup(team_object=None, raises=None):
-    """A `TeamObjectLookup` double that records the team ids it was asked to resolve."""
-    asked_for = []
-
-    async def _lookup(team_id, user_api_key_dict):
-        asked_for.append(team_id)
-        if raises is not None:
-            raise raises
-        return team_object
-
-    return _lookup, asked_for
+def _team_ids_looked_up(lookup: AsyncMock) -> list[str]:
+    return [awaited.args[0] for awaited in lookup.await_args_list]
 
 
 @pytest.mark.asyncio
@@ -906,7 +896,7 @@ async def test_filter_visible_search_tools_dashboard_session_still_honors_key_al
             search_tools=["db-tool-3"],
         ),
     )
-    lookup, asked_for = _recording_team_lookup()
+    lookup = AsyncMock()
 
     visible = await _filter_visible_search_tools(
         _search_tool_responses("db-tool-1", "db-tool-2", "db-tool-3"),
@@ -915,7 +905,7 @@ async def test_filter_visible_search_tools_dashboard_session_still_honors_key_al
     )
 
     assert [t["search_tool_name"] for t in visible] == ["db-tool-3"]
-    assert asked_for == []
+    lookup.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -930,8 +920,8 @@ async def test_filter_visible_search_tools_still_applies_a_real_team_allowlist()
         user_id="internal_user",
         team_id="team-1",
     )
-    lookup, asked_for = _recording_team_lookup(
-        team_object=LiteLLM_TeamTable(
+    lookup = AsyncMock(
+        return_value=LiteLLM_TeamTable(
             team_id="team-1",
             object_permission=LiteLLM_ObjectPermissionTable(
                 object_permission_id="op-team",
@@ -947,7 +937,7 @@ async def test_filter_visible_search_tools_still_applies_a_real_team_allowlist()
     )
 
     assert [t["search_tool_name"] for t in visible] == ["db-tool-2"]
-    assert asked_for == ["team-1"]
+    assert _team_ids_looked_up(lookup) == ["team-1"]
 
 
 @pytest.mark.asyncio
@@ -965,9 +955,7 @@ async def test_filter_visible_search_tools_propagates_a_real_team_lookup_failure
         user_id="internal_user",
         team_id="deleted-team",
     )
-    lookup, asked_for = _recording_team_lookup(
-        raises=HTTPException(status_code=404, detail={"error": "Team doesn't exist in db."})
-    )
+    lookup = AsyncMock(side_effect=HTTPException(status_code=404, detail={"error": "Team doesn't exist in db."}))
 
     with pytest.raises(HTTPException) as exc_info:
         await _filter_visible_search_tools(
@@ -977,7 +965,7 @@ async def test_filter_visible_search_tools_propagates_a_real_team_lookup_failure
         )
 
     assert exc_info.value.status_code == 404
-    assert asked_for == ["deleted-team"]
+    assert _team_ids_looked_up(lookup) == ["deleted-team"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
+++ b/tests/test_litellm/proxy/management_endpoints/search_endpoints/test_search_tool_management.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 sys.path.insert(
@@ -815,3 +816,196 @@ async def test_list_search_tools_admin_with_restricted_key_still_sees_all():
     assert response.status_code == 200
     names = {t["search_tool_name"] for t in response.json()["search_tools"]}
     assert names == {"db-tool-1", "db-tool-2", "db-tool-3"}
+
+
+def _search_tool_responses(*names):
+    from litellm.types.search import SearchToolInfoResponse
+
+    return [
+        SearchToolInfoResponse(
+            search_tool_id=f"id-{name}",
+            search_tool_name=name,
+            litellm_params={"search_provider": "perplexity"},
+            search_tool_info=None,
+            created_at=None,
+            updated_at=None,
+            is_from_config=False,
+        )
+        for name in names
+    ]
+
+
+def _recording_team_lookup(team_object=None, raises=None):
+    """A `TeamObjectLookup` double that records the team ids it was asked to resolve."""
+    asked_for = []
+
+    async def _lookup(team_id, user_api_key_dict):
+        asked_for.append(team_id)
+        if raises is not None:
+            raise raises
+        return team_object
+
+    return _lookup, asked_for
+
+
+@pytest.mark.asyncio
+async def test_list_search_tools_dashboard_session_key_does_not_look_up_the_ui_team():
+    """
+    Regression: the Admin UI session key is stamped with the reserved team id
+    ``litellm-dashboard``, which has no row in LiteLLM_TeamTable. Resolving it as a real team
+    raised 404, which the endpoint reported as a 500, so the Search Tools page was broken for
+    every non-admin browsing the dashboard.
+    """
+    from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+
+    dashboard_session_user = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="internal_user",
+        team_id=UI_SESSION_TOKEN_TEAM_ID,
+    )
+    ui_team_is_not_a_real_team = AsyncMock(
+        side_effect=HTTPException(
+            status_code=404,
+            detail={"error": f"Team doesn't exist in db. Team={UI_SESSION_TOKEN_TEAM_ID}."},
+        )
+    )
+
+    with (
+        _mock_search_tool_backend(_scoping_db_tools()),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_team_object",
+            ui_team_is_not_a_real_team,
+        ),
+        _override_auth(dashboard_session_user),
+    ):
+        response = TestClient(app).get("/search_tools/list")
+
+    assert response.status_code == 200
+    names = {t["search_tool_name"] for t in response.json()["search_tools"]}
+    assert names == {"db-tool-1", "db-tool-2", "db-tool-3"}
+    ui_team_is_not_a_real_team.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_filter_visible_search_tools_dashboard_session_still_honors_key_allowlist():
+    """
+    Skipping the synthetic team must not widen visibility: a dashboard session whose key
+    carries a search_tools allowlist stays scoped to it.
+    """
+    from litellm.constants import UI_SESSION_TOKEN_TEAM_ID
+    from litellm.proxy.search_endpoints.search_tool_management import (
+        _filter_visible_search_tools,
+    )
+
+    restricted_dashboard_session = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="internal_user",
+        team_id=UI_SESSION_TOKEN_TEAM_ID,
+        object_permission=LiteLLM_ObjectPermissionTable(
+            object_permission_id="op-key",
+            search_tools=["db-tool-3"],
+        ),
+    )
+    lookup, asked_for = _recording_team_lookup()
+
+    visible = await _filter_visible_search_tools(
+        _search_tool_responses("db-tool-1", "db-tool-2", "db-tool-3"),
+        restricted_dashboard_session,
+        lookup,
+    )
+
+    assert [t["search_tool_name"] for t in visible] == ["db-tool-3"]
+    assert asked_for == []
+
+
+@pytest.mark.asyncio
+async def test_filter_visible_search_tools_still_applies_a_real_team_allowlist():
+    """A caller with a real team is still resolved and scoped by that team's allowlist."""
+    from litellm.proxy.search_endpoints.search_tool_management import (
+        _filter_visible_search_tools,
+    )
+
+    team_member = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="internal_user",
+        team_id="team-1",
+    )
+    lookup, asked_for = _recording_team_lookup(
+        team_object=LiteLLM_TeamTable(
+            team_id="team-1",
+            object_permission=LiteLLM_ObjectPermissionTable(
+                object_permission_id="op-team",
+                search_tools=["db-tool-2"],
+            ),
+        )
+    )
+
+    visible = await _filter_visible_search_tools(
+        _search_tool_responses("db-tool-1", "db-tool-2", "db-tool-3"),
+        team_member,
+        lookup,
+    )
+
+    assert [t["search_tool_name"] for t in visible] == ["db-tool-2"]
+    assert asked_for == ["team-1"]
+
+
+@pytest.mark.asyncio
+async def test_filter_visible_search_tools_propagates_a_real_team_lookup_failure():
+    """
+    A caller whose real team cannot be resolved must not fall through to "no team", which
+    would drop that team's allowlist and show tools the caller may not call.
+    """
+    from litellm.proxy.search_endpoints.search_tool_management import (
+        _filter_visible_search_tools,
+    )
+
+    team_member = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="internal_user",
+        team_id="deleted-team",
+    )
+    lookup, asked_for = _recording_team_lookup(
+        raises=HTTPException(status_code=404, detail={"error": "Team doesn't exist in db."})
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _filter_visible_search_tools(
+            _search_tool_responses("db-tool-1", "db-tool-2"),
+            team_member,
+            lookup,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert asked_for == ["deleted-team"]
+
+
+@pytest.mark.asyncio
+async def test_list_search_tools_reports_a_missing_real_team_as_404():
+    """
+    The endpoint surfaces a genuine team lookup failure with its own status instead of
+    masking it as a 500 or quietly returning an unscoped list.
+    """
+    team_member = UserAPIKeyAuth(
+        user_role=LitellmUserRoles.INTERNAL_USER,
+        user_id="internal_user",
+        team_id="deleted-team",
+    )
+
+    with (
+        _mock_search_tool_backend(_scoping_db_tools()),
+        patch(
+            "litellm.proxy.auth.auth_checks.get_team_object",
+            AsyncMock(
+                side_effect=HTTPException(
+                    status_code=404,
+                    detail={"error": "Team doesn't exist in db. Team=deleted-team."},
+                )
+            ),
+        ),
+        _override_auth(team_member),
+    ):
+        response = TestClient(app).get("/search_tools/list")
+
+    assert response.status_code == 404
+    assert "search_tools" not in response.json()


### PR DESCRIPTION
## TLDR

Problem this solves:

- `GET /search_tools/list` returns 500 for every non-admin dashboard session
- Admin UI session keys carry team id `litellm-dashboard`, which has no DB row
- The team lookup 404s and the endpoint reports it as an opaque 500
- A genuine missing team was also masked as a 500

How it solves it:

- Skip the team lookup for that reserved sentinel id
- Such callers stay scoped by their key-level allowlist alone
- Real team ids are still resolved and their allowlist still applies
- A real lookup failure now surfaces its own status, not a 500

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy on `127.0.0.1:4011`, booted with

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --port 4011 --detailed_debug --use_v2_migration_resolver
```

Setup used for both runs: two search tools in the DB (`tavily-search`, `exa-search`), a non-admin user, a team whose `object_permission.search_tools` is `["tavily-search"]`, a virtual key on that team, and a real Admin UI session key minted through `POST /login` for that user. That session key was confirmed to carry the synthetic team id:

```bash
curl -s -X GET "http://127.0.0.1:4011/key/info" -H "Authorization: Bearer $UI_KEY" \
  | python -c 'import json,sys; i=json.load(sys.stdin)["info"]; print({k: i.get(k) for k in ("team_id","user_id","user_role","object_permission_id")})'
```

```
{'team_id': 'litellm-dashboard', 'user_id': 'search-tools-repro-user', 'user_role': None, 'object_permission_id': None}
```

The same three calls were run before and after:

```bash
for LABEL_KEY in "dashboard-session-key:$UI_KEY" "master-key:sk-1234" "team-virtual-key:$TEAM_KEY"; do
  echo "--- ${LABEL_KEY%%:*} ---"
  curl -s -o /tmp/body -w "HTTP %{http_code}\n" -X GET "http://127.0.0.1:4011/search_tools/list" \
    -H "Authorization: Bearer ${LABEL_KEY#*:}"
  cat /tmp/body; echo; echo
done
```

### Before, at `0acca3e86a`

```
--- dashboard-session-key ---
HTTP 500
{"detail":"404: {'error': \"Team doesn't exist in db. Team=litellm-dashboard. Create team via `/team/new` call.\"}"}

--- master-key ---
HTTP 200
{"search_tools":[{"search_tool_id":"bd2de242-487f-48ec-bc31-5ebe832889ee","search_tool_name":"exa-search","litellm_params":{"api_key":"tv****ch","search_provider":"tavily"},"search_tool_info":{},"created_at":"2026-08-06T06:16:12.285000+00:00","updated_at":"2026-08-06T06:16:12.285000+00:00","is_from_config":false},{"search_tool_id":"b7ad4915-9d44-4d76-9ea2-17f7c021dbf0","search_tool_name":"tavily-search","litellm_params":{"api_key":"tv****ch","search_provider":"tavily"},"search_tool_info":{},"created_at":"2026-08-06T06:16:12.082000+00:00","updated_at":"2026-08-06T06:16:12.082000+00:00","is_from_config":false}]}

--- team-virtual-key ---
HTTP 200
{"search_tools":[{"search_tool_id":"b7ad4915-9d44-4d76-9ea2-17f7c021dbf0","search_tool_name":"tavily-search","litellm_params":{"api_key":"tv****ch","search_provider":"tavily"},"search_tool_info":{},"created_at":"2026-08-06T06:16:12.082000+00:00","updated_at":"2026-08-06T06:16:12.082000+00:00","is_from_config":false}]}
```

### After, at `54e9964eb8`

```
--- dashboard-session-key ---
HTTP 200
{"search_tools":[{"search_tool_id":"bd2de242-487f-48ec-bc31-5ebe832889ee","search_tool_name":"exa-search","litellm_params":{"api_key":"tv****ch","search_provider":"tavily"},"search_tool_info":{},"created_at":"2026-08-06T06:16:12.285000+00:00","updated_at":"2026-08-06T06:16:12.285000+00:00","is_from_config":false},{"search_tool_id":"b7ad4915-9d44-4d76-9ea2-17f7c021dbf0","search_tool_name":"tavily-search","litellm_params":{"api_key":"tv****ch","search_provider":"tavily"},"search_tool_info":{},"created_at":"2026-08-06T06:16:12.082000+00:00","updated_at":"2026-08-06T06:16:12.082000+00:00","is_from_config":false}]}

--- master-key ---
HTTP 200
{"search_tools":[{"search_tool_id":"bd2de242-487f-48ec-bc31-5ebe832889ee","search_tool_name":"exa-search","litellm_params":{"api_key":"tv****ch","search_provider":"tavily"},"search_tool_info":{},"created_at":"2026-08-06T06:16:12.285000+00:00","updated_at":"2026-08-06T06:16:12.285000+00:00","is_from_config":false},{"search_tool_id":"b7ad4915-9d44-4d76-9ea2-17f7c021dbf0","search_tool_name":"tavily-search","litellm_params":{"api_key":"tv****ch","search_provider":"tavily"},"search_tool_info":{},"created_at":"2026-08-06T06:16:12.082000+00:00","updated_at":"2026-08-06T06:16:12.082000+00:00","is_from_config":false}]}

--- team-virtual-key ---
HTTP 200
{"search_tools":[{"search_tool_id":"b7ad4915-9d44-4d76-9ea2-17f7c021dbf0","search_tool_name":"tavily-search","litellm_params":{"api_key":"tv****ch","search_provider":"tavily"},"search_tool_info":{},"created_at":"2026-08-06T06:16:12.082000+00:00","updated_at":"2026-08-06T06:16:12.082000+00:00","is_from_config":false}]}
```

`diff` of the two captures shows only the dashboard block changed. The master key and the team virtual key return byte-identical bodies before and after, so the team allowlist filtering is neither widened nor narrowed: the team key still sees only `tavily-search`, not `exa-search`

## Type

🐛 Bug Fix

## Changes

`_filter_visible_search_tools` in `litellm/proxy/search_endpoints/search_tool_management.py` used to call `get_team_object` for any truthy `team_id`. Every Admin UI session key is stamped with `UI_SESSION_TOKEN_TEAM_ID` (`litellm-dashboard`), a reserved id that `/team/new` refuses to create, so it never has a row in `LiteLLM_TeamTable`, and the lookup raised a 404 that the endpoint's catch-all re-wrapped as a 500. This is a property of the session key rather than of the role, so it hit every non-admin browsing the Search Tools page

A new `_allowlist_team_id` helper resolves the team whose allowlist should scope the caller, returning `None` for the sentinel. Those callers fall through with `team_object=None` and are filtered by their key-level allowlist alone, which matches the treatment the same sentinel already gets in the MCP and agent permission paths. Any other team id is still looked up for real and its allowlist still applies

The endpoint also re-raises `HTTPException` untouched now, so a caller whose team genuinely does not exist gets that 404 instead of an opaque 500

The team lookup is injected as a `TeamObjectLookup` parameter defaulting to the real one, so the tests drive the filtering directly instead of patching class attributes. Five tests were added to the mapped file: a dashboard session key gets 200 and the lookup is never awaited, the same key still honors its key-level allowlist, a real team's allowlist still filters, a failing real lookup propagates, and a request for a genuinely missing team returns 404 with no `search_tools` payload

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
