### PR TITLE
fix(proxy): allow non-admins to reach /user/daily/activity/aggregated

### DIFF
--- a/litellm/proxy/_types.py
+++ b/litellm/proxy/_types.py
@@ -781,6 +781,7 @@ class LiteLLMRoutes(enum.Enum):
         "/model/update",
         "/model/delete",
         "/user/daily/activity",
+        "/user/daily/activity/aggregated",
         "/user/available_roles",  # read-only role metadata; any authenticated user may read
         "/user/list",  # org admins checked in endpoint; non-admins get 403
         "/model/{model_id}/update",

--- a/tests/test_litellm/proxy/auth/test_route_checks.py
+++ b/tests/test_litellm/proxy/auth/test_route_checks.py
@@ -3246,3 +3246,55 @@ def test_internal_user_still_blocked_from_another_users_info():
 
     assert exc_info.value.status_code == 403
     assert "key not allowed to access this user's info" in str(exc_info.value.detail)
+
+
+@pytest.mark.parametrize(
+    "route",
+    [
+        "/user/daily/activity",
+        "/user/daily/activity/aggregated",
+    ],
+)
+@pytest.mark.parametrize(
+    "user_role",
+    [
+        LitellmUserRoles.INTERNAL_USER.value,
+        LitellmUserRoles.INTERNAL_USER_VIEW_ONLY.value,
+    ],
+)
+def test_user_daily_activity_routes_reachable_by_non_admin(route, user_role):
+    """Both /user/daily/activity and its /aggregated sibling power the default
+    "Your Usage" dashboard view, and both handlers self-scope to the caller
+    (_user_has_admin_view -> require_caller_user_id_for_non_admin -> 403 on a
+    user_id mismatch). self_managed_routes is the ONLY list that grants either
+    route to a non-admin, so dropping one from it 401s every internal user's
+    main Usage page before the handler ever runs.
+    """
+    user_obj = LiteLLM_UserTable(
+        user_id="test_user",
+        user_email="test@example.com",
+        user_role=user_role,
+    )
+    valid_token = UserAPIKeyAuth(user_id="test_user", user_role=user_role)
+    request = MagicMock(spec=Request)
+    request.query_params = {}
+
+    RouteChecks.non_proxy_admin_allowed_routes_check(
+        user_obj=user_obj,
+        _user_role=user_role,
+        route=route,
+        request=request,
+        valid_token=valid_token,
+        request_data={},
+    )
+
+
+def test_user_daily_activity_aggregated_not_covered_by_prefix_match():
+    """check_route_access is exact-match plus explicit wildcards, so listing the
+    parent /user/daily/activity does not implicitly cover the /aggregated
+    sub-path. Pins the reason the sibling needs its own entry.
+    """
+    assert not RouteChecks.check_route_access(
+        route="/user/daily/activity/aggregated",
+        allowed_routes=["/user/daily/activity"],
+    )

--- a/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
+++ b/tests/test_litellm/proxy/management_endpoints/test_internal_user_endpoints.py
@@ -2295,6 +2295,75 @@ async def test_get_user_daily_activity_aggregated_admin_global_view(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_get_user_daily_activity_aggregated_non_admin_cannot_view_other_users(
+    monkeypatch,
+):
+    """
+    Same scoping contract as
+    test_get_user_daily_activity_non_admin_cannot_view_other_users, on the
+    aggregated route. Non-admins reach this handler now that the route is in
+    self_managed_routes, so the 403-on-mismatch and default-to-self behaviour
+    has to hold here too: opening the route must not widen access.
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from fastapi import HTTPException
+
+    from litellm.proxy.management_endpoints.internal_user_endpoints import (
+        get_user_daily_activity_aggregated,
+    )
+
+    mock_prisma_client = MagicMock()
+    monkeypatch.setattr("litellm.proxy.proxy_server.prisma_client", mock_prisma_client)
+
+    non_admin_key_dict = UserAPIKeyAuth(
+        user_id="regular-user-123",
+        user_role=LitellmUserRoles.INTERNAL_USER,
+    )
+
+    # Case 1: Non-admin targets another user's data — 403, helper never reached
+    with patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.get_daily_activity_aggregated",
+        new_callable=AsyncMock,
+    ) as mock_get_daily_agg:
+        with pytest.raises(HTTPException) as exc_info:
+            await get_user_daily_activity_aggregated(
+                start_date="2025-01-01",
+                end_date="2025-01-31",
+                model=None,
+                api_key=None,
+                user_id="other-user-456",
+                timezone=None,
+                user_api_key_dict=non_admin_key_dict,
+            )
+
+        assert exc_info.value.status_code == 403
+        assert "Non-admin users can only view their own spend data" in str(exc_info.value.detail)
+        mock_get_daily_agg.assert_not_called()
+
+    # Case 2: Non-admin omits user_id — scoped to their own user_id, not global
+    mock_response = MagicMock()
+    with patch(
+        "litellm.proxy.management_endpoints.internal_user_endpoints.get_daily_activity_aggregated",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_get_daily_agg:
+        result = await get_user_daily_activity_aggregated(
+            start_date="2025-01-01",
+            end_date="2025-01-31",
+            model=None,
+            api_key=None,
+            user_id=None,
+            timezone=None,
+            user_api_key_dict=non_admin_key_dict,
+        )
+
+        assert result is mock_response
+        mock_get_daily_agg.assert_called_once()
+        assert mock_get_daily_agg.call_args.kwargs["entity_id"] == "regular-user-123"
+
+
+@pytest.mark.asyncio
 async def test_delete_user_cleans_up_created_by_invitation_links(mocker):
     """
     Test that delete_user removes invitation links where the deleted user is the


### PR DESCRIPTION
## TLDR

Problem this solves:

- Internal users get 401 on `/user/daily/activity/aggregated`
- That route backs the default "Your Usage" dashboard view
- Every non-admin's main Usage page is broken

How it solves it:

- Adds the route to `LiteLLMRoutes.self_managed_routes`
- Sits next to its sibling `/user/daily/activity`, which was already listed
- Handler already self-scopes, so access is unchanged

## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [x] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

Live proxy, real Anthropic calls costing real money, no mocks. Before captured at `0acca3e86a`, after at `eea292abba`

Proxy booted with:

```bash
python litellm/proxy/proxy_cli.py --config litellm/proxy/dev_config.yaml --detailed_debug --use_v2_migration_resolver
```

Setup, two internal users so the scoping is observable. Both make a real call, so each has spend of their own:

```bash
ALICE=$(curl -s -X POST http://localhost:4000/user/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"user_email":"agg-alice@example.com","user_role":"internal_user"}' | jq -r .user_id)
BOB=$(curl -s -X POST http://localhost:4000/user/new -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d '{"user_email":"agg-bob@example.com","user_role":"internal_user"}' | jq -r .user_id)
ALICE_KEY=$(curl -s -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{\"user_id\":\"$ALICE\",\"models\":[\"anthropic-haiku-4-5\"]}" | jq -r .key)
BOB_KEY=$(curl -s -X POST http://localhost:4000/key/generate -H "Authorization: Bearer sk-1234" -H "Content-Type: application/json" -d "{\"user_id\":\"$BOB\",\"models\":[\"anthropic-haiku-4-5\"]}" | jq -r .key)

for K in "$ALICE_KEY" "$BOB_KEY"; do curl -s -X POST http://localhost:4000/v1/chat/completions -H "Authorization: Bearer $K" -H "Content-Type: application/json" -d '{"model":"anthropic-haiku-4-5","messages":[{"role":"user","content":"hi"}],"max_tokens":10}' | jq -c .usage; done
```

```
{"completion_tokens":4,"prompt_tokens":9,"total_tokens":13, ...}
{"completion_tokens":4,"prompt_tokens":9,"total_tokens":13, ...}
```

### Before, at `0acca3e86a`

Admin works, internal user is rejected at the auth layer before the handler runs:

```bash
curl -s -o /dev/null -w 'HTTP %{http_code}\n' "http://localhost:4000/user/daily/activity/aggregated?start_date=2026-08-06&end_date=2026-08-06" -H "Authorization: Bearer sk-1234"
curl -s -w '\nHTTP %{http_code}\n' "http://localhost:4000/user/daily/activity/aggregated?start_date=2026-08-06&end_date=2026-08-06" -H "Authorization: Bearer $ALICE_KEY"
```

```
HTTP 200
{"error":{"message":"Authentication Error, Only proxy admin can be used to generate, delete, update info for new keys/users/teams. Route=/user/daily/activity/aggregated. Your role=internal_user. Your user_id=06fa60****************************82","type":"auth_error","param":"None","code":"401"}}
HTTP 401
```

### After, at `eea292abba`

```bash
echo "1) admin, must stay 200"
curl -s -o /dev/null -w '   HTTP %{http_code}\n' "http://localhost:4000/user/daily/activity/aggregated?start_date=2026-08-06&end_date=2026-08-06" -H "Authorization: Bearer sk-1234"

echo "2) internal_user, own data (401 before the fix)"
curl -s -o /dev/null -w '   HTTP %{http_code}\n' "http://localhost:4000/user/daily/activity/aggregated?start_date=2026-08-06&end_date=2026-08-06" -H "Authorization: Bearer $ALICE_KEY"

echo "3) internal_user asking for another user's data, must stay 403"
curl -s -w '   HTTP %{http_code}\n' "http://localhost:4000/user/daily/activity/aggregated?start_date=2026-08-06&end_date=2026-08-06&user_id=$BOB" -H "Authorization: Bearer $ALICE_KEY"

echo "4) paginated sibling still 200 for internal_user"
curl -s -o /dev/null -w '   HTTP %{http_code}\n' "http://localhost:4000/user/daily/activity?start_date=2026-08-06&end_date=2026-08-06" -H "Authorization: Bearer $ALICE_KEY"
```

```
1) admin, must stay 200
   HTTP 200
2) internal_user, own data (401 before the fix)
   HTTP 200
3) internal_user asking for another user's data, must stay 403
{"detail":{"error":"Non-admin users can only view their own spend data."}}   HTTP 403
4) paginated sibling still 200 for internal_user
   HTTP 200
```

### The response really is scoped to the caller

Admin sees the whole proxy, 2 requests across both users' keys. Alice sees 1 request and only her own key, with Bob's key absent:

```bash
echo "admin:"; curl -s "http://localhost:4000/user/daily/activity/aggregated?start_date=2026-08-06&end_date=2026-08-06" -H "Authorization: Bearer sk-1234" | jq -c '{api_requests: .metadata.total_api_requests, keys: (.results[0].breakdown.api_keys | keys | map(.[0:8]))}'
echo "alice:"; curl -s "http://localhost:4000/user/daily/activity/aggregated?start_date=2026-08-06&end_date=2026-08-06" -H "Authorization: Bearer $ALICE_KEY" | jq -c '{api_requests: .metadata.total_api_requests, keys: (.results[0].breakdown.api_keys | keys | map(.[0:8]))}'
```

```
admin:
{"api_requests":2,"keys":["0046b8ca","7e830f8e"]}
alice:
{"api_requests":1,"keys":["0046b8ca"]}
```

`0046b8ca` is Alice's key and `7e830f8e` is Bob's, confirmed against `LiteLLM_VerificationToken` joined to `LiteLLM_UserTable`

## Type

🐛 Bug Fix

## Changes

`LiteLLMRoutes.self_managed_routes` listed `/user/daily/activity` but not `/user/daily/activity/aggregated`. `check_route_access` matches exactly, plus explicit wildcards, so the parent entry never covered the sub-path and `self_managed_routes` is the only list that grants either route to a non-admin. The aggregated route therefore fell through to the admin-only branch and 401'd before its handler could run

The handler needed no change. It already checks admin view first, then falls back to `require_caller_user_id_for_non_admin`, defaults a missing `user_id` to the caller's own, and returns 403 when a non-admin names someone else. That is the same self-scoping its paginated sibling relies on, so listing the route restores reachability without widening what any caller can read

Tests: `test_user_daily_activity_routes_reachable_by_non_admin` drives the real gate, `RouteChecks.non_proxy_admin_allowed_routes_check`, across both sibling routes and both non-admin roles. Removing either entry from the list fails it, which I verified by reverting the fix and watching exactly the two aggregated cases go red while the paginated ones stayed green. `test_user_daily_activity_aggregated_not_covered_by_prefix_match` pins the exact-match semantics that make the separate entry necessary, and `test_get_user_daily_activity_aggregated_non_admin_cannot_view_other_users` covers the handler branch that non-admins now reach, asserting the 403 on a mismatch and that an omitted `user_id` scopes to the caller instead of going global

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR
